### PR TITLE
fix: enforce Python >=3.14 minimum version for pip installs

### DIFF
--- a/client_dist/pyproject.toml
+++ b/client_dist/pyproject.toml
@@ -5,7 +5,7 @@ description = "Lightweight Python client for the Reflexio API"
 authors = [{name = "Reflexio Team"}]
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 dependencies = [
     "pydantic>=2.0.0",
     "requests>=2.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Python library for the Reflexio"
 authors = [{name = "Reflexio Team"}]
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.11"
+requires-python = ">=3.14"
 dependencies = [
     # Client deps (lightweight)
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary
- Bump `requires-python` from `>=3.11` to `>=3.14` in both `reflexio-ai` and `reflexio-client` packages
- Prevents pip install on Python <3.14 where PEP 758 syntax (`except ExcA, ExcB:`) causes SyntaxError

## Changes
- `pyproject.toml`: `requires-python = ">=3.11"` → `">=3.14"`
- `client_dist/pyproject.toml`: `requires-python = ">=3.11"` → `">=3.14"`

## Related PRs
- Enterprise PR: https://github.com/ReflexioAI/reflexio-enterprise/pull/8

## Test Plan
- Verify `requires-python` fields show `>=3.14` in both files
- Verify `uv run python -c "import reflexio"` succeeds