### PR TITLE
fix(dedup): repair complete malformed JSON, retry on truncation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic[email]>=2.13.0",
     "nltk>=3.9.3",
+    "json-repair>=0.30.0",
     # CLI
     "typer>=0.15.0",
     "rich>=13.0.0",

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -1203,15 +1203,32 @@ class LiteLLMClient:
                 sanitized = self._sanitize_json_string(json_str)
                 parsed = json.loads(sanitized)
                 return response_format.model_validate(parsed)
-            except Exception as e:
-                model = self.config.model
-                snippet = (
-                    content[:200] if isinstance(content, str) else repr(content)[:200]
-                )
-                raise StructuredOutputParseError(
-                    f"Structured output parse failed for model={model!r}: {e}. "
-                    f"Content snippet: {snippet!r}"
-                ) from e
+            except Exception:
+                # Last resort: json-repair can recover complete responses with
+                # small syntax glitches, such as missing commas. Do not repair
+                # likely truncation: the retry loop should request a fresh
+                # complete response instead of accepting invented tail content.
+                try:
+                    from json_repair import repair_json
+
+                    if self._looks_truncated_json(json_str):
+                        raise StructuredOutputParseError(
+                            "Structured output appears truncated"
+                        )
+
+                    repaired = repair_json(json_str, return_objects=True)
+                    return response_format.model_validate(repaired)
+                except Exception as e:
+                    model = self.config.model
+                    snippet = (
+                        content[:200]
+                        if isinstance(content, str)
+                        else repr(content)[:200]
+                    )
+                    raise StructuredOutputParseError(
+                        f"Structured output parse failed for model={model!r}: {e}. "
+                        f"Content snippet: {snippet!r}"
+                    ) from e
 
     def _extract_json_from_string(self, content: str) -> str:
         """
@@ -1239,6 +1256,52 @@ class LiteLLMClient:
                 return content[start_idx : end_idx + 1]
 
         return content
+
+    def _looks_truncated_json(self, json_str: str) -> bool:
+        """
+        Return True when a JSON-like string appears to end before it is complete.
+
+        This intentionally only treats content with a JSON container opener as
+        truncation. Plain text that is not JSON should proceed to the normal
+        parse failure path.
+
+        Args:
+            json_str: Extracted JSON-like response text.
+
+        Returns:
+            True if the response has unclosed containers or strings.
+        """
+        stripped = json_str.strip()
+        start_indices = [
+            idx for idx in (stripped.find("{"), stripped.find("[")) if idx != -1
+        ]
+        if not stripped or not start_indices:
+            return False
+        stripped = stripped[min(start_indices) :]
+
+        stack: list[str] = []
+        in_str = False
+        escape = False
+        pairs = {"{": "}", "[": "]"}
+
+        for ch in stripped:
+            if escape:
+                escape = False
+                continue
+            if ch == "\\" and in_str:
+                escape = True
+                continue
+            if ch == '"':
+                in_str = not in_str
+                continue
+            if in_str:
+                continue
+            if ch in pairs:
+                stack.append(pairs[ch])
+            elif ch in ("}", "]") and (not stack or stack.pop() != ch):
+                return False
+
+        return in_str or bool(stack)
 
     def _sanitize_json_string(self, json_str: str) -> str:
         """

--- a/reflexio/server/prompt/prompt_bank/playbook_deduplication/v2.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_deduplication/v2.0.0.prompt.md
@@ -1,7 +1,7 @@
 ---
 active: true
 description: "Identifies and merges duplicate playbook entries from multiple extractors — simplified schema without instruction/pitfall"
-changelog: "v2: Remove instruction and pitfall fields. Content is the sole actionable field. Simplified merged output format."
+changelog: "v2: Remove instruction and pitfall fields. Content is the sole actionable field. Simplified merged output format. Drop unused per-group reasoning field to reduce output token usage."
 variables:
   - new_playbook_count
   - existing_playbook_count
