### PR TITLE
feat(logs): support REFLEXIO_LOG_DIR env override for log base dir

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,7 @@ IS_TEST_ENV=true
 DEBUG_LOG_TO_CONSOLE=true
 # Mock LLM call response
 MOCK_LLM_RESPONSE=false
+# Override the base directory for log files. The .reflexio/logs suffix is
+# always preserved, so e.g. REFLEXIO_LOG_DIR=/tmp/foo writes logs to
+# /tmp/foo/.reflexio/logs/. Defaults to $HOME (i.e. ~/.reflexio/logs/).
+REFLEXIO_LOG_DIR=

--- a/reflexio/cli/log_format.py
+++ b/reflexio/cli/log_format.py
@@ -57,7 +57,13 @@ def _resolve_log_dir() -> Path:
             handlers create it on first write.
     """
     base = os.environ.get("REFLEXIO_LOG_DIR")
-    base_path = Path(base).expanduser() if base else Path.home()
+    if base:
+        base_path = Path(base).expanduser()
+        if not base_path.is_absolute():
+            base_path = Path.home() / base_path
+        base_path = base_path.resolve()
+    else:
+        base_path = Path.home()
     return base_path / ".reflexio" / "logs"
 
 

--- a/reflexio/cli/log_format.py
+++ b/reflexio/cli/log_format.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+import os
 import re
 import sys
 import threading
@@ -37,10 +38,32 @@ _LEVEL_COLORS: dict[str, str] = {
 # "ERROR - msg" style used by Next.js / some custom loggers.
 _LEVEL_RE = re.compile(r"^(?:\[)?(ERROR|CRITICAL|WARNING|WARN)(?:\])?(?::|\s+-\s+|\s+)")
 
-# Canonical log file paths — stored in ~/.reflexio/logs/ (not the project directory)
-_LOG_DIR = str(Path.home() / ".reflexio" / "logs")
-DEV_LOG_FILE = str(Path(_LOG_DIR) / "dev_server.log")
-LLM_IO_LOG_FILE = str(Path(_LOG_DIR) / "llm_io.log")
+
+# Canonical log file paths.
+# Default: ~/.reflexio/logs/. The REFLEXIO_LOG_DIR env var overrides only the
+# base directory (the ~ part) — the .reflexio/logs suffix is preserved so the
+# on-disk layout stays consistent regardless of where the base points.
+def _resolve_log_dir() -> Path:
+    """Return the directory log files are written to.
+
+    The ``REFLEXIO_LOG_DIR`` env var overrides the base directory only — the
+    ``.reflexio/logs`` suffix is preserved so the on-disk layout matches the
+    default home-relative layout. Resolved at module import time so the
+    public ``DEV_LOG_FILE`` / ``LLM_IO_LOG_FILE`` constants are stable across
+    a server's lifetime — change requires a restart.
+
+    Returns:
+        Path: Resolved log directory. Not created here; the rotating file
+            handlers create it on first write.
+    """
+    base = os.environ.get("REFLEXIO_LOG_DIR")
+    base_path = Path(base).expanduser() if base else Path.home()
+    return base_path / ".reflexio" / "logs"
+
+
+LOG_DIR: Path = _resolve_log_dir()
+DEV_LOG_FILE: str = str(LOG_DIR / "dev_server.log")
+LLM_IO_LOG_FILE: str = str(LOG_DIR / "llm_io.log")
 
 # Thread-safe sequential entry counter for LLM prompt/response entries
 _llm_entry_counter = itertools.count(1)


### PR DESCRIPTION
## Summary
- Adds `REFLEXIO_LOG_DIR` env var to override the base directory used for log files, while preserving the canonical `.reflexio/logs` suffix
- Default behavior is unchanged (`~/.reflexio/logs/`)
- Useful for sandboxes, container deployments, or test runs that cannot write under `$HOME`

## Changes
- `reflexio/cli/log_format.py`:
  - Introduces `_resolve_log_dir()` which reads `REFLEXIO_LOG_DIR` (with `~` expansion) and falls back to `Path.home()`
  - Always appends `.reflexio/logs` so the on-disk layout is identical regardless of base
  - Promotes the resolved directory to a public `LOG_DIR: Path` constant alongside `DEV_LOG_FILE` / `LLM_IO_LOG_FILE`
  - Resolution happens at module import time — changes require a restart (documented in the docstring)

## Test Plan
- [ ] Default path: unset `REFLEXIO_LOG_DIR`, start services, confirm logs land in `~/.reflexio/logs/`
- [ ] Override path: `REFLEXIO_LOG_DIR=/tmp/foo` → logs land in `/tmp/foo/.reflexio/logs/`
- [ ] Tilde expansion: `REFLEXIO_LOG_DIR=~/scratch` → logs land in `<home>/scratch/.reflexio/logs/`
- [ ] `uv run ruff check reflexio/cli/log_format.py` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Log files can now be stored in a custom directory by setting the `REFLEXIO_LOG_DIR` environment variable. The application's standard log directory structure is preserved, ensuring compatibility with existing log management processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->