### PR TITLE
feat(api): pluggable config-response hooks + storage schema field

### DIFF
--- a/reflexio/lib/_config.py
+++ b/reflexio/lib/_config.py
@@ -14,7 +14,9 @@ class ConfigMixin(ReflexioBase):
             dict: Response containing success status and message
         """
         try:
+            configurator = self.request_context.configurator
             if isinstance(config, dict):
+                config = configurator.normalize_config_payload(config)
                 config = Config(**config)
 
             # Validate storage connection before setting config.
@@ -22,11 +24,11 @@ class ConfigMixin(ReflexioBase):
             # like get_config() don't expose storage_config for security).
             storage_config = config.storage_config
             if storage_config is None:
-                storage_config = self.request_context.configurator.get_current_storage_configuration()
+                storage_config = configurator.get_current_storage_configuration()
                 config.storage_config = storage_config
 
             # Check if storage config is ready to test
-            if not self.request_context.configurator.is_storage_config_ready_to_test(
+            if not configurator.is_storage_config_ready_to_test(
                 storage_config=storage_config
             ):
                 return SetConfigResponse(
@@ -37,9 +39,7 @@ class ConfigMixin(ReflexioBase):
             (
                 success,
                 error_msg,
-            ) = self.request_context.configurator.test_and_init_storage_config(
-                storage_config=storage_config
-            )
+            ) = configurator.test_and_init_storage_config(storage_config=storage_config)
 
             if not success:
                 return SetConfigResponse(
@@ -48,7 +48,7 @@ class ConfigMixin(ReflexioBase):
                 )
 
             # Only set config if validation passed
-            self.request_context.configurator.set_config(config)
+            configurator.set_config(config)
 
             return SetConfigResponse(success=True, msg="Configuration set successfully")
         except Exception as e:

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .api_schema.validators import (
     NonEmptyStr,
@@ -161,9 +161,19 @@ class StorageConfigSQLite(BaseModel):
 
 
 class StorageConfigSupabase(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+
     url: NonEmptyStr
     key: NonEmptyStr
     db_url: NonEmptyStr
+    schema_name: str | None = Field(default=None, alias="schema")
+
+
+class StorageConfigManagedSupabase(BaseModel):
+    """Redacted API response for platform-managed Supabase storage."""
+
+    managed_by: Literal["platform"]
+    schema_present: bool = True
 
 
 class StorageConfigDisk(BaseModel):
@@ -173,7 +183,13 @@ class StorageConfigDisk(BaseModel):
     qmd_binary: str = "qmd"
 
 
-StorageConfig = StorageConfigSQLite | StorageConfigSupabase | StorageConfigDisk | None
+StorageConfig = (
+    StorageConfigSQLite
+    | StorageConfigSupabase
+    | StorageConfigManagedSupabase
+    | StorageConfigDisk
+    | None
+)
 
 
 class AzureOpenAIConfig(BaseModel):

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Callable
+from typing import Any
 
 from fastapi import (
     APIRouter,
@@ -120,7 +121,6 @@ from reflexio.models.api_schema.ui.converters import (
     to_profile_view,
     to_user_playbook_view,
 )
-from reflexio.models.config_schema import Config
 from reflexio.server.api_endpoints import account_api, publisher_api, retriever_api
 from reflexio.server.cache.reflexio_cache import (
     get_reflexio,
@@ -1088,7 +1088,7 @@ def run_playbook_aggregation(
 
 @core_router.post("/api/set_config")
 def set_config(
-    config: Config,
+    config: dict[str, Any],
     org_id: str = Depends(default_get_org_id),
 ) -> SetConfigResponse:
     """Set configuration for the organization.