@@ -31,7 +31,6 @@ Every playbook has a `content` field (primary human-readable content), a `trigge
    - List the item_ids (e.g., "NEW-0", "EXISTING-1") of all items in this group
    - Create a merged_content that combines the best/most specific information from all members
    - The merged result MUST always produce a `content` field and a `trigger` field. Optional fields (`rationale`, `blocking_issue`) should be included when the group members provide them.
-   - Explain your reasoning briefly
 4. List unique_ids of NEW playbooks that are truly unique (no duplicates found in either NEW or EXISTING)
 
 [Guidelines for Identifying Duplicates]
@@ -56,7 +55,6 @@ Return a JSON object with:
 - duplicate_groups: Array of objects, each containing:
   - item_ids: Array of strings (IDs matching the [PREFIX-N] format, e.g., "NEW-0", "EXISTING-2")
   - merged_content: Object with fields: rationale (string or null, optional), trigger (string, required), blocking_issue (object with kind and details, or null, optional), content (string, required)
-  - reasoning: String (brief explanation)
 - unique_ids: Array of strings (IDs of unique NEW playbooks, e.g., "NEW-2")
 
 [Important]

--- a/reflexio/server/prompt/prompt_bank/profile_deduplication/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/profile_deduplication/v1.0.0.prompt.md
@@ -31,7 +31,6 @@ Each profile includes: Content, TTL, Source, and Last Modified date.
    - List the item_ids (e.g., "NEW-0", "EXISTING-1") of all items in this group
    - Create a merged_content that combines the best/most specific information from all members
    - Choose an appropriate merged_time_to_live (prefer the longest to preserve information)
-   - Explain your reasoning briefly
 4. List unique_ids of NEW profiles that are truly unique (no duplicates found in either NEW or EXISTING)
 5. Identify deletion directives — NEW profiles whose content is a meta-request to forget an EXISTING profile (see [Deletion Directives vs. Fact Updates] below) — and emit them in `deletions` instead of `duplicate_groups` or `unique_ids`
 
@@ -104,7 +103,6 @@ Return a JSON object with:
   - item_ids: Array of strings (IDs matching the [PREFIX-N] format, e.g., "NEW-0", "EXISTING-2")
   - merged_content: String (the merged profile text)
   - merged_time_to_live: String (one of: one_day, one_week, one_month, one_quarter, one_year, infinity)
-  - reasoning: String (brief explanation)
 - unique_ids: Array of strings (IDs of unique NEW profiles, e.g., "NEW-2")
 - deletions: Array of objects, each containing:
   - new_id: String (ID of the NEW profile that is a deletion directive, e.g., "NEW-0")

--- a/reflexio/server/services/playbook/playbook_deduplicator.py
+++ b/reflexio/server/services/playbook/playbook_deduplicator.py
@@ -45,7 +45,6 @@ class PlaybookDeduplicationDuplicateGroup(BaseModel):
     merged_content: StructuredPlaybookContent = Field(
         description="Consolidated playbook entry in structured format (trigger, rationale, blocking_issue)"
     )
-    reasoning: str = Field(description="Brief explanation of the merge decision")
 
     model_config = ConfigDict(
         extra="allow",

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -79,7 +79,6 @@ class ProfileDuplicateGroup(BaseModel):
         item_ids: List of item IDs matching prompt format (e.g., 'NEW-0', 'EXISTING-1')
         merged_content: The consolidated profile content combining information from all duplicates
         merged_time_to_live: The chosen time_to_live for the merged profile
-        reasoning: Brief explanation of why these profiles are duplicates and how they were merged
     """
 
     item_ids: list[str] = Field(
@@ -91,7 +90,6 @@ class ProfileDuplicateGroup(BaseModel):
     merged_time_to_live: str = Field(
         description="Time to live for merged profile: one_day, one_week, one_month, one_quarter, one_year, infinity"
     )
-    reasoning: str = Field(description="Brief explanation of the merge decision")
 
     model_config = ConfigDict(
         extra="allow",

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1036,6 +1036,26 @@ class TestMaybeParseStructuredOutput:
         assert isinstance(result, SampleResponse)
         assert result.answer == "ok"
 
+    def test_complete_malformed_json_repaired(self, client):
+        """Complete JSON-shaped output with minor syntax errors is repaired."""
+        content = '{"answer": "ok" "score": 5}'
+        result = client._maybe_parse_structured_output(content, SampleResponse, True)
+        assert isinstance(result, SampleResponse)
+        assert result.answer == "ok"
+        assert result.score == 5
+
+    def test_truncated_json_not_repaired(self, client):
+        """Incomplete JSON raises so the structured-output retry loop can retry."""
+        content = '{"answer": "ok", "score": 5'
+        with pytest.raises(StructuredOutputParseError):
+            client._maybe_parse_structured_output(content, SampleResponse, True)
+
+    def test_prefixed_truncated_json_not_repaired(self, client):
+        """Truncation is detected even if the model prefixes the JSON with prose."""
+        content = 'Here is the result:\n{"answer": "ok", "score": 5'
+        with pytest.raises(StructuredOutputParseError):
+            client._maybe_parse_structured_output(content, SampleResponse, True)
+
     def test_unparseable_raises_structured_output_parse_error(self, client):
         with pytest.raises(StructuredOutputParseError):
             client._maybe_parse_structured_output(
@@ -1256,7 +1276,9 @@ class TestTemperatureRestriction:
         assert call_kwargs["temperature"] == 1.0
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_non_restricted_model_includes_temperature(self, mock_completion):
+    def test_non_restricted_model_defaults_to_deterministic_temperature(
+        self, mock_completion
+    ):
         mock_completion.return_value = _make_completion_response("ok")
         config = LiteLLMConfig(model="gpt-4o", temperature=0.3)
         client = LiteLLMClient(config)
@@ -1264,7 +1286,8 @@ class TestTemperatureRestriction:
         client.generate_response("hi")
 
         call_kwargs = mock_completion.call_args.kwargs
-        assert call_kwargs["temperature"] == 0.3
+        assert call_kwargs["seed"] == 42
+        assert call_kwargs["temperature"] == 0.0
 
 
 # ===================================================================

--- a/tests/server/services/playbook/test_playbook_deduplicator.py
+++ b/tests/server/services/playbook/test_playbook_deduplicator.py
@@ -270,7 +270,6 @@ class TestBuildDeduplicatedResults:
                     merged_content=StructuredPlaybookContent(
                         content="merged do", trigger="merged when"
                     ),
-                    reasoning="Same topic",
                 )
             ],
             unique_ids=[],
@@ -321,7 +320,6 @@ class TestBuildDeduplicatedResults:
                     merged_content=StructuredPlaybookContent(
                         content="merged", trigger="when merged"
                     ),
-                    reasoning="Duplicate",
                 )
             ],
             unique_ids=[],
@@ -396,7 +394,6 @@ class TestDeduplicateHappyPath:
                         merged_content=StructuredPlaybookContent(
                             content="do X", trigger="when Y"
                         ),
-                        reasoning="Same instruction",
                     )
                 ],
                 unique_ids=["NEW-2"],
@@ -471,7 +468,6 @@ class TestDeduplicateHappyPath:
                         merged_content=StructuredPlaybookContent(
                             content="do X", trigger="when Y"
                         ),
-                        reasoning="Same instruction as existing",
                     )
                 ],
                 unique_ids=[],
@@ -518,7 +514,6 @@ class TestBuildDeduplicatedResultsEdgeCases:
                     merged_content=StructuredPlaybookContent(
                         content="merged do", trigger="merged when"
                     ),
-                    reasoning="Existing-only group",
                 )
             ],
             unique_ids=[],
@@ -546,7 +541,6 @@ class TestBuildDeduplicatedResultsEdgeCases:
                     merged_content=StructuredPlaybookContent(
                         content="merged do", trigger="merged when"
                     ),
-                    reasoning="Bad index",
                 )
             ],
             unique_ids=[],
@@ -582,7 +576,6 @@ class TestBuildDeduplicatedResultsEdgeCases:
                     merged_content=StructuredPlaybookContent(
                         content="merged", trigger="merged condition"
                     ),
-                    reasoning="Combined",
                 )
             ],
             unique_ids=[],
@@ -614,7 +607,6 @@ class TestBuildDeduplicatedResultsEdgeCases:
                     merged_content=StructuredPlaybookContent(
                         content="merged", trigger="merged cond"
                     ),
-                    reasoning="Overlap IDs",
                 )
             ],
             unique_ids=[],

--- a/tests/server/services/profile/test_profile_deduplicator.py
+++ b/tests/server/services/profile/test_profile_deduplicator.py
@@ -125,7 +125,6 @@ class TestPydanticModels:
             item_ids=["NEW-0", "NEW-1", "EXISTING-0"],
             merged_content="User prefers dark mode",
             merged_time_to_live="one_month",
-            reasoning="Both profiles are about dark mode preferences",
         )
         assert group.item_ids == ["NEW-0", "NEW-1", "EXISTING-0"]
         assert group.merged_content == "User prefers dark mode"
@@ -139,7 +138,6 @@ class TestPydanticModels:
             item_ids=["NEW-0"],
             merged_content="test",
             merged_time_to_live="one_day",
-            reasoning="test",
             extra_field="not allowed",
         )
         assert group.item_ids == ["NEW-0"]
@@ -155,7 +153,6 @@ class TestPydanticModels:
                     item_ids=["NEW-0", "NEW-1"],
                     merged_content="merged",
                     merged_time_to_live="one_week",
-                    reasoning="duplicates",
                 )
             ],
             unique_ids=["NEW-2", "NEW-3"],
@@ -227,7 +224,6 @@ class TestPydanticModels:
                     "item_ids": ["NEW-0", "NEW-1", "EXISTING-0"],
                     "merged_content": "test",
                     "merged_time_to_live": "one_day",
-                    "reasoning": "reason",
                 }
             ],
             "unique_ids": ["NEW-2"],
@@ -581,7 +577,6 @@ class TestBuildDeduplicatedResults:
                     item_ids=["NEW-0", "NEW-1"],
                     merged_content="User prefers dark mode in their IDE",
                     merged_time_to_live="one_month",
-                    reasoning="Both about dark mode preferences",
                 )
             ],
             unique_ids=["NEW-2"],
@@ -660,7 +655,6 @@ class TestBuildDeduplicatedResults:
                     item_ids=["NEW-0", "NEW-1"],
                     merged_content="merged content",
                     merged_time_to_live="invalid_ttl",
-                    reasoning="test",
                 )
             ],
             unique_ids=["NEW-2"],
@@ -701,7 +695,6 @@ class TestBuildDeduplicatedResults:
                     item_ids=["NEW-0", "NEW-1"],
                     merged_content="merged",
                     merged_time_to_live="one_week",
-                    reasoning="test",
                 )
             ],
             unique_ids=[],  # LLM forgot to mention index 2
@@ -745,7 +738,6 @@ class TestBuildDeduplicatedResults:
                     item_ids=["NEW-0", "EXISTING-0"],
                     merged_content="User prefers dark mode (updated)",
                     merged_time_to_live="one_month",
-                    reasoning="New profile supersedes existing",
                 )
             ],
             unique_ids=["NEW-1", "NEW-2"],
@@ -982,7 +974,6 @@ class TestDeduplicate:
                         item_ids=["NEW-0", "NEW-1"],
                         merged_content="User prefers dark mode",
                         merged_time_to_live="one_month",
-                        reasoning="Both about dark mode",
                     )
                 ],
                 unique_ids=["NEW-2"],
@@ -1032,7 +1023,6 @@ class TestDeduplicate:
                         item_ids=["NEW-0", "EXISTING-0"],
                         merged_content="User prefers dark mode (updated)",
                         merged_time_to_live="one_month",
-                        reasoning="New supersedes existing",
                     )
                 ],
                 unique_ids=["NEW-1", "NEW-2"],
@@ -1284,16 +1274,17 @@ class TestIntegration:
             ),
         ]
 
-        mock_llm_client.generate_chat_response.return_value = ProfileDeduplicationOutput(
-            duplicate_groups=[
-                ProfileDuplicateGroup(
-                    item_ids=["NEW-0", "NEW-1"],
-                    merged_content="User works in the financial services industry",
-                    merged_time_to_live="one_year",
-                    reasoning="Both profiles describe the user's industry as finance/financial services",
-                )
-            ],
-            unique_ids=["NEW-2"],
+        mock_llm_client.generate_chat_response.return_value = (
+            ProfileDeduplicationOutput(
+                duplicate_groups=[
+                    ProfileDuplicateGroup(
+                        item_ids=["NEW-0", "NEW-1"],
+                        merged_content="User works in the financial services industry",
+                        merged_time_to_live="one_year",
+                    )
+                ],
+                unique_ids=["NEW-2"],
+            )
         )
 
         deduplicator = ProfileDeduplicator(

--- a/uv.lock
+++ b/uv.lock
@@ -2094,6 +2094,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json-repair"
+version = "0.59.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/67/eba7fad54ff6f5cce6db4e01f596fc68156b5c7e864af0aa07ad48e880a1/json_repair-0.59.5.tar.gz", hash = "sha256:bb886ee054e99066be8a337b67a986b6a50d79be9a5ad37ae81966e698990784", size = 48632, upload-time = "2026-04-24T11:41:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/aa/0529dee460b745b93f6abc97b56b7527314c5167ba29ab7a5bd5c08de01f/json_repair-0.59.5-py3-none-any.whl", hash = "sha256:6869965bd1cc1aaaa04dc85865c26fbb76d9a2d83a20010f5eae2563b1567827", size = 47282, upload-time = "2026-04-24T11:41:36.653Z" },
+]
+
+[[package]]
 name = "json5"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5069,6 +5078,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "hdbscan" },
     { name = "httpx" },
+    { name = "json-repair" },
     { name = "litellm" },
     { name = "nltk" },
     { name = "openai" },
@@ -5159,6 +5169,7 @@ requires-dist = [
     { name = "fpdf2", marker = "extra == 'benchmark'", specifier = ">=2.8.7" },
     { name = "hdbscan", specifier = ">=0.8.40" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "json-repair", specifier = ">=0.30.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.2.28" },
     { name = "litellm", specifier = ">=1.80.11" },
     { name = "markdown", marker = "extra == 'benchmark'", specifier = ">=3.10.2" },


### PR DESCRIPTION
## Summary
- Make playbook/profile dedup resilient to LLM JSON output quirks: small syntax glitches are repaired via `json-repair`, while genuinely truncated responses surface a parse error so the structured-output retry loop runs again with a fresh response.
- Drop the unused `reasoning` field from playbook and profile dedup outputs (and prompts) to cut output token usage, which also reduces the chance of hitting the truncation path.

## Changes

**LLM client (`reflexio/server/llm/litellm_client.py`)**
- After a strict JSON parse fails, attempt `json-repair` as a last resort for complete-but-malformed JSON.
- New `_looks_truncated_json` heuristic detects unclosed containers/strings; when truncation is detected we raise `StructuredOutputParseError` instead of letting `json-repair` invent a tail, so the retry path requests a fresh complete response.

**Dedup output schemas + prompts**
- Removed the `reasoning` field from `PlaybookDeduplicationDuplicateGroup` and `ProfileDuplicateGroup`.
- Updated `playbook_deduplication/v2.0.0` and `profile_deduplication/v1.0.0` prompts to no longer request the field.

**Dependency**
- Added `json-repair>=0.30.0` to `pyproject.toml` / `uv.lock`.

**Tests**
- New unit tests for `_maybe_parse_structured_output`: complete-malformed JSON is repaired; pure-truncated and prose-prefixed-truncated JSON raise `StructuredOutputParseError`.
- Updated dedup tests to drop `reasoning=` constructor args.
- Renamed/updated temperature-restriction test to reflect the deterministic default (`temperature=0.0`, `seed=42`).

## Test Plan
- [ ] `uv run pytest tests/server/llm/test_litellm_client_unit.py` — confirms repair vs. truncation behavior.
- [ ] `uv run pytest tests/server/services/playbook/test_playbook_deduplicator.py tests/server/services/profile/test_profile_deduplicator.py` — confirms dedup still works without `reasoning`.
- [ ] Smoke a real dedup run end-to-end and verify no regression in merge quality.