### PR TITLE
feat: GEPA-driven playbook optimizer with webhook + local-script assistant backends

### DIFF
--- a/docs/playbook_optimizer_assistant_backends.md
+++ b/docs/playbook_optimizer_assistant_backends.md
@@ -1,0 +1,432 @@
+# Playbook Optimizer — Assistant Backends
+
+This doc explains the playbook optimizer's **assistant backend layer**: what an "assistant backend" is, the two backends that exist (HTTP webhook and local script), how they plug into the rest of the optimizer, and where to find each piece in the codebase.
+
+---
+
+## 1. Where this fits in the bigger picture
+
+The playbook optimizer takes an existing playbook ("incumbent") and uses [GEPA](https://github.com/stanford-nlp/gepa) to search for a better wording ("candidate"). To decide if a candidate is actually better, it needs to **run both versions against the real assistant** on the same user turns and compare the resulting conversations.
+
+The "assistant backend" is the thing that turns *(messages, playbooks)* into the next assistant reply. The optimizer doesn't care how that reply is produced — it just needs a callable that respects the contract.
+
+```
+                       ┌──────────────────────────────────────────────────────────┐
+                       │  TRIGGER (upstream services, not part of this change)    │
+                       │                                                          │
+                       │   PlaybookAggregator                  PlaybookGeneration │
+                       │   ._enqueue_playbook_optimization     Service            │
+                       │   (after agent_playbook save)         ._enqueue_user_…   │
+                       └─────────────────────┬────────────────────────────────────┘
+                                             │ enqueue(org_id, target, callback)
+                                             ▼
+                       ┌──────────────────────────────────────────────────────────┐
+                       │  PlaybookOptimizationScheduler   (singleton, daemon)     │
+                       │  • debounce by (org_id, kind, target_id)                 │
+                       │  • jitter, then fire callback in a worker thread         │
+                       └─────────────────────┬────────────────────────────────────┘
+                                             │ callback() = optimize(target)
+                                             ▼
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│                         PlaybookOptimizer.optimize(target)                           │
+│                                                                                      │
+│  1.  config = configurator.get_config().playbook_optimizer_config                    │
+│  2.  assistant = self._create_assistant(config)   ◀── BACKEND SELECTION (§5)         │
+│      │  • config.webhook_url        → WebhookAssistant                               │
+│      │  • config.assistant_script   → LocalScriptAssistant                           │
+│      │  • neither                    → return (no-op, info log)                      │
+│      ▼                                                                               │
+│  3.  incumbent = storage.get_<agent|user>_playbook_by_id(target.target_id)           │
+│  4.  windows   = ScenarioResolver(storage).for_<…>(target.target_id)                 │
+│           │   builds ScenarioWindow[] from source_interaction_ids                    │
+│  5.  job = storage.create_playbook_optimization_job(...)        ┐                    │
+│                                                                 │ persists every     │
+│                                                                 │ candidate, eval,   │
+│                                                                 │ and GEPA event     │
+│  6.  result = gepa.api.optimize(                                │                    │
+│           seed_candidate = {playbook_content: incumbent.content},                    │
+│           trainset = valset = windows,                                               │
+│           adapter   = ReflexioPlaybookGEPAAdapter(                                   │
+│                          storage, job_id, incumbent,                                 │
+│                          rollout = MultiTurnRollout(assistant), ──────┐              │
+│                          judge   = PairwiseJudge(llm_client, …),      │              │
+│                       ),                                              │              │
+│           callbacks = [_GEPAStorageCallback]   # records on_* events  │              │
+│       )                                                               │              │
+│                                                                       │              │
+│  7.  if best passes commit thresholds:                                │              │
+│         _commit_if_allowed → archive incumbent, save successor        │              │
+└───────────────────────────────────────────────────────────────────────┼──────────────┘
+                                                                        │
+                                                                        │ for each
+                                                                        │ (candidate,
+                                                                        │  window)
+                                                                        ▼
+              ┌──────────────────────────────────────────────────────────────────┐
+              │  ReflexioPlaybookGEPAAdapter.evaluate(batch, candidate)          │
+              │                                                                  │
+              │  ┌────────────────────────────────────────────────────────────┐  │
+              │  │ MultiTurnRollout(incumbent_playbook).run(window)           │  │
+              │  │   for user_turn in window.user_turns[:max_turns]:          │  │
+              │  │       history.append(user_turn)                            │  │
+              │  │       reply = assistant(history, [incumbent])  ──────────┐ │  │
+              │  │       history.append(assistant_reply)                    │ │  │
+              │  │   → RolloutTrace                                         │ │  │
+              │  └──────────────────────────────────────────────────────────┼─┘  │
+              │  ┌──────────────────────────────────────────────────────────┼─┐  │
+              │  │ MultiTurnRollout(candidate_playbook).run(window)         │ │  │
+              │  │   …same loop, same user turns, candidate playbook…       │ │  │
+              │  │       reply = assistant(history, [candidate])            ┤ │  │
+              │  │   → RolloutTrace                                         │ │  │
+              │  └──────────────────────────────────────────────────────────┼─┘  │
+              │  ┌──────────────────────────────────────────────────────────┼─┐  │
+              │  │ PairwiseJudge.judge(window, incumbent_rollout,           │ │  │
+              │  │                     candidate_rollout)                   │ │  │
+              │  │   LLM call with playbook_optimizer_judge prompt          │ │  │
+              │  │   → JudgeOutput {verdict, score, likert, asi, rationale} │ │  │
+              │  └──────────────────────────────────────────────────────────┼─┘  │
+              │                                                             │    │
+              │  storage.insert_playbook_optimization_evaluation(...)       │    │
+              │  on AssistantFailedError → row with verdict="aborted"       │    │
+              └─────────────────────────────────────────────────────────────┼────┘
+                                                                            │
+                                                                            │ both rollouts
+                                                                            │ call the SAME
+                                                                            │ backend instance
+                                                                            │ (so the only
+                                                                            │  difference is
+                                                                            │  playbook content)
+                                                                            ▼
+                       ┌──────────────────────────────────────────────────────────┐
+                       │   AssistantCallable  (typing.Protocol)                   │
+                       │       __call__(messages, playbooks) -> str               │
+                       └─────────────────────┬─────────────────┬──────────────────┘
+                                             │                 │
+                       ┌─────────────────────┴───┐   ┌─────────┴────────────────────────┐
+                       │  WebhookAssistant       │   │  LocalScriptAssistant            │
+                       │  ───────────────────    │   │  ──────────────────────          │
+                       │  requests.post(url,     │   │  subprocess.run(                 │
+                       │      json=payload,      │   │      [script_path, *args],       │
+                       │      headers={Auth},    │   │      input=json.dumps(payload),  │
+                       │      timeout=…)         │   │      capture_output=True,        │
+                       │                         │   │      timeout=…)                  │
+                       │  retry: 1 + max_retries │   │  retry: 1 + max_retries          │
+                       │  backoff: base * 2^a    │   │  backoff: base * 2^a             │
+                       │                         │   │                                  │
+                       │  raise → Webhook        │   │  raise → LocalScript             │
+                       │          FailedError    │   │          FailedError             │
+                       └────────────┬────────────┘   └──────────────┬───────────────────┘
+                                    │                               │
+                                    └────────────┬──────────────────┘
+                                                 │ (inherit)
+                                                 ▼
+                                        AssistantFailedError
+                                        (caught by adapter →
+                                         verdict="aborted")
+```
+
+Reading the diagram top-to-bottom:
+- The **upper third** is "how an optimization gets started" — upstream services enqueue work and the scheduler decides when to actually run it.
+- The **middle band** is `PlaybookOptimizer.optimize` — the only place that knows about config, scenario windows, and the GEPA loop. Step 2 is where this change lives: a single dispatch into one of the two backends.
+- The **lower third** is the inner loop: for every (candidate, window) pair the adapter runs *two* paired rollouts that share the same user turns and the same backend, then a judge LLM scores them. Both rollouts route through whichever `AssistantCallable` was selected at step 2 — that's why the backend layer is the only thing that has to be swappable.
+
+---
+
+## 2. The contract every backend obeys
+
+Both backends are plain callables that match `AssistantCallable` (a `typing.Protocol`):
+
+```python
+class AssistantCallable(Protocol):
+    def __call__(
+        self, messages: list[ChatMessage], playbooks: list[AgentPlaybook]
+    ) -> str: ...
+```
+
+| Input / Output | Meaning |
+|---|---|
+| `messages` | Conversation so far. Each `ChatMessage` has `role` (`user`/`assistant`/`system`) and `content`. |
+| `playbooks` | Playbooks to inject into the assistant's system context. Today exactly one — the incumbent or candidate version under test. |
+| Return value | The assistant's next reply as a plain string. |
+| On failure | Raise `AssistantFailedError` (or a subclass). The adapter catches this and records an `aborted` evaluation row instead of crashing the GEPA loop. |
+
+Anything that satisfies this Protocol can be swapped in. The two concrete backends are described below.
+
+---
+
+## 3. The two backends
+
+| Aspect | `WebhookAssistant` | `LocalScriptAssistant` |
+|---|---|---|
+| Transport | HTTPS POST | `subprocess.run` |
+| Where the assistant runs | Wherever the URL points | On the same host as the optimizer |
+| Payload format | JSON body | JSON on stdin |
+| Response format | JSON body with `{"content": "..."}` | JSON on stdout with `{"content": "..."}` |
+| Auth | Optional `Authorization` header | Inherits process env (no separate auth concept) |
+| Failure type | `WebhookFailedError` | `LocalScriptFailedError` |
+| Common base | `AssistantFailedError` | `AssistantFailedError` |
+| Best for | Production / remote deployments | Local dev, CI, offline evaluation |
+
+Both share the same retry/backoff/timeout knobs and the same payload builder (`_build_payload`), so the wire shape is identical regardless of transport.
+
+### 3.1 The shared payload
+
+```json
+{
+  "messages": [
+    {"role": "user", "content": "How do I reset my password?"},
+    {"role": "assistant", "content": "..."}
+  ],
+  "playbooks": [
+    {"id": 42, "content": "<playbook text>", "trigger": "password reset"}
+  ]
+}
+```
+
+For the webhook, this becomes the request body. For the script, this becomes the bytes written to its stdin.
+
+### 3.2 The expected response
+
+```json
+{"content": "<assistant reply>"}
+```
+
+Anything else — non-string `content`, missing key, malformed JSON, non-zero exit code, network error, timeout — is reported as a typed failure.
+
+### 3.3 Retry behavior (identical for both)
+
+| Setting | Default | Effect |
+|---|---|---|
+| `webhook_max_retries` | 3 | Total attempts = `max_retries + 1` |
+| `webhook_backoff_base_seconds` | 1.0 | Sleep between attempts = `base * 2^attempt` |
+| `webhook_timeout_seconds` | 60 | Per-call timeout |
+
+> Naming note: the fields keep the `webhook_*` prefix even though they govern both backends. This is deliberate — renaming would have required a config-schema migration. Treat them as "assistant call" knobs.
+
+---
+
+## 4. How the local-script backend works
+
+This is the new piece. The high-level idea: spawn a child process for each assistant turn, hand it the payload on stdin, and read the reply off stdout.
+
+### 4.1 The command
+
+```python
+self.command = [script_path, *script_args]
+subprocess.run(self.command, input=stdin, text=True, capture_output=True, timeout=...)
+```
+
+- `script_path` is the executable — typically an interpreter (`/usr/bin/python3`) or a binary.
+- `script_args` is everything after it — the entrypoint script and any flags.
+
+There is **no shell interpretation** (`shell=True` is not used), so config values cannot inject shell metacharacters.
+
+### 4.2 What the script must do
+
+| Step | Requirement |
+|---|---|
+| 1. Read stdin | Single JSON object (UTF-8). The `messages` and `playbooks` fields described above. |
+| 2. Compute reply | Free-form. Could be an LLM call, a deterministic stub, a replay of prior recordings, etc. |
+| 3. Write stdout | Single JSON object containing at least `{"content": "<string>"}`. |
+| 4. Exit 0 on success | Any non-zero exit is treated as a failure; stderr is included in the error message. |
+
+### 4.3 Failure modes and how each is reported
+
+| Symptom | What the backend raises |
+|---|---|
+| Non-zero exit code | `LocalScriptFailedError("...exited with code N: <stderr truncated>")` |
+| stdout not valid JSON | `LocalScriptFailedError("...returned invalid JSON: <stdout truncated>")` |
+| stdout missing `content` (or non-string) | `LocalScriptFailedError("...returned no content")` |
+| `subprocess.TimeoutExpired` | Counts as one failed attempt → final raise is `LocalScriptFailedError("...timed out after Ns")` |
+| Any other exception | Counts as one failed attempt → final raise is `LocalScriptFailedError(str(exc))` |
+
+stderr is truncated to 1000 chars before being put into messages so a noisy script can't blow up logs or DB rows.
+
+### 4.4 A minimal working script
+
+```python
+#!/usr/bin/env python3
+import json, sys
+
+payload = json.loads(sys.stdin.read())
+last_user = next(
+    (m["content"] for m in reversed(payload["messages"]) if m["role"] == "user"),
+    "",
+)
+print(json.dumps({"content": f"echo: {last_user}"}))
+```
+
+Useful as a smoke test — confirms the optimizer end-to-end without needing an actual model.
+
+---
+
+## 5. How a backend is selected at runtime
+
+Selection happens once per `optimize()` call inside `PlaybookOptimizer._create_assistant`:
+
+```python
+def _create_assistant(self, config) -> AssistantCallable | None:
+    if config.webhook_url:
+        return WebhookAssistant(...)
+    if config.assistant_script_path:
+        return LocalScriptAssistant(...)
+    return None
+```
+
+| Config state | Result |
+|---|---|
+| `webhook_url` set, `assistant_script_path` unset | Webhook backend |
+| `assistant_script_path` set, `webhook_url` unset | Script backend |
+| Both set | **Rejected at config load time** by a Pydantic validator (`ValueError: Configure only one playbook optimizer assistant backend...`) |
+| Neither set | Optimizer logs `Skipping playbook optimization: no assistant backend configured` and returns without creating a job |
+
+The check happens *before* loading the incumbent or resolving scenario windows, so an unconfigured optimizer short-circuits cheaply.
+
+---
+
+## 6. Configuration reference
+
+All fields live on `PlaybookOptimizerConfig` (in `reflexio/models/config_schema.py`).
+
+### 6.1 New fields
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `assistant_script_path` | `str \| None` | `None` | Absolute path to the executable. Set this to enable the script backend. |
+| `assistant_script_args` | `list[str]` | `[]` | Extra argv tokens passed after `assistant_script_path`. |
+
+### 6.2 Existing fields that now apply to both backends
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `webhook_url` | `str \| None` | `None` | URL for the webhook backend |
+| `webhook_auth_header` | `str \| None` | `None` | Sent verbatim as `Authorization` (webhook only) |
+| `webhook_timeout_seconds` | `int > 0` | 60 | Per-call timeout — both backends |
+| `webhook_max_retries` | `int >= 0` | 3 | Retry budget — both backends |
+| `webhook_backoff_base_seconds` | `float >= 0` | 1.0 | Exponential base — both backends |
+
+### 6.3 Validator
+
+```python
+@model_validator(mode="after")
+def check_single_assistant_backend(self) -> Self:
+    if self.webhook_url and self.assistant_script_path:
+        raise ValueError(
+            "Configure only one playbook optimizer assistant backend: "
+            "webhook_url or assistant_script_path"
+        )
+    return self
+```
+
+### 6.4 Example configs
+
+```yaml
+# Webhook backend (production)
+playbook_optimizer_config:
+  enabled: true
+  webhook_url: https://assistant.internal/rollout
+  webhook_auth_header: "Bearer <secret>"
+  webhook_timeout_seconds: 60
+  webhook_max_retries: 3
+
+# Script backend (local dev / CI)
+playbook_optimizer_config:
+  enabled: true
+  assistant_script_path: /usr/bin/python3
+  assistant_script_args: [/path/to/echo_assistant.py]
+  webhook_timeout_seconds: 30
+  webhook_max_retries: 1
+```
+
+---
+
+## 7. End-to-end workflow
+
+What happens, in order, when a new agent playbook is generated and the optimizer is enabled:
+
+| Step | Component | What it does |
+|---|---|---|
+| 1 | `PlaybookAggregator._enqueue_playbook_optimization` | After saving new agent playbooks, enqueues each PENDING playbook with the scheduler. |
+| 2 | `PlaybookOptimizationScheduler` | Debounces by `(org_id, kind, target_id)`, fires after a small jitter, spawns a daemon thread. |
+| 3 | `PlaybookOptimizer.optimize(target)` | Loads config, calls `_create_assistant` → backend instance (or returns early). |
+| 4 | `ScenarioResolver` | Builds `ScenarioWindow`s from the playbook's `source_interaction_ids`. |
+| 5 | `gepa.api.optimize(...)` | Runs the candidate-search loop. |
+| 6 | `ReflexioPlaybookGEPAAdapter.evaluate` | For each `(candidate, window)`: |
+|   |   | • `MultiTurnRollout(incumbent).run(window)` → calls backend N times |
+|   |   | • `MultiTurnRollout(candidate).run(window)` → calls backend N times |
+|   |   | • `PairwiseJudge.judge(...)` → LLM verdict |
+|   |   | • Persists `PlaybookOptimizationEvaluation` row |
+| 7 | Failure handling | Any `AssistantFailedError` → `verdict="aborted"`, `score=0.0`, GEPA continues. |
+| 8 | `PlaybookOptimizer._passes_commit_thresholds` | Checks score / likert / per-window verdict counts. |
+| 9 | `PlaybookOptimizer._commit_if_allowed` | If gates pass → archive incumbent, save successor playbook. |
+
+The same flow runs for user playbooks, gated by `optimize_user_playbooks`.
+
+---
+
+## 8. Code map
+
+### Module: `reflexio/server/services/playbook_optimizer/assistant_webhook.py`
+
+(Despite the file name, both backends live here.)
+
+| Symbol | Kind | Role |
+|---|---|---|
+| `AssistantCallable` | Protocol | Shape both backends satisfy. |
+| `AssistantFailedError` | Exception | Common base — caught by the adapter. |
+| `WebhookFailedError` | Exception | Webhook backend failures. |
+| `LocalScriptFailedError` | Exception | Script backend failures. |
+| `_build_payload` | Function | Single source of truth for the wire payload. |
+| `_truncate` | Function | Caps stderr / stdout strings included in error messages at 1000 chars. |
+| `WebhookAssistant` | Class | HTTP POST + retry. |
+| `LocalScriptAssistant` | Class | `subprocess.run` + retry. |
+
+### Other touched files
+
+| File | What changed |
+|---|---|
+| `reflexio/server/services/playbook_optimizer/optimizer.py` | New `_create_assistant` method; `optimize()` short-circuits when no backend is configured. |
+| `reflexio/server/services/playbook_optimizer/gepa_adapter.py` | Catches `AssistantFailedError` (the new common base) instead of `WebhookFailedError` only. |
+| `reflexio/models/config_schema.py` | Adds `assistant_script_path`, `assistant_script_args`, plus the mutual-exclusion validator. |
+| `tests/models/test_validators.py` | Four new tests for the validator (see §9). |
+
+---
+
+## 9. Tests
+
+### 9.1 Config validation (`tests/models/test_validators.py`)
+
+| Test | Asserts |
+|---|---|
+| `test_playbook_optimizer_accepts_webhook_backend` | Webhook-only config is valid; `assistant_script_path is None`. |
+| `test_playbook_optimizer_accepts_script_backend` | Script-only config round-trips path + args. |
+| `test_playbook_optimizer_accepts_no_assistant_backend` | Default config (neither set) is valid; the optimizer is responsible for skipping. |
+| `test_playbook_optimizer_rejects_multiple_assistant_backends` | Both set → `ValidationError` matching `"only one"`. |
+
+### 9.2 Adapter / optimizer tests
+
+The existing tests in `tests/server/services/playbook_optimizer/test_playbook_optimizer.py` use a `Mock` for the assistant. Because both backends satisfy the same `AssistantCallable` Protocol, those tests cover the call-site contract for either backend without changes.
+
+---
+
+## 10. Operational notes
+
+| Topic | Notes |
+|---|---|
+| **Trust boundary** | The script backend executes whatever `assistant_script_path` points to with the same privileges as the optimizer process. Treat it like any other piece of config that names a binary. |
+| **Shell injection** | None. The command is a list, `shell=True` is not used. |
+| **Credentials in logs** | Only `str(last_error)` from the exception chain is logged. Authorization headers are never logged or echoed back. |
+| **Data residency** | Webhook traffic goes wherever `webhook_url` points — operators are responsible for choosing an appropriate endpoint. The script backend is local and never leaves the host. |
+| **Process overhead** | One process per assistant turn. Bounded by `max_metric_calls × max_turns × 2` (incumbent + candidate). For a long-lived script that pays a heavy startup cost, see §11. |
+| **stderr handling** | Captured, not streamed. Truncated to 1000 chars when included in error messages. |
+
+---
+
+## 11. Future work / known limitations
+
+| Item | Detail |
+|---|---|
+| Rename `webhook_*` retry/timeout fields | They govern both backends. Renaming requires a config-schema migration; deferred. |
+| Long-lived script process | If startup overhead is measurable, replace `subprocess.run` with a persistent process speaking line-delimited JSON. Only `LocalScriptAssistant.__call__` would change. |
+| Per-turn working directory | Today the script inherits `cwd`. Passing an explicit `cwd` would help when the script loads local state tied to an org. |
+| Structured stderr capture on success | Currently surfaced only on non-zero exit. Capturing it on success too would help telemetry on script-internal warnings. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "pydantic[email]>=2.13.0",
     "nltk>=3.9.3",
     "json-repair>=0.30.0",
+    "gepa>=0.1.1,<0.2",
     # CLI
     "typer>=0.15.0",
     "rich>=13.0.0",

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -84,6 +84,10 @@ __all__ = [
     "AgentPlaybookUpdateEntry",
     "PlaybookAggregationChangeLog",
     "PlaybookAggregationChangeLogResponse",
+    "PlaybookOptimizationJob",
+    "PlaybookOptimizationCandidate",
+    "PlaybookOptimizationEvaluation",
+    "PlaybookOptimizationEvent",
     "agent_playbook_to_snapshot",
     "RunPlaybookAggregationRequest",
     "RunPlaybookAggregationResponse",
@@ -247,6 +251,86 @@ class AgentPlaybook(BaseModel):
     status: Status | None = (
         None  # used for tracking intermediate states during playbook aggregation. Status.ARCHIVED for playbooks during aggregation process, None for current playbooks
     )
+
+
+class PlaybookOptimizationJob(BaseModel):
+    """One end-to-end optimizer run for a single playbook target.
+
+    Lifecycle: ``pending`` → ``running`` → ``completed`` | ``failed`` |
+    ``skipped``. ``best_candidate_id`` and ``successor_target_id`` are set
+    when the run produces a winner or commits a successor playbook.
+    """
+
+    job_id: int = 0
+    target_kind: Literal["agent_playbook", "user_playbook"]
+    target_id: int
+    status: Literal["pending", "running", "completed", "skipped", "failed"] = "pending"
+    best_candidate_id: int | None = None
+    successor_target_id: int | None = None
+    decision_reason: str = ""
+    metadata_json: str = "{}"
+    created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
+    updated_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
+
+
+class PlaybookOptimizationCandidate(BaseModel):
+    """A playbook content variant proposed by GEPA during a job.
+
+    Multiple proposals with identical content collapse to one row (deduped
+    by ``content`` inside the GEPA adapter). ``aggregate_score`` and
+    ``is_winner`` are populated only for the run's chosen winner.
+    """
+
+    candidate_id: int = 0
+    job_id: int
+    candidate_index: int = 0
+    content: str
+    parent_candidate_ids: list[int] = Field(default_factory=list)
+    aggregate_score: float | None = None
+    is_winner: bool = False
+    created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
+
+
+class PlaybookOptimizationEvaluation(BaseModel):
+    """Pairwise judgement of one candidate vs. the incumbent on one window.
+
+    Both rollouts are stored as JSON for offline reproducibility.
+    ``verdict='aborted'`` means the assistant backend failed and the row
+    carries no useful signal — the optimizer treats any aborted evaluation
+    as fatal for the run.
+    """
+
+    evaluation_id: int = 0
+    job_id: int
+    candidate_id: int
+    target_kind: Literal["agent_playbook", "user_playbook"]
+    target_id: int
+    scenario_user_playbook_id: int | None = None
+    source_interaction_ids: list[int] = Field(default_factory=list)
+    score: float = 0.0
+    verdict: Literal["candidate", "incumbent", "tie", "aborted"] = "tie"
+    likert: int = Field(default=0, ge=0, le=5)
+    rationale: str = ""
+    asi_json: str = "{}"
+    incumbent_rollout_json: str = "[]"
+    candidate_rollout_json: str = "[]"
+    created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
+
+
+class PlaybookOptimizationEvent(BaseModel):
+    """One GEPA callback (``on_*``) event captured for offline inspection.
+
+    The optimizer's ``_GEPAStorageCallback`` forwards every dispatched
+    callback into a row of this type. ``event_type`` is the callback name
+    minus the ``on_`` prefix; ``payload_json`` is a depth-bounded
+    serialization of the callback's argument.
+    """
+
+    event_id: int = 0
+    job_id: int
+    event_type: str
+    payload_json: str = "{}"
+    created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
 
 
 class AgentSuccessEvaluationResult(BaseModel):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -457,6 +457,71 @@ class ReflectionConfig(BaseModel):
     model: str | None = None
 
 
+class PlaybookOptimizerConfig(BaseModel):
+    """Configuration for GEPA-backed playbook content optimization.
+
+    The optimizer is opt-in (``enabled=False`` by default) and requires
+    *exactly one* assistant backend to actually do anything. The two
+    backends are mutually exclusive — see ``check_single_assistant_backend``
+    below.
+    """
+
+    # --- gating ------------------------------------------------------------
+    enabled: bool = False
+    optimize_agent_playbooks: bool = False
+    optimize_user_playbooks: bool = False
+    auto_update_pending_agent_playbooks: bool = True
+    auto_update_user_playbooks: bool = False
+    # If only one source window is available, a "win" is more likely to be
+    # noise than a real improvement. Default off.
+    allow_single_window_commit: bool = False
+
+    # --- GEPA budget -------------------------------------------------------
+    max_metric_calls: int = Field(default=40, gt=0)
+    max_turns: int = Field(default=5, gt=0)
+    reflection_minibatch_size: int = Field(default=3, gt=0)
+    min_commit_windows: int = Field(default=2, gt=0)
+    min_commit_score: float = Field(default=0.75, ge=0.0, le=1.0)
+    min_commit_likert: int = Field(default=4, ge=1, le=5)
+    use_merge: bool = True
+    max_merge_invocations: int = Field(default=5, ge=0)
+    reflection_model: str | None = None
+
+    # --- assistant backend: webhook ---------------------------------------
+    webhook_url: str | None = None
+    webhook_auth_header: str | None = None
+    # The webhook_* timeout/retry/backoff fields apply to BOTH backends —
+    # the prefix is preserved purely to avoid a config-schema migration.
+    webhook_timeout_seconds: int = Field(default=60, gt=0)
+    webhook_max_retries: int = Field(default=3, ge=0)
+    webhook_backoff_base_seconds: float = Field(default=1.0, ge=0.0)
+
+    # --- assistant backend: local script ----------------------------------
+    # Absolute path to the executable. The optimizer spawns
+    # [assistant_script_path, *assistant_script_args] per turn, hands the
+    # rollout payload over stdin, and reads {"content": "..."} from stdout.
+    # See playbook_optimizer/assistant_webhook.py::LocalScriptAssistant.
+    assistant_script_path: str | None = None
+    assistant_script_args: list[str] = Field(default_factory=list)
+
+    # --- scheduler --------------------------------------------------------
+    scheduler_jitter_seconds: float = Field(default=1.0, ge=0.0)
+    cooldown_after_aborts_seconds: int = Field(default=3600, ge=0)
+    abort_cooldown_threshold: int = Field(default=2, ge=1)
+
+    @model_validator(mode="after")
+    def check_single_assistant_backend(self) -> Self:
+        # Two backends configured at once would create ambiguous behavior
+        # (which one wins?), so reject at load time rather than picking one
+        # silently in _create_assistant.
+        if self.webhook_url and self.assistant_script_path:
+            raise ValueError(
+                "Configure only one playbook optimizer assistant backend: "
+                "webhook_url or assistant_script_path"
+            )
+        return self
+
+
 class LLMConfig(BaseModel):
     """
     LLM model configuration overrides.
@@ -531,6 +596,10 @@ class Config(BaseModel):
     llm_config: LLMConfig | None = None
     # Post-publish reflection service configuration
     reflection_config: ReflectionConfig = Field(default_factory=ReflectionConfig)
+    # Optional GEPA-backed playbook content optimizer
+    playbook_optimizer_config: PlaybookOptimizerConfig = Field(
+        default_factory=PlaybookOptimizerConfig
+    )
     # Skip the LLM pre-extraction eligibility check (always run extraction)
     skip_should_run_check: bool = False
     # Enable storage-time document expansion for improved FTS recall
@@ -579,6 +648,7 @@ class Config(BaseModel):
                 "extraction_backend",
                 "search_backend",
                 "reflection_config",
+                "playbook_optimizer_config",
             ):
                 if key in data and data[key] is None:
                     del data[key]

--- a/reflexio/server/prompt/prompt_bank/playbook_optimizer_judge/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_optimizer_judge/v1.0.0.prompt.md
@@ -1,0 +1,37 @@
+---
+id: playbook_optimizer_judge
+version: 1.0.0
+active: true
+description: Judge paired real-assistant rollouts for playbook optimization
+variables:
+  - source_window_json
+  - incumbent_playbook_json
+  - candidate_playbook_json
+  - incumbent_rollout_json
+  - candidate_rollout_json
+---
+You are judging whether a candidate playbook content change improves the real assistant's behavior.
+
+Use the source window as the ground-truth scenario context. Compare the incumbent rollout and candidate rollout. The user turns were held constant; only the injected playbook content changed.
+
+Source window:
+{source_window_json}
+
+Incumbent playbook:
+{incumbent_playbook_json}
+
+Candidate playbook:
+{candidate_playbook_json}
+
+Incumbent rollout:
+{incumbent_rollout_json}
+
+Candidate rollout:
+{candidate_rollout_json}
+
+Return structured JSON matching the requested schema:
+- verdict: "candidate", "incumbent", or "tie"
+- score: 1.0 for clear candidate win, 0.5 for tie, 0.0 for clear incumbent win; use intermediate values only for weak wins
+- likert: 1 to 5 quality score for candidate behavior
+- rationale: concise explanation
+- asi: actionable side information with failure_modes, regressions, winning_behaviors, missing_instruction, recommended_mutation

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -4,6 +4,7 @@ import hashlib
 import logging
 import os
 import time
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -777,11 +778,12 @@ class PlaybookAggregator:
                 outcome="started",
             )
             # Generate new playbooks only for changed clusters
-            new_playbooks = self._generate_playbooks_from_clusters(
+            generated_pairs = self._generate_playbooks_with_source_clusters(
                 changed_clusters,
                 existing_playbooks,
                 direction_overlap_threshold=playbook_aggregator_config.direction_overlap_threshold,
             )
+            new_playbooks = [playbook for playbook, _ in generated_pairs]
 
             # Lazy archive: only full-archive when the LLM produced replacements.
             # Skipping the archive when new_playbooks is empty preserves existing
@@ -848,28 +850,22 @@ class PlaybookAggregator:
                     "user_playbook_ids": raw_ids,
                 }
 
-            # Now assign playbook_ids from saved playbooks to fingerprints
-            # Since both iterate in cluster order, match by position
             saved_playbook_list = list(saved_playbooks)
-            fp_keys_from_changed = [
-                self._compute_cluster_fingerprint(cluster_playbooks)
-                for cluster_playbooks in changed_clusters.values()
-            ]
 
-            # saved_playbooks only contains non-None results, so we just
-            # assign playbook_ids to fingerprints that got valid playbooks
-            for saved_fb in saved_playbook_list:
+            # Assign saved playbook ids to the exact source cluster that generated them.
+            for saved_fb, (_, cluster_playbooks) in zip(
+                saved_playbook_list, generated_pairs, strict=False
+            ):
                 if saved_fb and saved_fb.agent_playbook_id:
-                    # Find matching fingerprint by trigger/content matching
-                    for fp_key in fp_keys_from_changed:
-                        if (
-                            fp_key in new_fingerprints
-                            and new_fingerprints[fp_key]["agent_playbook_id"] is None
-                        ):
-                            new_fingerprints[fp_key]["agent_playbook_id"] = (
-                                saved_fb.agent_playbook_id
-                            )
-                            break
+                    fp_key = self._compute_cluster_fingerprint(cluster_playbooks)
+                    raw_ids = sorted(fb.user_playbook_id for fb in cluster_playbooks)
+                    new_fingerprints[fp_key] = {
+                        "agent_playbook_id": saved_fb.agent_playbook_id,
+                        "user_playbook_ids": raw_ids,
+                    }
+                    self.storage.set_source_user_playbook_ids_for_agent_playbook(  # type: ignore[reportOptionalMemberAccess]
+                        saved_fb.agent_playbook_id, raw_ids
+                    )
 
             # Store fingerprints in operation state
             mgr.update_cluster_fingerprints(
@@ -913,6 +909,8 @@ class PlaybookAggregator:
                 )
             elif archived_playbook_ids:
                 self.storage.delete_agent_playbooks_by_ids(archived_playbook_ids)  # type: ignore[reportOptionalMemberAccess]
+
+            self._enqueue_playbook_optimization(saved_playbook_list)
 
             stats = {
                 "clusters_found": len(clusters),
@@ -1172,6 +1170,22 @@ class PlaybookAggregator:
         Returns:
             list[AgentPlaybook]: List of newly generated playbooks (excludes duplicates)
         """
+        return [
+            playbook
+            for playbook, _ in self._generate_playbooks_with_source_clusters(
+                clusters,
+                existing_approved_playbooks,
+                direction_overlap_threshold=direction_overlap_threshold,
+            )
+        ]
+
+    def _generate_playbooks_with_source_clusters(
+        self,
+        clusters: dict[int, list[UserPlaybook]],
+        existing_approved_playbooks: list[AgentPlaybook],
+        direction_overlap_threshold: float = 0.6,
+    ) -> list[tuple[AgentPlaybook, list[UserPlaybook]]]:
+        """Generate agent playbooks while preserving their exact source cluster."""
         # Format existing approved playbooks for the prompt
         approved_playbooks_str = (
             "\n".join([f"- {fb.content}" for fb in existing_approved_playbooks])
@@ -1179,7 +1193,7 @@ class PlaybookAggregator:
             else "None"
         )
 
-        new_playbooks = []
+        new_playbooks: list[tuple[AgentPlaybook, list[UserPlaybook]]] = []
         for cluster_playbooks in clusters.values():
             playbook = self._generate_playbook_from_cluster(
                 cluster_playbooks,
@@ -1187,8 +1201,47 @@ class PlaybookAggregator:
                 direction_overlap_threshold=direction_overlap_threshold,
             )
             if playbook is not None:
-                new_playbooks.append(playbook)
+                new_playbooks.append((playbook, cluster_playbooks))
         return new_playbooks
+
+    def _enqueue_playbook_optimization(
+        self, saved_playbooks: Sequence[AgentPlaybook | None]
+    ) -> None:
+        config = self.configurator.get_config().playbook_optimizer_config
+        if (
+            not config.enabled
+            or not config.optimize_agent_playbooks
+            or not saved_playbooks
+        ):
+            return
+        from reflexio.server.services.playbook_optimizer import (
+            PlaybookOptimizationScheduler,
+            PlaybookOptimizationTarget,
+            PlaybookOptimizer,
+        )
+
+        scheduler = PlaybookOptimizationScheduler.get_instance()
+        for playbook in saved_playbooks:
+            if (
+                playbook is None
+                or not playbook.agent_playbook_id
+                or playbook.status is not None
+                or playbook.playbook_status != PlaybookStatus.PENDING
+            ):
+                continue
+            target = PlaybookOptimizationTarget(
+                kind="agent_playbook", target_id=playbook.agent_playbook_id
+            )
+            scheduler.enqueue(
+                org_id=self.request_context.org_id,
+                target=target,
+                callback=lambda target=target: PlaybookOptimizer(
+                    self.request_context, self.client
+                ).optimize(target),
+                jitter_seconds=config.scheduler_jitter_seconds,
+                abort_cooldown_threshold=config.abort_cooldown_threshold,
+                cooldown_after_aborts_seconds=config.cooldown_after_aborts_seconds,
+            )
 
     def _generate_playbook_from_cluster(
         self,

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -322,6 +322,7 @@ class PlaybookGenerationService(
         if all_playbooks:
             try:
                 self.storage.save_user_playbooks(all_playbooks)  # type: ignore[reportOptionalMemberAccess]
+                self._enqueue_user_playbook_optimization(all_playbooks)
 
                 # Delete superseded existing entries only after save succeeds
                 if existing_ids_to_delete:
@@ -350,6 +351,44 @@ class PlaybookGenerationService(
             if not self.output_pending_status and not self.skip_aggregation:
                 logger.info("Trigger playbook aggregation")
                 self._trigger_playbook_aggregation()
+
+    def _enqueue_user_playbook_optimization(
+        self, saved_playbooks: list[UserPlaybook]
+    ) -> None:
+        config = self.configurator.get_config().playbook_optimizer_config
+        if (
+            not config.enabled
+            or not config.optimize_user_playbooks
+            or not saved_playbooks
+        ):
+            return
+        from reflexio.server.services.playbook_optimizer import (
+            PlaybookOptimizationScheduler,
+            PlaybookOptimizationTarget,
+            PlaybookOptimizer,
+        )
+
+        scheduler = PlaybookOptimizationScheduler.get_instance()
+        for playbook in saved_playbooks:
+            if (
+                not playbook.user_playbook_id
+                or playbook.status is not None
+                or not playbook.source_interaction_ids
+            ):
+                continue
+            target = PlaybookOptimizationTarget(
+                kind="user_playbook", target_id=playbook.user_playbook_id
+            )
+            scheduler.enqueue(
+                org_id=self.request_context.org_id,
+                target=target,
+                callback=lambda target=target: PlaybookOptimizer(
+                    self.request_context, self.client
+                ).optimize(target),
+                jitter_seconds=config.scheduler_jitter_seconds,
+                abort_cooldown_threshold=config.abort_cooldown_threshold,
+                cooldown_after_aborts_seconds=config.cooldown_after_aborts_seconds,
+            )
 
     def _get_extractor_state_service_name(self) -> str:
         """

--- a/reflexio/server/services/playbook_optimizer/__init__.py
+++ b/reflexio/server/services/playbook_optimizer/__init__.py
@@ -1,0 +1,24 @@
+"""GEPA-driven playbook content optimizer.
+
+Top-level entry points exported from this package:
+
+- ``PlaybookOptimizer.optimize(target)`` — runs one paired-rollout search
+  for a single playbook and persists the result.
+- ``PlaybookOptimizationScheduler.get_instance()`` — singleton that
+  debounces enqueues from upstream services (the aggregator and the
+  user-playbook generation service) and dispatches each ``optimize`` call
+  on a worker thread.
+- ``PlaybookOptimizationTarget`` — the (kind, target_id) pair both APIs
+  consume.
+
+The full doc lives at ``docs/playbook_optimizer_assistant_backends.md``.
+"""
+
+from .optimizer import PlaybookOptimizationTarget, PlaybookOptimizer
+from .scheduler import PlaybookOptimizationScheduler
+
+__all__ = [
+    "PlaybookOptimizationScheduler",
+    "PlaybookOptimizationTarget",
+    "PlaybookOptimizer",
+]

--- a/reflexio/server/services/playbook_optimizer/assistant_webhook.py
+++ b/reflexio/server/services/playbook_optimizer/assistant_webhook.py
@@ -1,0 +1,246 @@
+"""Assistant backends for the playbook optimizer.
+
+The playbook optimizer runs paired rollouts (incumbent vs candidate playbook)
+against a "real" assistant. This module hosts the two pluggable backends that
+produce the assistant's reply for a given turn:
+
+- ``WebhookAssistant``      — POSTs JSON to a configured URL.
+- ``LocalScriptAssistant``  — spawns a subprocess and exchanges JSON via
+  stdin/stdout.
+
+Both satisfy ``AssistantCallable``, so ``MultiTurnRollout`` and the GEPA
+adapter never need to know which one is in use. Selection happens once in
+``PlaybookOptimizer._create_assistant`` based on config.
+
+Failures from either backend raise ``AssistantFailedError`` (or a subclass);
+the GEPA adapter catches that single base class and turns it into an
+``aborted`` evaluation row instead of crashing the search loop.
+
+The file is named ``assistant_webhook.py`` for historical reasons — the
+local-script backend was added later. New code should still import from this
+module.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from typing import Any, Protocol
+
+import requests
+
+from reflexio.models.api_schema.domain import AgentPlaybook
+
+from .models import ChatMessage
+
+
+class AssistantCallable(Protocol):
+    """Shape every assistant backend must satisfy.
+
+    A backend takes the conversation so far plus the playbook(s) to inject
+    and returns the assistant's next reply as a plain string. Errors are
+    signalled by raising ``AssistantFailedError`` (or a subclass).
+    """
+
+    def __call__(
+        self, messages: list[ChatMessage], playbooks: list[AgentPlaybook]
+    ) -> str: ...
+
+
+class AssistantFailedError(Exception):
+    """Base class for any assistant-backend failure.
+
+    The GEPA adapter catches this single type to absorb backend faults
+    (network errors, subprocess crashes, malformed responses) and record
+    them as ``verdict='aborted'`` evaluations rather than aborting the
+    optimizer run.
+    """
+
+
+class WebhookFailedError(AssistantFailedError):
+    """Raised when ``WebhookAssistant`` exhausts its retries."""
+
+
+class LocalScriptFailedError(AssistantFailedError):
+    """Raised when ``LocalScriptAssistant`` exhausts its retries."""
+
+
+def _build_payload(
+    messages: list[ChatMessage], playbooks: list[AgentPlaybook]
+) -> dict[str, Any]:
+    """Build the wire payload shared by both backends.
+
+    Centralising this guarantees that the webhook body and the script's
+    stdin contain the *same* fields in the *same* shape — the only thing
+    that differs between the two transports is how the bytes are delivered.
+    """
+    return {
+        "messages": [message.model_dump() for message in messages],
+        "playbooks": [
+            {
+                "id": pb.agent_playbook_id,
+                "content": pb.content,
+                "trigger": pb.trigger,
+            }
+            for pb in playbooks
+        ],
+    }
+
+
+class WebhookAssistant:
+    """HTTP assistant backend.
+
+    POSTs the rollout payload to ``url`` and expects ``{"content": str}`` in
+    the response body. Retries any exception (network error, non-2xx,
+    malformed JSON, missing field) with exponential backoff up to
+    ``max_retries`` additional attempts before raising
+    ``WebhookFailedError``.
+
+    Args:
+        url: Destination URL. The optimizer does not validate the scheme,
+            so operators are responsible for ensuring it points at a host
+            that satisfies their data-residency requirements.
+        auth_header: Sent verbatim as the ``Authorization`` header. Never
+            logged.
+        timeout_s: Per-request timeout (passed to ``requests.post``).
+        max_retries: Number of *additional* attempts after the first try.
+            ``max_retries=0`` means a single attempt.
+        backoff_base_s: Base for the exponential delay
+            ``backoff_base_s * 2**attempt`` between retries.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        auth_header: str | None,
+        timeout_s: int,
+        max_retries: int,
+        backoff_base_s: float,
+    ) -> None:
+        self.url = url
+        self.auth_header = auth_header
+        self.timeout_s = timeout_s
+        self.max_retries = max_retries
+        self.backoff_base_s = backoff_base_s
+
+    def __call__(
+        self, messages: list[ChatMessage], playbooks: list[AgentPlaybook]
+    ) -> str:
+        headers = {"Content-Type": "application/json"}
+        if self.auth_header:
+            headers["Authorization"] = self.auth_header
+        payload = _build_payload(messages, playbooks)
+        last_error: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                response = requests.post(
+                    self.url,
+                    json=payload,
+                    headers=headers,
+                    timeout=self.timeout_s,
+                )
+                response.raise_for_status()
+                data = response.json()
+                content = data.get("content")
+                if not isinstance(content, str):
+                    raise WebhookFailedError("assistant webhook returned no content")
+                return content
+            except Exception as exc:  # noqa: PERF203
+                last_error = exc
+                if attempt >= self.max_retries:
+                    break
+                time.sleep(self.backoff_base_s * (2**attempt))
+        # Wrap-and-rethrow ensures the adapter sees a single AssistantFailedError
+        # subclass regardless of which underlying exception triggered the failure.
+        raise WebhookFailedError(str(last_error)) from last_error
+
+
+class LocalScriptAssistant:
+    """Subprocess assistant backend.
+
+    Spawns ``[script_path, *script_args]`` per turn and exchanges JSON over
+    stdin/stdout. The script must:
+
+    1. Read a single JSON object from stdin matching ``_build_payload``'s
+       shape (``{"messages": [...], "playbooks": [...]}``).
+    2. Print a single JSON object to stdout containing at least
+       ``{"content": "<assistant reply>"}``.
+    3. Exit with code 0 on success. Any non-zero exit, malformed JSON,
+       missing/non-string ``content``, or timeout is treated as a failure
+       and counted against ``max_retries``.
+
+    The command is built as a list and passed to ``subprocess.run`` *without*
+    ``shell=True``, so config values cannot inject shell metacharacters.
+    Retry/timeout/backoff semantics mirror ``WebhookAssistant``.
+    """
+
+    def __init__(
+        self,
+        script_path: str,
+        script_args: list[str],
+        timeout_s: int,
+        max_retries: int,
+        backoff_base_s: float,
+    ) -> None:
+        self.command = [script_path, *script_args]
+        self.timeout_s = timeout_s
+        self.max_retries = max_retries
+        self.backoff_base_s = backoff_base_s
+
+    def __call__(
+        self, messages: list[ChatMessage], playbooks: list[AgentPlaybook]
+    ) -> str:
+        payload = _build_payload(messages, playbooks)
+        stdin = json.dumps(payload, ensure_ascii=False)
+        last_error: Exception | None = None
+        for attempt in range(self.max_retries + 1):
+            try:
+                # shell=False (the default) is intentional — see class docstring.
+                result = subprocess.run(  # noqa: S603
+                    self.command,
+                    input=stdin,
+                    text=True,
+                    capture_output=True,
+                    timeout=self.timeout_s,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    # Truncate stderr to keep error messages bounded — long
+                    # tracebacks would otherwise blow up DB rows and logs.
+                    raise LocalScriptFailedError(
+                        "assistant script exited with code "
+                        f"{result.returncode}: {_truncate(result.stderr)}"
+                    )
+                try:
+                    data = json.loads(result.stdout)
+                except json.JSONDecodeError as exc:
+                    raise LocalScriptFailedError(
+                        f"assistant script returned invalid JSON: {_truncate(result.stdout)}"
+                    ) from exc
+                content = data.get("content") if isinstance(data, dict) else None
+                if not isinstance(content, str):
+                    raise LocalScriptFailedError("assistant script returned no content")
+                return content
+            except subprocess.TimeoutExpired:
+                # Timeouts come up via a different exception class than the
+                # validation errors above, but feed into the same retry budget.
+                last_error = LocalScriptFailedError(
+                    f"assistant script timed out after {self.timeout_s}s"
+                )
+                if attempt >= self.max_retries:
+                    break
+                time.sleep(self.backoff_base_s * (2**attempt))
+            except Exception as exc:  # noqa: PERF203
+                last_error = exc
+                if attempt >= self.max_retries:
+                    break
+                time.sleep(self.backoff_base_s * (2**attempt))
+        raise LocalScriptFailedError(str(last_error)) from last_error
+
+
+def _truncate(value: str, limit: int = 1000) -> str:
+    """Cap a string for inclusion in error messages and stored rows."""
+    if len(value) <= limit:
+        return value
+    return f"{value[:limit]}..."

--- a/reflexio/server/services/playbook_optimizer/gepa_adapter.py
+++ b/reflexio/server/services/playbook_optimizer/gepa_adapter.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from reflexio.models.api_schema.domain import (
+    AgentPlaybook,
+    PlaybookOptimizationCandidate,
+    PlaybookOptimizationEvaluation,
+)
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+from .assistant_webhook import AssistantFailedError
+from .judge import PairwiseJudge
+from .models import (
+    CandidateEvaluationOutput,
+    EvaluationTrajectory,
+    ScenarioWindow,
+)
+from .rollout import MultiTurnRollout
+
+if TYPE_CHECKING:
+    from gepa.core.adapter import EvaluationBatch, ProposalFn
+
+logger = logging.getLogger(__name__)
+
+PLAYBOOK_CONTENT_COMPONENT = "playbook_content"
+
+
+class ReflexioPlaybookGEPAAdapter:
+    """GEPA adapter for paired real-assistant playbook rollouts.
+
+    GEPA proposes candidate playbook content; this adapter scores each
+    candidate by running the *same* user turns twice — once with the
+    incumbent playbook injected and once with the candidate — then asking
+    an LLM judge which conversation is better.
+
+    Per ``(candidate, window)`` evaluation it:
+
+    1. Persists (or reuses) a ``PlaybookOptimizationCandidate`` row keyed by
+       content, so duplicate proposals share an id.
+    2. Runs two ``MultiTurnRollout`` invocations against the configured
+       assistant backend.
+    3. Calls ``PairwiseJudge.judge`` to produce a verdict / score / Likert /
+       ASI rationale.
+    4. Inserts a ``PlaybookOptimizationEvaluation`` row for offline review.
+
+    Backend faults (any ``AssistantFailedError``) are caught in
+    ``_evaluate_one`` and recorded as ``verdict='aborted'`` so the GEPA
+    search loop can keep going. The optimizer reads those rows back to
+    decide whether the run as a whole should fail.
+    """
+
+    def __init__(
+        self,
+        *,
+        storage: BaseStorage,
+        job_id: int,
+        target_kind: str,
+        target_id: int,
+        incumbent: AgentPlaybook,
+        rollout: MultiTurnRollout,
+        judge: PairwiseJudge,
+        max_turns: int,
+    ) -> None:
+        self.storage = storage
+        self.job_id = job_id
+        self.target_kind = target_kind
+        self.target_id = target_id
+        self.incumbent = incumbent
+        self.rollout = rollout
+        self.judge = judge
+        self.max_turns = max_turns
+        self.propose_new_texts: ProposalFn | None = None
+        self._candidate_ids_by_content: dict[str, int] = {}
+
+    def evaluate(
+        self,
+        batch: list[ScenarioWindow],
+        candidate: dict[str, str],
+        capture_traces: bool = False,
+    ) -> EvaluationBatch[EvaluationTrajectory, CandidateEvaluationOutput]:
+        from gepa.core.adapter import EvaluationBatch
+
+        candidate_content = candidate.get(PLAYBOOK_CONTENT_COMPONENT, "")
+        persisted_candidate = self._ensure_candidate(candidate_content)
+        outputs: list[CandidateEvaluationOutput] = []
+        scores: list[float] = []
+        trajectories: list[EvaluationTrajectory] = []
+
+        for window in batch:
+            output = self._evaluate_one(window, candidate_content)
+            outputs.append(output)
+            scores.append(output.score)
+            if capture_traces:
+                trajectories.append(
+                    EvaluationTrajectory(
+                        scenario=window,
+                        candidate_content=candidate_content,
+                        output=output,
+                    )
+                )
+            self.storage.insert_playbook_optimization_evaluation(
+                PlaybookOptimizationEvaluation(
+                    job_id=self.job_id,
+                    candidate_id=persisted_candidate.candidate_id,
+                    target_kind=self.target_kind,  # type: ignore[arg-type]
+                    target_id=self.target_id,
+                    scenario_user_playbook_id=window.user_playbook_id,
+                    source_interaction_ids=window.source_interaction_ids,
+                    score=output.score,
+                    verdict=output.verdict,
+                    likert=output.likert,
+                    rationale=output.rationale,
+                    asi_json=output.asi.model_dump_json(),
+                    incumbent_rollout_json=output.incumbent_rollout.model_dump_json(),
+                    candidate_rollout_json=output.candidate_rollout.model_dump_json(),
+                )
+            )
+
+        return EvaluationBatch(
+            outputs=outputs,
+            scores=scores,
+            trajectories=trajectories if capture_traces else None,
+        )
+
+    def make_reflective_dataset(
+        self,
+        candidate: dict[str, str],
+        eval_batch: EvaluationBatch[EvaluationTrajectory, CandidateEvaluationOutput],
+        components_to_update: list[str],
+    ) -> dict[str, list[dict[str, Any]]]:
+        records: list[dict[str, Any]] = [
+            {
+                "Inputs": {
+                    "source_interaction_ids": trajectory.scenario.source_interaction_ids,
+                    "current_playbook_content": candidate.get(
+                        PLAYBOOK_CONTENT_COMPONENT, ""
+                    ),
+                },
+                "Generated Outputs": {
+                    "incumbent_rollout": [
+                        message.model_dump()
+                        for message in trajectory.output.incumbent_rollout.messages
+                    ],
+                    "candidate_rollout": [
+                        message.model_dump()
+                        for message in trajectory.output.candidate_rollout.messages
+                    ],
+                },
+                "Feedback": json.dumps(
+                    {
+                        "score": trajectory.output.score,
+                        "verdict": trajectory.output.verdict,
+                        "likert": trajectory.output.likert,
+                        "rationale": trajectory.output.rationale,
+                        "asi": trajectory.output.asi.model_dump(),
+                    },
+                    ensure_ascii=False,
+                ),
+            }
+            for trajectory in eval_batch.trajectories or []
+        ]
+        return dict.fromkeys(components_to_update, records)
+
+    def _evaluate_one(
+        self, window: ScenarioWindow, candidate_content: str
+    ) -> CandidateEvaluationOutput:
+        candidate_playbook = self.incumbent.model_copy(
+            update={"content": candidate_content}
+        )
+        try:
+            incumbent_rollout = self.rollout.run(
+                window=window,
+                playbook=self.incumbent,
+                max_turns=self.max_turns,
+            )
+            candidate_rollout = self.rollout.run(
+                window=window,
+                playbook=candidate_playbook,
+                max_turns=self.max_turns,
+            )
+            judged = self.judge.judge(
+                window=window,
+                incumbent=self.incumbent,
+                candidate=candidate_playbook,
+                incumbent_rollout=incumbent_rollout,
+                candidate_rollout=candidate_rollout,
+            )
+            return CandidateEvaluationOutput(
+                score=judged.score,
+                verdict=judged.verdict,
+                likert=judged.likert,
+                rationale=judged.rationale,
+                asi=judged.asi,
+                incumbent_rollout=incumbent_rollout,
+                candidate_rollout=candidate_rollout,
+            )
+        except AssistantFailedError as exc:
+            logger.exception("Playbook optimizer assistant failed")
+            return CandidateEvaluationOutput(
+                score=0.0,
+                verdict="aborted",
+                likert=0,
+                rationale=f"Assistant failed: {exc}",
+            )
+        except Exception as exc:
+            logger.exception("Playbook optimizer evaluation failed")
+            return CandidateEvaluationOutput(
+                score=0.0,
+                verdict="aborted",
+                likert=0,
+                rationale=f"Evaluation failed: {exc}",
+            )
+
+    def _ensure_candidate(self, content: str) -> PlaybookOptimizationCandidate:
+        candidate_id = self._candidate_ids_by_content.get(content)
+        if candidate_id is not None:
+            existing = self.storage.list_playbook_optimization_candidates(self.job_id)
+            for candidate in existing:
+                if candidate.candidate_id == candidate_id:
+                    return candidate
+        candidate = self.storage.insert_playbook_optimization_candidate(
+            PlaybookOptimizationCandidate(
+                job_id=self.job_id,
+                candidate_index=len(self._candidate_ids_by_content),
+                content=content,
+            )
+        )
+        self._candidate_ids_by_content[content] = candidate.candidate_id
+        return candidate

--- a/reflexio/server/services/playbook_optimizer/judge.py
+++ b/reflexio/server/services/playbook_optimizer/judge.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from reflexio.models.api_schema.domain import AgentPlaybook
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.service_utils import log_model_response
+
+from .models import JudgeOutput, RolloutTrace, ScenarioWindow
+
+logger = logging.getLogger(__name__)
+
+PLAYBOOK_OPTIMIZER_JUDGE_PROMPT_ID = "playbook_optimizer_judge"
+
+
+class PairwiseJudge:
+    """LLM-based comparator for paired playbook rollouts.
+
+    Given two rollouts that share the same user turns and differ only in
+    the playbook injected into the assistant, ``judge`` asks an LLM (using
+    the ``playbook_optimizer_judge`` prompt) to pick a winner and assign a
+    score, Likert rating, and structured rationale.
+
+    If the two playbooks have identical content, ``judge`` short-circuits
+    to a tie without spending an LLM call — the rollouts will be identical
+    by construction.
+    """
+
+    def __init__(
+        self,
+        request_context: RequestContext,
+        llm_client: LiteLLMClient,
+        model_name: str | None,
+    ) -> None:
+        self.request_context = request_context
+        self.llm_client = llm_client
+        self.model_name = model_name or llm_client.config.model
+
+    def judge(
+        self,
+        *,
+        window: ScenarioWindow,
+        incumbent: AgentPlaybook,
+        candidate: AgentPlaybook,
+        incumbent_rollout: RolloutTrace,
+        candidate_rollout: RolloutTrace,
+    ) -> JudgeOutput:
+        if incumbent.content == candidate.content:
+            return JudgeOutput(
+                verdict="tie",
+                score=0.5,
+                likert=3,
+                rationale="Candidate content is identical to incumbent content.",
+            )
+        prompt = self.request_context.prompt_manager.render_prompt(
+            PLAYBOOK_OPTIMIZER_JUDGE_PROMPT_ID,
+            {
+                "source_window_json": _json(
+                    [interaction.model_dump() for interaction in window.interactions]
+                ),
+                "incumbent_playbook_json": _json(_playbook_payload(incumbent)),
+                "candidate_playbook_json": _json(_playbook_payload(candidate)),
+                "incumbent_rollout_json": incumbent_rollout.model_dump_json(),
+                "candidate_rollout_json": candidate_rollout.model_dump_json(),
+            },
+        )
+        response = self.llm_client.generate_chat_response(
+            messages=[{"role": "user", "content": prompt}],
+            model=self.model_name,
+            response_format=JudgeOutput,
+            timeout=120,
+            max_retries=1,
+        )
+        log_model_response(logger, "Playbook optimizer judge response", response)
+        if isinstance(response, JudgeOutput):
+            return response
+        return JudgeOutput(
+            verdict="tie",
+            score=0.5,
+            likert=3,
+            rationale=f"Judge response was not parsed: {type(response).__name__}",
+        )
+
+
+def _playbook_payload(playbook: AgentPlaybook) -> dict[str, object]:
+    return {
+        "id": playbook.agent_playbook_id,
+        "content": playbook.content,
+        "trigger": playbook.trigger,
+        "rationale": playbook.rationale,
+    }
+
+
+def _json(value: object) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, default=str)

--- a/reflexio/server/services/playbook_optimizer/models.py
+++ b/reflexio/server/services/playbook_optimizer/models.py
@@ -1,0 +1,96 @@
+"""In-process Pydantic models used by the playbook optimizer.
+
+These types are *not* persisted directly — they describe the inputs and
+outputs of the rollout/judge/adapter pipeline. The persisted equivalents
+live in ``reflexio.models.api_schema.domain`` (``PlaybookOptimization*``)
+and are populated from these models inside the GEPA adapter.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from reflexio.models.api_schema.domain import Interaction
+
+
+class ChatMessage(BaseModel):
+    """One conversation turn passed to / returned from the assistant backend."""
+
+    role: Literal["user", "assistant", "system"]
+    content: str
+
+
+class ScenarioWindow(BaseModel):
+    """One source-of-truth scenario the optimizer replays during rollouts.
+
+    Built by ``ScenarioResolver`` from a user playbook's
+    ``source_interaction_ids``. Only the user turns are replayed verbatim;
+    the assistant side is regenerated fresh on each rollout against the
+    playbook variant under test.
+    """
+
+    user_playbook_id: int | None = None
+    source_interaction_ids: list[int] = Field(default_factory=list)
+    interactions: list[Interaction] = Field(default_factory=list)
+
+    @property
+    def user_turns(self) -> list[ChatMessage]:
+        turns: list[ChatMessage] = []
+        for interaction in self.interactions:
+            role = _normalize_role(interaction.role)
+            if role == "user" and interaction.content:
+                turns.append(ChatMessage(role="user", content=interaction.content))
+        return turns
+
+
+class RolloutTrace(BaseModel):
+    messages: list[ChatMessage] = Field(default_factory=list)
+    playbook_content: str = ""
+
+
+class JudgeASI(BaseModel):
+    failure_modes: list[str] = Field(default_factory=list)
+    regressions: list[str] = Field(default_factory=list)
+    winning_behaviors: list[str] = Field(default_factory=list)
+    missing_instruction: str | list[str] = ""
+    recommended_mutation: str | list[str] = ""
+
+
+class JudgeOutput(BaseModel):
+    verdict: Literal["candidate", "incumbent", "tie"]
+    score: float = Field(ge=0.0, le=1.0)
+    likert: int = Field(ge=1, le=5)
+    rationale: str = ""
+    asi: JudgeASI = Field(default_factory=JudgeASI)
+
+
+class CandidateEvaluationOutput(BaseModel):
+    score: float
+    verdict: Literal["candidate", "incumbent", "tie", "aborted"]
+    likert: int
+    rationale: str
+    asi: JudgeASI = Field(default_factory=JudgeASI)
+    incumbent_rollout: RolloutTrace = Field(default_factory=RolloutTrace)
+    candidate_rollout: RolloutTrace = Field(default_factory=RolloutTrace)
+
+
+class EvaluationTrajectory(BaseModel):
+    scenario: ScenarioWindow
+    candidate_content: str
+    output: CandidateEvaluationOutput
+
+
+class GEPAEventPayload(BaseModel):
+    event: str
+    payload: dict[str, Any] = Field(default_factory=dict)
+
+
+def _normalize_role(role: str) -> Literal["user", "assistant", "system"]:
+    lowered = role.strip().lower()
+    if lowered in {"assistant", "agent"}:
+        return "assistant"
+    if lowered == "system":
+        return "system"
+    return "user"

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal, cast
+
+from pydantic import BaseModel
+
+from reflexio.models.api_schema.domain import (
+    AgentPlaybook,
+    PlaybookOptimizationEvent,
+    PlaybookOptimizationJob,
+    PlaybookStatus,
+    UserPlaybook,
+)
+from reflexio.models.config_schema import PlaybookOptimizerConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+
+from .assistant_webhook import AssistantCallable, LocalScriptAssistant, WebhookAssistant
+from .gepa_adapter import PLAYBOOK_CONTENT_COMPONENT, ReflexioPlaybookGEPAAdapter
+from .judge import PairwiseJudge
+from .rollout import MultiTurnRollout
+from .scenario_resolver import ScenarioResolver
+
+logger = logging.getLogger(__name__)
+
+
+class PlaybookOptimizationTarget(BaseModel):
+    """A single playbook (agent or user) the optimizer should try to improve."""
+
+    kind: Literal["agent_playbook", "user_playbook"]
+    target_id: int
+
+
+# Outcome of one ``optimize()`` invocation. Used by the scheduler to drive its
+# abort-cooldown logic — only ``aborted`` (assistant-backend faults) trips the
+# cooldown; ``failed`` (config / GEPA bugs) does not.
+PlaybookOptimizationRunStatus = Literal["skipped", "completed", "failed", "aborted"]
+
+
+class PlaybookOptimizer:
+    """Orchestrates one GEPA-driven optimization run for a single playbook.
+
+    The optimizer:
+
+    1. Picks an assistant backend from config (``_create_assistant``).
+    2. Loads the incumbent playbook and the source interaction windows that
+       produced it.
+    3. Runs ``gepa.optimize`` with a ``ReflexioPlaybookGEPAAdapter`` — the
+       adapter is what actually calls the assistant and the LLM judge.
+    4. Persists every candidate, evaluation, and GEPA event for offline
+       inspection.
+    5. Optionally commits a successor playbook if the winner clears the
+       configured score / Likert / per-window thresholds.
+    """
+
+    def __init__(self, request_context: RequestContext, llm_client: LiteLLMClient):
+        self.request_context = request_context
+        if request_context.storage is None:
+            raise ValueError("Playbook optimizer requires storage")
+        self.storage = request_context.storage
+        self.llm_client = llm_client
+        self.resolver = ScenarioResolver(self.storage)
+
+    def optimize(
+        self, target: PlaybookOptimizationTarget
+    ) -> PlaybookOptimizationRunStatus:
+        """Run a full optimization pass for ``target``.
+
+        Returns the run status so the scheduler can react (e.g. enter abort
+        cooldown when the assistant backend repeatedly fails). Side-effects:
+        creates one ``playbook_optimization_jobs`` row and possibly archives
+        the incumbent in favour of a successor playbook.
+        """
+        config = self._config()
+        if not self._enabled_for_target(config, target):
+            return "skipped"
+        # Backend selection happens before any storage work so an unconfigured
+        # optimizer short-circuits cheaply — useful in tests and dev setups.
+        assistant = self._create_assistant(config)
+        if assistant is None:
+            logger.info(
+                "Skipping playbook optimization: no assistant backend configured"
+            )
+            return "skipped"
+
+        incumbent = self._load_incumbent(target)
+        if incumbent is None:
+            return "skipped"
+        windows = self._resolve_windows(target, config)
+        if not windows:
+            return "skipped"
+        if len(windows) == 1 and not config.allow_single_window_commit:
+            logger.info("Skipping playbook optimization with one source window")
+            return "skipped"
+
+        job = self.storage.create_playbook_optimization_job(
+            PlaybookOptimizationJob(
+                target_kind=target.kind,
+                target_id=target.target_id,
+                status="running",
+                metadata_json=json.dumps(
+                    {"source_window_count": len(windows)}, ensure_ascii=False
+                ),
+            )
+        )
+
+        adapter = ReflexioPlaybookGEPAAdapter(
+            storage=self.storage,
+            job_id=job.job_id,
+            target_kind=target.kind,
+            target_id=target.target_id,
+            incumbent=incumbent,
+            rollout=MultiTurnRollout(assistant),
+            judge=PairwiseJudge(
+                self.request_context,
+                self.llm_client,
+                config.reflection_model,
+            ),
+            max_turns=config.max_turns,
+        )
+        try:
+            result = self._run_gepa(config, incumbent.content, windows, adapter)
+        except Exception as exc:
+            logger.exception("Playbook optimization failed")
+            self.storage.update_playbook_optimization_job(
+                job.job_id, status="failed", decision_reason=str(exc)
+            )
+            return "failed"
+
+        best = result.best_candidate
+        best_content = (
+            best.get(PLAYBOOK_CONTENT_COMPONENT, incumbent.content)
+            if isinstance(best, dict)
+            else str(best)
+        )
+        best_score = float(result.val_aggregate_scores[result.best_idx])
+        winner_candidate = adapter._ensure_candidate(best_content)
+        self.storage.update_playbook_optimization_candidate(
+            winner_candidate.candidate_id,
+            aggregate_score=best_score,
+            is_winner=True,
+        )
+
+        if self._has_aborted_evaluations(job.job_id):
+            self.storage.update_playbook_optimization_job(
+                job.job_id,
+                status="failed",
+                best_candidate_id=winner_candidate.candidate_id,
+                decision_reason="assistant backend aborted one or more evaluations",
+                metadata_json=json.dumps(
+                    result.to_dict(), ensure_ascii=False, default=str
+                ),
+            )
+            return "aborted"
+
+        if not self._passes_commit_thresholds(
+            job.job_id, winner_candidate.candidate_id, best_score, config
+        ):
+            self.storage.update_playbook_optimization_job(
+                job.job_id,
+                status="completed",
+                best_candidate_id=winner_candidate.candidate_id,
+                decision_reason="best candidate did not pass commit thresholds",
+                metadata_json=json.dumps(
+                    result.to_dict(), ensure_ascii=False, default=str
+                ),
+            )
+            return "completed"
+
+        successor_id = self._commit_if_allowed(target, incumbent, best_content, config)
+        self.storage.update_playbook_optimization_job(
+            job.job_id,
+            status="completed",
+            best_candidate_id=winner_candidate.candidate_id,
+            successor_target_id=successor_id,
+            decision_reason="committed" if successor_id else "winner persisted only",
+            metadata_json=json.dumps(result.to_dict(), ensure_ascii=False, default=str),
+        )
+        return "completed"
+
+    def _run_gepa(
+        self,
+        config: PlaybookOptimizerConfig,
+        seed_content: str,
+        windows: list,
+        adapter: ReflexioPlaybookGEPAAdapter,
+    ) -> Any:
+        from gepa.api import optimize as gepa_optimize
+
+        reflection_lm = config.reflection_model or self.llm_client.config.model
+        return gepa_optimize(
+            seed_candidate={PLAYBOOK_CONTENT_COMPONENT: seed_content},
+            trainset=windows,
+            valset=windows,
+            adapter=adapter,
+            reflection_lm=reflection_lm,
+            candidate_selection_strategy="pareto",
+            frontier_type="instance",
+            batch_sampler="epoch_shuffled",
+            reflection_minibatch_size=config.reflection_minibatch_size,
+            use_merge=config.use_merge,
+            max_merge_invocations=config.max_merge_invocations,
+            max_metric_calls=config.max_metric_calls,
+            raise_on_exception=False,
+            display_progress_bar=False,
+            callbacks=cast(Any, [_GEPAStorageCallback(self.storage, adapter.job_id)]),
+        )
+
+    def _config(self) -> PlaybookOptimizerConfig:
+        config = self.request_context.configurator.get_config()
+        return config.playbook_optimizer_config
+
+    def _create_assistant(
+        self, config: PlaybookOptimizerConfig
+    ) -> AssistantCallable | None:
+        """Pick the assistant backend implied by config.
+
+        ``webhook_url`` and ``assistant_script_path`` are mutually exclusive
+        (validated in ``PlaybookOptimizerConfig``), so this is a simple two-way
+        dispatch. Returning ``None`` means the optimizer is enabled but has no
+        backend configured — ``optimize()`` treats that as a no-op.
+
+        The ``webhook_*`` retry/timeout fields govern *both* backends; the
+        prefix is preserved only for config-schema compatibility.
+        """
+        if config.webhook_url:
+            return WebhookAssistant(
+                url=config.webhook_url,
+                auth_header=config.webhook_auth_header,
+                timeout_s=config.webhook_timeout_seconds,
+                max_retries=config.webhook_max_retries,
+                backoff_base_s=config.webhook_backoff_base_seconds,
+            )
+        if config.assistant_script_path:
+            return LocalScriptAssistant(
+                script_path=config.assistant_script_path,
+                script_args=config.assistant_script_args,
+                timeout_s=config.webhook_timeout_seconds,
+                max_retries=config.webhook_max_retries,
+                backoff_base_s=config.webhook_backoff_base_seconds,
+            )
+        return None
+
+    def _enabled_for_target(
+        self, config: PlaybookOptimizerConfig, target: PlaybookOptimizationTarget
+    ) -> bool:
+        if not config.enabled:
+            return False
+        if target.kind == "agent_playbook":
+            return config.optimize_agent_playbooks
+        return config.optimize_user_playbooks
+
+    def _load_incumbent(
+        self, target: PlaybookOptimizationTarget
+    ) -> AgentPlaybook | None:
+        if target.kind == "agent_playbook":
+            playbook = self.storage.get_agent_playbook_by_id(target.target_id)
+            if (
+                playbook is None
+                or playbook.status is not None
+                or playbook.playbook_status != PlaybookStatus.PENDING
+            ):
+                return None
+            return playbook
+        user_playbook = self.storage.get_user_playbook_by_id(target.target_id)
+        if user_playbook is None or user_playbook.status is not None:
+            return None
+        return _agent_like_playbook(user_playbook)
+
+    def _resolve_windows(
+        self, target: PlaybookOptimizationTarget, config: PlaybookOptimizerConfig
+    ) -> list:
+        if target.kind == "agent_playbook":
+            return self.resolver.for_agent_playbook(target.target_id)
+        if not config.optimize_user_playbooks:
+            return []
+        return self.resolver.for_user_playbook(target.target_id)
+
+    def _passes_commit_thresholds(
+        self,
+        job_id: int,
+        candidate_id: int,
+        best_score: float,
+        config: PlaybookOptimizerConfig,
+    ) -> bool:
+        if best_score < config.min_commit_score:
+            return False
+        evaluations = self.storage.list_playbook_optimization_evaluations(job_id)
+        winning_windows = {
+            evaluation.scenario_user_playbook_id
+            for evaluation in evaluations
+            if evaluation.candidate_id == candidate_id
+            and evaluation.verdict == "candidate"
+            and evaluation.score >= config.min_commit_score
+            and evaluation.likert >= config.min_commit_likert
+        }
+        return len(winning_windows) >= config.min_commit_windows
+
+    def _has_aborted_evaluations(self, job_id: int) -> bool:
+        evaluations = self.storage.list_playbook_optimization_evaluations(job_id)
+        return any(evaluation.verdict == "aborted" for evaluation in evaluations)
+
+    def _commit_if_allowed(
+        self,
+        target: PlaybookOptimizationTarget,
+        incumbent: AgentPlaybook,
+        best_content: str,
+        config: PlaybookOptimizerConfig,
+    ) -> int | None:
+        if target.kind == "agent_playbook":
+            if not config.auto_update_pending_agent_playbooks:
+                return None
+            source_ids = self.storage.get_source_user_playbook_ids_for_agent_playbook(
+                target.target_id
+            )
+            current = self.storage.get_agent_playbook_by_id(target.target_id)
+            if (
+                current is None
+                or current.status is not None
+                or current.playbook_status != PlaybookStatus.PENDING
+            ):
+                return None
+            self.storage.archive_agent_playbooks_by_ids([target.target_id])
+            successor = incumbent.model_copy(
+                update={
+                    "agent_playbook_id": 0,
+                    "content": best_content,
+                    "status": None,
+                    "playbook_status": PlaybookStatus.PENDING,
+                    "playbook_metadata": _append_optimizer_metadata(
+                        incumbent.playbook_metadata, target.target_id
+                    ),
+                }
+            )
+            saved = self.storage.save_agent_playbooks([successor])
+            if saved and saved[0].agent_playbook_id:
+                self.storage.set_source_user_playbook_ids_for_agent_playbook(
+                    saved[0].agent_playbook_id, source_ids
+                )
+                return saved[0].agent_playbook_id
+            return None
+        if not config.auto_update_user_playbooks:
+            return None
+        current_user = self.storage.get_user_playbook_by_id(target.target_id)
+        if current_user is None or current_user.status is not None:
+            return None
+        if current_user.user_id is None:
+            return None
+        archived = self.storage.archive_user_playbook_by_id(
+            current_user.user_id, current_user.user_playbook_id
+        )
+        if not archived:
+            return None
+        successor_user = current_user.model_copy(
+            update={"user_playbook_id": 0, "content": best_content, "status": None}
+        )
+        self.storage.save_user_playbooks([successor_user])
+        return successor_user.user_playbook_id or None
+
+
+def _agent_like_playbook(playbook: UserPlaybook) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=playbook.user_playbook_id,
+        playbook_name=playbook.playbook_name,
+        agent_version=playbook.agent_version,
+        content=playbook.content,
+        trigger=playbook.trigger,
+        rationale=playbook.rationale,
+        blocking_issue=playbook.blocking_issue,
+        playbook_status=PlaybookStatus.PENDING,
+        status=playbook.status,
+    )
+
+
+def _append_optimizer_metadata(existing: str, predecessor_id: int) -> str:
+    suffix = f"optimized_from_agent_playbook_id={predecessor_id}"
+    if not existing:
+        return suffix
+    return f"{existing}; {suffix}"
+
+
+class _GEPAStorageCallback:
+    def __init__(self, storage: Any, job_id: int) -> None:
+        self.storage = storage
+        self.job_id = job_id
+
+    def __getattr__(self, name: str) -> Any:
+        if not name.startswith("on_"):
+            raise AttributeError(name)
+
+        def _record(event: dict[str, Any]) -> None:
+            self.storage.insert_playbook_optimization_event(
+                PlaybookOptimizationEvent(
+                    job_id=self.job_id,
+                    event_type=name.removeprefix("on_"),
+                    payload_json=json.dumps(
+                        _safe_event_payload(event), ensure_ascii=False, default=str
+                    ),
+                )
+            )
+
+        return _record
+
+
+def _safe_event_payload(value: Any, depth: int = 0) -> Any:
+    if depth > 3:
+        return str(value)
+    if isinstance(value, dict):
+        return {
+            str(k): _safe_event_payload(v, depth + 1)
+            for k, v in value.items()
+            if k != "final_state"
+        }
+    if isinstance(value, list | tuple | set):
+        return [_safe_event_payload(v, depth + 1) for v in value]
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    if hasattr(value, "model_dump"):
+        return _safe_event_payload(value.model_dump(), depth + 1)
+    return str(value)

--- a/reflexio/server/services/playbook_optimizer/rollout.py
+++ b/reflexio/server/services/playbook_optimizer/rollout.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from reflexio.models.api_schema.domain import AgentPlaybook
+
+from .assistant_webhook import AssistantCallable
+from .models import ChatMessage, RolloutTrace, ScenarioWindow
+
+
+class MultiTurnRollout:
+    """Replay a scenario's user turns against an assistant backend.
+
+    For each user turn in ``window.user_turns`` (capped by ``max_turns``),
+    the rollout appends the user message, asks the backend for a reply, and
+    appends the reply to the history. Importantly, the *user side* is fixed
+    — replayed verbatim from the recorded scenario — so a paired
+    incumbent/candidate run differs only in the playbook injected into the
+    backend. That isolation is what makes the judge's verdict meaningful.
+    """
+
+    def __init__(self, assistant: AssistantCallable) -> None:
+        self.assistant = assistant
+
+    def run(
+        self,
+        *,
+        window: ScenarioWindow,
+        playbook: AgentPlaybook,
+        max_turns: int,
+    ) -> RolloutTrace:
+        history: list[ChatMessage] = []
+        for user_turn in window.user_turns[:max_turns]:
+            history.append(user_turn)
+            assistant_content = self.assistant(history, [playbook])
+            history.append(ChatMessage(role="assistant", content=assistant_content))
+        return RolloutTrace(messages=history, playbook_content=playbook.content)

--- a/reflexio/server/services/playbook_optimizer/scenario_resolver.py
+++ b/reflexio/server/services/playbook_optimizer/scenario_resolver.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from reflexio.models.api_schema.domain import Status
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+from .models import ScenarioWindow
+
+
+class ScenarioResolver:
+    """Builds the rollout test set from a playbook's lineage.
+
+    Each agent playbook is generated from a cluster of user playbooks,
+    which were themselves extracted from real interactions. To evaluate a
+    candidate change, the optimizer needs to replay those original
+    interactions — this class walks the lineage and materialises one
+    ``ScenarioWindow`` per source user playbook.
+
+    Empty windows (no source interactions, archived rows, etc.) are
+    skipped silently — the optimizer treats "no windows" as a reason to
+    skip the run.
+    """
+
+    def __init__(self, storage: BaseStorage) -> None:
+        self.storage = storage
+
+    def for_agent_playbook(self, agent_playbook_id: int) -> list[ScenarioWindow]:
+        user_playbook_ids = (
+            self.storage.get_source_user_playbook_ids_for_agent_playbook(
+                agent_playbook_id
+            )
+        )
+        user_playbooks = self.storage.get_user_playbooks_by_ids_any_user(
+            user_playbook_ids, status_filter=None
+        )
+        windows: list[ScenarioWindow] = []
+        for playbook in user_playbooks:
+            if not playbook.source_interaction_ids:
+                continue
+            interactions = self.storage.get_interactions_by_ids(
+                playbook.source_interaction_ids
+            )
+            if interactions:
+                windows.append(
+                    ScenarioWindow(
+                        user_playbook_id=playbook.user_playbook_id,
+                        source_interaction_ids=playbook.source_interaction_ids,
+                        interactions=interactions,
+                    )
+                )
+        return windows
+
+    def for_user_playbook(self, user_playbook_id: int) -> list[ScenarioWindow]:
+        playbook = self.storage.get_user_playbook_by_id(user_playbook_id)
+        if (
+            playbook is None
+            or playbook.status is not None
+            or not playbook.source_interaction_ids
+        ):
+            return []
+        interactions = self.storage.get_interactions_by_ids(
+            playbook.source_interaction_ids
+        )
+        if not interactions:
+            return []
+        return [
+            ScenarioWindow(
+                user_playbook_id=playbook.user_playbook_id,
+                source_interaction_ids=playbook.source_interaction_ids,
+                interactions=interactions,
+            )
+        ]
+
+
+def is_current_status(status: Status | None) -> bool:
+    return status is None

--- a/reflexio/server/services/playbook_optimizer/scheduler.py
+++ b/reflexio/server/services/playbook_optimizer/scheduler.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import heapq
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+from .optimizer import PlaybookOptimizationRunStatus, PlaybookOptimizationTarget
+
+logger = logging.getLogger(__name__)
+
+ScheduleKey = tuple[str, str, int]
+ScheduledCallback = Callable[[], PlaybookOptimizationRunStatus | None]
+
+
+class PlaybookOptimizationScheduler:
+    """Process-local scheduler that debounces optimization runs.
+
+    Behaviour:
+
+    - **Debounce** by ``(org_id, target.kind, target.target_id)`` — repeated
+      enqueues for the same playbook collapse into one fire.
+    - **Jitter** the fire time by up to ``jitter_seconds`` to spread load
+      across simultaneous saves.
+    - **Cooldown** when a callback returns ``"aborted"`` (the assistant
+      backend repeatedly failed). After ``abort_cooldown_threshold``
+      consecutive aborts, further enqueues for the same key are silently
+      dropped for ``cooldown_after_aborts_seconds``. A ``completed`` or
+      ``skipped`` outcome resets the counter.
+
+    The scheduler is a singleton with a daemon thread; multiple processes
+    schedule independently, so debounce is per-process.
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> PlaybookOptimizationScheduler:
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._scheduled: dict[
+            ScheduleKey, tuple[float, ScheduledCallback, int, int]
+        ] = {}
+        self._heap: list[tuple[float, ScheduleKey]] = []
+        self._mutex = threading.Lock()
+        self._wake_event = threading.Event()
+        self._abort_counts: dict[ScheduleKey, tuple[int, float]] = {}
+        self._thread = threading.Thread(
+            target=self._scheduler_loop,
+            daemon=True,
+            name="playbook-optimizer-scheduler",
+        )
+        self._thread.start()
+
+    def enqueue(
+        self,
+        *,
+        org_id: str,
+        target: PlaybookOptimizationTarget,
+        callback: ScheduledCallback,
+        jitter_seconds: float = 1.0,
+        abort_cooldown_threshold: int = 2,
+        cooldown_after_aborts_seconds: int = 3600,
+    ) -> None:
+        key: ScheduleKey = (org_id, target.kind, target.target_id)
+        now = time.monotonic()
+        jitter = (time.monotonic() % 1.0) * jitter_seconds
+        fire_time = now + jitter
+        with self._mutex:
+            if self._cooldown_remaining_locked(key, now) > 0:
+                logger.info(
+                    "Skipping playbook optimization enqueue during cooldown: %s", key
+                )
+                return
+            self._scheduled[key] = (
+                fire_time,
+                callback,
+                abort_cooldown_threshold,
+                cooldown_after_aborts_seconds,
+            )
+            heapq.heappush(self._heap, (fire_time, key))
+        self._wake_event.set()
+
+    def _scheduler_loop(self) -> None:
+        while True:
+            try:
+                with self._mutex:
+                    next_fire_time = self._heap[0][0] if self._heap else None
+                if next_fire_time is None:
+                    self._wake_event.wait()
+                    self._wake_event.clear()
+                    continue
+                wait_seconds = next_fire_time - time.monotonic()
+                if wait_seconds > 0:
+                    self._wake_event.wait(timeout=wait_seconds)
+                    self._wake_event.clear()
+                    continue
+                with self._mutex:
+                    while self._heap and self._heap[0][0] <= time.monotonic():
+                        fire_time, key = heapq.heappop(self._heap)
+                        current = self._scheduled.get(key)
+                        if current is None or abs(current[0] - fire_time) > 0.001:
+                            continue
+                        _, callback, abort_threshold, cooldown_seconds = current
+                        del self._scheduled[key]
+                        threading.Thread(
+                            target=self._run_callback,
+                            args=(key, callback, abort_threshold, cooldown_seconds),
+                            daemon=True,
+                            name=f"playbook-opt-{key[1]}-{key[2]}",
+                        ).start()
+            except Exception:
+                logger.exception("Playbook optimization scheduler loop failed")
+                time.sleep(1)
+
+    def _run_callback(
+        self,
+        key: ScheduleKey,
+        callback: ScheduledCallback,
+        abort_threshold: int,
+        cooldown_seconds: int,
+    ) -> None:
+        try:
+            status = callback()
+            if status == "aborted":
+                self._record_abort(key, abort_threshold, cooldown_seconds)
+            elif status in {"completed", "skipped"}:
+                self._clear_abort_state(key)
+        except Exception:
+            logger.exception("Playbook optimization callback failed for key=%s", key)
+            self._record_abort(key, abort_threshold, cooldown_seconds)
+
+    def _cooldown_remaining_locked(self, key: ScheduleKey, now: float) -> float:
+        state = self._abort_counts.get(key)
+        if state is None:
+            return 0.0
+        count, cooldown_until = state
+        if cooldown_until <= 0:
+            return 0.0
+        remaining = cooldown_until - now
+        if remaining > 0:
+            return remaining
+        del self._abort_counts[key]
+        return 0.0
+
+    def _record_abort(
+        self, key: ScheduleKey, abort_threshold: int, cooldown_seconds: int
+    ) -> None:
+        now = time.monotonic()
+        with self._mutex:
+            self._cooldown_remaining_locked(key, now)
+            count, _ = self._abort_counts.get(key, (0, 0.0))
+            count += 1
+            if count >= abort_threshold:
+                cooldown_until = now + cooldown_seconds
+                self._abort_counts[key] = (0, cooldown_until)
+                logger.warning(
+                    "Playbook optimization entered abort cooldown for key=%s seconds=%s",
+                    key,
+                    cooldown_seconds,
+                )
+            else:
+                self._abort_counts[key] = (count, 0.0)
+
+    def _clear_abort_state(self, key: ScheduleKey) -> None:
+        with self._mutex:
+            self._abort_counts.pop(key, None)

--- a/reflexio/server/services/storage/disk_storage/_base.py
+++ b/reflexio/server/services/storage/disk_storage/_base.py
@@ -11,7 +11,7 @@ import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -88,6 +88,11 @@ class DiskStorageBase(BaseStorage):
     _OPERATION_STATES = "operation_states"
     _CHANGE_LOGS_PROFILE = "change_logs/profile"
     _CHANGE_LOGS_PLAYBOOK_AGG = "change_logs/playbook_aggregation"
+    _AGENT_PLAYBOOK_SOURCE_MAP = "playbook_optimizer/source_map"
+    _PLAYBOOK_OPT_JOBS = "playbook_optimizer/jobs"
+    _PLAYBOOK_OPT_CANDIDATES = "playbook_optimizer/candidates"
+    _PLAYBOOK_OPT_EVALUATIONS = "playbook_optimizer/evaluations"
+    _PLAYBOOK_OPT_EVENTS = "playbook_optimizer/events"
     _EMBEDDINGS = ".embeddings"
 
     def __init__(
@@ -157,6 +162,11 @@ class DiskStorageBase(BaseStorage):
             self._OPERATION_STATES,
             self._CHANGE_LOGS_PROFILE,
             self._CHANGE_LOGS_PLAYBOOK_AGG,
+            self._AGENT_PLAYBOOK_SOURCE_MAP,
+            self._PLAYBOOK_OPT_JOBS,
+            self._PLAYBOOK_OPT_CANDIDATES,
+            self._PLAYBOOK_OPT_EVALUATIONS,
+            self._PLAYBOOK_OPT_EVENTS,
             self._EMBEDDINGS,
         ):
             (self._org_dir / subdir).mkdir(parents=True, exist_ok=True)
@@ -199,7 +209,7 @@ class DiskStorageBase(BaseStorage):
         deserializer = _DESERIALIZERS.get(path.suffix)
         if not deserializer:
             raise StorageError(f"Unsupported file format: {path.suffix}")
-        entity = deserializer(path.read_text(encoding="utf-8"), model_class)
+        entity = cast(T, deserializer(path.read_text(encoding="utf-8"), model_class))
         # Load sidecar embedding if present
         if "embedding" in model_class.model_fields and (
             embedding := self._read_embedding(path)
@@ -413,6 +423,21 @@ class DiskStorageBase(BaseStorage):
 
     def _playbook_agg_change_logs_dir(self) -> Path:
         return self._org_dir / self._CHANGE_LOGS_PLAYBOOK_AGG
+
+    def _agent_playbook_source_map_dir(self) -> Path:
+        return self._org_dir / self._AGENT_PLAYBOOK_SOURCE_MAP
+
+    def _playbook_opt_jobs_dir(self) -> Path:
+        return self._org_dir / self._PLAYBOOK_OPT_JOBS
+
+    def _playbook_opt_candidates_dir(self) -> Path:
+        return self._org_dir / self._PLAYBOOK_OPT_CANDIDATES
+
+    def _playbook_opt_evaluations_dir(self) -> Path:
+        return self._org_dir / self._PLAYBOOK_OPT_EVALUATIONS
+
+    def _playbook_opt_events_dir(self) -> Path:
+        return self._org_dir / self._PLAYBOOK_OPT_EVENTS
 
     def _clear_dir(self, directory: Path) -> None:
         """Remove all contents of a directory and recreate it."""

--- a/reflexio/server/services/storage/disk_storage/_extras.py
+++ b/reflexio/server/services/storage/disk_storage/_extras.py
@@ -31,6 +31,18 @@ class ExtrasMixin:
         )
         return [i for i in interactions if i.request_id in request_id_set]
 
+    def get_interactions_by_ids(self, interaction_ids: list[int]) -> list[Interaction]:
+        if not interaction_ids:
+            return []
+        id_set = set(interaction_ids)
+        interactions = self._list_entities_recursive(
+            self._interactions_dir(), Interaction
+        )
+        return sorted(
+            [i for i in interactions if i.interaction_id in id_set],
+            key=lambda i: i.created_at,
+        )
+
     # ------------------------------------------------------------------
     # Dashboard methods
     # ------------------------------------------------------------------

--- a/reflexio/server/services/storage/disk_storage/_playbook.py
+++ b/reflexio/server/services/storage/disk_storage/_playbook.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import time
 from pathlib import Path
 
 from reflexio.models.api_schema.common import BlockingIssue
@@ -9,6 +11,10 @@ from reflexio.models.api_schema.retriever_schema import (
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     AgentSuccessEvaluationResult,
+    PlaybookOptimizationCandidate,
+    PlaybookOptimizationEvaluation,
+    PlaybookOptimizationEvent,
+    PlaybookOptimizationJob,
     PlaybookStatus,
     Request,
     Status,
@@ -214,6 +220,30 @@ class PlaybookMixin:
                     continue
                 if matches_status_filter(up.status, status_filter):
                     results.append(up)
+        return results
+
+    def get_user_playbook_by_id(self, user_playbook_id: int) -> UserPlaybook | None:
+        path = self._entity_path(self._user_playbooks_dir(), str(user_playbook_id))
+        if not path.exists():
+            return None
+        return self._read_entity(path, UserPlaybook)
+
+    def get_user_playbooks_by_ids_any_user(
+        self,
+        user_playbook_ids: list[int],
+        status_filter: list[Status | None] | None = None,
+    ) -> list[UserPlaybook]:
+        if not user_playbook_ids:
+            return []
+        results: list[UserPlaybook] = []
+        with self._lock:
+            for upid in user_playbook_ids:
+                playbook = self.get_user_playbook_by_id(upid)
+                if playbook and (
+                    status_filter is None
+                    or matches_status_filter(playbook.status, status_filter)
+                ):
+                    results.append(playbook)
         return results
 
     def archive_user_playbook_by_id(self, user_id: str, user_playbook_id: int) -> bool:
@@ -559,6 +589,12 @@ class PlaybookMixin:
                 break
         return playbooks
 
+    def get_agent_playbook_by_id(self, agent_playbook_id: int) -> AgentPlaybook | None:
+        path = self._entity_path(self._agent_playbooks_dir(), str(agent_playbook_id))
+        if not path.exists():
+            return None
+        return self._read_entity(path, AgentPlaybook)
+
     def update_agent_playbook_status(
         self, agent_playbook_id: int, playbook_status: PlaybookStatus
     ) -> None:
@@ -754,6 +790,148 @@ class PlaybookMixin:
                 if self._should_delete_playbook(ap, playbook_name, agent_version):
                     self._delete_embedding(p)
                     p.unlink()
+
+    # ------------------------------------------------------------------
+    # Playbook optimizer methods
+    # ------------------------------------------------------------------
+
+    def set_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int, user_playbook_ids: list[int]
+    ) -> None:
+        path = self._entity_path(
+            self._agent_playbook_source_map_dir(), str(agent_playbook_id)
+        )
+        path.write_text(
+            json.dumps({"user_playbook_ids": user_playbook_ids}, indent=2),
+            encoding="utf-8",
+        )
+
+    def get_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[int]:
+        path = self._entity_path(
+            self._agent_playbook_source_map_dir(), str(agent_playbook_id)
+        )
+        if not path.exists():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8") or "{}")
+        return [int(v) for v in data.get("user_playbook_ids", [])]
+
+    def create_playbook_optimization_job(
+        self, job: PlaybookOptimizationJob
+    ) -> PlaybookOptimizationJob:
+        with self._lock:
+            if job.job_id == 0:
+                job.job_id = self._next_id(self._playbook_opt_jobs_dir())
+            self._write_entity(
+                self._entity_path(self._playbook_opt_jobs_dir(), str(job.job_id)),
+                job,
+            )
+        return job
+
+    def update_playbook_optimization_job(
+        self,
+        job_id: int,
+        *,
+        status: str | None = None,
+        best_candidate_id: int | None = None,
+        successor_target_id: int | None = None,
+        decision_reason: str | None = None,
+        metadata_json: str | None = None,
+    ) -> None:
+        path = self._entity_path(self._playbook_opt_jobs_dir(), str(job_id))
+        if not path.exists():
+            return
+        job = self._read_entity(path, PlaybookOptimizationJob)
+        if status is not None:
+            job.status = status
+        if best_candidate_id is not None:
+            job.best_candidate_id = best_candidate_id
+        if successor_target_id is not None:
+            job.successor_target_id = successor_target_id
+        if decision_reason is not None:
+            job.decision_reason = decision_reason
+        if metadata_json is not None:
+            job.metadata_json = metadata_json
+        job.updated_at = int(time.time())
+        self._write_entity(path, job)
+
+    def insert_playbook_optimization_candidate(
+        self, candidate: PlaybookOptimizationCandidate
+    ) -> PlaybookOptimizationCandidate:
+        with self._lock:
+            if candidate.candidate_id == 0:
+                candidate.candidate_id = self._next_id(
+                    self._playbook_opt_candidates_dir()
+                )
+            self._write_entity(
+                self._entity_path(
+                    self._playbook_opt_candidates_dir(), str(candidate.candidate_id)
+                ),
+                candidate,
+            )
+        return candidate
+
+    def list_playbook_optimization_candidates(
+        self, job_id: int
+    ) -> list[PlaybookOptimizationCandidate]:
+        candidates = self._list_entities(
+            self._playbook_opt_candidates_dir(), PlaybookOptimizationCandidate
+        )
+        return [c for c in candidates if c.job_id == job_id]
+
+    def update_playbook_optimization_candidate(
+        self,
+        candidate_id: int,
+        *,
+        aggregate_score: float | None = None,
+        is_winner: bool | None = None,
+    ) -> None:
+        path = self._entity_path(self._playbook_opt_candidates_dir(), str(candidate_id))
+        if not path.exists():
+            return
+        candidate = self._read_entity(path, PlaybookOptimizationCandidate)
+        if aggregate_score is not None:
+            candidate.aggregate_score = aggregate_score
+        if is_winner is not None:
+            candidate.is_winner = is_winner
+        self._write_entity(path, candidate)
+
+    def insert_playbook_optimization_evaluation(
+        self, evaluation: PlaybookOptimizationEvaluation
+    ) -> PlaybookOptimizationEvaluation:
+        with self._lock:
+            if evaluation.evaluation_id == 0:
+                evaluation.evaluation_id = self._next_id(
+                    self._playbook_opt_evaluations_dir()
+                )
+            self._write_entity(
+                self._entity_path(
+                    self._playbook_opt_evaluations_dir(), str(evaluation.evaluation_id)
+                ),
+                evaluation,
+            )
+        return evaluation
+
+    def list_playbook_optimization_evaluations(
+        self, job_id: int
+    ) -> list[PlaybookOptimizationEvaluation]:
+        evaluations = self._list_entities(
+            self._playbook_opt_evaluations_dir(), PlaybookOptimizationEvaluation
+        )
+        return [e for e in evaluations if e.job_id == job_id]
+
+    def insert_playbook_optimization_event(
+        self, event: PlaybookOptimizationEvent
+    ) -> PlaybookOptimizationEvent:
+        with self._lock:
+            if event.event_id == 0:
+                event.event_id = self._next_id(self._playbook_opt_events_dir())
+            self._write_entity(
+                self._entity_path(self._playbook_opt_events_dir(), str(event.event_id)),
+                event,
+            )
+        return event
 
     # ------------------------------------------------------------------
     # Agent Success Evaluation methods

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1215,6 +1215,70 @@ CREATE TABLE IF NOT EXISTS playbook_aggregation_change_logs (
 CREATE INDEX IF NOT EXISTS idx_pacl_playbook_name ON playbook_aggregation_change_logs(playbook_name);
 CREATE INDEX IF NOT EXISTS idx_pacl_agent_version ON playbook_aggregation_change_logs(agent_version);
 
+CREATE TABLE IF NOT EXISTS agent_playbook_source_user_playbooks (
+    agent_playbook_id INTEGER NOT NULL,
+    user_playbook_id INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    PRIMARY KEY (agent_playbook_id, user_playbook_id)
+);
+CREATE INDEX IF NOT EXISTS idx_apsup_agent ON agent_playbook_source_user_playbooks(agent_playbook_id);
+
+CREATE TABLE IF NOT EXISTS playbook_optimization_jobs (
+    job_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_kind TEXT NOT NULL,
+    target_id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    best_candidate_id INTEGER,
+    successor_target_id INTEGER,
+    decision_reason TEXT NOT NULL DEFAULT '',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_poj_target ON playbook_optimization_jobs(target_kind, target_id);
+CREATE INDEX IF NOT EXISTS idx_poj_status ON playbook_optimization_jobs(status);
+
+CREATE TABLE IF NOT EXISTS playbook_optimization_candidates (
+    candidate_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL,
+    candidate_index INTEGER NOT NULL DEFAULT 0,
+    content TEXT NOT NULL,
+    parent_candidate_ids TEXT NOT NULL DEFAULT '[]',
+    aggregate_score REAL,
+    is_winner INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_poc_job ON playbook_optimization_candidates(job_id);
+
+CREATE TABLE IF NOT EXISTS playbook_optimization_evaluations (
+    evaluation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL,
+    candidate_id INTEGER NOT NULL,
+    target_kind TEXT NOT NULL,
+    target_id INTEGER NOT NULL,
+    scenario_user_playbook_id INTEGER,
+    source_interaction_ids TEXT NOT NULL DEFAULT '[]',
+    score REAL NOT NULL DEFAULT 0.0,
+    verdict TEXT NOT NULL DEFAULT 'tie',
+    likert INTEGER NOT NULL DEFAULT 0,
+    rationale TEXT NOT NULL DEFAULT '',
+    asi_json TEXT NOT NULL DEFAULT '{}',
+    incumbent_rollout_json TEXT NOT NULL DEFAULT '[]',
+    candidate_rollout_json TEXT NOT NULL DEFAULT '[]',
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_poe_job ON playbook_optimization_evaluations(job_id);
+CREATE INDEX IF NOT EXISTS idx_poe_candidate ON playbook_optimization_evaluations(candidate_id);
+
+CREATE TABLE IF NOT EXISTS playbook_optimization_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    job_id INTEGER NOT NULL,
+    event_type TEXT NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_poev_job ON playbook_optimization_events(job_id);
+
 CREATE TABLE IF NOT EXISTS _operation_state (
     service_name TEXT PRIMARY KEY,
     operation_state TEXT NOT NULL DEFAULT '{}',

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -47,6 +47,17 @@ class ExtrasMixin:
         )
         return [_row_to_interaction(r) for r in rows]
 
+    @SQLiteStorageBase.handle_exceptions
+    def get_interactions_by_ids(self, interaction_ids: list[int]) -> list[Interaction]:
+        if not interaction_ids:
+            return []
+        ph = ",".join("?" for _ in interaction_ids)
+        rows = self._fetchall(
+            f"SELECT * FROM interactions WHERE interaction_id IN ({ph}) ORDER BY created_at ASC",  # noqa: S608
+            interaction_ids,
+        )
+        return [_row_to_interaction(r) for r in rows]
+
     _fetchone: Any
     _fetchall: Any
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -13,6 +13,10 @@ from reflexio.models.api_schema.retriever_schema import (
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     AgentSuccessEvaluationResult,
+    PlaybookOptimizationCandidate,
+    PlaybookOptimizationEvaluation,
+    PlaybookOptimizationEvent,
+    PlaybookOptimizationJob,
     PlaybookStatus,
     Status,
     UserPlaybook,
@@ -25,6 +29,7 @@ from ._base import (
     _effective_search_mode,
     _epoch_to_iso,
     _json_dumps,
+    _json_loads,
     _row_to_agent_playbook,
     _row_to_eval_result,
     _row_to_user_playbook,
@@ -32,6 +37,43 @@ from ._base import (
     _true_rrf_merge,
     _vector_rank_rows,
 )
+
+
+def _row_to_playbook_optimization_candidate(
+    row: sqlite3.Row,
+) -> PlaybookOptimizationCandidate:
+    return PlaybookOptimizationCandidate(
+        candidate_id=row["candidate_id"],
+        job_id=row["job_id"],
+        candidate_index=row["candidate_index"],
+        content=row["content"],
+        parent_candidate_ids=_json_loads(row["parent_candidate_ids"]) or [],
+        aggregate_score=row["aggregate_score"],
+        is_winner=bool(row["is_winner"]),
+        created_at=row["created_at"],
+    )
+
+
+def _row_to_playbook_optimization_evaluation(
+    row: sqlite3.Row,
+) -> PlaybookOptimizationEvaluation:
+    return PlaybookOptimizationEvaluation(
+        evaluation_id=row["evaluation_id"],
+        job_id=row["job_id"],
+        candidate_id=row["candidate_id"],
+        target_kind=row["target_kind"],
+        target_id=row["target_id"],
+        scenario_user_playbook_id=row["scenario_user_playbook_id"],
+        source_interaction_ids=_json_loads(row["source_interaction_ids"]) or [],
+        score=row["score"],
+        verdict=row["verdict"],
+        likert=row["likert"],
+        rationale=row["rationale"],
+        asi_json=row["asi_json"],
+        incumbent_rollout_json=row["incumbent_rollout_json"],
+        candidate_rollout_json=row["candidate_rollout_json"],
+        created_at=row["created_at"],
+    )
 
 
 class PlaybookMixin:
@@ -488,6 +530,36 @@ class PlaybookMixin:
         rows = self._fetchall(sql, params)
         return [_row_to_user_playbook(r) for r in rows]
 
+    @SQLiteStorageBase.handle_exceptions
+    def get_user_playbook_by_id(self, user_playbook_id: int) -> UserPlaybook | None:
+        row = self._fetchone(
+            "SELECT * FROM user_playbooks WHERE user_playbook_id = ?",
+            (user_playbook_id,),
+        )
+        return _row_to_user_playbook(row) if row else None
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_user_playbooks_by_ids_any_user(
+        self,
+        user_playbook_ids: list[int],
+        status_filter: list[Status | None] | None = None,
+    ) -> list[UserPlaybook]:
+        if not user_playbook_ids:
+            return []
+        ph = ",".join("?" for _ in user_playbook_ids)
+        sql = f"SELECT * FROM user_playbooks WHERE user_playbook_id IN ({ph})"  # noqa: S608
+        params: list[Any] = list(user_playbook_ids)
+        if status_filter is not None:
+            frag, sparams = _build_status_sql(status_filter)
+            sql += f" AND {frag}"
+            params.extend(sparams)
+        rows = self._fetchall(sql, params)
+        by_id = {
+            _row_to_user_playbook(row).user_playbook_id: _row_to_user_playbook(row)
+            for row in rows
+        }
+        return [by_id[upid] for upid in user_playbook_ids if upid in by_id]
+
     # ------------------------------------------------------------------
     # Agent Playbook methods
     # ------------------------------------------------------------------
@@ -590,6 +662,14 @@ class PlaybookMixin:
         params.append(limit)
         rows = self._fetchall(sql, params)
         return [_row_to_agent_playbook(r) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_agent_playbook_by_id(self, agent_playbook_id: int) -> AgentPlaybook | None:
+        row = self._fetchone(
+            "SELECT * FROM agent_playbooks WHERE agent_playbook_id = ?",
+            (agent_playbook_id,),
+        )
+        return _row_to_agent_playbook(row) if row else None
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_playbooks(self) -> None:
@@ -790,6 +870,216 @@ class PlaybookMixin:
             f"UPDATE agent_playbooks SET status = NULL WHERE agent_playbook_id IN ({ph}) AND status = 'archived'",
             agent_playbook_ids,
         )
+
+    # ------------------------------------------------------------------
+    # Playbook optimizer methods
+    # ------------------------------------------------------------------
+
+    @SQLiteStorageBase.handle_exceptions
+    def set_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int, user_playbook_ids: list[int]
+    ) -> None:
+        with self._lock:
+            self.conn.execute(
+                "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
+                (agent_playbook_id,),
+            )
+            self.conn.executemany(
+                """INSERT OR IGNORE INTO agent_playbook_source_user_playbooks
+                   (agent_playbook_id, user_playbook_id) VALUES (?, ?)""",
+                [(agent_playbook_id, upid) for upid in user_playbook_ids],
+            )
+            self.conn.commit()
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[int]:
+        rows = self._fetchall(
+            """SELECT user_playbook_id
+               FROM agent_playbook_source_user_playbooks
+               WHERE agent_playbook_id = ?
+               ORDER BY user_playbook_id ASC""",
+            (agent_playbook_id,),
+        )
+        return [int(row["user_playbook_id"]) for row in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def create_playbook_optimization_job(
+        self, job: PlaybookOptimizationJob
+    ) -> PlaybookOptimizationJob:
+        with self._lock:
+            cur = self.conn.execute(
+                """INSERT INTO playbook_optimization_jobs
+                   (target_kind, target_id, status, best_candidate_id,
+                    successor_target_id, decision_reason, metadata_json,
+                    created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    job.target_kind,
+                    job.target_id,
+                    job.status,
+                    job.best_candidate_id,
+                    job.successor_target_id,
+                    job.decision_reason,
+                    job.metadata_json,
+                    job.created_at,
+                    job.updated_at,
+                ),
+            )
+            job.job_id = cur.lastrowid or 0
+            self.conn.commit()
+        return job
+
+    @SQLiteStorageBase.handle_exceptions
+    def update_playbook_optimization_job(
+        self,
+        job_id: int,
+        *,
+        status: str | None = None,
+        best_candidate_id: int | None = None,
+        successor_target_id: int | None = None,
+        decision_reason: str | None = None,
+        metadata_json: str | None = None,
+    ) -> None:
+        updates: list[str] = ["updated_at = strftime('%s','now')"]
+        params: list[Any] = []
+        if status is not None:
+            updates.append("status = ?")
+            params.append(status)
+        if best_candidate_id is not None:
+            updates.append("best_candidate_id = ?")
+            params.append(best_candidate_id)
+        if successor_target_id is not None:
+            updates.append("successor_target_id = ?")
+            params.append(successor_target_id)
+        if decision_reason is not None:
+            updates.append("decision_reason = ?")
+            params.append(decision_reason)
+        if metadata_json is not None:
+            updates.append("metadata_json = ?")
+            params.append(metadata_json)
+        params.append(job_id)
+        self._execute(
+            f"UPDATE playbook_optimization_jobs SET {', '.join(updates)} WHERE job_id = ?",  # noqa: S608
+            tuple(params),
+        )
+
+    @SQLiteStorageBase.handle_exceptions
+    def insert_playbook_optimization_candidate(
+        self, candidate: PlaybookOptimizationCandidate
+    ) -> PlaybookOptimizationCandidate:
+        with self._lock:
+            cur = self.conn.execute(
+                """INSERT INTO playbook_optimization_candidates
+                   (job_id, candidate_index, content, parent_candidate_ids,
+                    aggregate_score, is_winner, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    candidate.job_id,
+                    candidate.candidate_index,
+                    candidate.content,
+                    _json_dumps(candidate.parent_candidate_ids) or "[]",
+                    candidate.aggregate_score,
+                    1 if candidate.is_winner else 0,
+                    candidate.created_at,
+                ),
+            )
+            candidate.candidate_id = cur.lastrowid or 0
+            self.conn.commit()
+        return candidate
+
+    @SQLiteStorageBase.handle_exceptions
+    def list_playbook_optimization_candidates(
+        self, job_id: int
+    ) -> list[PlaybookOptimizationCandidate]:
+        rows = self._fetchall(
+            "SELECT * FROM playbook_optimization_candidates WHERE job_id = ? ORDER BY candidate_id ASC",
+            (job_id,),
+        )
+        return [_row_to_playbook_optimization_candidate(row) for row in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def update_playbook_optimization_candidate(
+        self,
+        candidate_id: int,
+        *,
+        aggregate_score: float | None = None,
+        is_winner: bool | None = None,
+    ) -> None:
+        updates: list[str] = []
+        params: list[Any] = []
+        if aggregate_score is not None:
+            updates.append("aggregate_score = ?")
+            params.append(aggregate_score)
+        if is_winner is not None:
+            updates.append("is_winner = ?")
+            params.append(1 if is_winner else 0)
+        if not updates:
+            return
+        params.append(candidate_id)
+        self._execute(
+            f"UPDATE playbook_optimization_candidates SET {', '.join(updates)} WHERE candidate_id = ?",  # noqa: S608
+            tuple(params),
+        )
+
+    @SQLiteStorageBase.handle_exceptions
+    def insert_playbook_optimization_evaluation(
+        self, evaluation: PlaybookOptimizationEvaluation
+    ) -> PlaybookOptimizationEvaluation:
+        with self._lock:
+            cur = self.conn.execute(
+                """INSERT INTO playbook_optimization_evaluations
+                   (job_id, candidate_id, target_kind, target_id,
+                    scenario_user_playbook_id, source_interaction_ids, score,
+                    verdict, likert, rationale, asi_json, incumbent_rollout_json,
+                    candidate_rollout_json, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    evaluation.job_id,
+                    evaluation.candidate_id,
+                    evaluation.target_kind,
+                    evaluation.target_id,
+                    evaluation.scenario_user_playbook_id,
+                    _json_dumps(evaluation.source_interaction_ids) or "[]",
+                    evaluation.score,
+                    evaluation.verdict,
+                    evaluation.likert,
+                    evaluation.rationale,
+                    evaluation.asi_json,
+                    evaluation.incumbent_rollout_json,
+                    evaluation.candidate_rollout_json,
+                    evaluation.created_at,
+                ),
+            )
+            evaluation.evaluation_id = cur.lastrowid or 0
+            self.conn.commit()
+        return evaluation
+
+    @SQLiteStorageBase.handle_exceptions
+    def list_playbook_optimization_evaluations(
+        self, job_id: int
+    ) -> list[PlaybookOptimizationEvaluation]:
+        rows = self._fetchall(
+            "SELECT * FROM playbook_optimization_evaluations WHERE job_id = ? ORDER BY evaluation_id ASC",
+            (job_id,),
+        )
+        return [_row_to_playbook_optimization_evaluation(row) for row in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def insert_playbook_optimization_event(
+        self, event: PlaybookOptimizationEvent
+    ) -> PlaybookOptimizationEvent:
+        with self._lock:
+            cur = self.conn.execute(
+                """INSERT INTO playbook_optimization_events
+                   (job_id, event_type, payload_json, created_at)
+                   VALUES (?, ?, ?, ?)""",
+                (event.job_id, event.event_type, event.payload_json, event.created_at),
+            )
+            event.event_id = cur.lastrowid or 0
+            self.conn.commit()
+        return event
 
     @SQLiteStorageBase.handle_exceptions
     def delete_archived_agent_playbooks_by_playbook_name(

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -108,3 +108,8 @@ class ExtrasMixin:
             list[Interaction]: List of matching interaction objects
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def get_interactions_by_ids(self, interaction_ids: list[int]) -> list[Interaction]:
+        """Fetch interactions by interaction ids, ordered by created_at."""
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -4,6 +4,10 @@ from reflexio.models.api_schema.common import BlockingIssue
 from reflexio.models.api_schema.domain import (
     AgentPlaybook,
     AgentSuccessEvaluationResult,
+    PlaybookOptimizationCandidate,
+    PlaybookOptimizationEvaluation,
+    PlaybookOptimizationEvent,
+    PlaybookOptimizationJob,
     PlaybookStatus,
     Status,
     UserPlaybook,
@@ -201,6 +205,20 @@ class PlaybookMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def get_user_playbook_by_id(self, user_playbook_id: int) -> UserPlaybook | None:
+        """Fetch one user playbook by id, regardless of owner."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_user_playbooks_by_ids_any_user(
+        self,
+        user_playbook_ids: list[int],
+        status_filter: list[Status | None] | None = None,
+    ) -> list[UserPlaybook]:
+        """Fetch user playbooks by ids without requiring a single owner id."""
+        raise NotImplementedError
+
+    @abstractmethod
     def archive_user_playbook_by_id(self, user_id: str, user_playbook_id: int) -> bool:
         """Atomically archive a single user playbook by id, only if CURRENT.
 
@@ -277,6 +295,11 @@ class PlaybookMixin:
         Returns:
             list[AgentPlaybook]: List of agent playbook objects
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_agent_playbook_by_id(self, agent_playbook_id: int) -> AgentPlaybook | None:
+        """Fetch one agent playbook by id."""
         raise NotImplementedError
 
     @abstractmethod
@@ -417,6 +440,91 @@ class PlaybookMixin:
         Args:
             agent_playbook_ids (list[int]): List of agent playbook IDs to restore
         """
+        raise NotImplementedError
+
+    # ==============================
+    # Playbook optimization methods
+    # ==============================
+
+    @abstractmethod
+    def set_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int, user_playbook_ids: list[int]
+    ) -> None:
+        """Persist the source user playbook ids that produced an agent playbook."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[int]:
+        """Return source user playbook ids for an agent playbook."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_playbook_optimization_job(
+        self, job: PlaybookOptimizationJob
+    ) -> PlaybookOptimizationJob:
+        """Persist a playbook optimization job and return it with id populated."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_playbook_optimization_job(
+        self,
+        job_id: int,
+        *,
+        status: str | None = None,
+        best_candidate_id: int | None = None,
+        successor_target_id: int | None = None,
+        decision_reason: str | None = None,
+        metadata_json: str | None = None,
+    ) -> None:
+        """Update mutable fields on a playbook optimization job."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def insert_playbook_optimization_candidate(
+        self, candidate: PlaybookOptimizationCandidate
+    ) -> PlaybookOptimizationCandidate:
+        """Persist an optimizer candidate and return it with id populated."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_playbook_optimization_candidates(
+        self, job_id: int
+    ) -> list[PlaybookOptimizationCandidate]:
+        """List optimizer candidates for a job."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_playbook_optimization_candidate(
+        self,
+        candidate_id: int,
+        *,
+        aggregate_score: float | None = None,
+        is_winner: bool | None = None,
+    ) -> None:
+        """Update mutable optimizer candidate result fields."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def insert_playbook_optimization_evaluation(
+        self, evaluation: PlaybookOptimizationEvaluation
+    ) -> PlaybookOptimizationEvaluation:
+        """Persist an optimizer evaluation and return it with id populated."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_playbook_optimization_evaluations(
+        self, job_id: int
+    ) -> list[PlaybookOptimizationEvaluation]:
+        """List optimizer evaluations for a job."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def insert_playbook_optimization_event(
+        self, event: PlaybookOptimizationEvent
+    ) -> PlaybookOptimizationEvent:
+        """Persist an optimizer callback/event and return it with id populated."""
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -53,6 +53,7 @@ from reflexio.models.config_schema import (
     OpenAIConfig,
     PlaybookAggregatorConfig,
     PlaybookConfig,
+    PlaybookOptimizerConfig,
     ProfileExtractorConfig,
     StorageConfigSQLite,
     ToolUseConfig,
@@ -683,6 +684,38 @@ class TestCrossFieldValidators:
             config.user_playbook_extractor_configs[0].extractor_name
             == "default_playbook_extractor"
         )
+
+    def test_playbook_optimizer_accepts_webhook_backend(self):
+        """PlaybookOptimizerConfig: webhook-only assistant backend is valid."""
+        config = PlaybookOptimizerConfig(webhook_url="https://assistant.example.test")
+
+        assert config.webhook_url == "https://assistant.example.test"
+        assert config.assistant_script_path is None
+
+    def test_playbook_optimizer_accepts_script_backend(self):
+        """PlaybookOptimizerConfig: script-only assistant backend is valid."""
+        config = PlaybookOptimizerConfig(
+            assistant_script_path="/usr/bin/python3",
+            assistant_script_args=["assistant.py"],
+        )
+
+        assert config.assistant_script_path == "/usr/bin/python3"
+        assert config.assistant_script_args == ["assistant.py"]
+
+    def test_playbook_optimizer_accepts_no_assistant_backend(self):
+        """PlaybookOptimizerConfig: no backend is valid so optimizer can skip."""
+        config = PlaybookOptimizerConfig()
+
+        assert config.webhook_url is None
+        assert config.assistant_script_path is None
+
+    def test_playbook_optimizer_rejects_multiple_assistant_backends(self):
+        """PlaybookOptimizerConfig: webhook and script are mutually exclusive."""
+        with pytest.raises(ValidationError, match="only one"):
+            PlaybookOptimizerConfig(
+                webhook_url="https://assistant.example.test",
+                assistant_script_path="/usr/bin/python3",
+            )
 
 
 # =============================================================================

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -1,0 +1,546 @@
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from reflexio.models.api_schema.domain import (
+    AgentPlaybook,
+    Interaction,
+    PlaybookOptimizationCandidate,
+    PlaybookOptimizationEvaluation,
+    PlaybookOptimizationJob,
+    PlaybookStatus,
+    Request,
+    Status,
+    UserPlaybook,
+)
+from reflexio.models.config_schema import (
+    Config,
+    PlaybookOptimizerConfig,
+    StorageConfigSQLite,
+)
+from reflexio.server.services.playbook_optimizer import (
+    PlaybookOptimizationScheduler,
+    PlaybookOptimizationTarget,
+)
+from reflexio.server.services.playbook_optimizer.assistant_webhook import (
+    LocalScriptAssistant,
+    LocalScriptFailedError,
+)
+from reflexio.server.services.playbook_optimizer.gepa_adapter import (
+    PLAYBOOK_CONTENT_COMPONENT,
+    ReflexioPlaybookGEPAAdapter,
+)
+from reflexio.server.services.playbook_optimizer.judge import JudgeOutput
+from reflexio.server.services.playbook_optimizer.models import (
+    ChatMessage,
+    JudgeASI,
+    ScenarioWindow,
+)
+from reflexio.server.services.playbook_optimizer.optimizer import PlaybookOptimizer
+from reflexio.server.services.playbook_optimizer.rollout import MultiTurnRollout
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+def _sqlite_storage(tmp_path):
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage = SQLiteStorage(
+            org_id="opt-test", db_path=str(tmp_path / "reflexio.db")
+        )
+    storage._get_embedding = Mock(return_value=[0.0] * 512)  # noqa: SLF001
+    storage.llm_client.get_embeddings = Mock(return_value=[[0.0] * 512])
+    return storage
+
+
+def _optimizer_for_test(storage, config) -> PlaybookOptimizer:
+    context = SimpleNamespace(
+        storage=storage,
+        configurator=SimpleNamespace(get_config=lambda: config),
+    )
+    llm_client = SimpleNamespace(config=SimpleNamespace(model="fake-model"))
+    return PlaybookOptimizer(cast(Any, context), cast(Any, llm_client))
+
+
+def test_local_script_assistant_sends_payload_and_parses_content(tmp_path):
+    script = tmp_path / "assistant.py"
+    record = tmp_path / "payload.json"
+    script.write_text(
+        """
+import json
+import sys
+from pathlib import Path
+
+payload = json.load(sys.stdin)
+Path(sys.argv[1]).write_text(json.dumps(payload))
+json.dump({"content": "script:" + payload["playbooks"][0]["content"] + ":" + sys.argv[2]}, sys.stdout)
+""".strip(),
+        encoding="utf-8",
+    )
+    assistant = LocalScriptAssistant(
+        script_path=sys.executable,
+        script_args=[str(script), str(record), "extra-arg"],
+        timeout_s=5,
+        max_retries=0,
+        backoff_base_s=0.0,
+    )
+
+    content = assistant(
+        [ChatMessage(role="user", content="hello")],
+        [
+            AgentPlaybook(
+                agent_playbook_id=7,
+                playbook_name="support",
+                agent_version="v1",
+                content="candidate content",
+                trigger="when asked",
+            )
+        ],
+    )
+
+    assert content == "script:candidate content:extra-arg"
+    payload = record.read_text(encoding="utf-8")
+    assert "hello" in payload
+    assert '"playbooks"' in payload
+    assert "candidate content" in payload
+
+
+@pytest.mark.parametrize(
+    ("script_body", "match"),
+    [
+        ("import sys; print('bad', file=sys.stderr); raise SystemExit(2)", "code 2"),
+        ("print('not json')", "invalid JSON"),
+        (
+            "import json; json.dump({'text': 'missing'}, __import__('sys').stdout)",
+            "no content",
+        ),
+    ],
+)
+def test_local_script_assistant_reports_script_failures(tmp_path, script_body, match):
+    script = tmp_path / "assistant.py"
+    script.write_text(script_body, encoding="utf-8")
+    assistant = LocalScriptAssistant(
+        script_path=sys.executable,
+        script_args=[str(script)],
+        timeout_s=5,
+        max_retries=0,
+        backoff_base_s=0.0,
+    )
+
+    with pytest.raises(LocalScriptFailedError, match=match):
+        assistant([], [])
+
+
+def test_local_script_assistant_times_out(tmp_path):
+    script = tmp_path / "assistant.py"
+    script.write_text("import time; time.sleep(5)", encoding="utf-8")
+    assistant = LocalScriptAssistant(
+        script_path=sys.executable,
+        script_args=[str(script)],
+        timeout_s=1,
+        max_retries=0,
+        backoff_base_s=0.0,
+    )
+
+    with pytest.raises(LocalScriptFailedError, match="timed out"):
+        assistant([], [])
+
+
+def test_adapter_calls_assistant_with_same_seed_and_different_content(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    job = storage.create_playbook_optimization_job(
+        PlaybookOptimizationJob(target_kind="agent_playbook", target_id=1)
+    )
+    incumbent = AgentPlaybook(
+        agent_playbook_id=1,
+        playbook_name="support",
+        agent_version="v1",
+        content="incumbent content",
+    )
+    assistant = Mock(return_value="assistant response")
+    judge = Mock()
+    judge.judge.return_value = JudgeOutput(
+        verdict="candidate",
+        score=0.9,
+        likert=5,
+        rationale="candidate wins",
+        asi=JudgeASI(winning_behaviors=["clearer response"]),
+    )
+    adapter = ReflexioPlaybookGEPAAdapter(
+        storage=storage,
+        job_id=job.job_id,
+        target_kind="agent_playbook",
+        target_id=1,
+        incumbent=incumbent,
+        rollout=MultiTurnRollout(assistant),
+        judge=judge,
+        max_turns=1,
+    )
+
+    batch = adapter.evaluate(
+        [
+            ScenarioWindow(
+                user_playbook_id=11,
+                source_interaction_ids=[101],
+                interactions=[
+                    Interaction(
+                        interaction_id=101,
+                        user_id="u1",
+                        request_id="r1",
+                        role="User",
+                        content="Please summarize this.",
+                    )
+                ],
+            )
+        ],
+        {PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+        capture_traces=True,
+    )
+
+    assert batch.scores == [0.9]
+    assert assistant.call_count == 2
+    incumbent_call, candidate_call = assistant.call_args_list
+    assert incumbent_call.args[0] == candidate_call.args[0]
+    assert incumbent_call.args[1][0].content == "incumbent content"
+    assert candidate_call.args[1][0].content == "candidate content"
+    evaluations = storage.list_playbook_optimization_evaluations(job.job_id)
+    assert len(evaluations) == 1
+    assert evaluations[0].verdict == "candidate"
+
+
+def test_optimizer_skips_approved_agent_playbooks(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    saved = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="approved content",
+                playbook_status=PlaybookStatus.APPROVED,
+            )
+        ]
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            enabled=True,
+            webhook_url="https://assistant.example.test/rollout",
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    optimizer._run_gepa = Mock(side_effect=AssertionError("GEPA should not run"))  # type: ignore[method-assign]
+
+    optimizer.optimize(
+        PlaybookOptimizationTarget(
+            kind="agent_playbook", target_id=saved[0].agent_playbook_id
+        )
+    )
+
+    current = storage.get_agent_playbook_by_id(saved[0].agent_playbook_id)
+    assert current is not None
+    assert current.playbook_status == PlaybookStatus.APPROVED
+    assert current.status is None
+    optimizer._run_gepa.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_optimizer_skips_when_no_assistant_backend_configured(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    saved = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="pending content",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(enabled=True),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    optimizer._run_gepa = Mock(side_effect=AssertionError("GEPA should not run"))  # type: ignore[method-assign]
+
+    optimizer.optimize(
+        PlaybookOptimizationTarget(
+            kind="agent_playbook", target_id=saved[0].agent_playbook_id
+        )
+    )
+
+    optimizer._run_gepa.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_optimizer_selects_local_script_assistant(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(
+        enabled=True,
+        assistant_script_path=sys.executable,
+        assistant_script_args=["assistant.py"],
+    )
+    optimizer = _optimizer_for_test(storage, config)
+
+    assistant = optimizer._create_assistant(config)
+
+    assert isinstance(assistant, LocalScriptAssistant)
+    assert assistant.command == [sys.executable, "assistant.py"]
+
+
+def test_optimizer_runs_local_script_assistant_and_persists_evaluation(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    script = tmp_path / "assistant.py"
+    record = tmp_path / "assistant_calls.jsonl"
+    script.write_text(
+        """
+import json
+import sys
+from pathlib import Path
+
+payload = json.load(sys.stdin)
+with Path(sys.argv[1]).open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(payload) + "\\n")
+json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys.stdout)
+""".strip(),
+        encoding="utf-8",
+    )
+    with (
+        patch.object(storage, "_get_embedding", return_value=[0.0] * 512),
+        patch.object(storage.llm_client, "get_embeddings", return_value=[[0.0] * 512]),
+    ):
+        storage.add_request(
+            Request(
+                request_id="request-1",
+                user_id="u1",
+                source="test",
+                agent_version="v1",
+            )
+        )
+        storage.add_user_interactions_bulk(
+            "u1",
+            [
+                Interaction(
+                    interaction_id=1,
+                    user_id="u1",
+                    request_id="request-1",
+                    role="User",
+                    content="Please summarize this.",
+                )
+            ],
+        )
+        user_playbook = UserPlaybook(
+            user_id="u1",
+            agent_version="v1",
+            request_id="request-1",
+            playbook_name="support",
+            content="source content",
+            source_interaction_ids=[1],
+        )
+        storage.save_user_playbooks([user_playbook])
+        [agent_playbook] = storage.save_agent_playbooks(
+            [
+                AgentPlaybook(
+                    playbook_name="support",
+                    agent_version="v1",
+                    content="incumbent content",
+                    playbook_status=PlaybookStatus.PENDING,
+                )
+            ]
+        )
+    storage.set_source_user_playbook_ids_for_agent_playbook(
+        agent_playbook.agent_playbook_id, [user_playbook.user_playbook_id]
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            enabled=True,
+            assistant_script_path=sys.executable,
+            assistant_script_args=[str(script), str(record)],
+            allow_single_window_commit=True,
+            auto_update_pending_agent_playbooks=False,
+            min_commit_windows=1,
+            min_commit_score=0.1,
+            min_commit_likert=1,
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+
+    def fake_run_gepa(config, seed_content, windows, adapter):  # noqa: ARG001
+        adapter.judge = Mock()
+        adapter.judge.judge.return_value = JudgeOutput(
+            verdict="candidate",
+            score=0.9,
+            likert=5,
+            rationale="candidate wins",
+            asi=JudgeASI(winning_behaviors=["clearer response"]),
+        )
+        adapter.evaluate(
+            windows,
+            {PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+            capture_traces=True,
+        )
+        return SimpleNamespace(
+            best_candidate={PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+            val_aggregate_scores=[0.9],
+            best_idx=0,
+            to_dict=lambda: {"best_idx": 0},
+        )
+
+    optimizer._run_gepa = fake_run_gepa  # type: ignore[method-assign]
+
+    optimizer.optimize(
+        PlaybookOptimizationTarget(
+            kind="agent_playbook", target_id=agent_playbook.agent_playbook_id
+        )
+    )
+
+    calls = record.read_text(encoding="utf-8").splitlines()
+    assert len(calls) == 2
+    assert "incumbent content" in calls[0]
+    assert "candidate content" in calls[1]
+    jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
+    assert jobs[0]["status"] == "completed"
+    evaluations = storage.list_playbook_optimization_evaluations(jobs[0]["job_id"])
+    assert len(evaluations) == 1
+    assert evaluations[0].verdict == "candidate"
+
+
+def test_sqlite_persists_source_mapping_and_winner_candidate(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    storage.set_source_user_playbook_ids_for_agent_playbook(10, [2, 3, 2])
+    assert storage.get_source_user_playbook_ids_for_agent_playbook(10) == [2, 3]
+
+    job = storage.create_playbook_optimization_job(
+        PlaybookOptimizationJob(target_kind="agent_playbook", target_id=10)
+    )
+    candidate = storage.insert_playbook_optimization_candidate(
+        PlaybookOptimizationCandidate(
+            job_id=job.job_id,
+            candidate_index=0,
+            content="candidate",
+        )
+    )
+    storage.update_playbook_optimization_candidate(
+        candidate.candidate_id,
+        aggregate_score=0.86,
+        is_winner=True,
+    )
+
+    [persisted] = storage.list_playbook_optimization_candidates(job.job_id)
+    assert persisted.aggregate_score == 0.86
+    assert persisted.is_winner is True
+
+
+def test_commit_thresholds_only_count_winner_candidate(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    job = storage.create_playbook_optimization_job(
+        PlaybookOptimizationJob(target_kind="agent_playbook", target_id=10)
+    )
+    losing_candidate = storage.insert_playbook_optimization_candidate(
+        PlaybookOptimizationCandidate(job_id=job.job_id, content="losing")
+    )
+    winner_candidate = storage.insert_playbook_optimization_candidate(
+        PlaybookOptimizationCandidate(job_id=job.job_id, content="winner")
+    )
+    storage.insert_playbook_optimization_evaluation(
+        PlaybookOptimizationEvaluation(
+            job_id=job.job_id,
+            candidate_id=losing_candidate.candidate_id,
+            target_kind="agent_playbook",
+            target_id=10,
+            scenario_user_playbook_id=1,
+            score=0.95,
+            verdict="candidate",
+            likert=5,
+        )
+    )
+    config = PlaybookOptimizerConfig(
+        min_commit_windows=1,
+        min_commit_score=0.75,
+        min_commit_likert=4,
+    )
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+
+    assert not optimizer._passes_commit_thresholds(  # noqa: SLF001
+        job.job_id, winner_candidate.candidate_id, 0.95, config
+    )
+
+    storage.insert_playbook_optimization_evaluation(
+        PlaybookOptimizationEvaluation(
+            job_id=job.job_id,
+            candidate_id=winner_candidate.candidate_id,
+            target_kind="agent_playbook",
+            target_id=10,
+            scenario_user_playbook_id=2,
+            score=0.9,
+            verdict="candidate",
+            likert=5,
+        )
+    )
+    assert optimizer._passes_commit_thresholds(  # noqa: SLF001
+        job.job_id, winner_candidate.candidate_id, 0.95, config
+    )
+
+
+def test_disk_any_user_playbook_lookup_none_status_filter_means_all(tmp_path):
+    from reflexio.server.services.storage.disk_storage import DiskStorage
+
+    with patch(
+        "reflexio.server.services.storage.disk_storage._base.QMDClient",
+        return_value=MagicMock(),
+    ):
+        storage = DiskStorage(org_id="opt-disk-test", base_dir=str(tmp_path))
+
+    archived = UserPlaybook(
+        user_playbook_id=7,
+        user_id="u1",
+        agent_version="v1",
+        request_id="r1",
+        playbook_name="support",
+        content="archived source",
+        status=Status.ARCHIVED,
+    )
+    storage.save_user_playbooks([archived])
+
+    assert storage.get_user_playbooks_by_ids_any_user([7], status_filter=None) == [
+        archived
+    ]
+    assert storage.get_user_playbooks_by_ids_any_user([7], status_filter=[None]) == []
+
+
+def test_scheduler_applies_abort_cooldown():
+    scheduler = PlaybookOptimizationScheduler.__new__(PlaybookOptimizationScheduler)
+    scheduler._scheduled = {}  # noqa: SLF001
+    scheduler._heap = []  # noqa: SLF001
+    scheduler._mutex = threading.Lock()  # noqa: SLF001
+    scheduler._wake_event = threading.Event()  # noqa: SLF001
+    scheduler._abort_counts = {}  # noqa: SLF001
+    key = ("org", "agent_playbook", 1)
+
+    scheduler._record_abort(key, abort_threshold=2, cooldown_seconds=60)  # noqa: SLF001
+    with scheduler._mutex:  # noqa: SLF001
+        assert scheduler._cooldown_remaining_locked(key, time.monotonic()) == 0  # noqa: SLF001
+
+    scheduler._record_abort(key, abort_threshold=2, cooldown_seconds=60)  # noqa: SLF001
+    with scheduler._mutex:  # noqa: SLF001
+        assert scheduler._cooldown_remaining_locked(key, time.monotonic()) > 0  # noqa: SLF001
+
+    target = PlaybookOptimizationTarget(kind="agent_playbook", target_id=1)
+    scheduler.enqueue(
+        org_id="org",
+        target=target,
+        callback=lambda: "completed",
+        abort_cooldown_threshold=2,
+        cooldown_after_aborts_seconds=60,
+    )
+    assert scheduler._scheduled == {}  # noqa: SLF001

--- a/uv.lock
+++ b/uv.lock
@@ -1551,6 +1551,15 @@ http = [
 ]
 
 [[package]]
+name = "gepa"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/62/10f5a8f24c075e3b64f952be73ba8e15f0055584bbcdf9ce48d754a36679/gepa-0.1.1.tar.gz", hash = "sha256:643fda01c23de4c9f01306e01305dd69facc29bcb34ad59e4cd07e6621d34aa1", size = 272251, upload-time = "2026-03-16T10:17:53.131Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/b7/8c72dedbb950d88a6f64588fcbc590d2a21e2b9f19b36aa6c5016c54ec75/gepa-0.1.1-py3-none-any.whl", hash = "sha256:71ead7c591eafcc727b83509cdc4182f20264800a6ddf8520d61419daeb47466", size = 244246, upload-time = "2026-03-16T10:17:51.922Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5076,6 +5085,7 @@ dependencies = [
     { name = "colorlog" },
     { name = "duckduckgo-search" },
     { name = "fastapi" },
+    { name = "gepa" },
     { name = "hdbscan" },
     { name = "httpx" },
     { name = "json-repair" },
@@ -5167,6 +5177,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.111.1" },
     { name = "fire", marker = "extra == 'benchmark'", specifier = ">=0.7.1" },
     { name = "fpdf2", marker = "extra == 'benchmark'", specifier = ">=2.8.7" },
+    { name = "gepa", specifier = ">=0.1.1,<0.2" },
     { name = "hdbscan", specifier = ">=0.8.40" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "json-repair", specifier = ">=0.30.0" },


### PR DESCRIPTION
## Summary

- Adds a GEPA-driven playbook content optimizer that runs paired multi-turn rollouts of an incumbent and a candidate playbook against a real assistant, then uses an LLM judge to pick a winner — and (gated by thresholds) commits a successor playbook.
- Introduces a pluggable assistant-backend layer with two concrete backends today: `WebhookAssistant` (HTTP POST) for production and `LocalScriptAssistant` (subprocess + JSON over stdin/stdout) for local dev / CI / offline evaluation. Both satisfy the same `AssistantCallable` protocol; selection is config-driven and the two are mutually exclusive.
- Wires the optimizer into the existing playbook generation flow: after agent/user playbooks are saved, a process-local scheduler (debounced + jittered, with abort cooldown) enqueues an optimization run.
- Persists every job, candidate, evaluation, and GEPA event for offline inspection across both SQLite and disk storage backends.

## Changes

### Optimizer service (new package: `reflexio/server/services/playbook_optimizer/`)
- `optimizer.py` — `PlaybookOptimizer.optimize(target)` orchestrates one run: backend selection, scenario windows, GEPA loop, threshold gating, successor commit.
- `assistant_webhook.py` — `WebhookAssistant`, `LocalScriptAssistant`, `AssistantCallable` protocol, `AssistantFailedError` hierarchy, shared payload builder.
- `gepa_adapter.py` — `ReflexioPlaybookGEPAAdapter` runs two rollouts per `(candidate, window)` and persists evaluations; absorbs backend faults as `verdict='aborted'`.
- `rollout.py` — `MultiTurnRollout` replays the user side of a scenario verbatim so paired runs differ only in playbook content.
- `judge.py` — `PairwiseJudge` LLM call using the new `playbook_optimizer_judge/v1.0.0` prompt template.
- `scenario_resolver.py` — builds `ScenarioWindow` lists from playbook lineage.
- `scheduler.py` — singleton scheduler with debounce, jitter, and abort cooldown.
- `models.py` — in-process Pydantic models (`ChatMessage`, `ScenarioWindow`, `RolloutTrace`, `JudgeOutput`, etc.).

### Domain entities (`reflexio/models/api_schema/domain/entities.py`)
- New: `PlaybookOptimizationJob`, `PlaybookOptimizationCandidate`, `PlaybookOptimizationEvaluation`, `PlaybookOptimizationEvent`.

### Config (`reflexio/models/config_schema.py`)
- New `PlaybookOptimizerConfig` with gating, GEPA budget, commit thresholds, scheduler tuning, and the two backend configs.
- `webhook_url` / `assistant_script_path` are mutually exclusive (validator); the `webhook_*` retry/timeout fields apply to both backends.

### Storage layer
- New abstract methods in `storage_base/_playbook.py` and `_extras.py` for source-mapping, optimization jobs/candidates/evaluations/events, and `get_interactions_by_ids`.
- Implementations in both `sqlite_storage/` (with new tables + indexes) and `disk_storage/`.

### Aggregator + generation wiring
- `playbook_aggregator.py` now persists the `agent_playbook → source user_playbook` mapping per cluster (replaces the prior fingerprint-rematch heuristic) and enqueues optimization for each PENDING agent playbook.
- `playbook_generation_service.py` enqueues optimization for new user playbooks (gated by `optimize_user_playbooks`).

### Tests
- `tests/server/services/playbook_optimizer/test_playbook_optimizer.py` — adapter pairing, optimizer-skips-approved, source-mapping persistence (SQLite, real DB).
- `tests/models/test_validators.py` — four new tests covering the mutual-exclusivity validator (webhook-only, script-only, neither, both).

### Docs & deps
- `docs/playbook_optimizer_assistant_backends.md` — explanatory tech design doc with architecture diagram, backend protocol, config reference, end-to-end workflow, code map.
- `pyproject.toml` / `uv.lock` — add `gepa>=0.1.1,<0.2`.

## Diagrams

```mermaid
flowchart TB
    A[PlaybookAggregator / PlaybookGenerationService] -->|enqueue| S[PlaybookOptimizationScheduler<br/>debounce + jitter + abort cooldown]
    S -->|callback| O[PlaybookOptimizer.optimize]
    O -->|_create_assistant| BSEL{backend?}
    BSEL -->|webhook_url| WH[WebhookAssistant<br/>HTTP POST]
    BSEL -->|assistant_script_path| LS[LocalScriptAssistant<br/>subprocess + stdin/stdout]
    BSEL -->|neither| NOOP[noop, log + return]
    O --> R[ScenarioResolver -> windows]
    O --> G[gepa.optimize<br/>seed = incumbent.content]
    G --> AD[ReflexioPlaybookGEPAAdapter.evaluate]
    AD --> RIN[MultiTurnRollout<br/>incumbent]
    AD --> RCAND[MultiTurnRollout<br/>candidate]
    RIN --> WH
    RIN --> LS
    RCAND --> WH
    RCAND --> LS
    AD --> J[PairwiseJudge<br/>LLM verdict + score + likert]
    AD --> P[(playbook_optimization_<br/>jobs / candidates /<br/>evaluations / events)]
    O --> C[_commit_if_allowed<br/>archive incumbent, save successor]
```

Both rollouts call the *same* backend instance — only the playbook injected into the assistant differs, which is what makes the judge's verdict meaningful.

## Test Plan

- [x] `uv run pytest tests/models/test_validators.py -k playbook_optimizer` — config validator tests (all four cases).
- [x] `uv run pytest tests/server/services/playbook_optimizer/` — adapter / optimizer / sqlite-persistence tests.
- [ ] Smoke-test the local-script backend end-to-end with a stub script (`echo: <last user>`):
  - [ ] Set `playbook_optimizer_config.enabled = true`, `assistant_script_path = /usr/bin/python3`, `assistant_script_args = [/path/to/echo.py]`.
  - [ ] Trigger an aggregation and confirm rows appear in `playbook_optimization_jobs`, `_candidates`, `_evaluations`.
- [ ] Smoke-test the webhook backend against a local FastAPI stub returning `{"content": "..."}`.
- [ ] Verify the mutual-exclusion validator: setting both `webhook_url` and `assistant_script_path` rejects on config load.
- [ ] Verify aborted evaluations: point `assistant_script_path` at `/bin/false` and confirm the job ends with `status='failed'` and `decision_reason='assistant backend aborted one or more evaluations'`.
