### PR TITLE
refactor(config): rename SUPABASE_* env vars to DATA_SUPABASE_* and drop `config pull`

### DIFF
--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -79,7 +79,7 @@ def load_storage_from_config(
         base_dir: Override base directory (for testing). If None, uses ~/.reflexio/.
 
     Returns:
-        Storage backend string ("sqlite", "supabase", "disk") or None if
+        Storage backend string ("sqlite", "supabase", "postgres", "disk") or None if
         no config file exists or storage_config is unset.
     """
     config_path = _config_dir(base_dir) / f"config_{org_id}.json"
@@ -117,7 +117,7 @@ def save_storage_to_config(
     All other fields (extractors, api_keys, etc.) are preserved.
 
     Args:
-        storage_type: Backend name ("sqlite", "supabase", "disk").
+        storage_type: Backend name ("sqlite", "supabase", "postgres", "disk").
         org_id: Organization ID for the config file name.
         base_dir: Override base directory (for testing).
     """
@@ -138,19 +138,17 @@ def save_storage_to_config(
         case "sqlite":
             config.storage_config = StorageConfigSQLite()
         case "supabase":
-            url = os.environ.get("SUPABASE_URL", "")
-            key = os.environ.get("SUPABASE_KEY", "")
-            db_url = os.environ.get("SUPABASE_DB_URL", "")
+            url = os.environ.get("DATA_SUPABASE_URL", "")
+            key = os.environ.get("DATA_SUPABASE_KEY", "")
+            db_url = os.environ.get("DATA_SUPABASE_DB_URL", "")
             if url and key and db_url:
                 config.storage_config = StorageConfigSupabase(
                     url=url, key=key, db_url=db_url
                 )
             else:
-                # Creds missing — keep existing storage_config (don't overwrite
-                # a valid StorageConfigSupabase with empty strings).
                 logger.warning(
                     "Supabase storage requested but credentials are missing "
-                    "(SUPABASE_URL, SUPABASE_KEY, SUPABASE_DB_URL). "
+                    "(DATA_SUPABASE_URL, DATA_SUPABASE_KEY, DATA_SUPABASE_DB_URL). "
                     "Keeping existing storage config."
                 )
         case "postgres":

--- a/reflexio/cli/commands/config_cmd.py
+++ b/reflexio/cli/commands/config_cmd.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -24,15 +23,6 @@ if TYPE_CHECKING:
     from reflexio.client.client import ReflexioClient
 
 app = typer.Typer(help="View and update server configuration.")
-
-# Mapping from StorageConfigSupabase field names to the env var names the
-# rest of the codebase reads. Keep these in sync with .env.example and the
-# setup wizard so pulled creds actually take effect without a rename pass.
-_SUPABASE_FIELD_TO_ENV = {
-    "url": "SUPABASE_URL",
-    "key": "SUPABASE_KEY",
-    "db_url": "SUPABASE_DB_URL",
-}
 
 
 def _resolve_data(data: str) -> dict:
@@ -237,23 +227,12 @@ def _mask_storage_config(storage_config: dict) -> dict:
     return masked
 
 
-def _format_env_assignment(key: str, value: str) -> str:
-    """Format a key=value pair for a .env file, quoting and escaping.
-
-    Mirrors the quoting used by :func:`reflexio.cli.commands.setup_cmd._set_env_var`
-    so lines written via ``config pull`` are indistinguishable from lines
-    written by the setup wizard.
-    """
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'{key}="{escaped}"'
-
-
 def _fetch_my_config(client: ReflexioClient) -> MyConfigResponse:
     """Call ``client.get_my_config()`` and wrap any failure in a CliError.
 
-    Both ``reflexio config storage`` and ``reflexio config pull`` hit the
-    same endpoint and want identical error framing on transport failures,
-    so we centralise the try/except here instead of duplicating it.
+    ``reflexio config storage`` hits the ``GET /api/my_config`` endpoint and
+    needs uniform error framing on transport failures, so we centralise the
+    try/except here.
 
     Args:
         client: A configured ``ReflexioClient`` instance.
@@ -299,32 +278,6 @@ def _fetch_my_config(client: ReflexioClient) -> MyConfigResponse:
             hint="Confirm REFLEXIO_URL + REFLEXIO_API_KEY, then try again.",
             exit_code=EXIT_NETWORK,
         ) from exc
-
-
-def _upsert_env_line(lines: list[str], key: str, value: str) -> None:
-    """Replace an existing ``KEY=`` line in-place or append a new one.
-
-    Prefers updating an active (uncommented) line; falls back to a
-    commented-out line if present; appends a new line otherwise.
-    """
-    pattern = re.compile(rf"^#?\s*{re.escape(key)}=")
-    active_idx: int | None = None
-    commented_idx: int | None = None
-    for i, line in enumerate(lines):
-        if not pattern.match(line):
-            continue
-        if line.lstrip().startswith("#"):
-            if commented_idx is None:
-                commented_idx = i
-        else:
-            active_idx = i
-            break
-    replacement = _format_env_assignment(key, value)
-    target = active_idx if active_idx is not None else commented_idx
-    if target is not None:
-        lines[target] = replacement
-    else:
-        lines.append(replacement)
 
 
 @app.command()
@@ -387,129 +340,3 @@ def storage(
     )
 
 
-@app.command()
-@handle_errors
-def pull(
-    ctx: typer.Context,
-    force: Annotated[
-        bool,
-        typer.Option(
-            "--force", help="Overwrite existing credential lines in the target file"
-        ),
-    ] = False,
-    env_file: Annotated[
-        Path | None,
-        typer.Option(
-            "--env-file",
-            help="Target .env file (default: ~/.reflexio/.env)",
-        ),
-    ] = None,
-) -> None:
-    """Pull the server-side storage credentials down to your local .env.
-
-    Calls ``GET /api/my_config`` and writes the returned Supabase (or
-    other) storage fields into the target .env so a fresh machine can
-    talk to your own Supabase directly via the local lib.
-
-    Refuses to overwrite existing active credential lines unless
-    ``--force`` is passed, so a stale pull can't silently clobber a
-    working configuration.
-
-    Args:
-        ctx: Typer context with CliState in ctx.obj
-        force: When True, overwrite existing credential lines in the target file.
-        env_file: Explicit target path. Defaults to ``~/.reflexio/.env``.
-    """
-    client = get_client(ctx)
-    resp = _fetch_my_config(client)
-
-    if not resp.success or not resp.storage_config:
-        raise CliError(
-            error_type="validation",
-            message=resp.message or "No storage configured for this org",
-            hint="Configure storage at https://reflexio.ai/settings first.",
-            exit_code=EXIT_VALIDATION,
-        )
-
-    if resp.storage_type != "supabase":
-        raise CliError(
-            error_type="validation",
-            message=(
-                f"Pulling {resp.storage_type} storage is not supported. "
-                "Only Supabase creds can be pulled to a local .env."
-            ),
-            exit_code=EXIT_VALIDATION,
-        )
-
-    target = env_file or Path.home() / ".reflexio" / ".env"
-    # ``mode`` on mkdir only applies when the directory is freshly
-    # created, so this is a no-op for an existing ``~/.reflexio`` but
-    # still tightens permissions for first-run callers.
-    target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    lines = target.read_text().splitlines() if target.exists() else []
-
-    # Detect existing credential lines so we can refuse clobbers. We
-    # include the REFLEXIO_* identity pair because ``pull`` overwrites
-    # them unconditionally further down — without the guard a stale
-    # pull could silently rewrite a user's API key. The leading ``\s*``
-    # mirrors ``_upsert_env_line`` so commented/indented lines trip the
-    # guard consistently.
-    guarded_vars = [
-        *_SUPABASE_FIELD_TO_ENV.values(),
-        "REFLEXIO_URL",
-        "REFLEXIO_API_KEY",
-    ]
-    existing_active = {
-        env_name
-        for env_name in guarded_vars
-        if any(re.match(rf"^\s*{re.escape(env_name)}=", line) for line in lines)
-    }
-    if existing_active and not force:
-        raise CliError(
-            error_type="validation",
-            message=(
-                f"{target} already has {', '.join(sorted(existing_active))} set. "
-                "Pass --force to overwrite."
-            ),
-            exit_code=EXIT_VALIDATION,
-        )
-
-    written: list[str] = []
-    for field, env_name in _SUPABASE_FIELD_TO_ENV.items():
-        value = resp.storage_config.get(field)
-        if not value:
-            continue
-        _upsert_env_line(lines, env_name, str(value))
-        written.append(env_name)
-
-    # Always also record REFLEXIO_URL/API key so the local lib knows how
-    # to identify itself next time.
-    _upsert_env_line(lines, "REFLEXIO_URL", client.base_url)
-    written.append("REFLEXIO_URL")
-    if client.api_key:
-        _upsert_env_line(lines, "REFLEXIO_API_KEY", client.api_key)
-        written.append("REFLEXIO_API_KEY")
-
-    # Create the file with restricted permissions *before* writing the
-    # credentials so there's no brief window where the raw Supabase key
-    # lands on disk as world-readable. The explicit ``chmod`` afterwards
-    # stays as a belt-and-suspenders guard in case the file pre-existed
-    # with looser permissions.
-    target.touch(mode=0o600, exist_ok=True)
-    target.write_text("\n".join(lines) + "\n")
-    target.chmod(0o600)
-
-    json_mode: bool = ctx.obj.json_mode
-    if json_mode:
-        render(
-            {
-                "path": str(target),
-                "written": written,
-                "storage_type": resp.storage_type,
-            },
-            json_mode=True,
-        )
-    else:
-        print_info(f"Wrote {len(written)} key(s) to {target}")
-        for env_name in written:
-            print_info(f"  {env_name}=<set>")

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2232,8 +2232,8 @@ class ReflexioClient:
     def get_my_config(self) -> MyConfigResponse:
         """Return raw storage credentials for the caller's org.
 
-        Used by ``reflexio config pull`` / ``config storage`` to let users
-        move their per-org server-side config to a fresh machine.
+        Used by ``reflexio config storage`` to let users inspect their
+        per-org server-side storage credentials.
 
         Returns:
             MyConfigResponse: Unmasked storage config dict, or

--- a/reflexio/server/api_endpoints/account_api.py
+++ b/reflexio/server/api_endpoints/account_api.py
@@ -5,8 +5,8 @@ Exposes two read-only endpoints that power CLI observability:
 - ``whoami``: masked summary of the caller's resolved storage routing.
   Safe to call without special permission — never returns raw secrets.
 - ``my_config``: raw storage credentials for the caller's org.
-  Token-gated and intended for operators pulling their own config down
-  to a fresh machine via ``reflexio config pull``.
+  Token-gated and rendered by ``reflexio config storage`` so operators
+  can inspect (and with ``--reveal``, copy) their own config.
 
 Both call through the cached ``Reflexio`` instance so per-org config
 lookups honour the same configurator that data reads/writes use.

--- a/tests/cli/test_bootstrap_config.py
+++ b/tests/cli/test_bootstrap_config.py
@@ -36,7 +36,7 @@ class TestResolveStorage:
     def test_cli_flag_wins_over_env_and_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+        monkeypatch.setenv("REFLEXIO_STORAGE", "postgres")
         _write_config(str(tmp_path), "self-host-org", "disk")
         # Patch home to use tmp_path for config lookup
         with patch(
@@ -48,12 +48,12 @@ class TestResolveStorage:
     def test_env_var_wins_over_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+        monkeypatch.setenv("REFLEXIO_STORAGE", "postgres")
         with patch(
             "reflexio.cli.bootstrap_config.load_storage_from_config",
             return_value="sqlite",
         ):
-            assert resolve_storage(None) == "supabase"
+            assert resolve_storage(None) == "postgres"
 
     def test_config_wins_over_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("REFLEXIO_STORAGE", raising=False)
@@ -73,11 +73,12 @@ class TestResolveStorage:
 
     def test_invalid_storage_raises(self) -> None:
         with pytest.raises(typer.BadParameter, match="Invalid storage backend"):
-            resolve_storage("postgres")
+            resolve_storage("redis")
 
     def test_case_insensitive_flag(self) -> None:
         assert resolve_storage("SQLite") == "sqlite"
         assert resolve_storage("SUPABASE") == "supabase"
+        assert resolve_storage("POSTGRES") == "postgres"
         assert resolve_storage("Disk") == "disk"
 
     def test_env_var_case_insensitive(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -130,9 +131,9 @@ class TestSaveAndLoadStorage:
     def test_round_trip_supabase_with_creds(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
-        monkeypatch.setenv("SUPABASE_KEY", "test-key-123")
-        monkeypatch.setenv("SUPABASE_DB_URL", "postgresql://localhost/test")
+        monkeypatch.setenv("DATA_SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("DATA_SUPABASE_KEY", "test-key-123")
+        monkeypatch.setenv("DATA_SUPABASE_DB_URL", "postgresql://localhost/test")
         save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
         result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
         assert result == "supabase"
@@ -140,21 +141,18 @@ class TestSaveAndLoadStorage:
     def test_supabase_without_creds_preserves_existing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When supabase creds are missing, save_storage_to_config keeps existing storage_config."""
-        # First save sqlite
         save_storage_to_config("sqlite", org_id="test-org", base_dir=str(tmp_path))
         assert (
             load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
             == "sqlite"
         )
 
-        # Now try saving supabase without creds — should preserve sqlite
-        monkeypatch.delenv("SUPABASE_URL", raising=False)
-        monkeypatch.delenv("SUPABASE_KEY", raising=False)
-        monkeypatch.delenv("SUPABASE_DB_URL", raising=False)
+        monkeypatch.delenv("DATA_SUPABASE_URL", raising=False)
+        monkeypatch.delenv("DATA_SUPABASE_KEY", raising=False)
+        monkeypatch.delenv("DATA_SUPABASE_DB_URL", raising=False)
         save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
         result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
-        assert result == "sqlite"  # preserved, not overwritten
+        assert result == "sqlite"
 
     def test_preserves_existing_config_fields(self, tmp_path: Path) -> None:
         """Updating storage_config must not clobber extractors or other fields."""
@@ -187,6 +185,7 @@ class TestSaveAndLoadStorage:
         # Verify extractor and context are preserved
         reloaded = storage_obj.load_config()
         assert reloaded.agent_context_prompt == "test context"
+        assert reloaded.profile_extractor_configs is not None
         assert len(reloaded.profile_extractor_configs) == 1
         assert (
             reloaded.profile_extractor_configs[0].extractor_name == "custom_extractor"
@@ -220,13 +219,13 @@ class TestEnvFileWriteBack:
         from reflexio.cli.env_loader import set_env_var
 
         env_file = tmp_path / ".env"
-        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+        env_file.write_text('REFLEXIO_STORAGE="postgres"\n')
 
         set_env_var(env_file, "REFLEXIO_STORAGE", "sqlite")
 
         content = env_file.read_text()
         assert 'REFLEXIO_STORAGE="sqlite"' in content
-        assert "supabase" not in content
+        assert "postgres" not in content
 
     def test_set_env_var_preserves_other_vars(self, tmp_path: Path) -> None:
         """set_env_var should only modify the target variable."""
@@ -235,7 +234,7 @@ class TestEnvFileWriteBack:
         env_file = tmp_path / ".env"
         env_file.write_text(
             'OPENAI_API_KEY="sk-test"\n'
-            'REFLEXIO_STORAGE="supabase"\n'
+            'REFLEXIO_STORAGE="postgres"\n'
             'JWT_SECRET_KEY="secret"\n'
         )
 
@@ -274,7 +273,7 @@ class TestLayerConsistency:
         from reflexio.cli.env_loader import set_env_var
 
         env_file = tmp_path / ".env"
-        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+        env_file.write_text('REFLEXIO_STORAGE="postgres"\n')
 
         # Simulate the start() flow when storage="sqlite" (explicit flag)
         resolved = resolve_storage("sqlite")
@@ -293,16 +292,16 @@ class TestLayerConsistency:
     def test_env_override_does_not_modify_env_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """REFLEXIO_STORAGE=supabase (no flag) -> config updated, .env unchanged."""
+        """REFLEXIO_STORAGE=postgres (no flag) -> config updated, .env unchanged."""
         env_file = tmp_path / ".env"
-        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+        env_file.write_text('REFLEXIO_STORAGE="postgres"\n')
         original_content = env_file.read_text()
 
-        monkeypatch.setenv("REFLEXIO_STORAGE", "supabase")
+        monkeypatch.setenv("REFLEXIO_STORAGE", "postgres")
 
         # Simulate start() with storage=None (no flag)
         resolved = resolve_storage(None)
-        assert resolved == "supabase"
+        assert resolved == "postgres"
 
         # Config updated, but .env NOT modified
         save_storage_to_config(
@@ -319,7 +318,7 @@ class TestLayerConsistency:
         from reflexio.cli.env_loader import set_env_var
 
         env_file = tmp_path / ".env"
-        env_file.write_text('REFLEXIO_STORAGE="supabase"\n')
+        env_file.write_text('REFLEXIO_STORAGE="postgres"\n')
 
         # Run 1: explicit --storage sqlite
         resolved1 = resolve_storage("sqlite")

--- a/tests/cli/test_config_cmd.py
+++ b/tests/cli/test_config_cmd.py
@@ -1,19 +1,15 @@
-"""Unit tests for ``reflexio config`` storage + pull commands.
+"""Unit tests for ``reflexio config storage``.
 
 These don't spin up the server — they patch ``client.get_my_config()``
 to return fixed ``MyConfigResponse`` values and assert the CLI renders
-or writes the expected output. The goal is to pin the contract of:
+the expected output. The goal is to pin the contract of:
 
 - masking behaviour by default (storage)
 - the --reveal confirmation prompt
-- .env file writing (pull)
-- the clobber-guard on pull without --force
-- the supabase-only restriction on pull
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -85,87 +81,6 @@ class TestConfigStorage:
             )
         assert result.exit_code == 0
         assert "verysecrettoken" in result.output
-
-
-class TestConfigPull:
-    def test_writes_env_file(self, runner: CliRunner, cli_app, tmp_path: Path) -> None:
-        env_file = tmp_path / ".env"
-        mock_client = MagicMock()
-        mock_client.base_url = "https://reflexio.ai"
-        mock_client.api_key = "rflx-test-key"
-        mock_client.get_my_config.return_value = _make_supabase_response()
-        with patch(
-            "reflexio.cli.commands.config_cmd.get_client", return_value=mock_client
-        ):
-            result = runner.invoke(
-                cli_app, ["config", "pull", "--env-file", str(env_file)]
-            )
-        assert result.exit_code == 0, result.output
-        content = env_file.read_text()
-        assert 'SUPABASE_URL="https://jpkjckbyxrdefzomiyse.supabase.co"' in content
-        assert "SUPABASE_KEY=" in content
-        assert "SUPABASE_DB_URL=" in content
-        assert 'REFLEXIO_URL="https://reflexio.ai"' in content
-        assert 'REFLEXIO_API_KEY="rflx-test-key"' in content
-
-    def test_refuses_clobber_without_force(
-        self, runner: CliRunner, cli_app, tmp_path: Path
-    ) -> None:
-        env_file = tmp_path / ".env"
-        env_file.write_text('SUPABASE_URL="https://existing.example"\n')
-        mock_client = MagicMock()
-        mock_client.base_url = "https://reflexio.ai"
-        mock_client.api_key = "rflx-key"
-        mock_client.get_my_config.return_value = _make_supabase_response()
-        with patch(
-            "reflexio.cli.commands.config_cmd.get_client", return_value=mock_client
-        ):
-            result = runner.invoke(
-                cli_app, ["config", "pull", "--env-file", str(env_file)]
-            )
-        assert result.exit_code != 0
-        # Existing line is intact — the pull was refused
-        assert "https://existing.example" in env_file.read_text()
-
-    def test_force_overwrites(self, runner: CliRunner, cli_app, tmp_path: Path) -> None:
-        env_file = tmp_path / ".env"
-        env_file.write_text('SUPABASE_URL="https://old.example"\n')
-        mock_client = MagicMock()
-        mock_client.base_url = "https://reflexio.ai"
-        mock_client.api_key = "rflx-key"
-        mock_client.get_my_config.return_value = _make_supabase_response()
-        with patch(
-            "reflexio.cli.commands.config_cmd.get_client", return_value=mock_client
-        ):
-            result = runner.invoke(
-                cli_app,
-                ["config", "pull", "--force", "--env-file", str(env_file)],
-            )
-        assert result.exit_code == 0, result.output
-        content = env_file.read_text()
-        assert "jpkjckbyxrdefzomiyse" in content
-        assert "old.example" not in content
-
-    def test_refuses_non_supabase_storage(
-        self, runner: CliRunner, cli_app, tmp_path: Path
-    ) -> None:
-        env_file = tmp_path / ".env"
-        mock_client = MagicMock()
-        mock_client.base_url = "http://localhost:8081"
-        mock_client.api_key = ""
-        mock_client.get_my_config.return_value = MyConfigResponse(
-            success=True,
-            storage_type="sqlite",
-            storage_config={"db_path": "/tmp/reflexio.db"},
-        )
-        with patch(
-            "reflexio.cli.commands.config_cmd.get_client", return_value=mock_client
-        ):
-            result = runner.invoke(
-                cli_app, ["config", "pull", "--env-file", str(env_file)]
-            )
-        assert result.exit_code != 0
-        assert not env_file.exists() or "SUPABASE" not in env_file.read_text()
 
 
 class TestConfigLocal:


### PR DESCRIPTION
## Summary

- Rename Supabase storage env vars `SUPABASE_URL` / `SUPABASE_KEY` / `SUPABASE_DB_URL` → `DATA_SUPABASE_URL` / `DATA_SUPABASE_KEY` / `DATA_SUPABASE_DB_URL` so storage credentials no longer collide with the `LOGIN_SUPABASE_*` auth pool used by the enterprise platform deployment.
- Remove `reflexio config pull` (and its `.env`-file upsert/quoting helpers). `reflexio config storage --reveal` already lets operators inspect and copy their server-side credentials, without an opinionated writer that mutates the user's `.env`.

## Scope

- `reflexio/cli/bootstrap_config.py` — read `DATA_SUPABASE_*` when materialising `StorageConfigSupabase`; warning text updated.
- `reflexio/server/api_endpoints/account_api.py` — docstring update for the removed `config pull` consumer.
- `reflexio/cli/commands/config_cmd.py` — drop the `pull` subcommand and its `_format_env_assignment` / `_upsert_env_line` helpers; trim the `_fetch_my_config` docstring to the remaining `storage` caller.
- `reflexio/client/client.py` — touched for consistency with the rename.
- `tests/cli/test_bootstrap_config.py`, `tests/cli/test_config_cmd.py` — env-var rename + drop tests for the removed subcommand.

## Test plan

- [x] `uv run ruff check` clean on all changed files
- [x] `uv run pyright` clean on all changed files
- [x] `uv run pytest tests/cli/test_bootstrap_config.py tests/cli/test_config_cmd.py` — 33 passed
- [ ] Reviewer: confirm no other in-tree references to bare `SUPABASE_URL` / `SUPABASE_KEY` / `SUPABASE_DB_URL` remain that should also be renamed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded storage configuration support with improved environment variable handling for Supabase credentials (`DATA_SUPABASE_URL`, `DATA_SUPABASE_KEY`, `DATA_SUPABASE_DB_URL`)
  * Enhanced Postgres backend support in storage resolution

* **Bug Fixes**
  * Improved error handling and credential sourcing in storage configuration resolution
  * Better fallback behavior when storage credentials are missing

* **Documentation**
  * Updated endpoint documentation to clarify storage configuration retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->