### PR TITLE
feat: merge same-role turns, pin CLI model, activate v4.0.1 extraction prompt

### DIFF
--- a/reflexio/integrations/claude_code/hook/handler.js
+++ b/reflexio/integrations/claude_code/hook/handler.js
@@ -199,32 +199,51 @@ function parseTranscript(transcriptPath) {
 		}
 	}
 
-	// Pair up into interactions: each interaction = one user + one assistant
+	// Merge consecutive same-role entries into one logical turn. Claude Code
+	// writes one JSONL entry per API response, so a single assistant turn can
+	// span multiple entries (e.g. text, tool_use, then text again after a
+	// tool_result on the user side). Without merging, only the first entry
+	// gets paired and the rest either look like orphaned turns or get
+	// dropped — truncating the assistant response in the UI.
+	const merged = [];
+	for (const m of messages) {
+		const last = merged[merged.length - 1];
+		if (last && last.role === m.role) {
+			last.content = `${last.content}\n${m.content}`.slice(
+				0,
+				MAX_CONTENT_LENGTH,
+			);
+			if (m.tools_used && m.tools_used.length > 0) {
+				last.tools_used = [...(last.tools_used || []), ...m.tools_used];
+			}
+		} else {
+			merged.push({ ...m, tools_used: m.tools_used ? [...m.tools_used] : [] });
+		}
+	}
+
+	// Pair up into interactions: each interaction = one user + one assistant.
+	// Skip user turns with no assistant response (e.g. interrupted turns,
+	// meta slash commands) so we don't emit empty-assistant interactions.
 	const interactions = [];
 	let i = 0;
