### PR TITLE
docs: update Python version requirement from 3.11 to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 <div align="center">
 
-[![Python >= 3.11](https://img.shields.io/badge/python-%3E%3D3.11-blue)](https://www.python.org/)
+[![Python >= 3.12](https://img.shields.io/badge/python-%3E%3D3.12-blue)](https://www.python.org/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/reflexio-client)](https://pypi.org/project/reflexio-client/)
 [![Search p50 57ms](https://img.shields.io/badge/search-57ms%20p50-brightgreen)](reflexio/benchmarks/retrieval_latency/results/report.md)

--- a/client_dist/README.md
+++ b/client_dist/README.md
@@ -313,7 +313,7 @@ In async contexts (e.g., FastAPI), fire-and-forget uses the existing event loop.
 
 ## Requirements
 
-- Python >= 3.11
+- Python >= 3.12
 - `pydantic >= 2.0.0`
 - `requests >= 2.25.0`
 - `aiohttp >= 3.12.9`

--- a/reflexio/integrations/claude_code/README.md
+++ b/reflexio/integrations/claude_code/README.md
@@ -21,7 +21,7 @@ In future sessions, Reflexio searches for relevant profiles and playbooks before
 
 ## Prerequisites
 
-- **Python >=3.11** (the `reflexio-ai` package requires `>=3.11` — see `pyproject.toml`)
+- **Python >=3.12** (the `reflexio-ai` package requires `>=3.12` — see `pyproject.toml`)
 - **Node.js** (for the search hook that runs on every user message)
 - **An LLM API key** (e.g., `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) — only needed for **SQLite (local) mode**. Managed Reflexio and self-hosted servers handle extraction on their own — you only need the `REFLEXIO_API_KEY` for authentication.
 - **Claude Code** installed and working


### PR DESCRIPTION
## Summary

- Update Python version requirement references from `>= 3.11` to `>= 3.12` across documentation files to match `pyproject.toml` and `.python-version`

## Changes

- `README.md` — badge updated to `>= 3.12`
- `client_dist/README.md` — requirements section updated
- `reflexio/integrations/claude_code/README.md` — prerequisites section updated

## Test plan

- [ ] Verify badge renders correctly on GitHub
- [ ] Confirm no other `3.11` references remain in docs
