### PR TITLE
feat: add CLI-config state synchronization

### DIFF
--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -126,13 +126,21 @@ def save_storage_to_config(
                 config.storage_config = StorageConfigSupabase(
                     url=url, key=key, db_url=db_url
                 )
-            # If creds are missing, keep existing storage_config (don't overwrite
-            # a valid StorageConfigSupabase with empty strings).
+            else:
+                # Creds missing — keep existing storage_config (don't overwrite
+                # a valid StorageConfigSupabase with empty strings).
+                logger.warning(
+                    "Supabase storage requested but credentials are missing "
+                    "(SUPABASE_URL, SUPABASE_KEY, SUPABASE_DB_URL). "
+                    "Keeping existing storage config."
+                )
         case "disk":
             env_dir = os.environ.get("LOCAL_STORAGE_PATH", "").strip()
             fallback_dir = str(_config_dir(base_dir).parent / "disk-storage")
             dir_path = env_dir or fallback_dir
             config.storage_config = StorageConfigDisk(dir_path=dir_path)
+        case _:
+            raise ValueError(f"Unknown storage type: {storage_type}")
 
     storage_obj.save_config(config)
 

--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -1,0 +1,178 @@
+"""CLI bootstrap config: resolve and persist storage settings without a running server.
+
+Provides the priority chain: CLI flag > env var (.env) > config file > default.
+See docs_for_coding_agent/cli-config-state-management.md for the full design.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import typer
+
+logger = logging.getLogger(__name__)
+
+_VALID_STORAGE_BACKENDS = frozenset({"sqlite", "supabase", "disk"})
+_DEFAULT_ORG_ID = "self-host-org"
+_DEFAULT_STORAGE = "sqlite"
+
+# Maps StorageConfig subclass to backend string.  Lazy-imported in functions
+# that need it so module-level import stays lightweight (no Pydantic at import).
+_TYPE_TO_BACKEND: dict[type, str] = {}  # populated on first use
+
+
+def _ensure_type_map() -> dict[type, str]:
+    """Lazy-build the StorageConfig type → backend string map."""
+    if not _TYPE_TO_BACKEND:
+        from reflexio.models.config_schema import (
+            StorageConfigDisk,
+            StorageConfigSQLite,
+            StorageConfigSupabase,
+        )
+
+        _TYPE_TO_BACKEND.update(
+            {
+                StorageConfigSQLite: "sqlite",
+                StorageConfigSupabase: "supabase",
+                StorageConfigDisk: "disk",
+            }
+        )
+    return _TYPE_TO_BACKEND
+
+
+def _config_dir(base_dir: str | None = None) -> Path:
+    """Return the config directory path."""
+    if base_dir:
+        return Path(base_dir) / "configs"
+    return Path.home() / ".reflexio" / "configs"
+
+
+def load_storage_from_config(
+    org_id: str = _DEFAULT_ORG_ID,
+    *,
+    base_dir: str | None = None,
+) -> str | None:
+    """Read storage type from the local config file.
+
+    Args:
+        org_id: Organization ID for the config file name.
+        base_dir: Override base directory (for testing). If None, uses ~/.reflexio/.
+
+    Returns:
+        Storage backend string ("sqlite", "supabase", "disk") or None if
+        no config file exists or storage_config is unset.
+    """
+    config_path = _config_dir(base_dir) / f"config_{org_id}.json"
+    if not config_path.exists():
+        return None
+
+    try:
+        from reflexio.server.services.configurator.local_file_config_storage import (
+            LocalFileConfigStorage,
+        )
+
+        storage = LocalFileConfigStorage(org_id, base_dir=base_dir)
+        config = storage.load_config()
+    except Exception:
+        logger.debug("Failed to load config from %s", config_path, exc_info=True)
+        return None
+
+    sc = config.storage_config
+    if sc is None:
+        return None
+
+    type_map = _ensure_type_map()
+    return type_map.get(type(sc))
+
+
+def save_storage_to_config(
+    storage_type: str,
+    org_id: str = _DEFAULT_ORG_ID,
+    *,
+    base_dir: str | None = None,
+) -> None:
+    """Update storage_config in the local config file.
+
+    Loads the existing config, replaces only ``storage_config``, and saves.
+    All other fields (extractors, api_keys, etc.) are preserved.
+
+    Args:
+        storage_type: Backend name ("sqlite", "supabase", "disk").
+        org_id: Organization ID for the config file name.
+        base_dir: Override base directory (for testing).
+    """
+    from reflexio.models.config_schema import (
+        StorageConfigDisk,
+        StorageConfigSQLite,
+        StorageConfigSupabase,
+    )
+    from reflexio.server.services.configurator.local_file_config_storage import (
+        LocalFileConfigStorage,
+    )
+
+    storage_obj = LocalFileConfigStorage(org_id, base_dir=base_dir)
+    config = storage_obj.load_config()
+
+    match storage_type:
+        case "sqlite":
+            config.storage_config = StorageConfigSQLite()
+        case "supabase":
+            url = os.environ.get("SUPABASE_URL", "")
+            key = os.environ.get("SUPABASE_KEY", "")
+            db_url = os.environ.get("SUPABASE_DB_URL", "")
+            if url and key and db_url:
+                config.storage_config = StorageConfigSupabase(
+                    url=url, key=key, db_url=db_url
+                )
+            # If creds are missing, keep existing storage_config (don't overwrite
+            # a valid StorageConfigSupabase with empty strings).
+        case "disk":
+            env_dir = os.environ.get("LOCAL_STORAGE_PATH", "").strip()
+            fallback_dir = str(_config_dir(base_dir).parent / "disk-storage")
+            dir_path = env_dir or fallback_dir
+            config.storage_config = StorageConfigDisk(dir_path=dir_path)
+
+    storage_obj.save_config(config)
+
+
+def resolve_storage(cli_flag: str | None) -> str:
+    """Resolve storage backend using priority: CLI flag > env var > config file > default.
+
+    Do NOT use Typer's ``envvar=`` binding for ``--storage``. This function
+    handles the full resolution chain so callers can distinguish explicit CLI
+    flags (``cli_flag is not None``) from implicit fallback (``cli_flag is None``)
+    for write-back decisions.
+
+    Args:
+        cli_flag: Value from ``--storage`` flag, or ``None`` if not passed.
+
+    Returns:
+        Resolved storage backend string.
+
+    Raises:
+        typer.BadParameter: If the resolved value is not a known backend.
+    """
+    # 1. CLI flag (explicit user intent)
+    if cli_flag is not None:
+        result = cli_flag.lower()
+        if result not in _VALID_STORAGE_BACKENDS:
+            raise typer.BadParameter(
+                f"Invalid storage backend '{cli_flag}'. "
+                f"Must be one of: {', '.join(sorted(_VALID_STORAGE_BACKENDS))}"
+            )
+        return result
+
+    # 2. Environment variable (from .env or shell)
+    env_val = os.environ.get("REFLEXIO_STORAGE")
+    if env_val and env_val.lower() in _VALID_STORAGE_BACKENDS:
+        return env_val.lower()
+
+    # 3. Config file
+    from_config = load_storage_from_config()
+    if from_config and from_config in _VALID_STORAGE_BACKENDS:
+        return from_config
+
+    # 4. Hardcoded default
+    return _DEFAULT_STORAGE

--- a/reflexio/cli/commands/config_cmd.py
+++ b/reflexio/cli/commands/config_cmd.py
@@ -97,11 +97,16 @@ def show_local(ctx: typer.Context) -> None:
     Args:
         ctx: Typer context with CliState in ctx.obj
     """
-    from reflexio.cli.bootstrap_config import load_storage_from_config, resolve_storage
+    from reflexio.cli.bootstrap_config import (
+        _DEFAULT_ORG_ID,
+        _config_dir,
+        load_storage_from_config,
+        resolve_storage,
+    )
 
     persisted = load_storage_from_config()
     resolved = resolve_storage(None)  # full resolution without CLI flag
-    config_path = Path.home() / ".reflexio" / "configs" / "config_self-host-org.json"
+    config_path = _config_dir() / f"config_{_DEFAULT_ORG_ID}.json"
     resolved_mode = "local" if resolved in ("sqlite", "disk") else "cloud"
 
     json_mode: bool = ctx.obj.json_mode

--- a/reflexio/cli/commands/config_cmd.py
+++ b/reflexio/cli/commands/config_cmd.py
@@ -86,6 +86,41 @@ def show(
         print(json.dumps(config_data, indent=2, default=str))
 
 
+@app.command(name="local")
+@handle_errors
+def show_local(ctx: typer.Context) -> None:
+    """Show locally persisted settings (no server required).
+
+    Reads the local config file and resolves the effective storage backend
+    using the priority chain: CLI flag > env var > config file > default.
+
+    Args:
+        ctx: Typer context with CliState in ctx.obj
+    """
+    from reflexio.cli.bootstrap_config import load_storage_from_config, resolve_storage
+
+    persisted = load_storage_from_config()
+    resolved = resolve_storage(None)  # full resolution without CLI flag
+    config_path = Path.home() / ".reflexio" / "configs" / "config_self-host-org.json"
+    resolved_mode = "local" if resolved in ("sqlite", "disk") else "cloud"
+
+    json_mode: bool = ctx.obj.json_mode
+
+    data = {
+        "config_file": str(config_path),
+        "persisted_storage": persisted,
+        "resolved_storage": resolved,
+        "resolved_mode": resolved_mode,
+    }
+
+    if json_mode:
+        render(data, json_mode=True)
+    else:
+        print_info(f"Config file: {config_path}")
+        print_info(f"Persisted storage: {persisted or '(not set)'}")
+        print_info(f"Resolved storage:  {resolved} (mode: {resolved_mode})")
+
+
 @app.command(name="set")
 @handle_errors
 def set_config(

--- a/reflexio/cli/commands/services.py
+++ b/reflexio/cli/commands/services.py
@@ -10,10 +10,9 @@ import typer
 
 from reflexio.cli import run_services as run_mod
 from reflexio.cli import stop_services as stop_mod
+from reflexio.cli.bootstrap_config import _VALID_STORAGE_BACKENDS
 
 app = typer.Typer(help="Start and stop Reflexio services.")
-
-_VALID_STORAGE_BACKENDS = {"sqlite", "supabase", "disk"}
 
 
 def validate_storage_backend(storage: str | None) -> None:
@@ -69,10 +68,11 @@ def start(
 
     resolved = resolve_storage(storage)
     os.environ["REFLEXIO_STORAGE"] = resolved
-    save_storage_to_config(resolved)
 
-    # If user explicitly passed --storage, also persist to .env
+    # If user explicitly passed --storage, also persist to config and .env
     if storage is not None:
+        save_storage_to_config(resolved)
+
         from reflexio.cli.env_loader import get_env_path, set_env_var
 
         env_path = get_env_path()

--- a/reflexio/cli/commands/services.py
+++ b/reflexio/cli/commands/services.py
@@ -22,6 +22,11 @@ def validate_storage_backend(storage: str | None) -> None:
     If *storage* is not None, validates it against known backends and sets
     the ``REFLEXIO_STORAGE`` environment variable.
 
+    .. deprecated::
+        Prefer :func:`reflexio.cli.bootstrap_config.resolve_storage` which
+        implements the full priority chain (CLI flag > env var > config > default)
+        and config file persistence.
+
     Args:
         storage: Storage backend name (e.g. ``"sqlite"``, ``"supabase"``),
             or None to skip validation.
@@ -42,8 +47,12 @@ def validate_storage_backend(storage: str | None) -> None:
 
 @app.command()
 def start(
-    backend_port: Annotated[int, typer.Option(help="Backend server port")] = 8081,
-    docs_port: Annotated[int, typer.Option(help="Docs server port")] = 8082,
+    backend_port: Annotated[
+        int | None, typer.Option(help="Backend server port (default: 8081)")
+    ] = None,
+    docs_port: Annotated[
+        int | None, typer.Option(help="Docs server port (default: 8082)")
+    ] = None,
     only: Annotated[
         str | None, typer.Option(help="Comma-separated services: backend,docs")
     ] = None,
@@ -52,12 +61,24 @@ def start(
     ] = False,
     storage: Annotated[
         str | None,
-        typer.Option(help="Data storage backend: sqlite (default) or supabase"),
+        typer.Option(help="Data storage backend: sqlite (default), supabase, or disk"),
     ] = None,
 ) -> None:
     """Start Reflexio services (backend, docs)."""
-    validate_storage_backend(storage)
-    # Bridge to existing argparse-based implementation
+    from reflexio.cli.bootstrap_config import resolve_storage, save_storage_to_config
+
+    resolved = resolve_storage(storage)
+    os.environ["REFLEXIO_STORAGE"] = resolved
+    save_storage_to_config(resolved)
+
+    # If user explicitly passed --storage, also persist to .env
+    if storage is not None:
+        from reflexio.cli.env_loader import get_env_path, set_env_var
+
+        env_path = get_env_path()
+        if env_path.exists():
+            set_env_var(env_path, "REFLEXIO_STORAGE", resolved)
+
     args = argparse.Namespace(
         backend_port=backend_port,
         docs_port=docs_port,
@@ -69,8 +90,12 @@ def start(
 
 @app.command()
 def stop(
-    backend_port: Annotated[int, typer.Option(help="Backend server port")] = 8081,
-    docs_port: Annotated[int, typer.Option(help="Docs server port")] = 8082,
+    backend_port: Annotated[
+        int | None, typer.Option(help="Backend server port (default: 8081)")
+    ] = None,
+    docs_port: Annotated[
+        int | None, typer.Option(help="Docs server port (default: 8082)")
+    ] = None,
     only: Annotated[
         str | None, typer.Option(help="Comma-separated services: backend,docs")
     ] = None,

--- a/tests/cli/test_bootstrap_config.py
+++ b/tests/cli/test_bootstrap_config.py
@@ -1,0 +1,371 @@
+"""Tests for CLI bootstrap config: priority chain, write-back, and container safety."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from reflexio.cli.bootstrap_config import (
+    load_storage_from_config,
+    resolve_storage,
+    save_storage_to_config,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_config(base_dir: str, org_id: str, storage_type: str) -> None:
+    """Write a minimal config file with the given storage type for testing."""
+    save_storage_to_config(storage_type, org_id=org_id, base_dir=base_dir)
+
+
+# ---------------------------------------------------------------------------
+# resolve_storage — priority chain
+# ---------------------------------------------------------------------------
+
+
+class TestResolveStorage:
+    """Tests for resolve_storage() priority: CLI flag > env var > config > default."""
+
+    def test_cli_flag_wins_over_env_and_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+        _write_config(str(tmp_path), "self-host-org", "disk")
+        # Patch home to use tmp_path for config lookup
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value="disk",
+        ):
+            assert resolve_storage("sqlite") == "sqlite"
+
+    def test_env_var_wins_over_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value="sqlite",
+        ):
+            assert resolve_storage(None) == "supabase"
+
+    def test_config_wins_over_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("REFLEXIO_STORAGE", raising=False)
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value="disk",
+        ):
+            assert resolve_storage(None) == "disk"
+
+    def test_default_when_nothing_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("REFLEXIO_STORAGE", raising=False)
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value=None,
+        ):
+            assert resolve_storage(None) == "sqlite"
+
+    def test_invalid_storage_raises(self) -> None:
+        with pytest.raises(typer.BadParameter, match="Invalid storage backend"):
+            resolve_storage("postgres")
+
+    def test_case_insensitive_flag(self) -> None:
+        assert resolve_storage("SQLite") == "sqlite"
+        assert resolve_storage("SUPABASE") == "supabase"
+        assert resolve_storage("Disk") == "disk"
+
+    def test_env_var_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_STORAGE", "SUPABASE")
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value=None,
+        ):
+            assert resolve_storage(None) == "supabase"
+
+    def test_invalid_env_var_falls_to_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_STORAGE", "invalid_backend")
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value="disk",
+        ):
+            assert resolve_storage(None) == "disk"
+
+    def test_empty_env_var_falls_to_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_STORAGE", "")
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value="disk",
+        ):
+            assert resolve_storage(None) == "disk"
+
+
+# ---------------------------------------------------------------------------
+# save_storage_to_config / load_storage_from_config — round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveAndLoadStorage:
+    """Tests for config file round-trip persistence."""
+
+    def test_round_trip_sqlite(self, tmp_path: Path) -> None:
+        save_storage_to_config("sqlite", org_id="test-org", base_dir=str(tmp_path))
+        result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+        assert result == "sqlite"
+
+    def test_round_trip_disk(self, tmp_path: Path) -> None:
+        save_storage_to_config("disk", org_id="test-org", base_dir=str(tmp_path))
+        result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+        assert result == "disk"
+
+    def test_round_trip_supabase_with_creds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("SUPABASE_KEY", "test-key-123")
+        monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://localhost/test")
+        save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
+        result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+        assert result == "supabase"
+
+    def test_supabase_without_creds_preserves_existing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When supabase creds are missing, save_storage_to_config keeps existing storage_config."""
+        # First save sqlite
+        save_storage_to_config("sqlite", org_id="test-org", base_dir=str(tmp_path))
+        assert load_storage_from_config(org_id="test-org", base_dir=str(tmp_path)) == "sqlite"
+
+        # Now try saving supabase without creds — should preserve sqlite
+        monkeypatch.delenv("SUPABASE_URL", raising=False)
+        monkeypatch.delenv("SUPABASE_KEY", raising=False)
+        monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+        save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
+        result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+        assert result == "sqlite"  # preserved, not overwritten
+
+    def test_preserves_existing_config_fields(self, tmp_path: Path) -> None:
+        """Updating storage_config must not clobber extractors or other fields."""
+        from reflexio.models.config_schema import (
+            Config,
+            ProfileExtractorConfig,
+            StorageConfigSQLite,
+        )
+        from reflexio.server.services.configurator.local_file_config_storage import (
+            LocalFileConfigStorage,
+        )
+
+        # Create a config with a custom extractor
+        storage_obj = LocalFileConfigStorage("test-org", base_dir=str(tmp_path))
+        config = Config(
+            storage_config=StorageConfigSQLite(),
+            profile_extractor_configs=[
+                ProfileExtractorConfig(
+                    extractor_name="custom_extractor",
+                    extraction_definition_prompt="Custom prompt for testing",
+                ),
+            ],
+            agent_context_prompt="test context",
+        )
+        storage_obj.save_config(config)
+
+        # Now update storage to disk
+        save_storage_to_config("disk", org_id="test-org", base_dir=str(tmp_path))
+
+        # Verify extractor and context are preserved
+        reloaded = storage_obj.load_config()
+        assert reloaded.agent_context_prompt == "test context"
+        assert len(reloaded.profile_extractor_configs) == 1
+        assert reloaded.profile_extractor_configs[0].extractor_name == "custom_extractor"
+        assert load_storage_from_config(org_id="test-org", base_dir=str(tmp_path)) == "disk"
+
+    def test_load_returns_none_when_no_file(self, tmp_path: Path) -> None:
+        result = load_storage_from_config(
+            org_id="nonexistent", base_dir=str(tmp_path)
+        )
+        assert result is None
+
+    def test_load_returns_none_for_nonexistent_dir(self, tmp_path: Path) -> None:
+        result = load_storage_from_config(
+            org_id="test", base_dir=str(tmp_path / "does_not_exist")
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# .env write-back
+# ---------------------------------------------------------------------------
+
+
+class TestEnvFileWriteBack:
+    """Tests for .env file write-back behavior."""
+
+    def test_explicit_flag_updates_env_file(self, tmp_path: Path) -> None:
+        """When --storage is explicitly passed, .env file should be updated."""
+        from reflexio.cli.env_loader import set_env_var
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+
+        set_env_var(env_file, "REFLEXIO_STORAGE", "sqlite")
+
+        content = env_file.read_text()
+        assert 'REFLEXIO_STORAGE="sqlite"' in content
+        assert "supabase" not in content
+
+    def test_set_env_var_preserves_other_vars(self, tmp_path: Path) -> None:
+        """set_env_var should only modify the target variable."""
+        from reflexio.cli.env_loader import set_env_var
+
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            'OPENAI_API_KEY="sk-test"\n'
+            'REFLEXIO_STORAGE="supabase"\n'
+            'JWT_SECRET_KEY="secret"\n'
+        )
+
+        set_env_var(env_file, "REFLEXIO_STORAGE", "sqlite")
+
+        content = env_file.read_text()
+        assert 'OPENAI_API_KEY="sk-test"' in content
+        assert 'REFLEXIO_STORAGE="sqlite"' in content
+        assert 'JWT_SECRET_KEY="secret"' in content
+
+    def test_env_file_not_created_if_missing(self, tmp_path: Path) -> None:
+        """If .env doesn't exist, set_env_var creates it (expected behavior of env_loader)."""
+        from reflexio.cli.env_loader import set_env_var
+
+        env_file = tmp_path / ".env"
+        assert not env_file.exists()
+
+        # set_env_var reads existing content or empty string if file doesn't exist
+        set_env_var(env_file, "REFLEXIO_STORAGE", "sqlite")
+        assert env_file.exists()
+        assert 'REFLEXIO_STORAGE="sqlite"' in env_file.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Layer consistency
+# ---------------------------------------------------------------------------
+
+
+class TestLayerConsistency:
+    """Tests for consistency across process env, .env file, and config file."""
+
+    def test_explicit_flag_aligns_all_layers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--storage sqlite should update process env, .env, and config file."""
+        from reflexio.cli.env_loader import set_env_var
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+
+        # Simulate the start() flow when storage="sqlite" (explicit flag)
+        resolved = resolve_storage("sqlite")
+        monkeypatch.setenv("REFLEXIO_STORAGE", resolved)
+        save_storage_to_config(resolved, org_id="test-org", base_dir=str(tmp_path))
+        set_env_var(env_file, "REFLEXIO_STORAGE", resolved)
+
+        # Verify all three layers
+        assert os.environ["REFLEXIO_STORAGE"] == "sqlite"
+        assert 'REFLEXIO_STORAGE="sqlite"' in env_file.read_text()
+        assert (
+            load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+            == "sqlite"
+        )
+
+    def test_env_override_does_not_modify_env_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """REFLEXIO_STORAGE=supabase (no flag) -> config updated, .env unchanged."""
+        env_file = tmp_path / ".env"
+        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+        original_content = env_file.read_text()
+
+        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+
+        # Simulate start() with storage=None (no flag)
+        resolved = resolve_storage(None)
+        assert resolved == "supabase"
+
+        # Config updated, but .env NOT modified
+        save_storage_to_config(
+            resolved,
+            org_id="test-org",
+            base_dir=str(tmp_path),
+        )
+        assert env_file.read_text() == original_content  # .env unchanged
+
+    def test_sequential_starts_preserve_choice(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Run 1: --storage sqlite. Run 2: no flag. Both should use sqlite."""
+        from reflexio.cli.env_loader import set_env_var
+
+        env_file = tmp_path / ".env"
+        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+
+        # Run 1: explicit --storage sqlite
+        resolved1 = resolve_storage("sqlite")
+        assert resolved1 == "sqlite"
+        monkeypatch.setenv("REFLEXIO_STORAGE", resolved1)
+        save_storage_to_config(resolved1, org_id="test-org", base_dir=str(tmp_path))
+        set_env_var(env_file, "REFLEXIO_STORAGE", resolved1)
+
+        # Run 2: no flag — .env now says "sqlite" from run 1
+        resolved2 = resolve_storage(None)
+        assert resolved2 == "sqlite"  # consistent with run 1
+
+
+# ---------------------------------------------------------------------------
+# Docker / container safety
+# ---------------------------------------------------------------------------
+
+
+class TestContainerSafety:
+    """Tests for graceful behavior in container environments."""
+
+    def test_no_config_dir_returns_none(self, tmp_path: Path) -> None:
+        """In Docker, ~/.reflexio/configs/ doesn't exist. Graceful fallback."""
+        result = load_storage_from_config(
+            org_id="test", base_dir=str(tmp_path / "nonexistent")
+        )
+        assert result is None
+
+    def test_env_var_wins_when_no_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Container with REFLEXIO_STORAGE=supabase, no config file -> supabase."""
+        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value=None,
+        ):
+            assert resolve_storage(None) == "supabase"
+
+    def test_default_without_env_or_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No env var, no config file -> falls to 'sqlite' default."""
+        monkeypatch.delenv("REFLEXIO_STORAGE", raising=False)
+        with patch(
+            "reflexio.cli.bootstrap_config.load_storage_from_config",
+            return_value=None,
+        ):
+            assert resolve_storage(None) == "sqlite"

--- a/tests/cli/test_bootstrap_config.py
+++ b/tests/cli/test_bootstrap_config.py
@@ -55,9 +55,7 @@ class TestResolveStorage:
         ):
             assert resolve_storage(None) == "supabase"
 
-    def test_config_wins_over_default(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_config_wins_over_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("REFLEXIO_STORAGE", raising=False)
         with patch(
             "reflexio.cli.bootstrap_config.load_storage_from_config",
@@ -65,9 +63,7 @@ class TestResolveStorage:
         ):
             assert resolve_storage(None) == "disk"
 
-    def test_default_when_nothing_set(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_default_when_nothing_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("REFLEXIO_STORAGE", raising=False)
         with patch(
             "reflexio.cli.bootstrap_config.load_storage_from_config",
@@ -84,9 +80,7 @@ class TestResolveStorage:
         assert resolve_storage("SUPABASE") == "supabase"
         assert resolve_storage("Disk") == "disk"
 
-    def test_env_var_case_insensitive(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_env_var_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("REFLEXIO_STORAGE", "SUPABASE")
         with patch(
             "reflexio.cli.bootstrap_config.load_storage_from_config",
@@ -149,7 +143,10 @@ class TestSaveAndLoadStorage:
         """When supabase creds are missing, save_storage_to_config keeps existing storage_config."""
         # First save sqlite
         save_storage_to_config("sqlite", org_id="test-org", base_dir=str(tmp_path))
-        assert load_storage_from_config(org_id="test-org", base_dir=str(tmp_path)) == "sqlite"
+        assert (
+            load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+            == "sqlite"
+        )
 
         # Now try saving supabase without creds — should preserve sqlite
         monkeypatch.delenv("SUPABASE_URL", raising=False)
@@ -191,13 +188,16 @@ class TestSaveAndLoadStorage:
         reloaded = storage_obj.load_config()
         assert reloaded.agent_context_prompt == "test context"
         assert len(reloaded.profile_extractor_configs) == 1
-        assert reloaded.profile_extractor_configs[0].extractor_name == "custom_extractor"
-        assert load_storage_from_config(org_id="test-org", base_dir=str(tmp_path)) == "disk"
+        assert (
+            reloaded.profile_extractor_configs[0].extractor_name == "custom_extractor"
+        )
+        assert (
+            load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+            == "disk"
+        )
 
     def test_load_returns_none_when_no_file(self, tmp_path: Path) -> None:
-        result = load_storage_from_config(
-            org_id="nonexistent", base_dir=str(tmp_path)
-        )
+        result = load_storage_from_config(org_id="nonexistent", base_dir=str(tmp_path))
         assert result is None
 
     def test_load_returns_none_for_nonexistent_dir(self, tmp_path: Path) -> None:
@@ -246,8 +246,8 @@ class TestEnvFileWriteBack:
         assert 'REFLEXIO_STORAGE="sqlite"' in content
         assert 'JWT_SECRET_KEY="secret"' in content
 
-    def test_env_file_not_created_if_missing(self, tmp_path: Path) -> None:
-        """If .env doesn't exist, set_env_var creates it (expected behavior of env_loader)."""
+    def test_set_env_var_creates_file_if_absent(self, tmp_path: Path) -> None:
+        """If .env doesn't exist, set_env_var creates it and writes the variable."""
         from reflexio.cli.env_loader import set_env_var
 
         env_file = tmp_path / ".env"
@@ -348,9 +348,7 @@ class TestContainerSafety:
         )
         assert result is None
 
-    def test_env_var_wins_when_no_config(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_env_var_wins_when_no_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Container with REFLEXIO_STORAGE=supabase, no config file -> supabase."""
         monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
         with patch(

--- a/tests/cli/test_config_cmd.py
+++ b/tests/cli/test_config_cmd.py
@@ -166,3 +166,65 @@ class TestConfigPull:
             )
         assert result.exit_code != 0
         assert not env_file.exists() or "SUPABASE" not in env_file.read_text()
+
+
+class TestConfigLocal:
+    """Tests for ``reflexio config local`` — reads local config, no server needed."""
+
+    _PATCH_LOAD = "reflexio.cli.bootstrap_config.load_storage_from_config"
+    _PATCH_RESOLVE = "reflexio.cli.bootstrap_config.resolve_storage"
+
+    def test_human_readable_output(self, runner: CliRunner, cli_app) -> None:
+        with (
+            patch(self._PATCH_LOAD, return_value="sqlite"),
+            patch(self._PATCH_RESOLVE, return_value="sqlite"),
+        ):
+            result = runner.invoke(cli_app, ["config", "local"])
+        assert result.exit_code == 0, result.output
+        assert "Persisted storage: sqlite" in result.output
+        assert "Resolved storage:  sqlite" in result.output
+        assert "mode: local" in result.output
+
+    def test_human_readable_no_persisted(self, runner: CliRunner, cli_app) -> None:
+        with (
+            patch(self._PATCH_LOAD, return_value=None),
+            patch(self._PATCH_RESOLVE, return_value="sqlite"),
+        ):
+            result = runner.invoke(cli_app, ["config", "local"])
+        assert result.exit_code == 0, result.output
+        assert "(not set)" in result.output
+
+    def test_json_mode(self, runner: CliRunner, cli_app) -> None:
+        with (
+            patch(self._PATCH_LOAD, return_value="supabase"),
+            patch(self._PATCH_RESOLVE, return_value="supabase"),
+        ):
+            result = runner.invoke(cli_app, ["--json", "config", "local"])
+        assert result.exit_code == 0, result.output
+        import json
+
+        envelope = json.loads(result.output)
+        assert envelope["ok"] is True
+        data = envelope["data"]
+        assert data["persisted_storage"] == "supabase"
+        assert data["resolved_storage"] == "supabase"
+        assert data["resolved_mode"] == "cloud"
+        assert "config_file" in data
+
+    def test_cloud_mode_for_supabase(self, runner: CliRunner, cli_app) -> None:
+        with (
+            patch(self._PATCH_LOAD, return_value="supabase"),
+            patch(self._PATCH_RESOLVE, return_value="supabase"),
+        ):
+            result = runner.invoke(cli_app, ["config", "local"])
+        assert result.exit_code == 0, result.output
+        assert "mode: cloud" in result.output
+
+    def test_local_mode_for_disk(self, runner: CliRunner, cli_app) -> None:
+        with (
+            patch(self._PATCH_LOAD, return_value="disk"),
+            patch(self._PATCH_RESOLVE, return_value="disk"),
+        ):
+            result = runner.invoke(cli_app, ["config", "local"])
+        assert result.exit_code == 0, result.output
+        assert "mode: local" in result.output


### PR DESCRIPTION
## Summary
- Implement CLI-config state synchronization so that `reflexio services start --storage <backend>` persists the storage choice to both the config file and `.env`
- Add `bootstrap_config` module with `resolve_storage()` implementing the priority chain: CLI flag > env var > config file > default
- Add `config local` subcommand for offline config inspection without a running server
- Fix OS port defaults from `int = 8081` to `int | None = None` so env vars (`BACKEND_PORT`, `DOCS_PORT`) are properly consulted

## Changes

### New: `reflexio/cli/bootstrap_config.py`
- `resolve_storage()` — full priority chain resolution
- `save_storage_to_config()` — persist storage type to local config file, preserving other fields
- `load_storage_from_config()` — read storage type from config file

### Modified: `reflexio/cli/commands/services.py`
- `start()` uses `resolve_storage()` + conditional write-back to config and `.env`
- Port defaults changed to `int | None` for proper env var fallback
- `validate_storage_backend()` kept for backwards compat but marked deprecated
- `_VALID_STORAGE_BACKENDS` imported from `bootstrap_config` to avoid duplication

### Modified: `reflexio/cli/commands/config_cmd.py`
- New `config local` subcommand showing persisted storage, resolved storage, and mode

### New tests
- `tests/cli/test_bootstrap_config.py` — 25 tests covering priority chain, round-trip, write-back, layer consistency, container safety
- `tests/cli/test_config_cmd.py` — 5 new tests for `config local` (JSON mode, human-readable, mode mapping)

## Test Plan
- [x] 189 CLI tests pass (`pytest tests/cli/ -v`)
- [x] Ruff lint: clean
- [x] Pyright type check: clean
- [x] Priority chain verified: flag > env > config > default
- [x] Write-back verified: explicit `--storage` updates both `.env` and config
- [x] Container safety: graceful fallback when config file doesn't exist
