### PR TITLE
fix: prompt for LLM/embedding keys on first `services start`

### DIFF
--- a/reflexio/cli/commands/services.py
+++ b/reflexio/cli/commands/services.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -13,6 +15,85 @@ from reflexio.cli import stop_services as stop_mod
 from reflexio.cli.bootstrap_config import _VALID_STORAGE_BACKENDS
 
 app = typer.Typer(help="Start and stop Reflexio services.")
+
+
+def _ensure_llm_configured(env_path: Path) -> None:
+    """Run the first-run LLM + embedding wizard when no key is configured.
+
+    Called by ``services start`` before uvicorn boots. Replaces the ugly
+    ``RuntimeError: No LLM API keys found`` traceback that used to crash the
+    FastAPI lifespan handler on a fresh install.
+
+    Behaviour matrix:
+        - At least one LLM key AND an embedding-capable provider in env →
+          return silently, startup continues.
+        - No LLM key, interactive TTY → prompt for a provider + key, then
+          (conditionally) prompt for an embedding key, re-load the .env so
+          the new values land in ``os.environ``, and return.
+        - Missing only an embedding key (e.g. user set ANTHROPIC_API_KEY
+          manually) → prompt only for an embedding provider.
+        - No LLM key, non-interactive stdin (CI, nohup, container) → print a
+          clean pointer to the .env file and raise ``typer.Exit(1)`` so the
+          user never sees the uvicorn/starlette traceback.
+
+    Args:
+        env_path (Path): Path to the user's ``.env`` file (``~/.reflexio/.env``
+            in the default installation). Keys selected in the wizard are
+            written here.
+
+    Raises:
+        typer.Exit: When stdin is not a TTY and no LLM key is configured.
+    """
+    from dotenv import load_dotenv
+
+    from reflexio.cli.commands.setup_cmd import (
+        _prompt_embedding_provider,
+        _prompt_llm_provider,
+    )
+    from reflexio.server.llm.model_defaults import (
+        EMBEDDING_CAPABLE_PROVIDERS,
+        detect_available_providers,
+    )
+
+    providers = detect_available_providers()
+    has_embedding = any(p in EMBEDDING_CAPABLE_PROVIDERS for p in providers)
+    if providers and has_embedding:
+        return
+
+    if not sys.stdin.isatty():
+        typer.echo(
+            "\nReflexio is not fully configured yet — "
+            + ("no LLM API key" if not providers else "no embedding-capable provider")
+            + f" was found in {env_path}.\n"
+            "Set one of OPENAI_API_KEY, ANTHROPIC_API_KEY, GEMINI_API_KEY, ... "
+            "in that file, or run `reflexio setup init` interactively, "
+            "then retry `reflexio services start`."
+        )
+        raise typer.Exit(1)
+
+    if not providers:
+        typer.echo(
+            "\nWelcome to Reflexio! Let's pick an LLM provider before "
+            "starting the local services."
+        )
+        typer.echo(
+            "(If you wanted Managed or Self-hosted Reflexio instead, press "
+            "Ctrl+C and run `reflexio setup init`.)"
+        )
+        _, _, provider_key = _prompt_llm_provider(env_path)
+        _prompt_embedding_provider(env_path, provider_key)
+    else:
+        typer.echo(
+            "\nYour LLM provider doesn't support text embeddings — Reflexio "
+            "needs an embedding model for semantic search."
+        )
+        non_embedding_provider = next(
+            p for p in providers if p not in EMBEDDING_CAPABLE_PROVIDERS
+        )
+        _prompt_embedding_provider(env_path, non_embedding_provider)
+
+    load_dotenv(dotenv_path=env_path, override=True)
+    typer.echo()
 
 
 def validate_storage_backend(storage: str | None) -> None:
@@ -65,11 +146,16 @@ def start(
 ) -> None:
     """Start Reflexio services (backend, docs)."""
     from reflexio.cli.bootstrap_config import resolve_storage, save_storage_to_config
-    from reflexio.cli.env_loader import load_reflexio_env
+    from reflexio.cli.env_loader import get_env_path, load_reflexio_env
 
     # Load .env BEFORE resolve_storage so env vars from ~/.reflexio/.env
     # (e.g. REFLEXIO_STORAGE=supabase) are visible to the resolution chain.
     load_reflexio_env()
+
+    # First-run guard: if the backend's lifespan validator would reject the
+    # current env (no LLM key, or no embedding-capable provider), prompt now
+    # so users see a friendly wizard instead of a lifespan traceback.
+    _ensure_llm_configured(get_env_path())
 
     resolved = resolve_storage(storage)
     os.environ["REFLEXIO_STORAGE"] = resolved
