### PR TITLE
feat: force_extraction bypasses cheap pre-filter and LLM should_run vote

### DIFF
--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -262,7 +262,7 @@ def publish(
         bool,
         typer.Option(
             "--force-extraction",
-            help="Bypass batch_interval checks and always run extractors",
+            help="Bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run) and always run extractors",
         ),
     ] = False,
 ) -> None:

--- a/reflexio/cli/commands/shortcuts.py
+++ b/reflexio/cli/commands/shortcuts.py
@@ -144,7 +144,7 @@ def register_shortcuts(app: typer.Typer) -> None:
             bool,
             typer.Option(
                 "--force-extraction",
-                help="Bypass batch_interval checks and always run extractors",
+                help="Bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run) and always run extractors",
             ),
         ] = False,
     ) -> None:

--- a/reflexio/cli/commands/shortcuts.py
+++ b/reflexio/cli/commands/shortcuts.py
@@ -59,7 +59,8 @@ def _build_publish_args(
         file: Path to a JSON/JSONL payload file.
         stdin: When True, read JSON payload from stdin.
         skip_aggregation: When True, skip post-extract aggregation.
-        force_extraction: When True, bypass batch interval checks.
+        force_extraction: When True, bypass all extraction gates
+            (batch_interval, cheap pre-filter, LLM should_run).
 
     Returns:
         list[str]: argv list ready to hand to ``interactions_app(...)``.

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -412,8 +412,9 @@ class ReflexioClient:
                 in both cases.
             skip_aggregation: If True, extract profiles/playbooks but
                 skip aggregation to agent playbooks.
-            force_extraction: If True, bypass batch_interval checks
-                and always run extractors.
+            force_extraction: If True, bypass all extraction gates
+                (batch_interval, cheap pre-filter, LLM should_run) and
+                always run extractors.
 
         Returns:
             PublishUserInteractionResponse: Server response. In

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -383,9 +383,7 @@ class PublishUserInteractionRequest(BaseModel):
     skip_aggregation: bool = (
         False  # when True, extract profiles/playbooks but skip aggregation
     )
-    force_extraction: bool = (
-        False  # when True, bypass batch_interval checks and always run extractors
-    )
+    force_extraction: bool = False  # when True, bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run) and always run extractors
 
 
 # publish user interaction response

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -697,9 +697,11 @@ class BaseGenerationService(
 
         Template method that:
         1. Skips for non-auto runs and mock mode
-        2. Collects scoped interactions via _collect_scoped_interactions_for_precheck
-        3. Delegates prompt building to _build_should_run_prompt (subclass hook)
-        4. Makes a single LLM call to determine if extraction should proceed
+        2. Returns True immediately when service_config.force_extraction=True
+           (bypasses cheap pre-filter and LLM should_run vote)
+        3. Collects scoped interactions via _collect_scoped_interactions_for_precheck
+        4. Delegates prompt building to _build_should_run_prompt (subclass hook)
+        5. Makes a single LLM call to determine if extraction should proceed
 
         Override _build_should_run_prompt in subclasses to provide service-specific
         criteria and prompt construction. Default returns True (always run) when
@@ -717,6 +719,13 @@ class BaseGenerationService(
 
         # Skip for mock mode
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
+            return True
+
+        # `force_extraction=True` is the caller's explicit "no gates" signal —
+        # corrections, manual /learn, anything time-sensitive. Bypass the
+        # cheap pre-filter (slash-only / too-short rejects) and the LLM
+        # should_run vote so the extractor always runs on this batch.
+        if getattr(self.service_config, "force_extraction", False):
             return True
 
         # Skip if org config disables the pre-extraction check

--- a/reflexio/server/services/playbook/playbook_service_utils.py
+++ b/reflexio/server/services/playbook/playbook_service_utils.py
@@ -188,7 +188,7 @@ class PlaybookGenerationRequest(BaseModel):
     auto_run: bool = (
         True  # True for regular flow (checks batch_interval), False for rerun/manual
     )
-    force_extraction: bool = False  # when True, bypass batch_interval checks
+    force_extraction: bool = False  # when True, bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run)
 
 
 class PlaybookAggregatorRequest(BaseModel):

--- a/reflexio/server/services/profile/profile_generation_service_utils.py
+++ b/reflexio/server/services/profile/profile_generation_service_utils.py
@@ -46,7 +46,7 @@ class ProfileGenerationRequest(BaseModel):
     auto_run: bool = (
         True  # True for regular flow (checks batch_interval), False for rerun/manual
     )
-    force_extraction: bool = False  # when True, bypass batch_interval checks
+    force_extraction: bool = False  # when True, bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run)
 
 
 @dataclass(frozen=True)

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -602,6 +602,26 @@ class TestShouldRunBeforeExtraction:
         config = Config(storage_config={"type": "sqlite"})
         assert config.skip_should_run_check is False
 
+    def test_should_run_before_extraction_returns_true_when_force_extraction(
+        self, llm_client, request_context
+    ):
+        """force_extraction=True bypasses cheap pre-filter and LLM should_run vote."""
+        service = ConcreteGenerationService(llm_client, request_context)
+        service.service_config = MockServiceConfig(auto_run=True, force_extraction=True)
+
+        precheck_spy = MagicMock()
+        service._collect_scoped_interactions_for_precheck = precheck_spy  # type: ignore[method-assign]
+        llm_call_spy = MagicMock()
+        llm_client.generate_chat_response = llm_call_spy
+
+        result = service._should_run_before_extraction(
+            [MockExtractorConfig(extractor_name="test")]
+        )
+
+        assert result is True
+        precheck_spy.assert_not_called()
+        llm_call_spy.assert_not_called()
+
 
 # ===============================
 # Test: run()


### PR DESCRIPTION
## Summary
- `force_extraction=True` now bypasses the cheap pre-filter and the LLM `should_run` vote in `_should_run_before_extraction`, mirroring the existing `batch_interval` bypass at `_filter_configs_by_batch_interval`.
- The flag now has uniform "no gates" semantics, so corrections, manual `/learn`, and other time-sensitive callers always run the extractor on the requested batch instead of being silently filtered out as slash-only or short-content batches.
- Doc strings on the field are aligned across the API schema, client, CLI, and per-service config classes to reflect the broader bypass.

## Changes
- `reflexio/server/services/base_generation_service.py` — add `force_extraction` short-circuit at the top of `_should_run_before_extraction` (after `auto_run` and `MOCK_LLM_RESPONSE` guards, before org-config and cheap pre-filter); update the template-method docstring to list the new bypass.
- `reflexio/models/api_schema/domain/entities.py` — expand the inline comment on `PublishUserInteractionRequest.force_extraction` to describe all gates that get bypassed.
- `reflexio/client/client.py`, `reflexio/cli/commands/shortcuts.py`, `reflexio/server/services/playbook/playbook_service_utils.py`, `reflexio/server/services/profile/profile_generation_service_utils.py` — sync the doc strings on the flag to match.
- `tests/server/services/test_base_generation_service.py` — add `test_should_run_before_extraction_returns_true_when_force_extraction` asserting True is returned without invoking `_collect_scoped_interactions_for_precheck` or `llm_client.generate_chat_response`.

## Test Plan
- `uv run --active pytest tests/server/services/test_base_generation_service.py::TestShouldRunBeforeExtraction -x -q` — 3 passed (existing 2 + new force_extraction test).
- Manual verification of the file diff confirms ordering of guards in `_should_run_before_extraction` matches the existing `force_extraction` bypass at `_filter_configs_by_batch_interval` (line 364).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified force_extraction behavior across client, API, and service docs to state it bypasses all extraction gates and forces extractors to run.

* **CLI**
  * Updated publish command help text to reflect the clarified behavior.

* **Bug Fixes**
  * Added a fast-path so force_extraction reliably bypasses extraction gates.

* **Tests**
  * Added unit test coverage verifying the force_extraction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->