### PR TITLE
feat(playbook-optimizer): replayable source windows + train/validation split

### DIFF
--- a/docs/playbook_optimizer_assistant_backends.md
+++ b/docs/playbook_optimizer_assistant_backends.md
@@ -294,6 +294,7 @@ All fields live on `PlaybookOptimizerConfig` (in `reflexio/models/config_schema.
 |---|---|---|---|
 | `assistant_script_path` | `str \| None` | `None` | Absolute path to the executable. Set this to enable the script backend. |
 | `assistant_script_args` | `list[str]` | `[]` | Extra argv tokens passed after `assistant_script_path`. |
+| `max_validation_windows` | `int > 0` | 2 | Maximum source windows held out for validation; all remaining source windows form the GEPA training pool. |
 
 ### 6.2 Existing fields that now apply to both backends
 
@@ -304,6 +305,7 @@ All fields live on `PlaybookOptimizerConfig` (in `reflexio/models/config_schema.
 | `webhook_timeout_seconds` | `int > 0` | 60 | Per-call timeout — both backends |
 | `webhook_max_retries` | `int >= 0` | 3 | Retry budget — both backends |
 | `webhook_backoff_base_seconds` | `float >= 0` | 1.0 | Exponential base — both backends |
+| `reflection_minibatch_size` | `int > 0` | 2 | Number of training windows GEPA samples for each reflection minibatch |
 
 ### 6.3 Validator
 
@@ -349,7 +351,7 @@ What happens, in order, when a new agent playbook is generated and the optimizer
 | 1 | `PlaybookAggregator._enqueue_playbook_optimization` | After saving new agent playbooks, enqueues each PENDING playbook with the scheduler. |
 | 2 | `PlaybookOptimizationScheduler` | Debounces by `(org_id, kind, target_id)`, fires after a small jitter, spawns a daemon thread. |
 | 3 | `PlaybookOptimizer.optimize(target)` | Loads config, calls `_create_assistant` → backend instance (or returns early). |
-| 4 | `ScenarioResolver` | Builds `ScenarioWindow`s from the playbook's `source_interaction_ids`. |
+| 4 | `ScenarioResolver` | Builds `ScenarioWindow`s from snapshotted agent source windows or a user playbook's `source_interaction_ids`. |
 | 5 | `gepa.api.optimize(...)` | Runs the candidate-search loop. |
 | 6 | `ReflexioPlaybookGEPAAdapter.evaluate` | For each `(candidate, window)`: |
 |   |   | • `MultiTurnRollout(incumbent).run(window)` → calls backend N times |

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -88,6 +88,7 @@ __all__ = [
     "PlaybookOptimizationCandidate",
     "PlaybookOptimizationEvaluation",
     "PlaybookOptimizationEvent",
+    "AgentPlaybookSourceWindow",
     "agent_playbook_to_snapshot",
     "RunPlaybookAggregationRequest",
     "RunPlaybookAggregationResponse",
@@ -331,6 +332,13 @@ class PlaybookOptimizationEvent(BaseModel):
     event_type: str
     payload_json: str = "{}"
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
+
+
+class AgentPlaybookSourceWindow(BaseModel):
+    """Replayable source window snapshotted when an agent playbook is generated."""
+
+    user_playbook_id: int
+    source_interaction_ids: list[int] = Field(default_factory=list)
 
 
 class AgentSuccessEvaluationResult(BaseModel):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -479,7 +479,8 @@ class PlaybookOptimizerConfig(BaseModel):
     # --- GEPA budget -------------------------------------------------------
     max_metric_calls: int = Field(default=40, gt=0)
     max_turns: int = Field(default=5, gt=0)
-    reflection_minibatch_size: int = Field(default=3, gt=0)
+    reflection_minibatch_size: int = Field(default=2, gt=0)
+    max_validation_windows: int = Field(default=2, gt=0)
     min_commit_windows: int = Field(default=2, gt=0)
     min_commit_score: float = Field(default=0.75, ge=0.0, le=1.0)
     min_commit_likert: int = Field(default=4, ge=1, le=5)

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     AgentPlaybookSnapshot,
+    AgentPlaybookSourceWindow,
     AgentPlaybookUpdateEntry,
     PlaybookAggregationChangeLog,
     PlaybookStatus,
@@ -863,8 +864,18 @@ class PlaybookAggregator:
                         "agent_playbook_id": saved_fb.agent_playbook_id,
                         "user_playbook_ids": raw_ids,
                     }
-                    self.storage.set_source_user_playbook_ids_for_agent_playbook(  # type: ignore[reportOptionalMemberAccess]
-                        saved_fb.agent_playbook_id, raw_ids
+                    self.storage.set_source_windows_for_agent_playbook(  # type: ignore[reportOptionalMemberAccess]
+                        saved_fb.agent_playbook_id,
+                        [
+                            AgentPlaybookSourceWindow(
+                                user_playbook_id=fb.user_playbook_id,
+                                source_interaction_ids=list(fb.source_interaction_ids),
+                            )
+                            for fb in sorted(
+                                cluster_playbooks,
+                                key=lambda item: item.user_playbook_id,
+                            )
+                        ],
                     )
 
             # Store fingerprints in operation state

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from reflexio.models.api_schema.domain import (
     AgentPlaybook,
+    AgentPlaybookSourceWindow,
     PlaybookOptimizationEvent,
     PlaybookOptimizationJob,
     PlaybookStatus,
@@ -20,6 +21,7 @@ from reflexio.server.llm.litellm_client import LiteLLMClient
 from .assistant_webhook import AssistantCallable, LocalScriptAssistant, WebhookAssistant
 from .gepa_adapter import PLAYBOOK_CONTENT_COMPONENT, ReflexioPlaybookGEPAAdapter
 from .judge import PairwiseJudge
+from .models import ScenarioWindow
 from .rollout import MultiTurnRollout
 from .scenario_resolver import ScenarioResolver
 
@@ -94,15 +96,17 @@ class PlaybookOptimizer:
         if len(windows) == 1 and not config.allow_single_window_commit:
             logger.info("Skipping playbook optimization with one source window")
             return "skipped"
+        train_windows, validation_windows = _split_train_validation_windows(
+            windows, config
+        )
+        split_metadata = _split_metadata(windows, train_windows, validation_windows)
 
         job = self.storage.create_playbook_optimization_job(
             PlaybookOptimizationJob(
                 target_kind=target.kind,
                 target_id=target.target_id,
                 status="running",
-                metadata_json=json.dumps(
-                    {"source_window_count": len(windows)}, ensure_ascii=False
-                ),
+                metadata_json=json.dumps(split_metadata, ensure_ascii=False),
             )
         )
         logger.info(
@@ -133,7 +137,13 @@ class PlaybookOptimizer:
             max_turns=config.max_turns,
         )
         try:
-            result = self._run_gepa(config, incumbent.content, windows, adapter)
+            result = self._run_gepa(
+                config,
+                incumbent.content,
+                train_windows,
+                validation_windows,
+                adapter,
+            )
         except Exception as exc:
             logger.exception("Playbook optimization failed")
             self.storage.update_playbook_optimization_job(
@@ -178,13 +188,19 @@ class PlaybookOptimizer:
                 best_candidate_id=winner_candidate.candidate_id,
                 decision_reason="assistant backend aborted one or more evaluations",
                 metadata_json=json.dumps(
-                    result.to_dict(), ensure_ascii=False, default=str
+                    _result_metadata(result, split_metadata),
+                    ensure_ascii=False,
+                    default=str,
                 ),
             )
             return "aborted"
 
         if not self._passes_commit_thresholds(
-            job.job_id, winner_candidate.candidate_id, best_score, config
+            job.job_id,
+            winner_candidate.candidate_id,
+            validation_windows,
+            best_score,
+            config,
         ):
             logger.info(
                 "event=playbook_optimization_no_commit job_id=%d candidate_id=%d "
@@ -199,7 +215,9 @@ class PlaybookOptimizer:
                 best_candidate_id=winner_candidate.candidate_id,
                 decision_reason="best candidate did not pass commit thresholds",
                 metadata_json=json.dumps(
-                    result.to_dict(), ensure_ascii=False, default=str
+                    _result_metadata(result, split_metadata),
+                    ensure_ascii=False,
+                    default=str,
                 ),
             )
             return "completed"
@@ -219,7 +237,11 @@ class PlaybookOptimizer:
             best_candidate_id=winner_candidate.candidate_id,
             successor_target_id=successor_id,
             decision_reason="committed" if successor_id else "winner persisted only",
-            metadata_json=json.dumps(result.to_dict(), ensure_ascii=False, default=str),
+            metadata_json=json.dumps(
+                _result_metadata(result, split_metadata),
+                ensure_ascii=False,
+                default=str,
+            ),
         )
         return "completed"
 
@@ -227,7 +249,8 @@ class PlaybookOptimizer:
         self,
         config: PlaybookOptimizerConfig,
         seed_content: str,
-        windows: list,
+        train_windows: list[ScenarioWindow],
+        validation_windows: list[ScenarioWindow],
         adapter: ReflexioPlaybookGEPAAdapter,
     ) -> Any:
         from gepa.api import optimize as gepa_optimize
@@ -235,8 +258,8 @@ class PlaybookOptimizer:
         reflection_lm = config.reflection_model or self.llm_client.config.model
         return gepa_optimize(
             seed_candidate={PLAYBOOK_CONTENT_COMPONENT: seed_content},
-            trainset=windows,
-            valset=windows,
+            trainset=train_windows,
+            valset=validation_windows,
             adapter=adapter,
             reflection_lm=reflection_lm,
             candidate_selection_strategy="pareto",
@@ -325,16 +348,26 @@ class PlaybookOptimizer:
         self,
         job_id: int,
         candidate_id: int,
+        validation_windows: list[ScenarioWindow],
         best_score: float,
         config: PlaybookOptimizerConfig,
     ) -> bool:
         if best_score < config.min_commit_score:
             return False
         evaluations = self.storage.list_playbook_optimization_evaluations(job_id)
+        validation_keys = {_window_eval_key(window) for window in validation_windows}
         winning_windows = {
-            evaluation.scenario_user_playbook_id
+            _evaluation_key(
+                evaluation.scenario_user_playbook_id,
+                evaluation.source_interaction_ids,
+            )
             for evaluation in evaluations
             if evaluation.candidate_id == candidate_id
+            and _evaluation_key(
+                evaluation.scenario_user_playbook_id,
+                evaluation.source_interaction_ids,
+            )
+            in validation_keys
             and evaluation.verdict == "candidate"
             and evaluation.score >= config.min_commit_score
             and evaluation.likert >= config.min_commit_likert
@@ -355,8 +388,8 @@ class PlaybookOptimizer:
         if target.kind == "agent_playbook":
             if not config.auto_update_pending_agent_playbooks:
                 return None
-            source_ids = self.storage.get_source_user_playbook_ids_for_agent_playbook(
-                target.target_id
+            source_windows = _source_windows_with_backfill(
+                self.storage, target.target_id
             )
             current = self.storage.get_agent_playbook_by_id(target.target_id)
             if (
@@ -379,8 +412,8 @@ class PlaybookOptimizer:
             )
             saved = self.storage.save_agent_playbooks([successor])
             if saved and saved[0].agent_playbook_id:
-                self.storage.set_source_user_playbook_ids_for_agent_playbook(
-                    saved[0].agent_playbook_id, source_ids
+                self.storage.set_source_windows_for_agent_playbook(
+                    saved[0].agent_playbook_id, source_windows
                 )
                 return saved[0].agent_playbook_id
             return None
@@ -463,3 +496,89 @@ def _safe_event_payload(value: Any, depth: int = 0) -> Any:
     if hasattr(value, "model_dump"):
         return _safe_event_payload(value.model_dump(), depth + 1)
     return str(value)
+
+
+def _split_train_validation_windows(
+    windows: list[ScenarioWindow],
+    config: PlaybookOptimizerConfig,
+) -> tuple[list[ScenarioWindow], list[ScenarioWindow]]:
+    if len(windows) <= 1:
+        return windows, windows
+
+    ordered_windows = sorted(
+        windows,
+        key=lambda window: (
+            window.user_playbook_id if window.user_playbook_id is not None else -1,
+            tuple(window.source_interaction_ids),
+        ),
+    )
+    validation_count = min(config.max_validation_windows, len(ordered_windows) - 1)
+    validation_windows = ordered_windows[:validation_count]
+    train_windows = ordered_windows[validation_count:]
+    return train_windows, validation_windows
+
+
+def _source_windows_with_backfill(
+    storage: Any, agent_playbook_id: int
+) -> list[AgentPlaybookSourceWindow]:
+    source_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+    missing_ids = [
+        window.user_playbook_id
+        for window in source_windows
+        if not window.source_interaction_ids
+    ]
+    if not missing_ids:
+        return source_windows
+
+    playbooks = storage.get_user_playbooks_by_ids_any_user(
+        missing_ids, status_filter=None
+    )
+    source_ids_by_playbook_id = {
+        playbook.user_playbook_id: playbook.source_interaction_ids
+        for playbook in playbooks
+        if playbook.source_interaction_ids
+    }
+    return [
+        window
+        if window.source_interaction_ids
+        else AgentPlaybookSourceWindow(
+            user_playbook_id=window.user_playbook_id,
+            source_interaction_ids=list(
+                source_ids_by_playbook_id.get(window.user_playbook_id, [])
+            ),
+        )
+        for window in source_windows
+    ]
+
+
+def _split_metadata(
+    windows: list[ScenarioWindow],
+    train_windows: list[ScenarioWindow],
+    validation_windows: list[ScenarioWindow],
+) -> dict[str, Any]:
+    return {
+        "source_window_count": len(windows),
+        "train_window_count": len(train_windows),
+        "validation_window_count": len(validation_windows),
+        "validation_scenario_user_playbook_ids": [
+            window.user_playbook_id for window in validation_windows
+        ],
+    }
+
+
+def _result_metadata(result: Any, split_metadata: dict[str, Any]) -> dict[str, Any]:
+    metadata = result.to_dict()
+    if not isinstance(metadata, dict):
+        metadata = {"gepa_result": metadata}
+    metadata.update(split_metadata)
+    return metadata
+
+
+def _window_eval_key(window: ScenarioWindow) -> tuple[int | None, tuple[int, ...]]:
+    return window.user_playbook_id, tuple(window.source_interaction_ids)
+
+
+def _evaluation_key(
+    scenario_user_playbook_id: int | None, source_interaction_ids: list[int]
+) -> tuple[int | None, tuple[int, ...]]:
+    return scenario_user_playbook_id, tuple(source_interaction_ids)

--- a/reflexio/server/services/playbook_optimizer/scenario_resolver.py
+++ b/reflexio/server/services/playbook_optimizer/scenario_resolver.py
@@ -24,15 +24,33 @@ class ScenarioResolver:
         self.storage = storage
 
     def for_agent_playbook(self, agent_playbook_id: int) -> list[ScenarioWindow]:
-        user_playbook_ids = (
-            self.storage.get_source_user_playbook_ids_for_agent_playbook(
-                agent_playbook_id
-            )
-        )
-        user_playbooks = self.storage.get_user_playbooks_by_ids_any_user(
-            user_playbook_ids, status_filter=None
+        source_windows = self.storage.get_source_windows_for_agent_playbook(
+            agent_playbook_id
         )
         windows: list[ScenarioWindow] = []
+        legacy_user_playbook_ids: list[int] = []
+        for source_window in source_windows:
+            if not source_window.source_interaction_ids:
+                legacy_user_playbook_ids.append(source_window.user_playbook_id)
+                continue
+            interactions = self.storage.get_interactions_by_ids(
+                source_window.source_interaction_ids
+            )
+            if interactions:
+                windows.append(
+                    ScenarioWindow(
+                        user_playbook_id=source_window.user_playbook_id,
+                        source_interaction_ids=source_window.source_interaction_ids,
+                        interactions=interactions,
+                    )
+                )
+
+        if not legacy_user_playbook_ids:
+            return windows
+
+        user_playbooks = self.storage.get_user_playbooks_by_ids_any_user(
+            legacy_user_playbook_ids, status_filter=None
+        )
         for playbook in user_playbooks:
             if not playbook.source_interaction_ids:
                 continue

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -408,7 +408,7 @@ class ReflectionService:
             blocking_issue=cited.blocking_issue,
             status=None,
             source=cited.source,
-            source_interaction_ids=[],
+            source_interaction_ids=list(cited.source_interaction_ids),
         )
         storage.save_user_playbooks([new_playbook])
         try:

--- a/reflexio/server/services/storage/disk_storage/_playbook.py
+++ b/reflexio/server/services/storage/disk_storage/_playbook.py
@@ -10,6 +10,7 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
+    AgentPlaybookSourceWindow,
     AgentSuccessEvaluationResult,
     PlaybookOptimizationCandidate,
     PlaybookOptimizationEvaluation,
@@ -798,24 +799,90 @@ class PlaybookMixin:
     def set_source_user_playbook_ids_for_agent_playbook(
         self, agent_playbook_id: int, user_playbook_ids: list[int]
     ) -> None:
-        path = self._entity_path(
-            self._agent_playbook_source_map_dir(), str(agent_playbook_id)
-        )
-        path.write_text(
-            json.dumps({"user_playbook_ids": user_playbook_ids}, indent=2),
-            encoding="utf-8",
+        self.set_source_windows_for_agent_playbook(
+            agent_playbook_id,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=upid, source_interaction_ids=[]
+                )
+                for upid in user_playbook_ids
+            ],
         )
 
     def get_source_user_playbook_ids_for_agent_playbook(
         self, agent_playbook_id: int
     ) -> list[int]:
+        return [
+            window.user_playbook_id
+            for window in self.get_source_windows_for_agent_playbook(agent_playbook_id)
+        ]
+
+    def set_source_windows_for_agent_playbook(
+        self,
+        agent_playbook_id: int,
+        source_windows: list[AgentPlaybookSourceWindow],
+    ) -> None:
+        by_id: dict[int, list[int]] = {}
+        for window in source_windows:
+            ids = by_id.setdefault(window.user_playbook_id, [])
+            seen = set(ids)
+            for source_id in window.source_interaction_ids:
+                if source_id not in seen:
+                    ids.append(source_id)
+                    seen.add(source_id)
+        path = self._entity_path(
+            self._agent_playbook_source_map_dir(), str(agent_playbook_id)
+        )
+        path.write_text(
+            json.dumps(
+                {
+                    "source_windows": [
+                        {
+                            "user_playbook_id": upid,
+                            "source_interaction_ids": source_interaction_ids,
+                        }
+                        for upid, source_interaction_ids in by_id.items()
+                    ]
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+    def get_source_windows_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[AgentPlaybookSourceWindow]:
         path = self._entity_path(
             self._agent_playbook_source_map_dir(), str(agent_playbook_id)
         )
         if not path.exists():
             return []
         data = json.loads(path.read_text(encoding="utf-8") or "{}")
-        return [int(v) for v in data.get("user_playbook_ids", [])]
+        if isinstance(data, list):
+            return [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=int(v), source_interaction_ids=[]
+                )
+                for v in data
+            ]
+        if isinstance(data.get("source_windows"), list):
+            return [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=int(item["user_playbook_id"]),
+                    source_interaction_ids=[
+                        int(source_id)
+                        for source_id in item.get("source_interaction_ids", [])
+                    ],
+                )
+                for item in data["source_windows"]
+                if isinstance(item, dict) and item.get("user_playbook_id") is not None
+            ]
+        return [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=int(v), source_interaction_ids=[]
+            )
+            for v in data.get("user_playbook_ids", [])
+        ]
 
     def create_playbook_optimization_job(
         self, job: PlaybookOptimizationJob

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -614,6 +614,7 @@ class SQLiteStorageBase(BaseStorage):
         # Run after DDL so tables exist on fresh databases
         self._migrate_expanded_terms()
         self._migrate_agentic_signals()
+        self._migrate_agent_playbook_source_windows()
         return True
 
     def _try_load_sqlite_vec(self) -> bool:
@@ -879,6 +880,31 @@ class SQLiteStorageBase(BaseStorage):
                 if col not in cols:
                     self.conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} TEXT")  # noqa: S608
                     logger.info("Added %s column to %s", col, table)
+        self.conn.commit()
+
+    def _migrate_agent_playbook_source_windows(self) -> None:
+        """Add source window snapshots to existing agent source mappings."""
+        cols = {
+            row["name"]
+            for row in self.conn.execute(
+                "PRAGMA table_info(agent_playbook_source_user_playbooks)"
+            ).fetchall()
+        }
+        if not cols:
+            return
+        if "source_interaction_ids" not in cols:
+            self.conn.execute(
+                "ALTER TABLE agent_playbook_source_user_playbooks "
+                "ADD COLUMN source_interaction_ids TEXT NOT NULL DEFAULT '[]'"
+            )
+            logger.info(
+                "Added source_interaction_ids column to "
+                "agent_playbook_source_user_playbooks"
+            )
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_apsup_user "
+            "ON agent_playbook_source_user_playbooks(user_playbook_id)"
+        )
         self.conn.commit()
 
     # ------------------------------------------------------------------
@@ -1218,10 +1244,12 @@ CREATE INDEX IF NOT EXISTS idx_pacl_agent_version ON playbook_aggregation_change
 CREATE TABLE IF NOT EXISTS agent_playbook_source_user_playbooks (
     agent_playbook_id INTEGER NOT NULL,
     user_playbook_id INTEGER NOT NULL,
+    source_interaction_ids TEXT NOT NULL DEFAULT '[]',
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     PRIMARY KEY (agent_playbook_id, user_playbook_id)
 );
 CREATE INDEX IF NOT EXISTS idx_apsup_agent ON agent_playbook_source_user_playbooks(agent_playbook_id);
+CREATE INDEX IF NOT EXISTS idx_apsup_user ON agent_playbook_source_user_playbooks(user_playbook_id);
 
 CREATE TABLE IF NOT EXISTS playbook_optimization_jobs (
     job_id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -12,6 +12,7 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
+    AgentPlaybookSourceWindow,
     AgentSuccessEvaluationResult,
     PlaybookOptimizationCandidate,
     PlaybookOptimizationEvaluation,
@@ -879,6 +880,39 @@ class PlaybookMixin:
     def set_source_user_playbook_ids_for_agent_playbook(
         self, agent_playbook_id: int, user_playbook_ids: list[int]
     ) -> None:
+        self.set_source_windows_for_agent_playbook(
+            agent_playbook_id,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=upid, source_interaction_ids=[]
+                )
+                for upid in user_playbook_ids
+            ],
+        )
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_source_user_playbook_ids_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[int]:
+        return [
+            window.user_playbook_id
+            for window in self.get_source_windows_for_agent_playbook(agent_playbook_id)
+        ]
+
+    @SQLiteStorageBase.handle_exceptions
+    def set_source_windows_for_agent_playbook(
+        self,
+        agent_playbook_id: int,
+        source_windows: list[AgentPlaybookSourceWindow],
+    ) -> None:
+        by_id: dict[int, list[int]] = {}
+        for window in source_windows:
+            ids = by_id.setdefault(window.user_playbook_id, [])
+            seen = set(ids)
+            for source_id in window.source_interaction_ids:
+                if source_id not in seen:
+                    ids.append(source_id)
+                    seen.add(source_id)
         with self._lock:
             self.conn.execute(
                 "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
@@ -886,23 +920,37 @@ class PlaybookMixin:
             )
             self.conn.executemany(
                 """INSERT OR IGNORE INTO agent_playbook_source_user_playbooks
-                   (agent_playbook_id, user_playbook_id) VALUES (?, ?)""",
-                [(agent_playbook_id, upid) for upid in user_playbook_ids],
+                   (agent_playbook_id, user_playbook_id, source_interaction_ids)
+                   VALUES (?, ?, ?)""",
+                [
+                    (
+                        agent_playbook_id,
+                        upid,
+                        _json_dumps(source_interaction_ids) or "[]",
+                    )
+                    for upid, source_interaction_ids in by_id.items()
+                ],
             )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
-    def get_source_user_playbook_ids_for_agent_playbook(
+    def get_source_windows_for_agent_playbook(
         self, agent_playbook_id: int
-    ) -> list[int]:
+    ) -> list[AgentPlaybookSourceWindow]:
         rows = self._fetchall(
-            """SELECT user_playbook_id
+            """SELECT user_playbook_id, source_interaction_ids
                FROM agent_playbook_source_user_playbooks
                WHERE agent_playbook_id = ?
                ORDER BY user_playbook_id ASC""",
             (agent_playbook_id,),
         )
-        return [int(row["user_playbook_id"]) for row in rows]
+        return [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=int(row["user_playbook_id"]),
+                source_interaction_ids=_json_loads(row["source_interaction_ids"]) or [],
+            )
+            for row in rows
+        ]
 
     @SQLiteStorageBase.handle_exceptions
     def create_playbook_optimization_job(

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -3,6 +3,7 @@ from abc import abstractmethod
 from reflexio.models.api_schema.common import BlockingIssue
 from reflexio.models.api_schema.domain import (
     AgentPlaybook,
+    AgentPlaybookSourceWindow,
     AgentSuccessEvaluationResult,
     PlaybookOptimizationCandidate,
     PlaybookOptimizationEvaluation,
@@ -458,6 +459,22 @@ class PlaybookMixin:
         self, agent_playbook_id: int
     ) -> list[int]:
         """Return source user playbook ids for an agent playbook."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def set_source_windows_for_agent_playbook(
+        self,
+        agent_playbook_id: int,
+        source_windows: list[AgentPlaybookSourceWindow],
+    ) -> None:
+        """Persist replayable source windows that produced an agent playbook."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_source_windows_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[AgentPlaybookSourceWindow]:
+        """Return replayable source windows for an agent playbook."""
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -87,74 +87,108 @@ class TestSSRFPrevention:
     def test_always_blocks_aws_metadata_ip(self):
         """Cloud metadata IP 169.254.169.254 is ALWAYS blocked."""
         with pytest.raises(ValidationError, match="cloud metadata"):
-            CustomEndpointConfig(
-                model="x", api_key="k", api_base="http://169.254.169.254/latest"
+            CustomEndpointConfig.model_validate(
+                {
+                    "model": "x",
+                    "api_key": "k",
+                    "api_base": "http://169.254.169.254/latest",
+                }
             )
 
     def test_always_blocks_gcp_metadata_hostname(self):
         """GCP metadata hostname is ALWAYS blocked."""
         with pytest.raises(ValidationError, match="cloud metadata"):
-            CustomEndpointConfig(
-                model="x",
-                api_key="k",
-                api_base="http://metadata.google.internal/computeMetadata/v1",
+            CustomEndpointConfig.model_validate(
+                {
+                    "model": "x",
+                    "api_key": "k",
+                    "api_base": "http://metadata.google.internal/computeMetadata/v1",
+                }
             )
 
     def test_allows_public_urls(self):
         """Public URLs are always accepted."""
-        config = CustomEndpointConfig(
-            model="gpt-4", api_key="sk-test", api_base="https://api.openai.com/v1"
+        config = CustomEndpointConfig.model_validate(
+            {
+                "model": "gpt-4",
+                "api_key": "sk-test",
+                "api_base": "https://api.openai.com/v1",
+            }
         )
         assert str(config.api_base).startswith("https://api.openai.com")
 
     def test_allows_localhost_by_default(self, non_strict_mode):
         """Localhost is allowed when REFLEXIO_BLOCK_PRIVATE_URLS is not set."""
-        config = CustomEndpointConfig(
-            model="local-model", api_key="k", api_base="http://localhost:8080/v1"
+        config = CustomEndpointConfig.model_validate(
+            {
+                "model": "local-model",
+                "api_key": "k",
+                "api_base": "http://localhost:8080/v1",
+            }
         )
         assert "localhost" in str(config.api_base)
 
     def test_allows_private_ip_by_default(self, non_strict_mode):
         """Private IPs are allowed when REFLEXIO_BLOCK_PRIVATE_URLS is not set."""
-        config = CustomEndpointConfig(
-            model="local-model", api_key="k", api_base="http://192.168.1.100:8080/v1"
+        config = CustomEndpointConfig.model_validate(
+            {
+                "model": "local-model",
+                "api_key": "k",
+                "api_base": "http://192.168.1.100:8080/v1",
+            }
         )
         assert "192.168.1.100" in str(config.api_base)
 
     def test_blocks_localhost_in_strict_mode(self, strict_mode):
         """Localhost is blocked when REFLEXIO_BLOCK_PRIVATE_URLS=true."""
         with pytest.raises(ValidationError, match="localhost"):
-            CustomEndpointConfig(
-                model="x", api_key="k", api_base="http://localhost:8080/v1"
+            CustomEndpointConfig.model_validate(
+                {
+                    "model": "x",
+                    "api_key": "k",
+                    "api_base": "http://localhost:8080/v1",
+                }
             )
 
     def test_blocks_private_ip_in_strict_mode(self, strict_mode):
         """Private IPs are blocked when REFLEXIO_BLOCK_PRIVATE_URLS=true."""
         with pytest.raises(ValidationError, match="private"):
-            CustomEndpointConfig(
-                model="x", api_key="k", api_base="http://192.168.1.1/v1"
+            CustomEndpointConfig.model_validate(
+                {
+                    "model": "x",
+                    "api_key": "k",
+                    "api_base": "http://192.168.1.1/v1",
+                }
             )
 
     def test_blocks_loopback_ip_in_strict_mode(self, strict_mode):
         """Loopback IP 127.0.0.1 is blocked in strict mode."""
         with pytest.raises(ValidationError):
-            CustomEndpointConfig(
-                model="x", api_key="k", api_base="http://127.0.0.1:8080/v1"
+            CustomEndpointConfig.model_validate(
+                {
+                    "model": "x",
+                    "api_key": "k",
+                    "api_base": "http://127.0.0.1:8080/v1",
+                }
             )
 
     def test_azure_endpoint_ssrf_prevention(self):
         """AzureOpenAIConfig.endpoint is also protected against SSRF."""
         with pytest.raises(ValidationError, match="cloud metadata"):
-            AzureOpenAIConfig(
-                api_key="test-key",
-                endpoint="http://169.254.169.254/latest/meta-data/",
+            AzureOpenAIConfig.model_validate(
+                {
+                    "api_key": "test-key",
+                    "endpoint": "http://169.254.169.254/latest/meta-data/",
+                }
             )
 
     def test_azure_endpoint_allows_valid_url(self):
         """Valid Azure endpoints are accepted."""
-        config = AzureOpenAIConfig(
-            api_key="test-key",
-            endpoint="https://my-resource.openai.azure.com/",
+        config = AzureOpenAIConfig.model_validate(
+            {
+                "api_key": "test-key",
+                "endpoint": "https://my-resource.openai.azure.com/",
+            }
         )
         assert "openai.azure.com" in str(config.endpoint)
 
@@ -553,6 +587,8 @@ class TestTimeRangeValidation:
             start_time=datetime(2024, 1, 1, tzinfo=UTC),
             end_time=datetime(2024, 6, 1, tzinfo=UTC),
         )
+        assert req.start_time is not None
+        assert req.end_time is not None
         assert req.start_time < req.end_time
 
     def test_none_times_accepted(self):
@@ -618,9 +654,11 @@ class TestCrossFieldValidators:
     def test_openai_config_with_azure(self):
         """OpenAIConfig with only azure_config is valid."""
         config = OpenAIConfig(
-            azure_config=AzureOpenAIConfig(
-                api_key="test",
-                endpoint="https://my-resource.openai.azure.com/",
+            azure_config=AzureOpenAIConfig.model_validate(
+                {
+                    "api_key": "test",
+                    "endpoint": "https://my-resource.openai.azure.com/",
+                }
             )
         )
         assert config.azure_config is not None
@@ -708,6 +746,12 @@ class TestCrossFieldValidators:
 
         assert config.webhook_url is None
         assert config.assistant_script_path is None
+        assert config.max_validation_windows == 2
+
+    def test_playbook_optimizer_rejects_invalid_max_validation_windows(self):
+        """PlaybookOptimizerConfig: validation window cap must be positive."""
+        with pytest.raises(ValidationError):
+            PlaybookOptimizerConfig(max_validation_windows=0)
 
     def test_playbook_optimizer_rejects_multiple_assistant_backends(self):
         """PlaybookOptimizerConfig: webhook and script are mutually exclusive."""
@@ -752,20 +796,24 @@ class TestBackwardCompatibility:
 
     def test_config_accepts_old_window_names(self):
         """Config: extraction_window_size/stride still accepted as aliases."""
-        config = Config(
-            storage_config=StorageConfigSQLite(),
-            extraction_window_size=15,
-            extraction_window_stride=7,
+        config = Config.model_validate(
+            {
+                "storage_config": StorageConfigSQLite(),
+                "extraction_window_size": 15,
+                "extraction_window_stride": 7,
+            }
         )
         assert config.window_size == 15
         assert config.stride_size == 7
 
     def test_config_accepts_current_legacy_names(self):
         """Config: batch_size/batch_interval still accepted as aliases."""
-        config = Config(
-            storage_config=StorageConfigSQLite(),
-            batch_size=20,
-            batch_interval=8,
+        config = Config.model_validate(
+            {
+                "storage_config": StorageConfigSQLite(),
+                "batch_size": 20,
+                "batch_interval": 8,
+            }
         )
         assert config.window_size == 20
         assert config.stride_size == 8
@@ -782,24 +830,28 @@ class TestBackwardCompatibility:
 
     def test_config_prefers_new_names_when_both_present(self):
         """Config: new names win if old and new field names are both present."""
-        config = Config(
-            storage_config=StorageConfigSQLite(),
-            window_size=20,
-            stride_size=8,
-            batch_size=10,
-            batch_interval=5,
-            extraction_window_size=2,
-            extraction_window_stride=1,
+        config = Config.model_validate(
+            {
+                "storage_config": StorageConfigSQLite(),
+                "window_size": 20,
+                "stride_size": 8,
+                "batch_size": 10,
+                "batch_interval": 5,
+                "extraction_window_size": 2,
+                "extraction_window_stride": 1,
+            }
         )
         assert config.window_size == 20
         assert config.stride_size == 8
 
     def test_config_model_dump_uses_only_new_names(self):
         """Config: serialization emits window_size/stride_size only."""
-        config = Config(
-            storage_config=StorageConfigSQLite(),
-            batch_size=20,
-            batch_interval=8,
+        config = Config.model_validate(
+            {
+                "storage_config": StorageConfigSQLite(),
+                "batch_size": 20,
+                "batch_interval": 8,
+            }
         )
         dumped = config.model_dump()
         assert dumped["window_size"] == 20
@@ -819,22 +871,26 @@ class TestBackwardCompatibility:
 
     def test_profile_extractor_old_override_names(self):
         """ProfileExtractorConfig: old extraction_window_*_override names still work."""
-        config = ProfileExtractorConfig(
-            extractor_name="test",
-            extraction_definition_prompt="test",
-            extraction_window_size_override=30,
-            extraction_window_stride_override=10,
+        config = ProfileExtractorConfig.model_validate(
+            {
+                "extractor_name": "test",
+                "extraction_definition_prompt": "test",
+                "extraction_window_size_override": 30,
+                "extraction_window_stride_override": 10,
+            }
         )
         assert config.window_size_override == 30
         assert config.stride_size_override == 10
 
     def test_profile_extractor_current_legacy_override_names(self):
         """ProfileExtractorConfig: batch_*_override names still work."""
-        config = ProfileExtractorConfig(
-            extractor_name="test",
-            extraction_definition_prompt="test",
-            batch_size_override=30,
-            batch_interval_override=10,
+        config = ProfileExtractorConfig.model_validate(
+            {
+                "extractor_name": "test",
+                "extraction_definition_prompt": "test",
+                "batch_size_override": 30,
+                "batch_interval_override": 10,
+            }
         )
         assert config.window_size_override == 30
         assert config.stride_size_override == 10
@@ -843,11 +899,13 @@ class TestBackwardCompatibility:
 
     def test_profile_extractor_override_model_dump_uses_only_new_names(self):
         """ProfileExtractorConfig: serialization emits window/stride override names."""
-        config = ProfileExtractorConfig(
-            extractor_name="test",
-            extraction_definition_prompt="test",
-            batch_size_override=30,
-            batch_interval_override=10,
+        config = ProfileExtractorConfig.model_validate(
+            {
+                "extractor_name": "test",
+                "extraction_definition_prompt": "test",
+                "batch_size_override": 30,
+                "batch_interval_override": 10,
+            }
         )
         dumped = config.model_dump()
         assert dumped["window_size_override"] == 30
@@ -857,54 +915,64 @@ class TestBackwardCompatibility:
 
     def test_playbook_config_old_override_names(self):
         """PlaybookConfig: old extraction_window_*_override names still work."""
-        config = PlaybookConfig(
-            extractor_name="test",
-            extraction_definition_prompt="test",
-            extraction_window_size_override=25,
-            extraction_window_stride_override=5,
+        config = PlaybookConfig.model_validate(
+            {
+                "extractor_name": "test",
+                "extraction_definition_prompt": "test",
+                "extraction_window_size_override": 25,
+                "extraction_window_stride_override": 5,
+            }
         )
         assert config.window_size_override == 25
         assert config.stride_size_override == 5
 
     def test_playbook_config_current_legacy_override_names(self):
         """PlaybookConfig: batch_*_override names still work."""
-        config = PlaybookConfig(
-            extractor_name="test",
-            extraction_definition_prompt="test",
-            batch_size_override=25,
-            batch_interval_override=5,
+        config = PlaybookConfig.model_validate(
+            {
+                "extractor_name": "test",
+                "extraction_definition_prompt": "test",
+                "batch_size_override": 25,
+                "batch_interval_override": 5,
+            }
         )
         assert config.window_size_override == 25
         assert config.stride_size_override == 5
 
     def test_success_config_old_override_names(self):
         """AgentSuccessConfig: old extraction_window_*_override names still work."""
-        config = AgentSuccessConfig(
-            evaluation_name="test",
-            success_definition_prompt="test",
-            extraction_window_size_override=40,
-            extraction_window_stride_override=15,
+        config = AgentSuccessConfig.model_validate(
+            {
+                "evaluation_name": "test",
+                "success_definition_prompt": "test",
+                "extraction_window_size_override": 40,
+                "extraction_window_stride_override": 15,
+            }
         )
         assert config.window_size_override == 40
         assert config.stride_size_override == 15
 
     def test_success_config_current_legacy_override_names(self):
         """AgentSuccessConfig: batch_*_override names still work."""
-        config = AgentSuccessConfig(
-            evaluation_name="test",
-            success_definition_prompt="test",
-            batch_size_override=40,
-            batch_interval_override=15,
+        config = AgentSuccessConfig.model_validate(
+            {
+                "evaluation_name": "test",
+                "success_definition_prompt": "test",
+                "batch_size_override": 40,
+                "batch_interval_override": 15,
+            }
         )
         assert config.window_size_override == 40
         assert config.stride_size_override == 15
 
     def test_aggregator_config_old_field_names(self):
         """PlaybookAggregatorConfig: old field names still work via AliasChoices."""
-        config = PlaybookAggregatorConfig(
-            min_feedback_threshold=5,
-            refresh_count=3,
-            similarity_threshold=0.7,
+        config = PlaybookAggregatorConfig.model_validate(
+            {
+                "min_feedback_threshold": 5,
+                "refresh_count": 3,
+                "similarity_threshold": 0.7,
+            }
         )
         assert config.min_cluster_size == 5
         assert config.reaggregation_trigger_count == 3

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 import threading
 import time
@@ -11,6 +12,7 @@ import pytest
 
 from reflexio.models.api_schema.domain import (
     AgentPlaybook,
+    AgentPlaybookSourceWindow,
     Interaction,
     PlaybookOptimizationCandidate,
     PlaybookOptimizationEvaluation,
@@ -43,8 +45,14 @@ from reflexio.server.services.playbook_optimizer.models import (
     JudgeASI,
     ScenarioWindow,
 )
-from reflexio.server.services.playbook_optimizer.optimizer import PlaybookOptimizer
+from reflexio.server.services.playbook_optimizer.optimizer import (
+    PlaybookOptimizer,
+    _split_train_validation_windows,
+)
 from reflexio.server.services.playbook_optimizer.rollout import MultiTurnRollout
+from reflexio.server.services.playbook_optimizer.scenario_resolver import (
+    ScenarioResolver,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 
@@ -65,6 +73,51 @@ def _optimizer_for_test(storage, config) -> PlaybookOptimizer:
     )
     llm_client = SimpleNamespace(config=SimpleNamespace(model="fake-model"))
     return PlaybookOptimizer(cast(Any, context), cast(Any, llm_client))
+
+
+def _scenario_window(user_playbook_id: int) -> ScenarioWindow:
+    return ScenarioWindow(
+        user_playbook_id=user_playbook_id,
+        source_interaction_ids=[user_playbook_id * 10],
+        interactions=[
+            Interaction(
+                interaction_id=user_playbook_id * 10,
+                user_id="u1",
+                request_id=f"r{user_playbook_id}",
+                role="User",
+                content=f"scenario {user_playbook_id}",
+            )
+        ],
+    )
+
+
+def _seed_request_and_user_interaction(
+    storage: SQLiteStorage,
+    *,
+    interaction_id: int,
+    request_id: str,
+    content: str = "scenario",
+) -> None:
+    storage.add_request(
+        Request(
+            request_id=request_id,
+            user_id="u1",
+            source="test",
+            agent_version="v1",
+        )
+    )
+    storage.add_user_interactions_bulk(
+        "u1",
+        [
+            Interaction(
+                interaction_id=interaction_id,
+                user_id="u1",
+                request_id=request_id,
+                role="User",
+                content=content,
+            )
+        ],
+    )
 
 
 def test_local_script_assistant_sends_payload_and_parses_content(tmp_path):
@@ -291,6 +344,75 @@ def test_optimizer_selects_local_script_assistant(tmp_path):
     assert assistant.command == [sys.executable, "assistant.py"]
 
 
+def test_optimizer_splits_train_and_validation_windows(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=PlaybookOptimizerConfig(),
+        ),
+    )
+
+    windows = [_scenario_window(idx) for idx in range(30, 0, -1)]
+    train_windows, validation_windows = _split_train_validation_windows(
+        windows,
+        optimizer._config(),  # noqa: SLF001
+    )
+
+    assert len(train_windows) == 28
+    assert len(validation_windows) == 2
+    assert [w.user_playbook_id for w in validation_windows] == [1, 2]
+    assert {w.user_playbook_id for w in train_windows}.isdisjoint(
+        {w.user_playbook_id for w in validation_windows}
+    )
+
+
+def test_optimizer_split_holds_out_len_minus_one_for_small_sets(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(max_validation_windows=4)
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+
+    train_windows, validation_windows = _split_train_validation_windows(
+        [_scenario_window(idx) for idx in range(1, 6)],
+        optimizer._config(),  # noqa: SLF001
+    )
+    assert len(train_windows) == 1
+    assert len(validation_windows) == 4
+
+    train_windows, validation_windows = _split_train_validation_windows(
+        [_scenario_window(1), _scenario_window(2)],
+        optimizer._config(),  # noqa: SLF001
+    )
+    assert len(train_windows) == 1
+    assert len(validation_windows) == 1
+
+
+def test_optimizer_split_reuses_single_window_only_when_allowed(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(allow_single_window_commit=True)
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+
+    train_windows, validation_windows = _split_train_validation_windows(
+        [_scenario_window(1)],
+        optimizer._config(),  # noqa: SLF001
+    )
+
+    assert train_windows == validation_windows == [_scenario_window(1)]
+
+
 def test_optimizer_runs_local_script_assistant_and_persists_evaluation(tmp_path):
     storage = _sqlite_storage(tmp_path)
     script = tmp_path / "assistant.py"
@@ -358,6 +480,7 @@ json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys
         storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
         playbook_optimizer_config=PlaybookOptimizerConfig(
             enabled=True,
+            optimize_agent_playbooks=True,
             assistant_script_path=sys.executable,
             assistant_script_args=[str(script), str(record)],
             allow_single_window_commit=True,
@@ -369,7 +492,7 @@ json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys
     )
     optimizer = _optimizer_for_test(storage, config)
 
-    def fake_run_gepa(config, seed_content, windows, adapter):  # noqa: ARG001
+    def fake_run_gepa(config, seed_content, train_windows, validation_windows, adapter):  # noqa: ARG001
         adapter.judge = Mock()
         adapter.judge.judge.return_value = JudgeOutput(
             verdict="candidate",
@@ -379,7 +502,7 @@ json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys
             asi=JudgeASI(winning_behaviors=["clearer response"]),
         )
         adapter.evaluate(
-            windows,
+            validation_windows,
             {PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
             capture_traces=True,
         )
@@ -404,9 +527,80 @@ json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys
     assert "candidate content" in calls[1]
     jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
     assert jobs[0]["status"] == "completed"
+    metadata = json.loads(jobs[0]["metadata_json"])
+    assert metadata["source_window_count"] == 1
+    assert metadata["train_window_count"] == 1
+    assert metadata["validation_window_count"] == 1
     evaluations = storage.list_playbook_optimization_evaluations(jobs[0]["job_id"])
     assert len(evaluations) == 1
     assert evaluations[0].verdict == "candidate"
+
+
+def test_optimizer_passes_distinct_train_and_validation_sets_to_gepa(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            enabled=True,
+            optimize_agent_playbooks=True,
+            webhook_url="https://assistant.example.test/rollout",
+            auto_update_pending_agent_playbooks=False,
+            min_commit_windows=1,
+            min_commit_score=0.1,
+            min_commit_likert=1,
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    incumbent = AgentPlaybook(
+        agent_playbook_id=1,
+        playbook_name="support",
+        agent_version="v1",
+        content="incumbent",
+        playbook_status=PlaybookStatus.PENDING,
+    )
+    optimizer._load_incumbent = Mock(return_value=incumbent)  # type: ignore[method-assign]
+    optimizer._resolve_windows = Mock(  # type: ignore[method-assign]
+        return_value=[_scenario_window(idx) for idx in range(1, 6)]
+    )
+    captured: dict[str, list[ScenarioWindow]] = {}
+
+    def fake_run_gepa(config, seed_content, train_windows, validation_windows, adapter):  # noqa: ARG001
+        captured["train"] = train_windows
+        captured["validation"] = validation_windows
+        candidate = adapter._ensure_candidate("candidate content")  # noqa: SLF001
+        for window in validation_windows:
+            storage.insert_playbook_optimization_evaluation(
+                PlaybookOptimizationEvaluation(
+                    job_id=adapter.job_id,
+                    candidate_id=candidate.candidate_id,
+                    target_kind="agent_playbook",
+                    target_id=1,
+                    scenario_user_playbook_id=window.user_playbook_id,
+                    source_interaction_ids=window.source_interaction_ids,
+                    score=0.9,
+                    verdict="candidate",
+                    likert=5,
+                )
+            )
+        return SimpleNamespace(
+            best_candidate={PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+            val_aggregate_scores=[0.9],
+            best_idx=0,
+            to_dict=lambda: {"best_idx": 0},
+        )
+
+    optimizer._run_gepa = fake_run_gepa  # type: ignore[method-assign]
+
+    optimizer.optimize(PlaybookOptimizationTarget(kind="agent_playbook", target_id=1))
+
+    assert [w.user_playbook_id for w in captured["validation"]] == [1, 2]
+    assert [w.user_playbook_id for w in captured["train"]] == [3, 4, 5]
+    jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
+    metadata = json.loads(jobs[0]["metadata_json"])
+    assert metadata["source_window_count"] == 5
+    assert metadata["train_window_count"] == 3
+    assert metadata["validation_window_count"] == 2
+    assert metadata["validation_scenario_user_playbook_ids"] == [1, 2]
 
 
 def test_sqlite_persists_source_mapping_and_winner_candidate(tmp_path):
@@ -435,6 +629,141 @@ def test_sqlite_persists_source_mapping_and_winner_candidate(tmp_path):
     assert persisted.is_winner is True
 
 
+def test_scenario_resolver_uses_snapshotted_source_windows_after_user_delete(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    _seed_request_and_user_interaction(
+        storage, interaction_id=101, request_id="r101", content="original ask"
+    )
+    storage.save_user_playbooks(
+        [
+            UserPlaybook(
+                user_playbook_id=7,
+                user_id="u1",
+                agent_version="v1",
+                request_id="r101",
+                playbook_name="support",
+                content="source",
+                source_interaction_ids=[101],
+            )
+        ]
+    )
+    storage.set_source_windows_for_agent_playbook(
+        10,
+        [AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])],
+    )
+    storage.delete_user_playbooks_by_ids([7])
+
+    windows = ScenarioResolver(storage).for_agent_playbook(10)
+
+    assert len(windows) == 1
+    assert windows[0].user_playbook_id == 7
+    assert windows[0].source_interaction_ids == [101]
+    assert [turn.content for turn in windows[0].user_turns] == ["original ask"]
+
+
+def test_scenario_resolver_backfills_legacy_empty_source_windows(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    _seed_request_and_user_interaction(
+        storage, interaction_id=102, request_id="r102", content="legacy ask"
+    )
+    user_playbook = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="r102",
+        playbook_name="support",
+        content="source",
+        source_interaction_ids=[102],
+    )
+    storage.save_user_playbooks([user_playbook])
+    storage.set_source_user_playbook_ids_for_agent_playbook(
+        10, [user_playbook.user_playbook_id]
+    )
+
+    windows = ScenarioResolver(storage).for_agent_playbook(10)
+
+    assert len(windows) == 1
+    assert windows[0].user_playbook_id == user_playbook.user_playbook_id
+    assert windows[0].source_interaction_ids == [102]
+    assert [turn.content for turn in windows[0].user_turns] == ["legacy ask"]
+
+
+def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    _seed_request_and_user_interaction(
+        storage, interaction_id=201, request_id="r201", content="validate"
+    )
+    [agent_playbook] = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="incumbent content",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+    storage.set_source_windows_for_agent_playbook(
+        agent_playbook.agent_playbook_id,
+        [AgentPlaybookSourceWindow(user_playbook_id=12, source_interaction_ids=[201])],
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            enabled=True,
+            optimize_agent_playbooks=True,
+            webhook_url="https://assistant.example.test/rollout",
+            allow_single_window_commit=True,
+            min_commit_windows=1,
+            min_commit_score=0.1,
+            min_commit_likert=1,
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    optimizer._resolve_windows = Mock(  # type: ignore[method-assign]
+        return_value=[_scenario_window(12)]
+    )
+
+    def fake_run_gepa(config, seed_content, train_windows, validation_windows, adapter):  # noqa: ARG001
+        candidate = adapter._ensure_candidate("candidate content")  # noqa: SLF001
+        storage.insert_playbook_optimization_evaluation(
+            PlaybookOptimizationEvaluation(
+                job_id=adapter.job_id,
+                candidate_id=candidate.candidate_id,
+                target_kind="agent_playbook",
+                target_id=agent_playbook.agent_playbook_id,
+                scenario_user_playbook_id=12,
+                source_interaction_ids=[120],
+                score=0.9,
+                verdict="candidate",
+                likert=5,
+            )
+        )
+        return SimpleNamespace(
+            best_candidate={PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+            val_aggregate_scores=[0.9],
+            best_idx=0,
+            to_dict=lambda: {"best_idx": 0},
+        )
+
+    optimizer._run_gepa = fake_run_gepa  # type: ignore[method-assign]
+
+    optimizer.optimize(
+        PlaybookOptimizationTarget(
+            kind="agent_playbook", target_id=agent_playbook.agent_playbook_id
+        )
+    )
+
+    successors = [
+        playbook
+        for playbook in storage.get_agent_playbooks(playbook_name="support")
+        if playbook.content == "candidate content"
+    ]
+    assert len(successors) == 1
+    assert storage.get_source_windows_for_agent_playbook(
+        successors[0].agent_playbook_id
+    ) == [AgentPlaybookSourceWindow(user_playbook_id=12, source_interaction_ids=[201])]
+
+
 def test_commit_thresholds_only_count_winner_candidate(tmp_path):
     storage = _sqlite_storage(tmp_path)
     job = storage.create_playbook_optimization_job(
@@ -453,6 +782,7 @@ def test_commit_thresholds_only_count_winner_candidate(tmp_path):
             target_kind="agent_playbook",
             target_id=10,
             scenario_user_playbook_id=1,
+            source_interaction_ids=[10],
             score=0.95,
             verdict="candidate",
             likert=5,
@@ -472,7 +802,11 @@ def test_commit_thresholds_only_count_winner_candidate(tmp_path):
     )
 
     assert not optimizer._passes_commit_thresholds(  # noqa: SLF001
-        job.job_id, winner_candidate.candidate_id, 0.95, config
+        job.job_id,
+        winner_candidate.candidate_id,
+        [_scenario_window(2)],
+        0.95,
+        config,
     )
 
     storage.insert_playbook_optimization_evaluation(
@@ -482,13 +816,18 @@ def test_commit_thresholds_only_count_winner_candidate(tmp_path):
             target_kind="agent_playbook",
             target_id=10,
             scenario_user_playbook_id=2,
+            source_interaction_ids=[20],
             score=0.9,
             verdict="candidate",
             likert=5,
         )
     )
     assert optimizer._passes_commit_thresholds(  # noqa: SLF001
-        job.job_id, winner_candidate.candidate_id, 0.95, config
+        job.job_id,
+        winner_candidate.candidate_id,
+        [_scenario_window(2)],
+        0.95,
+        config,
     )
 
 

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -47,9 +47,17 @@ def temp_storage_dir():
 @pytest.fixture
 def request_context(temp_storage_dir):
     # Patch _get_embedding so storage doesn't try to call out for embeddings.
+    from reflexio.server.llm.litellm_client import LiteLLMClient
     from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
-    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+    with (
+        patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
+        patch.object(
+            LiteLLMClient,
+            "get_embeddings",
+            side_effect=lambda texts, *_args, **_kwargs: [[0.0] * 512 for _ in texts],
+        ),
+    ):
         ctx = RequestContext(org_id="test_org", storage_base_dir=temp_storage_dir)
         yield ctx
 
@@ -95,6 +103,7 @@ def _seed_playbook(
     user_id: str,
     playbook_name: str = "fb",
     content: str = "old rule",
+    source_interaction_ids: list[int] | None = None,
 ) -> UserPlaybook:
     pb = UserPlaybook(
         user_playbook_id=user_playbook_id,
@@ -106,6 +115,7 @@ def _seed_playbook(
         trigger="when X",
         rationale="because Y",
         source="seed",
+        source_interaction_ids=source_interaction_ids or [],
     )
     storage.save_user_playbooks([pb])
     return pb
@@ -370,6 +380,43 @@ class TestReplacePlaybook:
         assert current[0].user_id == "u1"
         assert current[0].agent_version == "v1"
         assert current[0].playbook_name == "fb"
+
+    def test_replace_preserves_source_interaction_ids(
+        self, request_context, service, llm_client
+    ):
+        _set_config(request_context)
+        storage = request_context.storage
+        _seed_playbook(storage, 1, "u1", source_interaction_ids=[10, 11])
+
+        cite = Citation(kind="playbook", real_id="1")
+        _seed_request_with_interactions(
+            storage,
+            "u1",
+            "r1",
+            [
+                _make_interaction("u1", "r1", "User", "hi"),
+                _make_interaction("u1", "r1", "Assistant", "hello", citations=[cite]),
+            ],
+        )
+
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="playbook",
+                    target_id="1",
+                    action="replace",
+                    new_content="new rule",
+                    reason="rule was wrong",
+                )
+            ]
+        )
+
+        result = service.run(ReflectionServiceRequest(user_id="u1"))
+
+        assert result.replaced_count == 1
+        current = storage.get_user_playbooks(user_id="u1", status_filter=[None])
+        assert len(current) == 1
+        assert current[0].source_interaction_ids == [10, 11]
 
 
 class TestNoChange:

--- a/tests/server/services/storage/test_disk_storage_reflection_methods.py
+++ b/tests/server/services/storage/test_disk_storage_reflection_methods.py
@@ -19,7 +19,11 @@ from reflexio.models.api_schema.domain.enums import (
     ProfileTimeToLive,
     Status,
 )
-from reflexio.models.api_schema.service_schemas import UserPlaybook, UserProfile
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybookSourceWindow,
+    UserPlaybook,
+    UserProfile,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -244,3 +248,49 @@ class TestDiskArchiveUserPlaybookById:
         assert disk_storage.archive_user_playbook_by_id("u2", 1) is False
         current = disk_storage.get_user_playbooks(user_id="u1", status_filter=[None])
         assert {p.user_playbook_id for p in current} == {1}
+
+
+class TestDiskAgentPlaybookSourceWindows:
+    def test_source_windows_round_trip(self, disk_storage):
+        disk_storage.set_source_windows_for_agent_playbook(
+            10,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=2, source_interaction_ids=[20, 21]
+                )
+            ],
+        )
+
+        assert disk_storage.get_source_user_playbook_ids_for_agent_playbook(10) == [2]
+        assert disk_storage.get_source_windows_for_agent_playbook(10) == [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=2, source_interaction_ids=[20, 21]
+            )
+        ]
+
+    def test_reads_legacy_id_only_map(self, disk_storage):
+        path = disk_storage._entity_path(  # noqa: SLF001
+            disk_storage._agent_playbook_source_map_dir(),  # noqa: SLF001
+            "10",
+        )
+        path.write_text(
+            '{"user_playbook_ids": [2, 3]}',
+            encoding="utf-8",
+        )
+
+        assert disk_storage.get_source_windows_for_agent_playbook(10) == [
+            AgentPlaybookSourceWindow(user_playbook_id=2, source_interaction_ids=[]),
+            AgentPlaybookSourceWindow(user_playbook_id=3, source_interaction_ids=[]),
+        ]
+
+    def test_reads_legacy_list_map(self, disk_storage):
+        path = disk_storage._entity_path(  # noqa: SLF001
+            disk_storage._agent_playbook_source_map_dir(),  # noqa: SLF001
+            "10",
+        )
+        path.write_text("[2, 3]", encoding="utf-8")
+
+        assert disk_storage.get_source_windows_for_agent_playbook(10) == [
+            AgentPlaybookSourceWindow(user_playbook_id=2, source_interaction_ids=[]),
+            AgentPlaybookSourceWindow(user_playbook_id=3, source_interaction_ids=[]),
+        ]

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -3,7 +3,11 @@
 import pytest
 
 from reflexio.models.api_schema.domain.enums import Status
-from reflexio.models.api_schema.service_schemas import AgentPlaybook, UserPlaybook
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    AgentPlaybookSourceWindow,
+    UserPlaybook,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -18,6 +22,7 @@ def _make_user_playbook(
     user_id: str,
     playbook_name: str,
     agent_version: str,
+    source_interaction_ids: list[int] | None = None,
 ) -> UserPlaybook:
     return UserPlaybook(
         user_playbook_id=user_playbook_id,
@@ -28,6 +33,7 @@ def _make_user_playbook(
         content=f"content-{user_playbook_id}",
         created_at=1_700_000_000 + user_playbook_id,
         source="test",
+        source_interaction_ids=source_interaction_ids or [],
     )
 
 
@@ -226,6 +232,57 @@ class TestArchiveUserPlaybookById:
         # u1's row untouched.
         current = storage.get_user_playbooks(user_id="u1", status_filter=[None])
         assert len(current) == 1
+
+
+class TestAgentPlaybookSourceWindows:
+    def test_source_windows_round_trip_and_legacy_ids(self, storage):
+        storage.set_source_windows_for_agent_playbook(
+            10,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=2, source_interaction_ids=[20, 21]
+                ),
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=3, source_interaction_ids=[30]
+                ),
+            ],
+        )
+
+        assert storage.get_source_user_playbook_ids_for_agent_playbook(10) == [2, 3]
+        windows = storage.get_source_windows_for_agent_playbook(10)
+        assert [w.user_playbook_id for w in windows] == [2, 3]
+        assert [w.source_interaction_ids for w in windows] == [[20, 21], [30]]
+
+    def test_legacy_id_writer_creates_empty_source_windows(self, storage):
+        storage.set_source_user_playbook_ids_for_agent_playbook(10, [2, 3, 2])
+
+        assert storage.get_source_user_playbook_ids_for_agent_playbook(10) == [2, 3]
+        assert storage.get_source_windows_for_agent_playbook(10) == [
+            AgentPlaybookSourceWindow(user_playbook_id=2, source_interaction_ids=[]),
+            AgentPlaybookSourceWindow(user_playbook_id=3, source_interaction_ids=[]),
+        ]
+
+    def test_source_windows_survive_user_playbook_delete(self, storage):
+        playbook = _make_user_playbook(2, "u1", "fb", "v1", source_interaction_ids=[20])
+        storage.save_user_playbooks([playbook])
+        storage.set_source_windows_for_agent_playbook(
+            10,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=playbook.user_playbook_id,
+                    source_interaction_ids=[20],
+                )
+            ],
+        )
+
+        storage.delete_user_playbooks_by_ids([playbook.user_playbook_id])
+
+        assert storage.get_source_windows_for_agent_playbook(10) == [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=playbook.user_playbook_id,
+                source_interaction_ids=[20],
+            )
+        ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Snapshot the source interaction window for each agent playbook at aggregation time so optimizer evaluation stays replayable when source user playbooks are later archived, deduped, or replaced by reflection.
- Switch GEPA to a train / held-out validation split: `max_validation_windows` (default 2) caps validation, the remainder is the training pool, and `reflection_minibatch_size` controls per-mutation sampling.
- Wire the new `AgentPlaybookSourceWindow` shape through schemas, storage_base, disk, and sqlite backends; persist `source_interaction_ids` per source user playbook.

## Changes

**Models / config**
- `reflexio/models/api_schema/domain/entities.py`: add `AgentPlaybookSourceWindow`.
- `reflexio/models/config_schema.py`: add `max_validation_windows` (default 2), tweak `reflection_minibatch_size` default to 2.

**Optimizer**
- `playbook_optimizer/optimizer.py`: train / validation split with hold-out cap; commit thresholds checked against held-out windows only.
- `playbook_optimizer/scenario_resolver.py`: replay scenarios from snapshotted source interaction ids when the underlying user playbook is missing or changed.
- `playbook/playbook_aggregator.py`: persist source windows alongside source user playbook ids when an agent playbook is generated.

**Storage**
- `storage_base/_playbook.py`: add abstract `set_/get_source_windows_for_agent_playbook`.
- `disk_storage/_playbook.py` and `sqlite_storage/_playbook.py`: implement window persistence (sqlite adds a `source_interaction_ids_json` column via base migration).
- `reflection/reflection_service.py`: minor wiring update for the new aggregator signature.

**Tests**
- Storage contract, disk, and reflection tests updated for the new interface.
- `test_playbook_optimizer.py`: extensive coverage for train/validation split, replay-from-snapshot, and minibatch behavior.
- `test_validators.py`: updates for the new schema field.

## Test Plan

- `uv run ruff check` and `uv run ruff format --check` on changed files.
- `uv run pyright` on changed files.
- `uv run pytest tests/server/services/playbook_optimizer tests/server/services/storage tests/server/services/reflection tests/models` — covers the new contract and optimizer logic.