@@ -78,7 +164,7 @@ def start(
     if storage is not None:
         save_storage_to_config(resolved)
 
-        from reflexio.cli.env_loader import get_env_path, set_env_var
+        from reflexio.cli.env_loader import set_env_var
 
         env_path = get_env_path()
         if env_path.exists():

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -12,6 +12,8 @@ from typing import Annotated
 
 import typer
 
+from reflexio.server.llm.model_defaults import EMBEDDING_CAPABLE_PROVIDERS
+
 
 class InstallLocation(Enum):
     """Where to install the Claude Code integration files.
@@ -22,6 +24,7 @@ class InstallLocation(Enum):
 
     CURRENT_PROJECT = "current_project"
     ALL_PROJECTS = "all_projects"
+
 
 app = typer.Typer(
     help="Configure Reflexio: run 'init' for plain CLI setup, or one of "
@@ -69,8 +72,6 @@ _PROVIDERS: dict[str, dict[str, str]] = {
     },
     "zai": {"env_var": "ZAI_API_KEY", "model": "glm-4-flash", "display": "ZAI"},
 }
-
-_EMBEDDING_PROVIDERS: frozenset[str] = frozenset({"openai", "gemini"})
 
 
 def _set_env_var(env_path: Path, key: str, value: str) -> None:
@@ -172,7 +173,7 @@ def _prompt_embedding_provider(env_path: Path, llm_provider_key: str) -> str | N
         str | None: Display name of the embedding provider, or None if the LLM
             provider already supports embeddings.
     """
-    if llm_provider_key in _EMBEDDING_PROVIDERS:
+    if llm_provider_key in EMBEDDING_CAPABLE_PROVIDERS:
         return None
 
     llm_display = _PROVIDERS[llm_provider_key]["display"]
@@ -862,9 +863,7 @@ def _remove_from_dir(base_dir: Path) -> None:
     typer.echo(f"  Removed hook from: {settings_path}")
 
 
-def _uninstall_claude_code(
-    project_dir: Path, *, global_install: bool = False
-) -> None:
+def _uninstall_claude_code(project_dir: Path, *, global_install: bool = False) -> None:
     """Remove the Reflexio integration from Claude Code.
 
     When ``--global`` or ``--project-dir`` is explicit, removes from that
@@ -980,7 +979,9 @@ def claude_code_setup(
         target = (
             Path.home()
             if global_install
-            else Path(project_dir) if project_dir is not None else Path.cwd()
+            else Path(project_dir)
+            if project_dir is not None
+            else Path.cwd()
         )
         _uninstall_claude_code(target, global_install=global_install)
         return
@@ -993,11 +994,7 @@ def claude_code_setup(
         location = InstallLocation.CURRENT_PROJECT
     else:
         location = _prompt_install_location()
-        target = (
-            Path.home()
-            if location == InstallLocation.ALL_PROJECTS
-            else Path.cwd()
-        )
+        target = Path.home() if location == InstallLocation.ALL_PROJECTS else Path.cwd()
 
     # Step 1: Load .env path
     from reflexio.cli.env_loader import load_reflexio_env
@@ -1056,7 +1053,9 @@ def claude_code_setup(
         typer.echo("Note: User-level hooks fire for ALL Claude Code sessions.")
     typer.echo("")
     if location == InstallLocation.ALL_PROJECTS:
-        typer.echo("Next: Start any Claude Code session — Reflexio is active in all projects.")
+        typer.echo(
+            "Next: Start any Claude Code session — Reflexio is active in all projects."
+        )
     else:
         typer.echo("Next: Start a Claude Code session in this project.")
     if is_remote:

--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -192,6 +192,11 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
 }
 
 
+EMBEDDING_CAPABLE_PROVIDERS: frozenset[str] = frozenset(
+    p for p, d in _PROVIDER_DEFAULTS.items() if d.embedding is not None
+)
+
+
 # ---------------------------------------------------------------------------
 # Model role enum and resolution
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_services_first_run.py
+++ b/tests/cli/test_services_first_run.py
@@ -1,0 +1,131 @@
+"""Tests for the first-run LLM wizard in ``services start``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from reflexio.cli.commands.services import _ensure_llm_configured
+
+
+class TestEnsureLlmConfigured:
+    """Covers the three branches of ``_ensure_llm_configured``:
+
+    already configured, interactive first-run, and non-interactive first-run.
+    The helper is what keeps a fresh ``pip install reflexio-ai`` from crashing
+    inside uvicorn's lifespan when no LLM key is set in ``~/.reflexio/.env``.
+    """
+
+    def test_returns_silently_when_embedding_provider_present(
+        self, tmp_path: Path
+    ) -> None:
+        """If an embedding-capable provider is available, no prompt fires."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        with (
+            patch(
+                "reflexio.server.llm.model_defaults.detect_available_providers",
+                return_value=["openai"],
+            ),
+            patch("reflexio.cli.commands.setup_cmd._prompt_llm_provider") as mock_llm,
+            patch(
+                "reflexio.cli.commands.setup_cmd._prompt_embedding_provider"
+            ) as mock_emb,
+        ):
+            _ensure_llm_configured(env)
+        mock_llm.assert_not_called()
+        mock_emb.assert_not_called()
+
+    def test_returns_silently_when_mixed_providers_include_embedding(
+        self, tmp_path: Path
+    ) -> None:
+        """A provider set with at least one embedding-capable entry must short-circuit."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        with (
+            patch(
+                "reflexio.server.llm.model_defaults.detect_available_providers",
+                return_value=["openai", "anthropic"],
+            ),
+            patch("reflexio.cli.commands.setup_cmd._prompt_llm_provider") as mock_llm,
+            patch(
+                "reflexio.cli.commands.setup_cmd._prompt_embedding_provider"
+            ) as mock_emb,
+        ):
+            _ensure_llm_configured(env)
+        mock_llm.assert_not_called()
+        mock_emb.assert_not_called()
+
+    def test_prompts_when_no_providers_and_tty(self, tmp_path: Path) -> None:
+        """No keys + interactive stdin → both wizard helpers run, env reloads with override."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        with (
+            patch(
+                "reflexio.server.llm.model_defaults.detect_available_providers",
+                return_value=[],
+            ),
+            patch("sys.stdin.isatty", return_value=True),
+            patch(
+                "reflexio.cli.commands.setup_cmd._prompt_llm_provider",
+                return_value=("OpenAI", "gpt-5-mini", "openai"),
+            ) as mock_llm,
+            patch(
+                "reflexio.cli.commands.setup_cmd._prompt_embedding_provider",
+                return_value=None,
+            ) as mock_emb,
+            patch("dotenv.load_dotenv") as mock_load,
+        ):
+            _ensure_llm_configured(env)
+        mock_llm.assert_called_once_with(env)
+        mock_emb.assert_called_once_with(env, "openai")
+        mock_load.assert_called_once_with(dotenv_path=env, override=True)
+
+    def test_exits_cleanly_when_no_providers_and_non_tty(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No keys + non-interactive stdin → friendly error, exit 1, no prompts."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        with (
+            patch(
+                "reflexio.server.llm.model_defaults.detect_available_providers",
+                return_value=[],
+            ),
+            patch("sys.stdin.isatty", return_value=False),
+            patch("reflexio.cli.commands.setup_cmd._prompt_llm_provider") as mock_llm,
+            pytest.raises(typer.Exit) as exc_info,
+        ):
+            _ensure_llm_configured(env)
+        assert exc_info.value.exit_code == 1
+        mock_llm.assert_not_called()
+        out = capsys.readouterr().out
+        assert "not fully configured" in out
+        assert str(env) in out
+        assert "reflexio setup init" in out
+
+    def test_prompts_only_for_embedding_when_llm_exists_without_embedding(
+        self, tmp_path: Path
+    ) -> None:
+        """Anthropic-only env → skip LLM prompt, run embedding prompt with anthropic."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        with (
+            patch(
+                "reflexio.server.llm.model_defaults.detect_available_providers",
+                return_value=["anthropic"],
+            ),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("reflexio.cli.commands.setup_cmd._prompt_llm_provider") as mock_llm,
+            patch(
+                "reflexio.cli.commands.setup_cmd._prompt_embedding_provider",
+                return_value="OpenAI",
+            ) as mock_emb,
+            patch("dotenv.load_dotenv"),
+        ):
+            _ensure_llm_configured(env)
+        mock_llm.assert_not_called()
+        mock_emb.assert_called_once_with(env, "anthropic")

