### PR TITLE
feat: add ShareLink domain model and storage mixin

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -112,6 +112,7 @@ __all__ = [
     "GetOperationStatusResponse",
     "CancelOperationRequest",
     "CancelOperationResponse",
+    "ShareLink",
 ]
 
 # ===============================
@@ -264,6 +265,30 @@ class AgentSuccessEvaluationResult(BaseModel):
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
     embedding: EmbeddingVector = []
+
+
+class ShareLink(BaseModel):
+    """A shareable public link that maps a token to a resource within an org.
+
+    Args:
+        id (int | None): Auto-generated primary key (None when creating).
+        org_id (str): The organization that owns the share link.
+        token (str): The share token (unique). Format: shr_<org_id_b64>.<random>.
+        resource_type (str): One of "profile", "request", "session", "user_playbook", "agent_playbook".
+        resource_id (str): The ID of the resource being shared.
+        created_at (int | None): Unix timestamp of creation.
+        expires_at (int | None): Optional Unix timestamp of expiration. None means never expires.
+        created_by_email (str | None): Optional email of the user who created the link.
+    """
+
+    id: int | None = None
+    org_id: str
+    token: str
+    resource_type: str
+    resource_id: str
+    created_at: int | None = None
+    expires_at: int | None = None
+    created_by_email: str | None = None
 
 
 # ===============================

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -271,7 +271,7 @@ class ShareLink(BaseModel):
     """A shareable public link that maps a token to a resource within an org.
 
     Args:
-        id (int | None): Auto-generated primary key (None when creating).
+        id (int): Primary key assigned by the storage layer.
         org_id (str): The organization that owns the share link.
         token (str): The share token (unique). Format: shr_<org_id_b64>.<random>.
         resource_type (str): One of "profile", "request", "session", "user_playbook", "agent_playbook".
@@ -281,7 +281,7 @@ class ShareLink(BaseModel):
         created_by_email (str | None): Optional email of the user who created the link.
     """
 
-    id: int | None = None
+    id: int
     org_id: str
     token: str
     resource_type: str

--- a/reflexio/server/services/storage/disk_storage/__init__.py
+++ b/reflexio/server/services/storage/disk_storage/__init__.py
@@ -4,9 +4,11 @@ from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
 from ._requests import RequestMixin
