### PR TITLE
feat(usage-metrics): add no-op recorder hook for production usage events

### DIFF
--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -29,6 +29,7 @@ from reflexio.server.services.extractor_interaction_utils import (
 )
 from reflexio.server.services.operation_state_utils import OperationStateManager
 from reflexio.server.services.service_utils import log_llm_messages, log_model_response
+from reflexio.server.usage_metrics import record_usage_event
 
 
 class StatusChangeOperation(StrEnum):
@@ -196,6 +197,60 @@ class BaseGenerationService(
             "failed": 0,
             "timed_out": 0,
         }
+
+    def _usage_pipeline(self) -> str | None:
+        service_name = self._get_service_name()
+        if "profile" in service_name:
+            return "profile"
+        if "playbook" in service_name:
+            return "playbook"
+        if "evaluation" in service_name:
+            return "evaluation"
+        return None
+
+    def _usage_context(self) -> dict[str, Any]:
+        service_config = self.service_config
+        return {
+            "org_id": self.org_id,
+            "user_id": getattr(service_config, "user_id", None),
+            "request_id": getattr(service_config, "request_id", None),
+            "source": getattr(service_config, "source", None),
+            "agent_version": getattr(service_config, "agent_version", None),
+            "pipeline": self._usage_pipeline(),
+        }
+
+    def _record_generation_event(
+        self,
+        *,
+        event_name: str,
+        outcome: str,
+        count_value: int = 1,
+        duration_ms: int | None = None,
+        error_kind: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        root_config = self.request_context.configurator.get_config()
+        record_usage_event(
+            **self._usage_context(),
+            event_name=event_name,
+            event_category="generation",
+            backend=getattr(root_config, "extraction_backend", None),
+            outcome=outcome,
+            count_value=count_value,
+            duration_ms=duration_ms,
+            error_kind=error_kind,
+            metadata=metadata,
+        )
+
+    @staticmethod
+    def _count_generated_results(results: list) -> int:
+        count = 0
+        for result in results:
+            if isinstance(result, list):
+                count += len(result)
+            elif result:
+                count += 1
+        return count
 
     @abstractmethod
     def _load_extractor_configs(self) -> list[TExtractorConfig]:
@@ -513,19 +568,45 @@ class BaseGenerationService(
             logger.error("Received None request for %s", self._get_service_name())
             return
 
+        generation_start = time.perf_counter()
         try:
             extractor_configs, identifier = self._prepare_generation_run(request)
             if extractor_configs is None:
                 return
 
+            self._record_generation_event(
+                event_name="generation_started",
+                outcome="started",
+                count_value=len(extractor_configs),
+                metadata={"identifier": identifier},
+            )
             all_results = self._execute_extractors(
                 extractor_configs, request, identifier
             )
+            generated_count = self._count_generated_results(all_results)
 
             if all_results:
                 self._process_results(all_results)
 
+            self._record_generation_event(
+                event_name="generation_succeeded",
+                outcome="success",
+                count_value=generated_count,
+                duration_ms=int((time.perf_counter() - generation_start) * 1000),
+                metadata={
+                    "identifier": identifier,
+                    "extractor_count": len(extractor_configs),
+                    "extractor_run_stats": self._last_extractor_run_stats,
+                },
+            )
+
         except Exception as e:
+            self._record_generation_event(
+                event_name="generation_failed",
+                outcome="failed",
+                duration_ms=int((time.perf_counter() - generation_start) * 1000),
+                error_kind=type(e).__name__,
+            )
             logger.error(
                 "Failed to run %s due to %s, exception type: %s",
                 self._get_service_name(),
@@ -585,7 +666,20 @@ class BaseGenerationService(
             self.service_config, "request_id", "unknown"
         )
 
-        if not self._should_run_before_extraction(extractor_configs):
+        should_run = self._should_run_before_extraction(extractor_configs)
+        self._record_generation_event(
+            event_name="generation_gate_evaluated",
+            outcome="should_run" if should_run else "should_skip",
+            count_value=len(extractor_configs),
+            metadata={
+                "identifier": identifier,
+                "extractor_names": [
+                    get_extractor_name(config) for config in extractor_configs
+                ],
+            },
+        )
+
+        if not should_run:
             logger.info(
                 "Pre-extraction check returned False for %s identifier=%s, skipping",
                 self._get_service_name(),

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import time
 import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
@@ -41,6 +42,7 @@ from reflexio.server.services.reflection.reflection_service import ReflectionSer
 from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionServiceRequest,
 )
+from reflexio.server.usage_metrics import record_usage_event
 
 if TYPE_CHECKING:
     from reflexio.server.services.search.agentic_search_service import (
@@ -141,6 +143,7 @@ class GenerationService:
         self._cleanup_old_interactions_if_needed()
 
         try:
+            publish_start = time.perf_counter()
             # Always generate a new UUID for request_id
             request_id = str(uuid.uuid4())
             result.request_id = request_id
@@ -162,6 +165,19 @@ class GenerationService:
             # Resolve agent_version: explicit > env var > default
             agent_version = resolve_agent_version(
                 publish_user_interaction_request.agent_version
+            )
+
+            record_usage_event(
+                org_id=self.org_id,
+                user_id=user_id,
+                request_id=request_id,
+                session_id=publish_user_interaction_request.session_id or None,
+                source=publish_user_interaction_request.source,
+                agent_version=agent_version,
+                event_name="publish_request_received",
+                event_category="publish",
+                outcome="received",
+                count_value=len(new_interactions),
             )
 
             # Store Request
@@ -215,6 +231,21 @@ class GenerationService:
                         new_request=new_request,
                         config=root_config,
                     )
+                )
+                record_usage_event(
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    session_id=new_request.session_id,
+                    source=source,
+                    agent_version=agent_version,
+                    backend="agentic",
+                    event_name="publish_request_succeeded",
+                    event_category="publish",
+                    outcome="success",
+                    count_value=len(new_interactions),
+                    duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                    metadata={"warning_count": len(result.warnings)},
                 )
                 return result
 
@@ -327,9 +358,36 @@ class GenerationService:
                     ),
                 )
 
