### PR TITLE
feat: add request correlation ID tracing for concurrent debugging

### DIFF
--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -75,12 +75,17 @@ DEBUG_LOG_TO_CONSOLE = os.environ.get("DEBUG_LOG_TO_CONSOLE", "").strip().lower(
 root_logger = logging.getLogger()
 
 if DEBUG_LOG_TO_CONSOLE and DEBUG_LOG_TO_CONSOLE not in ("false", "0", "no"):
+    # Correlation ID filter — injects %(correlation_id)s into every record
+    from reflexio.server.correlation import CorrelationIdFilter
+
+    _cid_filter = CorrelationIdFilter()
+
     # Enable verbose logging to console with colored output
     if not any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers):
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setLevel(logging.INFO)  # Excludes LLM_PROMPT (level 15)
         formatter = colorlog.ColoredFormatter(
-            "%(log_color)s%(name)s - %(levelname)s - %(message)s",
+            "%(log_color)s[%(correlation_id)s] %(name)s - %(levelname)s - %(message)s",
             log_colors={
                 "DEBUG": "cyan",
                 "INFO": "reset",
@@ -97,6 +102,7 @@ if DEBUG_LOG_TO_CONSOLE and DEBUG_LOG_TO_CONSOLE not in ("false", "0", "no"):
         from reflexio.cli.log_format import DuplicateFilter
 
         console_handler.addFilter(DuplicateFilter(window_seconds=5))
+        console_handler.addFilter(_cid_filter)
         root_logger.addHandler(console_handler)
 
     # File handlers
@@ -111,9 +117,12 @@ if DEBUG_LOG_TO_CONSOLE and DEBUG_LOG_TO_CONSOLE not in ("false", "0", "no"):
     )
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(
-        logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+        logging.Formatter(
+            "%(asctime)s [%(correlation_id)s] %(name)s %(levelname)s %(message)s"
+        )
     )
     file_handler.addFilter(_ExcludeLLMPrompt())
+    file_handler.addFilter(_cid_filter)
     root_logger.addHandler(file_handler)
 
     # LLM I/O log file — only LLM_PROMPT level, with structured delimiters

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -121,6 +121,7 @@ from reflexio.server.cache.reflexio_cache import (
     get_reflexio,
     invalidate_reflexio_cache,
 )
+from reflexio.server.correlation import correlation_id_var, generate_correlation_id
 
 logger = logging.getLogger(__name__)
 
@@ -231,6 +232,24 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
                 status_code=status.HTTP_504_GATEWAY_TIMEOUT,
                 content={"detail": "Request timeout"},
             )
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Middleware that assigns a unique correlation ID to each request.
+
+    The ID is stored in a ContextVar so it propagates to log records
+    (via CorrelationIdFilter) and to ThreadPoolExecutor workers when
+    ``contextvars.copy_context()`` is used.
+    """
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        cid = generate_correlation_id()
+        correlation_id_var.set(cid)
+        response = await call_next(request)
+        response.headers["X-Correlation-ID"] = cid
+        return response
 
 
 DEFAULT_ORG_ID = "self-host-org"
@@ -1638,6 +1657,9 @@ def create_app(
 
     # Bot protection
     app.add_middleware(BotProtectionMiddleware)
+
+    # Correlation ID — added last so it runs outermost (Starlette reverses order)
+    app.add_middleware(CorrelationIdMiddleware)
 
     # Override get_org_id dependency if custom one provided
     if get_org_id is not None:

--- a/reflexio/server/correlation.py
+++ b/reflexio/server/correlation.py
@@ -1,0 +1,40 @@
+"""Request correlation ID for tracing concurrent operations.
+
+Stores a short hex ID in a ContextVar so every log line emitted during a
+single HTTP request (including ThreadPoolExecutor worker threads) can be
+correlated back to the originating request.
+
+Usage in worker threads::
+
+    ctx = contextvars.copy_context()
+    executor.submit(ctx.run, fn, *args)
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import uuid
+
+# ContextVar holds the correlation ID for the current request.
+# Default is empty string (non-request contexts like startup, CLI).
+correlation_id_var: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "correlation_id", default=""
+)
+
+
+def generate_correlation_id() -> str:
+    """Generate a short 8-character hex correlation ID."""
+    return uuid.uuid4().hex[:8]
+
+
+class CorrelationIdFilter(logging.Filter):
+    """Logging filter that injects ``correlation_id`` into every log record.
+
+    Attach this filter to handlers so formatters can use
+    ``%(correlation_id)s``.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.correlation_id = correlation_id_var.get("")  # type: ignore[attr-defined]
+        return True

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -2,6 +2,7 @@
 Base class for generation services
 """
 
+import contextvars
 import logging
 import os
 import time
@@ -542,7 +543,9 @@ class BaseGenerationService(
             executor: ThreadPoolExecutor | None = None
             try:
                 executor = ThreadPoolExecutor(max_workers=1)
-                future = executor.submit(extractor.run)  # type: ignore[reportAttributeAccessIssue]
+                # Copy context so correlation ID propagates to worker thread
+                ctx = contextvars.copy_context()
+                future = executor.submit(ctx.run, extractor.run)  # type: ignore[reportAttributeAccessIssue]
                 result = future.result(timeout=EXTRACTOR_TIMEOUT_SECONDS)
                 if result:
                     all_results.append(result)

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextvars
 import logging
 import uuid
 from collections.abc import Callable
@@ -202,12 +203,17 @@ class GenerationService:
             # when threads are hung on LLM calls
             executor = ThreadPoolExecutor(max_workers=2)
             try:
+                # Each thread needs its own context copy — Context.run() is non-reentrant
                 futures = [
                     executor.submit(
-                        profile_generation_service.run, profile_generation_request
+                        contextvars.copy_context().run,
+                        profile_generation_service.run,
+                        profile_generation_request,
                     ),
                     executor.submit(
-                        playbook_generation_service.run, playbook_generation_request
+                        contextvars.copy_context().run,
+                        playbook_generation_service.run,
+                        playbook_generation_request,
                     ),
                 ]
 


### PR DESCRIPTION
## Summary
- Add ContextVar-based request correlation ID system for tracing concurrent operations
- New `correlation.py` module with `CorrelationIdFilter` and `correlation_id_var`
- `CorrelationIdMiddleware` assigns 8-char hex ID per request, adds `X-Correlation-ID` response header
- Updated log formatters to include `[correlation_id]` prefix in all log lines
- Propagate context to `ThreadPoolExecutor` workers in `generation_service.py` and `base_generation_service.py` using `contextvars.copy_context()`

## Motivation
When multiple users publish interactions concurrently, server log lines from different requests interleave without identification. This makes it impossible to trace a single request through the lock acquire → extraction → lock release lifecycle. Correlation IDs solve this by tagging every log line with the originating request.

## Test plan
- [ ] Start server with `DEBUG_LOG_TO_CONSOLE=true`, publish an interaction, verify correlation ID appears in all log lines
- [ ] Verify `X-Correlation-ID` header in response
- [ ] Run concurrent publishes, grep logs for a single correlation ID to trace its lifecycle
- [ ] Verify ThreadPoolExecutor workers (profile + playbook extraction) share the parent request's correlation ID