@@ -1113,10 +1113,10 @@ def set_config(
     return response
 
 
-@core_router.get("/api/get_config", response_model=Config)
+@core_router.get("/api/get_config")
 def get_config(
     org_id: str = Depends(default_get_org_id),
-) -> Config:
+) -> dict[str, Any]:
     """Get configuration for the organization.
 
     Args:
@@ -1128,8 +1128,7 @@ def get_config(
     # Create Reflexio instance to access the configurator through request_context
     reflexio = get_reflexio(org_id=org_id)
 
-    # Get the config using Reflexio's get_config method
-    return reflexio.get_config()
+    return reflexio.request_context.configurator.get_config_for_response()
 
 
 @core_router.post(

--- a/reflexio/server/api_endpoints/account_api.py
+++ b/reflexio/server/api_endpoints/account_api.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Any, cast
 
 from reflexio.lib._storage_labels import describe_storage
 from reflexio.models.api_schema.service_schemas import (
@@ -113,9 +114,8 @@ def my_config(org_id: str) -> MyConfigResponse:
             message=_GENERIC_STORAGE_LOAD_FAILURE,
         )
 
-    storage_config = (
-        reflexio.request_context.configurator.get_current_storage_configuration()
-    )
+    configurator = reflexio.request_context.configurator
+    storage_config = configurator.get_current_storage_configuration()
     if storage_config is None:
         return MyConfigResponse(
             success=False,
@@ -131,8 +131,13 @@ def my_config(org_id: str) -> MyConfigResponse:
         org_id,
         storage_type,
     )
+    storage_config_payload: dict[str, Any] = storage_config.model_dump()
+    redact = getattr(configurator, "redact_storage_config_for_response", None)
+    if callable(redact):
+        storage_config_payload = cast(dict[str, Any], redact(storage_config))
+
     return MyConfigResponse(
         success=True,
-        storage_config=storage_config.model_dump(),
+        storage_config=storage_config_payload,
         storage_type=storage_type,
     )

--- a/reflexio/server/services/configurator/base_configurator.py
+++ b/reflexio/server/services/configurator/base_configurator.py
@@ -73,6 +73,14 @@ class BaseConfigurator(ABC):
     def get_config(self) -> Config:
         return self.config
 
+    def get_config_for_response(self) -> dict[str, Any]:
+        """Return config serialized for API responses."""
+        return self.config.model_dump(mode="json")
+
+    def normalize_config_payload(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Normalize raw API config payloads before Pydantic validation."""
+        return config
+
     def get_agent_context(self) -> str:
         context = self.get_config().agent_context_prompt
         if not context:


### PR DESCRIPTION
## Summary

Loosen the `/api/get_config` and `/api/set_config` contracts so that downstream
configurators (e.g. enterprise) can return a redacted view of `storage_config`
and round-trip the redacted payload back through `set_config` without losing
state. Adds `StorageConfigSupabase.schema_name` (alias `schema`) and a sibling
`StorageConfigManagedSupabase` response model.

OS behavior is unchanged when no overrides are wired up. This is the surface
the enterprise platform-managed Supabase work depends on.

## Changes

- `BaseConfigurator` gains two pluggable hooks with default identity behavior:
  - `get_config_for_response() -> dict` — what `/api/get_config` returns
  - `normalize_config_payload(dict) -> dict` — pre-validate transform for
    `/api/set_config`
- `/api/set_config` now takes `dict[str, Any]` and runs the payload through
  `configurator.normalize_config_payload(...)` before instantiating `Config`.
- `/api/get_config` returns `dict[str, Any]` from
  `configurator.get_config_for_response()`.
- `account_api.my_config` calls `redact_storage_config_for_response` if the
  configurator exposes one (duck-typed via `getattr`).
- `StorageConfigSupabase` adds `schema_name: str | None = Field(alias="schema")`
  with `populate_by_name=True, serialize_by_alias=True` — round-trips JSON as
  `schema` while exposing `schema_name` to Python callers.
- New `StorageConfigManagedSupabase` (`managed_by: Literal["platform"]`,
  `schema_present: bool`) joins the `StorageConfig` union so the API can
  return the redacted shape.

## Test plan

- [x] Existing OS test suite passes
- [x] No behavior change for callers that don't override the new hooks
- [x] Pydantic round-trip: `StorageConfigSupabase(schema="org_42")` serializes
      to `{"schema": "org_42", ...}` and parses back identically (covered by
      enterprise tests in the linked PR)
- [x] Lint + type checks (`ruff`, `pyright`) clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added support for platform-managed Supabase storage configuration option.

* **Improvements**
  - Enhanced storage configuration management with improved validation and readiness testing procedures.
  - Refined configuration API responses for consistent data serialization across endpoints.
  - Optimized configuration payload handling with support for data normalization and optional redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->