### PR TITLE
feat: add install location selection to Claude Code setup wizard

### DIFF
--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -6,10 +6,22 @@ import contextlib
 import json
 import shutil
 import subprocess
+from enum import Enum
 from pathlib import Path
 from typing import Annotated
 
 import typer
+
+
+class InstallLocation(Enum):
+    """Where to install the Claude Code integration files.
+
+    CURRENT_PROJECT installs into ``<cwd>/.claude/`` — scoped to one project.
+    ALL_PROJECTS installs into ``~/.claude/`` — active in every Claude Code session.
+    """
+
+    CURRENT_PROJECT = "current_project"
+    ALL_PROJECTS = "all_projects"
 
 app = typer.Typer(
     help="Configure Reflexio: run 'init' for plain CLI setup, or one of "
@@ -113,6 +125,28 @@ def _prompt_llm_provider(env_path: Path) -> tuple[str, str, str]:
     _set_env_var(env_path, env_var, api_key)
 
     return display_name, model, selected_key
+
+
+def _prompt_install_location() -> InstallLocation:
+    """Interactively prompt the user to choose where to install the integration.
+
+    Returns:
+        InstallLocation: The chosen install location.
+    """
+    typer.echo("\nWhere should the Claude Code integration be installed?")
+    typer.echo("  [1] All projects (~/.claude/) — applies to every Claude Code session")
+    typer.echo(
+        "  [2] Current project only (./.claude/) — applies only when working in this directory"
+    )
+
+    choice = typer.prompt("Choice", type=int, default=1)
+    if choice == 1:
+        return InstallLocation.ALL_PROJECTS
+    if choice == 2:
+        return InstallLocation.CURRENT_PROJECT
+
+    typer.echo("Error: choice must be 1 or 2")
+    raise typer.Exit(1)
 
 
 _EMBEDDING_CHOICES: list[tuple[str, str, str]] = [
@@ -684,14 +718,43 @@ def _remove_hook_config(settings_path: Path) -> None:
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
 
 
-def _install_claude_code_integration(
-    project_dir: Path, *, expert: bool = False
-) -> tuple[Path, Path]:
-    """Install the Reflexio skill and hook into a Claude Code project.
+_MARKER_FILENAME = ".installed-by-reflexio"
+
+
+def _write_marker(marker_path: Path, location: InstallLocation) -> None:
+    """Write a JSON marker file recording the install location and timestamp.
 
     Args:
-        project_dir: Root directory of the Claude Code project.
+        marker_path: Where to write the marker file.
+        location: The install location enum value.
+    """
+    import datetime
+
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text(
+        json.dumps(
+            {
+                "location": location.value,
+                "installed_at": datetime.datetime.now(datetime.UTC).isoformat(),
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def _install_claude_code_integration(
+    target_dir: Path,
+    *,
+    expert: bool = False,
+    location: InstallLocation = InstallLocation.ALL_PROJECTS,
+) -> tuple[Path, Path]:
+    """Install the Reflexio skill and hook into a Claude Code project or user directory.
+
+    Args:
+        target_dir: Root directory — either the project root or ``Path.home()``.
         expert: If True, install the expert skill instead of the normal skill.
+        location: Where to install (current project or all projects).
 
     Returns:
         tuple[Path, Path]: (skill_path, handler_js_path) for the summary.
@@ -701,74 +764,175 @@ def _install_claude_code_integration(
         typer.echo(f"Error: integration files not found at {integration_dir}")
         raise typer.Exit(1)
 
+    claude_dir = target_dir / ".claude"
+
     # Copy skill
     skill_src = (
         integration_dir / "skill" / "SKILL-expert.md"
         if expert
         else integration_dir / "skill" / "SKILL.md"
     )
-    skill_dest = project_dir / ".claude" / "skills" / "reflexio" / "SKILL.md"
+    skill_dest = claude_dir / "skills" / "reflexio" / "SKILL.md"
     skill_dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(skill_src, skill_dest)
 
     # Copy rules file (always-in-context instructions)
     rules_src = integration_dir / "rules" / "reflexio.md"
-    rules_dest = project_dir / ".claude" / "rules" / "reflexio.md"
+    rules_dest = claude_dir / "rules" / "reflexio.md"
     rules_dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(rules_src, rules_dest)
 
     # Expert mode: also install /reflexio-extract command
     if expert:
         cmd_src = integration_dir / "commands" / "reflexio-extract" / "SKILL.md"
-        cmd_dest = (
-            project_dir / ".claude" / "commands" / "reflexio-extract" / "SKILL.md"
-        )
+        cmd_dest = claude_dir / "commands" / "reflexio-extract" / "SKILL.md"
         cmd_dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(cmd_src, cmd_dest)
 
     # Configure hook
     handler_js = integration_dir / "hook" / "handler.js"
-    settings_path = project_dir / ".claude" / "settings.json"
+    settings_path = claude_dir / "settings.json"
     _merge_hook_config(settings_path, handler_js)
+
+    # Write marker for uninstall auto-detection
+    marker_path = claude_dir / "skills" / "reflexio" / _MARKER_FILENAME
+    _write_marker(marker_path, location)
 
     return skill_dest, handler_js
 
 
-def _uninstall_claude_code(project_dir: Path) -> None:
-    """Remove the Reflexio integration from a Claude Code project.
+def _detect_install_locations(
+    project_dir: Path,
+) -> list[tuple[InstallLocation, Path]]:
+    """Detect where Reflexio is installed by checking marker files.
 
     Args:
-        project_dir: Root directory of the Claude Code project.
-    """
-    typer.confirm(
-        "This will remove the Reflexio skill and hook from this project. Continue?",
-        abort=True,
-    )
+        project_dir: The project directory to check for project-level installs.
 
-    # Remove skill directory
-    skill_dir = project_dir / ".claude" / "skills" / "reflexio"
+    Returns:
+        list[tuple[InstallLocation, Path]]: List of (location, base_dir) pairs
+            where the integration is installed.
+    """
+    locations: list[tuple[InstallLocation, Path]] = []
+    for loc, base in [
+        (InstallLocation.ALL_PROJECTS, Path.home()),
+        (InstallLocation.CURRENT_PROJECT, project_dir),
+    ]:
+        marker = base / ".claude" / "skills" / "reflexio" / _MARKER_FILENAME
+        if marker.exists():
+            locations.append((loc, base))
+    return locations
+
+
+def _remove_from_dir(base_dir: Path) -> None:
+    """Remove the Reflexio integration files from a .claude directory.
+
+    Args:
+        base_dir: The directory containing the .claude/ folder.
+    """
+    claude_dir = base_dir / ".claude"
+
+    # Remove skill directory (includes marker file)
+    skill_dir = claude_dir / "skills" / "reflexio"
     if skill_dir.exists():
         shutil.rmtree(skill_dir)
         typer.echo(f"  Removed skill: {skill_dir}")
 
     # Remove rules file
-    rules_file = project_dir / ".claude" / "rules" / "reflexio.md"
+    rules_file = claude_dir / "rules" / "reflexio.md"
     if rules_file.exists():
         rules_file.unlink()
         typer.echo(f"  Removed rules: {rules_file}")
 
     # Remove /reflexio-extract command
-    cmd_dir = project_dir / ".claude" / "commands" / "reflexio-extract"
+    cmd_dir = claude_dir / "commands" / "reflexio-extract"
     if cmd_dir.exists():
         shutil.rmtree(cmd_dir)
         typer.echo(f"  Removed command: {cmd_dir}")
 
     # Remove hook from settings
-    settings_path = project_dir / ".claude" / "settings.json"
+    settings_path = claude_dir / "settings.json"
     _remove_hook_config(settings_path)
     typer.echo(f"  Removed hook from: {settings_path}")
 
-    typer.echo("Reflexio integration removed from Claude Code project.")
+
+def _uninstall_claude_code(
+    project_dir: Path, *, global_install: bool = False
+) -> None:
+    """Remove the Reflexio integration from Claude Code.
+
+    When ``--global`` or ``--project-dir`` is explicit, removes from that
+    location directly. Otherwise auto-detects via marker files.
+
+    Args:
+        project_dir: Root directory of the Claude Code project.
+        global_install: If True, only remove from ~/.claude/.
+    """
+    # When --global is explicit, skip detection and remove from ~/.claude/
+    if global_install:
+        home = Path.home()
+        marker = home / ".claude" / "skills" / "reflexio" / _MARKER_FILENAME
+        if not marker.exists():
+            typer.confirm(
+                "No Reflexio marker found in ~/.claude/. Remove anyway?",
+                abort=True,
+            )
+        else:
+            typer.confirm(
+                "Remove Reflexio integration from ~/.claude/ (all projects)?",
+                abort=True,
+            )
+        _remove_from_dir(home)
+        typer.echo("Reflexio integration removed.")
+        return
+
+    locations = _detect_install_locations(project_dir)
+
+    if not locations:
+        typer.confirm(
+            f"No Reflexio marker found. Remove integration from {project_dir}/.claude/?",
+            abort=True,
+        )
+        _remove_from_dir(project_dir)
+        typer.echo("Reflexio integration removed.")
+        return
+
+    if len(locations) == 1:
+        loc, base = locations[0]
+        loc_label = (
+            "~/.claude/ (all projects)"
+            if loc == InstallLocation.ALL_PROJECTS
+            else f"{base}/.claude/ (current project)"
+        )
+        typer.confirm(
+            f"Found Reflexio integration at {loc_label}. Remove it?",
+            abort=True,
+        )
+        _remove_from_dir(base)
+        typer.echo("Reflexio integration removed.")
+        return
+
+    # Both locations have installs
+    typer.echo("\nReflexio is installed in multiple locations:")
+    typer.echo("  [1] All projects (~/.claude/)")
+    typer.echo(f"  [2] Current project ({project_dir}/.claude/)")
+    typer.echo("  [3] Both")
+    choice = typer.prompt("Which installation to remove?", type=int)
+
+    targets: list[tuple[InstallLocation, Path]] = []
+    if choice == 1:
+        targets = [locations[0]]
+    elif choice == 2:
+        targets = [locations[1]]
+    elif choice == 3:
+        targets = locations
+    else:
+        typer.echo("Error: choice must be 1, 2, or 3")
+        raise typer.Exit(1)
+
+    for _, base in targets:
+        _remove_from_dir(base)
+    typer.echo("Reflexio integration removed.")
 
 
 @app.command("claude-code")
@@ -791,13 +955,43 @@ def claude_code_setup(
             help="Target project directory (default: current directory)",
         ),
     ] = None,
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            help="Install to ~/.claude/ (user-level, applies to all projects)",
+        ),
+    ] = False,
 ) -> None:
     """Set up (or remove) the Reflexio integration for Claude Code."""
