### PR TITLE
fix: env loader improvements + future annotations

### DIFF
--- a/reflexio/cli/commands/services.py
+++ b/reflexio/cli/commands/services.py
@@ -65,6 +65,11 @@ def start(
 ) -> None:
     """Start Reflexio services (backend, docs)."""
     from reflexio.cli.bootstrap_config import resolve_storage, save_storage_to_config
+    from reflexio.cli.env_loader import load_reflexio_env
+
+    # Load .env BEFORE resolve_storage so env vars from ~/.reflexio/.env
+    # (e.g. REFLEXIO_STORAGE=supabase) are visible to the resolution chain.
+    load_reflexio_env()
 
     resolved = resolve_storage(storage)
     os.environ["REFLEXIO_STORAGE"] = resolved

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -95,6 +95,8 @@ def load_reflexio_env(
     for env_path in _ENV_SEARCH_PATHS:
         if env_path.exists():
             load_dotenv(dotenv_path=env_path)
+            sys.stdout.write(f"  Loaded env from: {env_path.resolve()}\n")
+            sys.stdout.flush()
             # Auto-generate any missing secret keys into the existing .env
             _backfill_missing_keys(env_path, auto_generate_keys or [])
             return env_path

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -7,10 +7,13 @@ Searches for .env in multiple locations. On first run, auto-creates
 from __future__ import annotations
 
 import importlib.resources
+import logging
 import re
 import secrets
 import sys
 from pathlib import Path
+
+_logger = logging.getLogger(__name__)
 
 from dotenv import load_dotenv
 
@@ -95,8 +98,7 @@ def load_reflexio_env(
     for env_path in _ENV_SEARCH_PATHS:
         if env_path.exists():
             load_dotenv(dotenv_path=env_path)
-            sys.stdout.write(f"  Loaded env from: {env_path.resolve()}\n")
-            sys.stdout.flush()
+            _logger.debug("Loaded env from: %s", env_path.resolve())
             # Auto-generate any missing secret keys into the existing .env
             _backfill_missing_keys(env_path, auto_generate_keys or [])
             return env_path


### PR DESCRIPTION
## Summary

- Load `.env` before `resolve_storage()` in `services start` so `REFLEXIO_STORAGE` from `~/.reflexio/.env` is visible
- Add `logging.debug` for env file path (replaces noisy `sys.stdout.write`)
- Add `from __future__ import annotations` to files with `TYPE_CHECKING` runtime NameErrors

## Related PRs

Enterprise: ReflexioAI/reflexio-enterprise#21