+from ._share_links import DiskShareLinkMixin
 
 
 class DiskStorage(
+    DiskShareLinkMixin,
     ProfileMixin,
     RequestMixin,
     PlaybookMixin,

--- a/reflexio/server/services/storage/disk_storage/_share_links.py
+++ b/reflexio/server/services/storage/disk_storage/_share_links.py
@@ -1,0 +1,99 @@
+"""Disk storage does not support share links (not needed for the disk use case)."""
+
+from reflexio.models.api_schema.domain import ShareLink
+
+
+class DiskShareLinkMixin:
+    """Disk storage does not implement share links."""
+
+    def create_share_link(
+        self,
+        token: str,
+        resource_type: str,
+        resource_id: str,
+        expires_at: int | None,
+        created_by_email: str | None,
+    ) -> ShareLink:
+        """Create a new share link.
+
+        Args:
+            token (str): The share token (unique).
+            resource_type (str): Type of resource (e.g., "profile", "user_playbook").
+            resource_id (str): ID of the resource being shared.
+            expires_at (int | None): Optional Unix timestamp of expiration.
+            created_by_email (str | None): Optional email of creator.
+
+        Returns:
+            ShareLink: The created share link with id and created_at populated.
+
+        Raises:
+            NotImplementedError: Share links are not supported with disk storage.
+        """
+        raise NotImplementedError("Share links are not supported with disk storage")
+
+    def get_share_link_by_token(self, token: str) -> ShareLink | None:
+        """Look up a share link by its token.
+
+        Args:
+            token (str): The share token.
+
+        Returns:
+            ShareLink | None: The share link if found, else None.
+
+        Raises:
+            NotImplementedError: Share links are not supported with disk storage.
+        """
+        raise NotImplementedError("Share links are not supported with disk storage")
+
+    def get_share_link_by_resource(
+        self, resource_type: str, resource_id: str
+    ) -> ShareLink | None:
+        """Look up an existing share link for a specific resource (for dedup).
+
+        Args:
+            resource_type (str): Type of resource.
+            resource_id (str): ID of the resource.
+
+        Returns:
+            ShareLink | None: The existing share link if any, else None.
+
+        Raises:
+            NotImplementedError: Share links are not supported with disk storage.
+        """
+        raise NotImplementedError("Share links are not supported with disk storage")
+
+    def get_share_links(self) -> list[ShareLink]:
+        """Return all share links for this org.
+
+        Returns:
+            list[ShareLink]: All share links, ordered by created_at ascending.
+
+        Raises:
+            NotImplementedError: Share links are not supported with disk storage.
+        """
+        raise NotImplementedError("Share links are not supported with disk storage")
+
+    def delete_share_link(self, link_id: int) -> bool:
+        """Delete a share link by ID.
+
+        Args:
+            link_id (int): The share link ID.
+
+        Returns:
+            bool: True if deleted, False if not found.
+
+        Raises:
+            NotImplementedError: Share links are not supported with disk storage.
+        """
+        raise NotImplementedError("Share links are not supported with disk storage")
+
+    def delete_all_share_links(self) -> int:
+        """Delete all share links for this org.
+
+        Returns:
+            int: Number of links deleted.
+
+        Raises:
+            NotImplementedError: Share links are not supported with disk storage.
+        """
+        raise NotImplementedError("Share links are not supported with disk storage")

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -10,6 +10,7 @@ from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
 from ._requests import RequestMixin
+from ._share_links import SQLiteShareLinkMixin
 
 
 class SQLiteStorage(
@@ -18,6 +19,7 @@ class SQLiteStorage(
     PlaybookMixin,
     OperationMixin,
     ExtrasMixin,
+    SQLiteShareLinkMixin,
     SQLiteStorageBase,
 ):
     """SQLite-based storage with FTS5 and hybrid search."""

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1191,7 +1191,6 @@ CREATE TABLE IF NOT EXISTS share_links (
     expires_at INTEGER,
     created_by_email TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_share_links_token ON share_links(token);
 CREATE INDEX IF NOT EXISTS idx_share_links_resource ON share_links(resource_type, resource_id);
 
 """

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1181,4 +1181,17 @@ CREATE VIRTUAL TABLE IF NOT EXISTS agent_playbooks_fts USING fts5(
     tokenize="porter unicode61"
 );
 
+CREATE TABLE IF NOT EXISTS share_links (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    org_id TEXT NOT NULL,
+    token TEXT NOT NULL UNIQUE,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    expires_at INTEGER,
+    created_by_email TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_share_links_token ON share_links(token);
+CREATE INDEX IF NOT EXISTS idx_share_links_resource ON share_links(resource_type, resource_id);
+
 """

--- a/reflexio/server/services/storage/sqlite_storage/_share_links.py
+++ b/reflexio/server/services/storage/sqlite_storage/_share_links.py
@@ -1,11 +1,13 @@
 """SQLite implementation of ShareLinkMixin."""
 
-import time
 from typing import Any
 
 from reflexio.models.api_schema.domain import ShareLink
 
-from ._base import SQLiteStorageBase
+from ._base import (
+    SQLiteStorageBase,
+    _epoch_now,
+)
 
 
 def _row_to_share_link(row: Any) -> ShareLink:
@@ -60,7 +62,7 @@ class SQLiteShareLinkMixin:
         Returns:
             ShareLink: The created share link with id and created_at populated.
         """
-        now = int(time.time())
+        now = _epoch_now()
         cur = self._execute(
             """INSERT INTO share_links
                (org_id, token, resource_type, resource_id, created_at, expires_at, created_by_email)

--- a/reflexio/server/services/storage/sqlite_storage/_share_links.py
+++ b/reflexio/server/services/storage/sqlite_storage/_share_links.py
@@ -1,0 +1,164 @@
+"""SQLite implementation of ShareLinkMixin."""
+
+import time
+from typing import Any
+
+from reflexio.models.api_schema.domain import ShareLink
+
+from ._base import SQLiteStorageBase
+
+
+def _row_to_share_link(row: Any) -> ShareLink:
+    """Convert a sqlite3.Row to a ShareLink model.
+
+    Args:
+        row: A sqlite3.Row from the share_links table.
+
+    Returns:
+        ShareLink: The populated model.
+    """
+    d = dict(row)
+    return ShareLink(
+        id=d["id"],
+        org_id=d["org_id"],
+        token=d["token"],
+        resource_type=d["resource_type"],
+        resource_id=d["resource_id"],
+        created_at=d["created_at"],
+        expires_at=d["expires_at"],
+        created_by_email=d["created_by_email"],
+    )
+
+
+class SQLiteShareLinkMixin:
+    """SQLite-backed share link operations."""
+
+    # Type hints for instance attributes/methods provided by SQLiteStorageBase via MRO
+    org_id: str
+    _execute: Any
+    _fetchone: Any
+    _fetchall: Any
+
+    @SQLiteStorageBase.handle_exceptions
+    def create_share_link(
+        self,
+        token: str,
+        resource_type: str,
+        resource_id: str,
+        expires_at: int | None,
+        created_by_email: str | None,
+    ) -> ShareLink:
+        """Create a new share link.
+
+        Args:
+            token (str): The share token (unique).
+            resource_type (str): Type of resource (e.g., "profile", "user_playbook").
+            resource_id (str): ID of the resource being shared.
+            expires_at (int | None): Optional Unix timestamp of expiration.
+            created_by_email (str | None): Optional email of creator.
+
+        Returns:
+            ShareLink: The created share link with id and created_at populated.
+        """
+        now = int(time.time())
+        cur = self._execute(
+            """INSERT INTO share_links
+               (org_id, token, resource_type, resource_id, created_at, expires_at, created_by_email)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                self.org_id,
+                token,
+                resource_type,
+                resource_id,
+                now,
+                expires_at,
+                created_by_email,
+            ),
+        )
+        return ShareLink(
+            id=cur.lastrowid,
+            org_id=self.org_id,
+            token=token,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            created_at=now,
+            expires_at=expires_at,
+            created_by_email=created_by_email,
+        )
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_share_link_by_token(self, token: str) -> ShareLink | None:
+        """Look up a share link by its token.
+
+        Args:
+            token (str): The share token.
+
+        Returns:
+            ShareLink | None: The share link if found, else None.
+        """
+        row = self._fetchone(
+            "SELECT * FROM share_links WHERE org_id = ? AND token = ?",
+            (self.org_id, token),
+        )
+        return _row_to_share_link(row) if row else None
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_share_link_by_resource(
+        self, resource_type: str, resource_id: str
+    ) -> ShareLink | None:
+        """Look up an existing share link for a specific resource.
+
+        Args:
+            resource_type (str): Type of resource.
+            resource_id (str): ID of the resource.
+
+        Returns:
+            ShareLink | None: The existing share link if any, else None.
+        """
+        row = self._fetchone(
+            "SELECT * FROM share_links WHERE org_id = ? AND resource_type = ? AND resource_id = ?",
+            (self.org_id, resource_type, resource_id),
+        )
+        return _row_to_share_link(row) if row else None
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_share_links(self) -> list[ShareLink]:
+        """Return all share links for this org.
+
+        Returns:
+            list[ShareLink]: All share links, ordered by created_at ascending.
+        """
+        rows = self._fetchall(
+            "SELECT * FROM share_links WHERE org_id = ? ORDER BY created_at ASC",
+            (self.org_id,),
+        )
+        return [_row_to_share_link(row) for row in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def delete_share_link(self, link_id: int) -> bool:
+        """Delete a share link by ID.
+
+        Args:
+            link_id (int): The share link ID.
+
+        Returns:
+            bool: True if deleted, False if not found.
+        """
+        cur = self._execute(
+            "DELETE FROM share_links WHERE org_id = ? AND id = ?",
+            (self.org_id, link_id),
+        )
+        return cur.rowcount > 0
+
+    @SQLiteStorageBase.handle_exceptions
+    def delete_all_share_links(self) -> int:
+        """Delete all share links for this org.
+
+        Returns:
+            int: Number of links deleted.
+        """
+        cur = self._execute(
+            "DELETE FROM share_links WHERE org_id = ?",
+            (self.org_id,),
+        )
+        return cur.rowcount

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -4,6 +4,7 @@ from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
 from ._requests import RequestMixin
+from ._share_links import ShareLinkMixin
 
 
 class BaseStorage(
@@ -12,6 +13,7 @@ class BaseStorage(
     PlaybookMixin,
     OperationMixin,
     ExtrasMixin,
+    ShareLinkMixin,
     BaseStorageCore,
 ):
     """Base class for storage."""
@@ -19,4 +21,4 @@ class BaseStorage(
     pass
 
 
-__all__ = ["BaseStorage", "PlaybookMixin", "matches_status_filter"]
+__all__ = ["BaseStorage", "PlaybookMixin", "ShareLinkMixin", "matches_status_filter"]

--- a/reflexio/server/services/storage/storage_base/_share_links.py
+++ b/reflexio/server/services/storage/storage_base/_share_links.py
@@ -4,11 +4,9 @@ Each BaseStorage subclass (SQLite, Supabase, Disk) must implement these methods.
 Storage instances are org-scoped, so org_id is not a method parameter.
 """
 
-from __future__ import annotations
-
 from abc import abstractmethod
 
-from reflexio.models.api_schema.domain.entities import ShareLink
+from reflexio.models.api_schema.domain import ShareLink
 
 
 class ShareLinkMixin:

--- a/reflexio/server/services/storage/storage_base/_share_links.py
+++ b/reflexio/server/services/storage/storage_base/_share_links.py
@@ -1,0 +1,95 @@
+"""Abstract ShareLink storage operations.
+
+Each BaseStorage subclass (SQLite, Supabase, Disk) must implement these methods.
+Storage instances are org-scoped, so org_id is not a method parameter.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+
+from reflexio.models.api_schema.domain.entities import ShareLink
+
+
+class ShareLinkMixin:
+    """Mixin defining share link CRUD operations on a per-org data storage."""
+
+    @abstractmethod
+    def create_share_link(
+        self,
+        token: str,
+        resource_type: str,
+        resource_id: str,
+        expires_at: int | None,
+        created_by_email: str | None,
+    ) -> ShareLink:
+        """Create a new share link.
+
+        Args:
+            token (str): The share token (unique).
+            resource_type (str): Type of resource (e.g., "profile", "user_playbook").
+            resource_id (str): ID of the resource being shared.
+            expires_at (int | None): Optional Unix timestamp of expiration.
+            created_by_email (str | None): Optional email of creator.
+
+        Returns:
+            ShareLink: The created share link with id and created_at populated.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_share_link_by_token(self, token: str) -> ShareLink | None:
+        """Look up a share link by its token.
+
+        Args:
+            token (str): The share token.
+
+        Returns:
+            ShareLink | None: The share link if found, else None.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_share_link_by_resource(
+        self, resource_type: str, resource_id: str
+    ) -> ShareLink | None:
+        """Look up an existing share link for a specific resource (for dedup).
+
+        Args:
+            resource_type (str): Type of resource.
+            resource_id (str): ID of the resource.
+
+        Returns:
+            ShareLink | None: The existing share link if any, else None.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_share_links(self) -> list[ShareLink]:
+        """Return all share links for this org.
+
+        Returns:
+            list[ShareLink]: All share links, ordered by created_at ascending.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_share_link(self, link_id: int) -> bool:
+        """Delete a share link by ID.
+
+        Args:
+            link_id (int): The share link ID.
+
+        Returns:
+            bool: True if deleted, False if not found.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_all_share_links(self) -> int:
+        """Delete all share links for this org.
+
+        Returns:
+            int: Number of links deleted.
+        """
+        raise NotImplementedError

--- a/tests/server/services/storage/test_sqlite_share_links.py
+++ b/tests/server/services/storage/test_sqlite_share_links.py
@@ -1,0 +1,134 @@
+"""Tests for SQLite share link storage implementation."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    """Create a fresh SQLiteStorage in a temp dir."""
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        yield SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "reflexio.db"))
+
+
+class TestCreateShareLink:
+    def test_creates_and_returns_link(self, storage):
+        link = storage.create_share_link(
+            token="shr_Mw.abc",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=None,
+            created_by_email=None,
+        )
+        assert link.id is not None
+        assert link.token == "shr_Mw.abc"
+        assert link.resource_type == "profile"
+        assert link.resource_id == "p1"
+        assert link.org_id == "test-org"
+        assert link.created_at is not None
+
+    def test_creates_with_expires_at(self, storage):
+        link = storage.create_share_link(
+            token="shr_Mw.exp",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=9999999999,
+            created_by_email="a@b.com",
+        )
+        assert link.expires_at == 9999999999
+        assert link.created_by_email == "a@b.com"
+
+
+class TestGetShareLinkByToken:
+    def test_found(self, storage):
+        created = storage.create_share_link(
+            token="shr_Mw.abc",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=None,
+            created_by_email=None,
+        )
+        found = storage.get_share_link_by_token("shr_Mw.abc")
+        assert found is not None
+        assert found.id == created.id
+
+    def test_not_found(self, storage):
+        assert storage.get_share_link_by_token("shr_doesnotexist") is None
+
+
+class TestGetShareLinkByResource:
+    def test_found(self, storage):
+        created = storage.create_share_link(
+            token="shr_Mw.abc",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=None,
+            created_by_email=None,
+        )
+        found = storage.get_share_link_by_resource("profile", "p1")
+        assert found is not None
+        assert found.id == created.id
+
+    def test_not_found(self, storage):
+        assert storage.get_share_link_by_resource("profile", "missing") is None
+
+
+class TestGetShareLinks:
+    def test_empty(self, storage):
+        assert storage.get_share_links() == []
+
+    def test_multiple(self, storage):
+        storage.create_share_link(
+            token="shr_Mw.a",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=None,
+            created_by_email=None,
+        )
+        storage.create_share_link(
+            token="shr_Mw.b",
+            resource_type="profile",
+            resource_id="p2",
+            expires_at=None,
+            created_by_email=None,
+        )
+        links = storage.get_share_links()
+        assert len(links) == 2
+
+
+class TestDeleteShareLink:
+    def test_deletes_existing(self, storage):
+        link = storage.create_share_link(
+            token="shr_Mw.a",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=None,
+            created_by_email=None,
+        )
+        assert storage.delete_share_link(link.id) is True
+        assert storage.get_share_link_by_token("shr_Mw.a") is None
+
+    def test_missing_returns_false(self, storage):
+        assert storage.delete_share_link(99999) is False
+
+
+class TestDeleteAllShareLinks:
+    def test_empty(self, storage):
+        assert storage.delete_all_share_links() == 0
+
+    def test_deletes_all(self, storage):
+        for i in range(3):
+            storage.create_share_link(
+                token=f"shr_Mw.{i}",
+                resource_type="profile",
+                resource_id=f"p{i}",
+                expires_at=None,
+                created_by_email=None,
+            )
+        assert storage.delete_all_share_links() == 3
+        assert storage.get_share_links() == []


### PR DESCRIPTION
## Summary

Adds the `ShareLink` domain model and storage layer (`ShareLinkMixin`) to the open-source package. This is the open-source half of moving share links from an auth-side (Reflexio-managed) database to the per-customer data storage, so that share link records live alongside the resources they reference.

## Changes

- **Domain model** (`models/api_schema/domain/entities.py`) — new `ShareLink` Pydantic class with `id: int`, `org_id`, `token`, `resource_type`, `resource_id`, `created_at`, `expires_at`, `created_by_email`.
- **Storage protocol** (`server/services/storage/storage_base/_share_links.py`) — abstract `ShareLinkMixin` with 6 methods: `create_share_link`, `get_share_link_by_token`, `get_share_link_by_resource`, `get_share_links`, `delete_share_link`, `delete_all_share_links`. `BaseStorage` now inherits this mixin.
- **SQLite implementation** (`server/services/storage/sqlite_storage/_share_links.py`, `_base.py`) — `SQLiteShareLinkMixin` plus the `share_links` table DDL (auto-created at startup). Uses the shared `_epoch_now()` helper and `self._execute/_fetchone/_fetchall` helpers for thread-safe queries.
- **Disk stub** (`server/services/storage/disk_storage/_share_links.py`) — `DiskShareLinkMixin` that raises `NotImplementedError` for each method (disk storage does not support share links).

## Storage instances are org-scoped

None of the new methods take an `org_id` parameter — the storage instance is already bound to a specific org. This matches the pattern used by every other mixin.

## Test plan

- [x] New contract tests in `tests/server/services/storage/test_sqlite_share_links.py` cover create / get-by-token / get-by-resource / list / delete / delete-all (12 tests, all passing)
- [x] Full storage test sweep: 148 tests passing (no regressions)
- [x] `ruff check` / `ruff format --check` clean
- [x] `pyright` clean on all new files