-    target = Path(project_dir) if project_dir else Path.cwd()
+    # Resolve install location
+    if global_install and project_dir is not None:
+        typer.echo("Error: --global and --project-dir are mutually exclusive")
+        raise typer.Exit(1)
 
+    # Uninstall uses auto-detection — no need for the interactive location prompt
     if uninstall:
-        _uninstall_claude_code(target)
+        target = (
+            Path.home()
+            if global_install
+            else Path(project_dir) if project_dir is not None else Path.cwd()
+        )
+        _uninstall_claude_code(target, global_install=global_install)
         return
+
+    if global_install:
+        target = Path.home()
+        location = InstallLocation.ALL_PROJECTS
+    elif project_dir is not None:
+        target = Path(project_dir)
+        location = InstallLocation.CURRENT_PROJECT
+    else:
+        location = _prompt_install_location()
+        target = (
+            Path.home()
+            if location == InstallLocation.ALL_PROJECTS
+            else Path.cwd()
+        )
 
     # Step 1: Load .env path
     from reflexio.cli.env_loader import load_reflexio_env
@@ -828,12 +1022,20 @@ def claude_code_setup(
 
     # Step 4: Install skill + hook
     typer.echo("")
-    skill_path, _ = _install_claude_code_integration(target, expert=expert)
+    skill_path, _ = _install_claude_code_integration(
+        target, expert=expert, location=location
+    )
     skill_type = "expert" if expert else "normal"
 
     # Step 5: Summary
+    location_label = (
+        "All projects (~/.claude/)"
+        if location == InstallLocation.ALL_PROJECTS
+        else f"Current project ({target}/.claude/)"
+    )
     typer.echo("")
     typer.echo("Setup complete!")
+    typer.echo(f"  Install location: {location_label}")
     if is_remote:
         typer.echo("  LLM Provider: managed by remote server")
     else:
@@ -843,8 +1045,14 @@ def claude_code_setup(
     typer.echo(f"  Storage: {storage_label}")
     typer.echo(f"  Skill ({skill_type}): {skill_path}")
     typer.echo("  Hooks: SessionStart + UserPromptSubmit")
+    if location == InstallLocation.ALL_PROJECTS:
+        typer.echo("")
+        typer.echo("Note: User-level hooks fire for ALL Claude Code sessions.")
     typer.echo("")
-    typer.echo("Next: Start a Claude Code session in this project.")
+    if location == InstallLocation.ALL_PROJECTS:
+        typer.echo("Next: Start any Claude Code session — Reflexio is active in all projects.")
+    else:
+        typer.echo("Next: Start a Claude Code session in this project.")
     if is_remote:
         typer.echo("Reflexio will connect to the remote server automatically.")
     else:

--- a/reflexio/integrations/claude_code/README.md
+++ b/reflexio/integrations/claude_code/README.md
@@ -41,10 +41,9 @@ This installs:
 
 ## Set Up Claude Code Integration
 
-Navigate to your project directory and run:
+Run the setup wizard:
 
 ```bash
-cd your-project/
 reflexio setup claude-code            # Normal mode (search-only)
 # or
 reflexio setup claude-code --expert   # Expert mode (search + publish + /reflexio-extract)
@@ -52,21 +51,42 @@ reflexio setup claude-code --expert   # Expert mode (search + publish + /reflexi
 
 The setup wizard will:
 
-1. Ask you to choose a storage backend (SQLite is the default — no external database needed)
-2. Ask you to choose an LLM provider and enter your API key — **only if using SQLite (local) storage**. If you chose Managed Reflexio or self-hosted, this step is skipped (the remote server handles extraction).
-3. Configure `REFLEXIO_USER_ID=claude-code` for consistent user identification
-4. Install the skill and search hook into your project's `.claude/` directory
+1. Ask you where to install — **all projects** (`~/.claude/`) or **current project only** (`./.claude/`)
+2. Ask you to choose a storage backend (SQLite is the default — no external database needed)
+3. Ask you to choose an LLM provider and enter your API key — **only if using SQLite (local) storage**. If you chose Managed Reflexio or self-hosted, this step is skipped (the remote server handles extraction).
+4. Configure `REFLEXIO_USER_ID=claude-code` for consistent user identification
+5. Install the skill, rules, and search hooks into the chosen `.claude/` directory
+
+You can also skip the interactive prompt with flags:
+
+```bash
+reflexio setup claude-code --global               # Install to ~/.claude/ (all projects)
+reflexio setup claude-code --project-dir ./myapp   # Install to ./myapp/.claude/
+```
+
+### Which location?
+
+| | All projects (`~/.claude/`) | Current project (`./.claude/`) |
+|---|---|---|
+| **Scope** | Every Claude Code session | Only this directory |
+| **Best for** | Desktop app users, personal preferences | CLI users, team-shared config |
+| **Hooks fire** | In all sessions | Only in this project |
+| **Priority** | Lower — project-level overrides | Higher — overrides user-level |
+
+If you have both user-level and project-level installs, Claude Code's priority rules apply: project-level skills, rules, and hooks take precedence over user-level ones.
 
 ### What gets installed
 
 **Normal mode:**
 
 - `.claude/skills/reflexio/SKILL.md` — the normal skill that teaches Claude to search Reflexio
+- `.claude/rules/reflexio.md` — always-in-context rules for Reflexio behavior
 - `.claude/settings.json` — adds `SessionStart` hook (auto-starts server) and `UserPromptSubmit` hook (runs `reflexio search` on every user message)
 
 **Expert mode:**
 
 - `.claude/skills/reflexio/SKILL.md` — the expert skill (different content from normal — includes instructions for publishing corrections and references `/reflexio-extract`)
+- `.claude/rules/reflexio.md` — always-in-context rules for Reflexio behavior
 - `.claude/commands/reflexio-extract/SKILL.md` — the `/reflexio-extract` slash command for manual extraction
 - `.claude/settings.json` — same `SessionStart` + `UserPromptSubmit` hooks as normal mode
 
@@ -95,11 +115,17 @@ The setup wizard will:
 ## Uninstall
 
 ```bash
-cd your-project/
 reflexio setup claude-code --uninstall
 ```
 
-This removes the skill, commands, and hooks from your project. Your extracted data in `~/.reflexio/` is preserved.
+The uninstaller auto-detects where Reflexio is installed (user-level, project-level, or both) and asks which to remove. You can also target a specific location:
+
+```bash
+reflexio setup claude-code --uninstall --global               # Remove from ~/.claude/
+reflexio setup claude-code --uninstall --project-dir ./myapp   # Remove from ./myapp/.claude/
+```
+
+This removes the skill, rules, commands, and hooks. Your extracted data in `~/.reflexio/` is preserved.
 
 To fully remove Reflexio:
 
@@ -319,16 +345,20 @@ User sends message to Claude Code
 
 ### File structure
 
+Integration files are installed to either `~/.claude/` (all projects) or `your-project/.claude/` (current project only). The layout is identical in both cases:
+
 ```
-your-project/
-└── .claude/
-    ├── settings.json                    ← Hook configuration (SessionStart + UserPromptSubmit)
-    ├── skills/
-    │   └── reflexio/
-    │       └── SKILL.md                 ← Normal or expert skill
-    └── commands/                         ← Expert mode only
-        └── reflexio-extract/
-            └── SKILL.md                 ← /reflexio-extract command
+~/.claude/ or your-project/.claude/
+├── settings.json                    ← Hook configuration (SessionStart + UserPromptSubmit)
+├── skills/
+│   └── reflexio/
+│       ├── SKILL.md                 ← Normal or expert skill
+│       └── .installed-by-reflexio   ← Marker for uninstall auto-detection
+├── rules/
+│   └── reflexio.md                  ← Always-in-context instructions
+└── commands/                         ← Expert mode only
+    └── reflexio-extract/
+        └── SKILL.md                 ← /reflexio-extract command
 
 ~/.reflexio/
 ├── .env                                 ← API keys, REFLEXIO_USER_ID

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,8 +10,14 @@ import pytest
 import typer
 
 from reflexio.cli.commands.setup_cmd import (
+    InstallLocation,
+    _detect_install_locations,
+    _install_claude_code_integration,
+    _prompt_install_location,
     _prompt_storage,
+    _remove_from_dir,
     _set_env_var,
+    _write_marker,
 )
 from reflexio.models.api_schema.service_schemas import WhoamiResponse
 
@@ -225,3 +232,209 @@ class TestPromptStorage:
             pytest.raises(typer.Exit),
         ):
             _prompt_storage(env)
+
+
+# ---------------------------------------------------------------------------
+# _prompt_install_location — location picker
+# ---------------------------------------------------------------------------
+
+
+class TestPromptInstallLocation:
+    """Covers the interactive install location picker."""
+
+    def test_choice_1_returns_all_projects(self) -> None:
+        """Choice 1 returns ALL_PROJECTS."""
+        with patch("typer.prompt", return_value=1):
+            result = _prompt_install_location()
+        assert result == InstallLocation.ALL_PROJECTS
+
+    def test_choice_2_returns_current_project(self) -> None:
+        """Choice 2 returns CURRENT_PROJECT."""
+        with patch("typer.prompt", return_value=2):
+            result = _prompt_install_location()
+        assert result == InstallLocation.CURRENT_PROJECT
+
+    def test_default_is_all_projects(self) -> None:
+        """Default prompt value is 1 (ALL_PROJECTS)."""
+        with patch("typer.prompt", return_value=1) as mock_prompt:
+            _prompt_install_location()
+        mock_prompt.assert_called_once_with("Choice", type=int, default=1)
+
+    def test_invalid_choice_exits(self) -> None:
+        """Choices outside 1/2 raise typer.Exit."""
+        with (
+            patch("typer.prompt", return_value=5),
+            pytest.raises(typer.Exit),
+        ):
+            _prompt_install_location()
+
+
+# ---------------------------------------------------------------------------
+# _install_claude_code_integration — both locations
+# ---------------------------------------------------------------------------
+
+
+class TestInstallClaudeCodeIntegration:
+    """Covers install to project-level and user-level locations."""
+
+    def test_project_level_creates_files(self, tmp_path: Path) -> None:
+        """Project-level install creates skill, rules, hooks, and marker."""
+        _install_claude_code_integration(
+            tmp_path, location=InstallLocation.CURRENT_PROJECT
+        )
+        claude_dir = tmp_path / ".claude"
+        assert (claude_dir / "skills" / "reflexio" / "SKILL.md").exists()
+        assert (claude_dir / "rules" / "reflexio.md").exists()
+        assert (claude_dir / "settings.json").exists()
+        # Marker file
+        marker = claude_dir / "skills" / "reflexio" / ".installed-by-reflexio"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["location"] == "current_project"
+
+    def test_user_level_creates_files_in_home(self, tmp_path: Path) -> None:
+        """User-level install creates files under the target dir (simulating ~)."""
+        _install_claude_code_integration(
+            tmp_path, location=InstallLocation.ALL_PROJECTS
+        )
+        claude_dir = tmp_path / ".claude"
+        assert (claude_dir / "skills" / "reflexio" / "SKILL.md").exists()
+        assert (claude_dir / "rules" / "reflexio.md").exists()
+        assert (claude_dir / "settings.json").exists()
+        marker = claude_dir / "skills" / "reflexio" / ".installed-by-reflexio"
+        assert marker.exists()
+        data = json.loads(marker.read_text())
+        assert data["location"] == "all_projects"
+        assert "installed_at" in data
+
+    def test_expert_mode_installs_command(self, tmp_path: Path) -> None:
+        """Expert mode also installs the reflexio-extract command."""
+        _install_claude_code_integration(
+            tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
+        )
+        cmd = tmp_path / ".claude" / "commands" / "reflexio-extract" / "SKILL.md"
+        assert cmd.exists()
+
+    def test_normal_mode_no_command(self, tmp_path: Path) -> None:
+        """Normal mode does not install the reflexio-extract command."""
+        _install_claude_code_integration(
+            tmp_path, location=InstallLocation.CURRENT_PROJECT
+        )
+        cmd = tmp_path / ".claude" / "commands" / "reflexio-extract" / "SKILL.md"
+        assert not cmd.exists()
+
+    def test_hooks_in_settings_json(self, tmp_path: Path) -> None:
+        """Hooks are written to settings.json with correct events."""
+        _install_claude_code_integration(
+            tmp_path, location=InstallLocation.ALL_PROJECTS
+        )
+        settings = json.loads(
+            (tmp_path / ".claude" / "settings.json").read_text()
+        )
+        assert "SessionStart" in settings["hooks"]
+        assert "UserPromptSubmit" in settings["hooks"]
+
+    def test_idempotent_install(self, tmp_path: Path) -> None:
+        """Running install twice doesn't corrupt files or duplicate hooks."""
+        for _ in range(2):
+            _install_claude_code_integration(
+                tmp_path, location=InstallLocation.ALL_PROJECTS
+            )
+        settings = json.loads(
+            (tmp_path / ".claude" / "settings.json").read_text()
+        )
+        # Each event should have exactly one hook entry
+        assert len(settings["hooks"]["SessionStart"]) == 1
+        assert len(settings["hooks"]["UserPromptSubmit"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _detect_install_locations / _remove_from_dir / uninstall
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallDetection:
+    """Covers marker-based install detection and removal."""
+
+    def test_detect_no_installs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Returns empty list when nothing is installed."""
+        fake_home = tmp_path / "empty_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        locations = _detect_install_locations(tmp_path / "project")
+        assert locations == []
+
+    def test_detect_project_level(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Detects project-level install via marker file."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        project = tmp_path / "project"
+        project.mkdir()
+        _install_claude_code_integration(
+            project, location=InstallLocation.CURRENT_PROJECT
+        )
+        locations = _detect_install_locations(project)
+        found_locs = {loc for loc, _ in locations}
+        assert InstallLocation.CURRENT_PROJECT in found_locs
+        assert InstallLocation.ALL_PROJECTS not in found_locs
+
+    def test_detect_user_level(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Detects user-level install via marker file in home dir."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        _install_claude_code_integration(
+            fake_home, location=InstallLocation.ALL_PROJECTS
+        )
+        locations = _detect_install_locations(tmp_path / "project")
+        found_locs = {loc for loc, _ in locations}
+        assert InstallLocation.ALL_PROJECTS in found_locs
+
+    def test_remove_from_dir_cleans_all_files(self, tmp_path: Path) -> None:
+        """_remove_from_dir removes skill, rules, commands, and hooks."""
+        _install_claude_code_integration(
+            tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
+        )
+        claude_dir = tmp_path / ".claude"
+        assert (claude_dir / "skills" / "reflexio").exists()
+        assert (claude_dir / "rules" / "reflexio.md").exists()
+        assert (claude_dir / "commands" / "reflexio-extract").exists()
+
+        _remove_from_dir(tmp_path)
+
+        assert not (claude_dir / "skills" / "reflexio").exists()
+        assert not (claude_dir / "rules" / "reflexio.md").exists()
+        assert not (claude_dir / "commands" / "reflexio-extract").exists()
+        # settings.json should have empty hooks
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        assert "hooks" not in settings or not settings.get("hooks")
+
+    def test_marker_file_metadata(self, tmp_path: Path) -> None:
+        """Marker file contains location and installed_at fields."""
+        marker = tmp_path / ".marker"
+        _write_marker(marker, InstallLocation.ALL_PROJECTS)
+        data = json.loads(marker.read_text())
+        assert data["location"] == "all_projects"
+        assert "installed_at" in data
+
+
+# ---------------------------------------------------------------------------
+# CLI flag mutual exclusion (tested via the command function directly)
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCodeSetupFlags:
+    """Tests for --global / --project-dir mutual exclusion."""
+
+    def test_global_and_project_dir_mutual_exclusion(self) -> None:
+        """Passing both --global and --project-dir raises typer.Exit."""
+        from reflexio.cli.commands.setup_cmd import claude_code_setup
+
+        with pytest.raises(typer.Exit):
+            claude_code_setup(
+                uninstall=False,
+                expert=False,
+                project_dir=Path("/tmp"),
+                global_install=True,
+            )


### PR DESCRIPTION
## Summary
- Add install location selection to `reflexio setup claude-code` wizard — users choose between "All projects" (`~/.claude/`) or "Current project only" (`./.claude/`)
- Add `--global` flag for non-interactive user-level installs, mutually exclusive with existing `--project-dir`
- Rewrite uninstall to auto-detect installation locations via marker files (`.installed-by-reflexio`)
- Update README with location comparison table, updated install/uninstall docs, and file structure diagram

## Test plan
- [x] 33 unit tests pass (4 new test classes: `TestPromptInstallLocation`, `TestInstallClaudeCodeIntegration`, `TestUninstallDetection`, `TestClaudeCodeSetupFlags`)
- [x] E2E tested via tmux: all 4 combinations (`--project-dir`, `--project-dir --expert`, `--global`, `--global --expert`)
- [x] Verified file contents match source, hooks point to real scripts, settings.json preserves existing config
- [x] Ruff lint + Pyright type-check clean
