### PR TITLE
feat(client): add deprecated search_profiles alias

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -3,6 +3,7 @@ import logging
 import os
 import time
 import uuid
+import warnings
 from collections.abc import Callable, Coroutine, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
@@ -553,6 +554,47 @@ class ReflexioClient:
             "POST", "/api/search_user_profiles", json=req.model_dump()
         )
         return SearchProfilesViewResponse(**response)
+
+    # NOTE: keep signature in sync with search_user_profiles
+    def search_profiles(
+        self,
+        request: SearchUserProfileRequest | dict | None = None,
+        *,
+        user_id: str | None = None,
+        generated_from_request_id: str | None = None,
+        query: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
+        top_k: int | None = None,
+        source: str | None = None,
+        custom_feature: str | None = None,
+        extractor_name: str | None = None,
+        threshold: float | None = None,
+        enable_reformulation: bool | None = None,
+        search_mode: SearchMode | None = None,
+    ) -> SearchProfilesViewResponse:
+        """Deprecated alias for :meth:`search_user_profiles`. Will be removed in a future release."""
+        warnings.warn(
+            "ReflexioClient.search_profiles() is deprecated; use "
+            "search_user_profiles() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.search_user_profiles(
+            request,
+            user_id=user_id,
+            generated_from_request_id=generated_from_request_id,
+            query=query,
+            start_time=start_time,
+            end_time=end_time,
+            top_k=top_k,
+            source=source,
+            custom_feature=custom_feature,
+            extractor_name=extractor_name,
+            threshold=threshold,
+            enable_reformulation=enable_reformulation,
+            search_mode=search_mode,
+        )
 
     def rerank_user_profiles(
         self,


### PR DESCRIPTION
## Summary
- Adds `ReflexioClient.search_profiles()` as a deprecated alias for `search_user_profiles()`.
- Lets older callers still using the shorter name keep working while emitting a `DeprecationWarning` so they can migrate before removal.

## Changes
- `reflexio/client/client.py`: new `search_profiles()` method that mirrors `search_user_profiles()`'s signature and forwards all arguments. Emits `DeprecationWarning` (stacklevel=2 so the warning points at the caller). Comment notes the signature must stay in sync with `search_user_profiles`.

## Test Plan
- [ ] `uv run ruff check reflexio/client/client.py` (passes locally)
- [ ] Call `client.search_profiles(...)` and confirm a `DeprecationWarning` is raised and the underlying `search_user_profiles` response is returned unchanged.
- [ ] Confirm existing `search_user_profiles` callers are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * `search_profiles()` method is now deprecated. Users are encouraged to migrate to `search_user_profiles()` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->