### PR TITLE
rename: batch_size → window_size, batch_interval → stride_size

### DIFF
--- a/docs/components/configure/config-editor.tsx
+++ b/docs/components/configure/config-editor.tsx
@@ -12,7 +12,7 @@ import {
 import {
   StorageSection,
   AgentContextSection,
-  BatchingSection,
+  WindowingSection,
   APIKeysSection,
   LLMModelsSection,
   ProfileExtractorsSection,
@@ -122,7 +122,7 @@ export function ConfigEditor() {
             value={config.agent_context_prompt}
             setConfig={setConfig}
           />
-          <BatchingSection config={config} setConfig={setConfig} />
+          <WindowingSection config={config} setConfig={setConfig} />
           <APIKeysSection value={config.api_key_config} setConfig={setConfig} />
           <LLMModelsSection value={config.llm_config} setConfig={setConfig} />
           <ProfileExtractorsSection

--- a/docs/components/configure/sections.tsx
+++ b/docs/components/configure/sections.tsx
@@ -99,7 +99,7 @@ export function AgentContextSection({
   );
 }
 
-export function BatchingSection({
+export function WindowingSection({
   config,
   setConfig,
 }: {
@@ -111,13 +111,13 @@ export function BatchingSection({
 
   return (
     <Section
-      title="Batching & presets"
+      title="Windowing & presets"
       description="Controls how many interactions are processed per extraction run."
     >
       <FieldRow
         label="Extraction preset"
         htmlFor="extraction-preset"
-        hint="Presets bundle batch size and interval. Pick 'Custom' to set values manually."
+        hint="Presets bundle window size and stride. Pick 'Custom' to set values manually."
       >
         <Select
           value={preset ?? "custom"}
@@ -129,8 +129,8 @@ export function BatchingSection({
               return {
                 ...prev,
                 extraction_preset: next,
-                batch_size: bs,
-                batch_interval: bi,
+                window_size: bs,
+                stride_size: bi,
               };
             });
           }}
@@ -155,30 +155,30 @@ export function BatchingSection({
 
       <div className="grid grid-cols-2 gap-3">
         <FieldRow
-          label="Batch size"
-          htmlFor="batch-size"
+          label="Window size"
+          htmlFor="window-size"
           hint="Messages per extraction run."
         >
           <NumberField
-            id="batch-size"
-            value={config.batch_size}
+            id="window-size"
+            value={config.window_size}
             onChange={(v) =>
-              setConfig((prev) => ({ ...prev, batch_size: v ?? 1 }))
+              setConfig((prev) => ({ ...prev, window_size: v ?? 1 }))
             }
             min={1}
             disabled={usingPreset}
           />
         </FieldRow>
         <FieldRow
-          label="Batch interval"
-          htmlFor="batch-interval"
-          hint="Must be ≤ batch size."
+          label="Stride"
+          htmlFor="stride-size"
+          hint="Must be ≤ window size."
         >
           <NumberField
-            id="batch-interval"
-            value={config.batch_interval}
+            id="stride-size"
+            value={config.stride_size}
             onChange={(v) =>
-              setConfig((prev) => ({ ...prev, batch_interval: v ?? 1 }))
+              setConfig((prev) => ({ ...prev, stride_size: v ?? 1 }))
             }
             min={1}
             disabled={usingPreset}
@@ -373,7 +373,7 @@ const LLM_FIELDS: {
   {
     key: "should_run_model_name",
     label: "Should-run model",
-    hint: "Model that decides whether to run extraction on a batch.",
+    hint: "Model that decides whether to run extraction on a window.",
   },
   {
     key: "generation_model_name",
@@ -554,19 +554,19 @@ export function ProfileExtractorsSection({
             onCheckedChange={(c) => updateAt(idx, { manual_trigger: c })}
           />
           <div className="grid grid-cols-2 gap-3">
-            <FieldRow label="Batch size override">
+            <FieldRow label="Window size override">
               <NumberField
-                value={item.batch_size_override}
-                onChange={(v) => updateAt(idx, { batch_size_override: v })}
+                value={item.window_size_override}
+                onChange={(v) => updateAt(idx, { window_size_override: v })}
                 min={1}
                 allowNull
                 placeholder="(inherit)"
               />
             </FieldRow>
-            <FieldRow label="Batch interval override">
+            <FieldRow label="Stride override">
               <NumberField
-                value={item.batch_interval_override}
-                onChange={(v) => updateAt(idx, { batch_interval_override: v })}
+                value={item.stride_size_override}
+                onChange={(v) => updateAt(idx, { stride_size_override: v })}
                 min={1}
                 allowNull
                 placeholder="(inherit)"

--- a/docs/lib/config-schema.ts
+++ b/docs/lib/config-schema.ts
@@ -58,8 +58,8 @@ export interface ProfileExtractorConfig {
   context_prompt: string | null;
   metadata_definition_prompt: string | null;
   manual_trigger: boolean;
-  batch_size_override: number | null;
-  batch_interval_override: number | null;
+  window_size_override: number | null;
+  stride_size_override: number | null;
 }
 
 export interface PlaybookAggregatorConfig {
@@ -81,8 +81,8 @@ export interface UserPlaybookExtractorConfig {
   metadata_definition_prompt: string | null;
   aggregation_config: PlaybookAggregatorConfig | null;
   deduplication_config: DeduplicationConfig | null;
-  batch_size_override: number | null;
-  batch_interval_override: number | null;
+  window_size_override: number | null;
+  stride_size_override: number | null;
 }
 
 export interface AgentSuccessConfig {
@@ -90,8 +90,8 @@ export interface AgentSuccessConfig {
   success_definition_prompt: string;
   metadata_definition_prompt: string | null;
   sampling_rate: number;
-  batch_size_override: number | null;
-  batch_interval_override: number | null;
+  window_size_override: number | null;
+  stride_size_override: number | null;
 }
 
 export interface ToolUseConfig {
@@ -107,14 +107,14 @@ export interface ReflexioConfig {
   user_playbook_extractor_configs: UserPlaybookExtractorConfig[] | null;
   agent_success_configs: AgentSuccessConfig[] | null;
   extraction_preset: ExtractionPreset | null;
-  batch_size: number;
-  batch_interval: number;
+  window_size: number;
+  stride_size: number;
   api_key_config: APIKeyConfig | null;
   llm_config: LLMConfig | null;
   enable_document_expansion: boolean;
 }
 
-// Preset → (batch_size, batch_interval). Mirrors _PRESET_VALUES in
+// Preset → (window_size, stride_size). Mirrors _PRESET_VALUES in
 // config_schema.py so the UI can preview what a preset will set.
 export const PRESET_VALUES: Record<ExtractionPreset, [number, number]> = {
   quick_chat: [5, 3],
@@ -139,8 +139,8 @@ export function defaultConfig(): ReflexioConfig {
     user_playbook_extractor_configs: [],
     agent_success_configs: null,
     extraction_preset: null,
-    batch_size: 10,
-    batch_interval: 5,
+    window_size: 10,
+    stride_size: 5,
     api_key_config: null,
     llm_config: null,
     enable_document_expansion: false,
@@ -154,8 +154,8 @@ export function defaultProfileExtractor(): ProfileExtractorConfig {
     context_prompt: null,
     metadata_definition_prompt: null,
     manual_trigger: false,
-    batch_size_override: null,
-    batch_interval_override: null,
+    window_size_override: null,
+    stride_size_override: null,
   };
 }
 
@@ -167,8 +167,8 @@ export function defaultPlaybookExtractor(): UserPlaybookExtractorConfig {
     metadata_definition_prompt: null,
     aggregation_config: null,
     deduplication_config: null,
-    batch_size_override: null,
-    batch_interval_override: null,
+    window_size_override: null,
+    stride_size_override: null,
   };
 }
 
@@ -178,8 +178,8 @@ export function defaultAgentSuccess(): AgentSuccessConfig {
     success_definition_prompt: "",
     metadata_definition_prompt: null,
     sampling_rate: 1.0,
-    batch_size_override: null,
-    batch_interval_override: null,
+    window_size_override: null,
+    stride_size_override: null,
   };
 }
 
@@ -264,8 +264,8 @@ export function serializeConfig(config: ReflexioConfig): unknown {
       ? config.agent_success_configs
       : null,
     extraction_preset: config.extraction_preset,
-    batch_size: config.batch_size,
-    batch_interval: config.batch_interval,
+    window_size: config.window_size,
+    stride_size: config.stride_size,
     api_key_config: cleanApiKeys(config.api_key_config),
     llm_config: cleanLlm(config.llm_config),
     enable_document_expansion: config.enable_document_expansion,

--- a/notebooks/06_real_world_simulation.ipynb
+++ b/notebooks/06_real_world_simulation.ipynb
@@ -30,7 +30,7 @@
    "id": "b9254f93",
    "metadata": {},
    "outputs": [],
-   "source": "config = client.get_config()\n\nconfig.profile_extractor_configs = [\n    ProfileExtractorConfig(\n        extractor_name=\"customer_info\",\n        profile_content_definition_prompt=(\n            \"Extract key user information: name, dietary restrictions, \"\n            \"allergies, preferences, account details, or any personal facts.\"\n        ),\n        context_prompt=\"Restaurant customer support conversation.\",\n        batch_interval_override=1,\n        batch_size_override=20,\n    )\n]\n\nconfig.playbook_configs = [\n    PlaybookConfig(\n        playbook_name=\"agent_quality\",\n        playbook_definition_prompt=(\n            \"Identify cases where the agent made mistakes, missed user needs, \"\n            \"gave incorrect info, or could have handled the situation better.\"\n        ),\n        playbook_aggregator_config=PlaybookAggregatorConfig(min_cluster_size=1),\n        batch_interval_override=1,\n        batch_size_override=20,\n    )\n]\n\nconfig.batch_interval = 1\nclient.set_config(config)\nshow_success(\"Configured Reflexio for customer support\")"
+   "source": "config = client.get_config()\n\nconfig.profile_extractor_configs = [\n    ProfileExtractorConfig(\n        extractor_name=\"customer_info\",\n        profile_content_definition_prompt=(\n            \"Extract key user information: name, dietary restrictions, \"\n            \"allergies, preferences, account details, or any personal facts.\"\n        ),\n        context_prompt=\"Restaurant customer support conversation.\",\n        stride_size_override=1,\n        window_size_override=20,\n    )\n]\n\nconfig.playbook_configs = [\n    PlaybookConfig(\n        playbook_name=\"agent_quality\",\n        playbook_definition_prompt=(\n            \"Identify cases where the agent made mistakes, missed user needs, \"\n            \"gave incorrect info, or could have handled the situation better.\"\n        ),\n        playbook_aggregator_config=PlaybookAggregatorConfig(min_cluster_size=1),\n        stride_size_override=1,\n        window_size_override=20,\n    )\n]\n\nconfig.stride_size = 1\nclient.set_config(config)\nshow_success(\"Configured Reflexio for customer support\")"
   },
   {
    "cell_type": "code",
@@ -352,7 +352,7 @@
    "id": "3ab9d24f",
    "metadata": {},
    "outputs": [],
-   "source": "# --- Cleanup: reset config and remove all data ---\ntry:\n    config = client.get_config()\n    config.profile_extractor_configs = []\n    config.playbook_configs = []\n    config.batch_interval = 5\n    client.set_config(config)\nexcept Exception:\n    pass\n\nclient.delete_all_interactions()\nclient.delete_all_profiles()\nclient.delete_all_playbooks()\nshow_success(\"Config reset and data cleaned up.\")"
+   "source": "# --- Cleanup: reset config and remove all data ---\ntry:\n    config = client.get_config()\n    config.profile_extractor_configs = []\n    config.playbook_configs = []\n    config.stride_size = 5\n    client.set_config(config)\nexcept Exception:\n    pass\n\nclient.delete_all_interactions()\nclient.delete_all_profiles()\nclient.delete_all_playbooks()\nshow_success(\"Config reset and data cleaned up.\")"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/07_langchain_integration.ipynb
+++ b/notebooks/07_langchain_integration.ipynb
@@ -28,7 +28,7 @@
    "id": "c92496ec",
    "metadata": {},
    "outputs": [],
-   "source": "# Set stride to 1 so profile and playbook extraction runs on every interaction\nconfig = client.get_config()\nconfig.batch_interval = 1\nconfig.batch_size = 10\nclient.set_config(config)\nshow_success(\"Config updated: batch_interval=1, batch_size=10\")"
+   "source": "# Set stride to 1 so profile and playbook extraction runs on every interaction\nconfig = client.get_config()\nconfig.stride_size = 1\nconfig.window_size = 10\nclient.set_config(config)\nshow_success(\"Config updated: stride_size=1, window_size=10\")"
   },
   {
    "cell_type": "code",
@@ -49,7 +49,7 @@
    "cell_type": "markdown",
    "id": "7cd5d029",
    "metadata": {},
-   "source": "## 2. Capturing Conversations with `ReflexioCallbackHandler`\n\nThe callback handler is the core of the integration. Add it to any LangChain chain or agent to automatically capture conversations and publish them to Reflexio for learning.\n\nThe handler:\n- Captures user messages, assistant responses, and tool calls\n- Publishes everything to Reflexio when the chain completes (fire-and-forget)\n- Works with any LangChain chain, agent, or runnable\n\nSince we set `batch_interval=1` above, Reflexio will run profile and playbook extraction on **every** published interaction."
+   "source": "## 2. Capturing Conversations with `ReflexioCallbackHandler`\n\nThe callback handler is the core of the integration. Add it to any LangChain chain or agent to automatically capture conversations and publish them to Reflexio for learning.\n\nThe handler:\n- Captures user messages, assistant responses, and tool calls\n- Publishes everything to Reflexio when the chain completes (fire-and-forget)\n- Works with any LangChain chain, agent, or runnable\n\nSince we set `stride_size=1` above, Reflexio will run profile and playbook extraction on **every** published interaction."
   },
   {
    "cell_type": "markdown",
@@ -137,7 +137,7 @@
    "cell_type": "markdown",
    "id": "7b467cea",
    "metadata": {},
-   "source": "### Verify the interaction was captured and user playbooks were generated\n\nAfter the agent runs, the conversation should be stored in Reflexio. Since `batch_interval=1`, profile and playbook extraction should have triggered automatically. We verify both the interactions and the user playbooks extracted from the implicit correction in Turn 2."
+   "source": "### Verify the interaction was captured and user playbooks were generated\n\nAfter the agent runs, the conversation should be stored in Reflexio. Since `stride_size=1`, profile and playbook extraction should have triggered automatically. We verify both the interactions and the user playbooks extracted from the implicit correction in Turn 2."
   },
   {
    "cell_type": "code",

--- a/notebooks/_display_helpers.py
+++ b/notebooks/_display_helpers.py
@@ -190,7 +190,7 @@ def show_config(config: Config) -> None:
 | **Playbook Configs** | {len(playbook_configs)} configured |
 | **Tools Registered** | {len(tools)} tools |
 | **Success Evaluators** | {len(success_configs)} configured |
-| **Extraction Window** | size={config.batch_size}, stride={config.batch_interval} |"""
+| **Extraction Window** | size={config.window_size}, stride={config.stride_size} |"""
 
     if extractors:
         names = ", ".join(f"`{e.extractor_name}`" for e in extractors)

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -131,7 +131,7 @@ Apply to all three modes:
 | `--agent-version`   | Tag the interaction with an agent version (used by playbook filtering). |
 | `--source`          | Free-form source tag (defaults to `cli`).                                |
 | `--skip-aggregation`| Extract profiles/playbooks but skip playbook aggregation.                |
-| `--force-extraction`| Bypass `batch_interval` gating and always run extractors.                |
+| `--force-extraction`| Bypass `stride_size` gating and always run extractors.                |
 
 Full options via `uv run reflexio interactions publish --help`.
 

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -131,7 +131,7 @@ Apply to all three modes:
 | `--agent-version`   | Tag the interaction with an agent version (used by playbook filtering). |
 | `--source`          | Free-form source tag (defaults to `cli`).                                |
 | `--skip-aggregation`| Extract profiles/playbooks but skip playbook aggregation.                |
-| `--force-extraction`| Bypass `stride_size` gating and always run extractors.                |
+| `--force-extraction`| Bypass all extraction gates (`stride_size`, cheap pre-filter, LLM `should_run`) and always run extractors. |
 
 Full options via `uv run reflexio interactions publish --help`.
 

--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -262,7 +262,7 @@ def publish(
         bool,
         typer.Option(
             "--force-extraction",
-            help="Bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run) and always run extractors",
+            help="Bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors",
         ),
     ] = False,
 ) -> None:

--- a/reflexio/cli/commands/shortcuts.py
+++ b/reflexio/cli/commands/shortcuts.py
@@ -60,7 +60,7 @@ def _build_publish_args(
         stdin: When True, read JSON payload from stdin.
         skip_aggregation: When True, skip post-extract aggregation.
         force_extraction: When True, bypass all extraction gates
-            (batch_interval, cheap pre-filter, LLM should_run).
+            (stride_size, cheap pre-filter, LLM should_run).
 
     Returns:
         list[str]: argv list ready to hand to ``interactions_app(...)``.
@@ -144,7 +144,7 @@ def register_shortcuts(app: typer.Typer) -> None:
             bool,
             typer.Option(
                 "--force-extraction",
-                help="Bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run) and always run extractors",
+                help="Bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors",
             ),
         ] = False,
     ) -> None:

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -416,7 +416,7 @@ class ReflexioClient:
             skip_aggregation: If True, extract profiles/playbooks but
                 skip aggregation to agent playbooks.
             force_extraction: If True, bypass all extraction gates
-                (batch_interval, cheap pre-filter, LLM should_run) and
+                (stride_size, cheap pre-filter, LLM should_run) and
                 always run extractors.
 
         Returns:
@@ -1884,7 +1884,7 @@ class ReflexioClient:
         """Manually trigger profile generation with window-sized interactions (fire-and-forget).
 
         Unlike rerun_profile_generation which uses ALL interactions and outputs PENDING status,
-        this method uses window-sized interactions (from batch_size config) and
+        this method uses window-sized interactions (from window_size config) and
         outputs profiles with CURRENT status.
 
         This is a fire-and-forget operation that runs asynchronously in the background.
@@ -2019,7 +2019,7 @@ class ReflexioClient:
         """Manually trigger playbook generation with window-sized interactions (fire-and-forget).
 
         Unlike rerun_playbook_generation which uses ALL interactions and outputs PENDING status,
-        this method uses window-sized interactions (from batch_size config) and
+        this method uses window-sized interactions (from window_size config) and
         outputs playbooks with CURRENT status.
 
         This is a fire-and-forget operation that runs asynchronously in the background.

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -418,7 +418,7 @@ class PublishUserInteractionRequest(BaseModel):
     skip_aggregation: bool = (
         False  # when True, extract profiles/playbooks but skip aggregation
     )
-    force_extraction: bool = False  # when True, bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run) and always run extractors
+    force_extraction: bool = False  # when True, bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors
 
 
 # publish user interaction response

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -17,12 +17,16 @@ from .api_schema.validators import (
 EMBEDDING_DIMENSIONS = 512
 
 # Default sliding window parameters for extraction
-DEFAULT_BATCH_SIZE = 10
-DEFAULT_BATCH_INTERVAL = 5
+DEFAULT_WINDOW_SIZE = 10
+DEFAULT_STRIDE_SIZE = 5
+
+# Deprecated aliases kept for older imports.
+DEFAULT_BATCH_SIZE = DEFAULT_WINDOW_SIZE
+DEFAULT_BATCH_INTERVAL = DEFAULT_STRIDE_SIZE
 
 
 class ExtractionPreset(StrEnum):
-    """Named extraction presets that bundle batch_size and batch_interval.
+    """Named extraction presets that bundle window_size and stride_size.
 
     Each preset targets a specific conversation pattern:
     - quick_chat: Short conversations (support bots, quick Q&A)
@@ -37,10 +41,10 @@ class ExtractionPreset(StrEnum):
     HIGH_VOLUME = "high_volume"
 
 
-# Preset parameter values: (batch_size, batch_interval)
+# Preset parameter values: (window_size, stride_size)
 _PRESET_VALUES: dict[ExtractionPreset, tuple[int, int]] = {
     ExtractionPreset.QUICK_CHAT: (5, 3),
-    ExtractionPreset.STANDARD: (DEFAULT_BATCH_SIZE, DEFAULT_BATCH_INTERVAL),
+    ExtractionPreset.STANDARD: (DEFAULT_WINDOW_SIZE, DEFAULT_STRIDE_SIZE),
     ExtractionPreset.LONG_FORM: (25, 10),
     ExtractionPreset.HIGH_VOLUME: (15, 8),
 }
@@ -50,8 +54,10 @@ _PRESET_VALUES: dict[ExtractionPreset, tuple[int, int]] = {
 # Field migration maps (old stored JSON name → new Python attr name)
 # ---------------------------------------------------------------------------
 _CONFIG_FIELD_MIGRATION: dict[str, str] = {
-    "extraction_window_size": "batch_size",
-    "extraction_window_stride": "batch_interval",
+    "batch_size": "window_size",
+    "batch_interval": "stride_size",
+    "extraction_window_size": "window_size",
+    "extraction_window_stride": "stride_size",
     "playbook_configs": "user_playbook_extractor_configs",
     "agent_feedback_configs": "user_playbook_extractor_configs",
 }
@@ -63,8 +69,10 @@ _AGGREGATOR_FIELD_MIGRATION: dict[str, str] = {
 }
 
 _EXTRACTOR_OVERRIDE_MIGRATION: dict[str, str] = {
-    "extraction_window_size_override": "batch_size_override",
-    "extraction_window_stride_override": "batch_interval_override",
+    "batch_size_override": "window_size_override",
+    "batch_interval_override": "stride_size_override",
+    "extraction_window_size_override": "window_size_override",
+    "extraction_window_stride_override": "stride_size_override",
 }
 
 _PROFILE_CONFIG_FIELD_MIGRATION: dict[str, str] = {
@@ -92,6 +100,26 @@ def _migrate_dict(data: Any, mapping: dict[str, str]) -> Any:
             if old in data and new not in data:
                 data[new] = data.pop(old)
     return data
+
+
+class _ExtractorWindowOverrideCompatMixin:
+    @property
+    def batch_size_override(self) -> int | None:
+        """Deprecated alias for window_size_override."""
+        return self.window_size_override  # type: ignore[attr-defined]
+
+    @batch_size_override.setter
+    def batch_size_override(self, value: int | None) -> None:
+        self.window_size_override = value  # type: ignore[attr-defined]
+
+    @property
+    def batch_interval_override(self) -> int | None:
+        """Deprecated alias for stride_size_override."""
+        return self.stride_size_override  # type: ignore[attr-defined]
+
+    @batch_interval_override.setter
+    def batch_interval_override(self, value: int | None) -> None:
+        self.stride_size_override = value  # type: ignore[attr-defined]
 
 
 class SearchMode(StrEnum):
@@ -293,7 +321,7 @@ class DeduplicationConfig(BaseModel):
     )
 
 
-class ProfileExtractorConfig(BaseModel):
+class ProfileExtractorConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     extractor_name: NonEmptyStr
     extraction_definition_prompt: SanitizedNonEmptyStr
     context_prompt: str | None = None
@@ -303,8 +331,8 @@ class ProfileExtractorConfig(BaseModel):
         None  # default enabled for all sources, if set, only extract profiles from the enabled request sources
     )
     manual_trigger: bool = False  # require manual triggering (rerun) to run extraction and skip auto extraction if set to True
-    batch_size_override: int | None = Field(default=None, gt=0)
-    batch_interval_override: int | None = Field(default=None, gt=0)
+    window_size_override: int | None = Field(default=None, gt=0)
+    stride_size_override: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="before")
     @classmethod
@@ -335,7 +363,7 @@ class PlaybookAggregatorConfig(BaseModel):
         return _migrate_dict(data, _AGGREGATOR_FIELD_MIGRATION)
 
 
-class UserPlaybookExtractorConfig(BaseModel):
+class UserPlaybookExtractorConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     extractor_name: NonEmptyStr
     extraction_definition_prompt: SanitizedNonEmptyStr
     context_prompt: str | None = None
@@ -345,8 +373,8 @@ class UserPlaybookExtractorConfig(BaseModel):
     request_sources_enabled: list[str] | None = (
         None  # default enabled for all sources, if set, only extract user playbooks from the enabled request sources
     )
-    batch_size_override: int | None = Field(default=None, gt=0)
-    batch_interval_override: int | None = Field(default=None, gt=0)
+    window_size_override: int | None = Field(default=None, gt=0)
+    stride_size_override: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="before")
     @classmethod
@@ -365,15 +393,15 @@ class ToolUseConfig(BaseModel):
 
 
 # define what success looks like for agent
-class AgentSuccessConfig(BaseModel):
+class AgentSuccessConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     evaluation_name: NonEmptyStr
     success_definition_prompt: SanitizedNonEmptyStr
     metadata_definition_prompt: str | None = None
     sampling_rate: float = Field(
         default=1.0, ge=0.0, le=1.0
-    )  # fraction of batch of interactions to be sampled for success evaluation
-    batch_size_override: int | None = Field(default=None, gt=0)
-    batch_interval_override: int | None = Field(default=None, gt=0)
+    )  # fraction of window of interactions to be sampled for success evaluation
+    window_size_override: int | None = Field(default=None, gt=0)
+    stride_size_override: int | None = Field(default=None, gt=0)
 
     @model_validator(mode="before")
     @classmethod
@@ -385,8 +413,8 @@ class ReflectionConfig(BaseModel):
     """Configuration for the sliding-window reflection step.
 
     Reflection runs inside ``GenerationService.run`` as its own
-    sliding-window step (window = global ``batch_size``, stride = global
-    ``batch_interval``, bookmark via ``OperationStateManager``). When
+    sliding-window step (window = global ``window_size``, stride = global
+    ``stride_size``, bookmark via ``OperationStateManager``). When
     the gate opens and at least one Assistant interaction in the window
     cites a current user playbook / user profile row, the LLM is asked
     whether any cited rows should be replaced. When ``enabled`` is
@@ -466,11 +494,11 @@ class Config(BaseModel):
     )
     # agent level success
     agent_success_configs: list[AgentSuccessConfig] | None = None
-    # extraction preset — selects bundled batch_size/batch_interval values
+    # extraction preset — selects bundled window_size/stride_size values
     extraction_preset: ExtractionPreset | None = None
     # extraction parameters
-    batch_size: int = Field(default=DEFAULT_BATCH_SIZE, gt=0)
-    batch_interval: int = Field(default=DEFAULT_BATCH_INTERVAL, gt=0)
+    window_size: int = Field(default=DEFAULT_WINDOW_SIZE, gt=0)
+    stride_size: int = Field(default=DEFAULT_STRIDE_SIZE, gt=0)
     # API key configuration for LLM providers
     api_key_config: APIKeyConfig | None = None
     # LLM model configuration overrides
@@ -499,8 +527,8 @@ class Config(BaseModel):
         data = _migrate_dict(data, _CONFIG_FIELD_MIGRATION)
         if isinstance(data, dict):
             for key in (
-                "batch_size",
-                "batch_interval",
+                "window_size",
+                "stride_size",
                 "extraction_backend",
                 "search_backend",
                 "reflection_config",
@@ -511,10 +539,10 @@ class Config(BaseModel):
 
     @model_validator(mode="after")
     def apply_extraction_preset(self) -> Self:
-        """Apply preset values when batch_size/batch_interval are at defaults.
+        """Apply preset values when window_size/stride_size are at defaults.
 
-        If a preset is selected but the user also explicitly set batch_size or
-        batch_interval, the explicit values win (checked via model_fields_set).
+        If a preset is selected but the user also explicitly set window_size or
+        stride_size, the explicit values win (checked via model_fields_set).
         """
         if self.extraction_preset is None:
             return self
@@ -523,20 +551,38 @@ class Config(BaseModel):
         if preset_values is None:
             return self
 
-        preset_batch_size, preset_batch_interval = preset_values
-        if "batch_size" not in self.model_fields_set:
-            self.batch_size = preset_batch_size
-        if "batch_interval" not in self.model_fields_set:
-            self.batch_interval = preset_batch_interval
+        preset_window_size, preset_stride_size = preset_values
+        if "window_size" not in self.model_fields_set:
+            self.window_size = preset_window_size
+        if "stride_size" not in self.model_fields_set:
+            self.stride_size = preset_stride_size
 
         return self
 
     @model_validator(mode="after")
-    def check_batch_interval_le_batch_size(self) -> Self:
-        """Validate that batch_interval <= batch_size."""
-        if self.batch_interval > self.batch_size:
-            raise ValueError("batch_interval must be <= batch_size")
+    def check_stride_size_le_window_size(self) -> Self:
+        """Validate that stride_size <= window_size."""
+        if self.stride_size > self.window_size:
+            raise ValueError("stride_size must be <= window_size")
         return self
+
+    @property
+    def batch_size(self) -> int:
+        """Deprecated alias for window_size."""
+        return self.window_size
+
+    @batch_size.setter
+    def batch_size(self, value: int) -> None:
+        self.window_size = value
+
+    @property
+    def batch_interval(self) -> int:
+        """Deprecated alias for stride_size."""
+        return self.stride_size
+
+    @batch_interval.setter
+    def batch_interval(self, value: int) -> None:
+        self.stride_size = value
 
     @model_validator(mode="after")
     def ensure_default_extractors(self) -> Self:

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -209,7 +209,7 @@ Main orchestrator flow:
 - **Extractor level**: `EXTRACTOR_TIMEOUT_SECONDS = 300` (5 min) — per-extractor safety net in `base_generation_service.py`
 - If one service/extractor times out, others continue unaffected
 
-**Batch Interval Processing**: Each extractor independently checks if it should run based on its configured batch_interval size and tracks its own operation state.
+**Stride Size Processing**: Each extractor independently checks if it should run based on its configured stride_size size and tracks its own operation state.
 
 Called by API endpoints via `Reflexio`
 
@@ -226,7 +226,7 @@ Called by API endpoints via `Reflexio`
 
 - `base_generation_service.py`: Abstract base for all services (parallel extractor execution via ThreadPoolExecutor, `EXTRACTOR_TIMEOUT_SECONDS = 300` per-extractor safety timeout)
 - `extractor_config_utils.py`: Shared utility for filtering extractor configs by source, `allow_manual_trigger`, and extractor names
-- `extractor_interaction_utils.py`: Per-extractor utilities for batch_interval checking and source filtering
+- `extractor_interaction_utils.py`: Per-extractor utilities for stride_size checking and source filtering
 - `operation_state_utils.py`: Centralized `OperationStateManager` for all `_operation_state` table interactions (progress tracking, concurrency locks, extractor/aggregator bookmarks, simple locks)
 - `deduplication_utils.py`: Shared utilities for LLM-based deduplication (used by ProfileDeduplicator and PlaybookDeduplicator)
 - `service_utils.py`: Utilities (`construct_messages_from_interactions()`, `format_interactions_to_history_string()` (prepends tool usage info when `tools_used` is present), `extract_json_from_string()`, `log_model_response()` for colored LLM response logging)
@@ -270,7 +270,7 @@ Key files:
 | **Scope** | Single user | Batch (all matching users, with progress) | Batch (all/single user, with progress) |
 | **Use Case** | Normal operation | Test prompt changes | Force regeneration |
 
-**Note**: All modes use `batch_size` (per-extractor override or global). The key difference is that Regular checks batch_interval before running, while Rerun/Manual always run. When no window is configured, rerun/manual falls back to `k=1000`.
+**Note**: All modes use `window_size` (per-extractor override or global). The key difference is that Regular checks stride_size before running, while Rerun/Manual always run. When no window is configured, rerun/manual falls back to `k=1000`.
 
 **Constructor Flags** (`ProfileGenerationService`):
 - `allow_manual_trigger`: Include `manual_trigger=True` extractors (default: False)
@@ -361,7 +361,7 @@ Aggregation clusters user playbooks by embedding similarity, then calls LLM per 
 | **Scope** | Single user | Batch (all matching users, with progress) | Batch (all/single user, with progress) |
 | **Use Case** | Normal operation | Test prompt changes | Force regeneration |
 
-**Note**: All modes use `batch_size` (per-extractor override or global). The key difference is that Regular checks batch_interval before running, while Rerun/Manual always run. When no window is configured, rerun/manual falls back to `k=1000`.
+**Note**: All modes use `window_size` (per-extractor override or global). The key difference is that Regular checks stride_size before running, while Rerun/Manual always run. When no window is configured, rerun/manual falls back to `k=1000`.
 
 **Constructor Flags** (`PlaybookGenerationService`):
 - `allow_manual_trigger`: Include `manual_trigger=True` extractors (default: False)
@@ -553,14 +553,14 @@ All services follow BaseGenerationService:
 - Receives **ExtractorConfig** (from YAML): Static configuration like prompts and settings
 - Receives **GenerationServiceConfig** (from request): Runtime parameters like user_id, source
 - **Collects its own interactions** using `extractor_interaction_utils.py`:
-  - Gets per-extractor batch_size/batch_interval parameters (override or global fallback)
+  - Gets per-extractor window_size/stride_size parameters (override or global fallback)
   - Applies source filtering based on `request_sources_enabled`
-  - Checks batch_interval threshold before running
+  - Checks stride_size threshold before running
   - Updates per-extractor bookmark state after processing (via `OperationStateManager`)
 
 **Per-Extractor Window Overrides**: Each extractor config can override global window settings:
-- `batch_size_override`: Override global `batch_size` for this extractor
-- `batch_interval_override`: Override global `batch_interval` for this extractor
+- `window_size_override`: Override global `window_size` for this extractor
+- `stride_size_override`: Override global `stride_size` for this extractor
 - Each extractor applies its own override or falls back to global values
 
 ### Key Rules

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1373,8 +1373,10 @@ def manual_profile_generation_endpoint(
 ) -> ManualProfileGenerationResponse:
     """Manually trigger profile generation with window-sized interactions and CURRENT output.
 
-    This behaves like regular generation (uses window_size from config,
-    outputs CURRENT profiles) but only runs profile extraction.
+    Runs with auto_run=False, which bypasses the regular stride/should_run
+    gates. Only profile extraction is triggered. Each extractor uses its own
+    window_size_override when present, falling back to the global window_size.
+    Output is CURRENT profiles only.
 
     Args:
         request (Request): The HTTP request object (for rate limiting)
@@ -1439,8 +1441,10 @@ def manual_playbook_generation_endpoint(
 ) -> ManualPlaybookGenerationResponse:
     """Manually trigger playbook generation with window-sized interactions and CURRENT output.
 
-    This behaves like regular generation (uses window_size from config,
-    outputs CURRENT playbooks) but only runs playbook extraction.
+    Runs with auto_run=False, which bypasses the regular stride/should_run
+    gates. Only playbook extraction is triggered. Each extractor uses its own
+    window_size_override when present, falling back to the global window_size.
+    Output is CURRENT playbooks only.
 
     Args:
         request (Request): The HTTP request object (for rate limiting)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1373,7 +1373,7 @@ def manual_profile_generation_endpoint(
 ) -> ManualProfileGenerationResponse:
     """Manually trigger profile generation with window-sized interactions and CURRENT output.
 
-    This behaves like regular generation (uses batch_size from config,
+    This behaves like regular generation (uses window_size from config,
     outputs CURRENT profiles) but only runs profile extraction.
 
     Args:
@@ -1439,7 +1439,7 @@ def manual_playbook_generation_endpoint(
 ) -> ManualPlaybookGenerationResponse:
     """Manually trigger playbook generation with window-sized interactions and CURRENT output.
 
-    This behaves like regular generation (uses batch_size from config,
+    This behaves like regular generation (uses window_size from config,
     outputs CURRENT playbooks) but only runs playbook extraction.
 
     Args:

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -25,7 +25,7 @@ from reflexio.server.services.extractor_config_utils import (
 from reflexio.server.services.extractor_interaction_utils import (
     get_effective_source_filter,
     get_extractor_window_params,
-    should_extractor_run_by_batch_interval,
+    should_extractor_run_by_stride,
 )
 from reflexio.server.services.operation_state_utils import OperationStateManager
 from reflexio.server.services.service_utils import log_llm_messages, log_model_response
@@ -326,35 +326,35 @@ class BaseGenerationService(
 
     def _get_extractor_state_service_name(self) -> str | None:
         """
-        Get the service name used for extractor state (batch_interval bookmark) lookups.
+        Get the service name used for extractor state (stride_size bookmark) lookups.
 
-        Override in subclasses that support batch_interval-based pre-filtering to return
+        Override in subclasses that support stride_size-based pre-filtering to return
         the OperationStateManager service name (e.g., "profile_extractor", "playbook_extractor").
-        Returns None by default, meaning batch_interval pre-filtering is skipped.
+        Returns None by default, meaning stride_size pre-filtering is skipped.
 
         Returns:
-            Optional[str]: Service name for OperationStateManager, or None to skip batch_interval pre-filtering
+            Optional[str]: Service name for OperationStateManager, or None to skip stride_size pre-filtering
         """
         return None
 
-    def _filter_configs_by_batch_interval(
+    def _filter_configs_by_stride(
         self, extractor_configs: list[TExtractorConfig]
     ) -> list[TExtractorConfig]:
         """
-        Filter extractor configs by batch_interval check before the should_run LLM call.
+        Filter extractor configs by stride_size check before the should_run LLM call.
 
         Skips filtering when:
-        - _get_extractor_state_service_name() returns None (service doesn't support batch_interval)
-        - auto_run is False (rerun/manual flows skip batch_interval)
+        - _get_extractor_state_service_name() returns None (service doesn't support stride_size)
+        - auto_run is False (rerun/manual flows skip stride_size)
 
-        For each config, resolves batch_size/batch_interval params and checks if enough new
-        interactions exist since the last run. Only configs that pass batch_interval are returned.
+        For each config, resolves window_size/stride_size params and checks if enough new
+        interactions exist since the last run. Only configs that pass stride_size are returned.
 
         Args:
             extractor_configs: List of extractor configs after source/manual_trigger filtering
 
         Returns:
-            List of extractor configs that pass the batch_interval check
+            List of extractor configs that pass the stride_size check
         """
         state_service_name = self._get_extractor_state_service_name()
         if state_service_name is None:
@@ -367,11 +367,11 @@ class BaseGenerationService(
             return extractor_configs
 
         root_config = self.request_context.configurator.get_config()
-        global_batch_size = (
-            getattr(root_config, "batch_size", None) if root_config else None
+        global_window_size = (
+            getattr(root_config, "window_size", None) if root_config else None
         )
-        global_batch_interval = (
-            getattr(root_config, "batch_interval", None) if root_config else None
+        global_stride_size = (
+            getattr(root_config, "stride_size", None) if root_config else None
         )
 
         state_manager = OperationStateManager(
@@ -383,8 +383,8 @@ class BaseGenerationService(
         passing_configs: list[TExtractorConfig] = []
         for config in extractor_configs:
             name = get_extractor_name(config)
-            _, batch_interval_size = get_extractor_window_params(
-                config, global_batch_size, global_batch_interval
+            _, stride_size = get_extractor_window_params(
+                config, global_window_size, global_stride_size
             )
 
             # Resolve effective source filter for this extractor
@@ -404,14 +404,14 @@ class BaseGenerationService(
             )
             new_count = sum(len(ri.interactions) for ri in new_interactions)
 
-            if should_extractor_run_by_batch_interval(new_count, batch_interval_size):
+            if should_extractor_run_by_stride(new_count, stride_size):
                 passing_configs.append(config)
             else:
                 logger.info(
-                    "Batch interval pre-filter: skipping extractor '%s' (new=%d, batch_interval=%s)",
+                    "Stride pre-filter: skipping extractor '%s' (new=%d, stride_size=%s)",
                     name,
                     new_count,
-                    batch_interval_size,
+                    stride_size,
                 )
 
         return passing_configs
@@ -542,7 +542,7 @@ class BaseGenerationService(
         Validate request, load config, filter extractor configs, and run pre-extraction checks.
 
         Loads the generation service config from the request, loads and filters extractor
-        configs by source, manual trigger, and batch_interval, then runs the pre-extraction gate.
+        configs by source, manual trigger, and stride_size, then runs the pre-extraction gate.
 
         Args:
             request: The request object containing parameters
@@ -573,10 +573,10 @@ class BaseGenerationService(
             )
             return None, ""
 
-        extractor_configs = self._filter_configs_by_batch_interval(extractor_configs)
+        extractor_configs = self._filter_configs_by_stride(extractor_configs)
         if not extractor_configs:
             logger.info(
-                "No extractor configs passed batch_interval check for %s",
+                "No extractor configs passed stride_size check for %s",
                 self._get_service_name(),
             )
             return None, ""
@@ -849,11 +849,11 @@ class BaseGenerationService(
             tuple: (deduplicated session data models, extractor configs that had scoped interactions)
         """
         root_config = self.request_context.configurator.get_config()
-        global_batch_size = (
-            getattr(root_config, "batch_size", None) if root_config else None
+        global_window_size = (
+            getattr(root_config, "window_size", None) if root_config else None
         )
-        global_batch_interval = (
-            getattr(root_config, "batch_interval", None) if root_config else None
+        global_stride_size = (
+            getattr(root_config, "stride_size", None) if root_config else None
         )
 
         deduped_sessions: dict[str, RequestInteractionDataModel] = {}
@@ -867,10 +867,10 @@ class BaseGenerationService(
             if should_skip:
                 continue
 
-            batch_size, _ = get_extractor_window_params(
-                config, global_batch_size, global_batch_interval
+            window_size, _ = get_extractor_window_params(
+                config, global_window_size, global_stride_size
             )
-            fetch_k = batch_size
+            fetch_k = window_size
             session_data_models, _ = self.storage.get_last_k_interactions_grouped(  # type: ignore[reportOptionalMemberAccess]
                 user_id=getattr(self.service_config, "user_id", None),
                 k=fetch_k,
@@ -1048,7 +1048,7 @@ class BaseGenerationService(
 
         Override this method to enable rerun functionality for the service.
         Returns a list of user IDs that have interactions matching the request filters.
-        Each extractor collects its own data using its configured batch_size.
+        Each extractor collects its own data using its configured window_size.
 
         Args:
             request: The rerun request object
@@ -1075,7 +1075,7 @@ class BaseGenerationService(
         """Create the request object to pass to self.run() for a single user.
 
         Override this method to enable rerun functionality for the service.
-        Each extractor collects its own data using its configured batch_size.
+        Each extractor collects its own data using its configured window_size.
 
         Args:
             user_id: The user ID to process

--- a/reflexio/server/services/configurator/base_configurator.py
+++ b/reflexio/server/services/configurator/base_configurator.py
@@ -14,6 +14,13 @@ from reflexio.server.services.storage.storage_base import BaseStorage
 
 logger = logging.getLogger(__name__)
 
+_CONFIG_NAME_ALIASES = {
+    "batch_size": "window_size",
+    "batch_interval": "stride_size",
+    "extraction_window_size": "window_size",
+    "extraction_window_stride": "stride_size",
+}
+
 
 class BaseConfigurator(ABC):
     """Abstract base for organization configurators.
@@ -81,7 +88,8 @@ class BaseConfigurator(ABC):
         config_name: str,
         config_value: str | int | float | bool | list | dict | BaseModel,
     ) -> None:
-        if config_name not in self.config.model_fields:
+        config_name = _CONFIG_NAME_ALIASES.get(config_name, config_name)
+        if config_name not in type(self.config).model_fields:
             raise ValueError(f"Invalid config name: {config_name}")
 
         setattr(self.config, config_name, config_value)

--- a/reflexio/server/services/extractor_interaction_utils.py
+++ b/reflexio/server/services/extractor_interaction_utils.py
@@ -2,13 +2,13 @@
 Utility functions for per-extractor interaction data collection.
 
 These functions are shared across ProfileExtractor, PlaybookExtractor, and AgentSuccessEvaluator
-to handle per-extractor batch_interval checking, source filtering, and sliding window iteration.
+to handle per-extractor stride checking, source filtering, and sliding window iteration.
 """
 
 import logging
 
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
-from reflexio.models.config_schema import DEFAULT_BATCH_INTERVAL, DEFAULT_BATCH_SIZE
+from reflexio.models.config_schema import DEFAULT_STRIDE_SIZE, DEFAULT_WINDOW_SIZE
 from reflexio.server.services.extractor_config_utils import get_extractor_name
 
 logger = logging.getLogger(__name__)
@@ -16,44 +16,46 @@ logger = logging.getLogger(__name__)
 
 def get_extractor_window_params[TExtractorConfig](
     extractor_config: TExtractorConfig,
-    global_batch_size: int | None,
-    global_batch_interval: int | None,
+    global_window_size: int | None,
+    global_stride_size: int | None,
 ) -> tuple[int, int]:
     """
-    Get effective batch_size and batch_interval for a specific extractor.
+    Get effective window_size and stride_size for a specific extractor.
 
     Uses extractor's override values if set, otherwise falls back to global values,
-    then to defaults (batch_size=10, batch_interval=5).
+    then to defaults (window_size=10, stride_size=5).
 
     Args:
         extractor_config: Extractor configuration object
-        global_batch_size: Global batch_size from config
-        global_batch_interval: Global batch_interval from config
+        global_window_size: Global window_size from config
+        global_stride_size: Global stride_size from config
 
     Returns:
-        Tuple of (batch_size, batch_interval_size) for this extractor
+        Tuple of (window_size, stride_size) for this extractor
     """
-    batch_size_override = getattr(extractor_config, "batch_size_override", None)
-    batch_interval_override = getattr(extractor_config, "batch_interval_override", None)
+    window_size_override = getattr(extractor_config, "window_size_override", None)
+    stride_size_override = getattr(extractor_config, "stride_size_override", None)
 
-    batch_size = (
-        batch_size_override
-        if batch_size_override is not None
+    window_size = (
+        window_size_override
+        if window_size_override is not None
         else (
-            global_batch_size if global_batch_size is not None else DEFAULT_BATCH_SIZE
+            global_window_size
+            if global_window_size is not None
+            else DEFAULT_WINDOW_SIZE
         )
     )
-    batch_interval_size = (
-        batch_interval_override
-        if batch_interval_override is not None
+    stride_size = (
+        stride_size_override
+        if stride_size_override is not None
         else (
-            global_batch_interval
-            if global_batch_interval is not None
-            else DEFAULT_BATCH_INTERVAL
+            global_stride_size
+            if global_stride_size is not None
+            else DEFAULT_STRIDE_SIZE
         )
     )
 
-    return batch_size, batch_interval_size
+    return window_size, stride_size
 
 
 def get_effective_source_filter[TExtractorConfig](
@@ -109,16 +111,16 @@ def get_effective_source_filter[TExtractorConfig](
     return (False, [triggering_source])
 
 
-def should_extractor_run_by_batch_interval(
+def should_extractor_run_by_stride(
     new_interaction_count: int,
-    batch_interval_size: int | None,
+    stride_size: int | None,
 ) -> bool:
     """
-    Determine if an extractor should run based on its batch_interval configuration.
+    Determine if an extractor should run based on its stride_size configuration.
 
     Args:
         new_interaction_count: Number of new interactions since last run
-        batch_interval_size: Configured batch_interval size for this extractor
+        stride_size: Configured stride_size for this extractor
 
     Returns:
         True if extractor should run, False otherwise
@@ -126,10 +128,10 @@ def should_extractor_run_by_batch_interval(
     if new_interaction_count <= 0:
         return False
 
-    if batch_interval_size is None or batch_interval_size <= 0:
-        return True  # No batch_interval configured, always run
+    if stride_size is None or stride_size <= 0:
+        return True  # No stride configured, always run
 
-    return new_interaction_count >= batch_interval_size
+    return new_interaction_count >= stride_size
 
 
 def filter_interactions_by_source(
@@ -169,8 +171,8 @@ from collections.abc import Iterator
 
 def iter_sliding_windows(
     request_interaction_data_models: list[RequestInteractionDataModel],
-    batch_size: int,
-    batch_interval_size: int | None,
+    window_size: int,
+    stride_size: int | None,
 ) -> Iterator[tuple[int, list[RequestInteractionDataModel]]]:
     """
     Yield sliding windows of RequestInteractionDataModel based on interaction count.
@@ -180,30 +182,28 @@ def iter_sliding_windows(
 
     Args:
         request_interaction_data_models: List of RequestInteractionDataModel to window over
-        batch_size: Target number of interactions per window
-        batch_interval_size: Step size in interactions between window starts (must be >= 1)
+        window_size: Target number of interactions per window
+        stride_size: Step size in interactions between window starts (must be >= 1)
 
     Yields:
         Tuples of (window_index, list_of_request_interaction_data_models)
 
     Example:
-        With 3 models having [10, 20, 15] interactions, batch_size=25, batch_interval_size=15:
+        With 3 models having [10, 20, 15] interactions, window_size=25, stride_size=15:
         - Window 0: models[0], models[1] (30 interactions, starts at 0)
         - Window 1: models[1], models[2] (35 interactions, starts at 15)
     """
     if not request_interaction_data_models:
         return
 
-    if batch_size <= 0:
-        # Invalid batch_size, yield single window with all data
+    if window_size <= 0:
+        # Invalid window_size, yield single window with all data
         yield (0, request_interaction_data_models)
         return
 
-    # Default batch_interval to batch_size if not valid
-    effective_batch_interval = (
-        batch_interval_size
-        if batch_interval_size and batch_interval_size > 0
-        else batch_size
+    # Default stride_size to window_size if not valid
+    effective_stride_size = (
+        stride_size if stride_size and stride_size > 0 else window_size
     )
 
     # Build cumulative interaction counts for each model
@@ -218,7 +218,7 @@ def iter_sliding_windows(
         return
 
     # If all data fits in one window, yield single window
-    if total_interactions <= batch_size:
+    if total_interactions <= window_size:
         yield (0, request_interaction_data_models)
         return
 
@@ -226,7 +226,7 @@ def iter_sliding_windows(
     window_start = 0  # Starting interaction index
 
     while window_start < total_interactions:
-        window_end = window_start + batch_size
+        window_end = window_start + window_size
 
         # Find models that overlap with [window_start, window_end)
         # A model overlaps if its start < window_end AND its end > window_start
@@ -244,8 +244,8 @@ def iter_sliding_windows(
             yield (window_idx, selected_models)
 
         window_idx += 1
-        window_start += effective_batch_interval
+        window_start += effective_stride_size
 
-        # Prevent infinite loop if batch_interval is 0 (shouldn't happen with validation above)
-        if effective_batch_interval <= 0:
+        # Prevent infinite loop if stride_size is 0 (shouldn't happen with validation above)
+        if effective_stride_size <= 0:
             break

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -116,7 +116,7 @@ class GenerationService:
 
         Each generation service (profile, playbook) handles its own:
         - Data collection based on extractor-specific configs
-        - Batch interval checking based on extractor-specific settings
+        - Stride checking based on extractor-specific settings
         - Operation state tracking per extractor
 
         Args:

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -33,7 +33,7 @@ Interactions
 ### Playbook Extraction (`playbook_extractor.py`)
 
 Extends `BaseGenerationService` extractor pattern. Each extractor:
-1. Checks batch_interval threshold before running
+1. Checks stride_size threshold before running
 2. Constructs messages from interactions (via `service_utils.py`)
 3. Runs LLM with `playbook_extraction_main` prompt
 4. Parses `StructuredPlaybookContent` output (trigger, instruction, pitfall, blocking_issue)

--- a/reflexio/server/services/playbook/playbook_extractor.py
+++ b/reflexio/server/services/playbook/playbook_extractor.py
@@ -119,7 +119,7 @@ class PlaybookExtractor:
         - Source filtering based on extractor config
         - Time range filtering for rerun flows
 
-        Note: Batch interval checking is handled upstream by BaseGenerationService._filter_configs_by_batch_interval()
+        Note: Stride checking is handled upstream by BaseGenerationService._filter_configs_by_stride()
         before the extractor is created.
 
         Returns:
@@ -127,16 +127,14 @@ class PlaybookExtractor:
         """
         # Get global config values
         config = self.request_context.configurator.get_config()
-        global_batch_size = getattr(config, "batch_size", None) if config else None
-        global_batch_interval = (
-            getattr(config, "batch_interval", None) if config else None
-        )
+        global_window_size = getattr(config, "window_size", None) if config else None
+        global_stride_size = getattr(config, "stride_size", None) if config else None
 
-        # Get effective batch_size for this extractor
-        batch_size, _ = get_extractor_window_params(
+        # Get effective window_size for this extractor
+        window_size, _ = get_extractor_window_params(
             self.config,
-            global_batch_size,
-            global_batch_interval,
+            global_window_size,
+            global_stride_size,
         )
 
         # Get effective source filter (None = get ALL sources)
@@ -159,7 +157,7 @@ class PlaybookExtractor:
         # Get window interactions with time range filter
         session_data_models, _ = storage.get_last_k_interactions_grouped(  # type: ignore[reportOptionalMemberAccess]
             user_id=self.service_config.user_id,
-            k=batch_size,
+            k=window_size,
             sources=effective_source,
             start_time=self.service_config.rerun_start_time,
             end_time=self.service_config.rerun_end_time,
@@ -202,10 +200,10 @@ class PlaybookExtractor:
         Returns:
             list[UserPlaybook]: List of extracted user playbook entries
         """
-        # Collect interactions using extractor's own batch_size/batch_interval settings
+        # Collect interactions using extractor's own window_size/stride_size settings
         request_interaction_data_models = self._get_interactions()
         if not request_interaction_data_models:
-            # No interactions or batch_interval not met
+            # No interactions or stride_size not met
             return []
 
         # should_generate check is handled at the service level (consolidated across all extractors)

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -56,7 +56,7 @@ class PlaybookGenerationServiceConfig:
         allow_manual_trigger: Whether to allow extractors with manual_trigger=True
         rerun_start_time: Optional start time filter for rerun flows (Unix timestamp)
         rerun_end_time: Optional end time filter for rerun flows (Unix timestamp)
-        auto_run: True for regular flow (checks batch_interval), False for rerun/manual (skips batch_interval)
+        auto_run: True for regular flow (checks stride_size), False for rerun/manual (skips stride_size)
         extractor_names: Optional list of extractor names to run (derived from playbook_name)
     """
 
@@ -353,10 +353,10 @@ class PlaybookGenerationService(
 
     def _get_extractor_state_service_name(self) -> str:
         """
-        Get the service name for batch_interval bookmark lookups.
+        Get the service name for stride_size bookmark lookups.
 
         Returns:
-            str: "playbook_extractor" for OperationStateManager batch_interval checks
+            str: "playbook_extractor" for OperationStateManager stride_size checks
         """
         return "playbook_extractor"
 
@@ -598,7 +598,7 @@ class PlaybookGenerationService(
         Run playbook generation with window-sized interactions and CURRENT output.
 
         Processes entries per-user. Each extractor collects its own data
-        using its configured batch_size.
+        using its configured window_size.
         Uses progress tracking via OperationStateManager.
 
         Args:

--- a/reflexio/server/services/playbook/playbook_service_utils.py
+++ b/reflexio/server/services/playbook/playbook_service_utils.py
@@ -198,9 +198,9 @@ class PlaybookGenerationRequest(BaseModel):
     rerun_end_time: int | None = None  # Unix timestamp for rerun flows
     playbook_name: str | None = None  # Filter to run only specific extractor
     auto_run: bool = (
-        True  # True for regular flow (checks batch_interval), False for rerun/manual
+        True  # True for regular flow (checks stride_size), False for rerun/manual
     )
-    force_extraction: bool = False  # when True, bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run)
+    force_extraction: bool = False  # when True, bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run)
 
 
 class PlaybookAggregatorRequest(BaseModel):

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -124,7 +124,7 @@ class ProfileExtractor:
         - Source filtering based on extractor config
         - Time range filtering for rerun flows
 
-        Note: Batch interval checking is handled upstream by BaseGenerationService._filter_configs_by_batch_interval()
+        Note: Stride checking is handled upstream by BaseGenerationService._filter_configs_by_stride()
         before the extractor is created.
 
         Returns:
@@ -132,16 +132,14 @@ class ProfileExtractor:
         """
         # Get global config values
         config = self.request_context.configurator.get_config()
-        global_batch_size = getattr(config, "batch_size", None) if config else None
-        global_batch_interval = (
-            getattr(config, "batch_interval", None) if config else None
-        )
+        global_window_size = getattr(config, "window_size", None) if config else None
+        global_stride_size = getattr(config, "stride_size", None) if config else None
 
-        # Get effective batch_size for this extractor
-        batch_size, _ = get_extractor_window_params(
+        # Get effective window_size for this extractor
+        window_size, _ = get_extractor_window_params(
             self.config,
-            global_batch_size,
-            global_batch_interval,
+            global_window_size,
+            global_stride_size,
         )
 
         # Get effective source filter (None = get ALL sources)
@@ -157,7 +155,7 @@ class ProfileExtractor:
         # Get window interactions with time range filter
         session_data_models, _ = storage.get_last_k_interactions_grouped(  # type: ignore[reportOptionalMemberAccess]
             user_id=self.service_config.user_id,
-            k=batch_size,
+            k=window_size,
             sources=effective_source,
             start_time=self.service_config.rerun_start_time,
             end_time=self.service_config.rerun_end_time,
@@ -197,7 +195,7 @@ class ProfileExtractor:
         Returns:
             Optional[list[UserProfile]]: List of extracted profiles, or None if no profiles found
         """
-        # Collect interactions using extractor's own batch_size/batch_interval settings
+        # Collect interactions using extractor's own window_size/stride_size settings
         request_interaction_data_models = self._get_interactions()
         if not request_interaction_data_models:
             return None

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -56,7 +56,7 @@ class ProfileGenerationServiceConfig:
         extractor_names: Optional list of extractor names to filter which extractors run
         rerun_start_time: Optional start time filter for rerun flows (Unix timestamp)
         rerun_end_time: Optional end time filter for rerun flows (Unix timestamp)
-        auto_run: True for regular flow (checks batch_interval), False for rerun/manual (skips batch_interval)
+        auto_run: True for regular flow (checks stride_size), False for rerun/manual (skips stride_size)
     """
 
     user_id: str
@@ -334,10 +334,10 @@ class ProfileGenerationService(
 
     def _get_extractor_state_service_name(self) -> str:
         """
-        Get the service name for batch_interval bookmark lookups.
+        Get the service name for stride_size bookmark lookups.
 
         Returns:
-            str: "profile_extractor" for OperationStateManager batch_interval checks
+            str: "profile_extractor" for OperationStateManager stride_size checks
         """
         return "profile_extractor"
 
@@ -649,10 +649,10 @@ class ProfileGenerationService(
         Run profile generation with window-sized interactions and CURRENT output.
 
         This is a manual trigger that behaves like regular generation
-        (uses batch_size, outputs CURRENT profiles) but only runs
+        (uses window_size, outputs CURRENT profiles) but only runs
         profile extraction (not feedback or agent success).
 
-        Each extractor collects its own data using its configured batch_size.
+        Each extractor collects its own data using its configured window_size.
         Uses progress tracking via OperationStateManager.
 
         Args:

--- a/reflexio/server/services/profile/profile_generation_service_utils.py
+++ b/reflexio/server/services/profile/profile_generation_service_utils.py
@@ -45,9 +45,9 @@ class ProfileGenerationRequest(BaseModel):
     rerun_start_time: int | None = None  # Unix timestamp for rerun flows
     rerun_end_time: int | None = None  # Unix timestamp for rerun flows
     auto_run: bool = (
-        True  # True for regular flow (checks batch_interval), False for rerun/manual
+        True  # True for regular flow (checks stride_size), False for rerun/manual
     )
-    force_extraction: bool = False  # when True, bypass all extraction gates (batch_interval, cheap pre-filter, LLM should_run)
+    force_extraction: bool = False  # when True, bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run)
 
 
 @dataclass(frozen=True)

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -2,8 +2,8 @@
 
 Invoked from ``GenerationService.run`` after the publish has saved its
 interactions and before the extractor pool spins up. Mirrors the
-extractor pattern: window of size ``batch_size`` (global), advanced
-every ``batch_interval`` interactions per ``OperationStateManager``
+extractor pattern: window of size ``window_size`` (global), advanced
+every ``stride_size`` interactions per ``OperationStateManager``
 bookmark. When the gate is open and at least one Assistant interaction
 in the window cites a *current* user playbook / user profile row, the
 service asks an LLM whether any of those cited rows should be replaced
@@ -91,8 +91,8 @@ class ReflectionService:
         if storage is None:
             return result
 
-        batch_size = config.batch_size if config else 10
-        batch_interval = config.batch_interval if config else 5
+        window_size = config.window_size if config else 10
+        stride_size = config.stride_size if config else 5
         sources = [request.source] if request.source else None
 
         mgr = OperationStateManager(
@@ -108,14 +108,14 @@ class ReflectionService:
             sources=sources,
         )
         new_count = sum(len(m.interactions) for m in new_models)
-        if new_count < batch_interval:
+        if new_count < stride_size:
             return result
         result.gate_open = True
 
-        # Pull window of last batch_size interactions for the user.
+        # Pull window of last window_size interactions for the user.
         window_models, _flat = storage.get_last_k_interactions_grouped(
             user_id=request.user_id,
-            k=batch_size,
+            k=window_size,
             sources=sources,
         )
         window_interactions = _flatten(window_models)

--- a/reflexio/server/services/reflection/reflection_service_utils.py
+++ b/reflexio/server/services/reflection/reflection_service_utils.py
@@ -2,7 +2,7 @@
 
 Reflection runs as its own sliding-window step inside the publish flow,
 mirroring the existing profile / playbook extractor pattern: a window
-of size ``batch_size`` (global) advanced every ``batch_interval``
+of size ``window_size`` (global) advanced every ``stride_size``
 interactions. When the gate passes and at least one Assistant
 interaction in the window carries citations, the service asks an LLM
 whether any cited user playbook / user profile rows should be replaced
@@ -89,7 +89,7 @@ class ReflectionResult(BaseModel):
         ran (bool): True iff the LLM was actually called. False when
             reflection short-circuited (disabled, gate not yet open, no
             citations in window, no current cited rows, LLM error).
-        gate_open (bool): True when the batch_interval bookmark gate
+        gate_open (bool): True when the stride_size bookmark gate
             permitted this run (regardless of whether citations existed).
         cited_count (int): Distinct citations seen on Assistant
             interactions in the window.

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -430,13 +430,13 @@ def reflexio_instance_manual_profile(
     """Create an Reflexio instance with manual profile generation config.
 
     This config has:
-    - batch_size set (required for manual generation)
+    - window_size set (required for manual generation)
     - allow_manual_trigger=True on the extractor
     """
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
-        batch_size=10,  # Required for manual generation
+        window_size=10,  # Required for manual generation
         profile_extractor_configs=[
             ProfileExtractorConfig(
                 extractor_name="manual_trigger_extractor",
@@ -472,13 +472,13 @@ def reflexio_instance_manual_playbook(
     """Create an Reflexio instance with manual playbook generation config.
 
     This config has:
-    - batch_size set (required for manual generation)
+    - window_size set (required for manual generation)
     - allow_manual_trigger=True on the extractor
     """
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
-        batch_size=10,  # Required for manual generation
+        window_size=10,  # Required for manual generation
         user_playbook_extractor_configs=[
             PlaybookConfig(
                 extractor_name="manual_trigger_playbook",
@@ -516,7 +516,7 @@ def reflexio_instance_multiple_profile_extractors(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
-        batch_size=20,
+        window_size=20,
         profile_extractor_configs=[
             ProfileExtractorConfig(
                 extractor_name="extractor_basic_info",
@@ -566,7 +566,7 @@ def reflexio_instance_multiple_playbook_extractors(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
-        batch_size=20,
+        window_size=20,
         user_playbook_extractor_configs=[
             PlaybookConfig(
                 extractor_name="api_only_playbook",

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -237,7 +237,7 @@ class TestOpenClawMultiUser:
         all_interactions = storage.get_all_interactions()
         assert len(all_interactions) == len(alpha_turns) + len(beta_turns)
 
-        # Seed user playbooks directly (bypassing extraction batch gate)
+        # Seed user playbooks directly (bypassing extraction stride gate)
         # to verify playbook scoping by user_id
         from reflexio.models.api_schema.service_schemas import UserPlaybook
 
@@ -286,7 +286,7 @@ class TestOpenClawMultiUser:
     ) -> None:
         """Profiles stored for one user_id are not visible to another.
 
-        Seeds profiles directly (bypassing extraction batch gate) and verifies
+        Seeds profiles directly (bypassing extraction stride gate) and verifies
         that get_user_profile scopes correctly by user_id.
         """
         instance = openclaw_profile_instance
@@ -339,7 +339,7 @@ class TestAgentPlaybookAggregation:
         instance = openclaw_playbook_instance
         storage = instance.request_context.storage
 
-        # Seed user playbooks directly (bypassing extraction batch gate)
+        # Seed user playbooks directly (bypassing extraction stride gate)
         # to test aggregation scoping across multiple users
         from reflexio.models.api_schema.service_schemas import UserPlaybook
 

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -203,7 +203,7 @@ class TestOpenClawMultiUser:
         attributed to the correct user, and user playbooks (seeded directly)
         are isolated per user_id.
 
-        Note: extraction is batch-gated (requires batch_interval interactions),
+        Note: extraction is stride-gated (requires stride_size interactions),
         so we verify interaction storage scoping and seed playbooks directly
         to test playbook isolation.
         """

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -1167,10 +1167,10 @@ def test_manual_playbook_generation_no_window_size(
     sample_interaction_requests: list[InteractionData],
     cleanup_playbook_only: Callable[[], None],
 ):
-    """Test manual_playbook_generation works without batch_size.
+    """Test manual_playbook_generation works without window_size.
 
     This test verifies:
-    1. Manual generation works when batch_size is not configured
+    1. Manual generation works when window_size is not configured
        (it defaults to fetching all available interactions with a reasonable limit)
     """
     user_id = "test_user_no_window"

--- a/tests/e2e_tests/test_profile_workflows.py
+++ b/tests/e2e_tests/test_profile_workflows.py
@@ -1036,10 +1036,10 @@ def test_manual_profile_generation_no_window_size(
     sample_interaction_requests: list[InteractionData],
     cleanup_profile_only: Callable[[], None],
 ):
-    """Test manual_profile_generation works without batch_size.
+    """Test manual_profile_generation works without window_size.
 
     This test verifies:
-    1. Manual generation works when batch_size is not configured
+    1. Manual generation works when window_size is not configured
        (it defaults to fetching all available interactions with a reasonable limit)
     """
     user_id = "test_user_no_window"

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -65,7 +65,7 @@ def reflexio_with_config(temp_storage, ensure_mock_env):
         context_prompt="Extract user preferences",
         extraction_definition_prompt="User likes and dislikes",
         metadata_definition_prompt="Metadata about preferences",
-        batch_interval_override=1,
+        stride_size_override=1,
     )
     reflexio.request_context.configurator.set_config_by_name(
         "profile_extractor_configs", [profile_extractor_config]

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -44,7 +44,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserProfile,
 )
 from reflexio.models.config_schema import (
-    DEFAULT_BATCH_INTERVAL,
+    DEFAULT_STRIDE_SIZE,
     AgentSuccessConfig,
     AnthropicConfig,
     AzureOpenAIConfig,
@@ -483,21 +483,21 @@ class TestNumericConstraints:
             ProfileExtractorConfig(
                 extractor_name="test",
                 extraction_definition_prompt="test",
-                batch_size_override=0,
+                window_size_override=0,
             )
         with pytest.raises(ValidationError):
             ProfileExtractorConfig(
                 extractor_name="test",
                 extraction_definition_prompt="test",
-                batch_interval_override=-1,
+                stride_size_override=-1,
             )
         # None is allowed (use global setting)
         config = ProfileExtractorConfig(
             extractor_name="test",
             extraction_definition_prompt="test",
-            batch_size_override=None,
+            window_size_override=None,
         )
-        assert config.batch_size_override is None
+        assert config.window_size_override is None
 
 
 # =============================================================================
@@ -625,30 +625,30 @@ class TestCrossFieldValidators:
         assert config.azure_config is not None
 
     def test_config_stride_le_window(self):
-        """Config: batch_interval must be <= batch_size."""
-        with pytest.raises(ValidationError, match="batch_interval"):
+        """Config: stride_size must be <= window_size."""
+        with pytest.raises(ValidationError, match="stride_size"):
             Config(
                 storage_config=StorageConfigSQLite(),
-                batch_size=10,
-                batch_interval=20,
+                window_size=10,
+                stride_size=20,
             )
 
     def test_config_stride_equal_window_ok(self):
-        """Config: batch_interval == batch_size is OK."""
+        """Config: stride_size == window_size is OK."""
         config = Config(
             storage_config=StorageConfigSQLite(),
-            batch_size=10,
-            batch_interval=10,
+            window_size=10,
+            stride_size=10,
         )
-        assert config.batch_interval == 10
+        assert config.stride_size == 10
 
     def test_config_stride_default_ok(self):
-        """Config: omitting batch_interval uses DEFAULT_BATCH_INTERVAL."""
+        """Config: omitting stride_size uses DEFAULT_STRIDE_SIZE."""
         config = Config(
             storage_config=StorageConfigSQLite(),
-            batch_size=10,
+            window_size=10,
         )
-        assert config.batch_interval == DEFAULT_BATCH_INTERVAL
+        assert config.stride_size == DEFAULT_STRIDE_SIZE
 
     def test_config_defaults_extractors_when_omitted(self):
         """Config: omitted extractor lists still get the default extractors."""
@@ -724,18 +724,65 @@ class TestBackwardCompatibility:
             extraction_window_size=15,
             extraction_window_stride=7,
         )
-        assert config.batch_size == 15
-        assert config.batch_interval == 7
+        assert config.window_size == 15
+        assert config.stride_size == 7
 
-    def test_config_new_names_preferred(self):
-        """Config: new field names batch_size/batch_interval work directly."""
+    def test_config_accepts_current_legacy_names(self):
+        """Config: batch_size/batch_interval still accepted as aliases."""
         config = Config(
             storage_config=StorageConfigSQLite(),
             batch_size=20,
             batch_interval=8,
         )
-        assert config.batch_size == 20
-        assert config.batch_interval == 8
+        assert config.window_size == 20
+        assert config.stride_size == 8
+
+    def test_config_new_names_preferred(self):
+        """Config: new field names window_size/stride_size work directly."""
+        config = Config(
+            storage_config=StorageConfigSQLite(),
+            window_size=20,
+            stride_size=8,
+        )
+        assert config.window_size == 20
+        assert config.stride_size == 8
+
+    def test_config_prefers_new_names_when_both_present(self):
+        """Config: new names win if old and new field names are both present."""
+        config = Config(
+            storage_config=StorageConfigSQLite(),
+            window_size=20,
+            stride_size=8,
+            batch_size=10,
+            batch_interval=5,
+            extraction_window_size=2,
+            extraction_window_stride=1,
+        )
+        assert config.window_size == 20
+        assert config.stride_size == 8
+
+    def test_config_model_dump_uses_only_new_names(self):
+        """Config: serialization emits window_size/stride_size only."""
+        config = Config(
+            storage_config=StorageConfigSQLite(),
+            batch_size=20,
+            batch_interval=8,
+        )
+        dumped = config.model_dump()
+        assert dumped["window_size"] == 20
+        assert dumped["stride_size"] == 8
+        assert "batch_size" not in dumped
+        assert "batch_interval" not in dumped
+
+    def test_config_deprecated_properties_read_write_new_fields(self):
+        """Config: deprecated Python properties still read/write canonical fields."""
+        config = Config(storage_config=StorageConfigSQLite())
+        config.batch_size = 22
+        config.batch_interval = 11
+        assert config.window_size == 22
+        assert config.stride_size == 11
+        assert config.batch_size == 22
+        assert config.batch_interval == 11
 
     def test_profile_extractor_old_override_names(self):
         """ProfileExtractorConfig: old extraction_window_*_override names still work."""
@@ -745,8 +792,35 @@ class TestBackwardCompatibility:
             extraction_window_size_override=30,
             extraction_window_stride_override=10,
         )
+        assert config.window_size_override == 30
+        assert config.stride_size_override == 10
+
+    def test_profile_extractor_current_legacy_override_names(self):
+        """ProfileExtractorConfig: batch_*_override names still work."""
+        config = ProfileExtractorConfig(
+            extractor_name="test",
+            extraction_definition_prompt="test",
+            batch_size_override=30,
+            batch_interval_override=10,
+        )
+        assert config.window_size_override == 30
+        assert config.stride_size_override == 10
         assert config.batch_size_override == 30
         assert config.batch_interval_override == 10
+
+    def test_profile_extractor_override_model_dump_uses_only_new_names(self):
+        """ProfileExtractorConfig: serialization emits window/stride override names."""
+        config = ProfileExtractorConfig(
+            extractor_name="test",
+            extraction_definition_prompt="test",
+            batch_size_override=30,
+            batch_interval_override=10,
+        )
+        dumped = config.model_dump()
+        assert dumped["window_size_override"] == 30
+        assert dumped["stride_size_override"] == 10
+        assert "batch_size_override" not in dumped
+        assert "batch_interval_override" not in dumped
 
     def test_playbook_config_old_override_names(self):
         """PlaybookConfig: old extraction_window_*_override names still work."""
@@ -756,8 +830,19 @@ class TestBackwardCompatibility:
             extraction_window_size_override=25,
             extraction_window_stride_override=5,
         )
-        assert config.batch_size_override == 25
-        assert config.batch_interval_override == 5
+        assert config.window_size_override == 25
+        assert config.stride_size_override == 5
+
+    def test_playbook_config_current_legacy_override_names(self):
+        """PlaybookConfig: batch_*_override names still work."""
+        config = PlaybookConfig(
+            extractor_name="test",
+            extraction_definition_prompt="test",
+            batch_size_override=25,
+            batch_interval_override=5,
+        )
+        assert config.window_size_override == 25
+        assert config.stride_size_override == 5
 
     def test_success_config_old_override_names(self):
         """AgentSuccessConfig: old extraction_window_*_override names still work."""
@@ -767,8 +852,19 @@ class TestBackwardCompatibility:
             extraction_window_size_override=40,
             extraction_window_stride_override=15,
         )
-        assert config.batch_size_override == 40
-        assert config.batch_interval_override == 15
+        assert config.window_size_override == 40
+        assert config.stride_size_override == 15
+
+    def test_success_config_current_legacy_override_names(self):
+        """AgentSuccessConfig: batch_*_override names still work."""
+        config = AgentSuccessConfig(
+            evaluation_name="test",
+            success_definition_prompt="test",
+            batch_size_override=40,
+            batch_interval_override=15,
+        )
+        assert config.window_size_override == 40
+        assert config.stride_size_override == 15
 
     def test_aggregator_config_old_field_names(self):
         """PlaybookAggregatorConfig: old field names still work via AliasChoices."""

--- a/tests/server/services/configurator/test_config_storage_contract.py
+++ b/tests/server/services/configurator/test_config_storage_contract.py
@@ -56,14 +56,14 @@ class TestConfigStorageContract:
     def test_save_and_load_round_trip(self, config_storage: ConfigStorage) -> None:
         """A saved config can be loaded back with key fields intact."""
         original = config_storage.get_default_config()
-        original.batch_size = 20
-        original.batch_interval = 10
+        original.window_size = 20
+        original.stride_size = 10
 
         config_storage.save_config(original)
         loaded = config_storage.load_config()
 
-        assert loaded.batch_size == original.batch_size
-        assert loaded.batch_interval == original.batch_interval
+        assert loaded.window_size == original.window_size
+        assert loaded.stride_size == original.stride_size
         assert loaded.storage_config == original.storage_config
 
     def test_load_without_save_returns_default(
@@ -75,4 +75,4 @@ class TestConfigStorageContract:
 
         assert isinstance(loaded, Config)
         assert loaded.storage_config == default.storage_config
-        assert loaded.batch_size == default.batch_size
+        assert loaded.window_size == default.window_size

--- a/tests/server/services/playbook/test_playbook_extractor.py
+++ b/tests/server/services/playbook/test_playbook_extractor.py
@@ -216,8 +216,8 @@ class TestOperationStateKey:
 class TestGetInteractions:
     """Tests for interaction collection logic (not user-scoped).
 
-    Note: Batch interval checking is handled upstream by BaseGenerationService._filter_configs_by_batch_interval()
-    before the extractor is created, so batch_interval tests are at the service level.
+    Note: Stride checking is handled upstream by BaseGenerationService._filter_configs_by_stride()
+    before the extractor is created, so stride_size tests are at the service level.
     """
 
     def test_passes_none_user_id_to_storage(
@@ -296,7 +296,7 @@ class TestGetInteractions:
         config = PlaybookConfig(
             extractor_name="quality_playbook",
             extraction_definition_prompt="Evaluate agent quality",
-            batch_size_override=50,
+            window_size_override=50,
         )
 
         request_context.storage.get_last_k_interactions_grouped.return_value = (

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -96,7 +96,7 @@ def test_generate_playbook(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up playbook config with batch_size
+        # Set up playbook config with window_size
         playbook_config = PlaybookConfig(
             extractor_name="test_playbook",
             extraction_definition_prompt="test",
@@ -107,7 +107,7 @@ def test_generate_playbook(mock_chat_completion):
         playbook_generation_service.configurator.set_config_by_name(
             "user_playbook_extractor_configs", [playbook_config]
         )
-        playbook_generation_service.configurator.set_config_by_name("batch_size", 100)
+        playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Store interactions in storage first
         request_obj = Request(
@@ -276,7 +276,7 @@ def test_error_handling(mock_chat_completion):
 
 
 def test_run_manual_regular_no_window_size(mock_chat_completion):
-    """Test run_manual_regular works even without batch_size configured.
+    """Test run_manual_regular works even without window_size configured.
 
     Since extractors handle window size at their level, the manual flow no longer
     validates window_size upfront. Extractors use a fallback of 1000 interactions
@@ -307,7 +307,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
         playbook_generation_service.configurator.set_config_by_name(
             "user_playbook_extractor_configs", [playbook_config]
         )
-        # batch_size is not configured
+        # window_size is not configured
 
         # Add some interactions to storage
         interaction = Interaction(
@@ -364,7 +364,7 @@ def test_run_manual_regular_no_interactions(mock_chat_completion):
         playbook_generation_service.configurator.set_config_by_name(
             "user_playbook_extractor_configs", [playbook_config]
         )
-        playbook_generation_service.configurator.set_config_by_name("batch_size", 100)
+        playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
         from reflexio.models.api_schema.service_schemas import (
             ManualPlaybookGenerationRequest,
@@ -407,7 +407,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
         playbook_generation_service.configurator.set_config_by_name(
             "user_playbook_extractor_configs", [playbook_config]
         )
-        playbook_generation_service.configurator.set_config_by_name("batch_size", 100)
+        playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # First, add some interactions to storage
         interaction = Interaction(
@@ -468,7 +468,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         playbook_generation_service.configurator.set_config_by_name(
             "user_playbook_extractor_configs", [playbook_config]
         )
-        playbook_generation_service.configurator.set_config_by_name("batch_size", 100)
+        playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Add interactions with source_a
         interaction_a = Interaction(
@@ -551,7 +551,7 @@ def test_run_manual_regular_output_pending_status_false(mock_chat_completion):
         playbook_generation_service.configurator.set_config_by_name(
             "user_playbook_extractor_configs", [playbook_config]
         )
-        playbook_generation_service.configurator.set_config_by_name("batch_size", 100)
+        playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Add interaction
         interaction = Interaction(
@@ -778,7 +778,7 @@ def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        service.configurator.set_config_by_name("batch_size", 200)
+        service.configurator.set_config_by_name("window_size", 200)
         service.service_config = service._load_generation_service_config(
             PlaybookGenerationRequest(
                 request_id="request-1",
@@ -812,14 +812,14 @@ def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
                 extractor_name="api_playbook",
                 extraction_definition_prompt="extract api-related playbook",
                 request_sources_enabled=["api"],
-                batch_size_override=120,
+                window_size_override=120,
                 aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
             ),
             PlaybookConfig(
                 extractor_name="web_playbook",
                 extraction_definition_prompt="extract web-related playbook",
                 request_sources_enabled=["web"],
-                batch_size_override=80,
+                window_size_override=80,
                 aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
             ),
         ]

--- a/tests/server/services/playbook/test_playbook_generation_service_integration.py
+++ b/tests/server/services/playbook/test_playbook_generation_service_integration.py
@@ -85,8 +85,8 @@ def mock_request_context():
             ),
         )
     ]
-    # Mock batch_size for extractor
-    context.configurator.get_config.return_value.batch_size = 100
+    # Mock window_size for extractor
+    context.configurator.get_config.return_value.window_size = 100
     context.prompt_manager = PromptManager()
     return context
 

--- a/tests/server/services/profile/test_profile_extractor.py
+++ b/tests/server/services/profile/test_profile_extractor.py
@@ -194,8 +194,8 @@ class TestOperationStateKey:
 class TestGetInteractions:
     """Tests for interaction collection logic.
 
-    Note: Batch interval checking is handled upstream by BaseGenerationService._filter_configs_by_batch_interval()
-    before the extractor is created, so batch_interval tests are at the service level.
+    Note: Stride checking is handled upstream by BaseGenerationService._filter_configs_by_stride()
+    before the extractor is created, so stride_size tests are at the service level.
     """
 
     def test_returns_interactions(
@@ -241,7 +241,7 @@ class TestGetInteractions:
         config = ProfileExtractorConfig(
             extractor_name="test_extractor",
             extraction_definition_prompt="Extract user preferences",
-            batch_size_override=50,
+            window_size_override=50,
         )
 
         # Mock storage

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -152,8 +152,8 @@ def _set_config(request_context, **overrides):
     cfg = Config.model_validate(
         {
             "storage_config": {"db_path": None},
-            "batch_size": 5,
-            "batch_interval": 2,
+            "window_size": 5,
+            "stride_size": 2,
             "reflection_config": ReflectionConfig().model_dump(),
             **overrides,
         }
@@ -192,11 +192,11 @@ class TestGate:
         assert result.gate_open is False
         llm_client.generate_chat_response.assert_not_called()
 
-    def test_gate_closed_when_below_batch_interval(
+    def test_gate_closed_when_below_stride_size(
         self, request_context, service, llm_client
     ):
-        _set_config(request_context, batch_size=10, batch_interval=5)
-        # Seed only 2 interactions; batch_interval=5.
+        _set_config(request_context, window_size=10, stride_size=5)
+        # Seed only 2 interactions; stride_size=5.
         _seed_request_with_interactions(
             request_context.storage,
             "u1",
@@ -217,7 +217,7 @@ class TestNoCitations:
     def test_window_without_citations_advances_bookmark(
         self, request_context, service, llm_client
     ):
-        _set_config(request_context, batch_size=5, batch_interval=2)
+        _set_config(request_context, window_size=5, stride_size=2)
         _seed_request_with_interactions(
             request_context.storage,
             "u1",

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -39,8 +39,8 @@ class MockExtractorConfig:
     extractor_name: str
     request_sources_enabled: list[str] | None = None
     manual_trigger: bool = False
-    batch_size_override: int | None = None
-    batch_interval_override: int | None = None
+    window_size_override: int | None = None
+    stride_size_override: int | None = None
 
 
 @dataclass
@@ -380,19 +380,19 @@ class TestFilterExtractorConfigsByServiceConfig:
 
 
 # ===============================
-# Test: _filter_configs_by_batch_interval
+# Test: _filter_configs_by_stride
 # ===============================
 
 
-class BatchIntervalEnabledService(ConcreteGenerationService):
-    """Concrete service with batch_interval pre-filtering enabled."""
+class StrideEnabledService(ConcreteGenerationService):
+    """Concrete service with stride_size pre-filtering enabled."""
 
     def _get_extractor_state_service_name(self):
         return "test_extractor"
 
 
-class TestFilterConfigsByBatchInterval:
-    """Tests for the _filter_configs_by_batch_interval method."""
+class TestFilterConfigsByStride:
+    """Tests for the _filter_configs_by_stride method."""
 
     def _make_request_interaction_models(self, n_interactions: int):
         """Create mock RequestInteractionDataModel objects with n interactions."""
@@ -408,7 +408,7 @@ class TestFilterConfigsByBatchInterval:
                 content=f"message {i}",
                 request_id="req1",
                 created_at=1000 + i,
-                role="user",
+                role="User",
             )
             for i in range(n_interactions)
         ]
@@ -429,7 +429,7 @@ class TestFilterConfigsByBatchInterval:
     def test_returns_all_configs_when_no_service_name(
         self, llm_client, request_context
     ):
-        """Verify _filter_configs_by_batch_interval returns all configs unchanged when
+        """Verify _filter_configs_by_stride returns all configs unchanged when
         _get_extractor_state_service_name() returns None (e.g., AgentSuccessEvaluationService).
         """
         service = ConcreteGenerationService(
@@ -446,13 +446,13 @@ class TestFilterConfigsByBatchInterval:
             MockExtractorConfig(extractor_name="ext1"),
             MockExtractorConfig(extractor_name="ext2"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
+        result = service._filter_configs_by_stride(configs)
         assert len(result) == 2
         assert result is configs  # Same list object returned, no filtering
 
     def test_returns_all_configs_when_auto_run_false(self, llm_client, request_context):
         """Verify all configs pass when auto_run=False (rerun/manual mode)."""
-        service = BatchIntervalEnabledService(
+        service = StrideEnabledService(
             llm_client,
             request_context,
             extractor_configs=[],
@@ -463,7 +463,7 @@ class TestFilterConfigsByBatchInterval:
             MockExtractorConfig(extractor_name="ext1"),
             MockExtractorConfig(extractor_name="ext2"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
+        result = service._filter_configs_by_stride(configs)
         assert len(result) == 2
         assert result is configs  # Same list object returned, no filtering
 
@@ -471,7 +471,7 @@ class TestFilterConfigsByBatchInterval:
         self, llm_client, request_context
     ):
         """Verify all configs pass when force_extraction=True (agent-curated publish)."""
-        service = BatchIntervalEnabledService(
+        service = StrideEnabledService(
             llm_client,
             request_context,
             extractor_configs=[],
@@ -482,14 +482,14 @@ class TestFilterConfigsByBatchInterval:
             MockExtractorConfig(extractor_name="ext1"),
             MockExtractorConfig(extractor_name="ext2"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
+        result = service._filter_configs_by_stride(configs)
         assert len(result) == 2
         assert result is configs  # Same list object returned, no filtering
 
-    def _setup_batch_interval_service(
+    def _setup_stride_size_service(
         self, llm_client, request_context, n_new_interactions
     ):
-        """Create a BatchIntervalEnabledService with mocked storage for batch_interval tests.
+        """Create a StrideEnabledService with mocked storage for stride_size tests.
 
         Mocks storage and configurator before creating the service so that
         self.storage in the service references the mock.
@@ -505,69 +505,67 @@ class TestFilterConfigsByBatchInterval:
         )
         request_context.storage = mock_storage
 
-        service = BatchIntervalEnabledService(
+        service = StrideEnabledService(
             llm_client,
             request_context,
             extractor_configs=[],
         )
         return service  # noqa: RET504
 
-    def test_filters_configs_when_batch_interval_not_met(
+    def test_filters_configs_when_stride_size_not_met(
         self, llm_client, request_context
     ):
-        """Verify configs are dropped when new interaction count < batch_interval."""
-        service = self._setup_batch_interval_service(llm_client, request_context, 2)
+        """Verify configs are dropped when new interaction count < stride_size."""
+        service = self._setup_stride_size_service(llm_client, request_context, 2)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
         configs = [
             MockExtractorConfig(extractor_name="ext1"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
+        result = service._filter_configs_by_stride(configs)
         assert len(result) == 0
 
-    def test_passes_configs_when_batch_interval_met(self, llm_client, request_context):
-        """Verify configs pass through when new interaction count >= batch_interval."""
-        service = self._setup_batch_interval_service(llm_client, request_context, 6)
+    def test_passes_configs_when_stride_size_met(self, llm_client, request_context):
+        """Verify configs pass through when new interaction count >= stride_size."""
+        service = self._setup_stride_size_service(llm_client, request_context, 6)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
         configs = [
             MockExtractorConfig(extractor_name="ext1"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
+        result = service._filter_configs_by_stride(configs)
         assert len(result) == 1
         assert result[0].extractor_name == "ext1"
 
     def test_handles_source_skip(self, llm_client, request_context):
-        """Verify configs that fail source filtering in batch_interval check are skipped."""
-        service = self._setup_batch_interval_service(llm_client, request_context, 10)
+        """Verify configs that fail source filtering in stride_size check are skipped."""
+        service = self._setup_stride_size_service(llm_client, request_context, 10)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
         # ext1 has sources_enabled=["mobile"] but triggering source is "api" -> should be skipped
-        # ext2 has no source restriction -> should pass batch_interval check
+        # ext2 has no source restriction -> should pass stride_size check
         configs = [
             MockExtractorConfig(
                 extractor_name="ext1", request_sources_enabled=["mobile"]
             ),
             MockExtractorConfig(extractor_name="ext2"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
-        # ext1 skipped by source filter, ext2 passes batch_interval
+        result = service._filter_configs_by_stride(configs)
+        # ext1 skipped by source filter, ext2 passes stride_size
         assert len(result) == 1
         assert result[0].extractor_name == "ext2"
 
-    def test_uses_per_extractor_batch_interval_override(
-        self, llm_client, request_context
-    ):
-        """Verify per-extractor batch_interval override is respected."""
-        service = self._setup_batch_interval_service(llm_client, request_context, 3)
+    def test_uses_per_extractor_stride_size_override(self, llm_client, request_context):
+        """Verify per-extractor stride_size override is respected."""
+        service = self._setup_stride_size_service(llm_client, request_context, 3)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
-        # 3 new interactions: ext1 (batch_interval=2 -> passes), ext2 (default batch_interval=5 -> fails)
+        # 3 new interactions: ext1 (stride_size=2 -> passes), ext2 (default stride_size=5 -> fails)
         configs = [
-            MockExtractorConfig(extractor_name="ext1", batch_interval_override=2),
+            MockExtractorConfig(extractor_name="ext1", stride_size_override=2),
             MockExtractorConfig(extractor_name="ext2"),
         ]
-        result = service._filter_configs_by_batch_interval(configs)
+        result = service._filter_configs_by_stride(configs)
         assert len(result) == 1
         assert result[0].extractor_name == "ext1"
 

--- a/tests/server/services/test_extractor_interaction_utils.py
+++ b/tests/server/services/test_extractor_interaction_utils.py
@@ -20,7 +20,7 @@ from reflexio.server.services.extractor_interaction_utils import (
     get_effective_source_filter,
     get_extractor_window_params,
     iter_sliding_windows,
-    should_extractor_run_by_batch_interval,
+    should_extractor_run_by_stride,
 )
 
 # ===============================
@@ -33,8 +33,8 @@ class MockExtractorConfig:
     """Mock extractor config for testing."""
 
     extractor_name: str
-    batch_size_override: int | None = None
-    batch_interval_override: int | None = None
+    window_size_override: int | None = None
+    stride_size_override: int | None = None
     request_sources_enabled: list[str] | None = None
 
 
@@ -43,8 +43,8 @@ class MockPlaybookConfig:
     """Mock playbook config with playbook_name."""
 
     playbook_name: str
-    batch_size: int | None = None
-    batch_interval: int | None = None
+    window_size: int | None = None
+    stride_size: int | None = None
     request_sources_enabled: list[str] | None = None
 
 
@@ -60,14 +60,14 @@ class TestGetExtractorWindowParams:
         """Test that extractor-level overrides take precedence over globals."""
         config = MockExtractorConfig(
             extractor_name="test",
-            batch_size_override=50,
-            batch_interval_override=10,
+            window_size_override=50,
+            stride_size_override=10,
         )
 
         window, stride = get_extractor_window_params(
             config,
-            global_batch_size=100,
-            global_batch_interval=20,
+            global_window_size=100,
+            global_stride_size=20,
         )
 
         assert window == 50
@@ -79,8 +79,8 @@ class TestGetExtractorWindowParams:
 
         window, stride = get_extractor_window_params(
             config,
-            global_batch_size=100,
-            global_batch_interval=20,
+            global_window_size=100,
+            global_stride_size=20,
         )
 
         assert window == 100
@@ -90,13 +90,13 @@ class TestGetExtractorWindowParams:
         """Test partial override - only window size set on extractor."""
         config = MockExtractorConfig(
             extractor_name="test",
-            batch_size_override=50,
+            window_size_override=50,
         )
 
         window, stride = get_extractor_window_params(
             config,
-            global_batch_size=100,
-            global_batch_interval=20,
+            global_window_size=100,
+            global_stride_size=20,
         )
 
         assert window == 50
@@ -108,8 +108,8 @@ class TestGetExtractorWindowParams:
 
         window, stride = get_extractor_window_params(
             config,
-            global_batch_size=None,
-            global_batch_interval=None,
+            global_window_size=None,
+            global_stride_size=None,
         )
 
         assert window == 10
@@ -119,14 +119,14 @@ class TestGetExtractorWindowParams:
         """Test that zero values ARE respected (0 is a valid override value)."""
         config = MockExtractorConfig(
             extractor_name="test",
-            batch_size_override=0,
-            batch_interval_override=0,
+            window_size_override=0,
+            stride_size_override=0,
         )
 
         window, stride = get_extractor_window_params(
             config,
-            global_batch_size=100,
-            global_batch_interval=20,
+            global_window_size=100,
+            global_stride_size=20,
         )
 
         # 0 should be treated as a valid override value (not None)
@@ -222,59 +222,53 @@ class TestGetEffectiveSourceFilter:
 
 
 # ===============================
-# Test: should_extractor_run_by_batch_interval
+# Test: should_extractor_run_by_stride
 # ===============================
 
 
-class TestShouldExtractorRunByBatchInterval:
-    """Tests for batch_interval-based execution checking."""
+class TestShouldExtractorRunByStride:
+    """Tests for stride_size-based execution checking."""
 
-    def test_run_when_count_equals_batch_interval(self):
-        """Test that extractor runs when count equals batch_interval."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=10, batch_interval_size=10
+    def test_run_when_count_equals_stride_size(self):
+        """Test that extractor runs when count equals stride_size."""
+        result = should_extractor_run_by_stride(
+            new_interaction_count=10, stride_size=10
         )
         assert result is True
 
-    def test_run_when_count_exceeds_batch_interval(self):
-        """Test that extractor runs when count exceeds batch_interval."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=15, batch_interval_size=10
+    def test_run_when_count_exceeds_stride_size(self):
+        """Test that extractor runs when count exceeds stride_size."""
+        result = should_extractor_run_by_stride(
+            new_interaction_count=15, stride_size=10
         )
         assert result is True
 
-    def test_skip_when_count_below_batch_interval(self):
-        """Test that extractor skips when count is below batch_interval."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=5, batch_interval_size=10
-        )
+    def test_skip_when_count_below_stride_size(self):
+        """Test that extractor skips when count is below stride_size."""
+        result = should_extractor_run_by_stride(new_interaction_count=5, stride_size=10)
         assert result is False
 
-    def test_run_when_batch_interval_is_none(self):
-        """Test that extractor always runs when batch_interval is None."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=1, batch_interval_size=None
+    def test_run_when_stride_size_is_none(self):
+        """Test that extractor always runs when stride_size is None."""
+        result = should_extractor_run_by_stride(
+            new_interaction_count=1, stride_size=None
         )
         assert result is True
 
-    def test_run_when_batch_interval_is_zero(self):
-        """Test that extractor always runs when batch_interval is 0."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=1, batch_interval_size=0
-        )
+    def test_run_when_stride_size_is_zero(self):
+        """Test that extractor always runs when stride_size is 0."""
+        result = should_extractor_run_by_stride(new_interaction_count=1, stride_size=0)
         assert result is True
 
     def test_skip_when_zero_interactions(self):
         """Test skip when there are no new interactions."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=0, batch_interval_size=10
-        )
+        result = should_extractor_run_by_stride(new_interaction_count=0, stride_size=10)
         assert result is False
 
-    def test_skip_with_zero_interactions_even_without_batch_interval(self):
-        """Test that zero interactions skips even without batch_interval configured."""
-        result = should_extractor_run_by_batch_interval(
-            new_interaction_count=0, batch_interval_size=None
+    def test_skip_with_zero_interactions_even_without_stride_size(self):
+        """Test that zero interactions skips even without stride_size configured."""
+        result = should_extractor_run_by_stride(
+            new_interaction_count=0, stride_size=None
         )
         # No interactions means nothing to process - always skip
         assert result is False
@@ -315,15 +309,13 @@ class TestIterSlidingWindows:
 
     def test_empty_list_yields_nothing(self):
         """Test that empty input yields nothing."""
-        windows = list(iter_sliding_windows([], batch_size=10, batch_interval_size=5))
+        windows = list(iter_sliding_windows([], window_size=10, stride_size=5))
         assert windows == []
 
     def test_single_model_fits_in_window(self):
         """Test single model that fits in window yields one window."""
         models = [_create_mock_request_interaction_model(5)]
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=5)
-        )
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=5))
 
         assert len(windows) == 1
         assert windows[0][0] == 0  # window index
@@ -335,9 +327,7 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(3),
             _create_mock_request_interaction_model(4),
         ]
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=5)
-        )
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=5))
 
         assert len(windows) == 1
         assert windows[0][0] == 0
@@ -347,7 +337,7 @@ class TestIterSlidingWindows:
         """Test basic sliding window with multiple windows needed."""
         # 3 models with 10 interactions each = 30 total
         # Model boundaries: [0-9], [10-19], [20-29]
-        # batch_size=15, stride=10 should yield 3 windows:
+        # window_size=15, stride=10 should yield 3 windows:
         # Window 0: covers [0-14] → models[0] and models[1] (overlaps both)
         # Window 1: covers [10-24] → models[1] and models[2] (model[0] ends at 10, exclusive)
         # Window 2: covers [20-34] → models[2] only (model[1] ends at 20, exclusive)
@@ -356,9 +346,7 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(10),
             _create_mock_request_interaction_model(10),
         ]
-        windows = list(
-            iter_sliding_windows(models, batch_size=15, batch_interval_size=10)
-        )
+        windows = list(iter_sliding_windows(models, window_size=15, stride_size=10))
 
         assert len(windows) == 3
         # Window 0: covers [0-14], includes models[0] and models[1]
@@ -378,9 +366,7 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(10),
             _create_mock_request_interaction_model(10),
         ]
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=10)
-        )
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=10))
 
         assert len(windows) == 3
         # Each window should contain exactly one model
@@ -395,10 +381,8 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(10),
             _create_mock_request_interaction_model(10),
         ]
-        # batch_size=5, stride=15 means windows at positions 0-4, 15-19
-        windows = list(
-            iter_sliding_windows(models, batch_size=5, batch_interval_size=15)
-        )
+        # window_size=5, stride=15 means windows at positions 0-4, 15-19
+        windows = list(iter_sliding_windows(models, window_size=5, stride_size=15))
 
         assert len(windows) == 2
         # Window 0: covers 0-4, only models[0]
@@ -409,11 +393,9 @@ class TestIterSlidingWindows:
         assert len(windows[1][1]) == 1
 
     def test_invalid_window_size_zero(self):
-        """Test that batch_size=0 yields single window with all data."""
+        """Test that window_size=0 yields single window with all data."""
         models = [_create_mock_request_interaction_model(10)]
-        windows = list(
-            iter_sliding_windows(models, batch_size=0, batch_interval_size=5)
-        )
+        windows = list(iter_sliding_windows(models, window_size=0, stride_size=5))
 
         assert len(windows) == 1
         assert windows[0][1] == models
@@ -421,9 +403,7 @@ class TestIterSlidingWindows:
     def test_invalid_window_size_negative(self):
         """Test that negative window_size yields single window with all data."""
         models = [_create_mock_request_interaction_model(10)]
-        windows = list(
-            iter_sliding_windows(models, batch_size=-5, batch_interval_size=5)
-        )
+        windows = list(iter_sliding_windows(models, window_size=-5, stride_size=5))
 
         assert len(windows) == 1
         assert windows[0][1] == models
@@ -434,10 +414,8 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(10),
             _create_mock_request_interaction_model(10),
         ]
-        # stride=0 should default to batch_size=10, yielding 2 non-overlapping windows
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=0)
-        )
+        # stride=0 should default to window_size=10, yielding 2 non-overlapping windows
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=0))
 
         assert len(windows) == 2
 
@@ -447,10 +425,8 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(10),
             _create_mock_request_interaction_model(10),
         ]
-        # stride=None should default to batch_size=10
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=None)
-        )
+        # stride=None should default to window_size=10
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=None))
 
         assert len(windows) == 2
 
@@ -463,10 +439,8 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(5),  # interactions 25-29
         ]
         # Total: 30 interactions
-        # batch_size=15, stride=10
-        windows = list(
-            iter_sliding_windows(models, batch_size=15, batch_interval_size=10)
-        )
+        # window_size=15, stride=10
+        windows = list(iter_sliding_windows(models, window_size=15, stride_size=10))
 
         assert len(windows) == 3
         # Window 0: covers [0-14], models[0] (0-4) and models[1] (5-24) overlap
@@ -484,9 +458,7 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(5),
             _create_mock_request_interaction_model(5),
         ]
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=5)
-        )
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=5))
 
         # First window should have models[0] and models[1] in order
         assert windows[0][1][0] is models[0]
@@ -500,9 +472,7 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(10),
         ]
         # Total: 20 interactions, empty model at position 10
-        windows = list(
-            iter_sliding_windows(models, batch_size=15, batch_interval_size=10)
-        )
+        windows = list(iter_sliding_windows(models, window_size=15, stride_size=10))
 
         assert len(windows) == 2
 
@@ -512,18 +482,14 @@ class TestIterSlidingWindows:
             _create_mock_request_interaction_model(0),
             _create_mock_request_interaction_model(0),
         ]
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=5)
-        )
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=5))
 
         assert windows == []
 
     def test_window_indices_are_sequential(self):
         """Test that window indices are sequential starting from 0."""
         models = [_create_mock_request_interaction_model(10) for _ in range(5)]
-        windows = list(
-            iter_sliding_windows(models, batch_size=10, batch_interval_size=10)
-        )
+        windows = list(iter_sliding_windows(models, window_size=10, stride_size=10))
 
         indices = [w[0] for w in windows]
         assert indices == list(range(5))

--- a/tests/server/services/test_generation_service.py
+++ b/tests/server/services/test_generation_service.py
@@ -118,7 +118,7 @@ def test_empty_session_id_allows_multiple_requests(mock_llm_responses):
 
 
 # NOTE: TestWindowSizeStrideOverrides class was removed because the global
-# _get_extraction_window_size() and _get_stride_size() methods were removed
-# from GenerationService. Each extractor now handles its own window/stride
+# _get_window_size() and _get_stride_size() methods were removed
+# from GenerationService. Each extractor now handles its own window_size/stride_size
 # calculation using the get_extractor_window_params() utility function.
 # See: reflexio/server/services/extractor_interaction_utils.py

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -100,7 +100,7 @@ def test_refresh_profiles_for_user(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up profile extractor config with batch_size
+        # Set up profile extractor config with window_size
         profile_extractor_config = ProfileExtractorConfig(
             extractor_name="test_extractor",
             should_extract_profile_prompt_override="test",
@@ -111,7 +111,7 @@ def test_refresh_profiles_for_user(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Create a PublishUserInteractionRequest first
         publish_request = PublishUserInteractionRequest(
@@ -172,7 +172,7 @@ def test_test_refresh_profiles_for_user_with_image_encoding(mock_chat_completion
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up profile extractor config with batch_size
+        # Set up profile extractor config with window_size
         profile_extractor_config = ProfileExtractorConfig(
             extractor_name="test_extractor",
             should_extract_profile_prompt_override="test",
@@ -183,7 +183,7 @@ def test_test_refresh_profiles_for_user_with_image_encoding(mock_chat_completion
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Create a PublishUserInteractionRequest first
         publish_request = PublishUserInteractionRequest(
@@ -259,7 +259,7 @@ def test_profile_extraction_message_construction():
                 ),
             )
 
-            # Set up profile extractor config with batch_size
+            # Set up profile extractor config with window_size
             profile_extractor_config = ProfileExtractorConfig(
                 extractor_name="test_extractor",
                 should_extract_profile_prompt_override="test",
@@ -271,7 +271,7 @@ def test_profile_extraction_message_construction():
                 "profile_extractor_configs", [profile_extractor_config]
             )
             profile_generation_service.configurator.set_config_by_name(
-                "batch_size", 100
+                "window_size", 100
             )
 
             # Create a PublishUserInteractionRequest
@@ -424,7 +424,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up profile extractor config with batch_size
+        # Set up profile extractor config with window_size
         profile_extractor_config = ProfileExtractorConfig(
             extractor_name="test_extractor",
             should_extract_profile_prompt_override="test",
@@ -435,7 +435,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # First, create CURRENT profiles (output_pending_status=False)
         publish_request1 = PublishUserInteractionRequest(
@@ -545,7 +545,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
 
 
 def test_run_manual_regular_no_window_size(mock_chat_completion):
-    """Test run_manual_regular works even without batch_size configured.
+    """Test run_manual_regular works even without window_size configured.
 
     Since extractors handle window size at their level, the manual flow no longer
     validates window_size upfront. Extractors use a fallback of 1000 interactions
@@ -575,7 +575,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        # batch_size is not configured
+        # window_size is not configured
 
         # Add some interactions to storage
         interaction = Interaction(
@@ -632,7 +632,7 @@ def test_run_manual_regular_no_interactions(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         from reflexio.models.api_schema.service_schemas import (
             ManualProfileGenerationRequest,
@@ -673,7 +673,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # First, add some interactions to storage
         interaction = InteractionData(
@@ -747,7 +747,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [profile_extractor_config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Add interactions with source_a
         interaction_a = InteractionData(
@@ -1051,7 +1051,7 @@ def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        service.configurator.set_config_by_name("batch_size", 240)
+        service.configurator.set_config_by_name("window_size", 240)
         service.service_config = service._load_generation_service_config(
             ProfileGenerationRequest(
                 user_id=user_id,
@@ -1090,13 +1090,13 @@ def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
                 extractor_name="api_profiles",
                 extraction_definition_prompt="communication preferences",
                 request_sources_enabled=["api"],
-                batch_size_override=150,
+                window_size_override=150,
             ),
             ProfileExtractorConfig(
                 extractor_name="web_profiles",
                 extraction_definition_prompt="shopping preferences",
                 request_sources_enabled=["web"],
-                batch_size_override=90,
+                window_size_override=90,
             ),
         ]
 

--- a/tests/server/services/test_profile_source_filtering.py
+++ b/tests/server/services/test_profile_source_filtering.py
@@ -66,7 +66,7 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up two profile extractor configs with batch_size
+        # Set up two profile extractor configs with window_size
         # Config 1: only enabled for "api" source
         config1 = ProfileExtractorConfig(
             extractor_name="api_extractor",
@@ -84,7 +84,7 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [config1, config2]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         # Create a PublishUserInteractionRequest
         publish_request = PublishUserInteractionRequest(
@@ -141,7 +141,7 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up config only enabled for "api" source with batch_size
+        # Set up config only enabled for "api" source with window_size
         config = ProfileExtractorConfig(
             extractor_name="api_only_extractor",
             extraction_definition_prompt="API only config",
@@ -151,7 +151,7 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
@@ -207,7 +207,7 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Config with request_sources_enabled=None (default) and batch_size
+        # Config with request_sources_enabled=None (default) and window_size
         config = ProfileExtractorConfig(
             extractor_name="all_sources_extractor",
             extraction_definition_prompt="All sources config",
@@ -217,7 +217,7 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
@@ -273,7 +273,7 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Config with request_sources_enabled=[] and batch_size
+        # Config with request_sources_enabled=[] and window_size
         config = ProfileExtractorConfig(
             extractor_name="empty_sources_extractor",
             extraction_definition_prompt="All sources config",
@@ -283,7 +283,7 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_configs", [config]
         )
-        profile_generation_service.configurator.set_config_by_name("batch_size", 100)
+        profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,

--- a/tests/test_data/scenarios/eval_config.json
+++ b/tests/test_data/scenarios/eval_config.json
@@ -5,8 +5,8 @@
       "extractor_name": "default_profile_extractor",
       "extraction_definition_prompt": "Extract key user information: name, location, occupation, preferences, constraints, family details, technical setup, communication preferences, or any personal facts.",
       "context_prompt": "Multi-user conversation between customers and a support agent.",
-      "batch_size_override": 20,
-      "batch_interval_override": 1
+      "window_size_override": 20,
+      "stride_size_override": 1
     }
   ],
   "user_playbook_extractor_configs": [
@@ -16,8 +16,8 @@
       "aggregation_config": {
         "min_cluster_size": 2
       },
-      "batch_size_override": 20,
-      "batch_interval_override": 1
+      "window_size_override": 20,
+      "stride_size_override": 1
     }
   ]
 }


### PR DESCRIPTION
## Summary

Renames the sliding-window extraction parameters for clarity:
- `batch_size` → `window_size`
- `batch_interval` → `stride_size`

The new names better reflect what the parameters actually do — `window_size` is the count of interactions per extraction window, and `stride_size` is how many new interactions trigger the next window.

## Scope

- **Schemas / config**: `models/config_schema.py`, API entities, validators
- **Services**: profile + playbook generation services, extractors, base generation, reflection, extractor utils
- **CLI / client**: `interactions.py`, `shortcuts.py`, `client.py`
- **Docs site**: config-editor, sections, schema, READMEs (server, CLI, playbook)
- **Tests**: server services + e2e (configurator, profile, playbook, reflection, integration)
- **Notebooks + helpers**, eval scenario data

## Test plan

- [ ] CI green
- [ ] Existing extractions continue to behave identically (rename-only, no behavior change)
- [ ] Loading a config with the old field names produces a clear error or alias resolution (verify in tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Extraction moved from batch-based controls to a window+stride model.
  * New configuration fields: window size and stride replace batch size and batch interval.
  * Extraction now triggers based on stride thresholds; presets and UI reflect windowing.

* **Documentation**
  * CLI, server, and client docs updated to use window/stride terminology.

* **Tests**
  * Test suites and fixtures updated to use window/stride names and validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->