### PR TITLE
feat(playbook_optimizer): structured logs for optimization lifecycle

### DIFF
--- a/reflexio/server/services/playbook_optimizer/gepa_adapter.py
+++ b/reflexio/server/services/playbook_optimizer/gepa_adapter.py
@@ -118,6 +118,16 @@ class ReflexioPlaybookGEPAAdapter:
                     candidate_rollout_json=output.candidate_rollout.model_dump_json(),
                 )
             )
+            logger.info(
+                "event=playbook_optimization_evaluation job_id=%d candidate_id=%d "
+                "scenario_user_playbook_id=%s verdict=%s score=%.3f likert=%d",
+                self.job_id,
+                persisted_candidate.candidate_id,
+                window.user_playbook_id,
+                output.verdict,
+                output.score,
+                output.likert,
+            )
 
         return EvaluationBatch(
             outputs=outputs,

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -105,6 +105,17 @@ class PlaybookOptimizer:
                 ),
             )
         )
+        logger.info(
+            "event=playbook_optimization_start job_id=%d target_kind=%s target_id=%d "
+            "windows=%d backend=%s max_metric_calls=%d max_turns=%d",
+            job.job_id,
+            target.kind,
+            target.target_id,
+            len(windows),
+            type(assistant).__name__,
+            config.max_metric_calls,
+            config.max_turns,
+        )
 
         adapter = ReflexioPlaybookGEPAAdapter(
             storage=self.storage,
@@ -136,6 +147,13 @@ class PlaybookOptimizer:
             else str(best)
         )
         best_score = float(result.val_aggregate_scores[result.best_idx])
+        logger.info(
+            "event=gepa_run_end job_id=%d best_idx=%d best_score=%.3f num_candidates=%d",
+            job.job_id,
+            result.best_idx,
+            best_score,
+            len(result.val_aggregate_scores),
+        )
         winner_candidate = adapter._ensure_candidate(best_content)
         self.storage.update_playbook_optimization_candidate(
             winner_candidate.candidate_id,
@@ -144,6 +162,12 @@ class PlaybookOptimizer:
         )
 
         if self._has_aborted_evaluations(job.job_id):
