### PR TITLE
feat: add skip_should_run_check config flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reflexio-ai"
-version = "0.2.9"
+version = "0.2.11"
 description = "A Python library for the Reflexio"
 authors = [{name = "Reflexio Team"}]
 readme = "README.md"

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -453,6 +453,8 @@ class Config(BaseModel):
     api_key_config: APIKeyConfig | None = None
     # LLM model configuration overrides
     llm_config: LLMConfig | None = None
+    # Skip the LLM pre-extraction eligibility check (always run extraction)
+    skip_should_run_check: bool = False
     # Enable storage-time document expansion for improved FTS recall
     enable_document_expansion: bool = False
 

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -622,6 +622,15 @@ class BaseGenerationService(
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
             return True
 
+        # Skip if org config disables the pre-extraction check
+        root_config = self.request_context.configurator.get_config()
+        if root_config and root_config.skip_should_run_check:
+            logger.info(
+                "skip_should_run_check is enabled for %s, bypassing pre-extraction check",
+                self._get_service_name(),
+            )
+            return True
+
         # Collect scoped interactions
         session_data_models, scoped_configs = (
             self._collect_scoped_interactions_for_precheck(extractor_configs)

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -569,6 +569,37 @@ class TestFilterConfigsByBatchInterval:
 
 
 # ===============================
+# Test: _should_run_before_extraction (skip_should_run_check flag)
+# ===============================
+
+
+class TestShouldRunBeforeExtraction:
+    """Tests for the skip_should_run_check config flag in _should_run_before_extraction."""
+
+    def test_skip_should_run_check_bypasses_llm_call(self, llm_client, request_context):
+        """When skip_should_run_check=True, extraction proceeds without LLM check."""
+        from reflexio.models.config_schema import Config
+
+        config = Config(storage_config={"type": "sqlite"}, skip_should_run_check=True)
+        request_context.configurator._config = config
+
+        service = ConcreteGenerationService(llm_client, request_context)
+        service.service_config = MockServiceConfig(auto_run=True)
+
+        configs = [MockExtractorConfig(extractor_name="test")]
+        result = service._should_run_before_extraction(configs)
+
+        assert result is True
+
+    def test_default_skip_should_run_check_does_not_bypass(self):
+        """When skip_should_run_check=False (default), the flag guard does not fire."""
+        from reflexio.models.config_schema import Config
+
+        config = Config(storage_config={"type": "sqlite"})
+        assert config.skip_should_run_check is False
+
+
+# ===============================
 # Test: run()
 # ===============================
 


### PR DESCRIPTION
## Summary
- Add `skip_should_run_check: bool = False` to the `Config` model
- Add early-return guard in `_should_run_before_extraction()` that bypasses the LLM eligibility check when the flag is enabled
- Add unit tests for the new flag in `test_base_generation_service.py`

## Context
Users have no way to bypass the LLM pre-extraction eligibility check. This flag lets orgs skip it to save cost/latency when they want every batch extracted.

## Test plan
- [x] `TestShouldRunBeforeExtraction::test_skip_should_run_check_bypasses_llm_call` — verifies flag returns True without LLM call
- [x] `TestShouldRunBeforeExtraction::test_default_skip_should_run_check_does_not_bypass` — verifies default is False
- [x] Full test suite (64 tests) passes