### PR TITLE
feat: auto-detect embedding default; refine slash-command filter for text-carrying commands

### DIFF
--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -1209,6 +1209,11 @@ class LiteLLMClient:
             if hasattr(self.config, key):
                 setattr(self.config, key, value)
                 self.logger.debug("Updated config: %s = %s", key, value)
+                # Invalidate the embedding-default cache when the provider
+                # surface changes — resolve_model_name(EMBEDDING) reads
+                # api_key_config, so a swap must force a re-detect.
+                if key == "api_key_config":
+                    self._default_embedding_model = None
             else:
                 self.logger.warning("Unknown config parameter: %s", key)
 

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -28,6 +28,7 @@ from reflexio.server.llm.image_utils import (
     encode_image_to_base64 as _encode_image_to_base64,
 )
 from reflexio.server.llm.llm_utils import is_pydantic_model
+from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.llm.providers.claude_code_provider import (
     register_if_enabled as _register_claude_code,
 )
@@ -269,6 +270,11 @@ class LiteLLMClient:
         # Pre-resolve API key configuration for the main model
         self._api_key, self._api_base, self._api_version = self._resolve_api_key()
 
+        # Lazily-resolved default embedding model. Populated on first call to
+        # _resolve_default_embedding_model so a client built with no embedding
+        # use case never pays the auto-detection cost.
+        self._default_embedding_model: str | None = None
+
         # Enable Braintrust observability when API key is configured
         if os.environ.get("BRAINTRUST_API_KEY") and "braintrust" not in (
             litellm.callbacks or []
@@ -453,6 +459,32 @@ class LiteLLMClient:
 
         return self._make_request(final_messages, **kwargs)
 
+    def _resolve_default_embedding_model(self) -> str:
+        """
+        Resolve the embedding model to use when callers do not specify one.
+
+        Routes through the same auto-detection chain as the rest of reflexio
+        (``resolve_model_name`` for ``ModelRole.EMBEDDING``) so a session that
+        has the local ONNX embedder enabled — or any non-OpenAI provider —
+        does not silently fall back to ``text-embedding-3-small`` and produce
+        OpenAI 401s. Higher-precedence org config and site-var overrides are
+        the caller's responsibility to resolve and pass via ``model=``; this
+        helper handles only the auto-detect tier.
+
+        Returns:
+            str: The auto-detected embedding model name (cached after first call).
+
+        Raises:
+            RuntimeError: Propagated from ``resolve_model_name`` when no
+                embedding-capable provider is available.
+        """
+        if self._default_embedding_model is None:
+            self._default_embedding_model = resolve_model_name(
+                ModelRole.EMBEDDING,
+                api_key_config=self.config.api_key_config,
+            )
+        return self._default_embedding_model
+
     def get_embedding(
         self, text: str, model: str | None = None, dimensions: int | None = None
     ) -> list[float]:
@@ -461,7 +493,10 @@ class LiteLLMClient:
 
         Args:
             text: The text to get embedding for.
-            model: Optional embedding model (defaults to 'text-embedding-3-small').
+            model: Optional embedding model. When omitted, the model is
+                auto-detected via ``resolve_model_name(ModelRole.EMBEDDING)``
+                so callers inherit the local-embedder gate and any non-OpenAI
+                provider configured for this client.
             dimensions: Optional number of dimensions for the embedding vector.
 
         Returns:
@@ -470,7 +505,7 @@ class LiteLLMClient:
         Raises:
             LiteLLMClientError: If embedding generation fails.
         """
-        embedding_model = model or "text-embedding-3-small"
+        embedding_model = model or self._resolve_default_embedding_model()
 
         # local/* models route through the in-process ONNX embedder — no
         # network call, no litellm API, no tiktoken truncation (the embedder
@@ -517,7 +552,10 @@ class LiteLLMClient:
 
         Args:
             texts: List of texts to get embeddings for.
-            model: Optional embedding model (defaults to 'text-embedding-3-small').
+            model: Optional embedding model. When omitted, the model is
+                auto-detected via ``resolve_model_name(ModelRole.EMBEDDING)``
+                so callers inherit the local-embedder gate and any non-OpenAI
+                provider configured for this client.
             dimensions: Optional number of dimensions for the embedding vectors.
 
         Returns:
@@ -529,7 +567,7 @@ class LiteLLMClient:
         if not texts:
             return []
 
-        embedding_model = model or "text-embedding-3-small"
+        embedding_model = model or self._resolve_default_embedding_model()
 
         # See matching short-circuit in get_embedding above.
         if embedding_model.startswith("local/") and _local_embedder_enabled():

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -5,6 +5,7 @@ Base class for generation services
 import contextvars
 import logging
 import os
+import re
 import time
 import uuid
 from abc import ABC, abstractmethod
@@ -60,6 +61,23 @@ _EXTRACTOR_PROMPT_PREFIXES = (
     "you are a signal detection",
     "you are an extractor",
 )
+# Matches a single slash-command token at the start of a message. The
+# ``:`` allows plugin-namespaced commands like ``/claude-smart:tag``.
+_SLASH_COMMAND_TOKEN_RE = re.compile(r"^/[A-Za-z0-9_:-]+\s*")
+
+
+def _is_pure_slash_command(content: str) -> bool:
+    """Whether ``content`` is a bare slash command with no substantive text.
+
+    ``/learn`` and ``/claude-smart:tag`` return True. ``/btw some note``
+    and ``/claude-smart:tag fix the foo`` return False because the text
+    after the command token carries user signal the extractors should see.
+    """
+    stripped = content.lstrip()
+    if not stripped.startswith("/"):
+        return False
+    remainder = _SLASH_COMMAND_TOKEN_RE.sub("", stripped, count=1)
+    return not remainder.strip()
 
 
 def _iter_user_contents(
@@ -87,8 +105,10 @@ def _cheap_should_run_reject(
     Rejection rules:
         - No user message at least ``_MIN_USER_CONTENT_LEN`` chars long
           (purely short commands / confirmations).
-        - Every user message starts with ``/`` (slash-command-only
-          batch; e.g. ``/commit``, ``/review``).
+        - Every user message is a bare slash-command dispatch with no
+          substantive trailing text (e.g. ``/commit``, ``/review``,
+          ``/claude-smart:tag``). Slash commands that carry user text
+          after the token (e.g. ``/btw some note``) are kept.
         - Any user message begins with a known extractor-prompt prefix
           (reflexio talking to itself via the claude-code LLM provider).
 
@@ -111,10 +131,11 @@ def _cheap_should_run_reject(
     if not any(len(c.strip()) >= _MIN_USER_CONTENT_LEN for c in user_contents):
         return "all_user_turns_too_short"
 
-    if all(c.lstrip().startswith("/") for c in user_contents):
+    if all(_is_pure_slash_command(c) for c in user_contents):
         return "all_slash_commands"
 
     return None
+
 
 # Timeout for individual extractor execution (safety net if LLM provider ignores its own timeout)
 EXTRACTOR_TIMEOUT_SECONDS = 300

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -617,6 +617,17 @@ class TestIsNonRetryableError:
 class TestGetEmbedding:
     """Tests for the single-text embedding endpoint."""
 
+    @pytest.fixture(autouse=True)
+    def _pin_default_model(self, monkeypatch):
+        # These tests exercise the litellm-backed default. Auto-detection
+        # in the test environment may resolve to local/* (LocalEmbedder)
+        # which short-circuits past the mocked litellm.embedding call.
+        monkeypatch.setattr(
+            LiteLLMClient,
+            "_resolve_default_embedding_model",
+            lambda _: "text-embedding-3-small",
+        )
+
     @patch("reflexio.server.llm.litellm_client.litellm.embedding")
     def test_valid_text(self, mock_embedding):
         mock_embedding.return_value = _make_embedding_response([0.1, 0.2, 0.3])
@@ -678,6 +689,17 @@ class TestGetEmbedding:
 class TestGetEmbeddings:
     """Tests for the batch embedding endpoint."""
 
+    @pytest.fixture(autouse=True)
+    def _pin_default_model(self, monkeypatch):
+        # See TestGetEmbedding._pin_default_model — these tests assert against
+        # the litellm-backed default and must not be intercepted by the
+        # local-embedder short-circuit.
+        monkeypatch.setattr(
+            LiteLLMClient,
+            "_resolve_default_embedding_model",
+            lambda _: "text-embedding-3-small",
+        )
+
     @patch("reflexio.server.llm.litellm_client.litellm.embedding")
     def test_batch_embeddings(self, mock_embedding):
         mock_embedding.return_value = _make_batch_embedding_response(
@@ -724,6 +746,72 @@ class TestGetEmbeddings:
 
 
 # ===================================================================
+# Default embedding-model resolution tests
+# ===================================================================
+
+
+class TestEmbeddingDefaultResolution:
+    """Tests for the caching and routing behavior of the embedding default."""
+
+    def test_resolve_default_embedding_model_is_cached(self, monkeypatch):
+        """``_resolve_default_embedding_model`` must hit resolve_model_name once.
+
+        The per-instance cache (``self._default_embedding_model``) is the
+        contract documented on ``LiteLLMClient`` — auto-detection is not free
+        (it probes env vars and provider registries), so repeated
+        ``get_embedding`` / ``get_embeddings`` calls on the same client must
+        not re-resolve.
+        """
+        call_count = {"n": 0}
+
+        def _fake_resolve(*args, **kwargs):
+            call_count["n"] += 1
+            return "text-embedding-3-small"
+
+        monkeypatch.setattr(
+            "reflexio.server.llm.litellm_client.resolve_model_name",
+            _fake_resolve,
+        )
+
+        client = _build_client()
+        with patch("reflexio.server.llm.litellm_client.litellm.embedding") as mock_emb:
+            mock_emb.return_value = _make_embedding_response([0.1, 0.2])
+            client.get_embedding("a")
+            client.get_embedding("b")
+            client.get_embeddings(["c", "d"])
+
+        assert call_count["n"] == 1
+
+    def test_get_embedding_routes_to_local_when_default_is_local(self, monkeypatch):
+        """When the auto-detected default is ``local/…``, ``get_embedding``
+        must take the LocalEmbedder branch and never call ``litellm.embedding``.
+        """
+        monkeypatch.setattr(
+            LiteLLMClient,
+            "_resolve_default_embedding_model",
+            lambda _: "local/minilm-l6-v2",
+        )
+        monkeypatch.setattr(
+            "reflexio.server.llm.litellm_client._local_embedder_enabled",
+            lambda: True,
+        )
+        fake_embedder = MagicMock()
+        fake_embedder.embed.return_value = [[0.9, 0.8, 0.7]]
+        monkeypatch.setattr(
+            "reflexio.server.llm.litellm_client.LocalEmbedder.get",
+            classmethod(lambda _cls: fake_embedder),
+        )
+
+        client = _build_client()
+        with patch("reflexio.server.llm.litellm_client.litellm.embedding") as mock_emb:
+            result = client.get_embedding("hello")
+
+        assert result == [0.9, 0.8, 0.7]
+        fake_embedder.embed.assert_called_once_with(["hello"])
+        mock_emb.assert_not_called()
+
+
+# ===================================================================
 # Embedding input truncation tests
 # ===================================================================
 
@@ -746,6 +834,15 @@ class TestEmbeddingTruncation:
         _get_embedding_limit.cache_clear()
         _get_embedding_encoding.cache_clear()
         _TRUNCATION_WARNED_MODELS.clear()
+
+    @pytest.fixture(autouse=True)
+    def _pin_default_model(self, monkeypatch):
+        # See TestGetEmbedding._pin_default_model.
+        monkeypatch.setattr(
+            LiteLLMClient,
+            "_resolve_default_embedding_model",
+            lambda _: "text-embedding-3-small",
+        )
 
     def test_get_embedding_limit_openai_family(self):
         """Known OpenAI embedding models resolve to the 8191 cap."""

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from reflexio.models.api_schema.domain.entities import Request
+from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
     Status,
@@ -21,6 +23,8 @@ from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     ExtractorExecutionError,
     StatusChangeOperation,
+    _cheap_should_run_reject,
+    _is_pure_slash_command,
 )
 
 # ===============================
@@ -1974,6 +1978,89 @@ class TestSequentialExecution:
         assert service._process_calls[0] == [{"name": "fast"}]
         assert service._last_extractor_run_stats["failed"] == 1
         assert service._last_extractor_run_stats["timed_out"] == 1
+
+
+class TestPureSlashCommand:
+    """Cases for the ``_is_pure_slash_command`` helper."""
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "/learn",
+            "  /tag ",
+            "/claude-smart:tag",
+            "/commit",
+            "/review",
+        ],
+    )
+    def test_bare_dispatch_is_pure(self, content):
+        assert _is_pure_slash_command(content) is True
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "/btw this is a side note I want recorded",
+            "/claude-smart:tag the previous turn was wrong because X",
+            "/commit fix the foo in bar",
+            "not a slash command at all",
+            "",
+            "   ",
+        ],
+    )
+    def test_non_pure_returns_false(self, content):
+        assert _is_pure_slash_command(content) is False
+
+    def test_handles_bare_slash_with_no_body(self):
+        """A lone ``/`` has no command-name token; treat as non-pure.
+
+        Pins the edge-case behavior after the switch from
+        ``startswith("/")`` to the token-regex approach — the old rule
+        would have flagged this as a slash command, the new rule does
+        not, and we want regressions here to be loud.
+        """
+        assert _is_pure_slash_command("/") is False
+        assert _is_pure_slash_command("  /  ") is False
+
+
+class TestCheapShouldRunReject:
+    """Regression tests for the ``all_slash_commands`` rule after the /btw fix."""
+
+    @staticmethod
+    def _batch(*contents: str) -> list[RequestInteractionDataModel]:
+        return [
+            RequestInteractionDataModel(
+                session_id="s",
+                request=Request(request_id="r", user_id="u"),
+                interactions=[
+                    Interaction(user_id="u", request_id="r", role="User", content=c)
+                    for c in contents
+                ],
+            )
+        ]
+
+    def test_btw_with_note_is_not_rejected(self):
+        batch = self._batch("/btw some side note with real content from the user")
+        assert _cheap_should_run_reject(batch) is None
+
+    def test_namespaced_tag_with_note_is_not_rejected(self):
+        batch = self._batch(
+            "/claude-smart:tag the last turn misunderstood what I was asking"
+        )
+        assert _cheap_should_run_reject(batch) is None
+
+    def test_bare_slash_command_still_rejected(self):
+        # Bare `/learn` also trips the length rule first; either rejection
+        # reason is fine — the contract is that it must be dropped.
+        batch = self._batch("/learn")
+        assert _cheap_should_run_reject(batch) is not None
+
+    def test_mixed_bare_slash_commands_still_rejected(self):
+        batch = self._batch("/learn", "/claude-smart:tag", "/review")
+        assert _cheap_should_run_reject(batch) is not None
+
+    def test_mixed_bare_and_content_bearing_passes(self):
+        batch = self._batch("/learn", "/btw actually keep this whole batch around")
+        assert _cheap_should_run_reject(batch) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Stop hardcoding `text-embedding-3-small` in `LiteLLMClient`; the default now flows through `resolve_model_name(ModelRole.EMBEDDING)` so clients inherit the local-embedder gate and any non-OpenAI provider configured for the session (no more silent OpenAI 401s when the local embedder or a non-OpenAI provider is enabled).
- Invalidate the per-instance embedding-default cache inside `update_config` when `api_key_config` is swapped, so a post-construction provider change actually takes effect instead of silently reusing the previously resolved model.
- Tighten `_cheap_should_run_reject`'s `all_slash_commands` rule: previously any message starting with `/` (including `/btw some note` or `/claude-smart:tag fix the foo`) caused the whole batch to be dropped. Now only *bare* slash-command dispatches are considered content-free; commands with trailing user text are kept so the extractors can see them.

## Changes

**`reflexio/server/llm/litellm_client.py`**
- Add `_default_embedding_model` instance cache and `_resolve_default_embedding_model()` helper that lazily calls `resolve_model_name(ModelRole.EMBEDDING, api_key_config=...)`.
- `get_embedding` and `get_embeddings` now fall back to `_resolve_default_embedding_model()` when the caller omits `model=`.
- `update_config()` clears `_default_embedding_model` whenever `api_key_config` is rewritten (provider surface changed -> re-detect).
- Docstrings updated to describe the auto-detect behavior.

**`reflexio/server/services/base_generation_service.py`**
- Add `_SLASH_COMMAND_TOKEN_RE` and `_is_pure_slash_command(content)` helper. It matches a single `/name` or `/plugin:name` token at the start and returns `True` only when nothing substantive follows.
- `_cheap_should_run_reject` swaps `lstrip().startswith("/")` for `_is_pure_slash_command(c)` in the `all_slash_commands` check.
- Rejection-rule docstring updated to describe the new behavior.

**Tests**
- `tests/server/llm/test_litellm_client_unit.py`:
  - `autouse=True` fixture `_pin_default_model` added to `TestGetEmbedding`, `TestGetEmbeddings`, and `TestEmbeddingTruncation` that pins `_resolve_default_embedding_model` -> `text-embedding-3-small`. Needed because the dev env has `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1`, which would otherwise route past the mocked `litellm.embedding`.
  - New `TestEmbeddingDefaultResolution` with two tests: caching contract (`resolve_model_name` called exactly once per client) and `local/*` routing (takes the `LocalEmbedder` branch, never touches `litellm.embedding`).
- `tests/server/services/test_base_generation_service.py`:
  - New `TestPureSlashCommand` covering bare dispatches, text-carrying commands, namespaced commands, and the `/` edge case.
  - New `TestCheapShouldRunReject` with regression cases: `/btw <note>` and `/claude-smart:tag <note>` are now kept; bare `/learn`, `/review`, etc. are still rejected; mixed batches with any content-bearing message pass.

## Test Plan
- [ ] `uv run pytest tests/server/llm/test_litellm_client_unit.py` passes
- [ ] `uv run pytest tests/server/services/test_base_generation_service.py` passes
- [ ] Sanity check: with `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` unset, a fresh `LiteLLMClient` with no embedding use case resolves lazily on first `get_embedding` call (no work in `__init__`).
- [ ] Sanity check: calling `client.update_config(api_key_config=<other>)` then `client.get_embedding(...)` re-resolves the default (does not return the old cached model).
- [ ] Manual: a batch with `/btw something worth remembering` no longer short-circuits at `_cheap_should_run_reject`.
