### PR TITLE
chore(release): reflexio-ai v0.2.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reflexio-ai"
-version = "0.2.9"
+version = "0.2.10"
 description = "A Python library for the Reflexio"
 authors = [{name = "Reflexio Team"}]
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Bump reflexio-ai version from 0.2.9 to 0.2.10

## Test plan

- [x] Built and uploaded to TestPyPI (verified artifact)
- [x] Installed from local wheel — `reflexio --version` shows 0.2.10
- [x] Published to real PyPI and verified `pip install reflexio-ai==0.2.10`
- [x] E2E tested: setup init (SQLite + managed), publish, profiles, regeneration, deletion, doctor check
- [x] Profile regeneration auto-promote working (1 profile promoted)
- [x] `user-playbooks regenerate` working
- [x] All CLI commands exercised from non-repo directory
