### PR TITLE
feat: configurable REFLEXIO_USER_ID for Claude Code integration

### DIFF
--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Annotated
@@ -165,9 +166,7 @@ def _oneline(text: str, max_len: int = _MAX_WARNING_LEN) -> str:
     return collapsed[: max_len - 1] + "…"
 
 
-def _print_publish_result(
-    result: PublishUserInteractionResponse, user_id: str
-) -> None:
+def _print_publish_result(result: PublishUserInteractionResponse, user_id: str) -> None:
     """Print human-readable publish result with diagnostics.
 
     Surfaces storage routing + extraction counts so users can tell *where*
@@ -227,7 +226,10 @@ def publish(
     user_id: Annotated[
         str | None,
         typer.Option(
-            help="User identifier (optional if provided in --file/--data payload)"
+            help=(
+                "User identifier. Falls back to REFLEXIO_USER_ID env var "
+                "or 'user_id' inside --file/--data payload."
+            )
         ),
     ] = None,
     session_id: Annotated[
@@ -294,9 +296,11 @@ def publish(
                 exit_code=EXIT_VALIDATION,
             )
         if user_id is None:
+            user_id = os.environ.get("REFLEXIO_USER_ID")
+        if user_id is None:
             raise CliError(
                 error_type="validation",
-                message="--user-id is required with --user-message",
+                message="--user-id is required with --user-message (or set REFLEXIO_USER_ID)",
                 exit_code=EXIT_VALIDATION,
             )
         interactions: list[InteractionData | dict] = [
@@ -347,11 +351,16 @@ def publish(
     resolved_version = resolve_agent_version(agent_version)
     for payload in payloads:
         interaction_items = _interactions_from_payload(payload)
-        resolved_user_id = payload.get("user_id") or user_id
+        resolved_user_id = (
+            payload.get("user_id") or user_id or os.environ.get("REFLEXIO_USER_ID")
+        )
         if not resolved_user_id:
             raise CliError(
                 error_type="validation",
-                message="--user-id is required (or include 'user_id' in the JSON payload)",
+                message=(
+                    "--user-id is required (or include 'user_id' in the JSON "
+                    "payload, or set REFLEXIO_USER_ID)"
+                ),
                 exit_code=EXIT_VALIDATION,
             )
         result = client.publish_interaction(

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import shutil
 import subprocess
 from enum import Enum
@@ -326,6 +327,35 @@ def _prompt_self_hosted(env_path: Path) -> str:
     _set_env_var(env_path, "REFLEXIO_API_KEY", reflexio_api_key)
 
     return "Self-hosted Reflexio"
+
+
+def _prompt_user_id(env_path: Path, fallback: str = "claude-code") -> str:
+    """
+    Prompt for REFLEXIO_USER_ID. Press Enter to accept the default.
+
+    Tags all interactions, profiles, and playbooks published by Claude Code.
+    Customize when you want per-developer attribution or to match a
+    managed/remote user account. If REFLEXIO_USER_ID is already set in
+    the environment (e.g. from a previous setup run), that value is offered
+    as the default.
+
+    Args:
+        env_path (Path): Path to the .env file to persist the value.
+        fallback (str): Default user_id when neither the env nor user input supplies one.
+
+    Returns:
+        str: The resolved user_id (trimmed; fallback if empty).
+    """
+    current = (os.environ.get("REFLEXIO_USER_ID") or "").strip()
+    default = current or fallback
+    typer.echo("")
+    typer.echo(
+        "User ID tags interactions, profiles, and playbooks published by Claude Code."
+    )
+    typer.echo("Press Enter to keep the default.")
+    user_id = (typer.prompt("User ID", default=default) or default).strip() or fallback
+    _set_env_var(env_path, "REFLEXIO_USER_ID", user_id)
+    return user_id
 
 
 def _prompt_storage(env_path: Path) -> str:
@@ -1021,7 +1051,7 @@ def claude_code_setup(
         embedding_label = _prompt_embedding_provider(env_path, provider_key)
 
     # Step 3.5: Configure user_id for Claude Code
-    _set_env_var(env_path, "REFLEXIO_USER_ID", "claude-code")
+    user_id = _prompt_user_id(env_path)
 
     # Step 4: Install skill + hook
     typer.echo("")
@@ -1046,6 +1076,7 @@ def claude_code_setup(
     if embedding_label:
         typer.echo(f"  Embedding Provider: {embedding_label}")
     typer.echo(f"  Storage: {storage_label}")
+    typer.echo(f"  User ID: {user_id}")
     typer.echo(f"  Skill ({skill_type}): {skill_path}")
     typer.echo("  Hooks: SessionStart + UserPromptSubmit")
     if location == InstallLocation.ALL_PROJECTS:

--- a/reflexio/integrations/claude_code/README.md
+++ b/reflexio/integrations/claude_code/README.md
@@ -69,7 +69,7 @@ The setup wizard will:
 1. Ask you where to install — **all projects** (`~/.claude/`) or **current project only** (`./.claude/`)
 2. Ask you to choose a storage backend (SQLite is the default — no external database needed)
 3. Ask you to choose an LLM provider and enter your API key — **only if using SQLite (local) storage**. If you chose Managed Reflexio or self-hosted, this step is skipped (the remote server handles extraction).
-4. Configure `REFLEXIO_USER_ID=claude-code` for consistent user identification
+4. Prompt for `REFLEXIO_USER_ID` (default: `claude-code`) — tags every interaction, profile, and playbook published by Claude Code. Press Enter to accept the default, or enter your own identifier (e.g. your email, GitHub handle, or a managed-account user ID). Re-running setup offers the current value as the default.
 5. Install the skill, rules, and search hooks into the chosen `.claude/` directory
 
 You can also skip the interactive prompt with flags:
@@ -232,7 +232,7 @@ This captures richer context than the automatic mid-session publish because Clau
 ### Step 4: Verify what was extracted
 
 ```bash
-# Check playbooks (behavioral rules)
+# Check playbooks (behavioral rules) — replace claude-code with your configured user_id
 reflexio user-playbooks list --user-id claude-code
 
 # Check profiles (facts about you and your environment)
@@ -242,7 +242,7 @@ reflexio user-profiles list --user-id claude-code
 reflexio search "write a Python function"
 ```
 
-Note: `reflexio search` uses the `REFLEXIO_USER_ID` from your `.env` (set to `claude-code` by the setup wizard), so you don't need to pass `--user-id` explicitly.
+Note: `reflexio search` and `reflexio publish` both fall back to `REFLEXIO_USER_ID` from your `.env` (set by the setup wizard, default `claude-code`), so you don't need to pass `--user-id` explicitly when publishing or searching. The read-only listings above still require `--user-id` as an explicit filter.
 
 ### Step 5: Next session — knowledge applied
 
@@ -291,14 +291,14 @@ cat ~/.reflexio/logs/server.log
 ### Query extracted data
 
 ```bash
-# List playbooks
+# List playbooks — replace claude-code with your configured user_id
 reflexio user-playbooks list --user-id claude-code
 
 # List profiles
 reflexio user-profiles list --user-id claude-code
 
-# Search (what Claude sees on every message)
-reflexio search "your task description" --user-id claude-code
+# Search (what Claude sees on every message) — picks up REFLEXIO_USER_ID from .env automatically
+reflexio search "your task description"
 ```
 
 ### Query the SQLite database directly

--- a/reflexio/integrations/claude_code/commands/reflexio-extract/SKILL.md
+++ b/reflexio/integrations/claude_code/commands/reflexio-extract/SKILL.md
@@ -44,7 +44,6 @@ sleep 5
 ```bash
 cat > /tmp/reflexio-extract.json << 'EXTRACT_EOF'
 {
-  "user_id": "claude-code",
   "agent_version": "claude-code",
   "source": "claude-code-expert",
   "interactions": [
@@ -76,12 +75,12 @@ Notice the three things the example models: (1) the `content` field names the fa
 
 4. Publish with forced extraction:
 ```bash
-reflexio publish --user-id claude-code --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-extract.json && rm -f /tmp/reflexio-extract.json
+reflexio publish --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-extract.json && rm -f /tmp/reflexio-extract.json
 ```
 
 The publish returns as soon as the server has accepted the payload — the actual extraction (LLM calls + storage writes) runs as a background task on the server. This avoids the gateway timeouts you'd hit if extraction took longer than the deployment's request budget.
 
-5. Report what was published (brief summary to the user) and tell them the extraction is running in the background. They can verify the results a minute later with:
+5. Report what was published (brief summary to the user) and tell them the extraction is running in the background. They can verify the results a minute later with (replace `claude-code` below with the `REFLEXIO_USER_ID` configured during setup if different):
 ```bash
 reflexio user-profiles list --user-id claude-code --limit 10
 reflexio user-playbooks list --user-id claude-code --limit 10

--- a/reflexio/integrations/claude_code/hook/handler.js
+++ b/reflexio/integrations/claude_code/hook/handler.js
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 /**
@@ -25,6 +25,23 @@ import { join } from "node:path";
 
 const MAX_INTERACTIONS = 200;
 const MAX_CONTENT_LENGTH = 10_000;
+
+/**
+ * Read a variable from ~/.reflexio/.env when it is not set in process.env.
+ * Returns the raw string value (with surrounding quotes stripped), or empty
+ * string if the file is missing or the key is absent.
+ */
+function readEnvVar(key) {
+	const envPath = join(homedir(), ".reflexio", ".env");
+	try {
+		const content = readFileSync(envPath, "utf-8");
+		const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const match = content.match(new RegExp(`^${escaped}="?([^"\\n]*)"?`, "m"));
+		return match ? match[1] : "";
+	} catch {
+		return "";
+	}
+}
 
 async function main() {
 	// Read event JSON from stdin
@@ -72,8 +89,12 @@ async function main() {
 	}
 
 	// Build payload
-	const userId = process.env.REFLEXIO_USER_ID || "claude-code";
-	const agentVersion = process.env.REFLEXIO_AGENT_VERSION || "claude-code";
+	const userId =
+		process.env.REFLEXIO_USER_ID || readEnvVar("REFLEXIO_USER_ID") || "claude-code";
+	const agentVersion =
+		process.env.REFLEXIO_AGENT_VERSION ||
+		readEnvVar("REFLEXIO_AGENT_VERSION") ||
+		"claude-code";
 
 	const payload = JSON.stringify({
 		user_id: userId,

--- a/reflexio/integrations/claude_code/hook/search_hook.js
+++ b/reflexio/integrations/claude_code/hook/search_hook.js
@@ -22,14 +22,16 @@ const LOG_DIR = join(homedir(), ".reflexio", "logs");
 const STARTING_FLAG = join(LOG_DIR, ".server-starting");
 
 /**
- * Read REFLEXIO_URL from ~/.reflexio/.env when the env var is not set.
- * Returns the URL string, or empty string if not found.
+ * Read a variable from ~/.reflexio/.env when it is not set in process.env.
+ * Returns the raw string value (with surrounding quotes stripped), or empty
+ * string if the file is missing or the key is absent.
  */
-function readEnvUrl() {
+function readEnvVar(key) {
 	const envPath = join(homedir(), ".reflexio", ".env");
 	try {
 		const content = readFileSync(envPath, "utf-8");
-		const match = content.match(/^REFLEXIO_URL="?([^"\n]*)"?/m);
+		const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const match = content.match(new RegExp(`^${escaped}="?([^"\\n]*)"?`, "m"));
 		return match ? match[1] : "";
 	} catch {
 		return "";
@@ -60,7 +62,8 @@ async function main() {
 		process.exit(0);
 	}
 
-	const userId = process.env.REFLEXIO_USER_ID || "claude-code";
+	const userId =
+		process.env.REFLEXIO_USER_ID || readEnvVar("REFLEXIO_USER_ID") || "claude-code";
 
 	try {
 		const result = execFileSync(
@@ -94,7 +97,7 @@ async function main() {
 		}
 
 		// Remote server — can't start it locally, just exit
-		const serverUrl = process.env.REFLEXIO_URL || readEnvUrl();
+		const serverUrl = process.env.REFLEXIO_URL || readEnvVar("REFLEXIO_URL");
 		const isLocal =
 			!serverUrl ||
 			serverUrl.includes("127.0.0.1") ||

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -59,7 +59,6 @@ Write a summary JSON and publish it:
 ```bash
 cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
 {
-  "user_id": "claude-code",
   "agent_version": "claude-code",
   "source": "claude-code-expert",
   "interactions": [
@@ -76,7 +75,7 @@ cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
   ]
 }
 SUMMARY_EOF
-reflexio publish --user-id claude-code --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-summary.json && rm -f /tmp/reflexio-summary.json
+reflexio publish --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-summary.json && rm -f /tmp/reflexio-summary.json
 ```
 
 `tools_used` is **required** on the second turn whenever the original approach involved a failed or rejected tool call — the error string or rejection moment is the evidence Reflexio needs to extract a precise behavioral rule instead of a vague profile entry. For pure-text corrections (user corrected your wording or choice with no tool friction), the field can be omitted.

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -365,3 +365,121 @@ class TestConfigShow:
         result = runner.invoke(app, ["config", "show"])
         assert result.exit_code == 0, result.output
         assert "key" in result.output
+
+
+class TestPublishUserIdResolution:
+    """Tests for 'interactions publish' user_id precedence: payload > flag > env > error."""
+
+    @staticmethod
+    def _write_payload(tmp_path, include_user_id: bool = False, **extras) -> str:
+        """Write a minimal publish payload JSON and return its path."""
+        payload: dict[str, object] = {
+            "interactions": [
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ]
+        }
+        if include_user_id:
+            payload["user_id"] = extras.pop("payload_user_id", "payload-user")
+        payload.update(extras)
+        path = tmp_path / "payload.json"
+        path.write_text(json.dumps(payload))
+        return str(path)
+
+    def test_env_user_id_used_when_flag_missing(
+        self, runner, app, mock_client, tmp_path, monkeypatch
+    ) -> None:
+        """No flag, no payload user_id — REFLEXIO_USER_ID env var is used."""
+        monkeypatch.setenv("REFLEXIO_USER_ID", "env-user")
+        mock_client.publish_interaction.return_value = MagicMock(
+            counts={"interactions": 2}, user_id="env-user"
+        )
+        payload_file = self._write_payload(tmp_path)
+
+        result = runner.invoke(app, ["interactions", "publish", "--file", payload_file])
+
+        assert result.exit_code == 0, result.output
+        mock_client.publish_interaction.assert_called_once()
+        assert mock_client.publish_interaction.call_args.kwargs["user_id"] == "env-user"
+
+    def test_payload_user_id_beats_env(
+        self, runner, app, mock_client, tmp_path, monkeypatch
+    ) -> None:
+        """Payload user_id takes precedence over env var."""
+        monkeypatch.setenv("REFLEXIO_USER_ID", "env-user")
+        mock_client.publish_interaction.return_value = MagicMock(
+            counts={"interactions": 2}, user_id="payload-user"
+        )
+        payload_file = self._write_payload(tmp_path, include_user_id=True)
+
+        result = runner.invoke(app, ["interactions", "publish", "--file", payload_file])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["user_id"]
+            == "payload-user"
+        )
+
+    def test_flag_beats_env(
+        self, runner, app, mock_client, tmp_path, monkeypatch
+    ) -> None:
+        """--user-id flag wins over env var when payload lacks user_id."""
+        monkeypatch.setenv("REFLEXIO_USER_ID", "env-user")
+        mock_client.publish_interaction.return_value = MagicMock(
+            counts={"interactions": 2}, user_id="flag-user"
+        )
+        payload_file = self._write_payload(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "interactions",
+                "publish",
+                "--user-id",
+                "flag-user",
+                "--file",
+                payload_file,
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["user_id"] == "flag-user"
+        )
+
+    def test_error_when_all_sources_missing(
+        self, runner, app, mock_client, tmp_path, monkeypatch
+    ) -> None:
+        """No flag, no payload user_id, no env var → validation error."""
+        monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
+        payload_file = self._write_payload(tmp_path)
+
+        result = runner.invoke(app, ["interactions", "publish", "--file", payload_file])
+
+        assert result.exit_code != 0
+        assert "REFLEXIO_USER_ID" in result.output or "user-id" in result.output.lower()
+        mock_client.publish_interaction.assert_not_called()
+
+    def test_single_turn_env_fallback(
+        self, runner, app, mock_client, monkeypatch
+    ) -> None:
+        """Single-turn mode also falls back to REFLEXIO_USER_ID when --user-id omitted."""
+        monkeypatch.setenv("REFLEXIO_USER_ID", "env-user")
+        mock_client.publish_interaction.return_value = MagicMock(
+            counts={"interactions": 2}, user_id="env-user"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "interactions",
+                "publish",
+                "--user-message",
+                "hi",
+                "--agent-response",
+                "hello",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_client.publish_interaction.call_args.kwargs["user_id"] == "env-user"

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -16,6 +16,7 @@ from reflexio.cli.commands.setup_cmd import (
     _install_openclaw_integration,
     _prompt_install_location,
     _prompt_storage,
+    _prompt_user_id,
     _remove_from_dir,
     _set_env_var,
     _write_marker,
@@ -329,9 +330,7 @@ class TestInstallClaudeCodeIntegration:
         _install_claude_code_integration(
             tmp_path, location=InstallLocation.ALL_PROJECTS
         )
-        settings = json.loads(
-            (tmp_path / ".claude" / "settings.json").read_text()
-        )
+        settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
         assert "SessionStart" in settings["hooks"]
         assert "UserPromptSubmit" in settings["hooks"]
 
@@ -341,9 +340,7 @@ class TestInstallClaudeCodeIntegration:
             _install_claude_code_integration(
                 tmp_path, location=InstallLocation.ALL_PROJECTS
             )
-        settings = json.loads(
-            (tmp_path / ".claude" / "settings.json").read_text()
-        )
+        settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
         # Each event should have exactly one hook entry
         assert len(settings["hooks"]["SessionStart"]) == 1
         assert len(settings["hooks"]["UserPromptSubmit"]) == 1
@@ -357,7 +354,9 @@ class TestInstallClaudeCodeIntegration:
 class TestUninstallDetection:
     """Covers marker-based install detection and removal."""
 
-    def test_detect_no_installs(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_detect_no_installs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Returns empty list when nothing is installed."""
         fake_home = tmp_path / "empty_home"
         fake_home.mkdir()