+            logger.warning(
+                "event=playbook_optimization_aborted job_id=%d "
+                "reason='assistant backend aborted one or more evaluations' best_score=%.3f",
+                job.job_id,
+                best_score,
+            )
             self.storage.update_playbook_optimization_job(
                 job.job_id,
                 status="failed",
@@ -158,6 +182,13 @@ class PlaybookOptimizer:
         if not self._passes_commit_thresholds(
             job.job_id, winner_candidate.candidate_id, best_score, config
         ):
+            logger.info(
+                "event=playbook_optimization_no_commit job_id=%d "
+                "best_candidate_id=%d best_score=%.3f reason='did not pass commit thresholds'",
+                job.job_id,
+                winner_candidate.candidate_id,
+                best_score,
+            )
             self.storage.update_playbook_optimization_job(
                 job.job_id,
                 status="completed",
@@ -170,6 +201,14 @@ class PlaybookOptimizer:
             return "completed"
 
         successor_id = self._commit_if_allowed(target, incumbent, best_content, config)
+        logger.info(
+            "event=playbook_optimization_committed job_id=%d "
+            "best_candidate_id=%d successor_target_id=%s best_score=%.3f",
+            job.job_id,
+            winner_candidate.candidate_id,
+            successor_id if successor_id is not None else "none",
+            best_score,
+        )
         self.storage.update_playbook_optimization_job(
             job.job_id,
             status="completed",

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -106,7 +106,8 @@ class PlaybookOptimizer:
             )
         )
         logger.info(
-            "event=playbook_optimization_start job_id=%d target_kind=%s target_id=%d "
+            "event=playbook_optimization_start job_id=%d candidate_id=none "
+            "target_kind=%s target_id=%d "
             "windows=%d backend=%s max_metric_calls=%d max_turns=%d",
             job.job_id,
             target.kind,
@@ -147,25 +148,28 @@ class PlaybookOptimizer:
             else str(best)
         )
         best_score = float(result.val_aggregate_scores[result.best_idx])
-        logger.info(
-            "event=gepa_run_end job_id=%d best_idx=%d best_score=%.3f num_candidates=%d",
-            job.job_id,
-            result.best_idx,
-            best_score,
-            len(result.val_aggregate_scores),
-        )
         winner_candidate = adapter._ensure_candidate(best_content)
         self.storage.update_playbook_optimization_candidate(
             winner_candidate.candidate_id,
             aggregate_score=best_score,
             is_winner=True,
         )
+        logger.info(
+            "event=gepa_run_end job_id=%d candidate_id=%d "
+            "best_idx=%d best_score=%.3f num_candidates=%d",
+            job.job_id,
+            winner_candidate.candidate_id,
+            result.best_idx,
+            best_score,
+            len(result.val_aggregate_scores),
+        )
 
         if self._has_aborted_evaluations(job.job_id):
             logger.warning(
-                "event=playbook_optimization_aborted job_id=%d "
+                "event=playbook_optimization_aborted job_id=%d candidate_id=%d "
                 "reason='assistant backend aborted one or more evaluations' best_score=%.3f",
                 job.job_id,
+                winner_candidate.candidate_id,
                 best_score,
             )
             self.storage.update_playbook_optimization_job(
@@ -183,8 +187,8 @@ class PlaybookOptimizer:
             job.job_id, winner_candidate.candidate_id, best_score, config
         ):
             logger.info(
-                "event=playbook_optimization_no_commit job_id=%d "
-                "best_candidate_id=%d best_score=%.3f reason='did not pass commit thresholds'",
+                "event=playbook_optimization_no_commit job_id=%d candidate_id=%d "
+                "best_score=%.3f reason='did not pass commit thresholds'",
                 job.job_id,
                 winner_candidate.candidate_id,
                 best_score,
@@ -202,8 +206,8 @@ class PlaybookOptimizer:
 
         successor_id = self._commit_if_allowed(target, incumbent, best_content, config)
         logger.info(
-            "event=playbook_optimization_committed job_id=%d "
-            "best_candidate_id=%d successor_target_id=%s best_score=%.3f",
+            "event=playbook_optimization_committed job_id=%d candidate_id=%d "
+            "successor_target_id=%s best_score=%.3f",
             job.job_id,
             winner_candidate.candidate_id,
             successor_id if successor_id is not None else "none",


### PR DESCRIPTION
## Summary
- Add structured `event=...` log lines at the key lifecycle points of a playbook optimization run so operators can trace job progress without reading raw GEPA traces.
- Logs cover: optimization start, per-evaluation verdict/score, GEPA run end, abort, no-commit, and successful commit.
- All lifecycle events use a normalized `candidate_id` key (`none` before a winner exists, the winner's candidate id afterwards) so log lines can be correlated by `(job_id, candidate_id)`.

## Changes
- `reflexio/server/services/playbook_optimizer/optimizer.py`: emit structured logs for `playbook_optimization_start`, `gepa_run_end`, `playbook_optimization_aborted`, `playbook_optimization_no_commit`, and `playbook_optimization_committed`. Standardize the candidate field on `candidate_id` across all five events; move the `gepa_run_end` log after the winner candidate is ensured so it can include the same key.
- `reflexio/server/services/playbook_optimizer/gepa_adapter.py`: emit a `playbook_optimization_evaluation` log per candidate evaluation with verdict, score, and likert.

## Test Plan
- [ ] Run an end-to-end playbook optimization job and confirm the new log lines appear in order (`start` → `evaluation`* → `gepa_run_end` → one of `committed`/`no_commit`/`aborted`).
- [ ] Verify every line carries `job_id=...` and `candidate_id=...` (with `candidate_id=none` only on `start`) so logs can be correlated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging for playbook optimization evaluations with detailed performance metrics including job ID, candidate identification, and evaluation scores.
  * Added comprehensive structured event logging throughout the optimization workflow capturing key stages: optimization initiation, evaluation results, abort scenarios, threshold assessment outcomes, and successful commit events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
