### PR TITLE
feat: SessionEnd hook, expert skill restructure, cache invalidation, CLI fix

### DIFF
--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -18,7 +18,7 @@ from reflexio.cli.output import (
     print_interactions,
     render,
 )
-from reflexio.cli.state import get_client, resolve_agent_version
+from reflexio.cli.state import get_client, require_user_id, resolve_agent_version
 from reflexio.models.api_schema.service_schemas import (
     InteractionData,
     PublishUserInteractionResponse,
@@ -391,7 +391,8 @@ def list_interactions(
 ) -> None:
     """List interactions, optionally filtered by user."""
     client = get_client(ctx)
-    result = client.get_interactions(user_id=user_id, top_k=limit)
+    resolved_user_id = require_user_id(user_id, command_hint="interactions list")
+    result = client.get_interactions(user_id=resolved_user_id, top_k=limit)
     interactions = result.interactions or []
 
     json_mode: bool = ctx.obj.json_mode

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -826,12 +826,19 @@ def _install_claude_code_integration(
     rules_dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(rules_src, rules_dest)
 
-    # Expert mode: also install /reflexio-extract command
+    # Expert mode: also install /reflexio-extract command and skill references
     if expert:
         cmd_src = integration_dir / "commands" / "reflexio-extract" / "SKILL.md"
         cmd_dest = claude_dir / "commands" / "reflexio-extract" / "SKILL.md"
         cmd_dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(cmd_src, cmd_dest)
+
+        refs_src = integration_dir / "skill" / "references"
+        if refs_src.exists():
+            refs_dest = claude_dir / "skills" / "reflexio" / "references"
+            if refs_dest.exists():
+                shutil.rmtree(refs_dest)
+            shutil.copytree(refs_src, refs_dest)
 
     # Configure hook
     handler_js = integration_dir / "hook" / "handler.js"

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -685,22 +685,25 @@ def _upsert_hook(hooks: dict, event_name: str, hook_command: str) -> None:
     event_hooks.append(hook_entry)
 
 
-def _merge_hook_config(settings_path: Path, handler_js_path: Path) -> None:
+def _merge_hook_config(
+    settings_path: Path, handler_js_path: Path, *, expert: bool = False
+) -> None:
     """Add or update Reflexio hooks in .claude/settings.json.
 
-    Installs two hooks:
+    Installs two hooks (three in expert mode):
     - SessionStart: checks if the Reflexio server is running and starts it in
       the background if not (~10ms, non-blocking).
-    - UserPromptSubmit: runs `reflexio search` on every user prompt and injects
+    - UserPromptSubmit: runs ``reflexio search`` on every user prompt and injects
       results as context Claude sees.
 
-    No Stop hook is installed — conversation capture is handled by the expert
-    skill's mid-session publish or by an explicit `/reflexio-extract` command,
-    giving the user control over when to extract learnings.
+    In expert mode, also installs a Stop hook that captures the full session
+    transcript on exit as a safety net — ensures learnings are extracted even
+    when the user doesn't manually invoke ``/reflexio-extract``.
 
     Args:
         settings_path: Path to the project's .claude/settings.json.
         handler_js_path: Absolute path to handler.js in the installed package.
+        expert: When True, also install the Stop hook for session capture.
     """
     settings: dict = {}
     if settings_path.exists():
@@ -716,6 +719,10 @@ def _merge_hook_config(settings_path: Path, handler_js_path: Path) -> None:
     # Search hook (UserPromptSubmit) — injects Reflexio context before Claude responds
     search_hook_js = handler_js_path.parent / "search_hook.js"
     _upsert_hook(hooks, "UserPromptSubmit", f"node {search_hook_js}")
+
+    # Stop hook (Stop) — captures full session transcript on exit (expert mode only)
+    if expert:
+        _upsert_hook(hooks, "Stop", f"node {handler_js_path}")
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
@@ -829,7 +836,7 @@ def _install_claude_code_integration(
     # Configure hook
     handler_js = integration_dir / "hook" / "handler.js"
     settings_path = claude_dir / "settings.json"
-    _merge_hook_config(settings_path, handler_js)
+    _merge_hook_config(settings_path, handler_js, expert=expert)
 
     # Write marker for uninstall auto-detection
     marker_path = claude_dir / "skills" / "reflexio" / _MARKER_FILENAME
@@ -1078,7 +1085,10 @@ def claude_code_setup(
     typer.echo(f"  Storage: {storage_label}")
     typer.echo(f"  User ID: {user_id}")
     typer.echo(f"  Skill ({skill_type}): {skill_path}")
-    typer.echo("  Hooks: SessionStart + UserPromptSubmit")
+    hooks_list = "SessionStart + UserPromptSubmit"
+    if expert:
+        hooks_list += " + Stop"
+    typer.echo(f"  Hooks: {hooks_list}")
     if location == InstallLocation.ALL_PROJECTS:
         typer.echo("")
         typer.echo("Note: User-level hooks fire for ALL Claude Code sessions.")

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import shlex
 import shutil
 import subprocess
 from enum import Enum
@@ -685,6 +686,24 @@ def _upsert_hook(hooks: dict, event_name: str, hook_command: str) -> None:
     event_hooks.append(hook_entry)
 
 
+def _remove_reflexio_hook(hooks: dict, event_name: str) -> None:
+    """Remove any Reflexio hook entry for the given event.
+
+    Args:
+        hooks: The hooks dict from settings.json.
+        event_name: The hook event name to clean up.
+    """
+    if event_name not in hooks:
+        return
+    hooks[event_name] = [
+        entry
+        for entry in hooks[event_name]
+        if not any("reflexio" in h.get("command", "") for h in entry.get("hooks", []))
+    ]
+    if not hooks[event_name]:
+        del hooks[event_name]
+
+
 def _merge_hook_config(
     settings_path: Path, handler_js_path: Path, *, expert: bool = False
 ) -> None:
@@ -714,15 +733,23 @@ def _merge_hook_config(
 
     # Session start hook (SessionStart) — checks/starts Reflexio server proactively
     session_start_hook_sh = handler_js_path.parent / "session_start_hook.sh"
-    _upsert_hook(hooks, "SessionStart", f"bash {session_start_hook_sh}")
+    _upsert_hook(
+        hooks, "SessionStart", f"bash {shlex.quote(str(session_start_hook_sh))}"
+    )
 
     # Search hook (UserPromptSubmit) — injects Reflexio context before Claude responds
     search_hook_js = handler_js_path.parent / "search_hook.js"
-    _upsert_hook(hooks, "UserPromptSubmit", f"node {search_hook_js}")
+    _upsert_hook(
+        hooks, "UserPromptSubmit", f"node {shlex.quote(str(search_hook_js))}"
+    )
 
     # SessionEnd hook — captures full session transcript on exit (expert mode only)
     if expert:
-        _upsert_hook(hooks, "SessionEnd", f"node {handler_js_path}")
+        _upsert_hook(
+            hooks, "SessionEnd", f"node {shlex.quote(str(handler_js_path))}"
+        )
+    else:
+        _remove_reflexio_hook(hooks, "SessionEnd")
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
@@ -827,18 +854,24 @@ def _install_claude_code_integration(
     shutil.copy2(rules_src, rules_dest)
 
     # Expert mode: also install /reflexio-extract command and skill references
+    # Normal mode: remove expert-only artifacts from any prior expert install
+    cmd_dir = claude_dir / "commands" / "reflexio-extract"
+    refs_dir = claude_dir / "skills" / "reflexio" / "references"
     if expert:
         cmd_src = integration_dir / "commands" / "reflexio-extract" / "SKILL.md"
-        cmd_dest = claude_dir / "commands" / "reflexio-extract" / "SKILL.md"
-        cmd_dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(cmd_src, cmd_dest)
+        cmd_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(cmd_src, cmd_dir / "SKILL.md")
 
         refs_src = integration_dir / "skill" / "references"
         if refs_src.exists():
-            refs_dest = claude_dir / "skills" / "reflexio" / "references"
-            if refs_dest.exists():
-                shutil.rmtree(refs_dest)
-            shutil.copytree(refs_src, refs_dest)
+            if refs_dir.exists():
+                shutil.rmtree(refs_dir)
+            shutil.copytree(refs_src, refs_dir)
+    else:
+        if cmd_dir.exists():
+            shutil.rmtree(cmd_dir)
+        if refs_dir.exists():
+            shutil.rmtree(refs_dir)
 
     # Configure hook
     handler_js = integration_dir / "hook" / "handler.js"

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -696,14 +696,14 @@ def _merge_hook_config(
     - UserPromptSubmit: runs ``reflexio search`` on every user prompt and injects
       results as context Claude sees.
 
-    In expert mode, also installs a Stop hook that captures the full session
+    In expert mode, also installs a SessionEnd hook that captures the full session
     transcript on exit as a safety net — ensures learnings are extracted even
     when the user doesn't manually invoke ``/reflexio-extract``.
 
     Args:
         settings_path: Path to the project's .claude/settings.json.
         handler_js_path: Absolute path to handler.js in the installed package.
-        expert: When True, also install the Stop hook for session capture.
+        expert: When True, also install the SessionEnd hook for session capture.
     """
     settings: dict = {}
     if settings_path.exists():
@@ -720,9 +720,9 @@ def _merge_hook_config(
     search_hook_js = handler_js_path.parent / "search_hook.js"
     _upsert_hook(hooks, "UserPromptSubmit", f"node {search_hook_js}")
 
-    # Stop hook (Stop) — captures full session transcript on exit (expert mode only)
+    # SessionEnd hook — captures full session transcript on exit (expert mode only)
     if expert:
-        _upsert_hook(hooks, "Stop", f"node {handler_js_path}")
+        _upsert_hook(hooks, "SessionEnd", f"node {handler_js_path}")
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     settings_path.write_text(json.dumps(settings, indent=2) + "\n")
@@ -745,7 +745,7 @@ def _remove_hook_config(settings_path: Path) -> None:
     if not hooks:
         return
 
-    for event_name in ["Stop", "UserPromptSubmit", "SessionStart"]:
+    for event_name in ["SessionEnd", "Stop", "UserPromptSubmit", "SessionStart"]:
         event_hooks = hooks.get(event_name, [])
         hooks[event_name] = [
             entry
@@ -1087,7 +1087,7 @@ def claude_code_setup(
     typer.echo(f"  Skill ({skill_type}): {skill_path}")
     hooks_list = "SessionStart + UserPromptSubmit"
     if expert:
-        hooks_list += " + Stop"
+        hooks_list += " + SessionEnd"
     typer.echo(f"  Hooks: {hooks_list}")
     if location == InstallLocation.ALL_PROJECTS:
         typer.echo("")

--- a/reflexio/client/cache.py
+++ b/reflexio/client/cache.py
@@ -103,6 +103,7 @@ class InMemoryCache:
         with self._lock:
             self._cache[cache_key] = {
                 "data": value,
+                "method_name": method_name,
                 "timestamp": datetime.now(),
                 "expires_at": datetime.now() + timedelta(seconds=self._ttl_seconds),
             }
@@ -110,6 +111,30 @@ class InMemoryCache:
             # Cleanup expired entries periodically (every 100 sets)
             if len(self._cache) % 100 == 0:
                 self._cleanup_expired()
+
+    def clear(self) -> None:
+        """Remove all entries from the cache."""
+        with self._lock:
+            self._cache.clear()
+
+    def invalidate(self, method_name: str) -> int:
+        """Remove all entries cached under a given method name.
+
+        Args:
+            method_name: The method name whose entries should be removed.
+
+        Returns:
+            int: Number of entries removed.
+        """
+        with self._lock:
+            keys_to_remove = [
+                key
+                for key, entry in self._cache.items()
+                if entry.get("method_name") == method_name
+            ]
+            for key in keys_to_remove:
+                del self._cache[key]
+            return len(keys_to_remove)
 
     def _cleanup_expired(self) -> None:
         """

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -440,9 +440,12 @@ class ReflexioClient:
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
         )
-        return self._publish_interaction_sync(
+        result = self._publish_interaction_sync(
             request, wait_for_response=wait_for_response
         )
+        self._cache.invalidate("get_profiles")
+        self._cache.invalidate("get_agent_playbooks")
+        return result
 
     def search_interactions(
         self,
@@ -706,6 +709,7 @@ class ReflexioClient:
             search_query=search_query,
         )
 
+        self._cache.invalidate("get_profiles")
         if wait_for_response:
             # Synchronous blocking call
             return self._delete_profile_sync(request)
@@ -898,6 +902,7 @@ class ReflexioClient:
         """
         request = DeleteAgentPlaybookRequest(agent_playbook_id=agent_playbook_id)
 
+        self._cache.invalidate("get_agent_playbooks")
         if wait_for_response:
             # Synchronous blocking call
             return self._delete_agent_playbook_sync(request)
@@ -1388,6 +1393,7 @@ class ReflexioClient:
             "/api/update_agent_playbook",
             json=request.model_dump(),
         )
+        self._cache.invalidate("get_agent_playbooks")
         return UpdateAgentPlaybookResponse(**response)
 
     def update_agent_playbook_status(
@@ -1421,6 +1427,7 @@ class ReflexioClient:
             "/api/update_agent_playbook_status",
             json=request.model_dump(),
         )
+        self._cache.invalidate("get_agent_playbooks")
         return UpdatePlaybookStatusResponse(**response)
 
     def get_agent_playbooks(
@@ -2069,6 +2076,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE", "/api/delete_profiles_by_ids", json=req.model_dump()
         )
+        self._cache.invalidate("get_profiles")
         return BulkDeleteResponse(**response)
 
     def delete_agent_playbooks_by_ids(
@@ -2086,6 +2094,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE", "/api/delete_agent_playbooks_by_ids", json=req.model_dump()
         )
+        self._cache.invalidate("get_agent_playbooks")
         return BulkDeleteResponse(**response)
 
     def delete_user_playbooks_by_ids(
@@ -2136,6 +2145,7 @@ class ReflexioClient:
             BulkDeleteResponse: Response containing success status and deleted count
         """
         response = self._make_request("DELETE", "/api/delete_all_interactions")
+        self._cache.clear()
         return BulkDeleteResponse(**response)
 
     def delete_all_profiles(self) -> BulkDeleteResponse:
@@ -2145,6 +2155,7 @@ class ReflexioClient:
             BulkDeleteResponse: Response containing success status and deleted count
         """
         response = self._make_request("DELETE", "/api/delete_all_profiles")
+        self._cache.invalidate("get_profiles")
         return BulkDeleteResponse(**response)
 
     def delete_all_playbooks(self) -> BulkDeleteResponse:
@@ -2158,6 +2169,7 @@ class ReflexioClient:
             BulkDeleteResponse: Response containing success status and deleted count
         """
         response = self._make_request("DELETE", "/api/delete_all_playbooks")
+        self._cache.clear()
         return BulkDeleteResponse(**response)
 
     def delete_all_user_playbooks(self) -> BulkDeleteResponse:
@@ -2167,7 +2179,7 @@ class ReflexioClient:
             BulkDeleteResponse: Response containing success status and deleted count
         """
         response = self._make_request("DELETE", "/api/delete_all_user_playbooks")
-        return BulkDeleteResponse(**response)
+        return BulkDeleteResponse(**response)  # user playbooks not cached
 
     def delete_all_agent_playbooks(self) -> BulkDeleteResponse:
         """Delete all agent playbooks (agent only, not user).
@@ -2176,4 +2188,5 @@ class ReflexioClient:
             BulkDeleteResponse: Response containing success status and deleted count
         """
         response = self._make_request("DELETE", "/api/delete_all_agent_playbooks")
+        self._cache.invalidate("get_agent_playbooks")
         return BulkDeleteResponse(**response)

--- a/reflexio/integrations/claude_code/hook/HOOK.md
+++ b/reflexio/integrations/claude_code/hook/HOOK.md
@@ -31,7 +31,7 @@ This ensures the server is ready before the first `UserPromptSubmit` search hook
 ### On `SessionEnd` (session end)
 
 1. Reads the session transcript JSONL file from `transcript_path` in the event payload
-2. Extracts user queries and assistant text responses (skips thinking blocks, tool calls, system messages)
+2. Extracts user queries and assistant responses — preserves text and tool_use blocks (as `tools_used` metadata), skips thinking blocks and system messages
 3. Writes the formatted payload to a temp file
 4. Spawns a detached `reflexio interactions publish --force-extraction --file <payload>` process (fire-and-forget)
 5. Logs publish output to `~/.reflexio/logs/stop-hook.log` for diagnostics

--- a/reflexio/integrations/claude_code/hook/HOOK.md
+++ b/reflexio/integrations/claude_code/hook/HOOK.md
@@ -33,10 +33,13 @@ This ensures the server is ready before the first `UserPromptSubmit` search hook
 1. Reads the session transcript JSONL file from `transcript_path` in the event payload
 2. Extracts user queries and assistant text responses (skips thinking blocks, tool calls, system messages)
 3. Writes the formatted payload to a temp file
-4. Spawns a detached `reflexio interactions publish --file <payload>` process (fire-and-forget)
-5. Outputs `{}` on stdout and exits immediately — does not block session shutdown
+4. Spawns a detached `reflexio interactions publish --force-extraction --file <payload>` process (fire-and-forget)
+5. Logs publish output to `~/.reflexio/logs/stop-hook.log` for diagnostics
+6. Outputs `{}` on stdout and exits immediately — does not block session shutdown
 
-The Reflexio server then analyzes the conversation for learning signals (corrections, friction, re-steering) and extracts playbooks and user profiles automatically.
+The `--force-extraction` flag ensures extraction always runs, even if a mid-session publish already happened within the batch interval. The Reflexio server then analyzes the conversation for learning signals (corrections, friction, re-steering) and extracts playbooks and user profiles automatically.
+
+**Installed automatically with expert mode** (`reflexio setup claude-code --expert`). Not installed in normal mode.
 
 ## Prerequisites
 
@@ -55,7 +58,7 @@ The Reflexio server then analyzes the conversation for learning signals (correct
 
 ## Installation
 
-Run `reflexio setup claude-code` to install automatically, or add to your Claude Code `settings.json` manually:
+Run `reflexio setup claude-code` to install automatically (add `--expert` for the Stop hook), or add to your Claude Code `settings.json` manually:
 
 ```json
 {
@@ -81,6 +84,17 @@ Run `reflexio setup claude-code` to install automatically, or add to your Claude
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node /path/to/reflexio/integrations/claude_code/hook/handler.js"
+          }
+        ]
+      }
     ]
   }
 }
@@ -90,7 +104,7 @@ Run `reflexio setup claude-code` to install automatically, or add to your Claude
 
 - The SessionStart hook adds ~10ms latency — all server work runs in a background process
 - The flag file prevents concurrent server starts across hooks and sessions
-- The Stop hook checks `stop_hook_active` to prevent infinite loops
 - Publishing is fire-and-forget — failures do not affect the Claude Code session
+- Publish errors are logged to `~/.reflexio/logs/stop-hook.log` for diagnostics
 - Transcript data is written to a temp file with restricted permissions (0600)
 - The temp file is cleaned up after publishing

--- a/reflexio/integrations/claude_code/hook/HOOK.md
+++ b/reflexio/integrations/claude_code/hook/HOOK.md
@@ -1,7 +1,7 @@
 ---
 name: reflexio-hooks
 description: "Claude Code hooks for Reflexio: server auto-start, context search, and session capture"
-events: ["SessionStart", "UserPromptSubmit", "Stop"]
+events: ["SessionStart", "UserPromptSubmit", "SessionEnd"]
 requires:
   bins: ["reflexio", "node", "bash", "curl"]
 ---
@@ -28,7 +28,7 @@ This ensures the server is ready before the first `UserPromptSubmit` search hook
 2. Injects matching profiles and playbooks as context Claude sees before responding
 3. Falls back to starting the server if it is down (redundant safety net for mid-session crashes)
 
-### On `Stop` (session end)
+### On `SessionEnd` (session end)
 
 1. Reads the session transcript JSONL file from `transcript_path` in the event payload
 2. Extracts user queries and assistant text responses (skips thinking blocks, tool calls, system messages)
@@ -58,7 +58,7 @@ The `--force-extraction` flag ensures extraction always runs, even if a mid-sess
 
 ## Installation
 
-Run `reflexio setup claude-code` to install automatically (add `--expert` for the Stop hook), or add to your Claude Code `settings.json` manually:
+Run `reflexio setup claude-code` to install automatically (add `--expert` for the SessionEnd hook), or add to your Claude Code `settings.json` manually:
 
 ```json
 {
@@ -85,7 +85,7 @@ Run `reflexio setup claude-code` to install automatically (add `--expert` for th
         ]
       }
     ],
-    "Stop": [
+    "SessionEnd": [
       {
         "matcher": "",
         "hooks": [

--- a/reflexio/integrations/claude_code/hook/handler.js
+++ b/reflexio/integrations/claude_code/hook/handler.js
@@ -115,7 +115,13 @@ async function main() {
 		"sh",
 		[
 			"-c",
-			`reflexio interactions publish --user-id "${userId}" --file "${payloadFile}" --source "claude-code" --agent-version "${agentVersion}" --session-id "${sessionId || "unknown"}" --force-extraction >> "${logFile}" 2>&1 ; rm -f "${payloadFile}"`,
+			'reflexio interactions publish --user-id "$1" --file "$2" --source "claude-code" --agent-version "$3" --session-id "$4" --force-extraction >> "$5" 2>&1; rm -f "$2"',
+			"sh",
+			userId,
+			payloadFile,
+			agentVersion,
+			sessionId || "unknown",
+			logFile,
 		],
 		{
 			detached: true,

--- a/reflexio/integrations/claude_code/hook/handler.js
+++ b/reflexio/integrations/claude_code/hook/handler.js
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -20,11 +20,11 @@ import { join } from "node:path";
  * The hook reads event JSON from stdin with these fields:
  *   - session_id: string
  *   - transcript_path: string (path to .jsonl transcript file)
- *   - stop_hook_active: boolean (true if this is a hook-triggered stop)
  */
 
 const MAX_INTERACTIONS = 200;
 const MAX_CONTENT_LENGTH = 10_000;
+const LOG_DIR = join(homedir(), ".reflexio", "logs");
 
 /**
  * Read a variable from ~/.reflexio/.env when it is not set in process.env.
@@ -56,12 +56,6 @@ async function main() {
 		event = JSON.parse(input);
 	} catch {
 		console.error("[reflexio] Failed to parse event JSON from stdin");
-		output({});
-		return;
-	}
-
-	// Guard: prevent infinite loops when stop_hook_active is set
-	if (event.stop_hook_active) {
 		output({});
 		return;
 	}
@@ -115,11 +109,13 @@ async function main() {
 	// Cleanup is handled by the shell command itself (rm -f after publish),
 	// not by Node.js event handlers, since child.unref() means the parent
 	// exits before the child finishes.
+	mkdirSync(LOG_DIR, { recursive: true, mode: 0o700 });
+	const logFile = join(LOG_DIR, "stop-hook.log");
 	const child = spawn(
 		"sh",
 		[
 			"-c",
-			`reflexio interactions publish --user-id "${userId}" --file "${payloadFile}" --source "claude-code" --agent-version "${agentVersion}" --session-id "${sessionId || "unknown"}" ; rm -f "${payloadFile}"`,
+			`reflexio interactions publish --user-id "${userId}" --file "${payloadFile}" --source "claude-code" --agent-version "${agentVersion}" --session-id "${sessionId || "unknown"}" --force-extraction >> "${logFile}" 2>&1 ; rm -f "${payloadFile}"`,
 		],
 		{
 			detached: true,

--- a/reflexio/integrations/claude_code/hook/handler.js
+++ b/reflexio/integrations/claude_code/hook/handler.js
@@ -4,7 +4,7 @@ import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 /**
- * Claude Code Stop hook for Reflexio.
+ * Claude Code SessionEnd hook for Reflexio.
  *
  * Reads the full session transcript from the JSONL file provided in the
  * Stop event payload, extracts user queries and assistant text responses,
@@ -13,7 +13,7 @@ import { join } from "node:path";
  * Usage in settings.json:
  *   {
  *     "hooks": {
- *       "Stop": [{ "type": "command", "command": "node /path/to/handler.js" }]
+ *       "SessionEnd": [{ "type": "command", "command": "node /path/to/handler.js" }]
  *     }
  *   }
  *

--- a/reflexio/integrations/claude_code/rules/reflexio.md
+++ b/reflexio/integrations/claude_code/rules/reflexio.md
@@ -1,12 +1,12 @@
 # Reflexio: Cross-Session Memory
 
-This project uses Reflexio to remember corrections and preferences across sessions.
+This project uses Reflexio to remember corrections and preferences across sessions. Reflexio publishes to a server for LLM-powered extraction — it complements local memory, which is project-scoped.
 
 ## How It Works
 
 A `UserPromptSubmit` hook automatically runs `reflexio search` on every message you receive. When relevant corrections or preferences exist, they are injected as context before your response.
 
-## What You MUST Do
+## Applying Corrections from Reflexio
 
 1. **When you see a block titled "IMPORTANT: Apply These Corrections (from Reflexio)"** — read it carefully and follow every instruction it contains. These are explicit corrections from the user's past sessions. Behavior Corrections tell you what to do differently. User Preferences tell you how the user works.
 
@@ -20,4 +20,28 @@ A `UserPromptSubmit` hook automatically runs `reflexio search` on every message 
    ```
    If `REFLEXIO_URL` points to a remote server, do not attempt to start it — proceed without Reflexio results.
 
-3. **Never mention Reflexio to the user** unless they ask about it. It should be invisible.
+3. Avoid mentioning Reflexio to the user unless they ask about it. It should be invisible.
+
+## When to Publish to Reflexio
+
+Reflexio captures learnings that persist across sessions and projects via server-side LLM extraction. It complements local memory — Reflexio is cross-project, local memory is project-scoped.
+
+When the user corrects your approach, shares facts about themselves, or confirms a non-obvious procedure worked, consider publishing to Reflexio by invoking the `/reflexio` skill.
+
+### Profiles (facts — publish when stated)
+User shares a fact or preference about themselves or their environment:
+- "I'm a data scientist", "my name is David"
+- "We use polars not pandas", "I prefer tabs over spaces"
+- "The staging DB is on port 5433"
+
+### Playbooks (corrections — publish after confirmation)
+User corrects your approach or rejects a tool call, and the correction is confirmed:
+- "No, use X instead of Y", "Don't do that", "Always use Z"
+- User rejects a tool call
+- Confirmation can be explicit ("good", "thanks") or implicit (user moves on, no further correction)
+
+### Successful procedures (publish after confirmation)
+You complete a task using a non-obvious approach and the user confirms it worked.
+
+### Reflexio vs local memory
+Reflexio publishes to a server for cross-session extraction. Local memory writes files scoped to the current project. When a correction could apply beyond this project, Reflexio is the better fit.

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -1,67 +1,28 @@
 ---
 name: reflexio-expert
-description: "Publish user corrections and preferences to Reflexio cross-session memory. Profiles capture facts ('user prefers polars') — publish immediately when stated. Playbooks capture optimal procedures ('when X, do Y') — publish after user confirms the correction worked. Separate from Claude's built-in local memory — Reflexio uses LLM-powered server-side extraction across sessions."
-when_to_use: "Use when: user states a preference or fact about themselves/environment (publish profile immediately), user corrects your approach and confirms it worked (publish playbook), or you complete a task successfully and user confirms (publish playbook). Do NOT route corrections to local memory instead of Reflexio."
+description: "Use when user corrects your approach, states a preference, rejects a tool call, or when a completed correction needs publishing to cross-session memory."
 ---
 
-# Reflexio: Learn from Past Sessions (Expert)
+# Reflexio: Publish to Cross-Session Memory
 
-Reflexio remembers corrections and preferences from your past conversations with this user.
+Publish corrections and preferences to Reflexio so they persist across sessions and projects.
 
-> **Reflexio is NOT the same as Claude's built-in memory system.** Claude's memory saves local notes to files. Reflexio publishes to a server that uses LLM-powered extraction to create structured playbooks and profiles — these are retrieved via hooks and applied automatically in future sessions. When a user corrects you, publish to Reflexio first, then optionally save to local memory too.
+## Quick Reference
 
-**This skill triggers on these events (DO NOT route to local memory instead):**
-1. **User states a fact or preference** → publish profile to Reflexio **immediately** (no confirmation needed)
-2. **User corrects your approach** → apply the correction, then publish playbook after confirmation:
-   - **Explicit**: user says "good", "perfect", "yes", "thanks"
-   - **Implicit**: user moves on to next topic, ends conversation, or gives no further correction
-3. **Successful task completion** → if user confirms (explicitly or implicitly), publish the successful procedure as a playbook
+| Event | Action |
+|-------|--------|
+| User states fact/preference | Publish profile immediately |
+| User corrects you | Apply correction, publish playbook after confirmation |
+| Successful non-obvious procedure | Publish playbook after user confirms |
+| User runs `/reflexio-extract` | Full session extraction (see command) |
 
-The user can also run `/reflexio-extract` at any time to summarize the full conversation and extract learnings.
+## How to Publish
 
----
+**Step 1 — Ensure server is running** (local server only). If `REFLEXIO_URL` points to a remote server, skip this. Otherwise run `reflexio status check` and start if needed — see [references/server-management.md](references/server-management.md).
 
-## Step-by-Step: When User Gives a Task
+**Step 2 — Write and publish the payload:**
 
-Follow these steps IN ORDER:
-
-**Step 1 — Ensure server is running (local server only):**
-Check the `REFLEXIO_URL` environment variable. If it points to a remote server (anything other than `localhost` or `127.0.0.1`), **skip this step entirely** — managed Reflexio servers are always running. Go directly to Step 2.
-
-If `REFLEXIO_URL` is unset or points to localhost/127.0.0.1 (local server):
-```bash
-reflexio status check
-```
-If this fails with a connection error, start the server in a background subagent:
-```
-Agent(prompt="Start the Reflexio server: nohup reflexio services start --only backend > ~/.reflexio/logs/server.log 2>&1 & sleep 5 && reflexio status check", run_in_background=true)
-```
-Then continue to Step 2 immediately (don't wait for the subagent).
-
-**Step 2 — Search for relevant corrections:**
-```bash
-reflexio search "<the user's request or task description>"
-```
-If the server wasn't ready yet (connection error), skip this and proceed — you'll retry later.
-
-**Step 3 — Apply results and do the task:**
-- If search returned playbooks → follow the content guidance in each playbook
-- If search returned profiles → adapt your approach to the user's preferences
-- If search returned nothing or failed → proceed normally
-
----
-
-## Step-by-Step: When User Corrects You
-
-When the user corrects your approach or states a preference, follow these steps:
-
-**Step 1 — Apply the correction** to your work first.
-
-**Step 2 — Ensure server is running (local server only)** — same as Step 1 above: skip entirely if `REFLEXIO_URL` points to a remote server. For local servers, run `reflexio status check` and start if needed.
-
-**Step 3 — Publish the correction to Reflexio:**
-
-Write a summary JSON and publish it:
+For corrections (user corrected your approach):
 ```bash
 cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
 {
@@ -71,12 +32,12 @@ cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
     {"role": "user", "content": "<what the user originally asked>"},
     {
       "role": "assistant",
-      "content": "<your initial approach, INCLUDING any self-correction text you wrote like 'this isn't quite X' — preserve such phrases verbatim>",
+      "content": "<your initial approach — preserve self-correction phrases verbatim>",
       "tools_used": [
         {"tool_name": "<tool>", "tool_data": {"input": "<params> — FAILED: <exact error>  OR  — REJECTED BY USER"}}
       ]
     },
-    {"role": "user", "content": "<the user's correction — preserve their exact words; if the correction was a tool-call rejection with no words, write '[rejected tool use — see tools_used above]' and explain what the rejection was objecting to>"},
+    {"role": "user", "content": "<the user's correction — preserve exact words>"},
     {"role": "assistant", "content": "<your acknowledgment and corrected approach>"}
   ]
 }
@@ -84,34 +45,7 @@ SUMMARY_EOF
 reflexio publish --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-summary.json && rm -f /tmp/reflexio-summary.json
 ```
 
-`tools_used` is **required** on the second turn whenever the original approach involved a failed or rejected tool call — the error string or rejection moment is the evidence Reflexio needs to extract a precise behavioral rule instead of a vague profile entry. For pure-text corrections (user corrected your wording or choice with no tool friction), the field can be omitted.
-
-**Detect correction patterns:**
-
-_Verbal corrections:_
-- "No, use X instead of Y"
-- "Don't do X, always do Y"
-- "I prefer X", "Always use X in this project"
-- "That's wrong, the correct approach is..."
-
-_Non-verbal / implicit corrections (also publish these):_
-- **Tool-call rejection** — the user rejected a tool use mid-response. This is a correction even without any words; the "correction" is the rejection itself, and the thing being corrected is whatever tool call you were about to make. Record it in `tools_used` with `— REJECTED BY USER` and write `[rejected tool use — see tools_used above]` in the following user turn's `content`.
-- **Self-correction you wrote out loud** — mid-response you realized you were doing the wrong thing and said so ("actually this isn't CVR…", "I should have…"). Publish this too, because the user didn't need to correct you only because you caught it — the underlying mistake is still extractable as a rule. Preserve the self-correction sentence verbatim in the assistant turn's `content`.
-- **Repeated tool failure with user intervention** — you failed the same operation 2+ times and the user stepped in to redirect. The redirect is the correction; the failures are the context. List every failed attempt under `tools_used` on the original assistant turn.
-
-**When to publish:**
-- **Simple correction** (e.g., "always use type hints") → publish immediately, context is self-contained
-- **Multi-turn correction** (user corrects, then explains why, then adds exceptions) → wait until complete, then publish the full chain
-
-**Tip:** The user can also run `/reflexio-extract` at the end of the session to do a comprehensive extraction of all learnings — including intermediate reasoning, tool calls, and context that mid-session publishes might miss.
-
----
-
-## Step-by-Step: Proactive Extraction (High-Signal Moments)
-
-Beyond explicit corrections, certain moments during a session carry high learning value — even when the user says nothing. When you detect any of the patterns below, publish to Reflexio using the same mechanism as corrections. Do not wait for user input.
-
-**Payload format** — same as corrections, but the "user" turn is the original request (no correction needed), and the "assistant" turn captures the full failure → recovery arc:
+For proactive moments (self-recovered failure, workaround — no user correction):
 ```bash
 cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
 {
@@ -121,7 +55,7 @@ cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
     {"role": "user", "content": "<what the user originally asked>"},
     {
       "role": "assistant",
-      "content": "<what you tried, what went wrong, and how you recovered — preserve self-correction phrases verbatim>",
+      "content": "<what you tried, what went wrong, how you recovered>",
       "tools_used": [
         {"tool_name": "<tool>", "tool_data": {"input": "<params> — FAILED: <exact error>"}},
         {"tool_name": "<tool>", "tool_data": {"input": "<corrected params> — succeeded"}}
@@ -133,102 +67,32 @@ SUMMARY_EOF
 reflexio publish --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-summary.json && rm -f /tmp/reflexio-summary.json
 ```
 
-List every failed attempt in `tools_used` in chronological order, followed by the successful one. Include exact error messages verbatim — they are load-bearing evidence for extracting precise behavioral rules.
+`tools_used` is required when the approach involved a failed or rejected tool call — the error string is the evidence Reflexio needs to extract a precise behavioral rule. For pure-text corrections, the field can be omitted.
 
-### Patterns to detect and publish:
+## Correction Patterns
 
-**A. Self-recovered tool failures**
-You tried a tool call, got an error, and fixed it yourself without user input. The error message and your recovery strategy are extractable as a behavioral rule (trigger → pitfall → instruction).
+_Verbal:_ "No, use X instead", "Don't do X, always do Y", "I prefer X", "That's wrong"
 
-_Example:_ You ran a SQL query with `JOIN channels ON l.channel_id`, got `invalid identifier 'L.CHANNEL_ID'`, discovered the column is actually `l.stream_channel_id` by introspecting the schema, and rewrote the query.
+_Non-verbal:_
+- **Tool-call rejection** — user rejected a tool use. Record in `tools_used` with `— REJECTED BY USER`.
+- **Self-correction** — you caught your own mistake mid-response ("actually this isn't…", "I should have…"). Publish it — the underlying mistake is extractable even though the user didn't need to correct you.
+- **Repeated failure with user redirect** — 2+ failures, user stepped in. List all failed attempts in `tools_used`.
 
-**B. Retry chains (2+ failures on same operation)**
-You attempted the same operation 2+ times with different errors before succeeding. Each retry and the eventual fix form a learning arc. Publish the full chain as one interaction — list all attempts in `tools_used`.
+## Proactive Extraction
 
-_Example:_ File edit failed (wrong indentation), retried with different context (still wrong), then read the file first and got it right. The pattern "read before editing unfamiliar files" is extractable.
+See [references/proactive-patterns.md](references/proactive-patterns.md) for 5 high-signal patterns: self-recovered failures, retry chains, documentation gaps, workarounds, anomalous results.
 
-**C. Discovered documentation or behavior gaps**
-Tool documentation or expected behavior said X, but reality was Y. The discrepancy is a reusable rule that prevents future agents from making the same incorrect assumption.
+## End-of-Session Nudge
 
-_Example:_ API docs say `--format json` is supported, but the CLI returns `unknown flag`. You discovered `--output-format json` works instead.
-
-**D. Workarounds for limitations**
-An API, tool, or system doesn't support what you needed, so you used an alternative approach. The limitation and workaround are a reusable playbook rule.
-
-_Example:_ The database doesn't support `LATERAL JOIN`, so you rewrote the query using a correlated subquery. Or: the MCP tool doesn't accept wildcards, so you listed the directory first and filtered client-side.
-
-**E. Anomalous or implausible results**
-Results that are unexpected — zeros where you expected values, row counts that don't match documentation, mean/median divergence suggesting data skew, results that contradict what the user described. Publish how you detected the anomaly and what you did about it.
-
-_Example:_ Query returned 0 rows when the user said "we have thousands of records." You discovered the table uses soft deletes and added `WHERE deleted_at IS NULL` — or found the user was looking at a different environment.
-
-### When to publish proactively:
-
-- **Publish immediately** after recovering from the situation — don't batch multiple unrelated patterns into one publish
-- **Don't publish routine successes** — only friction, failures, surprises, and workarounds. If a tool call succeeded on the first try with no surprises, there's nothing to extract
-- **Keep the bar reasonable** — a single typo in a file path that you immediately corrected is not worth publishing. The signal is in non-obvious failures where the recovery required understanding something new about the system
-
----
-
-## End-of-Session Extraction Nudge
-
-When you detect the session is winding down — the user says "thanks", "that's all", "looks good", the task is complete, or the conversation is naturally ending — check whether the session had any friction:
-
-- Tool failures (even self-recovered ones)
-- User corrections or preference statements
-- Workarounds or unexpected behavior
-- Retry chains
-
-If **any** friction occurred during the session, proactively suggest:
+When the session winds down and there was any friction (failures, corrections, workarounds), suggest:
 
 > "This session had some learnings worth capturing. Want me to run `/reflexio-extract` to publish them for future sessions?"
 
-If the session was entirely smooth with no friction, skip the suggestion.
-
----
-
-## What Reflexio Stores
-
-**User Profiles** — stable facts learned from conversations:
-- **About the user**: expertise, background, role
-- **User preferences**: communication style, tools, conventions
-- **About the environment**: project setup, team conventions, constraints
-
-**User Playbooks** — behavioral corrections with top-level fields:
-- **trigger**: when does this rule apply?
-- **content**: the actionable behavioral rule
-- **rationale**: why the correction matters
-- **blocking_issue**: what prevents correct behavior (if applicable)
-
-You don't decide what gets extracted — the Reflexio server LLM analyzes your published summary and determines profiles vs playbooks automatically.
-
----
-
-## Server Management
-
-The Reflexio server must be running for `reflexio search` and `reflexio publish` to work.
-
-**Managed Reflexio (remote server):** If `REFLEXIO_URL` points to a non-localhost URL (e.g., `https://reflexio.ai`), the server is always running. Do NOT run `reflexio status check` or attempt to start the server. If a command fails with a connection error, report it to the user — it's a network or configuration issue, not a server-start issue.
-
-**Local server** (`REFLEXIO_URL` unset or pointing to localhost/127.0.0.1):
-
-**Check:** `reflexio status check`
-**Start (background subagent):**
-```
-Agent(prompt="Start the Reflexio server: nohup reflexio services start --only backend > ~/.reflexio/logs/server.log 2>&1 & sleep 5 && reflexio status check", run_in_background=true)
-```
-
-- Always use a background subagent to start the server — never run it in the main agent (it blocks)
-- Never ask the user to start the server — handle it silently
-- If `reflexio` is not found, ask the user to install it: `pip install reflexio-ai`
-
----
+Skip if the session was entirely smooth.
 
 ## Tips
 
-- **Use the user's actual request as the search query** — not keywords
-- **Preserve the user's exact words** in the correction summary
-- **Include enough context** — what you did wrong + the correction + why + **the evidence**. Evidence means the actual failed tool input, the exact error message, or the verbatim self-correction sentence. Without the evidence, Reflexio can only extract a vague profile entry; with the evidence, it can extract a precise playbook rule with trigger, content, rationale, and blocking_issue fields. If you're only publishing one correction, make it count by including the failure.
-- **If Reflexio is unreachable, proceed normally** — it enhances but never blocks
-- **Don't mention Reflexio to the user** unless they ask
-- **Suggest `/reflexio-extract`** at end of session if there was any friction (see End-of-Session Extraction Nudge above)
+- Preserve the user's exact words in corrections
+- Include evidence: failed tool input, exact error message, or self-correction sentence
+- If Reflexio is unreachable, proceed normally — it enhances but never blocks
+- Avoid mentioning Reflexio unless the user asks

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -1,7 +1,7 @@
 ---
 name: reflexio-expert
-description: "Publish user corrections and preferences to Reflexio cross-session memory. Profiles capture facts ('user prefers polars') — publish immediately when stated. Playbooks capture optimal procedures ('when X, do Y') — publish after user confirms the correction worked. Also search past playbooks and profiles before starting tasks. Separate from Claude's built-in local memory — Reflexio uses LLM-powered server-side extraction across sessions."
-when_to_use: "Use when: user states a preference or fact about themselves/environment (publish profile immediately), user corrects your approach and confirms it worked (publish playbook), you complete a task successfully and user confirms (publish playbook), or user gives you any task (search first). Do NOT route corrections to local memory instead of Reflexio."
+description: "Publish user corrections and preferences to Reflexio cross-session memory. Profiles capture facts ('user prefers polars') — publish immediately when stated. Playbooks capture optimal procedures ('when X, do Y') — publish after user confirms the correction worked. Separate from Claude's built-in local memory — Reflexio uses LLM-powered server-side extraction across sessions."
+when_to_use: "Use when: user states a preference or fact about themselves/environment (publish profile immediately), user corrects your approach and confirms it worked (publish playbook), or you complete a task successfully and user confirms (publish playbook). Do NOT route corrections to local memory instead of Reflexio."
 ---
 
 # Reflexio: Learn from Past Sessions (Expert)
@@ -16,7 +16,6 @@ Reflexio remembers corrections and preferences from your past conversations with
    - **Explicit**: user says "good", "perfect", "yes", "thanks"
    - **Implicit**: user moves on to next topic, ends conversation, or gives no further correction
 3. **Successful task completion** → if user confirms (explicitly or implicitly), publish the successful procedure as a playbook
-4. **Task requests** → search Reflexio for past playbooks and profiles before starting
 
 The user can also run `/reflexio-extract` at any time to summarize the full conversation and extract learnings.
 

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -1,6 +1,6 @@
 ---
 name: reflexio-expert
-description: "Search past session memory for user corrections, preferences, and project conventions, AND publish new corrections when the user says 'no, do X instead' or states a preference. Retrieves behavioral rules (e.g. 'always use type hints', 'use pnpm not npm') so you follow them from the start. Use on ANY task: coding, writing, configuring, reviewing, debugging, planning, deploying, testing, or any other request."
+description: "Search past session memory for user corrections, preferences, and project conventions. Publish corrections when the user says 'no, do X instead' or states a preference. Proactively publish high-signal moments: self-recovered tool failures, retry chains, documentation gaps, workarounds, and anomalous results. Suggest /reflexio-extract at end of session when friction occurred. Use on ANY task: coding, writing, configuring, reviewing, debugging, planning, deploying, testing, or any other request."
 ---
 
 # Reflexio: Learn from Past Sessions (Expert)

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -1,16 +1,22 @@
 ---
 name: reflexio-expert
-description: "Search past session memory for user corrections, preferences, and project conventions. Publish corrections when the user says 'no, do X instead' or states a preference. Proactively publish high-signal moments: self-recovered tool failures, retry chains, documentation gaps, workarounds, and anomalous results. Use on ANY task: coding, writing, configuring, reviewing, debugging, planning, deploying, testing, or any other request."
+description: "Publish user corrections and preferences to Reflexio cross-session memory. Profiles capture facts ('user prefers polars') — publish immediately when stated. Playbooks capture optimal procedures ('when X, do Y') — publish after user confirms the correction worked. Also search past playbooks and profiles before starting tasks. Separate from Claude's built-in local memory — Reflexio uses LLM-powered server-side extraction across sessions."
+when_to_use: "Use when: user states a preference or fact about themselves/environment (publish profile immediately), user corrects your approach and confirms it worked (publish playbook), you complete a task successfully and user confirms (publish playbook), or user gives you any task (search first). Do NOT route corrections to local memory instead of Reflexio."
 ---
 
 # Reflexio: Learn from Past Sessions (Expert)
 
 Reflexio remembers corrections and preferences from your past conversations with this user.
 
-**This skill triggers on THREE types of messages:**
-1. **Task requests** — user asks you to do something → search Reflexio first
-2. **Corrections and preferences** — user says "no, do X instead", "always use Y", "I prefer Z" → publish to Reflexio
-3. **High-signal moments** — tool failures you self-recover from, retry chains, workarounds, anomalies → publish to Reflexio
+> **Reflexio is NOT the same as Claude's built-in memory system.** Claude's memory saves local notes to files. Reflexio publishes to a server that uses LLM-powered extraction to create structured playbooks and profiles — these are retrieved via hooks and applied automatically in future sessions. When a user corrects you, publish to Reflexio first, then optionally save to local memory too.
+
+**This skill triggers on these events (DO NOT route to local memory instead):**
+1. **User states a fact or preference** → publish profile to Reflexio **immediately** (no confirmation needed)
+2. **User corrects your approach** → apply the correction, then publish playbook after confirmation:
+   - **Explicit**: user says "good", "perfect", "yes", "thanks"
+   - **Implicit**: user moves on to next topic, ends conversation, or gives no further correction
+3. **Successful task completion** → if user confirms (explicitly or implicitly), publish the successful procedure as a playbook
+4. **Task requests** → search Reflexio for past playbooks and profiles before starting
 
 The user can also run `/reflexio-extract` at any time to summarize the full conversation and extract learnings.
 

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -7,9 +7,10 @@ description: "Search past session memory for user corrections, preferences, and 
 
 Reflexio remembers corrections and preferences from your past conversations with this user.
 
-**This skill triggers on TWO types of messages:**
+**This skill triggers on THREE types of messages:**
 1. **Task requests** — user asks you to do something → search Reflexio first
 2. **Corrections and preferences** — user says "no, do X instead", "always use Y", "I prefer Z" → publish to Reflexio
+3. **High-signal moments** — tool failures you self-recover from, retry chains, workarounds, anomalies → publish to Reflexio
 
 The user can also run `/reflexio-extract` at any time to summarize the full conversation and extract learnings.
 
@@ -101,6 +102,86 @@ _Non-verbal / implicit corrections (also publish these):_
 
 ---
 
+## Step-by-Step: Proactive Extraction (High-Signal Moments)
+
+Beyond explicit corrections, certain moments during a session carry high learning value — even when the user says nothing. When you detect any of the patterns below, publish to Reflexio using the same mechanism as corrections. Do not wait for user input.
+
+**Payload format** — same as corrections, but the "user" turn is the original request (no correction needed), and the "assistant" turn captures the full failure → recovery arc:
+```bash
+cat > /tmp/reflexio-summary.json << 'SUMMARY_EOF'
+{
+  "agent_version": "claude-code",
+  "source": "claude-code-expert",
+  "interactions": [
+    {"role": "user", "content": "<what the user originally asked>"},
+    {
+      "role": "assistant",
+      "content": "<what you tried, what went wrong, and how you recovered — preserve self-correction phrases verbatim>",
+      "tools_used": [
+        {"tool_name": "<tool>", "tool_data": {"input": "<params> — FAILED: <exact error>"}},
+        {"tool_name": "<tool>", "tool_data": {"input": "<corrected params> — succeeded"}}
+      ]
+    }
+  ]
+}
+SUMMARY_EOF
+reflexio publish --agent-version claude-code --source claude-code-expert --skip-aggregation --force-extraction --file /tmp/reflexio-summary.json && rm -f /tmp/reflexio-summary.json
+```
+
+List every failed attempt in `tools_used` in chronological order, followed by the successful one. Include exact error messages verbatim — they are load-bearing evidence for extracting precise behavioral rules.
+
+### Patterns to detect and publish:
+
+**A. Self-recovered tool failures**
+You tried a tool call, got an error, and fixed it yourself without user input. The error message and your recovery strategy are extractable as a behavioral rule (trigger → pitfall → instruction).
+
+_Example:_ You ran a SQL query with `JOIN channels ON l.channel_id`, got `invalid identifier 'L.CHANNEL_ID'`, discovered the column is actually `l.stream_channel_id` by introspecting the schema, and rewrote the query.
+
+**B. Retry chains (2+ failures on same operation)**
+You attempted the same operation 2+ times with different errors before succeeding. Each retry and the eventual fix form a learning arc. Publish the full chain as one interaction — list all attempts in `tools_used`.
+
+_Example:_ File edit failed (wrong indentation), retried with different context (still wrong), then read the file first and got it right. The pattern "read before editing unfamiliar files" is extractable.
+
+**C. Discovered documentation or behavior gaps**
+Tool documentation or expected behavior said X, but reality was Y. The discrepancy is a reusable rule that prevents future agents from making the same incorrect assumption.
+
+_Example:_ API docs say `--format json` is supported, but the CLI returns `unknown flag`. You discovered `--output-format json` works instead.
+
+**D. Workarounds for limitations**
+An API, tool, or system doesn't support what you needed, so you used an alternative approach. The limitation and workaround are a reusable playbook rule.
+
+_Example:_ The database doesn't support `LATERAL JOIN`, so you rewrote the query using a correlated subquery. Or: the MCP tool doesn't accept wildcards, so you listed the directory first and filtered client-side.
+
+**E. Anomalous or implausible results**
+Results that are unexpected — zeros where you expected values, row counts that don't match documentation, mean/median divergence suggesting data skew, results that contradict what the user described. Publish how you detected the anomaly and what you did about it.
+
+_Example:_ Query returned 0 rows when the user said "we have thousands of records." You discovered the table uses soft deletes and added `WHERE deleted_at IS NULL` — or found the user was looking at a different environment.
+
+### When to publish proactively:
+
+- **Publish immediately** after recovering from the situation — don't batch multiple unrelated patterns into one publish
+- **Don't publish routine successes** — only friction, failures, surprises, and workarounds. If a tool call succeeded on the first try with no surprises, there's nothing to extract
+- **Keep the bar reasonable** — a single typo in a file path that you immediately corrected is not worth publishing. The signal is in non-obvious failures where the recovery required understanding something new about the system
+
+---
+
+## End-of-Session Extraction Nudge
+
+When you detect the session is winding down — the user says "thanks", "that's all", "looks good", the task is complete, or the conversation is naturally ending — check whether the session had any friction:
+
+- Tool failures (even self-recovered ones)
+- User corrections or preference statements
+- Workarounds or unexpected behavior
+- Retry chains
+
+If **any** friction occurred during the session, proactively suggest:
+
+> "This session had some learnings worth capturing. Want me to run `/reflexio-extract` to publish them for future sessions?"
+
+If the session was entirely smooth with no friction, skip the suggestion.
+
+---
+
 ## What Reflexio Stores
 
 **User Profiles** — stable facts learned from conversations:
@@ -145,4 +226,4 @@ Agent(prompt="Start the Reflexio server: nohup reflexio services start --only ba
 - **Include enough context** — what you did wrong + the correction + why + **the evidence**. Evidence means the actual failed tool input, the exact error message, or the verbatim self-correction sentence. Without the evidence, Reflexio can only extract a vague profile entry; with the evidence, it can extract a precise playbook rule with trigger, content, rationale, and blocking_issue fields. If you're only publishing one correction, make it count by including the failure.
 - **If Reflexio is unreachable, proceed normally** — it enhances but never blocks
 - **Don't mention Reflexio to the user** unless they ask
-- **Suggest `/reflexio-extract`** if a session had many corrections or learnings
+- **Suggest `/reflexio-extract`** at end of session if there was any friction (see End-of-Session Extraction Nudge above)

--- a/reflexio/integrations/claude_code/skill/SKILL-expert.md
+++ b/reflexio/integrations/claude_code/skill/SKILL-expert.md
@@ -1,6 +1,6 @@
 ---
 name: reflexio-expert
-description: "Search past session memory for user corrections, preferences, and project conventions. Publish corrections when the user says 'no, do X instead' or states a preference. Proactively publish high-signal moments: self-recovered tool failures, retry chains, documentation gaps, workarounds, and anomalous results. Suggest /reflexio-extract at end of session when friction occurred. Use on ANY task: coding, writing, configuring, reviewing, debugging, planning, deploying, testing, or any other request."
+description: "Search past session memory for user corrections, preferences, and project conventions. Publish corrections when the user says 'no, do X instead' or states a preference. Proactively publish high-signal moments: self-recovered tool failures, retry chains, documentation gaps, workarounds, and anomalous results. Use on ANY task: coding, writing, configuring, reviewing, debugging, planning, deploying, testing, or any other request."
 ---
 
 # Reflexio: Learn from Past Sessions (Expert)

--- a/reflexio/integrations/claude_code/skill/SKILL.md
+++ b/reflexio/integrations/claude_code/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reflexio
-description: "Search past session memory for user corrections, preferences, and project conventions. Retrieves behavioral rules the user has established (e.g. 'always use type hints', 'use pnpm not npm') so you follow them from the start. Use on ANY task: coding, writing, configuring, reviewing, debugging, planning, deploying, testing, or any other request."
+description: "Use when starting any task to check for past corrections and user preferences that should guide your approach."
 ---
 
 # Reflexio: Learn from Past Sessions

--- a/reflexio/integrations/claude_code/skill/references/proactive-patterns.md
+++ b/reflexio/integrations/claude_code/skill/references/proactive-patterns.md
@@ -1,0 +1,38 @@
+# Proactive Extraction Patterns
+
+Beyond explicit corrections, certain moments during a session carry high learning value — even when the user says nothing. When you detect any of the patterns below, publish to Reflexio using the same mechanism as corrections. Do not wait for user input.
+
+Use the same payload format as corrections, but the "user" turn is the original request (no correction needed), and the "assistant" turn captures the full failure → recovery arc. List every failed attempt in `tools_used` in chronological order, followed by the successful one. Include exact error messages verbatim — they are load-bearing evidence for extracting precise behavioral rules.
+
+## Patterns
+
+### A. Self-recovered tool failures
+You tried a tool call, got an error, and fixed it yourself without user input. The error message and your recovery strategy are extractable as a behavioral rule (trigger → pitfall → instruction).
+
+_Example:_ You ran a SQL query with `JOIN channels ON l.channel_id`, got `invalid identifier 'L.CHANNEL_ID'`, discovered the column is actually `l.stream_channel_id` by introspecting the schema, and rewrote the query.
+
+### B. Retry chains (2+ failures on same operation)
+You attempted the same operation 2+ times with different errors before succeeding. Each retry and the eventual fix form a learning arc. Publish the full chain as one interaction — list all attempts in `tools_used`.
+
+_Example:_ File edit failed (wrong indentation), retried with different context (still wrong), then read the file first and got it right. The pattern "read before editing unfamiliar files" is extractable.
+
+### C. Discovered documentation or behavior gaps
+Tool documentation or expected behavior said X, but reality was Y. The discrepancy is a reusable rule that prevents future agents from making the same incorrect assumption.
+
+_Example:_ API docs say `--format json` is supported, but the CLI returns `unknown flag`. You discovered `--output-format json` works instead.
+
+### D. Workarounds for limitations
+An API, tool, or system doesn't support what you needed, so you used an alternative approach. The limitation and workaround are a reusable playbook rule.
+
+_Example:_ The database doesn't support `LATERAL JOIN`, so you rewrote the query using a correlated subquery. Or: the MCP tool doesn't accept wildcards, so you listed the directory first and filtered client-side.
+
+### E. Anomalous or implausible results
+Results that are unexpected — zeros where you expected values, row counts that don't match documentation, mean/median divergence suggesting data skew, results that contradict what the user described. Publish how you detected the anomaly and what you did about it.
+
+_Example:_ Query returned 0 rows when the user said "we have thousands of records." You discovered the table uses soft deletes and added `WHERE deleted_at IS NULL` — or found the user was looking at a different environment.
+
+## When to publish proactively
+
+- **Publish immediately** after recovering from the situation — don't batch multiple unrelated patterns into one publish
+- **Don't publish routine successes** — only friction, failures, surprises, and workarounds. If a tool call succeeded on the first try with no surprises, there's nothing to extract
+- **Keep the bar reasonable** — a single typo in a file path that you immediately corrected is not worth publishing. The signal is in non-obvious failures where the recovery required understanding something new about the system

--- a/reflexio/integrations/claude_code/skill/references/server-management.md
+++ b/reflexio/integrations/claude_code/skill/references/server-management.md
@@ -13,7 +13,7 @@ If `REFLEXIO_URL` points to a non-localhost URL (e.g., `https://reflexio.ai`), t
 **Check:** `reflexio status check`
 
 **Start (background subagent):**
-```
+```text
 Agent(prompt="Start the Reflexio server: nohup reflexio services start --only backend > ~/.reflexio/logs/server.log 2>&1 & sleep 5 && reflexio status check", run_in_background=true)
 ```
 

--- a/reflexio/integrations/claude_code/skill/references/server-management.md
+++ b/reflexio/integrations/claude_code/skill/references/server-management.md
@@ -1,0 +1,22 @@
+# Server Management
+
+The Reflexio server must be running for `reflexio search` and `reflexio publish` to work.
+
+## Managed Reflexio (remote server)
+
+If `REFLEXIO_URL` points to a non-localhost URL (e.g., `https://reflexio.ai`), the server is always running. Do NOT run `reflexio status check` or attempt to start the server. If a command fails with a connection error, report it to the user — it's a network or configuration issue, not a server-start issue.
+
+## Local server
+
+`REFLEXIO_URL` unset or pointing to localhost/127.0.0.1:
+
+**Check:** `reflexio status check`
+
+**Start (background subagent):**
+```
+Agent(prompt="Start the Reflexio server: nohup reflexio services start --only backend > ~/.reflexio/logs/server.log 2>&1 & sleep 5 && reflexio status check", run_in_background=true)
+```
+
+- Always use a background subagent to start the server — never run it in the main agent (it blocks)
+- Never ask the user to start the server — handle it silently
+- If `reflexio` is not found, ask the user to install it: `pip install reflexio-ai`

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -384,6 +384,27 @@ class TestInstallClaudeCodeIntegration:
         assert len(settings["hooks"]["SessionStart"]) == 1
         assert len(settings["hooks"]["UserPromptSubmit"]) == 1
 
+    def test_normal_reinstall_removes_expert_artifacts(self, tmp_path: Path) -> None:
+        """Re-installing in normal mode removes expert-only files and hooks."""
+        # First install in expert mode
+        _install_claude_code_integration(
+            tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
+        )
+        claude_dir = tmp_path / ".claude"
+        assert (claude_dir / "commands" / "reflexio-extract").exists()
+        assert (claude_dir / "skills" / "reflexio" / "references").exists()
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        assert "SessionEnd" in settings["hooks"]
+
+        # Re-install in normal mode
+        _install_claude_code_integration(
+            tmp_path, expert=False, location=InstallLocation.CURRENT_PROJECT
+        )
+        assert not (claude_dir / "commands" / "reflexio-extract").exists()
+        assert not (claude_dir / "skills" / "reflexio" / "references").exists()
+        settings = json.loads((claude_dir / "settings.json").read_text())
+        assert "SessionEnd" not in settings.get("hooks", {})
+
     def test_idempotent_install(self, tmp_path: Path) -> None:
         """Running install twice doesn't corrupt files or duplicate hooks."""
         for _ in range(2):

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -325,6 +325,24 @@ class TestInstallClaudeCodeIntegration:
         cmd = tmp_path / ".claude" / "commands" / "reflexio-extract" / "SKILL.md"
         assert not cmd.exists()
 
+    def test_expert_mode_installs_references(self, tmp_path: Path) -> None:
+        """Expert mode copies skill references directory."""
+        _install_claude_code_integration(
+            tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
+        )
+        refs = tmp_path / ".claude" / "skills" / "reflexio" / "references"
+        assert refs.exists()
+        assert (refs / "proactive-patterns.md").exists()
+        assert (refs / "server-management.md").exists()
+
+    def test_normal_mode_no_references(self, tmp_path: Path) -> None:
+        """Normal mode does not install skill references."""
+        _install_claude_code_integration(
+            tmp_path, location=InstallLocation.CURRENT_PROJECT
+        )
+        refs = tmp_path / ".claude" / "skills" / "reflexio" / "references"
+        assert not refs.exists()
+
     def test_hooks_in_settings_json(self, tmp_path: Path) -> None:
         """Hooks are written to settings.json with correct events."""
         _install_claude_code_integration(

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -334,6 +334,38 @@ class TestInstallClaudeCodeIntegration:
         assert "SessionStart" in settings["hooks"]
         assert "UserPromptSubmit" in settings["hooks"]
 
+    def test_normal_mode_no_stop_hook(self, tmp_path: Path) -> None:
+        """Normal mode does not install the Stop hook."""
+        _install_claude_code_integration(
+            tmp_path, location=InstallLocation.CURRENT_PROJECT
+        )
+        settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert "Stop" not in settings["hooks"]
+
+    def test_expert_mode_installs_stop_hook(self, tmp_path: Path) -> None:
+        """Expert mode installs the Stop hook alongside SessionStart and UserPromptSubmit."""
+        _install_claude_code_integration(
+            tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
+        )
+        settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert "Stop" in settings["hooks"]
+        assert len(settings["hooks"]["Stop"]) == 1
+        # Verify the Stop hook command points to handler.js
+        stop_cmd = settings["hooks"]["Stop"][0]["hooks"][0]["command"]
+        assert "handler.js" in stop_cmd
+        assert stop_cmd.startswith("node ")
+
+    def test_expert_mode_stop_hook_idempotent(self, tmp_path: Path) -> None:
+        """Running expert install twice doesn't duplicate the Stop hook."""
+        for _ in range(2):
+            _install_claude_code_integration(
+                tmp_path, expert=True, location=InstallLocation.ALL_PROJECTS
+            )
+        settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert len(settings["hooks"]["Stop"]) == 1
+        assert len(settings["hooks"]["SessionStart"]) == 1
+        assert len(settings["hooks"]["UserPromptSubmit"]) == 1
+
     def test_idempotent_install(self, tmp_path: Path) -> None:
         """Running install twice doesn't corrupt files or duplicate hooks."""
         for _ in range(2):
@@ -413,6 +445,20 @@ class TestUninstallDetection:
         # settings.json should have empty hooks
         settings = json.loads((claude_dir / "settings.json").read_text())
         assert "hooks" not in settings or not settings.get("hooks")
+
+    def test_remove_from_dir_cleans_stop_hook(self, tmp_path: Path) -> None:
+        """Uninstall removes the Stop hook installed by expert mode."""
+        _install_claude_code_integration(
+            tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
+        )
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        assert "Stop" in settings["hooks"]
+
+        _remove_from_dir(tmp_path)
+
+        settings = json.loads(settings_path.read_text())
+        assert "hooks" not in settings or "Stop" not in settings.get("hooks", {})
 
     def test_marker_file_metadata(self, tmp_path: Path) -> None:
         """Marker file contains location and installed_at fields."""

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -334,35 +334,35 @@ class TestInstallClaudeCodeIntegration:
         assert "SessionStart" in settings["hooks"]
         assert "UserPromptSubmit" in settings["hooks"]
 
-    def test_normal_mode_no_stop_hook(self, tmp_path: Path) -> None:
-        """Normal mode does not install the Stop hook."""
+    def test_normal_mode_no_session_end_hook(self, tmp_path: Path) -> None:
+        """Normal mode does not install the SessionEnd hook."""
         _install_claude_code_integration(
             tmp_path, location=InstallLocation.CURRENT_PROJECT
         )
         settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-        assert "Stop" not in settings["hooks"]
+        assert "SessionEnd" not in settings["hooks"]
 
-    def test_expert_mode_installs_stop_hook(self, tmp_path: Path) -> None:
-        """Expert mode installs the Stop hook alongside SessionStart and UserPromptSubmit."""
+    def test_expert_mode_installs_session_end_hook(self, tmp_path: Path) -> None:
+        """Expert mode installs SessionEnd hook alongside SessionStart and UserPromptSubmit."""
         _install_claude_code_integration(
             tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
         )
         settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-        assert "Stop" in settings["hooks"]
-        assert len(settings["hooks"]["Stop"]) == 1
-        # Verify the Stop hook command points to handler.js
-        stop_cmd = settings["hooks"]["Stop"][0]["hooks"][0]["command"]
-        assert "handler.js" in stop_cmd
-        assert stop_cmd.startswith("node ")
+        assert "SessionEnd" in settings["hooks"]
+        assert len(settings["hooks"]["SessionEnd"]) == 1
+        # Verify the SessionEnd hook command points to handler.js
+        cmd = settings["hooks"]["SessionEnd"][0]["hooks"][0]["command"]
+        assert "handler.js" in cmd
+        assert cmd.startswith("node ")
 
-    def test_expert_mode_stop_hook_idempotent(self, tmp_path: Path) -> None:
-        """Running expert install twice doesn't duplicate the Stop hook."""
+    def test_expert_mode_session_end_hook_idempotent(self, tmp_path: Path) -> None:
+        """Running expert install twice doesn't duplicate the SessionEnd hook."""
         for _ in range(2):
             _install_claude_code_integration(
                 tmp_path, expert=True, location=InstallLocation.ALL_PROJECTS
             )
         settings = json.loads((tmp_path / ".claude" / "settings.json").read_text())
-        assert len(settings["hooks"]["Stop"]) == 1
+        assert len(settings["hooks"]["SessionEnd"]) == 1
         assert len(settings["hooks"]["SessionStart"]) == 1
         assert len(settings["hooks"]["UserPromptSubmit"]) == 1
 
@@ -446,19 +446,19 @@ class TestUninstallDetection:
         settings = json.loads((claude_dir / "settings.json").read_text())
         assert "hooks" not in settings or not settings.get("hooks")
 
-    def test_remove_from_dir_cleans_stop_hook(self, tmp_path: Path) -> None:
-        """Uninstall removes the Stop hook installed by expert mode."""
+    def test_remove_from_dir_cleans_session_end_hook(self, tmp_path: Path) -> None:
+        """Uninstall removes the SessionEnd hook installed by expert mode."""
         _install_claude_code_integration(
             tmp_path, expert=True, location=InstallLocation.CURRENT_PROJECT
         )
         settings_path = tmp_path / ".claude" / "settings.json"
         settings = json.loads(settings_path.read_text())
-        assert "Stop" in settings["hooks"]
+        assert "SessionEnd" in settings["hooks"]
 
         _remove_from_dir(tmp_path)
 
         settings = json.loads(settings_path.read_text())
-        assert "hooks" not in settings or "Stop" not in settings.get("hooks", {})
+        assert "hooks" not in settings or "SessionEnd" not in settings.get("hooks", {})
 
     def test_marker_file_metadata(self, tmp_path: Path) -> None:
         """Marker file contains location and installed_at fields."""

--- a/tests/client/test_cache.py
+++ b/tests/client/test_cache.py
@@ -137,6 +137,54 @@ class TestInMemoryCache:
             assert result == f"value_{thread_id}"  # noqa: S101
 
 
+    def test_clear_removes_all_entries(self):
+        """Test that clear() removes all cached entries."""
+        cache = InMemoryCache()
+        cache.set("method_a", "value1", key="1")
+        cache.set("method_b", "value2", key="2")
+        cache.set("method_a", "value3", key="3")
+
+        cache.clear()
+
+        assert cache.get("method_a", key="1") is None
+        assert cache.get("method_b", key="2") is None
+        assert cache.get("method_a", key="3") is None
+
+    def test_invalidate_removes_matching_method(self):
+        """Test that invalidate() removes only entries for the given method."""
+        cache = InMemoryCache()
+        cache.set("get_profiles", "profiles_1", user_id="u1")
+        cache.set("get_profiles", "profiles_2", user_id="u2")
+        cache.set("get_agent_playbooks", "playbooks_1", limit=100)
+
+        removed = cache.invalidate("get_profiles")
+
+        assert removed == 2
+        assert cache.get("get_profiles", user_id="u1") is None
+        assert cache.get("get_profiles", user_id="u2") is None
+        assert cache.get("get_agent_playbooks", limit=100) == "playbooks_1"
+
+    def test_invalidate_returns_zero_for_nonexistent_method(self):
+        """Test that invalidate() returns 0 when no entries match."""
+        cache = InMemoryCache()
+        cache.set("get_profiles", "value", user_id="u1")
+
+        removed = cache.invalidate("nonexistent_method")
+
+        assert removed == 0
+        assert cache.get("get_profiles", user_id="u1") == "value"
+
+    def test_invalidate_on_empty_cache(self):
+        """Test that invalidate() on empty cache returns 0."""
+        cache = InMemoryCache()
+        assert cache.invalidate("any_method") == 0
+
+    def test_clear_on_empty_cache(self):
+        """Test that clear() on empty cache doesn't error."""
+        cache = InMemoryCache()
+        cache.clear()  # should not raise
+
+
 class TestReflexioClientCache:
     """Test cases for cache integration in ReflexioClient."""
 
@@ -327,6 +375,77 @@ class TestReflexioClientCache:
 
         # Verify API was only called once
         assert mock_session.request.call_count == 1  # noqa: S101
+
+    @patch("reflexio.client.client.requests.Session")
+    def test_delete_all_profiles_invalidates_cache(self, mock_session_class):
+        """Test that delete_all_profiles clears the profiles cache."""
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [
+            # First get_profiles call
+            {"success": True, "user_profiles": [], "msg": None},
+            # delete_all_profiles call
+            {"success": True, "deleted_count": 5, "msg": "Deleted"},
+            # Second get_profiles call (after invalidation)
+            {"success": True, "user_profiles": [], "msg": None},
+        ]
+        mock_session.request.return_value = mock_response
+
+        client = ReflexioClient(api_key="test_key")
+
+        # Populate cache
+        request = {"user_id": "user1", "start_time": None, "end_time": None, "top_k": 30}
+        client.get_profiles(request)
+        assert mock_session.request.call_count == 1  # noqa: S101
+
+        # Cache should be hit
+        client.get_profiles(request)
+        assert mock_session.request.call_count == 1  # noqa: S101
+
+        # Delete all profiles — should invalidate cache
+        client.delete_all_profiles()
+        assert mock_session.request.call_count == 2  # noqa: S101
+
+        # Next get_profiles should miss cache and hit API
+        client.get_profiles(request)
+        assert mock_session.request.call_count == 3  # noqa: S101
+
+    @patch("reflexio.client.client.requests.Session")
+    def test_delete_all_interactions_clears_all_cache(self, mock_session_class):
+        """Test that delete_all_interactions clears the entire cache."""
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [
+            # get_profiles
+            {"success": True, "user_profiles": [], "msg": None},
+            # get_agent_playbooks
+            {"success": True, "agent_playbooks": [], "msg": None},
+            # delete_all_interactions
+            {"success": True, "deleted_count": 10, "msg": "Deleted"},
+            # get_profiles again (cache miss)
+            {"success": True, "user_profiles": [], "msg": None},
+            # get_agent_playbooks again (cache miss)
+            {"success": True, "agent_playbooks": [], "msg": None},
+        ]
+        mock_session.request.return_value = mock_response
+
+        client = ReflexioClient(api_key="test_key")
+
+        # Populate both caches
+        client.get_profiles({"user_id": "u1", "start_time": None, "end_time": None, "top_k": 30})
+        client.get_agent_playbooks({"limit": 100})
+        assert mock_session.request.call_count == 2  # noqa: S101
+
+        # Nuclear delete — clears everything
+        client.delete_all_interactions()
+        assert mock_session.request.call_count == 3  # noqa: S101
+
+        # Both caches should miss
+        client.get_profiles({"user_id": "u1", "start_time": None, "end_time": None, "top_k": 30})
+        client.get_agent_playbooks({"limit": 100})
+        assert mock_session.request.call_count == 5  # noqa: S101
 
     @patch("reflexio.client.client.requests.Session")
     def test_cache_expiration_integration(self, mock_session_class):


### PR DESCRIPTION
## Summary

Comprehensive improvement to the Claude Code integration: fix the session-end hook, restructure the expert skill for reliable triggering, add cache invalidation on mutations, and fix CLI issues.

## Changes

### SessionEnd hook (handler.js + setup_cmd.py + HOOK.md)
- Use `SessionEnd` instead of `Stop` — `Stop` fires per-turn, `SessionEnd` fires once on exit
- Add `--force-extraction` so extraction always runs at session end
- Redirect publish output to `~/.reflexio/logs/stop-hook.log` (was silently discarded)
- Remove dead `stop_hook_active` guard (not in Claude Code payload)
- Use positional args (`$1`..`$5`) in sh -c instead of template literal interpolation (prevents shell injection)
- Auto-install hook when expert mode enabled; remove on normal-mode re-install
- Shell-quote all hook paths with `shlex.quote` for paths with spaces

### Expert skill restructure (SKILL-expert.md + rules/reflexio.md + references/)
- Move triggering logic to `rules/reflexio.md` (always loaded) — "When to Publish to Reflexio" section with profile/playbook guidance and confirmation model
- Simplify skill from 235 → 98 lines — keep only the how-to (payload formats, patterns)
- Move heavy content to `references/proactive-patterns.md` and `references/server-management.md`
- Rewrite `description` to triggering conditions only per skill creation guidelines
- Setup wizard copies `references/` in expert mode; removes on normal-mode re-install
- Normal-mode re-install cleans up all expert artifacts (SessionEnd hook, references/, reflexio-extract command)

### Client cache invalidation (cache.py + client.py)
- Add `clear()` and `invalidate(method_name)` to `InMemoryCache`
- Call invalidation in all 12 mutation methods (delete, update, publish)
- Fixes: `delete-all` → `list` now returns empty instead of stale cached data

### CLI fix (interactions.py)
- `reflexio interactions list` without `--user-id` failed with Pydantic validation error
- Now uses `require_user_id()` to fall back to `REFLEXIO_USER_ID` env var

## Test plan

- [x] `node --check handler.js` — syntax valid
- [x] `ruff check` + `pyright` on all Python files — clean
- [x] 47 setup_cmd tests pass (9 new: SessionEnd hook, references, expert→normal downgrade)
- [x] 21 cache tests pass (7 new: clear, invalidate, client integration)
- [x] handler.js transcript parsing verified against real Claude Code JSONL
- [x] Manual testing of expert skill correction capture
