### PR TITLE
fix(api): keep HTTP path /api/search_profiles after Python rename

### DIFF
--- a/reflexio/benchmarks/retrieval_latency/bench.py
+++ b/reflexio/benchmarks/retrieval_latency/bench.py
@@ -188,7 +188,7 @@ def _service_call(
 
 # Map retrieval type to (HTTP path, request builder) for the http layer.
 _HTTP_ROUTES: dict[RetrievalType, tuple[str, Callable[[int], Any]]] = {
-    "profile": ("/api/search_user_profiles", _build_profile_request),
+    "profile": ("/api/search_profiles", _build_profile_request),
     "user_playbook": ("/api/search_user_playbooks", _build_user_playbook_request),
     "agent_playbook": ("/api/search_agent_playbooks", _build_agent_playbook_request),
     "unified": ("/api/search", _build_unified_request),

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -551,7 +551,7 @@ class ReflexioClient:
             search_mode=search_mode,
         )
         response = self._make_request(
-            "POST", "/api/search_user_profiles", json=req.model_dump()
+            "POST", "/api/search_profiles", json=req.model_dump()
         )
         return SearchProfilesViewResponse(**response)
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -431,7 +431,7 @@ def add_user_profile_endpoint(
 
 
 @core_router.post(
-    "/api/search_user_profiles",
+    "/api/search_profiles",
     response_model=SearchProfilesViewResponse,
     response_model_exclude_none=True,
 )

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -100,7 +100,7 @@ class TestSearchEndpoints:
             return_value=mock_response,
         ):
             response = client.post(
-                "/api/search_user_profiles",
+                "/api/search_profiles",
                 json={"user_id": "user-1", "query": "test user"},
             )
         assert response.status_code == 200
@@ -129,7 +129,7 @@ class TestSearchEndpoints:
         assert data["interactions"] == []
 
     def test_search_profiles_missing_body_returns_422(self, client):
-        response = client.post("/api/search_user_profiles")
+        response = client.post("/api/search_profiles")
         assert response.status_code == 422
 
 


### PR DESCRIPTION
## Summary
- PR #40 renamed both the Python client method (`search_profiles` → `search_user_profiles`) AND the HTTP path (`/api/search_profiles` → `/api/search_user_profiles`).
- The Python rename + deprecated `search_profiles` alias is enough to clean up the call surface; the path rename is unnecessarily breaking for deployed callers.
- This PR keeps everything PR #40 added on the Python side and only reverts the wire path back to `/api/search_profiles`, so existing integrations keep working without re-deployment.

## Changes
- `reflexio/client/client.py`: `_make_request` posts to `/api/search_profiles` again.
- `reflexio/server/api.py`: route decorator pinned back to `/api/search_profiles` (handler function name stays `search_user_profiles`).
- `reflexio/benchmarks/retrieval_latency/bench.py`: `_HTTP_ROUTES["profile"]` path string.
- `tests/server/api_endpoints/test_api_routes.py`: 2 path strings in `TestSearchEndpoints`.

The deprecated `ReflexioClient.search_profiles` alias from PR #40 is unchanged — Python callers still get the deprecation nudge.

## Test plan
- [x] `uv run ruff check` — passes on all 4 changed files.
- [x] `uv run pyright` — 0 errors on the two source files.
- [x] `uv run pytest tests/server/api_endpoints/test_api_routes.py -k search_profiles` — both `test_search_profiles_returns_200` and `test_search_profiles_missing_body_returns_422` pass against the reverted path.
- [ ] Manual: confirm in a deployed environment that calls to `POST /api/search_profiles` continue to route to the renamed handler.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the profile search API endpoint path to use a standardized naming convention. Changes applied consistently across client, server, and test components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->