--- a/uv.lock
+++ b/uv.lock
@@ -4260,7 +4260,7 @@ wheels = [
 
 [[package]]
 name = "reflexio-ai"
-version = "0.2.11"
+version = "0.2.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- A fresh `pip install reflexio-ai` followed by `reflexio services start` used to crash inside uvicorn's lifespan with `RuntimeError: No LLM API keys found`, burying the user under a starlette traceback.
- This PR guards `services start` with the same interactive wizard used by `reflexio setup init`, so first-run users get a friendly prompt instead of a traceback.
- Non-interactive shells (CI, `nohup`, containers) now exit cleanly with a one-line pointer to `~/.reflexio/.env`.

## Changes
**CLI**
- `reflexio/cli/commands/services.py`: new `_ensure_llm_configured()` helper called before uvicorn boots. Handles three branches — already configured, interactive first-run (LLM and/or embedding prompt), non-interactive first-run (clean `typer.Exit(1)`).
- `reflexio/cli/commands/setup_cmd.py`: drop the duplicated `_EMBEDDING_PROVIDERS` constant in favour of the shared one.

**Model defaults**
- `reflexio/server/llm/model_defaults.py`: expose `EMBEDDING_CAPABLE_PROVIDERS` derived from `_PROVIDER_DEFAULTS`, so the wizard and setup flow share a single source of truth.

**Tests**
- `tests/cli/test_services_first_run.py`: five unit tests covering all branches — embedding-capable provider present, mixed providers including an embedding one, interactive first-run, non-interactive first-run, and anthropic-only env (LLM prompt skipped, embedding prompt runs).

## Test Plan
- [x] `uv run pytest tests/cli/test_services_first_run.py` — 5 passed
- [x] `uv run ruff check` + `ruff format` clean
- [x] `uv run pyright` on changed files — 0 errors
- [ ] Manual: remove all `*_API_KEY` vars from `~/.reflexio/.env`, run `reflexio services start` in an interactive shell, confirm wizard fires and services boot after key entry
- [ ] Manual: same but pipe stdin from `/dev/null`, confirm clean exit with pointer message (no traceback)