+            record_usage_event(
+                org_id=self.org_id,
+                user_id=user_id,
+                request_id=request_id,
+                session_id=new_request.session_id,
+                source=source,
+                agent_version=agent_version,
+                backend="classic",
+                event_name="publish_request_succeeded",
+                event_category="publish",
+                outcome="success",
+                count_value=len(new_interactions),
+                duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                metadata={"warning_count": len(result.warnings)},
+            )
             return result
 
         except Exception as e:
+            record_usage_event(
+                org_id=self.org_id,
+                user_id=user_id,
+                request_id=result.request_id,
+                session_id=publish_user_interaction_request.session_id or None,
+                source=publish_user_interaction_request.source,
+                agent_version=publish_user_interaction_request.agent_version,
+                event_name="publish_request_failed",
+                event_category="publish",
+                outcome="failed",
+                error_kind=type(e).__name__,
+            )
             # log exception
             logger.error(
                 "Failed to refresh user profile for user id: %s due to %s, exception type: %s",

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -142,8 +142,14 @@ class GenerationService:
         # Check if cleanup is needed before adding new interactions
         self._cleanup_old_interactions_if_needed()
 
+        publish_start = time.perf_counter()
+        # Resolve agent_version: explicit > env var > default. Resolved here
+        # (before the try) so success and failure telemetry share the same value.
+        agent_version = resolve_agent_version(
+            publish_user_interaction_request.agent_version
+        )
+
         try:
-            publish_start = time.perf_counter()
             # Always generate a new UUID for request_id
             request_id = str(uuid.uuid4())
             result.request_id = request_id
@@ -161,11 +167,6 @@ class GenerationService:
                     user_id,
                 )
                 return result
-
-            # Resolve agent_version: explicit > env var > default
-            agent_version = resolve_agent_version(
-                publish_user_interaction_request.agent_version
-            )
 
             record_usage_event(
                 org_id=self.org_id,
@@ -382,10 +383,11 @@ class GenerationService:
                 request_id=result.request_id,
                 session_id=publish_user_interaction_request.session_id or None,
                 source=publish_user_interaction_request.source,
-                agent_version=publish_user_interaction_request.agent_version,
+                agent_version=agent_version,
                 event_name="publish_request_failed",
                 event_category="publish",
                 outcome="failed",
+                duration_ms=int((time.perf_counter() - publish_start) * 1000),
                 error_kind=type(e).__name__,
             )
             # log exception

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -662,15 +662,6 @@ class PlaybookAggregator:
             agent_version=self.agent_version,
             outcome="should_run",
         )
