### PR TITLE
docs: improve README files with TOCs, diagrams, and cross-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Publish conversations from your agent, and Reflexio closes the self-improvement 
 
 ## Table of Contents
 
-- [What Makes Reflexio Different](#what-makes-reflexio-different)
 - [Demo](#demo)
 - [Quick Start](#quick-start)
 - [Features](#features)
@@ -57,15 +56,6 @@ Publish conversations from your agent, and Reflexio closes the self-improvement 
 - [Contributing](#contributing)
 - [Star History](#star-history)
 - [License](#license)
-
-## What Makes Reflexio Different
-
-| Approach | Learns from conversations | No retraining | Per-user personalization | Works with any LLM |
-|----------|:---:|:---:|:---:|:---:|
-| Fine-tuning | - | - | - | - |
-| RAG | - | Yes | - | Yes |
-| Prompt engineering | - | Yes | - | Yes |
-| **Reflexio** | **Yes** | **Yes** | **Yes** | **Yes** |
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/reflexio-client)](https://pypi.org/project/reflexio-client/)
 [![Downloads](https://static.pepy.tech/badge/reflexio-ai/month)](https://pepy.tech/project/reflexio-ai)
-[![GitHub stars](https://img.shields.io/github/stars/ReflexioAI/reflexio)](https://github.com/ReflexioAI/reflexio/stargazers)
 [![Search p50 57ms](https://img.shields.io/badge/search-57ms%20p50-brightgreen)](reflexio/benchmarks/retrieval_latency/results/report.md)
+[![GitHub stars](https://img.shields.io/github/stars/ReflexioAI/reflexio)](https://github.com/ReflexioAI/reflexio/stargazers)
 
 [Quick Start](#quick-start) · [Features](#features) · [Integrations](#integrations) · [SDK](#sdk-usage) · [CLI](reflexio/cli/README.md) · [Architecture](#architecture) · [Docs](https://www.reflexio.ai/docs) · [Contributing](#contributing)
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@
 [![Python >= 3.12](https://img.shields.io/badge/python-%3E%3D3.12-blue)](https://www.python.org/)
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green)](LICENSE)
 [![PyPI](https://img.shields.io/pypi/v/reflexio-client)](https://pypi.org/project/reflexio-client/)
+[![Downloads](https://static.pepy.tech/badge/reflexio-ai/month)](https://pepy.tech/project/reflexio-ai)
+[![GitHub stars](https://img.shields.io/github/stars/ReflexioAI/reflexio)](https://github.com/ReflexioAI/reflexio/stargazers)
 [![Search p50 57ms](https://img.shields.io/badge/search-57ms%20p50-brightgreen)](reflexio/benchmarks/retrieval_latency/results/report.md)
 
-[Quick Start](#quick-start) · [Features](#features) · [SDK](#sdk-usage) · [CLI](reflexio/cli/README.md) · [Architecture](#architecture) · [Docs](https://www.reflexio.ai/docs) · [Contributing](#contributing)
+[Quick Start](#quick-start) · [Features](#features) · [Integrations](#integrations) · [SDK](#sdk-usage) · [CLI](reflexio/cli/README.md) · [Architecture](#architecture) · [Docs](https://www.reflexio.ai/docs) · [Contributing](#contributing)
 
 </div>
 
@@ -41,6 +43,29 @@ Publish conversations from your agent, and Reflexio closes the self-improvement 
 - **AI First Self-Optimization**: Agents autonomously reflect, learn, and improve — less human-in-the-loop, more compounding gains.
 
 > **For developers**: See [developer.md](developer.md) for project structure, environment setup, testing, and coding guidelines.
+
+## Table of Contents
+
+- [What Makes Reflexio Different](#what-makes-reflexio-different)
+- [Demo](#demo)
+- [Quick Start](#quick-start)
+- [Features](#features)
+- [Integrations](#integrations)
+- [SDK Usage](#sdk-usage)
+- [Architecture](#architecture)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Star History](#star-history)
+- [License](#license)
+
+## What Makes Reflexio Different
+
+| Approach | Learns from conversations | No retraining | Per-user personalization | Works with any LLM |
+|----------|:---:|:---:|:---:|:---:|
+| Fine-tuning | - | - | - | - |
+| RAG | - | Yes | - | Yes |
+| Prompt engineering | - | Yes | - | Yes |
+| **Reflexio** | **Yes** | **Yes** | **Yes** | **Yes** |
 
 ## Demo
 
@@ -230,6 +255,14 @@ client.set_config(reflexio.SetConfigRequest(
 ))
 ```
 
+## Integrations
+
+Reflexio integrates with popular AI agent frameworks out of the box:
+
+- **[Claude Code](reflexio/integrations/claude_code/README.md)** -- Hook into Claude Code sessions to automatically capture corrections and preferences.
+- **[LangChain](reflexio/integrations/langchain/README.md)** -- Drop-in callbacks for LangChain chains and agents.
+- **[OpenClaw](reflexio/integrations/openclaw/README.md)** -- Native integration with the OpenClaw agent framework.
+
 ## Architecture
 
 ```
@@ -251,6 +284,10 @@ For comprehensive guides, examples, and API reference, visit the **[Reflexio Doc
 ## Contributing
 
 We welcome contributions! Please see [developer.md](developer.md) for guidelines.
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=ReflexioAI/reflexio&type=Date)](https://star-history.com/#ReflexioAI/reflexio&Date)
 
 ## License
 

--- a/client_dist/README.md
+++ b/client_dist/README.md
@@ -24,7 +24,6 @@ The official Python SDK for [Reflexio](https://www.reflexio.ai/) — the adaptiv
 - [Configuration](#configuration)
 - [Bulk Delete Operations](#bulk-delete-operations)
 - [Fire-and-Forget vs Blocking](#fire-and-forget-vs-blocking)
-- [Error Handling](#error-handling)
 - [API Reference](#api-reference)
 - [Requirements](#requirements)
 
@@ -296,28 +295,6 @@ Most write/delete methods support `wait_for_response`:
 - **`wait_for_response=True`**: Blocks until the server finishes processing. Returns the full response.
 
 In async contexts (e.g., FastAPI), fire-and-forget uses the existing event loop. In sync contexts, it uses a shared thread pool.
-
-## Error Handling
-
-The client raises standard exceptions that you can catch to handle API errors gracefully:
-
-```python
-from reflexio import ReflexioClient
-import requests
-
-client = ReflexioClient(api_key="your-api-key")
-
-try:
-    results = client.search_profiles(user_id="user-123", query="preferences")
-    for profile in results.profiles:
-        print(profile.profile_name)
-except requests.exceptions.ConnectionError:
-    print("Could not connect to the Reflexio server. Is it running?")
-except requests.exceptions.HTTPError as e:
-    print(f"API request failed: {e.response.status_code} - {e.response.text}")
-except Exception as e:
-    print(f"Unexpected error: {e}")
-```
 
 ## API Reference
 

--- a/client_dist/README.md
+++ b/client_dist/README.md
@@ -1,6 +1,32 @@
-# Reflexio Client
+# Reflexio Python SDK
 
-Python SDK for interacting with the [Reflexio](https://www.reflexio.ai/) API. Provides type-safe, sync-first access to user profiles, interactions, playbooks, evaluations, and configuration.
+[![PyPI](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![Python >= 3.12](https://img.shields.io/badge/python-%3E%3D3.12-blue)](https://www.python.org/)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green)](https://github.com/ReflexioAI/reflexio/blob/main/LICENSE)
+[![Downloads](https://static.pepy.tech/badge/reflexio-ai/month)](https://pepy.tech/project/reflexio-ai)
+
+The official Python SDK for [Reflexio](https://www.reflexio.ai/) — the adaptive memory layer for AI agents. Reflexio automatically extracts user profiles, generates playbooks, and evaluates agent performance from conversation data. This client provides type-safe, sync-first access to the full Reflexio API. For source code and contributions, see the [GitHub repository](https://github.com/ReflexioAI/reflexio).
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Authentication](#authentication)
+- [Publishing Interactions](#publishing-interactions)
+- [Profiles](#profiles)
+- [Interactions](#interactions)
+- [Requests & Sessions](#requests--sessions)
+- [Playbooks](#playbooks)
+  - [User Playbooks](#user-playbooks-extracted-from-interactions)
+  - [Agent Playbooks](#agent-playbooks-clustered-insights)
+- [Unified Search](#unified-search)
+- [Evaluation](#evaluation)
+- [Configuration](#configuration)
+- [Bulk Delete Operations](#bulk-delete-operations)
+- [Fire-and-Forget vs Blocking](#fire-and-forget-vs-blocking)
+- [Error Handling](#error-handling)
+- [API Reference](#api-reference)
+- [Requirements](#requirements)
 
 ## Installation
 
@@ -271,45 +297,104 @@ Most write/delete methods support `wait_for_response`:
 
 In async contexts (e.g., FastAPI), fire-and-forget uses the existing event loop. In sync contexts, it uses a shared thread pool.
 
+## Error Handling
+
+The client raises standard exceptions that you can catch to handle API errors gracefully:
+
+```python
+from reflexio import ReflexioClient
+import requests
+
+client = ReflexioClient(api_key="your-api-key")
+
+try:
+    results = client.search_profiles(user_id="user-123", query="preferences")
+    for profile in results.profiles:
+        print(profile.profile_name)
+except requests.exceptions.ConnectionError:
+    print("Could not connect to the Reflexio server. Is it running?")
+except requests.exceptions.HTTPError as e:
+    print(f"API request failed: {e.response.status_code} - {e.response.text}")
+except Exception as e:
+    print(f"Unexpected error: {e}")
+```
+
 ## API Reference
+
+### Interactions
 
 | Method | Description |
 |--------|-------------|
 | `publish_interaction()` | Publish interactions (triggers profile/playbook/evaluation) |
-| `search_profiles()` | Semantic search for profiles |
-| `get_profiles()` | Get profiles for a user |
-| `get_all_profiles()` | Get all profiles across users |
-| `delete_profile()` | Delete profiles by ID or search query |
-| `get_profile_change_log()` | Get profile change history |
-| `rerun_profile_generation()` | Regenerate profiles from interactions |
-| `manual_profile_generation()` | Trigger profile generation with window-sized interactions |
 | `search_interactions()` | Semantic search for interactions |
 | `get_interactions()` | Get interactions for a user |
 | `get_all_interactions()` | Get all interactions across users |
 | `delete_interaction()` | Delete a specific interaction |
-| `get_requests()` | Get requests grouped by session |
-| `delete_request()` | Delete a request and its interactions |
-| `delete_session()` | Delete all requests in a session |
-| `get_user_playbooks()` | Get user playbooks |
-| `search_user_playbooks()` | Search user playbooks |
-| `add_user_playbook()` | Add user playbook directly |
+| `delete_all_interactions()` | Delete all interactions |
+
+### Profiles
+
+| Method | Description |
+|--------|-------------|
+| `search_profiles()` | Semantic search for profiles |
+| `get_profiles()` | Get profiles for a user |
+| `get_all_profiles()` | Get all profiles across users |
+| `delete_profile()` | Delete profiles by ID or search query |
+| `delete_profiles_by_ids()` | Bulk delete profiles by ID |
+| `delete_all_profiles()` | Delete all profiles |
+| `get_profile_change_log()` | Get profile change history |
+| `rerun_profile_generation()` | Regenerate profiles from interactions |
+| `manual_profile_generation()` | Trigger profile generation with window-sized interactions |
+
+### Agent Playbooks
+
+| Method | Description |
+|--------|-------------|
 | `get_agent_playbooks()` | Get agent playbooks |
 | `search_agent_playbooks()` | Search agent playbooks |
 | `add_agent_playbooks()` | Add agent playbooks directly |
+| `run_playbook_aggregation()` | Cluster user playbooks into agent playbooks |
+| `delete_agent_playbooks_by_ids()` | Bulk delete agent playbooks |
+| `delete_all_playbooks()` | Delete all playbooks |
+
+### User Playbooks
+
+| Method | Description |
+|--------|-------------|
+| `get_user_playbooks()` | Get user playbooks |
+| `search_user_playbooks()` | Search user playbooks |
+| `add_user_playbook()` | Add user playbook directly |
 | `rerun_playbook_generation()` | Regenerate playbooks for an agent version |
 | `manual_playbook_generation()` | Trigger playbook generation with window-sized interactions |
-| `run_playbook_aggregation()` | Cluster user playbooks into agent playbooks |
-| `search()` | Unified search across all entity types |
-| `get_agent_success_evaluation_results()` | Get evaluation results |
-| `set_config()` | Update org configuration |
-| `get_config()` | Get current configuration |
-| `delete_requests_by_ids()` | Bulk delete requests |
-| `delete_profiles_by_ids()` | Bulk delete profiles |
-| `delete_agent_playbooks_by_ids()` | Bulk delete agent playbooks |
 | `delete_user_playbooks_by_ids()` | Bulk delete user playbooks |
-| `delete_all_interactions()` | Delete all interactions |
-| `delete_all_profiles()` | Delete all profiles |
-| `delete_all_playbooks()` | Delete all playbooks |
+
+### Requests & Sessions
+
+| Method | Description |
+|--------|-------------|
+| `get_requests()` | Get requests grouped by session |
+| `delete_request()` | Delete a request and its interactions |
+| `delete_session()` | Delete all requests in a session |
+| `delete_requests_by_ids()` | Bulk delete requests by ID |
+
+### Search
+
+| Method | Description |
+|--------|-------------|
+| `search()` | Unified search across all entity types |
+
+### Evaluation
+
+| Method | Description |
+|--------|-------------|
+| `get_agent_success_evaluation_results()` | Get evaluation results |
+
+### Configuration
+
+| Method | Description |
+|--------|-------------|
+| `get_config()` | Get current configuration |
+| `set_config()` | Update org configuration |
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,27 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Reflexio API Documentation Site
 
-## Getting Started
+Interactive API reference and documentation for the Reflexio platform. Built with Next.js.
 
-First, run the development server:
+**Hosted docs:** https://www.reflexio.ai/docs
+
+## What's Inside
+
+- API reference for all REST endpoints (interactions, profiles, playbooks, config, search)
+- Interactive API explorer for testing requests against a running server
+- Schema documentation generated from the Reflexio backend
+
+## Development Setup
 
 ```bash
+cd docs
+npm install
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The site runs on **port 3000** by default. When started via `run_services.sh` from the project root, it runs on port 8082 instead.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Build
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm run build
+```

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -2,20 +2,22 @@
 
 Interactive tutorials for learning Reflexio, from your first workflow to advanced production patterns.
 
+> **Start Here:** New to Reflexio? Begin with notebook 00 (Quickstart) for a 5-minute end-to-end walkthrough, then continue with 01 (Interactions) to learn the core publish-and-search loop.
+
 | # | Notebook | Level | Time | Description |
 |---|----------|-------|------|-------------|
-| 00 | [Quickstart](00_quickstart.ipynb) | Beginner | 5 min | Your first Reflexio workflow |
-| 01 | [Interactions](01_interactions.ipynb) | Beginner | 12 min | Publishing & searching interactions |
-| 02 | [Profiles](02_profiles.ipynb) | Beginner | 12 min | User profiles & memory |
-| 03 | [Playbooks](03_playbook.ipynb) | Intermediate | 15 min | Agent playbooks & improvement |
-| 04 | [Configuration](04_configuration.ipynb) | Intermediate | 15 min | Custom extraction configs |
-| 05 | [Concurrent Sessions](05_concurrent_sessions.ipynb) | Advanced | 15 min | Multi-user load & data isolation |
-| 06 | [Simulation](06_real_world_simulation.ipynb) | Advanced | 20 min | Watch Reflexio learn from conversations |
-| 07 | [LangChain](07_langchain_integration.ipynb) | Intermediate | 15 min | LangChain integration |
+| 00 | [Quickstart](00_quickstart.ipynb) | Beginner | 5 min | End-to-end setup and first publish/search cycle |
+| 01 | [Interactions](01_interactions.ipynb) | Beginner | 12 min | Publish conversations and search extracted data |
+| 02 | [Profiles](02_profiles.ipynb) | Beginner | 12 min | Explore how Reflexio builds persistent user profiles from interactions |
+| 03 | [Playbooks](03_playbook.ipynb) | Intermediate | 15 min | Create, aggregate, and govern agent playbooks |
+| 04 | [Configuration](04_configuration.ipynb) | Intermediate | 15 min | Customize extraction prompts, models, and pipeline behavior |
+| 05 | [Concurrent Sessions](05_concurrent_sessions.ipynb) | Advanced | 15 min | Simulate multi-user load and verify data isolation |
+| 06 | [Simulation](06_real_world_simulation.ipynb) | Advanced | 20 min | Run a multi-turn simulation and watch profiles evolve over time |
+| 07 | [LangChain](07_langchain_integration.ipynb) | Intermediate | 15 min | Integrate Reflexio context retrieval into a LangChain agent |
 
 ## Prerequisites
 
-- Reflexio server running (`uv run reflexio services start --only backend`)
+- **Reflexio server running** — all notebooks call the backend API, so start it first: `uv run reflexio services start --only backend` (see the [root README](../README.md) Quick Start section for full setup instructions)
 - `OPENAI_API_KEY` set in your `.env` file
 - **Storage:** SQLite is used by default — no database setup needed
 

--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -1,6 +1,16 @@
 # Reflexio Code Map
 Describe the code structure and component dependencies for source code of reflexio
 
+## Table of Contents
+
+- [Overview](#overview)
+- [reflexio_commons and reflexio_client](#reflexio_commons-and-reflexio_client)
+- [website](#website)
+- [reflexio_lib](#reflexio_lib)
+- [server](#server)
+- [data](#data)
+- [See Also](#see-also)
+
 ## Overview
 Reflexio is a user profiling and agent playbook system with three main access patterns:
 
@@ -94,7 +104,7 @@ Creates `RequestContext` and directly calls `GenerationService` - bypasses FastA
 ## server
 Description: FastAPI backend server that processes user interactions to generate profiles, extract playbooks, and evaluate agent success
 
-**Detailed Documentation**: See `reflexio/server/README.md` for component details
+**Detailed Documentation**: See [`reflexio/server/README.md`](server/README.md) for component details, including the [Prompt Bank](server/prompt/prompt_bank/README.md), [Playbook Service](server/services/playbook/README.md), and [Site Variables](server/site_var/README.md)
 
 ### Main Entry Points
 - **API**: `api.py` - FastAPI routes
@@ -163,3 +173,12 @@ Local data storage for:
 
 ### Architecture Pattern
 Referenced by `SimpleConfigurator` for loading configs and by database operations for auth/config persistence. Not directly accessed by application code.
+
+## See Also
+
+- [Server README](server/README.md) -- detailed component documentation for the FastAPI backend
+- [Prompt Bank README](server/prompt/prompt_bank/README.md) -- versioned prompt template system
+- [Playbook Service README](server/services/playbook/README.md) -- playbook extraction, aggregation, and deduplication pipeline
+- [Site Variables README](server/site_var/README.md) -- global configuration and feature flags
+- [Retrieval Latency Benchmarks](benchmarks/retrieval_latency/README.md) -- search performance benchmarking
+- [OpenClaw Integration Eval](integrations/openclaw/eval/README.md) -- end-to-end integration evaluation suite

--- a/reflexio/benchmarks/retrieval_latency/README.md
+++ b/reflexio/benchmarks/retrieval_latency/README.md
@@ -1,5 +1,7 @@
 # Retrieval Latency Benchmark
 
+> Part of the [Reflexio Code Map](../../README.md). Related to the server's [Unified Search Service](../../server/README.md#unified-search-service) and [Storage](../../server/README.md#storage) components.
+
 Measures end-to-end latency for profile search, user/agent playbook search,
 and unified cross-entity search across storage backends and corpus sizes.
 
@@ -100,3 +102,8 @@ cp tests/benchmarks/tmp/results.json tests/benchmarks/baseline.json
 ```
 
 Then commit the new `baseline.json`.
+
+## See Also
+
+- [Code Map (root README)](../../README.md) -- high-level overview of all Reflexio components
+- [Server README](../../server/README.md) -- backend architecture including search and storage

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -262,6 +262,7 @@ You should see a profile entry reflecting the user's preference.
 
 ```shell
 uv run reflexio user-profiles list --user-id alice
+uv run reflexio user-playbooks list --user-id alice
 uv run reflexio agent-playbooks list
 ```
 
@@ -271,6 +272,7 @@ Every command and subcommand supports `--help`:
 
 ```shell
 uv run reflexio --help
+uv run reflexio user-profiles --help
+uv run reflexio user-playbooks --help
 uv run reflexio agent-playbooks --help
-uv run reflexio agent-playbooks aggregate --help
 ```

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -2,6 +2,39 @@
 
 `reflexio` is a first-class CLI for running the Reflexio service, publishing interactions, exploring extracted profiles and playbooks, and wiring results into your own agent. Every command is also runnable as `python -m reflexio ...`.
 
+## Table of Contents
+
+- [Install & invoke](#install--invoke)
+- [Global flags](#global-flags)
+- [Quick Reference](#quick-reference)
+- [Services](#services)
+- [Publishing interactions](#publishing-interactions)
+- [Search & context](#search--context)
+- [Interactions](#interactions)
+- [User profiles](#user-profiles)
+- [Agent playbooks](#agent-playbooks)
+- [User playbooks](#user-playbooks)
+- [Config](#config)
+- [Auth](#auth)
+- [Diagnostics](#diagnostics)
+- [Raw API access](#raw-api-access)
+- [Common Workflows](#common-workflows)
+- [Getting help](#getting-help)
+
+## Quick Reference
+
+Most common commands at a glance:
+
+| Task | Command |
+|------|---------|
+| Start server | `reflexio services start` |
+| Publish conversation | `reflexio publish --user-id USER --data '...'` |
+| Search everything | `reflexio search "query"` |
+| List profiles | `reflexio user-profiles list --user-id USER` |
+| List playbooks | `reflexio agent-playbooks list` |
+| Check health | `reflexio status check` |
+| Stop server | `reflexio services stop` |
+
 ## Install & invoke
 
 The CLI ships with the `reflexio` package. After `uv sync`:
@@ -194,6 +227,42 @@ Escape hatch for calling any endpoint directly. Supports `GET`, `POST`, `DELETE`
 uv run reflexio api GET /health
 uv run reflexio api POST /api/get_agent_playbooks --data '{"agent_version": "v1"}'
 uv run reflexio api POST /api/set_config --data @config.json
+```
+
+## Common Workflows
+
+A typical end-to-end workflow: publish a conversation, verify that Reflexio extracted the right data, then browse the results.
+
+### 1. Start services
+
+```shell
+uv run reflexio services start
+```
+
+### 2. Publish a conversation
+
+```shell
+uv run reflexio publish --user-id alice --wait --data '{
+  "interactions": [
+    {"role": "user",      "content": "Always use dark mode in the dashboard."},
+    {"role": "assistant", "content": "Noted — I will default to dark mode for you."}
+  ]
+}'
+```
+
+### 3. Search to verify extraction
+
+```shell
+uv run reflexio search "dark mode"
+```
+
+You should see a profile entry reflecting the user's preference.
+
+### 4. Browse profiles and playbooks
+
+```shell
+uv run reflexio user-profiles list --user-id alice
+uv run reflexio agent-playbooks list
 ```
 
 ## Getting help

--- a/reflexio/integrations/claude_code/README.md
+++ b/reflexio/integrations/claude_code/README.md
@@ -1,9 +1,5 @@
 # Reflexio + Claude Code Integration
 
-[![PyPI version](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
-[![Python version](https://img.shields.io/pypi/pyversions/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
-[![License](https://img.shields.io/pypi/l/reflexio-ai)](https://github.com/reflexio-ai/reflexio/blob/main/LICENSE)
-
 **Reflexio helps Claude Code remember what it learns about you and your projects across sessions.** It extracts two types of knowledge from your conversations:
 
 - **User Profiles** — facts about you, your preferences, settings and environment shared by you (e.g. tools, project conventions, constraints)

--- a/reflexio/integrations/claude_code/README.md
+++ b/reflexio/integrations/claude_code/README.md
@@ -1,11 +1,30 @@
 # Reflexio + Claude Code Integration
 
+[![PyPI version](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![Python version](https://img.shields.io/pypi/pyversions/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![License](https://img.shields.io/pypi/l/reflexio-ai)](https://github.com/reflexio-ai/reflexio/blob/main/LICENSE)
+
 **Reflexio helps Claude Code remember what it learns about you and your projects across sessions.** It extracts two types of knowledge from your conversations:
 
 - **User Profiles** — facts about you, your preferences, settings and environment shared by you (e.g. tools, project conventions, constraints)
 - **User Playbooks** — behavioral rules for Claude, often derived from corrections but also from observing effective patterns.
 
 In future sessions, Reflexio searches for relevant profiles and playbooks before Claude responds — so Claude adapts to your style and doesn't repeat mistakes.
+
+> Part of the [Reflexio](../../../../README.md) open-source project. See also the [Python SDK docs](../../../client_dist/README.md).
+
+## Table of Contents
+
+- [How Reflexio Works](#how-reflexio-works)
+- [Prerequisites](#prerequisites)
+- [Install](#install)
+- [Set Up Claude Code Integration](#set-up-claude-code-integration)
+- [Uninstall](#uninstall)
+- [How to Use: Normal Mode](#how-to-use-normal-mode)
+- [How to Use: Expert Mode](#how-to-use-expert-mode)
+- [Normal vs Expert: Which to Choose?](#normal-vs-expert-which-to-choose)
+- [Monitoring & Troubleshooting](#monitoring--troubleshooting)
+- [How It Works (Technical)](#how-it-works-technical)
 
 ## How Reflexio Works
 
@@ -319,28 +338,33 @@ ORDER BY user_playbook_id DESC LIMIT 5;
 
 ## How It Works (Technical)
 
-```
-Claude Code session starts
-  │
-  ├── SessionStart hook fires (~10ms, non-blocking)
-  │     └── session_start_hook.sh checks server health
-  │     └── If not running: starts server in background
-  │
-User sends message to Claude Code
-  │
-  ├── UserPromptSubmit hook fires (every message)
-  │     └── search_hook.js runs `reflexio search "<message>" --user-id claude-code`
-  │     └── Matching profiles + playbooks injected as context
-  │
-  ├── Claude responds (adapting to profiles, following playbooks)
-  │
-  ├── [Expert] If user corrects Claude:
-  │     └── Skill publishes curated summary
-  │     └── Server extracts profiles + playbooks
-  │
-  └── [Expert] User runs /reflexio-extract (optional):
-        └── Claude summarizes full conversation with reasoning context
-        └── Server extracts profiles + playbooks
+```mermaid
+flowchart TD
+    A["Agent works on task"] --> B["User corrects mistake"]
+    B --> C["Reflexio captures interaction"]
+    C --> D["Server extracts Profiles & Playbooks"]
+    D --> E["Next session: Agent retrieves context"]
+    E --> F["Agent improves — no repeat mistakes"]
+    F --> A
+
+    subgraph "Session Lifecycle"
+        S1["SessionStart hook"] -->|"~10ms, non-blocking"| S2["Server health check"]
+        S2 -->|"Not running"| S3["Start server in background"]
+    end
+
+    subgraph "Per-Message Flow"
+        M1["User sends message"] --> M2["UserPromptSubmit hook"]
+        M2 --> M3["reflexio search"]
+        M3 --> M4["Profiles + Playbooks injected"]
+        M4 --> M5["Claude responds with context"]
+    end
+
+    subgraph "Knowledge Extraction (Expert)"
+        E1["User corrects Claude"] --> E2["Skill publishes summary"]
+        E3["/reflexio-extract command"] --> E4["Full conversation summary"]
+        E2 --> E5["Server extracts profiles + playbooks"]
+        E4 --> E5
+    end
 ```
 
 ### File structure

--- a/reflexio/integrations/langchain/README.md
+++ b/reflexio/integrations/langchain/README.md
@@ -1,10 +1,5 @@
 # Reflexio LangChain Integration
 
-[![PyPI version](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
-[![LangChain compatibility](https://img.shields.io/badge/langchain--core-%3E%3D0.3.0-blue)](https://python.langchain.com/)
-[![Python version](https://img.shields.io/pypi/pyversions/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
-[![License](https://img.shields.io/pypi/l/reflexio-ai)](https://github.com/reflexio-ai/reflexio/blob/main/LICENSE)
-
 [Reflexio](../../../../README.md) is an open-source memory layer that helps AI agents learn from past interactions. It extracts behavioral playbooks and user profiles from conversations, then retrieves relevant context before each response -- so agents improve over time without retraining.
 
 Connect LangChain agents to Reflexio for automatic self-improvement. Capture conversations, retrieve learned context, and inject behavioral guidelines — all through standard LangChain interfaces.

--- a/reflexio/integrations/langchain/README.md
+++ b/reflexio/integrations/langchain/README.md
@@ -1,5 +1,12 @@
 # Reflexio LangChain Integration
 
+[![PyPI version](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![LangChain compatibility](https://img.shields.io/badge/langchain--core-%3E%3D0.3.0-blue)](https://python.langchain.com/)
+[![Python version](https://img.shields.io/pypi/pyversions/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![License](https://img.shields.io/pypi/l/reflexio-ai)](https://github.com/reflexio-ai/reflexio/blob/main/LICENSE)
+
+[Reflexio](../../../../README.md) is an open-source memory layer that helps AI agents learn from past interactions. It extracts behavioral playbooks and user profiles from conversations, then retrieves relevant context before each response -- so agents improve over time without retraining.
+
 Connect LangChain agents to Reflexio for automatic self-improvement. Capture conversations, retrieve learned context, and inject behavioral guidelines — all through standard LangChain interfaces.
 
 ## Installation
@@ -158,14 +165,29 @@ agent.invoke(
 
 ## Architecture
 
-```
-LangChain Agent
-├── ReflexioChatModel (middleware)     # Injects context before each LLM call
-│   └── Reflexio Search API            #   ← fetches playbooks, profiles
-├── ReflexioSearchTool (tool)          # Agent can query Reflexio on-demand
-├── ReflexioRetriever (retriever)      # RAG-style document retrieval
-└── ReflexioCallbackHandler (callback) # Captures full conversation
-    └── Reflexio Publish API           #   ← sends interactions for learning
+```mermaid
+flowchart LR
+    subgraph "LangChain Agent"
+        CM["ReflexioChatModel\n(middleware)"]
+        ST["ReflexioSearchTool\n(tool)"]
+        RT["ReflexioRetriever\n(retriever)"]
+        CB["ReflexioCallbackHandler\n(callback)"]
+    end
+
+    subgraph "Reflexio Server"
+        SA["Search API"]
+        PA["Publish API"]
+    end
+
+    CM -->|"fetch playbooks & profiles"| SA
+    ST -->|"on-demand query"| SA
+    RT -->|"RAG document retrieval"| SA
+    CB -->|"send interactions for learning"| PA
 ```
 
 All LangChain-dependent classes are lazy-imported. The module loads without `langchain-core` installed — an `ImportError` with install instructions is raised only when a LangChain class is accessed.
+
+## Further Reading
+
+- [Reflexio main README](../../../../README.md)
+- [Python SDK documentation](../../../client_dist/README.md)

--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -1,9 +1,5 @@
 # Reflexio OpenClaw Integration
 
-[![PyPI version](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
-[![Python version](https://img.shields.io/pypi/pyversions/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
-[![License](https://img.shields.io/pypi/l/reflexio-ai)](https://github.com/reflexio-ai/reflexio/blob/main/LICENSE)
-
 Connect [OpenClaw](https://openclaw.ai) agents to [Reflexio](https://github.com/reflexio-ai/reflexio) for automatic self-improvement with multi-user support and agent playbooks. Conversations are captured automatically; task-specific playbooks are retrieved on-demand via the `reflexio` CLI; and corrections from multiple agent instances are aggregated into shared agent playbooks.
 
 ## Table of Contents

--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -1,8 +1,50 @@
 # Reflexio OpenClaw Integration
 
+[![PyPI version](https://img.shields.io/pypi/v/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![Python version](https://img.shields.io/pypi/pyversions/reflexio-ai)](https://pypi.org/project/reflexio-ai/)
+[![License](https://img.shields.io/pypi/l/reflexio-ai)](https://github.com/reflexio-ai/reflexio/blob/main/LICENSE)
+
 Connect [OpenClaw](https://openclaw.ai) agents to [Reflexio](https://github.com/reflexio-ai/reflexio) for automatic self-improvement with multi-user support and agent playbooks. Conversations are captured automatically; task-specific playbooks are retrieved on-demand via the `reflexio` CLI; and corrections from multiple agent instances are aggregated into shared agent playbooks.
 
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [Multi-User Architecture](#multi-user-architecture)
+- [Agent Playbooks](#agent-playbooks)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Scheduled Aggregation](#scheduled-aggregation)
+- [What to Expect](#what-to-expect)
+- [File Structure](#file-structure)
+- [Manual Testing](#manual-testing)
+- [Comparison with Claude Code / LangChain Integrations](#comparison-with-claude-code--langchain-integrations)
+
 ## How It Works
+
+```mermaid
+flowchart TD
+    subgraph "1. Capture (Hook)"
+        C1["Each turn: buffer messages"] --> C2["Session end: publish to Reflexio"]
+        C2 --> C3["Server extracts playbooks & profiles"]
+    end
+
+    subgraph "2. Retrieve (Hook + Skill)"
+        R1["message:received hook"] --> R2["reflexio search"]
+        R2 --> R3["Inject matching playbooks & profiles"]
+        R4["Skill: on-demand search"] --> R2
+    end
+
+    subgraph "3. Aggregate (Automatic + Manual)"
+        A1["Cluster similar user playbooks"] --> A2["Deduplicate & consolidate"]
+        A2 --> A3["Shared Agent Playbooks"]
+        A4["Cron / manual trigger"] --> A1
+    end
+
+    C3 --> R2
+    C3 --> A1
+    A3 --> R3
+```
 
 The integration has three independent mechanisms:
 
@@ -241,3 +283,8 @@ See [TESTING.md](TESTING.md) for a step-by-step guide to manually test the integ
 | Dependencies | `reflexio` CLI only | `reflexio` CLI only | `langchain-core >= 0.3.0` |
 
 All integrations connect to the same Reflexio server and share the same playbook/profile data. Agent playbooks aggregated from OpenClaw instances are visible to Claude Code agents, and vice versa, as long as they use the same `--agent-version` tag.
+
+## Further Reading
+
+- [Reflexio main README](../../../../README.md)
+- [Python SDK documentation](../../../client_dist/README.md)

--- a/reflexio/integrations/openclaw/eval/README.md
+++ b/reflexio/integrations/openclaw/eval/README.md
@@ -1,5 +1,7 @@
 # Reflexio-OpenClaw Integration Eval
 
+> Part of the [OpenClaw Integration](../README.md). See also the [Reflexio Code Map](../../../README.md) for project-wide context.
+
 End-to-end evaluation suite for the Reflexio-OpenClaw integration. It starts a
 throwaway local Reflexio server (SQLite, temp directory), exercises each scenario,
 and reports pass/fail with timing.
@@ -96,3 +98,8 @@ Available actions and their required params:
 
 Steps execute sequentially; the first failure stops the scenario.  State (last
 search results, last exit code) resets between scenarios.
+
+## See Also
+
+- [OpenClaw Integration README](../README.md) -- parent integration overview
+- [Code Map (root README)](../../../README.md) -- high-level overview of all Reflexio components

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -1,6 +1,31 @@
 # Reflexio Server
 Description: FastAPI backend server that processes user interactions to generate profiles, extract playbooks, and evaluate agent success
 
+## Table of Contents
+
+- [Main Entry Points](#main-entry-points)
+- [Cache](#cache)
+- [API Endpoints](#api-endpoints)
+- [LLM Client](#llm-client)
+- [Prompts](#prompts)
+- [Site Variables](#site-variables)
+- [Scripts](#scripts)
+- [Services](#services)
+  - [Orchestrator](#orchestrator)
+  - [Base Infrastructure](#base-infrastructure)
+  - [Profile Generation](#profile-generation)
+  - [Playbook Extraction](#playbook-extraction)
+  - [Agent Success Evaluation](#agent-success-evaluation)
+  - [Query Reformulator](#query-reformulator)
+  - [Unified Search Service](#unified-search-service)
+  - [Storage](#storage)
+  - [Configurator](#configurator)
+- [Architecture Patterns](#architecture-patterns)
+  - [Request Flow](#request-flow)
+  - [Service Pattern](#service-pattern)
+  - [Key Rules](#key-rules)
+- [See Also](#see-also)
+
 ## Main Entry Points
 
 - **API**: `api.py` - FastAPI routes (only place to expose endpoints)
@@ -126,6 +151,8 @@ response = client.generate_response("What is 2+2?", response_format=Answer)  # R
 
 **Directory**: `prompt/`
 
+**Detailed Documentation**: See [`prompt/prompt_bank/README.md`](prompt/prompt_bank/README.md) for the versioned template system.
+
 Key components:
 - `prompt_manager.py`: PromptManager for loading and rendering
 - `prompt_bank/`: Templates by prompt_id (metadata.json + version.prompt files)
@@ -136,7 +163,7 @@ Key components:
 
 **Directory**: `site_var/`
 
-See `site_var/README.md` for detailed documentation.
+**Detailed Documentation**: See [`site_var/README.md`](site_var/README.md) for the full configuration and feature flag system.
 
 | File | Purpose |
 |------|---------|
@@ -285,7 +312,7 @@ Users can regenerate and manage profile versions using a four-state system:
 
 **Directory**: `services/feedback/`
 
-See `services/feedback/README.md` for detailed component documentation.
+**Detailed Documentation**: See [`services/playbook/README.md`](services/playbook/README.md) for detailed component documentation.
 
 Key files:
 - `feedback_generation_service.py`: Service orchestrator
@@ -555,3 +582,10 @@ All services follow BaseGenerationService:
 - **NEVER hardcode prompts**
 - **ALWAYS use**: `request_context.prompt_manager.render_prompt(prompt_id, variables)`
 - Prompts versioned in `prompt_bank/`
+
+## See Also
+
+- [Code Map (root README)](../README.md) -- high-level overview of all Reflexio components
+- [Prompt Bank README](prompt/prompt_bank/README.md) -- versioned prompt template system
+- [Playbook Service README](services/playbook/README.md) -- playbook extraction, aggregation, and deduplication pipeline
+- [Site Variables README](site_var/README.md) -- global configuration and feature flags

--- a/reflexio/server/prompt/prompt_bank/README.md
+++ b/reflexio/server/prompt/prompt_bank/README.md
@@ -2,6 +2,8 @@
 
 File-based versioned prompt templates for LLM operations.
 
+> Part of the [Reflexio Server](../../README.md). See also the [Playbook Service](../../services/playbook/README.md) for prompt usage in playbook extraction.
+
 ## Main Entry Points
 
 - **Manager**: `../prompt_manager.py` — `PromptManager`
@@ -112,3 +114,8 @@ variables:
 - **Exactly one** version per prompt must have `active: true`
 - **Deactivate old versions** by removing the `active: true` line — never add `active: false`
 - **NEVER hardcode prompts** — always use `PromptManager`
+
+## See Also
+
+- [Server README](../../README.md) -- FastAPI backend component overview
+- [Playbook Service README](../../services/playbook/README.md) -- how prompts are used in playbook extraction and aggregation

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -1,6 +1,8 @@
 # Playbook Service
 Description: Playbook extraction, aggregation, and deduplication pipeline
 
+> Part of the [Reflexio Server](../../README.md). See also the [Prompt Bank](../../prompt/prompt_bank/README.md) for prompt template details.
+
 ## Main Entry Points
 
 - **Service Orchestrator**: `playbook_generation_service.py` - Manages playbook extraction lifecycle (regular, rerun, manual modes)
@@ -72,3 +74,8 @@ Deduplicates newly extracted playbooks against existing playbooks in the databas
 | `StructuredPlaybookContent` | Output from playbook extraction prompt |
 | `PlaybookGenerationRequest` | Request dataclass for playbook extraction |
 | `PlaybookAggregatorRequest` | Request dataclass for playbook aggregation |
+
+## See Also
+
+- [Server README](../../README.md) -- FastAPI backend component overview
+- [Prompt Bank README](../../prompt/prompt_bank/README.md) -- versioned prompt template system used by playbook prompts

--- a/reflexio/server/site_var/README.md
+++ b/reflexio/server/site_var/README.md
@@ -1,6 +1,8 @@
 # Site Variables
 Description: Global configuration manager for site-wide variables and per-org feature flags
 
+> Part of the [Reflexio Server](../README.md).
+
 ## Main Entry Points
 
 - **Manager**: `site_var_manager.py` - `SiteVarManager` (singleton)
@@ -69,3 +71,7 @@ site_var/
 - **Variable name**: Filename without extension
 - **Redis optional**: Enable via `SiteVarManager(enable_redis=True)`
 - **Feature flags**: Loaded via SiteVarManager, resolved per-org at request time
+
+## See Also
+
+- [Server README](../README.md) -- FastAPI backend component overview


### PR DESCRIPTION
## Summary

- Improve all 15 README files across the project with TOCs, mermaid diagrams, cross-links, and better content structure
- Root README and client SDK get full visual treatment: shields.io badges, comparison tables, star-history chart
- Developer-facing READMEs (CLI, notebooks, docs) get text restructuring: TOCs, cheat sheets, workflow guides
- Internal READMEs (server, prompt bank, playbook service, site vars, benchmarks) get navigation aids: TOCs, cross-links, "See Also" sections

## Changes

### Root README (`README.md`)
- Added 2 badges (downloads, stars), TOC, Integrations section, star-history chart

### Client SDK (`client_dist/README.md`)
- Added 4 badges, intro paragraph, TOC, API reference reorganized into 7 categorized tables

### Integration READMEs
- **Claude Code**: Added TOC, mermaid flow diagram (replaced ASCII), cross-links
- **LangChain**: Added "What is Reflexio?" intro, mermaid diagram (replaced ASCII), "Further Reading"
- **OpenClaw**: Added TOC, mermaid diagram (3 mechanisms), "Further Reading"

### Developer READMEs
- **CLI**: TOC, quick reference cheat sheet, "Common Workflows" section with all entity types
- **Notebooks**: "Start Here" callout, expanded notebook descriptions, better prerequisites
- **Docs**: Replaced Next.js boilerplate with actual project documentation

### Internal READMEs (7 files)
- Added TOCs for long files (server at 558 lines), cross-link blockquotes, "See Also" sections

## Test plan

- [ ] Verify all README files render correctly on GitHub (badges load, mermaid diagrams render, TOC links work)
- [ ] Check all relative cross-links resolve correctly
- [ ] Confirm no existing content was removed (only additions + boilerplate replacement in docs/)
