### PR TITLE
fix: remove bare load_dotenv() calls that poison env vars

### DIFF
--- a/reflexio/cli/errors.py
+++ b/reflexio/cli/errors.py
@@ -58,7 +58,7 @@ def _classify_http_error(exc: requests.HTTPError) -> CliError:
         return CliError(
             error_type="auth",
             message=f"Authentication failed (HTTP {status})",
-            hint="Run: reflexio auth login --api-key <key> --url <url>",
+            hint="Run: reflexio auth login --api-key <key> --server-url <url>",
             exit_code=EXIT_AUTH,
         )
     if status == 422:

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -11,7 +11,6 @@ from urllib.parse import urljoin
 
 import aiohttp
 import requests
-from dotenv import load_dotenv
 
 from reflexio.defaults import DEFAULT_AGENT_VERSION
 from reflexio.models.api_schema.retriever_schema import (
@@ -47,9 +46,6 @@ from reflexio.models.api_schema.retriever_schema import (
     UpdateUserPlaybookResponse,
 )
 from reflexio.models.config_schema import SearchMode
-
-# Load environment variables from .env file
-load_dotenv()
 
 IS_TEST_ENV = os.environ.get("IS_TEST_ENV", "false").strip() == "true"
 

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -17,7 +17,6 @@ from typing import Any
 
 import litellm
 import tiktoken
-from dotenv import load_dotenv
 from pydantic import BaseModel
 
 from reflexio.models.config_schema import APIKeyConfig
@@ -29,9 +28,6 @@ from reflexio.server.llm.image_utils import (
     encode_image_to_base64 as _encode_image_to_base64,
 )
 from reflexio.server.llm.llm_utils import is_pydantic_model
-
-# Load environment variables from .env file
-load_dotenv()
 
 # Suppress LiteLLM's verbose logging
 litellm.suppress_debug_info = True


### PR DESCRIPTION
## Summary
- Remove all bare `load_dotenv()` calls that poison env vars — `find_dotenv()` traverses parent directories and can load `.env` files with empty values (e.g. `REFLEXIO_API_KEY=`), which then block correct values from `~/.reflexio/.env` because `load_dotenv(override=False)` won't overwrite existing vars
- Fix incorrect `--url` flag in auth error hint (correct flag is `--server-url`)

## Changes
- **client.py**: Remove module-level `load_dotenv()` and unused import — the CLI entry point handles env loading via `load_reflexio_env()`
- **litellm_client.py**: Remove module-level `load_dotenv()` and unused import — the server `__init__.py` already calls `load_reflexio_env()` before this module is imported
- **errors.py**: Fix hint `--url` → `--server-url`

## Related PRs
- Enterprise PR: https://github.com/ReflexioAI/reflexio-enterprise/pull/6

## Test Plan
- [x] Verified `reflexio status whoami` works with a poisoning `~/.env` present
- [x] Verified imports don't poison env: `from reflexio.server.llm.litellm_client import LiteLLMClient` loads correct key
- [x] Published test conversations to reflexio.ai — profiles and playbooks extracted
- [x] 1689 unit tests passed