-        record_usage_event(
-            org_id=self.request_context.org_id,
-            event_name="aggregation_started",
-            event_category="aggregation",
-            pipeline="playbook",
-            playbook_name=playbook_aggregator_request.playbook_name,
-            agent_version=self.agent_version,
-            outcome="started",
-        )
         logger.info(
             "Running user playbook aggregation for '%s' (agent_version=%s)",
             playbook_aggregator_request.playbook_name,
@@ -774,6 +765,17 @@ class PlaybookAggregator:
                     self.storage.archive_agent_playbooks_by_ids(archived_playbook_ids)  # type: ignore[reportOptionalMemberAccess]
 
         try:
+            # Emit the started event inside the protected block so any failure
+            # from here on is paired with an aggregation_failed event.
+            record_usage_event(
+                org_id=self.request_context.org_id,
+                event_name="aggregation_started",
+                event_category="aggregation",
+                pipeline="playbook",
+                playbook_name=playbook_aggregator_request.playbook_name,
+                agent_version=self.agent_version,
+                outcome="started",
+            )
             # Generate new playbooks only for changed clusters
             new_playbooks = self._generate_playbooks_from_clusters(
                 changed_clusters,

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import time
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -32,6 +33,7 @@ from reflexio.server.services.playbook.playbook_service_utils import (
     ensure_playbook_content,
 )
 from reflexio.server.services.service_utils import log_model_response
+from reflexio.server.usage_metrics import record_usage_event
 
 logger = logging.getLogger(__name__)
 
@@ -572,6 +574,7 @@ class PlaybookAggregator:
         Returns:
             dict: Aggregation stats with keys: clusters_found, user_playbooks_processed, playbooks_generated, skipped (optional)
         """
+        aggregation_start = time.perf_counter()
         _empty_stats = {
             "clusters_found": 0,
             "user_playbooks_processed": 0,
@@ -586,6 +589,17 @@ class PlaybookAggregator:
             not playbook_aggregator_config
             or playbook_aggregator_config.min_cluster_size < 2
         ):
+            skip_reason = "no aggregator config or min_cluster_size < 2"
+            record_usage_event(
+                org_id=self.request_context.org_id,
+                event_name="aggregation_gate_evaluated",
+                event_category="aggregation",
+                pipeline="playbook",
+                playbook_name=playbook_aggregator_request.playbook_name,
+                agent_version=self.agent_version,
+                outcome="should_skip",
+                metadata={"skip_reason": skip_reason},
+            )
             logger.info(
                 "Skipping user playbook aggregation for '%s' (agent_version=%s): no aggregator config or min_cluster_size < 2, config: %s",
                 playbook_aggregator_request.playbook_name,
@@ -594,7 +608,7 @@ class PlaybookAggregator:
             )
             return {
                 **_empty_stats,
-                "skipped": "no aggregator config or min_cluster_size < 2",
+                "skipped": skip_reason,
             }
 
         # Check if we should run aggregation based on new playbooks count
@@ -620,11 +634,43 @@ class PlaybookAggregator:
                 new_count,
                 trigger_count,
             )
+            record_usage_event(
+                org_id=self.request_context.org_id,
+                event_name="aggregation_gate_evaluated",
+                event_category="aggregation",
+                pipeline="playbook",
+                playbook_name=playbook_aggregator_request.playbook_name,
+                agent_version=self.agent_version,
+                outcome="should_skip",
+                count_value=new_count,
+                metadata={
+                    "new_user_playbooks": new_count,
+                    "trigger_count": trigger_count,
+                },
+            )
             return {
                 **_empty_stats,
                 "skipped": f"not enough new playbooks ({new_count} < {trigger_count})",
             }
 
+        record_usage_event(
+            org_id=self.request_context.org_id,
+            event_name="aggregation_gate_evaluated",
+            event_category="aggregation",
+            pipeline="playbook",
+            playbook_name=playbook_aggregator_request.playbook_name,
+            agent_version=self.agent_version,
+            outcome="should_run",
+        )
+        record_usage_event(
+            org_id=self.request_context.org_id,
+            event_name="aggregation_started",
+            event_category="aggregation",
+            pipeline="playbook",
+            playbook_name=playbook_aggregator_request.playbook_name,
+            agent_version=self.agent_version,
+            outcome="started",
+        )
         logger.info(
             "Running user playbook aggregation for '%s' (agent_version=%s)",
             playbook_aggregator_request.playbook_name,
@@ -701,6 +747,20 @@ class PlaybookAggregator:
                     )
                     # Still update bookmark
                     self._update_operation_state(playbook_name, user_playbooks)
+                    record_usage_event(
+                        org_id=self.request_context.org_id,
+                        event_name="aggregation_succeeded",
+                        event_category="aggregation",
+                        pipeline="playbook",
+                        playbook_name=playbook_name,
+                        agent_version=self.agent_version,
+                        outcome="success",
+                        count_value=0,
+                        duration_ms=int(
+                            (time.perf_counter() - aggregation_start) * 1000
+                        ),
+                        metadata={"skipped": "no cluster changes detected"},
+                    )
                     return {**_empty_stats, "skipped": "no cluster changes detected"}
 
                 logger.info(
@@ -836,13 +896,37 @@ class PlaybookAggregator:
             elif archived_playbook_ids:
                 self.storage.delete_agent_playbooks_by_ids(archived_playbook_ids)  # type: ignore[reportOptionalMemberAccess]
 
-            return {
+            stats = {
                 "clusters_found": len(clusters),
                 "user_playbooks_processed": len(user_playbooks),
                 "playbooks_generated": len(saved_playbook_list),
             }
+            record_usage_event(
+                org_id=self.request_context.org_id,
+                event_name="aggregation_succeeded",
+                event_category="aggregation",
+                pipeline="playbook",
+                playbook_name=playbook_name,
+                agent_version=self.agent_version,
+                outcome="success",
+                count_value=len(saved_playbook_list),
+                duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
+                metadata=stats,
+            )
+            return stats
 
         except Exception as e:
+            record_usage_event(
+                org_id=self.request_context.org_id,
+                event_name="aggregation_failed",
+                event_category="aggregation",
+                pipeline="playbook",
+                playbook_name=playbook_aggregator_request.playbook_name,
+                agent_version=self.agent_version,
+                outcome="failed",
+                duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
+                error_kind=type(e).__name__,
+            )
             # Restore archived playbooks if any error occurs during aggregation
             logger.error(
                 "Error during playbook aggregation for '%s': %s. Restoring archived playbooks.",
@@ -854,9 +938,9 @@ class PlaybookAggregator:
                     playbook_name, agent_version=self.agent_version
                 )
             elif archived_playbook_ids:
-                self.storage.restore_archived_agent_playbooks_by_ids(
+                self.storage.restore_archived_agent_playbooks_by_ids(  # type: ignore[reportOptionalMemberAccess]
                     archived_playbook_ids
-                )  # type: ignore[reportOptionalMemberAccess]
+                )
             # Re-raise the exception after restoring
             raise
 

--- a/reflexio/server/usage_metrics.py
+++ b/reflexio/server/usage_metrics.py
@@ -1,0 +1,113 @@
+"""Optional usage metrics hook.
+
+This module intentionally has no storage or vendor dependency. Deployments that
+want usage metrics can register a recorder; deployments that do not register one
+pay only a cheap function-call/no-op cost.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class UsageEvent:
+    org_id: str
+    event_name: str
+    event_category: str
+    user_id: str | None = None
+    request_id: str | None = None
+    session_id: str | None = None
+    pipeline: str | None = None
+    entity_type: str | None = None
+    entity_id: str | None = None
+    extractor_name: str | None = None
+    playbook_name: str | None = None
+    source: str | None = None
+    agent_version: str | None = None
+    backend: str | None = None
+    outcome: str | None = None
+    count_value: int = 1
+    duration_ms: int | None = None
+    error_kind: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    created_at: float = field(default_factory=time.time)
+
+
+UsageEventRecorder = Callable[[UsageEvent], None]
+
+_recorder: UsageEventRecorder | None = None
+
+
+def configure_usage_event_recorder(recorder: UsageEventRecorder | None) -> None:
+    """Set the process-global usage metrics recorder.
+
+    Args:
+        recorder: Callable that accepts UsageEvent, or None to disable metrics.
+    """
+    global _recorder
+    _recorder = recorder
+
+
+def record_usage_event(
+    *,
+    org_id: str,
+    event_name: str,
+    event_category: str,
+    user_id: str | None = None,
+    request_id: str | None = None,
+    session_id: str | None = None,
+    pipeline: str | None = None,
+    entity_type: str | None = None,
+    entity_id: str | None = None,
+    extractor_name: str | None = None,
+    playbook_name: str | None = None,
+    source: str | None = None,
+    agent_version: str | None = None,
+    backend: str | None = None,
+    outcome: str | None = None,
+    count_value: int = 1,
+    duration_ms: int | None = None,
+    error_kind: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    """Record one usage event if a recorder is configured.
+
+    The product path must never fail because metrics failed, so this function
+    catches and logs all recorder errors.
+    """
+    recorder = _recorder
+    if recorder is None:
+        return
+    try:
+        recorder(
+            UsageEvent(
+                org_id=str(org_id),
+                event_name=event_name,
+                event_category=event_category,
+                user_id=user_id,
+                request_id=request_id,
+                session_id=session_id,
+                pipeline=pipeline,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                extractor_name=extractor_name,
+                playbook_name=playbook_name,
+                source=source,
+                agent_version=agent_version,
+                backend=backend,
+                outcome=outcome,
+                count_value=count_value,
+                duration_ms=duration_ms,
+                error_kind=error_kind,
+                metadata=metadata or {},
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Usage metrics recorder failed: %s", exc)


### PR DESCRIPTION
## Summary

Adds a no-op usage-metrics recorder hook to the shared OSS module so deployments can opt into emitting append-only usage events without coupling the OSS code to any storage or vendor. Without a recorder registered, every emit is a single attribute load — OSS and self-hosted users see no behavior change.

## Changes

- **`reflexio/server/usage_metrics.py`** — new module with:
  - `UsageEvent` dataclass (frozen, slotted) covering org/user/request/session, event_name+category, pipeline, entity, extractor/playbook, source/agent_version/backend, outcome, count_value, duration_ms, error_kind, metadata, created_at.
  - `configure_usage_event_recorder(recorder)` to set/clear a process-global recorder.
  - `record_usage_event(...)` which builds the event and dispatches to the recorder; catches and logs any recorder exception so product paths cannot fail because metrics failed.
- **`reflexio/server/services/generation_service.py`** — emits `publish_request_received`, `publish_request_succeeded` (per backend: `agentic` and `classic`), and `publish_request_failed` with duration and `error_kind`.
- **`reflexio/server/services/base_generation_service.py`** — emits `generation_gate_evaluated` (`should_run`/`should_skip`), `generation_started`, `generation_succeeded`, and `generation_failed` with timing and per-extractor stats.
- **`reflexio/server/services/playbook/playbook_aggregator.py`** — emits `aggregation_gate_evaluated`, `aggregation_started`, `aggregation_succeeded`, and `aggregation_failed` with timing and cluster stats.

## Test Plan

- [ ] `uv run pytest tests/server/services/test_base_generation_service.py tests/server/services/test_generation_service.py tests/server/services/playbook/test_playbook_aggregator.py tests/server/services/playbook/test_playbook_aggregator_clustering.py` — full pre-existing tests over the changed services; 161/161 pass on this branch.
- [ ] Manual recorder smoke: register `events.append`, run a publish, assert expected event names appear.
- [ ] Confirm hot-path cost when no recorder is registered: `record_usage_event` returns after a single attribute load (no allocation, no I/O).

## Notes

- No new dependencies. No public API renames. Existing schemas are unchanged.
- The downstream enterprise PR wires a `SupabaseUsageMetricsWriter` as the recorder so events flow into a dedicated metrics Supabase project on a background thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added comprehensive usage event tracking across generation, publish, and playbook aggregation flows to improve monitoring and telemetry.
  * Emitted events now capture start/success/failure, durations, counts, and skip/run gate outcomes for richer observability.
  * Introduced a deployable usage metrics framework allowing optional registration of a global event recorder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->