### PR TITLE
feat: add PUT /api/update_user_profile endpoint

### DIFF
--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -2,6 +2,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+from datetime import UTC, datetime
+
 from reflexio.lib._base import (
     STORAGE_NOT_CONFIGURED_MSG,
     ReflexioBase,
@@ -13,6 +15,8 @@ from reflexio.models.api_schema.retriever_schema import (
     GetUserProfilesResponse,
     SearchUserProfileRequest,
     SearchUserProfileResponse,
+    UpdateUserProfileRequest,
+    UpdateUserProfileResponse,
 )
 from reflexio.models.api_schema.service_schemas import (
     AddUserProfileRequest,
@@ -107,6 +111,55 @@ class ProfilesMixin(ReflexioBase):
             request = DeleteUserProfileRequest(**request)
         self._get_storage().delete_user_profile(request)
         return DeleteUserProfileResponse(success=True, message="Deleted successfully")
+
+    @_require_storage(UpdateUserProfileResponse, msg_field="msg")
+    def update_user_profile(
+        self,
+        request: UpdateUserProfileRequest | dict,
+    ) -> UpdateUserProfileResponse:
+        """Apply a partial update to an existing user profile.
+
+        Fetches the current profile by ``(user_id, profile_id)``, applies the
+        non-None fields from ``request``, refreshes ``last_modified_timestamp``,
+        and persists the whole record via
+        :meth:`BaseStorage.update_user_profile_by_id`. The storage layer
+        regenerates the embedding for the updated content.
+
+        Args:
+            request (Union[UpdateUserProfileRequest, dict]): The update request.
+                ``user_id`` and ``profile_id`` are required; ``content`` and
+                ``custom_features`` are optional — only non-None fields are
+                applied.
+
+        Returns:
+            UpdateUserProfileResponse: ``success=True`` when the profile was
+                updated, ``success=False`` with a descriptive ``msg`` when it
+                could not be found.
+        """
+        if isinstance(request, dict):
+            request = UpdateUserProfileRequest(**request)
+        storage = self._get_storage()
+        profiles = storage.get_user_profile(request.user_id)
+        existing = next(
+            (p for p in profiles if p.profile_id == request.profile_id), None
+        )
+        if existing is None:
+            return UpdateUserProfileResponse(
+                success=False,
+                msg=(
+                    f"Profile not found: user_id={request.user_id!r} "
+                    f"profile_id={request.profile_id!r}"
+                ),
+            )
+        if request.content is not None:
+            existing.content = request.content
+        if request.custom_features is not None:
+            existing.custom_features = request.custom_features
+        existing.last_modified_timestamp = int(datetime.now(UTC).timestamp())
+        storage.update_user_profile_by_id(request.user_id, request.profile_id, existing)
+        return UpdateUserProfileResponse(
+            success=True, msg="User profile updated successfully"
+        )
 
     @_require_storage(BulkDeleteResponse)
     def delete_all_profiles_bulk(self) -> BulkDeleteResponse:

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -345,6 +345,25 @@ class UpdateUserPlaybookResponse(BaseModel):
     msg: str | None = None
 
 
+class UpdateUserProfileRequest(BaseModel):
+    """Partial update for an existing user profile.
+
+    Only non-None fields are applied. ``user_id`` and ``profile_id`` are
+    required; all other fields are optional, matching the UI edit flow
+    where the user typically changes ``content`` and/or ``custom_features``.
+    """
+
+    user_id: str
+    profile_id: str
+    content: str | None = None
+    custom_features: dict[str, object] | None = None
+
+
+class UpdateUserProfileResponse(BaseModel):
+    success: bool
+    msg: str | None = None
+
+
 class TimeSeriesDataPoint(BaseModel):
     """A single data point in a time series."""
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -53,6 +53,8 @@ from reflexio.models.api_schema.retriever_schema import (
     UpdatePlaybookStatusResponse,
     UpdateUserPlaybookRequest,
     UpdateUserPlaybookResponse,
+    UpdateUserProfileRequest,
+    UpdateUserProfileResponse,
 )
 from reflexio.models.api_schema.service_schemas import (
     AddAgentPlaybookRequest,
@@ -1214,6 +1216,27 @@ def update_user_playbook_endpoint(
         UpdateUserPlaybookResponse: Response containing success status and message
     """
     return publisher_api.update_user_playbook(org_id=org_id, request=request)
+
+
+@core_router.put(
+    "/api/update_user_profile",
+    response_model=UpdateUserProfileResponse,
+    response_model_exclude_none=True,
+)
+def update_user_profile_endpoint(
+    request: UpdateUserProfileRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> UpdateUserProfileResponse:
+    """Apply a partial update to an existing user profile.
+
+    Args:
+        request (UpdateUserProfileRequest): The update request
+        org_id (str): Organization ID
+
+    Returns:
+        UpdateUserProfileResponse: Response containing success status and message
+    """
+    return publisher_api.update_user_profile(org_id=org_id, request=request)
 
 
 @core_router.post(

--- a/reflexio/server/api_endpoints/publisher_api.py
+++ b/reflexio/server/api_endpoints/publisher_api.py
@@ -11,6 +11,8 @@ from reflexio.models.api_schema.retriever_schema import (
     UpdatePlaybookStatusResponse,
     UpdateUserPlaybookRequest,
     UpdateUserPlaybookResponse,
+    UpdateUserProfileRequest,
+    UpdateUserProfileResponse,
 )
 from reflexio.models.api_schema.service_schemas import (
     AddAgentPlaybookRequest,
@@ -486,3 +488,23 @@ def update_user_playbook(
     except Exception as e:
         logger.error("Failed to update user playbook: %s", e)
         return UpdateUserPlaybookResponse(success=False, msg=str(e))
+
+
+def update_user_profile(
+    org_id: str, request: UpdateUserProfileRequest
+) -> UpdateUserProfileResponse:
+    """Apply a partial update to an existing user profile.
+
+    Args:
+        org_id (str): Organization ID
+        request (UpdateUserProfileRequest): The update request
+
+    Returns:
+        UpdateUserProfileResponse: Response containing success status and message
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    try:
+        return reflexio.update_user_profile(request)
+    except Exception as e:
+        logger.error("Failed to update user profile: %s", e)
+        return UpdateUserProfileResponse(success=False, msg=str(e))

--- a/tests/lib/test_profiles_unit.py
+++ b/tests/lib/test_profiles_unit.py
@@ -14,6 +14,7 @@ from reflexio.lib._profiles import ProfilesMixin
 from reflexio.models.api_schema.retriever_schema import (
     GetUserProfilesRequest,
     SearchUserProfileRequest,
+    UpdateUserProfileRequest,
 )
 from reflexio.models.api_schema.service_schemas import (
     AddUserProfileRequest,
@@ -673,3 +674,102 @@ class TestDowngradeAllProfiles:
         call_arg = mock_service.run_downgrade.call_args[0][0]
         assert isinstance(call_arg, DowngradeProfilesRequest)
         assert call_arg.only_affected_users is False
+
+
+# ---------------------------------------------------------------------------
+# update_user_profile
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateUserProfile:
+    def test_updates_content(self):
+        """Applies content update and calls storage.update_user_profile_by_id."""
+        mixin = _make_mixin()
+        existing = _sample_profile(profile_id="p1", user_id="user1", content="old")
+        _get_storage(mixin).get_user_profile.return_value = [existing]
+
+        response = mixin.update_user_profile(
+            UpdateUserProfileRequest(
+                user_id="user1", profile_id="p1", content="new content"
+            )
+        )
+
+        assert response.success is True
+        storage = _get_storage(mixin)
+        storage.update_user_profile_by_id.assert_called_once()
+        _user_id, _profile_id, new_profile = (
+            storage.update_user_profile_by_id.call_args[0]
+        )
+        assert _user_id == "user1"
+        assert _profile_id == "p1"
+        assert new_profile.content == "new content"
+
+    def test_updates_custom_features(self):
+        """Applies custom_features update while preserving content."""
+        mixin = _make_mixin()
+        existing = _sample_profile(profile_id="p1", user_id="user1", content="original")
+        _get_storage(mixin).get_user_profile.return_value = [existing]
+
+        response = mixin.update_user_profile(
+            UpdateUserProfileRequest(
+                user_id="user1",
+                profile_id="p1",
+                custom_features={"tier": "pro"},
+            )
+        )
+
+        assert response.success is True
+        _, _, new_profile = _get_storage(mixin).update_user_profile_by_id.call_args[0]
+        assert new_profile.content == "original"
+        assert new_profile.custom_features == {"tier": "pro"}
+
+    def test_profile_not_found_returns_failure(self):
+        """Returns success=False with descriptive msg when no matching profile."""
+        mixin = _make_mixin()
+        _get_storage(mixin).get_user_profile.return_value = []
+
+        response = mixin.update_user_profile(
+            UpdateUserProfileRequest(user_id="missing", profile_id="p1")
+        )
+
+        assert response.success is False
+        assert "not found" in (response.msg or "").lower()
+        _get_storage(mixin).update_user_profile_by_id.assert_not_called()
+
+    def test_profile_mismatch_returns_failure(self):
+        """Does not update when user has profiles but profile_id doesn't match."""
+        mixin = _make_mixin()
+        _get_storage(mixin).get_user_profile.return_value = [
+            _sample_profile(profile_id="other", user_id="user1")
+        ]
+
+        response = mixin.update_user_profile(
+            UpdateUserProfileRequest(user_id="user1", profile_id="p1")
+        )
+
+        assert response.success is False
+        _get_storage(mixin).update_user_profile_by_id.assert_not_called()
+
+    def test_storage_not_configured(self):
+        """Returns success=False when storage is not configured."""
+        mixin = _make_mixin(storage_configured=False)
+
+        response = mixin.update_user_profile(
+            UpdateUserProfileRequest(user_id="u", profile_id="p")
+        )
+
+        assert response.success is False
+        assert response.msg == STORAGE_NOT_CONFIGURED_MSG
+
+    def test_dict_input(self):
+        """Accepts dict input and auto-converts to UpdateUserProfileRequest."""
+        mixin = _make_mixin()
+        _get_storage(mixin).get_user_profile.return_value = [
+            _sample_profile(profile_id="p1", user_id="user1")
+        ]
+
+        response = mixin.update_user_profile(
+            {"user_id": "user1", "profile_id": "p1", "content": "updated"}
+        )
+
+        assert response.success is True

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 from reflexio.models.api_schema.retriever_schema import (
     SearchInteractionResponse,
     SearchUserProfileResponse,
+    UpdateUserProfileResponse,
 )
 from reflexio.models.api_schema.service_schemas import (
     PublishUserInteractionResponse,
@@ -129,4 +130,40 @@ class TestSearchEndpoints:
 
     def test_search_profiles_missing_body_returns_422(self, client):
         response = client.post("/api/search_profiles")
+        assert response.status_code == 422
+
+
+class TestUpdateUserProfileRoute:
+    """Tests for PUT /api/update_user_profile."""
+
+    def test_dispatches_to_publisher_api(self, client):
+        mock_response = UpdateUserProfileResponse(
+            success=True, msg="User profile updated successfully"
+        )
+        with patch(
+            "reflexio.server.api_endpoints.publisher_api.update_user_profile",
+            return_value=mock_response,
+        ) as mock_dispatch:
+            response = client.put(
+                "/api/update_user_profile",
+                json={
+                    "user_id": "user-1",
+                    "profile_id": "p1",
+                    "content": "updated content",
+                },
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert mock_dispatch.call_count == 1
+        kwargs = mock_dispatch.call_args.kwargs
+        assert kwargs["org_id"] == "test-org"
+        assert kwargs["request"].profile_id == "p1"
+        assert kwargs["request"].content == "updated content"
+
+    def test_missing_required_fields_returns_422(self, client):
+        response = client.put(
+            "/api/update_user_profile",
+            json={"user_id": "user-1"},  # profile_id missing
+        )
         assert response.status_code == 422


### PR DESCRIPTION
## Summary

Adds `PUT /api/update_user_profile` to fix a pre-existing bug: the frontend (`website/lib/api.ts:updateProfile`) has been calling this endpoint since the shareable-public-links PR introduced the profile-edit UI, but the backend route was never wired — every edit returned 404.

## Changes

- **Schema** (`models/api_schema/retriever_schema.py`): `UpdateUserProfileRequest` / `UpdateUserProfileResponse`. Required: `user_id`, `profile_id`. Optional: `content`, `custom_features` (matches the frontend TS types exactly).
- **ProfilesMixin.update_user_profile** (`lib/_profiles.py`): fetches the existing profile via `storage.get_user_profile(user_id)`, applies non-None fields, refreshes `last_modified_timestamp`, and delegates to `storage.update_user_profile_by_id`. Returns `success=False` with a descriptive message when the profile can't be found.
- **Dispatcher** (`server/api_endpoints/publisher_api.py`): `update_user_profile(org_id, request)` wrapping the mixin call with the standard try/except + error logging.
- **Route** (`server/api.py`): `PUT /api/update_user_profile` mirroring the existing `update_user_playbook` pattern.
- **Storage layer is unchanged** — `update_user_profile_by_id` already exists on SQLite, Supabase, and Disk.

## Test plan

- [x] `uv run pytest tests/lib/test_profiles_unit.py -k TestUpdateUserProfile -v` — 6 unit tests (content update, custom_features update, missing profile, profile_id mismatch, storage not configured, dict input)
- [x] `uv run pytest tests/server/api_endpoints/test_api_routes.py -k TestUpdateUserProfileRoute -v` — 2 integration tests (route dispatches; 422 on missing fields)
- [x] Full sweep `tests/server/api_endpoints/` + `tests/lib/test_profiles_unit.py` — 118/118 pass, no regressions
- [x] `ruff check` / `ruff format --check` — clean
- [ ] Manual: click "edit" on a profile in the UI → save → backend log shows 200 on `PUT /api/update_user_profile` → profile content updated in storage