@@ -365,7 +364,9 @@ class TestUninstallDetection:
         locations = _detect_install_locations(tmp_path / "project")
         assert locations == []
 
-    def test_detect_project_level(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_detect_project_level(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Detects project-level install via marker file."""
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -380,7 +381,9 @@ class TestUninstallDetection:
         assert InstallLocation.CURRENT_PROJECT in found_locs
         assert InstallLocation.ALL_PROJECTS not in found_locs
 
-    def test_detect_user_level(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_detect_user_level(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Detects user-level install via marker file in home dir."""
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -489,7 +492,10 @@ class TestInstallOpenclawIntegration:
         )
 
         with (
-            patch("reflexio.cli.commands.setup_cmd.shutil.which", return_value="/usr/bin/openclaw"),
+            patch(
+                "reflexio.cli.commands.setup_cmd.shutil.which",
+                return_value="/usr/bin/openclaw",
+            ),
             patch(
                 "reflexio.cli.commands.setup_cmd.subprocess.run",
                 _make_openclaw_subprocess_stub(),
@@ -515,7 +521,10 @@ class TestInstallOpenclawIntegration:
         (skills_dir / "SKILL.md").write_text("STALE_PIP_INSTALLED_CONTENT")
 
         with (
-            patch("reflexio.cli.commands.setup_cmd.shutil.which", return_value="/usr/bin/openclaw"),
+            patch(
+                "reflexio.cli.commands.setup_cmd.shutil.which",
+                return_value="/usr/bin/openclaw",
+            ),
             patch(
                 "reflexio.cli.commands.setup_cmd.subprocess.run",
                 _make_openclaw_subprocess_stub(),
@@ -533,4 +542,101 @@ class TestInstallOpenclawIntegration:
             / "SKILL.md"
         )
         assert (skills_dir / "SKILL.md").read_text() == source_skill.read_text()
-        assert "STALE_PIP_INSTALLED_CONTENT" not in (skills_dir / "SKILL.md").read_text()
+        assert (
+            "STALE_PIP_INSTALLED_CONTENT" not in (skills_dir / "SKILL.md").read_text()
+        )
+
+
+# ---------------------------------------------------------------------------
+# _prompt_user_id — optional custom user_id during Claude Code setup
+# ---------------------------------------------------------------------------
+
+
+class TestPromptUserId:
+    """Tests for _prompt_user_id: default, custom value, whitespace, env-driven default."""
+
+    def test_default_is_persisted_when_user_accepts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pressing Enter keeps the fallback 'claude-code'."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
+        monkeypatch.setattr(typer, "prompt", lambda *_, **kwargs: kwargs["default"])
+
+        result = _prompt_user_id(env)
+
+        assert result == "claude-code"
+        assert 'REFLEXIO_USER_ID="claude-code"' in env.read_text()
+
+    def test_custom_value_is_persisted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A user-entered value is persisted verbatim."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
+        monkeypatch.setattr(typer, "prompt", _fixed_prompt("alice"))
+
+        result = _prompt_user_id(env)
+
+        assert result == "alice"
+        assert 'REFLEXIO_USER_ID="alice"' in env.read_text()
+
+    def test_whitespace_is_stripped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Surrounding whitespace is trimmed before persistence."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
+        monkeypatch.setattr(typer, "prompt", _fixed_prompt("  bob  "))
+
+        result = _prompt_user_id(env)
+
+        assert result == "bob"
+        assert 'REFLEXIO_USER_ID="bob"' in env.read_text()
+
+    def test_existing_env_value_offered_as_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-running setup offers the currently configured user_id as the default."""
+        env = tmp_path / ".env"
+        env.write_text('REFLEXIO_USER_ID="alice"\n')
+        monkeypatch.setenv("REFLEXIO_USER_ID", "alice")
+
+        captured: dict[str, object] = {}
+
+        def _fake_prompt(*_: object, **kwargs: object) -> object:
+            captured.update(kwargs)
+            return kwargs["default"]
+
+        monkeypatch.setattr(typer, "prompt", _fake_prompt)
+
+        result = _prompt_user_id(env)
+
+        assert captured["default"] == "alice"
+        assert result == "alice"
+
+    def test_empty_input_falls_back_to_default(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the user somehow submits an empty/whitespace-only string, fall back."""
+        env = tmp_path / ".env"
+        env.write_text("")
+        monkeypatch.delenv("REFLEXIO_USER_ID", raising=False)
+        monkeypatch.setattr(typer, "prompt", _fixed_prompt("   "))
+
+        result = _prompt_user_id(env)
+
+        assert result == "claude-code"
+        assert 'REFLEXIO_USER_ID="claude-code"' in env.read_text()
+
+
+def _fixed_prompt(return_value: str):
+    """Build a typer.prompt stub that returns a fixed value, ignoring args/kwargs."""
+
+    def _stub(*_args: object, **_kwargs: object) -> str:
+        return return_value
+
+    return _stub


### PR DESCRIPTION
## Summary
- Makes `REFLEXIO_USER_ID` configurable during Claude Code setup instead of being hardcoded to `claude-code`.
- Lets `reflexio publish` fall back to the env var when no `--user-id` flag or payload field is provided (matches existing `reflexio search` behavior).
- Teaches the Claude Code hooks (`handler.js`, `search_hook.js`) to read `REFLEXIO_USER_ID` from `~/.reflexio/.env` when the process env doesn't have it.

## Changes
**CLI**
- `setup_cmd.py`: new `_prompt_user_id` helper; setup now interactively prompts for `REFLEXIO_USER_ID` (default `claude-code`, or the currently configured value when re-running) and includes it in the summary.
- `interactions.py`: `publish` resolves user_id from payload > `--user-id` > `REFLEXIO_USER_ID` env; error messages updated.

**Hooks**
- `search_hook.js`: generalized `readEnvUrl` → `readEnvVar(key)`; uses it to resolve `REFLEXIO_USER_ID`.
- `handler.js`: added `readEnvVar` and uses it for `REFLEXIO_USER_ID` / `REFLEXIO_AGENT_VERSION`.

**Docs / skills**
- `integrations/claude_code/README.md`: documents the new prompt and the env-var fallback for publish/search.
- `commands/reflexio-extract/SKILL.md`, `skill/SKILL-expert.md`: drop hardcoded `user_id` from example payloads and `reflexio publish` flags.

**Tests**
- New `TestPublishUserIdResolution` class covering payload > flag > env > error precedence in both single-turn and file-payload modes.
- New `TestPromptUserId` class covering default acceptance, custom value, whitespace handling, env-driven default, and empty-input fallback.

## Test Plan
- [x] `uv run ruff check` / `ruff format` pass on changed files
- [ ] `uv run pytest tests/cli/test_commands.py tests/cli/test_setup_cmd.py`
- [x] Manually re-run `reflexio setup claude-code` and confirm the prompt accepts a custom user_id and persists it to `.env`
- [ ] Manually run `reflexio publish --file payload.json` with `REFLEXIO_USER_ID` set and confirm it resolves without `--user-id`
