### PR TITLE
feat: add retrieval latency benchmark and embedding input truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,6 +190,7 @@ demo/reflexio_storage/
 benchmarks/locomo/output/*
 !benchmarks/locomo/output/.gitkeep
 benchmarks/locomo/data/locomo10.json
+reflexio/benchmarks/retrieval_latency/results/
 
 # IDE
 .vscode/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,7 @@ ignore = [
 "conftest.py" = ["ARG001"]
 "notebooks/**" = ["S101", "F821", "S105", "S106", "ANN", "PTH", "RET504", "S113", "ARG001"]
 "reflexio/scripts/**" = ["S101", "G004", "ANN"]
+"reflexio/benchmarks/**" = ["S311"]
 "reflexio/server/api.py" = ["B008", "ARG001", "ARG002"]
 "reflexio/server/api_endpoints/**" = ["B008", "ARG001", "ARG002"]
 "reflexio/integrations/**" = ["ARG002"]

--- a/reflexio/benchmarks/__init__.py
+++ b/reflexio/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmarks for Reflexio. Not part of the shipped API surface."""

--- a/reflexio/benchmarks/retrieval_latency/README.md
+++ b/reflexio/benchmarks/retrieval_latency/README.md
@@ -1,0 +1,102 @@
+# Retrieval Latency Benchmark
+
+Measures end-to-end latency for profile search, user/agent playbook search,
+and unified cross-entity search across storage backends and corpus sizes.
+
+## What it measures
+
+Four retrieval types × two layers × N storage backends × K corpus sizes.
+
+**Layers:**
+
+| Layer      | What it times                                               |
+|------------|-------------------------------------------------------------|
+| `service`  | `reflexio.search_*()` called directly in-process            |
+| `http`     | FastAPI `TestClient` POST to `/api/search_*` (no TCP — ASGI transport only) |
+
+The `http` layer measures FastAPI routing, Pydantic serialization, and
+middleware cost on top of the service layer. It does *not* include kernel
+socket or network RTT — the goal is to isolate framework overhead from
+storage work. Add a uvicorn-backed variant later if you need wall-clock HTTP.
+
+**Retrieval types:** `profile`, `user_playbook`, `agent_playbook`, `unified`.
+
+**Backends:** `sqlite` (always available) and `supabase` (requires a local
+`supabase start` + `SUPABASE_ANON_KEY` / `SUPABASE_DB_URL` env vars; skipped
+gracefully otherwise).
+
+## Controlling embedder cost
+
+Query embeddings are pre-cached on disk at
+`~/.cache/reflexio-benchmarks/embeddings-<model>.json`. First run populates
+the cache via the real embedding API (requires `OPENAI_API_KEY` or the
+configured provider key); subsequent runs are offline.
+
+Document embeddings during corpus seeding use deterministic hash-derived
+fake vectors. Document vector *content* doesn't affect query-time latency
+(only row count does), so this is a sound optimization. Query-time
+retrieval always uses the real cached query vector.
+
+Query reformulation (a separate LLM call) is disabled on every request so
+it doesn't contaminate the timing — it's a known LLM cost, orthogonal to
+retrieval.
+
+## Usage
+
+```bash
+# Default sweep: sizes 100/1000/10000, sqlite + supabase if available,
+# both layers, all four retrieval types, 50 trials + 5 warmup per cell.
+uv run python -m reflexio.benchmarks.retrieval_latency.bench
+
+# Small smoke run (for local iteration):
+uv run python -m reflexio.benchmarks.retrieval_latency.bench \
+    --sizes 100 --trials 10 --warmup 2 \
+    --backend sqlite --layer service --retrieval profile
+
+# Diff against a committed baseline:
+uv run python -m reflexio.benchmarks.retrieval_latency.bench \
+    --baseline tests/benchmarks/baseline.json
+```
+
+## Output
+
+Each run writes `results.json` and `report.md` to
+`reflexio/benchmarks/retrieval_latency/results/<timestamp>/` — next to the
+script itself, so reports travel with the code that produced them (override
+with `--output-dir`). The `results/` directory is gitignored; commit a report
+manually only when you want to save it as a baseline or reference.
+
+`results.json` contains the full config block, per-cell aggregated stats,
+and every raw trial row. `report.md` renders the stats as markdown tables,
+one per retrieval type, rows grouped by `(backend, layer)`. Cell format:
+`p50 / p95 (mean)` in milliseconds. When `--baseline` is passed, a ΔP95
+column flags cells where p95 has grown by 20% or more (`⚠`).
+
+## Interpreting the numbers
+
+Sanity checks to run on any report:
+
+- p95 should scale sub-linearly with N (both FTS and vector indexes are built).
+- HTTP layer > service layer on the same cell (framework tax).
+- Unified search ≈ `max(profile, user_playbook, agent_playbook)` plus a small
+  Phase A fixed cost — unified runs the three entity searches in parallel.
+- If a cell has wildly higher variance than its neighbors, suspect GC or a
+  cold cache — re-run with more warmup.
+
+## Pytest smoke test
+
+`tests/benchmarks/test_retrieval_latency_smoke.py` runs a tiny version of
+this benchmark at `N=50, trials=10, sqlite + service only` and asserts that
+p95 has not regressed past 3× the committed baseline. It's marked
+`skip_in_precommit`, so it runs in `test-all` but not on every commit. To
+regenerate the baseline after an intentional perf change:
+
+```bash
+uv run python -m reflexio.benchmarks.retrieval_latency.bench \
+    --sizes 50 --trials 10 --warmup 2 \
+    --backend sqlite --layer service \
+    --output-dir tests/benchmarks/tmp/
+cp tests/benchmarks/tmp/results.json tests/benchmarks/baseline.json
+```
+
+Then commit the new `baseline.json`.

--- a/reflexio/benchmarks/retrieval_latency/__init__.py
+++ b/reflexio/benchmarks/retrieval_latency/__init__.py
@@ -1,0 +1,1 @@
+"""Retrieval latency benchmark — profile, playbook, unified search."""

--- a/reflexio/benchmarks/retrieval_latency/backends.py
+++ b/reflexio/benchmarks/retrieval_latency/backends.py
@@ -1,0 +1,175 @@
+"""
+Backend setup helpers for the retrieval latency benchmark.
+
+Each supported backend is exposed as a context manager that:
+
+1. Builds a ``Config`` with the appropriate ``StorageConfig``.
+2. Instantiates a ``Reflexio`` facade and obtains the underlying storage.
+3. Yields a :class:`BackendHandle` (reflexio instance + storage + org_id).
+4. Tears down temporary resources on exit.
+
+SQLite is always available. Supabase is only available when the local
+stack is running (``supabase start``) and the expected env vars are set; in
+all other cases the helper yields ``None`` so the benchmark loop can skip
+cleanly with a clear warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.models.config_schema import (
+    Config,
+    StorageConfigSQLite,
+    StorageConfigSupabase,
+)
+from reflexio.server.services.configurator.configurator import DefaultConfigurator
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+logger = logging.getLogger(__name__)
+
+BENCH_ORG_ID = "bench_org"
+
+
+@dataclass
+class BackendHandle:
+    """
+    Handle to a live Reflexio facade wired to a specific storage backend.
+
+    Attributes:
+        name (str): Short backend identifier, e.g. ``"sqlite"``.
+        reflexio (Reflexio): Service-layer facade — call ``search_profiles``
+            etc. directly on this for the service layer benchmark.
+        storage (BaseStorage): Underlying storage instance, needed for
+            swapping ``_get_embedding`` during seeding and the timed loop.
+        org_id (str): Organization ID used for this benchmark run.
+    """
+
+    name: str
+    reflexio: Reflexio
+    storage: BaseStorage
+    org_id: str
+
+
+def _make_reflexio(config: Config, org_id: str) -> Reflexio:
+    """
+    Build a Reflexio instance from an in-memory ``Config``.
+
+    Args:
+        config (Config): Fully populated benchmark config.
+        org_id (str): Organization ID for the Reflexio instance.
+
+    Returns:
+        Reflexio: A facade with storage wired up through the configurator.
+    """
+    configurator = DefaultConfigurator(org_id=org_id, config=config)
+    return Reflexio(org_id=org_id, configurator=configurator)
+
+
+@contextmanager
+def sqlite_backend() -> Iterator[BackendHandle]:
+    """
+    Construct an isolated SQLite-backed Reflexio instance in a tmpdir.
+
+    Mirrors the contract-test storage fixture pattern: fresh directory,
+    fresh database, no shared state with other runs.
+
+    Yields:
+        BackendHandle: A live handle with name ``"sqlite"``.
+    """
+    with tempfile.TemporaryDirectory(prefix="reflexio-bench-sqlite-") as tmp:
+        db_path = str(Path(tmp) / "reflexio.db")
+        config = Config(storage_config=StorageConfigSQLite(db_path=db_path))
+        reflexio = _make_reflexio(config, BENCH_ORG_ID)
+        storage = reflexio._get_storage()
+        yield BackendHandle(
+            name="sqlite",
+            reflexio=reflexio,
+            storage=storage,
+            org_id=BENCH_ORG_ID,
+        )
+
+
+def _supabase_env_ready() -> StorageConfigSupabase | None:
+    """
+    Read Supabase env vars and return a populated config, or ``None``.
+
+    Falls back to the default local ``supabase start`` URL when only the
+    keys are provided.
+
+    Returns:
+        StorageConfigSupabase | None: A config if all three fields can be
+        resolved, otherwise ``None``.
+    """
+    url = os.environ.get("SUPABASE_URL", "http://127.0.0.1:54321")
+    key = os.environ.get("SUPABASE_ANON_KEY") or os.environ.get("SUPABASE_KEY")
+    db_url = os.environ.get("SUPABASE_DB_URL")
+    if not (key and db_url):
+        return None
+    return StorageConfigSupabase(url=url, key=key, db_url=db_url)
+
+
+@contextmanager
+def supabase_backend() -> Iterator[BackendHandle | None]:
+    """
+    Construct a Supabase-backed Reflexio instance if the local stack is up.
+
+    Yields ``None`` (and logs a warning) when the Supabase env vars are
+    missing or the connection fails, so the benchmark loop can skip this
+    backend gracefully without aborting the whole run.
+
+    Yields:
+        BackendHandle | None: Live handle, or ``None`` if unavailable.
+    """
+    storage_config = _supabase_env_ready()
+    if storage_config is None:
+        logger.warning(
+            "Supabase backend skipped: set SUPABASE_ANON_KEY and SUPABASE_DB_URL "
+            "(and optionally SUPABASE_URL) to enable it."
+        )
+        yield None
+        return
+
+    config = Config(storage_config=storage_config)
+    try:
+        reflexio = _make_reflexio(config, BENCH_ORG_ID)
+        storage = reflexio._get_storage()
+    except Exception as err:  # noqa: BLE001
+        logger.warning(
+            "Supabase backend skipped: failed to connect — %s. "
+            "Is `supabase start` running?",
+            err,
+        )
+        yield None
+        return
+
+    try:
+        yield BackendHandle(
+            name="supabase",
+            reflexio=reflexio,
+            storage=storage,
+            org_id=BENCH_ORG_ID,
+        )
+    finally:
+        # Best-effort cleanup: wipe the benchmark org's rows so repeated
+        # runs don't accumulate forever. Swallow errors — a failing cleanup
+        # must not mask a real measurement failure.
+        try:
+            reflexio.delete_all_profiles_bulk()
+            reflexio.delete_all_user_playbooks_bulk()
+            reflexio.delete_all_agent_playbooks_bulk()
+        except Exception as err:  # noqa: BLE001
+            logger.warning("Supabase cleanup failed: %s", err)
+
+
+BACKENDS = {
+    "sqlite": sqlite_backend,
+    "supabase": supabase_backend,
+}

--- a/reflexio/benchmarks/retrieval_latency/bench.py
+++ b/reflexio/benchmarks/retrieval_latency/bench.py
@@ -1,0 +1,642 @@
+"""
+Retrieval latency benchmark — main CLI entry point.
+
+Measures end-to-end latency for profile search, user/agent playbook search,
+and unified cross-entity search across storage backends and corpus sizes.
+Two layers are supported:
+
+- ``service`` — direct method call on :class:`Reflexio` (in-process, no
+  HTTP). Measures reformulation + embedding lookup + storage retrieval.
+- ``http`` — FastAPI ``TestClient`` POST to the corresponding ``/api/...``
+  endpoint. Measures the same thing plus FastAPI routing, Pydantic
+  serialization, and middleware overhead. No sockets — TCP/kernel cost is
+  not included.
+
+Query embeddings are pre-cached on disk (see :mod:`embed_cache`), so
+embedder latency does not contaminate the measurement. Document embeddings
+during seeding are deterministic fakes — document vector content doesn't
+affect query-time latency, only row count does.
+
+Usage::
+
+    uv run python -m reflexio.benchmarks.retrieval_latency.bench \\
+        --sizes 100,1000 --trials 30 --backend sqlite --layer service,http
+
+See ``--help`` for the full flag list.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+import time
+from collections.abc import Callable
+from contextlib import ExitStack
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from reflexio.benchmarks.retrieval_latency.backends import (
+    BACKENDS,
+    BENCH_ORG_ID,
+    BackendHandle,
+)
+from reflexio.benchmarks.retrieval_latency.embed_cache import (
+    QueryEmbedCache,
+    make_cached_query_embedder,
+    patch_storage_get_embedding,
+)
+from reflexio.benchmarks.retrieval_latency.report import (
+    RunResults,
+    aggregate,
+    load_baseline,
+    render_markdown,
+    write_results_json,
+)
+from reflexio.benchmarks.retrieval_latency.scenarios import QUERIES
+from reflexio.benchmarks.retrieval_latency.seed import pick_bench_user_id, seed_corpus
+from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.models.api_schema.retriever_schema import (
+    SearchAgentPlaybookRequest,
+    SearchUserPlaybookRequest,
+    SearchUserProfileRequest,
+    UnifiedSearchRequest,
+)
+
+logger = logging.getLogger("reflexio.benchmarks.retrieval_latency")
+
+Layer = Literal["service", "http"]
+RetrievalType = Literal["profile", "user_playbook", "agent_playbook", "unified"]
+
+DEFAULT_SIZES = (100, 1_000, 10_000)
+DEFAULT_TRIALS = 50
+DEFAULT_WARMUP = 5
+DEFAULT_BACKENDS = ("sqlite", "supabase")
+DEFAULT_LAYERS = ("service", "http")
+DEFAULT_RETRIEVALS = ("profile", "user_playbook", "agent_playbook", "unified")
+
+# Default output lives next to the bench module so reports are colocated with
+# the script that produced them, not stranded at the repo root.
+_THIS_DIR = Path(__file__).resolve().parent
+_DEFAULT_OUTPUT_ROOT = _THIS_DIR / "results"
+
+
+def _build_profile_request(query_idx: int) -> SearchUserProfileRequest:
+    """
+    Build a profile search request bound to the canned query set.
+
+    Reformulation is disabled so the benchmark does not measure LLM cost.
+
+    Args:
+        query_idx (int): Index into the canned query set (wraps around).
+
+    Returns:
+        SearchUserProfileRequest: A ready-to-execute request.
+    """
+    return SearchUserProfileRequest(
+        user_id=pick_bench_user_id(query_idx),
+        query=QUERIES[query_idx % len(QUERIES)],
+        top_k=10,
+        enable_reformulation=False,
+    )
+
+
+def _build_user_playbook_request(query_idx: int) -> SearchUserPlaybookRequest:
+    """
+    Build a user playbook search request.
+
+    Args:
+        query_idx (int): Index into the canned query set (wraps around).
+
+    Returns:
+        SearchUserPlaybookRequest: A ready-to-execute request.
+    """
+    return SearchUserPlaybookRequest(
+        query=QUERIES[query_idx % len(QUERIES)],
+        user_id=pick_bench_user_id(query_idx),
+        top_k=10,
+        enable_reformulation=False,
+    )
+
+
+def _build_agent_playbook_request(query_idx: int) -> SearchAgentPlaybookRequest:
+    """
+    Build an agent playbook search request.
+
+    Args:
+        query_idx (int): Index into the canned query set (wraps around).
+
+    Returns:
+        SearchAgentPlaybookRequest: A ready-to-execute request.
+    """
+    return SearchAgentPlaybookRequest(
+        query=QUERIES[query_idx % len(QUERIES)],
+        top_k=10,
+        enable_reformulation=False,
+    )
+
+
+def _build_unified_request(query_idx: int) -> UnifiedSearchRequest:
+    """
+    Build a unified search request.
+
+    Args:
+        query_idx (int): Index into the canned query set (wraps around).
+
+    Returns:
+        UnifiedSearchRequest: A ready-to-execute request.
+    """
+    return UnifiedSearchRequest(
+        query=QUERIES[query_idx % len(QUERIES)],
+        user_id=pick_bench_user_id(query_idx),
+        top_k=10,
+        enable_reformulation=False,
+    )
+
+
+def _service_call(
+    reflexio: Reflexio,
+    retrieval: RetrievalType,
+    query_idx: int,
+    org_id: str,
+) -> None:
+    """
+    Execute one service-layer retrieval call in-process.
+
+    Dispatches on ``retrieval`` to the matching ``Reflexio`` facade method.
+    The response is discarded — the benchmark measures time, not accuracy.
+
+    Args:
+        reflexio (Reflexio): Live service-layer facade.
+        retrieval (RetrievalType): Which retrieval path to exercise.
+        query_idx (int): Query index to use for this call.
+        org_id (str): Org ID for unified search's feature-flag checks.
+    """
+    match retrieval:
+        case "profile":
+            reflexio.search_profiles(_build_profile_request(query_idx))
+        case "user_playbook":
+            reflexio.search_user_playbooks(_build_user_playbook_request(query_idx))
+        case "agent_playbook":
+            reflexio.search_agent_playbooks(_build_agent_playbook_request(query_idx))
+        case "unified":
+            reflexio.unified_search(_build_unified_request(query_idx), org_id=org_id)
+
+
+# Map retrieval type to (HTTP path, request builder) for the http layer.
+_HTTP_ROUTES: dict[RetrievalType, tuple[str, Callable[[int], Any]]] = {
+    "profile": ("/api/search_profiles", _build_profile_request),
+    "user_playbook": ("/api/search_user_playbooks", _build_user_playbook_request),
+    "agent_playbook": ("/api/search_agent_playbooks", _build_agent_playbook_request),
+    "unified": ("/api/search", _build_unified_request),
+}
+
+
+def _http_call(client: Any, retrieval: RetrievalType, query_idx: int) -> None:
+    """
+    Execute one HTTP-layer retrieval call via FastAPI ``TestClient``.
+
+    Args:
+        client: A fastapi.testclient.TestClient bound to the benchmark app.
+        retrieval (RetrievalType): Which retrieval path to exercise.
+        query_idx (int): Query index to use for this call.
+
+    Raises:
+        RuntimeError: If the endpoint returns a non-200 response — that
+            indicates a wiring problem, not a latency result, and should
+            abort the run.
+    """
+    path, build = _HTTP_ROUTES[retrieval]
+    payload = build(query_idx).model_dump(mode="json")
+    resp = client.post(path, json=payload)
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"HTTP benchmark call failed: {retrieval} {path} -> "
+            f"{resp.status_code} {resp.text[:200]}"
+        )
+
+
+def _make_test_client(handle: BackendHandle) -> Any:
+    """
+    Build a FastAPI ``TestClient`` wired to the benchmark Reflexio instance.
+
+    The server-side ``get_reflexio`` cache is pre-populated so FastAPI
+    handlers reuse our pre-seeded instance instead of creating their own
+    (which would have no data and no custom storage config).
+
+    Args:
+        handle (BackendHandle): The live benchmark backend handle.
+
+    Returns:
+        TestClient: A fastapi.testclient.TestClient bound to a fresh app.
+    """
+    from fastapi.testclient import TestClient
+
+    from reflexio.server.api import create_app
+    from reflexio.server.cache import reflexio_cache
+
+    with reflexio_cache._reflexio_cache_lock:
+        reflexio_cache._reflexio_cache[(handle.org_id, None)] = handle.reflexio
+
+    app = create_app(get_org_id=lambda: handle.org_id)
+    return TestClient(app)
+
+
+def _time_loop(
+    call: Callable[[int], None],
+    trials: int,
+    warmup: int,
+) -> list[float]:
+    """
+    Run ``warmup`` + ``trials`` timed invocations and return sample ms.
+
+    Warmup invocations are discarded. Each sample uses
+    :func:`time.perf_counter_ns` so the clock is monotonic and has
+    sub-microsecond resolution on all supported platforms.
+
+    Args:
+        call (Callable[[int], None]): Fn that takes a query index and runs
+            one benchmark invocation.
+        trials (int): Number of timed samples to collect.
+        warmup (int): Number of untimed warmup invocations.
+
+    Returns:
+        list[float]: ``trials`` latency samples in milliseconds.
+    """
+    for i in range(warmup):
+        call(i)
+    samples: list[float] = []
+    for i in range(trials):
+        t0 = time.perf_counter_ns()
+        call(i)
+        samples.append((time.perf_counter_ns() - t0) / 1_000_000.0)
+    return samples
+
+
+def _git_sha() -> str:
+    """
+    Return the current git HEAD short SHA, or ``"unknown"`` if unavailable.
+
+    Used for run provenance in the results JSON. Never raises — the
+    benchmark must complete even when the checkout isn't a git repo.
+
+    Returns:
+        str: Short SHA or ``"unknown"``.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return out.stdout.strip() or "unknown"
+    except subprocess.SubprocessError, FileNotFoundError, OSError:
+        return "unknown"
+
+
+def _run_one_cell(
+    handle: BackendHandle,
+    client: Any | None,
+    retrieval: RetrievalType,
+    layer: Layer,
+    n: int,
+    trials: int,
+    warmup: int,
+) -> list[dict[str, Any]]:
+    """
+    Benchmark one ``(backend, retrieval, layer, n)`` cell and return rows.
+
+    Args:
+        handle (BackendHandle): Live backend handle.
+        client: FastAPI TestClient (only required for ``layer='http'``).
+        retrieval (RetrievalType): Which retrieval path to exercise.
+        layer (Layer): ``service`` or ``http``.
+        n (int): Corpus size already seeded into the backend.
+        trials (int): Timed samples per cell.
+        warmup (int): Untimed warmup invocations per cell.
+
+    Returns:
+        list[dict]: One row per trial, ready to append to raw results.
+    """
+    if layer == "service":
+
+        def call(qi: int) -> None:
+            _service_call(handle.reflexio, retrieval, qi, handle.org_id)
+    else:
+        if client is None:
+            raise RuntimeError("http layer requires a TestClient")
+
+        def call(qi: int) -> None:
+            _http_call(client, retrieval, qi)
+
+    samples = _time_loop(call, trials=trials, warmup=warmup)
+    return [
+        {
+            "backend": handle.name,
+            "retrieval_type": retrieval,
+            "layer": layer,
+            "n": n,
+            "trial": i,
+            "elapsed_ms": sample,
+            "query_idx": i % len(QUERIES),
+        }
+        for i, sample in enumerate(samples)
+    ]
+
+
+def _run_for_backend(
+    handle: BackendHandle,
+    sizes: list[int],
+    layers: list[Layer],
+    retrievals: list[RetrievalType],
+    trials: int,
+    warmup: int,
+    embed_cache: QueryEmbedCache,
+) -> list[dict[str, Any]]:
+    """
+    Run the full (N × retrieval × layer) sweep on one backend.
+
+    For each N: wipes the backend, re-seeds ``n`` rows of each entity type,
+    then patches the storage with the cached query embedder and executes
+    every (retrieval × layer) cell.
+
+    A single wipe failure is tolerated (and logged) so a flaky delete doesn't
+    abort a full run, but two consecutive failures raise — repeated failures
+    silently contaminate larger-N cells with stale rows from smaller-N runs,
+    which looks like a perf change in the report for no real reason.
+
+    Args:
+        handle (BackendHandle): Live backend handle.
+        sizes (list[int]): Corpus sizes to sweep.
+        layers (list[Layer]): Layers to benchmark.
+        retrievals (list[RetrievalType]): Retrieval types to benchmark.
+        trials (int): Timed samples per cell.
+        warmup (int): Untimed warmup invocations per cell.
+        embed_cache (QueryEmbedCache): Pre-populated query embedding cache.
+
+    Returns:
+        list[dict]: All raw rows for this backend.
+
+    Raises:
+        RuntimeError: If ``_wipe_backend`` fails twice in a row on the same
+            backend, indicating delete is broken and every subsequent cell
+            would be reading contaminated data.
+    """
+    rows: list[dict[str, Any]] = []
+    client: Any | None = None
+    if "http" in layers:
+        client = _make_test_client(handle)
+    consecutive_wipe_failures = 0
+    for n in sizes:
+        logger.info("Backend=%s, seeding N=%d", handle.name, n)
+        if _wipe_backend(handle):
+            consecutive_wipe_failures = 0
+        else:
+            consecutive_wipe_failures += 1
+            if consecutive_wipe_failures >= 2:
+                raise RuntimeError(
+                    f"Backend {handle.name!r} wipe failed twice in a row; "
+                    "aborting so larger-N cells don't get contaminated with "
+                    "rows from previous runs."
+                )
+        seed_corpus(handle.reflexio, handle.storage, n)
+        cached = make_cached_query_embedder(embed_cache)
+        with patch_storage_get_embedding(handle.storage, cached):
+            for retrieval in retrievals:
+                for layer in layers:
+                    logger.info(
+                        "Measuring backend=%s retrieval=%s layer=%s N=%d",
+                        handle.name,
+                        retrieval,
+                        layer,
+                        n,
+                    )
+                    rows.extend(
+                        _run_one_cell(
+                            handle=handle,
+                            client=client,
+                            retrieval=retrieval,
+                            layer=layer,
+                            n=n,
+                            trials=trials,
+                            warmup=warmup,
+                        )
+                    )
+    return rows
+
+
+def _wipe_backend(handle: BackendHandle) -> bool:
+    """
+    Delete all seeded data from a backend so the next ``N`` starts fresh.
+
+    Logs and swallows a single failure — the caller tracks consecutive
+    failures and aborts on the second one, so one flaky delete doesn't kill
+    a whole run but a broken delete path does.
+
+    Args:
+        handle (BackendHandle): Live backend handle.
+
+    Returns:
+        bool: ``True`` if every delete-all call succeeded, ``False`` if any
+            raised. ``False`` signals the caller to bump its consecutive
+            failure counter.
+    """
+    try:
+        handle.reflexio.delete_all_profiles_bulk()
+        handle.reflexio.delete_all_user_playbooks_bulk()
+        handle.reflexio.delete_all_agent_playbooks_bulk()
+    except Exception as err:  # noqa: BLE001
+        logger.warning("Backend wipe failed on %s: %s", handle.name, err)
+        return False
+    return True
+
+
+def _parse_csv_list[T](raw: str, valid: tuple[T, ...]) -> list[T]:
+    """
+    Parse a comma-separated CLI value against an allowlist.
+
+    Args:
+        raw (str): Raw CLI value, e.g. ``"sqlite,supabase"``.
+        valid (tuple[T, ...]): Allowed values.
+
+    Returns:
+        list[T]: Parsed values in input order.
+
+    Raises:
+        ValueError: If any entry is not in ``valid``.
+    """
+    items = [x.strip() for x in raw.split(",") if x.strip()]
+    for item in items:
+        if item not in valid:
+            raise ValueError(f"Invalid value {item!r}; choose from {valid}")
+    return items  # type: ignore[return-value]
+
+
+def _parse_sizes(raw: str) -> list[int]:
+    """
+    Parse a comma-separated list of corpus sizes from the CLI.
+
+    Args:
+        raw (str): E.g. ``"100,1000,10000"``.
+
+    Returns:
+        list[int]: Parsed integers, sorted ascending.
+
+    Raises:
+        ValueError: If any token is not a positive integer.
+    """
+    sizes = [int(x.strip()) for x in raw.split(",") if x.strip()]
+    if any(s <= 0 for s in sizes):
+        raise ValueError("Sizes must be positive integers")
+    return sorted(sizes)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """
+    Parse CLI arguments for the benchmark.
+
+    Args:
+        argv (list[str] | None): Argument list, or ``None`` for sys.argv.
+
+    Returns:
+        argparse.Namespace: Parsed args.
+    """
+    parser = argparse.ArgumentParser(
+        prog="reflexio-bench-retrieval",
+        description="Retrieval latency benchmark (profile / playbook / unified).",
+    )
+    parser.add_argument(
+        "--sizes",
+        type=_parse_sizes,
+        default=list(DEFAULT_SIZES),
+        help="Comma-separated corpus sizes (default: 100,1000,10000).",
+    )
+    parser.add_argument(
+        "--trials",
+        type=int,
+        default=DEFAULT_TRIALS,
+        help="Timed samples per cell (default: 50).",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=DEFAULT_WARMUP,
+        help="Untimed warmup invocations per cell (default: 5).",
+    )
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default=",".join(DEFAULT_BACKENDS),
+        help="Comma-separated backends (default: sqlite,supabase).",
+    )
+    parser.add_argument(
+        "--layer",
+        type=str,
+        default=",".join(DEFAULT_LAYERS),
+        help="Comma-separated layers (default: service,http).",
+    )
+    parser.add_argument(
+        "--retrieval",
+        type=str,
+        default=",".join(DEFAULT_RETRIEVALS),
+        help="Comma-separated retrieval types (default: all four).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for results.json + report.md. "
+        f"Default: {_DEFAULT_OUTPUT_ROOT}/<timestamp>/",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help="Optional baseline results.json to diff the report against.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """
+    CLI entry point: parse args, run the sweep, write outputs.
+
+    Args:
+        argv (list[str] | None): Optional override of sys.argv.
+
+    Returns:
+        int: Exit code — 0 on success, 1 on a skipped-every-backend run.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    args = _parse_args(argv)
+
+    backends = _parse_csv_list(args.backend, DEFAULT_BACKENDS)
+    layers = cast(list[Layer], _parse_csv_list(args.layer, DEFAULT_LAYERS))
+    retrievals = cast(
+        list[RetrievalType], _parse_csv_list(args.retrieval, DEFAULT_RETRIEVALS)
+    )
+
+    embed_cache = QueryEmbedCache()
+    embed_cache.ensure(QUERIES)
+
+    raw: list[dict[str, Any]] = []
+    with ExitStack() as stack:
+        for backend_name in backends:
+            handle = stack.enter_context(BACKENDS[backend_name]())
+            if handle is None:
+                logger.warning("Skipping backend %s (unavailable)", backend_name)
+                continue
+            raw.extend(
+                _run_for_backend(
+                    handle=handle,
+                    sizes=args.sizes,
+                    layers=layers,
+                    retrievals=retrievals,
+                    trials=args.trials,
+                    warmup=args.warmup,
+                    embed_cache=embed_cache,
+                )
+            )
+
+    if not raw:
+        logger.error("No rows collected — every backend was skipped.")
+        return 1
+
+    stats = aggregate(raw)
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d_%H%M%S")
+    output_dir = args.output_dir or _DEFAULT_OUTPUT_ROOT / timestamp
+    results = RunResults(
+        config={
+            "timestamp": timestamp,
+            "git_sha": _git_sha(),
+            "org_id": BENCH_ORG_ID,
+            "sizes": args.sizes,
+            "trials": args.trials,
+            "warmup": args.warmup,
+            "backends": backends,
+            "layers": layers,
+            "retrievals": retrievals,
+        },
+        raw=raw,
+        stats=stats,
+    )
+    write_results_json(results, output_dir / "results.json")
+    baseline = load_baseline(args.baseline) if args.baseline else {}
+    (output_dir / "report.md").write_text(render_markdown(results, baseline))
+    logger.info(
+        "Wrote %s and %s", output_dir / "results.json", output_dir / "report.md"
+    )
+    print(json.dumps({"status": "ok", "output_dir": str(output_dir)}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reflexio/benchmarks/retrieval_latency/embed_cache.py
+++ b/reflexio/benchmarks/retrieval_latency/embed_cache.py
@@ -1,0 +1,330 @@
+"""
+Embedding cache + deterministic fake embedder for retrieval latency benchmarks.
+
+This module controls the cost of embedding generation during a benchmark run.
+Retrieval latency measurement should not be dominated by embedder API calls,
+but query-side vectors must still be realistic so the vector-search path
+computes meaningful cosine similarities.
+
+Two helpers are provided:
+
+1. :class:`QueryEmbedCache` — on-disk cache of real embeddings for the fixed
+   query set. Populated once via :class:`LiteLLMClient`, then reused on every
+   subsequent run. First-time population requires a configured embedding API
+   key (typically ``OPENAI_API_KEY``).
+2. :func:`make_fake_document_embedder` — deterministic pseudo-random vector
+   generator used during corpus seeding. Document vector *content* does not
+   affect query-time latency (only row count does), so fake vectors are a
+   sound optimization for a latency benchmark.
+
+Both helpers expose a :func:`patch_storage_get_embedding` style context
+manager that swaps out the storage instance's bound ``_get_embedding`` method
+for the duration of a ``with`` block.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import struct
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Literal
+
+from reflexio.models.config_schema import EMBEDDING_DIMENSIONS
+from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+
+logger = logging.getLogger(__name__)
+
+# Track the storage-level canonical dimension so fake document vectors
+# always fit the vec0 column width. Query cache entries are populated
+# through LiteLLMClient at this same dimension for consistency.
+DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+DEFAULT_EMBEDDING_DIMS = EMBEDDING_DIMENSIONS
+
+_CACHE_DIR = Path.home() / ".cache" / "reflexio-benchmarks"
+_DOCUMENT_PREFIX = "search_document: "
+_QUERY_PREFIX = "search_query: "
+
+
+EmbeddingPurpose = Literal["document", "query"]
+
+EmbeddingFn = Callable[[str, EmbeddingPurpose], list[float]]
+
+
+def _cache_path(model: str) -> Path:
+    """
+    Return the on-disk cache path for embeddings of a given model.
+
+    Args:
+        model (str): Embedding model identifier (e.g. text-embedding-3-small).
+
+    Returns:
+        Path: JSON cache file path. Parent directory is not created here.
+    """
+    safe = model.replace("/", "_")
+    return _CACHE_DIR / f"embeddings-{safe}.json"
+
+
+def _hash_key(text: str) -> str:
+    """
+    Return a stable short hash key for a full (prefixed) embedding input.
+
+    Args:
+        text (str): The full text that will be passed to the embedding model.
+
+    Returns:
+        str: Hex digest suitable for use as a JSON dict key.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+class QueryEmbedCache:
+    """
+    On-disk cache of real embedding vectors for the benchmark query set.
+
+    The cache file is a flat JSON dict mapping SHA256(prefixed_text) → vector.
+    Population happens lazily via :meth:`ensure` and only touches the network
+    when the cache is missing an entry.
+
+    Attributes:
+        model (str): Embedding model used to populate the cache.
+        dimensions (int): Expected vector dimensionality.
+    """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_EMBEDDING_MODEL,
+        dimensions: int = DEFAULT_EMBEDDING_DIMS,
+    ) -> None:
+        """
+        Initialize the cache, loading any existing on-disk entries.
+
+        Args:
+            model (str): Embedding model name. Must match whatever the live
+                storage backend is configured with.
+            dimensions (int): Expected embedding dimensionality. Must match
+                the storage vector column width.
+        """
+        self.model = model
+        self.dimensions = dimensions
+        self._path = _cache_path(model)
+        self._data: dict[str, list[float]] = {}
+        if self._path.exists():
+            try:
+                self._data = json.loads(self._path.read_text())
+            except (OSError, json.JSONDecodeError) as err:
+                logger.warning(
+                    "Failed to load embed cache at %s: %s — starting fresh",
+                    self._path,
+                    err,
+                )
+                self._data = {}
+
+    def ensure(self, queries: Iterable[str]) -> None:
+        """
+        Make sure every query has a real embedding in the cache.
+
+        Populates missing entries via the live embedding API in a single
+        batched call. Writes the cache to disk at the end of population so
+        subsequent runs skip the network entirely.
+
+        Args:
+            queries (Iterable[str]): Raw query strings (no prefix). The
+                ``search_query:`` prefix is applied internally.
+
+        Raises:
+            RuntimeError: If the embedder cannot be reached and the cache is
+                not already populated for every query.
+        """
+        missing: list[str] = []
+        missing_prefixed: list[str] = []
+        for q in queries:
+            prefixed = _QUERY_PREFIX + q
+            if _hash_key(prefixed) not in self._data:
+                missing.append(q)
+                missing_prefixed.append(prefixed)
+        if not missing:
+            return
+
+        logger.info(
+            "Embed cache miss for %d queries (model=%s) — fetching",
+            len(missing),
+            self.model,
+        )
+        client = LiteLLMClient(LiteLLMConfig(model=self.model))
+        try:
+            vectors = client.get_embeddings(
+                missing_prefixed, self.model, self.dimensions
+            )
+        except Exception as err:  # noqa: BLE001
+            raise RuntimeError(
+                f"Failed to populate query embed cache for model {self.model}: "
+                f"{err}. Set OPENAI_API_KEY (or the appropriate provider key) "
+                "and re-run."
+            ) from err
+
+        for prefixed, vec in zip(missing_prefixed, vectors, strict=True):
+            if len(vec) != self.dimensions:
+                raise RuntimeError(
+                    f"Embed cache got vector of length {len(vec)}, expected "
+                    f"{self.dimensions} for model {self.model}"
+                )
+            self._data[_hash_key(prefixed)] = list(vec)
+
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(self._data))
+
+    def lookup(self, text: str, purpose: EmbeddingPurpose) -> list[float]:
+        """
+        Return a cached embedding for the given raw text.
+
+        Args:
+            text (str): Raw text (no prefix).
+            purpose (EmbeddingPurpose): ``"document"`` or ``"query"``.
+
+        Returns:
+            list[float]: The cached embedding vector.
+
+        Raises:
+            KeyError: If the text is not in the cache.
+        """
+        prefix = _DOCUMENT_PREFIX if purpose == "document" else _QUERY_PREFIX
+        key = _hash_key(prefix + text)
+        try:
+            return self._data[key]
+        except KeyError as err:
+            raise KeyError(
+                f"Query embed cache miss for text={text!r} purpose={purpose}. "
+                "Did you forget to call QueryEmbedCache.ensure() for the query set?"
+            ) from err
+
+
+def _deterministic_vector(text: str, dimensions: int) -> list[float]:
+    """
+    Generate a deterministic pseudo-random unit vector from text.
+
+    Uses SHA256 as a cheap keyed PRNG, converts the digest stream into
+    little-endian float32 values, then normalizes to unit length. The
+    output is stable across runs and machines.
+
+    Args:
+        text (str): Input text (the hash seed).
+        dimensions (int): Desired vector length.
+
+    Returns:
+        list[float]: Unit-length vector of ``dimensions`` floats.
+    """
+    # Derive 4*dimensions pseudo-random bytes from chained SHA256 of
+    # (text, counter). This is not cryptographic — it just needs to be
+    # stable and unbiased enough to exercise cosine similarity paths.
+    need = dimensions * 4
+    buf = bytearray()
+    counter = 0
+    while len(buf) < need:
+        h = hashlib.sha256(f"{text}:{counter}".encode()).digest()
+        buf.extend(h)
+        counter += 1
+    floats = [
+        struct.unpack("<i", bytes(buf[i * 4 : (i + 1) * 4]))[0] / 2**31
+        for i in range(dimensions)
+    ]
+    norm = sum(x * x for x in floats) ** 0.5
+    if norm == 0.0:
+        return [0.0] * dimensions
+    return [x / norm for x in floats]
+
+
+def make_fake_document_embedder(
+    dimensions: int = DEFAULT_EMBEDDING_DIMS,
+) -> Callable[[str, EmbeddingPurpose], list[float]]:
+    """
+    Build a fake ``_get_embedding`` replacement for corpus seeding.
+
+    Returns deterministic hash-derived vectors so seeding is fast (no API
+    calls) while preserving vector column width and cosine-similarity
+    determinism across runs. Only valid for seeding — query-time retrieval
+    should use a real :class:`QueryEmbedCache` so BM25/vector ranking is
+    meaningful.
+
+    Args:
+        dimensions (int): Vector length to produce. Must match the storage
+            backend's vector column width.
+
+    Returns:
+        Callable: A bound-method-compatible ``(text, purpose) → vector``
+            function ready to patch onto a storage instance.
+    """
+
+    def fake(text: str, purpose: EmbeddingPurpose = "document") -> list[float]:
+        # Include purpose in the seed so doc and query versions of the same
+        # text get different vectors — mirrors how the real embedder treats
+        # the search_document/search_query prefixes as distinct inputs.
+        return _deterministic_vector(f"{purpose}:{text}", dimensions)
+
+    return fake
+
+
+def make_cached_query_embedder(
+    cache: QueryEmbedCache,
+    fallback_dims: int = DEFAULT_EMBEDDING_DIMS,
+) -> Callable[[str, EmbeddingPurpose], list[float]]:
+    """
+    Build a ``_get_embedding`` replacement backed by :class:`QueryEmbedCache`.
+
+    Document lookups fall back to fake deterministic vectors (seeding already
+    happened; any ``purpose='document'`` call during the timed loop would be
+    an oversight but must not crash). Query lookups raise if the cache is
+    empty — that indicates :meth:`QueryEmbedCache.ensure` was skipped.
+
+    Args:
+        cache (QueryEmbedCache): Populated cache for the benchmark query set.
+        fallback_dims (int): Vector width for any document-side lookups that
+            leak into the timed loop.
+
+    Returns:
+        Callable: A bound-method-compatible ``(text, purpose) → vector`` fn.
+    """
+
+    def cached(text: str, purpose: EmbeddingPurpose = "document") -> list[float]:
+        if purpose == "query":
+            return cache.lookup(text, "query")
+        return _deterministic_vector(f"document:{text}", fallback_dims)
+
+    return cached
+
+
+@contextmanager
+def patch_storage_get_embedding(
+    storage: Any,
+    replacement: EmbeddingFn,
+) -> Iterator[None]:
+    """
+    Temporarily replace a storage instance's ``_get_embedding`` bound method.
+
+    Used to swap in either the fake seeding embedder or the cached query
+    embedder for the duration of a benchmark phase.
+
+    ``storage`` is typed ``Any`` because ``_get_embedding`` is declared on the
+    sqlite storage mixins rather than on ``BaseStorage`` itself — a Protocol
+    that required the attribute would reject real storage instances.
+
+    Args:
+        storage (Any): A BaseStorage-like instance exposing a
+            ``_get_embedding`` method. Writing to ``storage._get_embedding``
+            goes into the instance dict, so subsequent lookups resolve to the
+            plain replacement function (no auto-binding).
+        replacement (EmbeddingFn): The ``(text, purpose) → vector`` fn to bind.
+
+    Yields:
+        None: During the ``with`` block, ``storage._get_embedding`` routes to
+        ``replacement``. On exit, the original bound method is restored.
+    """
+    original = storage._get_embedding
+    storage._get_embedding = replacement
+    try:
+        yield
+    finally:
+        storage._get_embedding = original

--- a/reflexio/benchmarks/retrieval_latency/report.py
+++ b/reflexio/benchmarks/retrieval_latency/report.py
@@ -1,0 +1,317 @@
+"""
+Statistics and markdown rendering for retrieval latency benchmark results.
+
+Input: a flat list of trial rows produced by :mod:`bench`, each with
+``{backend, retrieval_type, layer, n, trial, elapsed_ms}``.
+
+Output: markdown tables grouped by retrieval type, optional diff column
+against a committed baseline file.
+
+All quantile math uses :mod:`statistics` to avoid pulling in numpy.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from reflexio.benchmarks.retrieval_latency.scenarios import QUERIES
+
+# Flag a cell when p95 has grown by more than this factor since the baseline.
+REGRESSION_THRESHOLD = 1.20
+
+
+@dataclass(frozen=True)
+class CellKey:
+    """
+    Immutable key identifying one (backend, retrieval_type, layer, n) cell.
+
+    Attributes:
+        backend (str): Storage backend name, e.g. ``"sqlite"``.
+        retrieval_type (str): One of ``profile``, ``user_playbook``,
+            ``agent_playbook``, ``unified``.
+        layer (str): ``service`` or ``http``.
+        n (int): Corpus size for this cell.
+    """
+
+    backend: str
+    retrieval_type: str
+    layer: str
+    n: int
+
+
+@dataclass
+class CellStats:
+    """
+    Aggregated latency stats for one benchmark cell.
+
+    Attributes:
+        trials (int): Number of timed samples summarized.
+        mean_ms (float): Arithmetic mean latency in milliseconds.
+        p50_ms (float): Median latency.
+        p95_ms (float): 95th percentile.
+        p99_ms (float): 99th percentile.
+        max_ms (float): Slowest sample observed.
+    """
+
+    trials: int
+    mean_ms: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    max_ms: float
+
+
+@dataclass
+class RunResults:
+    """
+    Full results of a benchmark run, aggregated and raw.
+
+    Attributes:
+        config (dict): Top-level metadata (CLI args, git sha, timestamp).
+        raw (list[dict]): All trial rows, unmodified.
+        stats (dict[str, CellStats]): Aggregated stats keyed by
+            ``backend|retrieval_type|layer|n``.
+    """
+
+    config: dict[str, Any]
+    raw: list[dict[str, Any]] = field(default_factory=list)
+    stats: dict[str, CellStats] = field(default_factory=dict)
+
+
+def _quantile(sorted_samples: list[float], q: float) -> float:
+    """
+    Return the ``q``-th quantile of an already-sorted sample list.
+
+    Uses the linear interpolation method so small N (e.g. 10 samples for
+    the smoke test) still gives a stable number.
+
+    Args:
+        sorted_samples (list[float]): Sorted list of samples.
+        q (float): Target quantile in ``[0, 1]``.
+
+    Returns:
+        float: Interpolated quantile value.
+    """
+    if not sorted_samples:
+        return 0.0
+    if len(sorted_samples) == 1:
+        return sorted_samples[0]
+    pos = q * (len(sorted_samples) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_samples) - 1)
+    frac = pos - lo
+    return sorted_samples[lo] * (1 - frac) + sorted_samples[hi] * frac
+
+
+def compute_stats(samples: list[float]) -> CellStats:
+    """
+    Compute mean / p50 / p95 / p99 / max for one cell's samples.
+
+    Args:
+        samples (list[float]): Latency samples in milliseconds.
+
+    Returns:
+        CellStats: Aggregated stats. Empty input returns zeros.
+    """
+    if not samples:
+        return CellStats(
+            trials=0, mean_ms=0.0, p50_ms=0.0, p95_ms=0.0, p99_ms=0.0, max_ms=0.0
+        )
+    sorted_s = sorted(samples)
+    return CellStats(
+        trials=len(samples),
+        mean_ms=statistics.fmean(sorted_s),
+        p50_ms=_quantile(sorted_s, 0.50),
+        p95_ms=_quantile(sorted_s, 0.95),
+        p99_ms=_quantile(sorted_s, 0.99),
+        max_ms=sorted_s[-1],
+    )
+
+
+def cell_key_str(k: CellKey) -> str:
+    """
+    Serialize a :class:`CellKey` into a flat string for JSON keys.
+
+    Args:
+        k (CellKey): The cell identifier.
+
+    Returns:
+        str: ``backend|retrieval_type|layer|n`` form.
+    """
+    return f"{k.backend}|{k.retrieval_type}|{k.layer}|{k.n}"
+
+
+def aggregate(raw: list[dict[str, Any]]) -> dict[str, CellStats]:
+    """
+    Bucket raw trial rows by cell and compute aggregated stats per cell.
+
+    Args:
+        raw (list[dict]): Trial rows as emitted by :mod:`bench`.
+
+    Returns:
+        dict[str, CellStats]: Mapping from flat cell key to stats.
+    """
+    buckets: dict[str, list[float]] = {}
+    for row in raw:
+        k = CellKey(
+            backend=row["backend"],
+            retrieval_type=row["retrieval_type"],
+            layer=row["layer"],
+            n=row["n"],
+        )
+        buckets.setdefault(cell_key_str(k), []).append(row["elapsed_ms"])
+    return {key: compute_stats(samples) for key, samples in buckets.items()}
+
+
+def write_results_json(results: RunResults, path: Path) -> None:
+    """
+    Persist aggregated + raw results to disk as JSON.
+
+    Args:
+        results (RunResults): Fully populated run results.
+        path (Path): Output file path. Parent directory is created.
+    """
+    payload = {
+        "config": results.config,
+        "stats": {k: asdict(v) for k, v in results.stats.items()},
+        "raw": results.raw,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def load_baseline(path: Path) -> dict[str, CellStats]:
+    """
+    Load aggregated baseline stats from a previously-written results file.
+
+    Args:
+        path (Path): Baseline results.json file.
+
+    Returns:
+        dict[str, CellStats]: Stats indexed by flat cell key. Empty dict
+        if the file is missing or malformed.
+    """
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text())
+    return {
+        k: CellStats(**v)
+        for k, v in data.get("stats", {}).items()  # type: ignore[arg-type]
+    }
+
+
+def _fmt_cell(stats: CellStats) -> str:
+    """
+    Render a single cell's stats as ``p50 / p95 (mean)`` ms.
+
+    Args:
+        stats (CellStats): The cell's aggregated stats.
+
+    Returns:
+        str: Human-readable one-line summary, or ``"—"`` for empty cells.
+    """
+    if stats.trials == 0:
+        return "—"
+    return f"{stats.p50_ms:.1f} / {stats.p95_ms:.1f} ({stats.mean_ms:.1f})"
+
+
+def _diff_cell(current: CellStats, baseline: CellStats | None) -> str:
+    """
+    Render a baseline-diff cell showing ΔP95 and a regression marker.
+
+    Args:
+        current (CellStats): This run's stats for the cell.
+        baseline (CellStats | None): Prior run's stats, if any.
+
+    Returns:
+        str: ``+42%`` or ``-8%`` with a ``⚠`` marker if current p95 is
+        above the regression threshold.
+    """
+    if baseline is None or baseline.p95_ms == 0 or current.trials == 0:
+        return "—"
+    ratio = current.p95_ms / baseline.p95_ms
+    delta = (ratio - 1.0) * 100
+    marker = " ⚠" if ratio >= REGRESSION_THRESHOLD else ""
+    return f"{delta:+.0f}%{marker}"
+
+
+def render_markdown(
+    results: RunResults, baseline: dict[str, CellStats] | None = None
+) -> str:
+    """
+    Render the full run results as a markdown report.
+
+    One table per retrieval type, rows grouped by (backend, layer, N),
+    with an optional ΔP95 column against the committed baseline.
+
+    Args:
+        results (RunResults): Fully populated run results.
+        baseline (dict[str, CellStats] | None): Optional baseline stats.
+
+    Returns:
+        str: Markdown report suitable for writing to ``report.md``.
+    """
+    retrieval_types = sorted({row["retrieval_type"] for row in results.raw})
+    backends = sorted({row["backend"] for row in results.raw})
+    layers = sorted({row["layer"] for row in results.raw})
+    sizes = sorted({row["n"] for row in results.raw})
+
+    lines: list[str] = ["# Retrieval latency benchmark", ""]
+    lines.append(f"- Trials per cell: {results.config.get('trials', '?')}")
+    lines.append(f"- Warmup per cell: {results.config.get('warmup', '?')}")
+    lines.append(f"- Query set: {len(QUERIES)} fixed queries (see scenarios.py)")
+    lines.append("- Cell format: `p50 / p95 (mean)` in ms")
+    if baseline:
+        lines.append(f"- Regression threshold: p95 ≥ {REGRESSION_THRESHOLD:.0%}")
+    lines.append("")
+
+    for rt in retrieval_types:
+        lines.append(f"## {rt}")
+        lines.append("")
+        header = ["backend", "layer", *[f"N={n}" for n in sizes]]
+        if baseline:
+            header.append("ΔP95")
+        lines.append("| " + " | ".join(header) + " |")
+        lines.append("|" + "|".join(["---"] * len(header)) + "|")
+
+        for backend in backends:
+            for layer in layers:
+                row_cells: list[str] = [backend, layer]
+                latest_stats: CellStats | None = None
+                for n in sizes:
+                    key = cell_key_str(CellKey(backend, rt, layer, n))
+                    stats = results.stats.get(
+                        key,
+                        CellStats(0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                    )
+                    row_cells.append(_fmt_cell(stats))
+                    if stats.trials > 0:
+                        latest_stats = stats
+                if baseline and latest_stats is not None:
+                    # Diff against the largest-N cell we have for this row.
+                    largest_n = max(
+                        (
+                            n
+                            for n in sizes
+                            if cell_key_str(CellKey(backend, rt, layer, n))
+                            in results.stats
+                        ),
+                        default=None,
+                    )
+                    base_key = (
+                        cell_key_str(CellKey(backend, rt, layer, largest_n))
+                        if largest_n is not None
+                        else None
+                    )
+                    base_stats = baseline.get(base_key) if base_key else None
+                    row_cells.append(_diff_cell(latest_stats, base_stats))
+                elif baseline:
+                    row_cells.append("—")
+                lines.append("| " + " | ".join(row_cells) + " |")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/reflexio/benchmarks/retrieval_latency/results/report.md
+++ b/reflexio/benchmarks/retrieval_latency/results/report.md
@@ -1,0 +1,43 @@
+# Retrieval latency benchmark
+
+- Trials per cell: 30
+- Warmup per cell: 3
+- Query set: 20 fixed queries (see scenarios.py)
+- Cell format: `p50 / p95 (mean)` in ms
+
+## agent_playbook
+
+
+| backend | layer   | N=100              | N=1000             |
+| ------- | ------- | ------------------ | ------------------ |
+| sqlite  | http    | 18.8 / 39.1 (21.4) | 19.2 / 21.3 (19.7) |
+| sqlite  | service | 15.2 / 16.9 (15.5) | 16.9 / 21.6 (17.6) |
+
+
+## profile
+
+
+| backend | layer   | N=100           | N=1000             |
+| ------- | ------- | --------------- | ------------------ |
+| sqlite  | http    | 4.1 / 5.6 (4.4) | 20.7 / 25.6 (21.2) |
+| sqlite  | service | 1.8 / 2.2 (2.0) | 17.4 / 21.2 (17.9) |
+
+
+## unified
+
+
+| backend | layer   | N=100              | N=1000             |
+| ------- | ------- | ------------------ | ------------------ |
+| sqlite  | http    | 24.7 / 30.3 (25.4) | 58.8 / 71.8 (59.9) |
+| sqlite  | service | 20.1 / 21.5 (20.1) | 57.5 / 72.7 (58.3) |
+
+
+## user_playbook
+
+
+| backend | layer   | N=100           | N=1000             |
+| ------- | ------- | --------------- | ------------------ |
+| sqlite  | http    | 3.9 / 4.8 (4.2) | 19.5 / 22.0 (19.8) |
+| sqlite  | service | 1.6 / 2.0 (1.7) | 17.1 / 17.8 (17.1) |
+
+

--- a/reflexio/benchmarks/retrieval_latency/results/results.json
+++ b/reflexio/benchmarks/retrieval_latency/results/results.json
@@ -1,0 +1,4478 @@
+{
+  "config": {
+    "timestamp": "2026-04-13_021000",
+    "git_sha": "67604eb",
+    "org_id": "bench_org",
+    "sizes": [
+      100,
+      1000
+    ],
+    "trials": 30,
+    "warmup": 3,
+    "backends": [
+      "sqlite"
+    ],
+    "layers": [
+      "service",
+      "http"
+    ],
+    "retrievals": [
+      "profile",
+      "user_playbook",
+      "agent_playbook",
+      "unified"
+    ]
+  },
+  "stats": {
+    "sqlite|profile|service|100": {
+      "trials": 30,
+      "mean_ms": 1.9613554666666666,
+      "p50_ms": 1.823375,
+      "p95_ms": 2.18392515,
+      "p99_ms": 3.8979523200000017,
+      "max_ms": 4.596792
+    },
+    "sqlite|profile|http|100": {
+      "trials": 30,
+      "mean_ms": 4.401726433333334,
+      "p50_ms": 4.062396,
+      "p95_ms": 5.604022249999999,
+      "p99_ms": 9.384655820000004,
+      "max_ms": 10.867583
+    },
+    "sqlite|user_playbook|service|100": {
+      "trials": 30,
+      "mean_ms": 1.6744153333333334,
+      "p50_ms": 1.6405625000000001,
+      "p95_ms": 1.95754115,
+      "p99_ms": 1.98251689,
+      "max_ms": 1.983375
+    },
+    "sqlite|user_playbook|http|100": {
+      "trials": 30,
+      "mean_ms": 4.154295666666667,
+      "p50_ms": 3.928146,
+      "p95_ms": 4.8435042,
+      "p99_ms": 7.295504680000002,
+      "max_ms": 8.292875
+    },
+    "sqlite|agent_playbook|service|100": {
+      "trials": 30,
+      "mean_ms": 15.4721001,
+      "p50_ms": 15.2380835,
+      "p95_ms": 16.94073545,
+      "p99_ms": 17.560502,
+      "max_ms": 17.662292
+    },
+    "sqlite|agent_playbook|http|100": {
+      "trials": 30,
+      "mean_ms": 21.4020056,
+      "p50_ms": 18.756396,
+      "p95_ms": 39.11567674999997,
+      "p99_ms": 55.063582820000015,
+      "max_ms": 59.560625
+    },
+    "sqlite|unified|service|100": {
+      "trials": 30,
+      "mean_ms": 20.123704133333334,
+      "p50_ms": 20.071208,
+      "p95_ms": 21.47605625,
+      "p99_ms": 22.263936610000002,
+      "max_ms": 22.463541
+    },
+    "sqlite|unified|http|100": {
+      "trials": 30,
+      "mean_ms": 25.373548433333333,
+      "p50_ms": 24.6919585,
+      "p95_ms": 30.264070499999995,
+      "p99_ms": 32.83827907,
+      "max_ms": 33.477125
+    },
+    "sqlite|profile|service|1000": {
+      "trials": 30,
+      "mean_ms": 17.851333333333333,
+      "p50_ms": 17.368499999999997,
+      "p95_ms": 21.221340999999995,
+      "p99_ms": 22.13025564,
+      "max_ms": 22.22975
+    },
+    "sqlite|profile|http|1000": {
+      "trials": 30,
+      "mean_ms": 21.228937466666665,
+      "p50_ms": 20.72525,
+      "p95_ms": 25.55049825,
+      "p99_ms": 26.439850930000002,
+      "max_ms": 26.75525
+    },
+    "sqlite|user_playbook|service|1000": {
+      "trials": 30,
+      "mean_ms": 17.128815266666667,
+      "p50_ms": 17.0567915,
+      "p95_ms": 17.8434878,
+      "p99_ms": 20.624102680000004,
+      "max_ms": 21.758208
+    },
+    "sqlite|user_playbook|http|1000": {
+      "trials": 30,
+      "mean_ms": 19.799073500000002,
+      "p50_ms": 19.4842085,
+      "p95_ms": 22.01218155,
+      "p99_ms": 22.41753518,
+      "max_ms": 22.555708
+    },
+    "sqlite|agent_playbook|service|1000": {
+      "trials": 30,
+      "mean_ms": 17.64712216666667,
+      "p50_ms": 16.858729,
+      "p95_ms": 21.63322744999999,
+      "p99_ms": 25.146945790000004,
+      "max_ms": 25.730208
+    },
+    "sqlite|agent_playbook|http|1000": {
+      "trials": 30,
+      "mean_ms": 19.70230283333333,
+      "p50_ms": 19.203916999999997,
+      "p95_ms": 21.319635599999998,
+      "p99_ms": 24.040728430000005,
+      "max_ms": 25.12325
+    },
+    "sqlite|unified|service|1000": {
+      "trials": 30,
+      "mean_ms": 58.32456943333333,
+      "p50_ms": 57.47095899999999,
+      "p95_ms": 72.6891814,
+      "p99_ms": 75.96141410999999,
+      "max_ms": 77.021666
+    },
+    "sqlite|unified|http|1000": {
+      "trials": 30,
+      "mean_ms": 59.93885133333333,
+      "p50_ms": 58.8470625,
+      "p95_ms": 71.77371279999997,
+      "p99_ms": 75.88308911,
+      "max_ms": 76.002291
+    }
+  },
+  "raw": [
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 1.811,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 1.741459,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 1.772292,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 1.7765,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 2.097666,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 2.180167,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 4.596792,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 2.138875,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 1.836542,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 1.811667,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 2.187,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 2.046333,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 2.016208,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 2.053083,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 2.119958,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 2.003959,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 1.855792,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 1.737041,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 1.718958,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 1.862375,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 1.7635,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 1.708375,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 1.713083,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 1.680292,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 1.733458,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 1.873958,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 1.780041,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 1.835083,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 1.660166,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 1.729041,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 4.315167,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 4.093792,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 3.720417,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 4.137209,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 4.15425,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 4.274291,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 3.937667,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 3.890334,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 3.755125,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 4.535125,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 4.949292,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 5.420666,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 5.19425,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 5.131458,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 5.2395,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 5.754041,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 10.867583,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 3.741416,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 3.783417,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 3.83525,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 3.559709,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 3.459583,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 3.403667,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 3.426625,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 3.389875,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 3.769917,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 4.43025,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 4.14825,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 3.702667,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 4.031,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 1.584417,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 1.60125,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 1.573333,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 1.537458,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 1.569542,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 1.683709,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 1.681042,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 1.67925,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 1.563209,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 1.62025,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 1.929583,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 1.893916,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 1.733542,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 1.734792,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 1.980416,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 1.983375,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 1.665459,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 1.602125,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 1.578167,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 1.5695,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 1.7165,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 1.685625,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 1.584167,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 1.555625,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 1.599708,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 1.660875,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 1.727917,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 1.724708,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 1.606583,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 1.606417,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 3.71375,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 3.649625,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 3.837084,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 4.853667,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 4.301791,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 4.334833,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 3.8745,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 3.872958,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 3.543208,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 3.672791,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 3.998583,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 3.623083,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 3.761625,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 3.658208,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 4.121292,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 4.206083,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 4.796083,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 4.831083,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 8.292875,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 3.757416,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 3.2875,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 4.106875,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 3.526333,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 3.778875,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 4.4595,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 4.7465,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 3.981792,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 4.275458,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 4.081791,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 3.683708,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 14.806625,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 14.688959,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 14.812083,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 14.765375,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 14.938584,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 17.662292,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 15.48275,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 16.352417,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 16.107708,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 15.657375,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 16.349792,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 16.487833,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 17.311292,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 15.925417,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 15.705041,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 15.901375,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 15.569333,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 15.277333,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 15.88075,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 14.895625,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 15.124333,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 14.77025,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 14.664834,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 15.143459,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 14.753875,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 15.331625,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 14.786959,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 15.198834,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 14.927208,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 14.883667,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 18.086459,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 17.511458,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 17.808791,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 17.712625,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 17.050542,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 17.616959,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 18.183791,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 19.637125,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 17.199125,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 18.122458,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 20.55875,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 18.835084,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 18.632584,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 18.975375,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 44.053583,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 59.560625,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 33.080458,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 23.492917,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 17.275875,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 17.742792,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 21.188208,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 19.526125,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 19.357958,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 18.264083,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 17.623667,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 19.036709,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 18.913667,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 19.227542,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 19.107125,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 18.677708,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 19.720834,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 20.25975,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 20.508375,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 20.625041,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 19.901667,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 20.220458,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 22.463541,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 20.777334,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 19.140125,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 19.369542,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 20.458125,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 20.036459,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 20.32325,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 21.110375,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 20.445583,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 20.093083,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 20.5195,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 18.954625,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 18.732834,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 19.894458,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 19.233417,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 19.164,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 19.728958,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 20.098542,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 19.677875,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 20.049333,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 20.617333,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 21.77525,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 19.831666,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 19.979791,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 0,
+      "elapsed_ms": 22.806083,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 1,
+      "elapsed_ms": 22.946541,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 2,
+      "elapsed_ms": 22.445792,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 3,
+      "elapsed_ms": 22.653542,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 4,
+      "elapsed_ms": 23.316,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 5,
+      "elapsed_ms": 25.098208,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 6,
+      "elapsed_ms": 24.572708,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 7,
+      "elapsed_ms": 22.805958,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 8,
+      "elapsed_ms": 25.353458,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 9,
+      "elapsed_ms": 24.769667,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 10,
+      "elapsed_ms": 24.2115,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 11,
+      "elapsed_ms": 24.23125,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 12,
+      "elapsed_ms": 24.967917,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 13,
+      "elapsed_ms": 28.507541,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 14,
+      "elapsed_ms": 27.628625,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 15,
+      "elapsed_ms": 31.274208,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 16,
+      "elapsed_ms": 33.477125,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 17,
+      "elapsed_ms": 27.425666,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 18,
+      "elapsed_ms": 26.126583,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 19,
+      "elapsed_ms": 29.029458,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 20,
+      "elapsed_ms": 24.61425,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 21,
+      "elapsed_ms": 25.184542,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 22,
+      "elapsed_ms": 23.911125,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 23,
+      "elapsed_ms": 27.197708,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 24,
+      "elapsed_ms": 23.601791,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 25,
+      "elapsed_ms": 26.275208,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 26,
+      "elapsed_ms": 24.354625,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 27,
+      "elapsed_ms": 26.665958,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 28,
+      "elapsed_ms": 22.667708,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 100,
+      "trial": 29,
+      "elapsed_ms": 23.085708,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 17.178458,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 17.053959,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 16.346083,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 17.628459,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 16.377333,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 18.907041,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 18.187917,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 22.22975,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 16.098917,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 16.841,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 21.886666,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 18.981292,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 18.514708,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 19.220875,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 19.010375,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 19.278292,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 18.507333,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 17.11025,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 16.828,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 16.544292,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 16.867083,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 17.022584,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 16.214083,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 16.319584,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 16.104542,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 20.408166,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 18.028166,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 18.288916,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 15.997334,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "service",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 17.558542,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 19.180042,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 19.2215,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 18.561666,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 18.894458,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 19.380375,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 21.557208,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 22.236666,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 22.679,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 25.147125,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 25.407292,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 25.667667,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 23.338875,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 22.788083,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 21.735208,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 25.312333,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 21.6215,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 20.889375,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 19.259042,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 20.077666,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 19.386583,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 18.570209,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 18.394459,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 18.613042,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 18.794292,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 19.190833,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 26.75525,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 20.627709,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 20.822791,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 23.522208,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "profile",
+      "layer": "http",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 19.235667,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 16.770167,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 16.313958,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 16.577917,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 16.345583,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 15.88425,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 17.8475,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 17.272667,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 17.38025,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 16.286333,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 16.704583,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 17.716459,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 17.251,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 17.561583,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 17.838584,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 17.654709,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 17.678125,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 17.324458,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 17.201834,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 16.837583,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 17.099541,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 16.440625,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 16.267375,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 16.344333,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 16.374916,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 17.416208,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 21.758208,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 17.6155,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 17.014042,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 16.321959,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 16.764208,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 19.019083,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 21.930209,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 19.479958,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 19.051917,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 19.037167,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 20.123417,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 19.44975,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 20.558041,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 19.069541,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 18.334541,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 19.4865,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 20.392125,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 20.137416,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 19.921,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 22.555708,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 20.140875,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 19.583792,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 22.07925,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 18.856375,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 19.473708,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 18.598542,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 19.077709,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 18.890958,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 18.660583,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 19.641708,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 20.231416,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 19.481917,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 19.66125,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 21.850208,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "user_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 19.197541,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 16.418833,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 16.6635,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 16.006083,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 16.309083,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 15.729416,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 19.084,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 17.716041,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 18.509542,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 15.541042,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 16.144708,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 18.773666,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 18.82225,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 18.729959,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 18.829291,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 25.730208,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 23.718959,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 18.993125,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 17.615167,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 16.453292,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 16.372958,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 17.926834,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 16.195833,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 16.220459,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 15.636583,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 16.313333,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 18.611667,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 17.706416,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 17.053958,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 15.747834,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "service",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 15.839625,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 19.443125,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 18.667375,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 18.7825,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 18.328,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 18.946708,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 20.385666,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 20.040292,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 20.285084,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 17.980333,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 18.440416,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 25.12325,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 20.921417,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 21.072042,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 21.390417,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 21.202417,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 20.713459,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 21.233125,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 21.143,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 18.810917,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 18.945208,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 18.701958,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 18.635916,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 18.730833,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 18.15225,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 17.820625,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 20.019375,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 19.4645,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 20.473459,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 18.250709,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "agent_playbook",
+      "layer": "http",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 18.964709,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 57.057334,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 54.555833,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 73.365625,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 54.14425,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 53.123917,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 63.04725,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 54.275792,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 53.258625,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 48.205375,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 52.156458,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 60.02675,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 69.77125,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 59.753583,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 62.037958,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 71.862417,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 77.021666,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 57.884584,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 51.055833,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 65.439667,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 52.910666,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 61.573417,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 53.523458,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 48.989416,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 59.620375,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 49.988584,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 59.536666,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 60.867542,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 58.870083,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 51.1395,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "service",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 54.673209,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 0,
+      "elapsed_ms": 62.511375,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 1,
+      "elapsed_ms": 54.661459,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 2,
+      "elapsed_ms": 58.281834,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 3,
+      "elapsed_ms": 58.871,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 4,
+      "elapsed_ms": 51.474,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 5,
+      "elapsed_ms": 64.441958,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 6,
+      "elapsed_ms": 60.530083,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 7,
+      "elapsed_ms": 60.913583,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 8,
+      "elapsed_ms": 56.7695,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 9,
+      "elapsed_ms": 63.58875,
+      "query_idx": 9
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 10,
+      "elapsed_ms": 76.002291,
+      "query_idx": 10
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 11,
+      "elapsed_ms": 63.13225,
+      "query_idx": 11
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 12,
+      "elapsed_ms": 58.823125,
+      "query_idx": 12
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 13,
+      "elapsed_ms": 60.170125,
+      "query_idx": 13
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 14,
+      "elapsed_ms": 66.004125,
+      "query_idx": 14
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 15,
+      "elapsed_ms": 62.540083,
+      "query_idx": 15
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 16,
+      "elapsed_ms": 60.170667,
+      "query_idx": 16
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 17,
+      "elapsed_ms": 52.90475,
+      "query_idx": 17
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 18,
+      "elapsed_ms": 55.663541,
+      "query_idx": 18
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 19,
+      "elapsed_ms": 58.37175,
+      "query_idx": 19
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 20,
+      "elapsed_ms": 55.409125,
+      "query_idx": 0
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 21,
+      "elapsed_ms": 54.931916,
+      "query_idx": 1
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 22,
+      "elapsed_ms": 58.054833,
+      "query_idx": 2
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 23,
+      "elapsed_ms": 52.031333,
+      "query_idx": 3
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 24,
+      "elapsed_ms": 54.598709,
+      "query_idx": 4
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 25,
+      "elapsed_ms": 62.573708,
+      "query_idx": 5
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 26,
+      "elapsed_ms": 67.107834,
+      "query_idx": 6
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 27,
+      "elapsed_ms": 75.59125,
+      "query_idx": 7
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 28,
+      "elapsed_ms": 57.2085,
+      "query_idx": 8
+    },
+    {
+      "backend": "sqlite",
+      "retrieval_type": "unified",
+      "layer": "http",
+      "n": 1000,
+      "trial": 29,
+      "elapsed_ms": 54.832083,
+      "query_idx": 9
+    }
+  ]
+}

--- a/reflexio/benchmarks/retrieval_latency/scenarios.py
+++ b/reflexio/benchmarks/retrieval_latency/scenarios.py
@@ -1,0 +1,134 @@
+"""
+Canned query set and vocabulary for the retrieval latency benchmark.
+
+The query set, vocabulary, and templates are frozen as module-level
+constants so that benchmark runs are bit-for-bit reproducible across
+machines and across time. Do not mutate.
+"""
+
+from __future__ import annotations
+
+# 20 queries spanning short / long / keyword-heavy / semantic-heavy.
+# Query diversity matters because hybrid search behavior depends on
+# how many FTS tokens match vs how well the query vector aligns.
+QUERIES: tuple[str, ...] = (
+    # short, keyword-heavy
+    "refund policy",
+    "shipping delay",
+    "cancel subscription",
+    "password reset",
+    "billing error",
+    # short, semantic
+    "user was frustrated with the agent",
+    "agent apologized and offered compensation",
+    "customer wants to speak to a manager",
+    "sales opportunity upsell",
+    "technical issue escalation",
+    # long, conversational
+    "the user complained that the previous agent had been rude and dismissive during a prior call",
+    "looking for playbooks where we recommend offering a discount when a customer threatens to churn",
+    "anything related to the enterprise plan negotiation playbook for high-value accounts",
+    "profiles of users who have reported repeated shipping problems in the last month",
+    # long, semantic
+    "what do we know about users who rely on the mobile app and have poor network conditions",
+    "situations where the agent should not offer a refund because policy prevents it",
+    "user asks about product roadmap and pricing changes",
+    # keyword-heavy, rare tokens
+    "api key rotation quota limit",
+    "webhook signature verification failure",
+    "gdpr data export request",
+)
+
+
+# Fixed small vocabulary used to build synthetic profiles and playbooks.
+# Enough diversity for non-trivial BM25 scoring but not large enough to
+# dominate memory at N=10_000.
+VOCABULARY: tuple[str, ...] = (
+    "refund",
+    "shipping",
+    "cancel",
+    "subscription",
+    "password",
+    "billing",
+    "frustrated",
+    "apologized",
+    "manager",
+    "sales",
+    "technical",
+    "escalation",
+    "rude",
+    "dismissive",
+    "discount",
+    "churn",
+    "enterprise",
+    "negotiation",
+    "mobile",
+    "network",
+    "roadmap",
+    "pricing",
+    "policy",
+    "quota",
+    "webhook",
+    "gdpr",
+    "export",
+    "verification",
+    "signature",
+    "rotation",
+    "limit",
+    "profile",
+    "playbook",
+    "agent",
+    "user",
+    "request",
+    "session",
+    "context",
+    "history",
+    "interaction",
+    "feedback",
+    "resolution",
+    "complaint",
+    "praise",
+    "upgrade",
+    "downgrade",
+    "trial",
+    "payment",
+    "invoice",
+    "receipt",
+    "tax",
+    "shipping",
+    "delivery",
+    "tracking",
+    "return",
+    "exchange",
+    "warranty",
+    "bug",
+    "crash",
+    "error",
+    "timeout",
+    "latency",
+    "performance",
+    "slow",
+    "fast",
+    "reliable",
+    "consistent",
+    "intermittent",
+    "regression",
+    "feature",
+)
+
+
+# Templated sentences used to build synthetic playbook/profile content.
+# Each template has at least one `{word}` slot so the synthetic text has
+# real token variety across the corpus.
+CONTENT_TEMPLATES: tuple[str, ...] = (
+    "The user asked about {word} and the agent should clarify policy details.",
+    "When the customer mentions {word}, confirm the account status first.",
+    "Escalate to a senior agent if the user repeats {word} after one attempt.",
+    "Offer a {word} to retain accounts showing churn risk indicators.",
+    "Capture the {word} and log it against the user's profile for follow-up.",
+    "The agent should proactively mention {word} during enterprise calls.",
+    "If {word} is unclear, ask a clarifying question before committing.",
+    "Document the {word} in the session notes with a timestamp.",
+    "Do not promise {word} without checking the internal knowledge base.",
+    "Recommend {word} as the next step when the user sounds uncertain.",
+)

--- a/reflexio/benchmarks/retrieval_latency/seed.py
+++ b/reflexio/benchmarks/retrieval_latency/seed.py
@@ -1,0 +1,255 @@
+"""
+Deterministic synthetic corpus for the retrieval latency benchmark.
+
+Builds ``UserProfile``, ``UserPlaybook``, and ``AgentPlaybook`` objects from
+a fixed vocabulary and template set, then inserts them through the real
+service-layer add methods (``Reflexio.add_user_profile`` et al.) so that the
+storage index, FTS table, and vector index are exercised through the same
+code paths that production uses.
+
+Profiles and user playbooks are spread across a small fixed user pool so
+that a per-user filter (``user_id``) still hits a non-trivial number of
+rows — without that, profile search would always return at most one row
+regardless of N.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import uuid
+from collections.abc import Iterable
+from datetime import UTC, datetime
+
+from reflexio.benchmarks.retrieval_latency.embed_cache import (
+    make_fake_document_embedder,
+    patch_storage_get_embedding,
+)
+from reflexio.benchmarks.retrieval_latency.scenarios import (
+    CONTENT_TEMPLATES,
+    VOCABULARY,
+)
+from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.models.api_schema.domain.entities import (
+    AddAgentPlaybookRequest,
+    AddUserPlaybookRequest,
+    AddUserProfileRequest,
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
+
+logger = logging.getLogger(__name__)
+
+# Small pool of user_ids — profiles and user-playbooks distribute across
+# these so that per-user filters still touch a meaningful number of rows.
+USER_POOL_SIZE = 10
+# Small pool of agent versions / playbook names — gives playbook-name filters
+# enough selectivity to look like real usage without being single-row lookups.
+AGENT_VERSION_POOL_SIZE = 3
+PLAYBOOK_NAME_POOL_SIZE = 5
+
+# Per-entity RNG seeds. All derived from a single base so the entire corpus
+# is reproducible from one number, but each entity type gets its own stream so
+# they don't collide content with each other.
+_BENCH_SEED_BASE = 42
+_PROFILE_SEED = _BENCH_SEED_BASE
+_USER_PLAYBOOK_SEED = _BENCH_SEED_BASE + 1
+_AGENT_PLAYBOOK_SEED = _BENCH_SEED_BASE + 2
+
+# Batch size used when sending profiles/playbooks through add_* — keeps
+# request objects under a sensible size and amortizes storage transactions.
+_SEED_BATCH_SIZE = 100
+
+
+def _user_id(idx: int) -> str:
+    """
+    Deterministically map an object index to a user_id in the fixed pool.
+
+    Args:
+        idx (int): The sequential index of the object being generated.
+
+    Returns:
+        str: A user_id string of the form ``bench_user_{i}``.
+    """
+    return f"bench_user_{idx % USER_POOL_SIZE}"
+
+
+def _agent_version(idx: int) -> str:
+    """
+    Deterministically map an object index to an agent_version.
+
+    Args:
+        idx (int): The sequential index of the object being generated.
+
+    Returns:
+        str: An agent_version string of the form ``bench_agent_v{i}``.
+    """
+    return f"bench_agent_v{idx % AGENT_VERSION_POOL_SIZE}"
+
+
+def _playbook_name(idx: int) -> str:
+    """
+    Deterministically map an object index to a playbook_name.
+
+    Args:
+        idx (int): The sequential index of the object being generated.
+
+    Returns:
+        str: A playbook_name string of the form ``bench_playbook_{i}``.
+    """
+    return f"bench_playbook_{idx % PLAYBOOK_NAME_POOL_SIZE}"
+
+
+def _content(rng: random.Random) -> str:
+    """
+    Build one line of synthetic content from the fixed vocabulary.
+
+    Picks a template and fills its single slot with a vocabulary word. Also
+    appends 3–8 extra vocabulary tokens to give BM25 some additional surface
+    area to match against.
+
+    Args:
+        rng (random.Random): Seeded RNG controlling all choices.
+
+    Returns:
+        str: A synthetic content string (typically 10–20 tokens).
+    """
+    template = rng.choice(CONTENT_TEMPLATES)
+    word = rng.choice(VOCABULARY)
+    extra_count = rng.randint(3, 8)
+    extras = " ".join(rng.choice(VOCABULARY) for _ in range(extra_count))
+    return f"{template.format(word=word)} {extras}"
+
+
+def build_profiles(n: int) -> list[UserProfile]:
+    """
+    Build ``n`` deterministic synthetic ``UserProfile`` objects.
+
+    Args:
+        n (int): Number of profiles to generate.
+
+    Returns:
+        list[UserProfile]: Profiles spread across the fixed user pool. Each
+        has a fresh UUID profile_id, a synthetic content string, and a
+        current timestamp (fixed across a single run via ``rng`` for
+        determinism at the seeding step).
+    """
+    rng = random.Random(_PROFILE_SEED)
+    now = int(datetime.now(UTC).timestamp())
+    return [
+        UserProfile(
+            profile_id=f"bench_profile_{i}_{uuid.UUID(int=rng.getrandbits(128))}",
+            user_id=_user_id(i),
+            content=_content(rng),
+            last_modified_timestamp=now,
+            generated_from_request_id=f"bench_req_{i}",
+        )
+        for i in range(n)
+    ]
+
+
+def build_user_playbooks(n: int) -> list[UserPlaybook]:
+    """
+    Build ``n`` deterministic synthetic ``UserPlaybook`` objects.
+
+    Args:
+        n (int): Number of user playbooks to generate.
+
+    Returns:
+        list[UserPlaybook]: Playbooks spread across the fixed user and
+        agent-version pools. ``user_playbook_id`` is left at the default
+        ``0`` so storage assigns fresh IDs during insertion.
+    """
+    rng = random.Random(_USER_PLAYBOOK_SEED)
+    return [
+        UserPlaybook(
+            user_id=_user_id(i),
+            agent_version=_agent_version(i),
+            playbook_name=_playbook_name(i),
+            request_id=f"bench_req_{i}",
+            content=_content(rng),
+        )
+        for i in range(n)
+    ]
+
+
+def build_agent_playbooks(n: int) -> list[AgentPlaybook]:
+    """
+    Build ``n`` deterministic synthetic ``AgentPlaybook`` objects.
+
+    Args:
+        n (int): Number of agent playbooks to generate.
+
+    Returns:
+        list[AgentPlaybook]: Playbooks spread across the fixed agent-version
+        and playbook-name pools.
+    """
+    rng = random.Random(_AGENT_PLAYBOOK_SEED)
+    return [
+        AgentPlaybook(
+            agent_version=_agent_version(i),
+            playbook_name=_playbook_name(i),
+            content=_content(rng),
+        )
+        for i in range(n)
+    ]
+
+
+def _batched[T](items: list[T], size: int) -> Iterable[list[T]]:
+    """
+    Yield contiguous batches of ``items`` with length up to ``size``.
+
+    Args:
+        items (list[T]): Input list to batch.
+        size (int): Maximum batch length.
+
+    Yields:
+        list[T]: Each batch in order.
+    """
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+def seed_corpus(reflexio: Reflexio, storage: object, n: int) -> None:
+    """
+    Insert a full synthetic corpus into the given Reflexio instance.
+
+    Document embeddings are generated from a deterministic fake embedder
+    for the duration of this call — document vector *content* doesn't affect
+    query-time latency (only row count does), so the optimization trades
+    vector meaningfulness for seeding speed. Query-time retrieval is
+    expected to patch the storage with a real query embedding cache instead.
+
+    Args:
+        reflexio (Reflexio): Service-layer facade with storage wired up.
+        storage: The underlying ``BaseStorage`` instance to patch.
+        n (int): Number of each entity type to seed (profiles, user
+            playbooks, agent playbooks — ``3 * n`` total rows).
+    """
+    fake = make_fake_document_embedder()
+    with patch_storage_get_embedding(storage, fake):
+        logger.info("Seeding %d profiles / user_playbooks / agent_playbooks", n)
+        for batch in _batched(build_profiles(n), _SEED_BATCH_SIZE):
+            reflexio.add_user_profile(AddUserProfileRequest(user_profiles=batch))
+        for batch in _batched(build_user_playbooks(n), _SEED_BATCH_SIZE):
+            reflexio.add_user_playbook(AddUserPlaybookRequest(user_playbooks=batch))
+        for batch in _batched(build_agent_playbooks(n), _SEED_BATCH_SIZE):
+            reflexio.add_agent_playbook(AddAgentPlaybookRequest(agent_playbooks=batch))
+    logger.info("Seeding complete (n=%d)", n)
+
+
+def pick_bench_user_id(query_idx: int) -> str:
+    """
+    Choose a user_id for profile/user-playbook search from the seeded pool.
+
+    Rotates through the pool by query index so successive queries aren't
+    always hitting the same user's rows.
+
+    Args:
+        query_idx (int): Index of the current query (0-based).
+
+    Returns:
+        str: A user_id that exists in the seeded corpus.
+    """
+    return f"bench_user_{query_idx % USER_POOL_SIZE}"

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2084,7 +2084,7 @@ class ReflexioClient:
     def get_my_config(self) -> MyConfigResponse:
         """Return raw storage credentials for the caller's org.
 
-        Used by ``reflexio config pull`` / ``config show`` to let users
+        Used by ``reflexio config pull`` / ``config storage`` to let users
         move their per-org server-side config to a fresh machine.
 
         Returns:

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -12,9 +12,11 @@ import os
 import re
 import time
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 import litellm
+import tiktoken
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
@@ -34,8 +36,133 @@ load_dotenv()
 # Suppress LiteLLM's verbose logging
 litellm.suppress_debug_info = True
 
+_LOGGER = logging.getLogger(__name__)
+
+# OpenAI's documented max input length for text-embedding-3-* and ada-002 is
+# 8191 tokens. Used as the fallback limit only when a model's name looks
+# OpenAI-family but litellm's registry has no entry for it.
+_OPENAI_EMBEDDING_FALLBACK_MAX_TOKENS = 8191
+
+# Models whose truncation warning has already been emitted this process. Keeps
+# batch backfills of millions of long docs from flooding logs — the first hit
+# per model goes to WARNING, everything after to DEBUG.
+_TRUNCATION_WARNED_MODELS: set[str] = set()
+
+# Model-name prefixes that route through OpenAI's embedding API (and therefore
+# share the 8191-token cap). Anything that does not start with one of these is
+# treated as "unknown provider" when litellm has no registry entry.
+_OPENAI_EMBEDDING_FAMILY_PREFIXES = ("text-embedding-", "openai/", "azure/")
+
 # Python-to-JSON keyword replacements used by _sanitize_json_string.
 _PYTHON_TO_JSON_REPLACEMENTS = {"True": "true", "False": "false", "None": "null"}
+
+
+@lru_cache(maxsize=32)
+def _get_embedding_limit(model: str) -> int | None:
+    """
+    Resolve the maximum input token count for an embedding model.
+
+    Consults ``litellm.get_model_info`` first so provider-specific caps are
+    respected (OpenAI ~8191, Cohere 512, Voyage 32000, etc.). When litellm has
+    no entry for the model, falls back to the OpenAI 8191 cap only when the
+    model name looks OpenAI-family; otherwise returns ``None`` to disable
+    truncation for unknown providers (safer than over-truncating their input).
+
+    Args:
+        model (str): Embedding model name (e.g. 'text-embedding-3-small',
+            'cohere/embed-english-v3.0').
+
+    Returns:
+        int | None: Maximum input tokens, or ``None`` when the limit is unknown
+            and no safe fallback applies.
+    """
+    try:
+        info = litellm.get_model_info(model)
+    except Exception:
+        info = None
+    if info and info.get("mode") == "embedding":
+        max_tokens = info.get("max_input_tokens")
+        if isinstance(max_tokens, int) and max_tokens > 0:
+            return max_tokens
+    if model.startswith(_OPENAI_EMBEDDING_FAMILY_PREFIXES):
+        return _OPENAI_EMBEDDING_FALLBACK_MAX_TOKENS
+    return None
+
+
+@lru_cache(maxsize=16)
+def _get_embedding_encoding(model: str) -> tiktoken.Encoding:
+    """
+    Return the tiktoken encoding for an embedding model, falling back to cl100k_base.
+
+    For non-OpenAI providers tiktoken does not know the real tokenizer, so the
+    cl100k_base fallback is an approximate proxy for token counting. That is
+    acceptable here because we truncate toward the provider's cap with the
+    proxy, which tends to over-truncate by a small fraction rather than under-
+    truncate and cause upstream 400s.
+
+    Args:
+        model (str): Embedding model name (e.g. 'text-embedding-3-small').
+
+    Returns:
+        tiktoken.Encoding: Encoder to use for token counting and truncation.
+    """
+    try:
+        return tiktoken.encoding_for_model(model)
+    except KeyError:
+        return tiktoken.get_encoding("cl100k_base")
+
+
+def _truncate_for_embedding(
+    text: str, model: str, max_tokens: int | None = None
+) -> str:
+    """
+    Truncate a string so its token count fits within an embedding model's input limit.
+
+    The token budget is auto-resolved from ``_get_embedding_limit`` by default.
+    When the model has no known limit (unknown provider not in litellm's
+    registry and not OpenAI-family), returns the text unchanged — over-
+    truncating an unknown provider's input is worse than passing it through
+    and letting the provider's own error surface.
+
+    Args:
+        text (str): Raw input text.
+        model (str): Embedding model name, used to pick the tokenizer and the
+            per-provider token cap.
+        max_tokens (int | None): Override for the resolved budget. Primarily
+            used by tests to exercise the truncation path on short strings;
+            leave as ``None`` in production callers.
+
+    Returns:
+        str: Original text if it already fits (or the model has no known
+            limit), otherwise a token-bounded prefix.
+    """
+    if not text:
+        return text
+    if max_tokens is None:
+        max_tokens = _get_embedding_limit(model)
+    if max_tokens is None:
+        return text
+    encoding = _get_embedding_encoding(model)
+    tokens = encoding.encode(text, disallowed_special=())
+    if len(tokens) <= max_tokens:
+        return text
+    if model in _TRUNCATION_WARNED_MODELS:
+        _LOGGER.debug(
+            "Truncating embedding input from %d to %d tokens for model %s",
+            len(tokens),
+            max_tokens,
+            model,
+        )
+    else:
+        _TRUNCATION_WARNED_MODELS.add(model)
+        _LOGGER.warning(
+            "Truncating embedding input from %d to %d tokens for model %s "
+            "(further occurrences will be logged at DEBUG)",
+            len(tokens),
+            max_tokens,
+            model,
+        )
+    return encoding.decode(tokens[:max_tokens])
 
 
 @dataclass
@@ -130,7 +257,9 @@ class LiteLLMClient:
         self._api_key, self._api_base, self._api_version = self._resolve_api_key()
 
         # Enable Braintrust observability when API key is configured
-        if os.environ.get("BRAINTRUST_API_KEY") and "braintrust" not in (litellm.callbacks or []):
+        if os.environ.get("BRAINTRUST_API_KEY") and "braintrust" not in (
+            litellm.callbacks or []
+        ):
             litellm.callbacks = litellm.callbacks or []
             litellm.callbacks.append("braintrust")
             self.logger.info("Braintrust observability enabled")
@@ -324,6 +453,7 @@ class LiteLLMClient:
             LiteLLMClientError: If embedding generation fails.
         """
         embedding_model = model or "text-embedding-3-small"
+        text = _truncate_for_embedding(text, embedding_model)
 
         try:
             params = {"model": embedding_model, "input": [text]}
@@ -370,6 +500,7 @@ class LiteLLMClient:
             return []
 
         embedding_model = model or "text-embedding-3-small"
+        texts = [_truncate_for_embedding(t, embedding_model) for t in texts]
 
         try:
             params = {"model": embedding_model, "input": texts}
@@ -413,7 +544,7 @@ class LiteLLMClient:
         max_retries_arg = kwargs.pop("max_retries", self.config.max_retries)
         try:
             max_retries = max(1, int(max_retries_arg))
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             max_retries = max(1, int(self.config.max_retries))
 
         actual_model = kwargs.pop("model", self.config.model)

--- a/tests/benchmarks/baseline.json
+++ b/tests/benchmarks/baseline.json
@@ -1,0 +1,7 @@
+{
+  "config": {
+    "note": "Placeholder baseline. Regenerate by running the smoke benchmark on main and overwriting this file (see reflexio/benchmarks/retrieval_latency/README.md)."
+  },
+  "stats": {},
+  "raw": []
+}

--- a/tests/benchmarks/test_retrieval_latency_smoke.py
+++ b/tests/benchmarks/test_retrieval_latency_smoke.py
@@ -1,0 +1,112 @@
+"""
+Smoke test for the retrieval latency benchmark.
+
+Runs a tiny version of the full benchmark (N=50, 10 trials, sqlite +
+service layer only) and asserts that p95 has not regressed by more than
+3× against the committed baseline. The 3× tolerance is deliberately
+generous: the smoke test is an alarm for catastrophic slowdowns, not a
+precise measurement — a p95 that's 3× slower on an unchanged baseline
+almost certainly indicates a real regression (e.g. an accidental per-row
+LLM call, a missing index, a broken query plan).
+
+Marked ``skip_in_precommit`` so it runs in ``test-all`` but not on every
+commit; seeding 150 rows and running 40 timed retrievals still takes a
+few seconds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from reflexio.benchmarks.retrieval_latency.bench import main as bench_main
+from reflexio.benchmarks.retrieval_latency.report import (
+    CellKey,
+    cell_key_str,
+    load_baseline,
+)
+from tests.server.test_utils import skip_in_precommit
+
+_SMOKE_SIZES = "50"
+_SMOKE_TRIALS = 10
+_SMOKE_WARMUP = 2
+_REGRESSION_TOLERANCE = 3.0  # Allow up to 3× slowdown before failing.
+
+_BASELINE_PATH = Path(__file__).resolve().parent / "baseline.json"
+
+
+@skip_in_precommit
+@pytest.mark.integration
+def test_retrieval_latency_smoke(tmp_path: Path) -> None:
+    """
+    End-to-end smoke test of the benchmark harness.
+
+    Runs the tiny benchmark in a tmpdir, then verifies that:
+
+    1. The harness completes successfully (exit code 0, both output files
+       present).
+    2. Aggregated stats exist for every cell we expect.
+    3. If the committed baseline has stats for a cell, this run's p95 is
+       within ``_REGRESSION_TOLERANCE × baseline.p95``.
+
+    An empty baseline file (the initial committed state) makes the
+    regression check a no-op; the test still verifies the harness runs.
+
+    Args:
+        tmp_path (Path): pytest-provided temporary output directory.
+    """
+    output_dir = tmp_path / "smoke"
+    exit_code = bench_main(
+        [
+            "--sizes",
+            _SMOKE_SIZES,
+            "--trials",
+            str(_SMOKE_TRIALS),
+            "--warmup",
+            str(_SMOKE_WARMUP),
+            "--backend",
+            "sqlite",
+            "--layer",
+            "service",
+            "--retrieval",
+            "profile,user_playbook,agent_playbook,unified",
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+    assert exit_code == 0, "benchmark harness exited with non-zero status"
+    assert (output_dir / "results.json").exists()
+    assert (output_dir / "report.md").exists()
+
+    current = load_baseline(output_dir / "results.json")
+    assert current, "smoke run produced no aggregated stats"
+
+    expected_retrievals = {"profile", "user_playbook", "agent_playbook", "unified"}
+    missing: list[str] = []
+    for rt in expected_retrievals:
+        key = cell_key_str(CellKey("sqlite", rt, "service", int(_SMOKE_SIZES)))
+        if key not in current:
+            missing.append(key)
+    assert not missing, f"smoke run missing stats for cells: {missing}"
+
+    baseline = load_baseline(_BASELINE_PATH)
+    if not baseline:
+        # First-time run before a baseline is committed — harness OK, skip
+        # regression check. Regenerate the baseline via the README recipe.
+        return
+
+    regressions: list[str] = []
+    for key, stats in current.items():
+        base = baseline.get(key)
+        if base is None or base.p95_ms == 0 or stats.p95_ms == 0:
+            continue
+        ratio = stats.p95_ms / base.p95_ms
+        if ratio > _REGRESSION_TOLERANCE:
+            regressions.append(
+                f"{key}: p95 {stats.p95_ms:.1f}ms is {ratio:.1f}× "
+                f"baseline {base.p95_ms:.1f}ms"
+            )
+    assert not regressions, (
+        "Retrieval latency regressed past tolerance:\n  " + "\n  ".join(regressions)
+    )

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -7,6 +7,7 @@ prompt caching. All LiteLLM SDK calls are mocked -- no real API requests are mad
 
 import base64
 import json
+import logging
 import struct
 import tempfile
 import zlib
@@ -37,6 +38,9 @@ from reflexio.server.llm.litellm_client import (
     LiteLLMClient,
     LiteLLMClientError,
     LiteLLMConfig,
+    _get_embedding_encoding,
+    _get_embedding_limit,
+    _truncate_for_embedding,
     create_litellm_client,
 )
 
@@ -717,6 +721,171 @@ class TestGetEmbeddings:
 
         assert result[0] == [0.1, 0.2]
         assert result[1] == [0.3, 0.4]
+
+
+# ===================================================================
+# Embedding input truncation tests
+# ===================================================================
+
+
+class TestEmbeddingTruncation:
+    """Tests for the embedding-input truncation helpers."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_caches(self):
+        """
+        Clear both embedding-helper lru_caches and the warned-models set
+        before and after every test so ordering can't leak mocked values.
+        """
+        from reflexio.server.llm.litellm_client import _TRUNCATION_WARNED_MODELS
+
+        _get_embedding_limit.cache_clear()
+        _get_embedding_encoding.cache_clear()
+        _TRUNCATION_WARNED_MODELS.clear()
+        yield
+        _get_embedding_limit.cache_clear()
+        _get_embedding_encoding.cache_clear()
+        _TRUNCATION_WARNED_MODELS.clear()
+
+    def test_get_embedding_limit_openai_family(self):
+        """Known OpenAI embedding models resolve to the 8191 cap."""
+        # Patch the registry so the assertion doesn't ride on whatever value
+        # the installed litellm build happens to report today.
+        with patch(
+            "reflexio.server.llm.litellm_client.litellm.get_model_info",
+            return_value={"mode": "embedding", "max_input_tokens": 8191},
+        ):
+            assert _get_embedding_limit("text-embedding-3-small") == 8191
+            assert _get_embedding_limit("text-embedding-3-large") == 8191
+            assert _get_embedding_limit("text-embedding-ada-002") == 8191
+
+    @pytest.mark.parametrize(
+        ("model", "mock_kwargs", "expected"),
+        [
+            # Unknown text-embedding-* name — litellm has no entry, OpenAI fallback.
+            ("text-embedding-bogus", {"side_effect": Exception("unmapped")}, 8191),
+            # openai/* prefix, unknown to litellm — fallback.
+            ("openai/custom-embed", {"side_effect": Exception("unmapped")}, 8191),
+            # azure/* prefix, unknown to litellm — fallback.
+            ("azure/custom-embed", {"side_effect": Exception("unmapped")}, 8191),
+            # Unknown non-OpenAI provider — no safe fallback, return None.
+            ("mystery-provider/embed-v1", {"side_effect": Exception("unmapped")}, None),
+            # Registry reports a non-embedding mode — don't trust max_input_tokens.
+            (
+                "mystery/chat-model",
+                {"return_value": {"mode": "chat", "max_input_tokens": 100000}},
+                None,
+            ),
+            # Cohere-style provider with a small cap — return exactly what litellm says.
+            (
+                "cohere/embed-english-v3.0",
+                {"return_value": {"mode": "embedding", "max_input_tokens": 512}},
+                512,
+            ),
+        ],
+    )
+    def test_get_embedding_limit_variants(self, model, mock_kwargs, expected):
+        """Exhaustive table of registry lookup + prefix-fallback outcomes."""
+        with patch(
+            "reflexio.server.llm.litellm_client.litellm.get_model_info",
+            **mock_kwargs,
+        ):
+            assert _get_embedding_limit(model) == expected
+
+    def test_get_embedding_encoding_unknown_model_falls_back_to_cl100k(self):
+        """Unknown model names use the cl100k_base tokenizer as a proxy."""
+        encoding = _get_embedding_encoding("totally-custom-model")
+        assert encoding.name == "cl100k_base"
+
+    def test_truncate_empty_string_is_pass_through(self):
+        assert _truncate_for_embedding("", "text-embedding-3-small") == ""
+
+    def test_truncate_short_text_is_unchanged(self):
+        """Text already within the limit is returned unchanged."""
+        text = "hello world"
+        result = _truncate_for_embedding(text, "text-embedding-3-small")
+        assert result == text
+
+    def test_truncate_long_text_is_shortened(self):
+        """A tiny override limit exercises the truncation path on short input."""
+        text = "word " * 200
+        result = _truncate_for_embedding(text, "text-embedding-3-small", max_tokens=10)
+        encoding = _get_embedding_encoding("text-embedding-3-small")
+        assert len(encoding.encode(result)) <= 10
+        assert len(result) < len(text)
+
+    def test_truncate_unknown_provider_is_pass_through(self):
+        """Unknown non-OpenAI models skip truncation entirely."""
+        text = "word " * 5000
+        with patch(
+            "reflexio.server.llm.litellm_client.litellm.get_model_info",
+            side_effect=Exception("unmapped"),
+        ):
+            result = _truncate_for_embedding(text, "mystery-provider/embed-v1")
+        assert result == text
+
+    def test_truncate_preserves_prefix_from_storage_caller(self):
+        """Prefix (`search_document:` / `search_query:`) survives truncation.
+
+        Mirrors how sqlite_storage._base._get_embedding builds its input: the
+        prefix is concatenated onto the text before reaching the LLM client,
+        so the truncation budget must be spent on the suffix, not the prefix.
+        """
+        encoding = _get_embedding_encoding("text-embedding-3-small")
+        prefix = "search_document: "
+        body = encoding.decode(list(range(9000)))
+        result = _truncate_for_embedding(prefix + body, "text-embedding-3-small")
+        assert result.startswith(prefix)
+        assert len(encoding.encode(result)) <= 8191
+
+    def test_truncate_warning_emitted_once_then_debug(self, caplog):
+        """First oversized text for a model warns; subsequent calls go to DEBUG."""
+        encoding = _get_embedding_encoding("text-embedding-3-small")
+        oversized = encoding.decode(list(range(9000)))
+
+        with caplog.at_level(
+            logging.WARNING, logger="reflexio.server.llm.litellm_client"
+        ):
+            _truncate_for_embedding(oversized, "text-embedding-3-small")
+            _truncate_for_embedding(oversized, "text-embedding-3-small")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "Truncating embedding input" in warnings[0].getMessage()
+        assert "text-embedding-3-small" in warnings[0].getMessage()
+
+    @patch("reflexio.server.llm.litellm_client.litellm.embedding")
+    def test_get_embedding_long_text_is_truncated_before_call(self, mock_embedding):
+        """The string reaching litellm.embedding is always under the cap."""
+        mock_embedding.return_value = _make_embedding_response([0.1, 0.2, 0.3])
+        client = _build_client()
+        encoding = _get_embedding_encoding("text-embedding-3-small")
+        oversized = encoding.decode(list(range(9000)))
+
+        client.get_embedding(oversized)
+
+        call_kwargs = mock_embedding.call_args.kwargs
+        sent_text = call_kwargs["input"][0]
+        assert len(encoding.encode(sent_text)) <= 8191
+        assert sent_text != oversized
+
+    @patch("reflexio.server.llm.litellm_client.litellm.embedding")
+    def test_get_embeddings_truncates_each_element_independently(self, mock_embedding):
+        """Batch truncation is per-element: short strings are not rewritten."""
+        mock_embedding.return_value = _make_batch_embedding_response(
+            [[0.1, 0.2], [0.3, 0.4]]
+        )
+        client = _build_client()
+        encoding = _get_embedding_encoding("text-embedding-3-small")
+        short = "hello"
+        oversized = encoding.decode(list(range(9000)))
+
+        client.get_embeddings([short, oversized])
+
+        sent_texts = mock_embedding.call_args.kwargs["input"]
+        assert sent_texts[0] == short
+        assert sent_texts[1] != oversized
+        assert len(encoding.encode(sent_texts[1])) <= 8191
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

- Add a reusable **retrieval latency benchmark suite** at `reflexio/benchmarks/retrieval_latency/` that measures profile, user/agent playbook, and unified cross-entity search across storage backends, corpus sizes, and layers (`service` vs `http` via FastAPI `TestClient`).
- Fix a production-affecting bug in `LiteLLMClient` where embedding inputs longer than the provider's token cap would surface as provider 400s. Inputs are now token-truncated per model with a registry-aware limit and a once-per-model log warning.
- Add a small `skip_in_precommit` smoke test + committed baseline so `/test-all` catches retrieval regressions past 3× p95.
- Drive-by: correct a stale `config show` docstring reference in `ReflexioClient.get_my_config` (the command is now `config storage`).

## Changes

**Retrieval latency benchmark (`reflexio/benchmarks/retrieval_latency/`)**
- `bench.py` — CLI driver. Sweeps `(retrieval_type × backend × layer × N)` cells with configurable trials/warmup; supports `--baseline` diffing and flags cells where p95 regressed ≥20%.
- `backends.py` — runs each trial against either the in-process service layer or the FastAPI `TestClient` (ASGI transport, no TCP) to isolate framework overhead from storage work.
- `scenarios.py` — 20 fixed queries and corpus generators for each retrieval type.
- `seed.py` — populates storages with deterministic hash-derived fake document vectors (query-time latency depends on row count, not vector content, so this is a sound cost optimization).
- `embed_cache.py` — disk-cached real query embeddings at `~/.cache/reflexio-benchmarks/embeddings-<model>.json`, so only the first run hits the embedding API.
- `report.py` — renders per-retrieval-type markdown tables grouped by `(backend, layer)` with `p50 / p95 (mean)` cell format.
- `README.md` — full usage, layer semantics, interpretation sanity checks, and baseline regeneration instructions.
- One reference report committed under `results/` as a baseline; `results/` is gitignored so future runs don't pollute the working tree.
- `pyproject.toml` — relaxes `S311` (non-crypto random) for `reflexio/benchmarks/**` so seed generators can use `random` without noqa spam.

**Embedding input truncation (`reflexio/server/llm/litellm_client.py`)**
- `_get_embedding_limit(model)` — LRU-cached. Consults `litellm.get_model_info` first (so Cohere 512, Voyage 32k, etc. are respected); falls back to the documented OpenAI 8191 cap only when the model name looks OpenAI-family (`text-embedding-`, `openai/`, `azure/`); returns `None` for unknown non-OpenAI providers so we don't over-truncate their input.
- `_get_embedding_encoding(model)` — LRU-cached tiktoken encoder; non-OpenAI providers get `cl100k_base` as an approximate proxy (tends to over-truncate by a small fraction rather than under-truncate and cause 400s).
- `_truncate_for_embedding(text, model, max_tokens=None)` — called from `get_embedding` and `get_embeddings` (per-element for batches). Emits a `WARNING` the first time a given model's input is truncated, then `DEBUG` on every subsequent hit — keeps large backfills from flooding logs.

**Tests**
- `tests/server/llm/test_litellm_client_unit.py` — new test cases covering: known OpenAI family, unknown OpenAI-prefix fallback, Cohere small-cap, non-embedding mode rejection, unknown-provider pass-through, short/empty/long text paths, prefix preservation (mirrors how `sqlite_storage._get_embedding` builds `search_document: …`), warn-once behavior, and end-to-end assertions that the string reaching `litellm.embedding` is always under the cap.
- `tests/benchmarks/test_retrieval_latency_smoke.py` — `skip_in_precommit` smoke test at `N=50, trials=10, sqlite + service` asserting p95 within 3× of the committed `baseline.json`.

## Test Plan

- [x] `ruff check` / `ruff format` — clean
- [x] Unit tests for truncation helpers exercise registry hit, miss + OpenAI-family fallback, miss + unknown provider, non-embedding mode, and Cohere-style small caps
- [ ] Run the benchmark end-to-end against sqlite: `uv run python -m reflexio.benchmarks.retrieval_latency.bench --sizes 100 --trials 10 --warmup 2 --backend sqlite --layer service --retrieval profile`
- [ ] Run the smoke test: `uv run pytest tests/benchmarks/test_retrieval_latency_smoke.py -v`
- [ ] Confirm warn-once log behavior during a real backfill
- [ ] `/test-all` on the full suite