-	while (i < messages.length && interactions.length < MAX_INTERACTIONS) {
-		if (messages[i].role === "user") {
-			interactions.push({
-				role: "user",
-				content: messages[i].content,
-			});
-			i++;
-			// Attach the next assistant response, if any
-			if (i < messages.length && messages[i].role === "assistant") {
+	while (i < merged.length && interactions.length < MAX_INTERACTIONS) {
+		if (merged[i].role === "user") {
+			if (i + 1 < merged.length && merged[i + 1].role === "assistant") {
+				interactions.push({ role: "user", content: merged[i].content });
 				interactions.push({
 					role: "assistant",
-					content: messages[i].content,
-					tools_used: messages[i].tools_used || [],
+					content: merged[i + 1].content,
+					tools_used: merged[i + 1].tools_used || [],
 				});
+				i += 2;
+			} else {
+				// Unpaired user turn — drop it rather than publish an
+				// interaction with an empty assistant side.
 				i++;
 			}
 		} else {
-			// Orphaned assistant message (no preceding user) — still include it
-			interactions.push({
-				role: "assistant",
-				content: messages[i].content,
-				tools_used: messages[i].tools_used || [],
-			});
+			// Orphaned assistant turn (no preceding user) — skip; without a
+			// user query it has no value for playbook extraction.
 			i++;
 		}
 	}

--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -44,7 +44,9 @@ PROVIDER_KEY = "claude-code"
 ENV_ENABLE = "CLAUDE_SMART_USE_LOCAL_CLI"
 _ENV_CLI_PATH = "CLAUDE_SMART_CLI_PATH"
 _ENV_TIMEOUT = "CLAUDE_SMART_CLI_TIMEOUT"
+_ENV_MODEL = "CLAUDE_SMART_CLI_MODEL"
 _DEFAULT_TIMEOUT_SECONDS = 120
+_DEFAULT_CLI_MODEL = "claude-sonnet-4-6"
 
 _TRUTHY_ENV_VALUES = {"1", "true", "yes"}
 _UNSUPPORTED_PARAMS_WARNED: set[str] = set()
@@ -304,7 +306,8 @@ def _run_cli(
     Raises:
         ClaudeCodeCLIError: On non-zero exit, timeout, or malformed JSON.
     """
-    cmd = [cli_path, "-p", "--output-format", "json"]
+    model = os.environ.get(_ENV_MODEL) or _DEFAULT_CLI_MODEL
+    cmd = [cli_path, "-p", "--output-format", "json", "--model", model]
     if system_prompt:
         cmd.extend(["--append-system-prompt", system_prompt])
 

--- a/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.0.1.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.0.1.prompt.md
@@ -243,4 +243,3 @@ Note: the content does NOT invent an escalation path or suggest "check your emai
 * Each playbook MUST correspond to a triggering agent behavior OR a successful task completion in the trajectory
 * Vague, stylistic, or unanchored advice is invalid for BOTH categories
 * Each entry must describe a **distinct, independent** policy or recipe
-* For successful trajectories with substantive domain work, DO NOT return an empty list — extract at least one Success Path Recipe

--- a/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.0.1.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.0.1.prompt.md
@@ -1,7 +1,7 @@
 ---
-active: false
-description: "Context setting prompt for playbook extraction — simplified schema with content as the sole actionable field, strong grounding rules to prevent hallucinated policies"
-changelog: "v4: Remove instruction and pitfall fields. Content is now the sole actionable field. Strong grounding rules: content must be derived from evidence in the interactions, never hallucinate policies or escalation paths not mentioned by the user."
+active: true
+description: "Context setting prompt for playbook extraction — Success Path Recipes only when the original trajectory had removable inefficiency; content is an optimized, replayable path"
+changelog: "v4.0.1: Success Path Recipes only when the original path contained removable inefficiency (failed attempt, parameter retuning, tool swap, detour). Content is framed as the optimized straight-line path, specific enough to replay without re-deriving anything. Clean first-try successes yield zero recipes; the prior 'MUST yield at least one' forcing clause is removed."
 variables:
   - agent_context_prompt
   - extraction_definition_prompt
@@ -50,20 +50,26 @@ If the `trigger` can be reduced to "user asks for X" and the `content` is "do X"
 ## Category 2 — Success Path Recipes
 
 Extract a **Success Path Recipe** when ALL are true:
-1. The agent successfully completed a task (produced final deliverables, resolved the user's request, or reached the intended end state).
-2. The trajectory contains domain-specific work — computation, data transformation, document analysis, multi-step orchestration — not just conversation.
-3. The solution path contains at least one of:
-   - Domain formulas, constants, or parameter values the agent used
-   - Specific tool sequences that worked
-   - Input/output format specifics that mattered
-   - Concrete values or answers the agent computed
-   - Key decisions the agent made and why
+1. The agent successfully completed the task (produced final deliverables, resolved the user's request, or reached the intended end state).
+2. The original trajectory contained **removable inefficiency** — at least one of:
+   - A failed tool call before a successful retry
+   - Parameters that had to be tuned after returning wrong or incomplete results
+   - A tool swapped mid-task after the first choice did not work
+   - A redundant or dead-end step that did not contribute to the final answer
+   - Discovery work (reading docs, probing formats, sampling data) that a future agent, armed with what was learned, could skip
+3. The inefficiency is removable: given what the final working approach turned out to be, a future agent could go straight there.
+
+If the agent reached the answer on a clean first-try path with no retries, tuning, tool swaps, or detours, **do not emit a recipe** — there is nothing to optimize.
 
 A Success Path Recipe does NOT require a user-correction signal.
 
 ### Success Path content format
 
-The `content` field must contain the **actual recipe with concrete values** — tools used, key parameters, formulas, sequence of operations, format conversions discovered. The recipe is the value. A generic "follow best practices" is worthless; a specific step-by-step sequence with real values is gold.
+The `content` field must contain the **optimized, replayable path** — the straight-line sequence of tools, parameters, and values that the original trajectory eventually converged to, with the detours removed.
+
+It must be specific enough that a future agent can execute it step by step without re-deriving anything: name the exact tool, the exact parameter values, the exact file paths / column names / constants, and the order of operations.
+
+Also call out, in one short line, which step in the original path was the detour and what the correct first move is — so the reader knows what NOT to repeat. A generic "follow best practices" is worthless; a specific step-by-step sequence with real values, plus the detour to skip, is gold.
 
 ━━━━━━━━━━━━━━━━━━━━━━
 ## Content Grounding Rules (CRITICAL)
@@ -98,10 +104,11 @@ For **Correction SOPs**:
 6. Draft `content`: reason through what the agent did wrong and what the user's feedback tells us the agent should do differently. Ground every statement in evidence from the conversation. If the user told the agent what to do, capture that. If the user only told the agent what NOT to do, capture the avoidance. Do not guess what the right action is if the conversation doesn't tell you.
 
 For **Success Path Recipes**:
-1. Identify whether the agent completed a substantive task successfully
-2. Enumerate the domain-specific work: formulas, tool sequences, parameter choices, concrete values
-3. Frame the trigger as a reusable task-type description (domain + action)
-4. Compose `content` as an actionable recipe with specific values from the trajectory
+1. Identify whether the agent completed the task successfully
+2. Scan the trajectory for **removable inefficiency**: a failed tool call followed by a retry, parameters retuned after bad output, a tool swapped mid-task, redundant or dead-end steps, or discovery work a future agent could skip. If none are present, **stop — do not emit a recipe.**
+3. Enumerate the final working approach: formulas, tool sequences, parameter choices, file paths, column names, concrete values
+4. Frame the trigger as a reusable task-type description (domain + action)
+5. Compose `content` as the **optimized straight-line path** — specific enough to replay without re-deriving anything — and add one short line naming the detour from the original trajectory that the reader should skip
 
 Repeat for **every distinct** policy or recipe the conversation supports.
 
@@ -169,8 +176,8 @@ Note: `"blocking_issue"` is OPTIONAL on each entry — include ONLY when the age
 
 **How many entries to return:**
 * Emit one entry per distinct Correction SOP.
-* Emit one entry per distinct Success Path Recipe when the trajectory contains domain-specific work that completed successfully.
-* A successful trajectory with substantive domain work MUST yield at least one Success Path Recipe. Empty lists are acceptable ONLY when the trajectory is trivially short (fewer than 4 non-trivial agent actions) or the agent produced no meaningful deliverables.
+* Emit one entry per distinct Success Path Recipe **only when the trajectory contained removable inefficiency** (see Category 2, condition 2). Clean first-try successes yield zero recipes — padding the playbook with recipes that just restate an already-efficient path degrades its value.
+* Correction SOPs are independent of recipe emission: extract a SOP whenever a correction signal is present, regardless of whether any recipe qualifies.
 
 Return an empty list only when truly nothing applies:
 

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -31,8 +31,8 @@ _PROMPT_BANK_DIR = (
 PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     "playbook_extraction_main": ("v1.0.0", "playbook_extraction"),
     "playbook_extraction_main_incremental": ("v1.0.0", "playbook_extraction"),
-    "playbook_extraction_context": ("v4.0.0", None),
-    "playbook_extraction_context_incremental": ("v4.0.0", None),
+    "playbook_extraction_context": ("v4.0.1", None),
+    "playbook_extraction_context_incremental": ("v4.0.1", None),
     "playbook_should_generate": ("v3.0.0", "boolean_evaluation"),
     "playbook_should_generate_expert": ("v1.0.0", "boolean_evaluation"),
     "playbook_extraction_context_expert": ("v3.0.0", None),


### PR DESCRIPTION
## Summary
- **Transcript parser:** merge consecutive same-role entries before pairing so multi-entry assistant turns (text → tool_use → text after tool_result) publish as a single logical interaction instead of being truncated or split into orphans.
- **Claude Code provider:** honor `CLAUDE_SMART_CLI_MODEL` and pass `--model` explicitly (default `claude-sonnet-4-6`) so local-CLI extraction is pinned to a known model regardless of the user's CLI default.
- **Playbook extraction prompt:** ship `v4.0.1` as the active version; retire `v4.0.0`. The new prompt only emits Success Path Recipes when the original trajectory had removable inefficiency (failed attempt, param retuning, tool swap, detour). Clean first-try successes yield zero recipes — the prior "MUST yield at least one" forcing clause is gone, including a stray contradictory sentence in the output rules that was removed in a follow-up fix.
- **Prompt version map test:** bump `playbook_extraction_context` (and its incremental variant) from `v4.0.0` to `v4.0.1` to match the active prompt.

## Changes
**`integrations/claude_code/hook/handler.js`**
- Add a pre-pair merge pass that concatenates consecutive same-role entries (respecting `MAX_CONTENT_LENGTH`) and unions their `tools_used`.
- Pair into `(user, assistant)` interactions; drop unpaired user turns and orphaned assistant turns so every emitted interaction has both sides.

**`server/llm/providers/claude_code_provider.py`**
- Add `_ENV_MODEL = "CLAUDE_SMART_CLI_MODEL"` and `_DEFAULT_CLI_MODEL = "claude-sonnet-4-6"`.
- `_run_cli` now appends `--model <model>` to the Claude Code CLI invocation.

**`server/prompt/prompt_bank/playbook_extraction_context/`**
- `v4.0.0.prompt.md`: `active: true` → `false`.
- `v4.0.1.prompt.md`: new, `active: true`. See its changelog for the rules change. Follow-up fix removes a leftover "extract at least one Success Path Recipe" line from the output-fields rules that contradicted the v4.0.1 gating (changelog line 4, gating lines 62/108, emit guidance line 179).

**`tests/server/services/test_prompt_model_mapping.py`**
- Update `PROMPT_VERSION_MAP` entries for `playbook_extraction_context` and `playbook_extraction_context_incremental` from `v4.0.0` to `v4.0.1`.

## Test Plan
- Manual: run a Claude Code session with multi-entry assistant turns and confirm the published interactions contain the full assistant response (not just the first chunk) and no empty-assistant rows.
- Manual: with `CLAUDE_SMART_USE_LOCAL_CLI=1`, start extraction and confirm the spawned CLI command includes `--model claude-sonnet-4-6` by default, and honors `CLAUDE_SMART_CLI_MODEL=<other>` when set.
- Manual: run extraction on a clean first-try trajectory and confirm zero Success Path Recipes are produced; run on a trajectory with a detour and confirm a recipe is emitted.
- Automated: `pytest tests/server/services/test_prompt_model_mapping.py` passes with the `v4.0.1` entries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable Claude Code CLI model selection via environment variable
  * Playbook extraction now identifies correction SOPs and success path recipes from agent trajectories with gating logic to prevent unnecessary recipe generation

* **Updates**
  * Enhanced transcript parsing with consecutive message merging and improved interaction pairing
  * Previous playbook extraction prompt version disabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
