### PR TITLE
feat(profile): add deletion directive channel for forget/remove requests

### DIFF
--- a/reflexio/integrations/openclaw-embedded/plugin/prompts/profile_extraction.md
+++ b/reflexio/integrations/openclaw-embedded/plugin/prompts/profile_extraction.md
@@ -120,7 +120,8 @@ Note: if the same session also surfaces a behavioral rule (e.g., "verify column 
 3. Always include `ttl` for new profiles; pick the shortest TTL that the fact will plausibly remain true for.
 4. Never output behavioral rules for the agent here — those belong to the playbook extractor.
 5. **Never extract secrets or credentials.** Do not create profile entries for API keys, access tokens, passwords, OAuth secrets, private keys, auth headers, `.env` values, connection strings, or any other credential-shaped content, even if the user pasted such content into the conversation. Treat those as noise; skip them.
-6. Return `[]` when there is nothing new to extract.
+6. **Forget / delete / remove requests.** When the user explicitly asks to forget, delete, or stop remembering a stored fact (e.g. "forget that I like X", "remove my interest in Y", "don't remember that I work at Z"), emit a single profile entry whose `content` begins with "Requested removal of" and names the topic in positive form — for example, `"Requested removal of interest in self-improving agents from stored profiles"`. Do NOT rephrase the request as a new fact ("User is no longer interested in X", "User stopped caring about Y") — that looks like a fact update and will be merged into a zombie profile instead of erasing the original. The downstream deduplicator recognizes the "Requested removal of…" phrasing and uses it to delete the matching existing profile outright.
+7. Return `[]` when there is nothing new to extract.
 
 ## Existing profiles for context (do NOT re-extract these)
 

--- a/reflexio/server/prompt/prompt_bank/profile_deduplication/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/profile_deduplication/v1.0.0.prompt.md
@@ -33,6 +33,7 @@ Each profile includes: Content, TTL, Source, and Last Modified date.
    - Choose an appropriate merged_time_to_live (prefer the longest to preserve information)
    - Explain your reasoning briefly
 4. List unique_ids of NEW profiles that are truly unique (no duplicates found in either NEW or EXISTING)
+5. Identify deletion directives — NEW profiles whose content is a meta-request to forget an EXISTING profile (see [Deletion Directives vs. Fact Updates] below) — and emit them in `deletions` instead of `duplicate_groups` or `unique_ids`
 
 [Guidelines for Identifying Duplicates]
 - Profiles about the SAME topic/entity/preference are duplicates even if worded differently
@@ -55,6 +56,48 @@ Each profile includes: Content, TTL, Source, and Last Modified date.
 When merging, choose the longest TTL from the group:
 - infinity > one_year > one_quarter > one_month > one_week > one_day
 
+[Deletion Directives vs. Fact Updates]
+A NEW profile is a **deletion directive** when its content is about the ACT of
+forgetting, removing, or no-longer-storing an existing fact — not a new fact
+about the user. Signals:
+- Content begins with (or contains) the literal phrase **"Requested removal of"** — the upstream extractor emits this marker for every deletion request, so its presence is the strongest signal
+- Content refers to the profile-storage system itself: "Asked to forget X", "Wants us to stop remembering X"
+- Verbs like "removal", "forget", "delete", "stop storing" applied to an existing topic
+- Content describes an intention about the stored memory rather than the user's own state
+
+When a NEW profile is a deletion directive AND it matches an EXISTING profile
+on the same topic:
+- Emit it in `deletions` with `new_id` and the matched `existing_ids`
+- Do NOT include it in `duplicate_groups` or `unique_ids`
+- Do NOT create a merged profile like "Previously interested in X, but requested
+  removal of this interest" — that is a zombie profile. The correct outcome is:
+  the EXISTING profile is gone and no replacement is written.
+
+Contrast with **fact updates** (keep existing merge behavior):
+- "User is now vegetarian" (previously "likes beef") → duplicate_group, merge with newest-wins. This is a replacement of one fact with another.
+- "User no longer works at Acme" (previously "works at Acme") → duplicate_group. The user is stating a new fact about themselves.
+
+If a NEW deletion directive does not match any EXISTING profile, still emit it
+in `deletions` with an empty `existing_ids: []` — do not add it to `unique_ids`,
+because it is not a fact worth storing on its own.
+
+Example — deletion directive:
+- NEW-0: "Requested removal of interest in self-improving agents from stored profiles"
+- EXISTING-0: "User is interested in self-improving agents"
+```json
+{{
+  "duplicate_groups": [],
+  "unique_ids": [],
+  "deletions": [
+    {{
+      "new_id": "NEW-0",
+      "existing_ids": ["EXISTING-0"],
+      "reasoning": "NEW-0 is a meta-request to forget the stored fact in EXISTING-0, not a new fact about the user. Delete EXISTING-0 without writing a replacement."
+    }}
+  ]
+}}
+```
+
 [Output Format]
 Return a JSON object with:
 - duplicate_groups: Array of objects, each containing:
@@ -63,9 +106,13 @@ Return a JSON object with:
   - merged_time_to_live: String (one of: one_day, one_week, one_month, one_quarter, one_year, infinity)
   - reasoning: String (brief explanation)
 - unique_ids: Array of strings (IDs of unique NEW profiles, e.g., "NEW-2")
+- deletions: Array of objects, each containing:
+  - new_id: String (ID of the NEW profile that is a deletion directive, e.g., "NEW-0")
+  - existing_ids: Array of strings (IDs of EXISTING profiles to delete, e.g., ["EXISTING-0"]; may be empty)
+  - reasoning: String (why this was classified as a deletion directive)
 
 [Important]
-- Every NEW profile must appear EXACTLY ONCE (either in a duplicate_group's item_ids or in unique_ids)
-- EXISTING profiles only appear in item_ids when they are superseded by a merged version
-- Be conservative - only group true duplicates
+- Every NEW profile must appear EXACTLY ONCE — either in a duplicate_group's item_ids, in unique_ids, or as the new_id of a deletion directive
+- EXISTING profiles appear in duplicate_groups when superseded by a merge, or in a deletion directive's existing_ids when erased without replacement
+- Be conservative — only group true duplicates, and only classify as a deletion directive when the NEW is clearly a memory-erasure request rather than a fact update
 - If there are no EXISTING profiles, just deduplicate among the NEW profiles

--- a/reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.0.0.prompt.md
@@ -136,4 +136,5 @@ Note: if the same session surfaces a behavioral rule (e.g., "verify column types
 2. If the information is already in existing profiles, do NOT re-extract it
 3. Always include time_to_live for new profiles
 4. Only include metadata if a metadata definition is provided
-5. Return {{"profiles": null}} if there is nothing to extract
+5. **Forget / delete / remove requests.** When the user explicitly asks to forget, delete, or stop remembering a stored fact (e.g. "forget that I like X", "remove my interest in Y", "don't remember that I work at Z"), emit a single profile whose `content` begins with "Requested removal of" and names the topic in positive form. Do NOT rephrase the request as a new fact ("User is no longer interested in X", "User stopped caring about Y") — that looks like a fact update and will be merged into a zombie profile instead of erasing the original. The downstream deduplicator recognizes the "Requested removal of…" phrasing and uses it to delete the matching existing profile outright.
+6. Return {{"profiles": null}} if there is nothing to extract

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -33,6 +33,39 @@ logger = logging.getLogger(__name__)
 _format_profile_timestamp = format_dedup_timestamp
 
 
+# Canonical prefix emitted by the extractor for forget/delete requests. The
+# dedup LLM routes matching NEW profiles into `deletions`; any fallback path
+# that skips the LLM step must strip these markers before returning so they
+# are never persisted as facts.
+_DELETION_MARKER_PREFIX = "Requested removal of"
+
+
+def _strip_deletion_markers(
+    profiles: list[UserProfile],
+) -> list[UserProfile]:
+    """
+    Drop profiles whose content is a canonical deletion marker.
+
+    Used on fallback paths (LLM error, unexpected response type, empty dedup
+    output) to prevent "Requested removal of …" markers emitted by the
+    extractor from being persisted as regular profile facts when the dedup
+    LLM step is skipped or yields no deletions. Persisting such markers would
+    recreate the exact zombie-profile failure mode the deletion-directive
+    channel was introduced to eliminate.
+
+    Args:
+        profiles (list[UserProfile]): Profiles to filter.
+
+    Returns:
+        list[UserProfile]: Profiles with deletion markers removed.
+    """
+    return [
+        p
+        for p in profiles
+        if not (p.content or "").lstrip().startswith(_DELETION_MARKER_PREFIX)
+    ]
+
+
 # ===============================
 # Profile-specific Pydantic Output Schemas for LLM
 # ===============================
@@ -372,16 +405,16 @@ class ProfileDeduplicator(BaseDeduplicator):
                     "Unexpected response type from deduplication LLM: %s",
                     type(response),
                 )
-                return new_profiles, [], []
+                return _strip_deletion_markers(new_profiles), [], []
 
             dedup_output = response
         except Exception as e:
             logger.error("Failed to identify duplicates: %s", str(e))
-            return new_profiles, [], []
+            return _strip_deletion_markers(new_profiles), [], []
 
         if not dedup_output.duplicate_groups and not dedup_output.deletions:
             logger.info("No duplicate or deletion actions for request %s", request_id)
-            return new_profiles, [], []
+            return _strip_deletion_markers(new_profiles), [], []
 
         logger.info(
             "Found %d duplicate profile groups and %d deletion directives for request %s",
@@ -453,9 +486,33 @@ class ProfileDeduplicator(BaseDeduplicator):
                 prefix, idx = parsed
                 if prefix == "NEW":
                     group_new_indices.append(idx)
-                    handled_new_indices.add(idx)
                 elif prefix == "EXISTING":
                     group_existing_indices.append(idx)
+
+            # Reject groups that overlap with profiles already consumed by a
+            # deletion directive. Merging such a group would write a
+            # replacement profile containing content the user asked to forget.
+            conflicting_new = [i for i in group_new_indices if i in handled_new_indices]
+            conflicting_existing = [
+                i
+                for i in group_existing_indices
+                if 0 <= i < len(existing_profiles)
+                and existing_profiles[i].profile_id
+                and existing_profiles[i].profile_id in seen_delete_ids
+            ]
+            if conflicting_new or conflicting_existing:
+                logger.warning(
+                    "Skipping duplicate group %s: overlaps with deletion "
+                    "directives (NEW indices=%s, EXISTING indices=%s)",
+                    group.item_ids,
+                    conflicting_new,
+                    conflicting_existing,
+                )
+                continue
+
+            # Mark NEW indices as handled only after the overlap check passes.
+            for idx in group_new_indices:
+                handled_new_indices.add(idx)
 
             # Collect existing profile IDs to delete and their profiles for changelog (deduplicated)
             for eidx in group_existing_indices:

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -33,11 +33,6 @@ logger = logging.getLogger(__name__)
 _format_profile_timestamp = format_dedup_timestamp
 
 
-# Backward-compat alias — existing unit tests import this name from this
-# module. Delegates to the shared helper in deduplication_utils.
-_format_profile_timestamp = format_dedup_timestamp
-
-
 # ===============================
 # Profile-specific Pydantic Output Schemas for LLM
 # ===============================
@@ -71,6 +66,38 @@ class ProfileDuplicateGroup(BaseModel):
     )
 
 
+class ProfileDeletionDirective(BaseModel):
+    """
+    Represents a NEW profile that is a meta-request to forget an EXISTING fact.
+
+    Used when the user explicitly asks the system to erase a previously-stored
+    profile (e.g. "forget that I like X"). Unlike a duplicate group, a deletion
+    directive removes the matched EXISTING profile(s) without writing any merged
+    or replacement profile — the NEW directive is consumed, not retained.
+
+    Attributes:
+        new_id: ID of the NEW profile that expresses the deletion directive (e.g. 'NEW-0')
+        existing_ids: IDs of EXISTING profiles to delete without replacement (e.g. ['EXISTING-0'])
+        reasoning: Brief explanation of why this was classified as a deletion directive
+            rather than a fact update
+    """
+
+    new_id: str = Field(
+        description="ID of the NEW profile that is a deletion directive (e.g. 'NEW-0')"
+    )
+    existing_ids: list[str] = Field(
+        description="IDs of EXISTING profiles to delete without replacement (e.g. ['EXISTING-0'])"
+    )
+    reasoning: str = Field(
+        description="Brief explanation of the deletion classification"
+    )
+
+    model_config = ConfigDict(
+        extra="allow",
+        json_schema_extra={"additionalProperties": False},
+    )
+
+
 class ProfileDeduplicationOutput(BaseModel):
     """
     Output schema for profile deduplication with NEW/EXISTING format.
@@ -78,6 +105,10 @@ class ProfileDeduplicationOutput(BaseModel):
     Attributes:
         duplicate_groups: List of duplicate groups to merge
         unique_ids: List of IDs of unique NEW profiles (e.g., 'NEW-2')
+        deletions: List of deletion directives — NEW profiles that are pure
+            meta-requests to erase an EXISTING profile. Both the NEW and the
+            matched EXISTING profile(s) are removed; no merged replacement is
+            produced.
     """
 
     duplicate_groups: list[ProfileDuplicateGroup] = Field(
@@ -86,6 +117,14 @@ class ProfileDeduplicationOutput(BaseModel):
     unique_ids: list[str] = Field(
         default=[],
         description="IDs of unique NEW profiles (e.g., 'NEW-2')",
+    )
+    deletions: list[ProfileDeletionDirective] = Field(
+        default=[],
+        description=(
+            "NEW profiles that are pure deletion directives (the user asked to "
+            "forget/remove a stored fact). Both the NEW and matched EXISTING "
+            "profiles are removed; no merged replacement is written."
+        ),
     )
 
     model_config = ConfigDict(
@@ -340,13 +379,14 @@ class ProfileDeduplicator(BaseDeduplicator):
             logger.error("Failed to identify duplicates: %s", str(e))
             return new_profiles, [], []
 
-        if not dedup_output.duplicate_groups:
-            logger.info("No duplicate profiles found for request %s", request_id)
+        if not dedup_output.duplicate_groups and not dedup_output.deletions:
+            logger.info("No duplicate or deletion actions for request %s", request_id)
             return new_profiles, [], []
 
         logger.info(
-            "Found %d duplicate profile groups for request %s",
+            "Found %d duplicate profile groups and %d deletion directives for request %s",
             len(dedup_output.duplicate_groups),
+            len(dedup_output.deletions),
             request_id,
         )
 
@@ -388,6 +428,19 @@ class ProfileDeduplicator(BaseDeduplicator):
 
         now_ts = int(datetime.now(UTC).timestamp())
 
+        # Process deletion directives first. A directive is a NEW profile that
+        # is a meta-request to forget an EXISTING profile. Both the NEW and the
+        # matched EXISTING profile(s) are removed with no merged replacement.
+        self._apply_deletion_directives(
+            dedup_output.deletions,
+            new_profiles=new_profiles,
+            existing_profiles=existing_profiles,
+            handled_new_indices=handled_new_indices,
+            existing_ids_to_delete=existing_ids_to_delete,
+            seen_delete_ids=seen_delete_ids,
+            superseded_profiles=superseded_profiles,
+        )
+
         # Process duplicate groups
         for group in dedup_output.duplicate_groups:
             group_new_indices: list[int] = []
@@ -406,12 +459,13 @@ class ProfileDeduplicator(BaseDeduplicator):
 
             # Collect existing profile IDs to delete and their profiles for changelog (deduplicated)
             for eidx in group_existing_indices:
-                if 0 <= eidx < len(existing_profiles):
-                    pid = existing_profiles[eidx].profile_id
-                    if pid and pid not in seen_delete_ids:
-                        seen_delete_ids.add(pid)
-                        existing_ids_to_delete.append(pid)
-                        superseded_profiles.append(existing_profiles[eidx])
+                self._mark_existing_for_deletion(
+                    f"EXISTING-{eidx}",
+                    existing_profiles,
+                    existing_ids_to_delete,
+                    seen_delete_ids,
+                    superseded_profiles,
+                )
 
             # Get template from first NEW profile in group (for metadata)
             template_profile: UserProfile | None = None
@@ -483,6 +537,90 @@ class ProfileDeduplicator(BaseDeduplicator):
                 result_profiles.append(profile)
 
         return result_profiles, existing_ids_to_delete, superseded_profiles
+
+    def _apply_deletion_directives(
+        self,
+        directives: list[ProfileDeletionDirective],
+        *,
+        new_profiles: list[UserProfile],
+        existing_profiles: list[UserProfile],
+        handled_new_indices: set[int],
+        existing_ids_to_delete: list[str],
+        seen_delete_ids: set[str],
+        superseded_profiles: list[UserProfile],
+    ) -> None:
+        """
+        Apply deletion directives in place: consume the NEW profile and mark matched
+        EXISTING profile(s) for deletion without producing a merged replacement.
+
+        A directive is a NEW profile whose content is a meta-request to forget an
+        EXISTING profile (e.g. "Requested removal of interest in X from stored
+        profiles"). The NEW is suppressed from the result set and the matched
+        EXISTING rows are added to the deletion list.
+
+        Args:
+            directives: Deletion directives from the LLM.
+            new_profiles: Flat list of NEW profiles (indexed by NEW-N id).
+            existing_profiles: List of EXISTING profiles (indexed by EXISTING-M id).
+            handled_new_indices: Set of NEW indices already accounted for; this
+                method adds the consumed directive indices to it.
+            existing_ids_to_delete: Output list of profile IDs to delete; this
+                method appends to it.
+            seen_delete_ids: Set used to deduplicate IDs across all deletion paths.
+            superseded_profiles: Output list of deleted profile objects for the
+                changelog; this method appends to it.
+        """
+        for directive in directives:
+            self._consume_new_index(
+                directive.new_id, len(new_profiles), handled_new_indices
+            )
+            for eid in directive.existing_ids:
+                self._mark_existing_for_deletion(
+                    eid,
+                    existing_profiles,
+                    existing_ids_to_delete,
+                    seen_delete_ids,
+                    superseded_profiles,
+                )
+            logger.info(
+                "Profile deletion directive %s -> delete %s: %s",
+                directive.new_id,
+                directive.existing_ids,
+                directive.reasoning,
+            )
+
+    @staticmethod
+    def _consume_new_index(
+        new_id: str, new_profile_count: int, handled_new_indices: set[int]
+    ) -> None:
+        """Mark a NEW-N id as handled so the safety fallback does not re-add it."""
+        parsed = parse_item_id(new_id)
+        if parsed is None:
+            return
+        prefix, idx = parsed
+        if prefix == "NEW" and 0 <= idx < new_profile_count:
+            handled_new_indices.add(idx)
+
+    @staticmethod
+    def _mark_existing_for_deletion(
+        existing_id: str,
+        existing_profiles: list[UserProfile],
+        existing_ids_to_delete: list[str],
+        seen_delete_ids: set[str],
+        superseded_profiles: list[UserProfile],
+    ) -> None:
+        """Resolve an EXISTING-N id to a profile_id and queue it for deletion."""
+        parsed = parse_item_id(existing_id)
+        if parsed is None:
+            return
+        prefix, idx = parsed
+        if prefix != "EXISTING" or not (0 <= idx < len(existing_profiles)):
+            return
+        pid = existing_profiles[idx].profile_id
+        if pid and pid not in seen_delete_ids:
+            seen_delete_ids.add(pid)
+            existing_ids_to_delete.append(pid)
+            superseded_profiles.append(existing_profiles[idx])
 
     def _merge_custom_features(self, profiles: list[UserProfile]) -> dict | None:
         """

--- a/tests/server/services/profile/test_profile_deduplicator.py
+++ b/tests/server/services/profile/test_profile_deduplicator.py
@@ -1122,6 +1122,117 @@ class TestDeduplicate:
         # The directive must be consumed — not leak back as a stored fact.
         assert profiles == []
 
+    def test_deduplicate_strips_markers_on_llm_exception(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+    ):
+        """When the LLM call raises, fallback must strip canonical deletion markers.
+
+        Regression guard: if the LLM fails, returning `new_profiles` verbatim
+        would persist "Requested removal of …" markers as regular facts — the
+        exact zombie-profile outcome the deletion-directive channel was built
+        to prevent. The fallback must suppress markers while preserving
+        ordinary profiles.
+        """
+        timestamp = int(datetime.now(UTC).timestamp())
+        ordinary = UserProfile(
+            profile_id=str(uuid.uuid4()),
+            user_id="test_user",
+            content="User prefers dark mode",
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="req_ok",
+            profile_time_to_live=ProfileTimeToLive.ONE_MONTH,
+            source="extractor_a",
+        )
+        marker = UserProfile(
+            profile_id=str(uuid.uuid4()),
+            user_id="test_user",
+            content=(
+                "Requested removal of interest in self-improving agents "
+                "from stored profiles"
+            ),
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="req_forget",
+            profile_time_to_live=ProfileTimeToLive.ONE_DAY,
+            source="extractor_a",
+        )
+
+        mock_request_context.storage.search_user_profile.return_value = []
+        mock_llm_client.generate_chat_response.side_effect = RuntimeError(
+            "LLM unavailable"
+        )
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        profiles, delete_ids, superseded = deduplicator.deduplicate(
+            new_profiles=[ordinary, marker],
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        assert delete_ids == []
+        assert superseded == []
+        assert [p.profile_id for p in profiles] == [ordinary.profile_id]
+
+    def test_deduplicate_strips_markers_on_empty_output(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+    ):
+        """Empty dedup output (no groups, no deletions) still strips markers.
+
+        If the LLM returns nothing to act on but a marker profile is present in
+        `new_profiles`, the fallback must drop the marker rather than persist
+        it as a fact.
+        """
+        timestamp = int(datetime.now(UTC).timestamp())
+        ordinary = UserProfile(
+            profile_id=str(uuid.uuid4()),
+            user_id="test_user",
+            content="User prefers dark mode",
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="req_ok",
+            profile_time_to_live=ProfileTimeToLive.ONE_MONTH,
+            source="extractor_a",
+        )
+        marker = UserProfile(
+            profile_id=str(uuid.uuid4()),
+            user_id="test_user",
+            content="Requested removal of preference for tabs over spaces",
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="req_forget",
+            profile_time_to_live=ProfileTimeToLive.ONE_DAY,
+            source="extractor_a",
+        )
+
+        mock_request_context.storage.search_user_profile.return_value = []
+        mock_llm_client.generate_chat_response.return_value = (
+            ProfileDeduplicationOutput(
+                duplicate_groups=[],
+                unique_ids=[],
+                deletions=[],
+            )
+        )
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        profiles, delete_ids, superseded = deduplicator.deduplicate(
+            new_profiles=[ordinary, marker],
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        assert delete_ids == []
+        assert superseded == []
+        assert [p.profile_id for p in profiles] == [ordinary.profile_id]
+
 
 # ===============================
 # Test: Integration

--- a/tests/server/services/profile/test_profile_deduplicator.py
+++ b/tests/server/services/profile/test_profile_deduplicator.py
@@ -32,6 +32,7 @@ from reflexio.server.services.deduplication_utils import parse_item_id
 from reflexio.server.services.profile.profile_deduplicator import (
     ProfileDeduplicationOutput,
     ProfileDeduplicator,
+    ProfileDeletionDirective,
     ProfileDuplicateGroup,
     _format_profile_timestamp,
 )
@@ -167,6 +168,56 @@ class TestPydanticModels:
         output = ProfileDeduplicationOutput()
         assert output.duplicate_groups == []
         assert output.unique_ids == []
+        assert output.deletions == []
+
+    def test_deletion_directive_creation(self):
+        """Test that ProfileDeletionDirective can be created with valid data."""
+        directive = ProfileDeletionDirective(
+            new_id="NEW-0",
+            existing_ids=["EXISTING-0", "EXISTING-1"],
+            reasoning="User asked to forget this topic",
+        )
+        assert directive.new_id == "NEW-0"
+        assert directive.existing_ids == ["EXISTING-0", "EXISTING-1"]
+        assert directive.reasoning == "User asked to forget this topic"
+
+    def test_deletion_directive_json_schema_forbids_extra(self):
+        """Test that ProfileDeletionDirective's JSON schema forbids additional properties."""
+        schema = ProfileDeletionDirective.model_json_schema()
+        assert schema.get("additionalProperties") is False
+
+    def test_deduplication_output_with_deletions(self):
+        """Test that ProfileDeduplicationOutput accepts deletions."""
+        output = ProfileDeduplicationOutput(
+            duplicate_groups=[],
+            unique_ids=[],
+            deletions=[
+                ProfileDeletionDirective(
+                    new_id="NEW-0",
+                    existing_ids=["EXISTING-0"],
+                    reasoning="deletion request",
+                )
+            ],
+        )
+        assert len(output.deletions) == 1
+        assert output.deletions[0].new_id == "NEW-0"
+
+    def test_deduplication_output_deletions_from_dict(self):
+        """Test that ProfileDeduplicationOutput with deletions validates from dict."""
+        data = {
+            "duplicate_groups": [],
+            "unique_ids": [],
+            "deletions": [
+                {
+                    "new_id": "NEW-0",
+                    "existing_ids": ["EXISTING-0"],
+                    "reasoning": "forget request",
+                }
+            ],
+        }
+        output = ProfileDeduplicationOutput.model_validate(data)
+        assert len(output.deletions) == 1
+        assert output.deletions[0].existing_ids == ["EXISTING-0"]
 
     def test_deduplication_output_from_dict(self):
         """Test that ProfileDeduplicationOutput can be validated from dict."""
@@ -719,6 +770,120 @@ class TestBuildDeduplicatedResults:
         assert len(superseded) == 1
         assert superseded[0].profile_id == "existing_1"
 
+    def test_build_deduplicated_results_handles_deletion_directive(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        sample_profiles,
+    ):
+        """A deletion directive erases the EXISTING profile without writing a replacement.
+
+        This is the core bug fix: "forget that I am interested in X" used to
+        produce a merged "Previously interested in X, but requested removal"
+        profile. With the deletion channel, the NEW directive is consumed and
+        the EXISTING profile is deleted outright.
+        """
+        timestamp = int(datetime.now(UTC).timestamp())
+        existing_profile = UserProfile(
+            profile_id="existing_old_interest",
+            user_id="test_user",
+            content="User is interested in self-improving agents",
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="old_req",
+        )
+
+        dedup_output = ProfileDeduplicationOutput(
+            duplicate_groups=[],
+            unique_ids=["NEW-1", "NEW-2"],
+            deletions=[
+                ProfileDeletionDirective(
+                    new_id="NEW-0",
+                    existing_ids=["EXISTING-0"],
+                    reasoning=(
+                        "NEW-0 is a meta-request to forget EXISTING-0; "
+                        "not a fact about the user."
+                    ),
+                )
+            ],
+        )
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        result_profiles, delete_ids, superseded = (
+            deduplicator._build_deduplicated_results(
+                new_profiles=sample_profiles,
+                existing_profiles=[existing_profile],
+                dedup_output=dedup_output,
+                user_id="test_user",
+                request_id="test_request",
+            )
+        )
+
+        # EXISTING profile is marked for deletion.
+        assert delete_ids == ["existing_old_interest"]
+        assert len(superseded) == 1
+        assert superseded[0].profile_id == "existing_old_interest"
+
+        # NEW-0 (the directive) was consumed — not re-added by the safety fallback.
+        assert all(p.content != sample_profiles[0].content for p in result_profiles), (
+            "Deletion directive NEW profile should not appear in result_profiles"
+        )
+
+        # Only NEW-1 and NEW-2 (the unrelated unique profiles) remain.
+        assert len(result_profiles) == 2
+        assert {p.content for p in result_profiles} == {
+            sample_profiles[1].content,
+            sample_profiles[2].content,
+        }
+
+    def test_build_deduplicated_results_deletion_directive_no_match(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        sample_profiles,
+    ):
+        """A deletion directive with empty existing_ids still consumes the NEW.
+
+        If the LLM emits a deletion directive but matches no EXISTING profile,
+        the NEW profile must still be suppressed — a meta-statement like
+        "Requested removal of X" is not a fact worth storing on its own.
+        """
+        dedup_output = ProfileDeduplicationOutput(
+            duplicate_groups=[],
+            unique_ids=["NEW-1", "NEW-2"],
+            deletions=[
+                ProfileDeletionDirective(
+                    new_id="NEW-0",
+                    existing_ids=[],
+                    reasoning="No matching existing profile found.",
+                )
+            ],
+        )
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        result_profiles, delete_ids, superseded = (
+            deduplicator._build_deduplicated_results(
+                new_profiles=sample_profiles,
+                existing_profiles=[],
+                dedup_output=dedup_output,
+                user_id="test_user",
+                request_id="test_request",
+            )
+        )
+
+        assert delete_ids == []
+        assert superseded == []
+        # NEW-0 must not survive into result_profiles.
+        assert all(p.content != sample_profiles[0].content for p in result_profiles)
+        assert len(result_profiles) == 2
+
 
 # ===============================
 # Test: Deduplicate Main Method
@@ -888,6 +1053,74 @@ class TestDeduplicate:
         assert len(delete_ids) == 1
         assert delete_ids[0] == "existing_1"
         assert len(superseded) == 1
+
+    def test_deduplicate_applies_deletions_when_no_duplicate_groups(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        sample_profiles,
+    ):
+        """A deletion-only LLM response must still erase the EXISTING profile.
+
+        Regression guard: the public `deduplicate()` used to short-circuit when
+        `duplicate_groups` was empty, which silently dropped deletion directives
+        and returned the 'Requested removal of ...' NEW profile as a new fact —
+        the exact zombie-profile failure the deletion channel was meant to fix.
+        """
+        timestamp = int(datetime.now(UTC).timestamp())
+        existing_profile = UserProfile(
+            profile_id="existing_forgettable",
+            user_id="test_user",
+            content="User is interested in self-improving agents",
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="old_req",
+        )
+        directive_profile = UserProfile(
+            profile_id=str(uuid.uuid4()),
+            user_id="test_user",
+            content=(
+                "Requested removal of interest in self-improving agents "
+                "from stored profiles"
+            ),
+            last_modified_timestamp=timestamp,
+            generated_from_request_id="req_directive",
+            profile_time_to_live=ProfileTimeToLive.ONE_DAY,
+            source="extractor_a",
+        )
+
+        mock_request_context.storage.search_user_profile.return_value = [
+            existing_profile
+        ]
+        mock_llm_client.generate_chat_response.return_value = (
+            ProfileDeduplicationOutput(
+                duplicate_groups=[],
+                unique_ids=[],
+                deletions=[
+                    ProfileDeletionDirective(
+                        new_id="NEW-0",
+                        existing_ids=["EXISTING-0"],
+                        reasoning="Meta-request to forget EXISTING-0.",
+                    )
+                ],
+            )
+        )
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        profiles, delete_ids, superseded = deduplicator.deduplicate(
+            new_profiles=[directive_profile],
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        assert delete_ids == ["existing_forgettable"]
+        assert len(superseded) == 1
+        assert superseded[0].profile_id == "existing_forgettable"
+        # The directive must be consumed — not leak back as a stored fact.
+        assert profiles == []
 
 
 # ===============================


### PR DESCRIPTION
## Summary
- Adds a dedicated **deletion directive** channel to profile deduplication so that "forget that I …" / "remove my interest in …" requests actually erase the stored profile instead of producing a zombie merged entry like *"Previously interested in X, but requested removal"*.
- Teaches both profile extractors (OpenClaw plugin + server-side) to emit deletion requests in a canonical `"Requested removal of …"` shape that the deduplicator can recognize.
- Extends the deduplication prompt, Pydantic schema, and deduplicator implementation to route these directives into a new `deletions` output that removes the matched EXISTING profile without writing a replacement.
- Hardens all dedup fallback paths (LLM error, unexpected response type, empty output) to strip canonical deletion markers from `new_profiles` before returning so they are never persisted as facts when the LLM step is skipped.

## Changes

**Extraction prompts** — emit deletion markers
- `reflexio/integrations/openclaw-embedded/plugin/prompts/profile_extraction.md` — new rule instructing the extractor to emit `"Requested removal of …"` for forget/delete requests rather than rephrasing them as negated facts.
- `reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.0.0.prompt.md` — matching guidance for the server-side extractor.

**Deduplication prompt** — recognize and route directives
- `reflexio/server/prompt/prompt_bank/profile_deduplication/v1.0.0.prompt.md` — adds a `[Deletion Directives vs. Fact Updates]` section, a worked JSON example, a new `deletions` output field, and updates the "every NEW profile appears EXACTLY ONCE" invariant to include the deletion bucket.

**Deduplicator** — new schema + logic + fallback safety
- `reflexio/server/services/profile/profile_deduplicator.py`:
  - New `ProfileDeletionDirective` Pydantic model.
  - `ProfileDeduplicationOutput` gains a `deletions` field.
  - `deduplicate()` no longer short-circuits when `duplicate_groups` is empty but deletions exist.
  - New `_apply_deletion_directives()` helper plus `_consume_new_index()` / `_mark_existing_for_deletion()` utilities (the latter refactored out of the duplicate-group loop for reuse).
  - Module-level `_DELETION_MARKER_PREFIX` constant and `_strip_deletion_markers()` helper applied at the three fallback return sites (LLM exception, unexpected response type, empty dedup output) to prevent raw markers from leaking through and being persisted as facts.

**Tests**
- `tests/server/services/profile/test_profile_deduplicator.py`:
  - Schema tests for `ProfileDeletionDirective` and the new `deletions` field (including dict round-trip and `additionalProperties: false`).
  - `test_build_deduplicated_results_handles_deletion_directive` — the core bug-fix case: EXISTING is deleted, NEW directive is consumed, unrelated NEWs survive.
  - `test_build_deduplicated_results_deletion_directive_no_match` — empty `existing_ids` still suppresses the NEW directive.
  - `test_deduplicate_applies_deletions_when_no_duplicate_groups` — regression guard for the short-circuit bug at the public `deduplicate()` boundary.
  - `test_deduplicate_strips_markers_on_llm_exception` — LLM failure fallback must drop markers.
  - `test_deduplicate_strips_markers_on_empty_output` — empty dedup output fallback must drop markers.

## Test Plan
- [x] `ruff check` / `ruff format` pass on the modified Python files.
- [x] `uv run pytest tests/server/services/profile/test_profile_deduplicator.py` — 41/41 pass.
- [ ] Manual smoke: in a session, say "forget that I like X" after a profile for X has been stored and verify the stored profile disappears rather than turning into a "previously liked X" zombie entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory management: Users can explicitly request forgetting/deleting stored facts; such requests are recognized and processed as deletions rather than new facts.

* **Bug Fixes / Reliability**
  * Deletion requests are consistently applied (preventing re-creation or merging) and are removed from outputs on failures or empty responses so they don't reappear as stored facts.

* **Tests / Documentation**
  * Updated prompts and tests to cover deletion flows and ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
