### PR TITLE
fix: add future annotations to fix TYPE_CHECKING runtime NameErrors

### DIFF
--- a/reflexio/lib/_base.py
+++ b/reflexio/lib/_base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import logging
 from collections.abc import Callable

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import random
 from typing import TYPE_CHECKING

--- a/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
@@ -5,6 +5,8 @@ Each new request upserts the fire time for its group.
 When the fire time arrives, a daemon thread runs the evaluation callback.
 """
 
+from __future__ import annotations
+
 import heapq
 import logging
 import os

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from collections.abc import Callable

--- a/reflexio/server/services/playbook/playbook_extractor.py
+++ b/reflexio/server/services/playbook/playbook_extractor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 from typing import TYPE_CHECKING

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from dataclasses import dataclass, field

--- a/reflexio/server/services/playbook/playbook_service_utils.py
+++ b/reflexio/server/services/playbook/playbook_service_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from typing import Any
 

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import time

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -1,5 +1,7 @@
 """Service to generate user profiles from interactions"""
 
+from __future__ import annotations
+
 import logging
 import uuid
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Summary
- Fix `NameError` at runtime caused by `TYPE_CHECKING`-guarded imports and self-referencing class names used in unquoted annotations
- Added `from __future__ import annotations` to 9 files so annotations are deferred and not evaluated at class definition time

## Changes
- `_base.py`: `QueryReformulator` self-ref in return type
- `profile_generation_service.py`: `LiteLLMClient`, `RequestContext` in `__init__` params
- `playbook_generation_service.py`: `LiteLLMClient`, `RequestContext` in `__init__` params
- `delayed_group_evaluator.py`: `GroupEvaluationScheduler` self-ref in classmethod return
- `agent_success_evaluator.py`: `AgentSuccessGenerationServiceConfig` TYPE_CHECKING import
- `generation_service.py`: `GenerationService` self-ref in return type
- `playbook_extractor.py`: `PlaybookGenerationServiceConfig` TYPE_CHECKING import
- `playbook_service_utils.py`: `StructuredPlaybookContent` self-ref in return type
- `profile_extractor.py`: `ProfileExtractor` self-ref + `ProfileGenerationServiceConfig` TYPE_CHECKING import

## Related PRs
- Enterprise PR: https://github.com/ReflexioAI/reflexio-enterprise/pull/15

## Test Plan
- [x] All imports succeed without NameError
- [x] AST scanner confirms 0 remaining forward-reference issues
- [x] 1748 unit tests passing (23 collection errors → 0)
