### PR TITLE
perf: lazy-load ML libraries to fix slow CLI startup

### DIFF
--- a/reflexio/lib/__init__.py
+++ b/reflexio/lib/__init__.py
@@ -1,5 +1,23 @@
 """Reflexio library package."""
 
-from reflexio.lib.reflexio_lib import Reflexio
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reflexio.lib.reflexio_lib import Reflexio
 
 __all__ = ["Reflexio"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
+def __getattr__(name: str) -> type:
+    if name == "Reflexio":
+        from reflexio.lib.reflexio_lib import Reflexio
+
+        globals()["Reflexio"] = Reflexio  # cache after first access
+        return Reflexio
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/reflexio/lib/_generation.py
+++ b/reflexio/lib/_generation.py
@@ -15,16 +15,6 @@ from reflexio.models.api_schema.service_schemas import (
     RerunProfileGenerationRequest,
     RerunProfileGenerationResponse,
 )
-from reflexio.server.services.playbook.playbook_aggregator import PlaybookAggregator
-from reflexio.server.services.playbook.playbook_generation_service import (
-    PlaybookGenerationService,
-)
-from reflexio.server.services.playbook.playbook_service_utils import (
-    PlaybookAggregatorRequest,
-)
-from reflexio.server.services.profile.profile_generation_service import (
-    ProfileGenerationService,
-)
 
 
 class GenerationMixin(ReflexioBase):
@@ -43,6 +33,13 @@ class GenerationMixin(ReflexioBase):
         """
         if not self._is_storage_configured():
             raise ValueError(STORAGE_NOT_CONFIGURED_MSG)
+        from reflexio.server.services.playbook.playbook_aggregator import (
+            PlaybookAggregator,
+        )
+        from reflexio.server.services.playbook.playbook_service_utils import (
+            PlaybookAggregatorRequest,
+        )
+
         playbook_aggregator = PlaybookAggregator(
             llm_client=self.llm_client,
             request_context=self.request_context,
@@ -87,6 +84,10 @@ class GenerationMixin(ReflexioBase):
         Returns:
             RerunProfileGenerationResponse: Response containing success status, message, and count of profiles generated
         """
+        from reflexio.server.services.profile.profile_generation_service import (
+            ProfileGenerationService,
+        )
+
         return self._run_generation_service(
             request,
             RerunProfileGenerationRequest,
@@ -108,6 +109,10 @@ class GenerationMixin(ReflexioBase):
         Returns:
             ManualProfileGenerationResponse: Response containing success status, message, and count of profiles generated
         """
+        from reflexio.server.services.profile.profile_generation_service import (
+            ProfileGenerationService,
+        )
+
         return self._run_generation_service(
             request,
             ManualProfileGenerationRequest,
@@ -129,6 +134,10 @@ class GenerationMixin(ReflexioBase):
         Returns:
             RerunPlaybookGenerationResponse: Response containing success status, message, and count of playbooks generated
         """
+        from reflexio.server.services.playbook.playbook_generation_service import (
+            PlaybookGenerationService,
+        )
+
         return self._run_generation_service(
             request,
             RerunPlaybookGenerationRequest,
@@ -150,6 +159,10 @@ class GenerationMixin(ReflexioBase):
         Returns:
             ManualPlaybookGenerationResponse: Response containing success status, message, and count of playbooks generated
         """
+        from reflexio.server.services.playbook.playbook_generation_service import (
+            PlaybookGenerationService,
+        )
+
         return self._run_generation_service(
             request,
             ManualPlaybookGenerationRequest,

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import hashlib
 import logging
 import os
+from typing import TYPE_CHECKING
 
-import hdbscan
-import numpy as np
-from sklearn.cluster import AgglomerativeClustering
-from sklearn.metrics.pairwise import cosine_distances
+if TYPE_CHECKING:
+    import numpy as np
 
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
@@ -922,6 +923,9 @@ class PlaybookAggregator:
             return self._cluster_by_trigger_mock(user_playbooks, min_cluster_size)
 
         # Extract embeddings from user playbooks
+        import numpy as np
+        from sklearn.metrics.pairwise import cosine_distances
+
         embeddings = np.array([playbook.embedding for playbook in user_playbooks])
 
         if len(embeddings) < min_cluster_size:
@@ -1025,6 +1029,8 @@ class PlaybookAggregator:
         Returns:
             np.ndarray: Cluster labels for each point
         """
+        from sklearn.cluster import AgglomerativeClustering
+
         logger.info(
             "Using Agglomerative Clustering for %d playbooks (< %d threshold), distance_threshold=%.2f",
             len(distance_matrix),
@@ -1058,6 +1064,8 @@ class PlaybookAggregator:
         Returns:
             np.ndarray: Cluster labels for each point (-1 indicates noise)
         """
+        import hdbscan
+
         logger.info(
             "Using HDBSCAN for %d playbooks (>= %d threshold), distance_threshold=%.2f",
             len(distance_matrix),

--- a/tests/lib/test_generation_unit.py
+++ b/tests/lib/test_generation_unit.py
@@ -48,7 +48,7 @@ def _make_mixin(*, storage_configured: bool = True) -> GenerationMixin:
 
 
 class TestRunPlaybookAggregation:
-    @patch("reflexio.lib._generation.PlaybookAggregator")
+    @patch("reflexio.server.services.playbook.playbook_aggregator.PlaybookAggregator")
     def test_calls_aggregator_run_with_correct_args(self, mock_agg_cls):
         """Constructs PlaybookAggregator and calls run() with correct request."""
         mixin = _make_mixin()


### PR DESCRIPTION
## Summary

- **PEP 562 lazy `__getattr__`** on `reflexio/lib/__init__.py` — defers loading the `Reflexio` facade class until accessed, breaking the import chain that pulled in heavy server deps when CLI commands imported lightweight utilities like `_storage_labels`
- **Inline ML imports** in `playbook_aggregator.py` — moves `hdbscan`, `numpy`, `sklearn` into the 3 methods that use them, with `TYPE_CHECKING` guard for type annotations
- **Inline server imports** in `_generation.py` — moves `PlaybookAggregator`, `PlaybookGenerationService`, `ProfileGenerationService` into method bodies

## Motivation

The CLI took ~2-4s to start because `config_cmd.py` imported `mask_secret` from `reflexio.lib._storage_labels`, which triggered `reflexio/lib/__init__.py` to eagerly load the entire `Reflexio` facade → all mixins → `playbook_aggregator.py` → `sklearn`, `hdbscan`, `numpy`. These ML libraries are only needed for server-side playbook aggregation.

## Impact

| Metric | Before | After |
|--------|--------|-------|
| `reflexio --help` | ~37s | ~0.5s |
| `_storage_labels` import | 2.5s | 0.3s |

## Test plan

- [x] `uv run pytest tests/ -k "test_storage_labels or test_generation or test_playbook_aggregat"` — 119 passed
- [x] `uv run pyright` on changed files — no new errors
- [x] `uv run ruff check` on changed files — all passed
- [x] `time uv run reflexio --help` — verified <0.5s startup
