### PR TITLE
feat(playbook-optimizer): drop allow_single_window_commit, gate runs by adoption path

### DIFF
--- a/docs/playbook_optimizer_assistant_backends.md
+++ b/docs/playbook_optimizer_assistant_backends.md
@@ -280,7 +280,7 @@ def _create_assistant(self, config) -> AssistantCallable | None:
 | Both set | **Rejected at config load time** by a Pydantic validator (`ValueError: Configure only one playbook optimizer assistant backend...`) |
 | Neither set | Optimizer logs `Skipping playbook optimization: no assistant backend configured` and returns without creating a job |
 
-The check happens *before* loading the incumbent or resolving scenario windows, so an unconfigured optimizer short-circuits cheaply.
+The backend check happens *before* loading the incumbent or resolving scenario windows, so an unconfigured optimizer short-circuits cheaply. After source-window resolution, the optimizer also skips before job creation when the validation holdout is smaller than `min_commit_windows` or the target kind has no enabled auto-update path.
 
 ---
 
@@ -296,6 +296,21 @@ All fields live on `PlaybookOptimizerConfig` (in `reflexio/models/config_schema.
 | `assistant_script_args` | `list[str]` | `[]` | Extra argv tokens passed after `assistant_script_path`. |
 | `max_validation_windows` | `int > 0` | 2 | Maximum source windows held out for validation; all remaining source windows form the GEPA training pool. |
 
+Reflexio always passes `cache_evaluation=True` to GEPA so the same accepted
+candidate/window pair is never scored twice across iterations.
+
+Single-window optimization is eligible when `min_commit_windows=1`. In that
+case Reflexio also passes `valset=None` so GEPA reuses the training loader
+as validation.
+
+With the default `min_commit_windows=2` and `max_validation_windows=2`, the
+optimizer needs at least three source windows to run: two are held out for
+validation and at least one stays in the training pool. Targets with one or
+two source windows are skipped before any job row is written. Note that the
+default `max_metric_calls` and `max_turns` were lowered (from 40 → 20 and
+5 → 4) in this release to keep nightly runs cheaper — raise them if you
+need deeper exploration.
+
 ### 6.2 Existing fields that now apply to both backends
 
 | Field | Type | Default | Notes |
@@ -305,6 +320,8 @@ All fields live on `PlaybookOptimizerConfig` (in `reflexio/models/config_schema.
 | `webhook_timeout_seconds` | `int > 0` | 60 | Per-call timeout — both backends |
 | `webhook_max_retries` | `int >= 0` | 3 | Retry budget — both backends |
 | `webhook_backoff_base_seconds` | `float >= 0` | 1.0 | Exponential base — both backends |
+| `max_metric_calls` | `int > 0` | 20 | GEPA metric-call budget per optimization run |
+| `max_turns` | `int > 0` | 4 | Maximum user turns replayed per source window rollout |
 | `reflection_minibatch_size` | `int > 0` | 2 | Number of training windows GEPA samples for each reflection minibatch |
 
 ### 6.3 Validator

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -472,13 +472,10 @@ class PlaybookOptimizerConfig(BaseModel):
     optimize_user_playbooks: bool = False
     auto_update_pending_agent_playbooks: bool = True
     auto_update_user_playbooks: bool = False
-    # If only one source window is available, a "win" is more likely to be
-    # noise than a real improvement. Default off.
-    allow_single_window_commit: bool = False
 
     # --- GEPA budget -------------------------------------------------------
-    max_metric_calls: int = Field(default=40, gt=0)
-    max_turns: int = Field(default=5, gt=0)
+    max_metric_calls: int = Field(default=20, gt=0)
+    max_turns: int = Field(default=4, gt=0)
     reflection_minibatch_size: int = Field(default=2, gt=0)
     max_validation_windows: int = Field(default=2, gt=0)
     min_commit_windows: int = Field(default=2, gt=0)

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -93,12 +93,28 @@ class PlaybookOptimizer:
         windows = self._resolve_windows(target, config)
         if not windows:
             return "skipped"
-        if len(windows) == 1 and not config.allow_single_window_commit:
-            logger.info("Skipping playbook optimization with one source window")
-            return "skipped"
         train_windows, validation_windows = _split_train_validation_windows(
             windows, config
         )
+        if len(validation_windows) < config.min_commit_windows:
+            logger.info(
+                "Skipping playbook optimization: validation windows below "
+                "min_commit_windows target_kind=%s target_id=%d "
+                "validation_windows=%d min_commit_windows=%d",
+                target.kind,
+                target.target_id,
+                len(validation_windows),
+                config.min_commit_windows,
+            )
+            return "skipped"
+        if not _can_adopt_winner(target, config):
+            logger.info(
+                "Skipping playbook optimization: no configured adoption path "
+                "target_kind=%s target_id=%d",
+                target.kind,
+                target.target_id,
+            )
+            return "skipped"
         split_metadata = _split_metadata(windows, train_windows, validation_windows)
 
         job = self.storage.create_playbook_optimization_job(
@@ -259,7 +275,9 @@ class PlaybookOptimizer:
         return gepa_optimize(
             seed_candidate={PLAYBOOK_CONTENT_COMPONENT: seed_content},
             trainset=train_windows,
-            valset=validation_windows,
+            valset=None
+            if _same_window_sequence(train_windows, validation_windows)
+            else validation_windows,
             adapter=adapter,
             reflection_lm=reflection_lm,
             candidate_selection_strategy="pareto",
@@ -271,6 +289,7 @@ class PlaybookOptimizer:
             max_metric_calls=config.max_metric_calls,
             raise_on_exception=False,
             display_progress_bar=False,
+            cache_evaluation=True,
             callbacks=cast(Any, [_GEPAStorageCallback(self.storage, adapter.job_id)]),
         )
 
@@ -385,9 +404,12 @@ class PlaybookOptimizer:
         best_content: str,
         config: PlaybookOptimizerConfig,
     ) -> int | None:
+        # The optimize() entrypoint already gates on _can_adopt_winner before
+        # creating the job, but check again so this stays correct if called
+        # from elsewhere.
+        if not _can_adopt_winner(target, config):
+            return None
         if target.kind == "agent_playbook":
-            if not config.auto_update_pending_agent_playbooks:
-                return None
             source_windows = _source_windows_with_backfill(
                 self.storage, target.target_id
             )
@@ -416,8 +438,6 @@ class PlaybookOptimizer:
                     saved[0].agent_playbook_id, source_windows
                 )
                 return saved[0].agent_playbook_id
-            return None
-        if not config.auto_update_user_playbooks:
             return None
         current_user = self.storage.get_user_playbook_by_id(target.target_id)
         if current_user is None or current_user.status is not None:
@@ -448,6 +468,15 @@ def _agent_like_playbook(playbook: UserPlaybook) -> AgentPlaybook:
         playbook_status=PlaybookStatus.PENDING,
         status=playbook.status,
     )
+
+
+def _can_adopt_winner(
+    target: PlaybookOptimizationTarget,
+    config: PlaybookOptimizerConfig,
+) -> bool:
+    if target.kind == "agent_playbook":
+        return config.auto_update_pending_agent_playbooks
+    return config.auto_update_user_playbooks
 
 
 def _append_optimizer_metadata(existing: str, predecessor_id: int) -> str:
@@ -516,6 +545,18 @@ def _split_train_validation_windows(
     validation_windows = ordered_windows[:validation_count]
     train_windows = ordered_windows[validation_count:]
     return train_windows, validation_windows
+
+
+def _same_window_sequence(
+    left: list[ScenarioWindow],
+    right: list[ScenarioWindow],
+) -> bool:
+    if len(left) != len(right):
+        return False
+    return all(
+        _window_eval_key(left_window) == _window_eval_key(right_window)
+        for left_window, right_window in zip(left, right, strict=True)
+    )
 
 
 def _source_windows_with_backfill(

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -746,6 +746,8 @@ class TestCrossFieldValidators:
 
         assert config.webhook_url is None
         assert config.assistant_script_path is None
+        assert config.max_metric_calls == 20
+        assert config.max_turns == 4
         assert config.max_validation_windows == 2
 
     def test_playbook_optimizer_rejects_invalid_max_validation_windows(self):

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -394,9 +394,9 @@ def test_optimizer_split_holds_out_len_minus_one_for_small_sets(tmp_path):
     assert len(validation_windows) == 1
 
 
-def test_optimizer_split_reuses_single_window_only_when_allowed(tmp_path):
+def test_optimizer_split_reuses_single_window(tmp_path):
     storage = _sqlite_storage(tmp_path)
-    config = PlaybookOptimizerConfig(allow_single_window_commit=True)
+    config = PlaybookOptimizerConfig()
     optimizer = _optimizer_for_test(
         storage,
         Config(
@@ -411,6 +411,217 @@ def test_optimizer_split_reuses_single_window_only_when_allowed(tmp_path):
     )
 
     assert train_windows == validation_windows == [_scenario_window(1)]
+
+
+def test_optimizer_skips_when_validation_windows_cannot_satisfy_commit_threshold(
+    tmp_path,
+):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            enabled=True,
+            optimize_agent_playbooks=True,
+            webhook_url="https://assistant.example.test/rollout",
+            min_commit_windows=2,
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    optimizer._load_incumbent = Mock(  # type: ignore[method-assign]
+        return_value=AgentPlaybook(
+            agent_playbook_id=1,
+            playbook_name="support",
+            agent_version="v1",
+            content="incumbent",
+            playbook_status=PlaybookStatus.PENDING,
+        )
+    )
+    optimizer._resolve_windows = Mock(  # type: ignore[method-assign]
+        return_value=[_scenario_window(1), _scenario_window(2)]
+    )
+    optimizer._run_gepa = Mock(side_effect=AssertionError("GEPA should not run"))  # type: ignore[method-assign]
+
+    result = optimizer.optimize(
+        PlaybookOptimizationTarget(kind="agent_playbook", target_id=1)
+    )
+
+    assert result == "skipped"
+    optimizer._run_gepa.assert_not_called()  # type: ignore[attr-defined]
+    jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
+    assert jobs == []
+
+
+@pytest.mark.parametrize(
+    ("target", "optimizer_config"),
+    [
+        (
+            PlaybookOptimizationTarget(kind="agent_playbook", target_id=1),
+            PlaybookOptimizerConfig(
+                enabled=True,
+                optimize_agent_playbooks=True,
+                auto_update_pending_agent_playbooks=False,
+                webhook_url="https://assistant.example.test/rollout",
+            ),
+        ),
+        (
+            PlaybookOptimizationTarget(kind="user_playbook", target_id=1),
+            PlaybookOptimizerConfig(
+                enabled=True,
+                optimize_user_playbooks=True,
+                auto_update_user_playbooks=False,
+                webhook_url="https://assistant.example.test/rollout",
+            ),
+        ),
+    ],
+)
+def test_optimizer_skips_when_winner_cannot_be_adopted(
+    tmp_path, target, optimizer_config
+):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=optimizer_config,
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    optimizer._load_incumbent = Mock(  # type: ignore[method-assign]
+        return_value=AgentPlaybook(
+            agent_playbook_id=1,
+            playbook_name="support",
+            agent_version="v1",
+            content="incumbent",
+            playbook_status=PlaybookStatus.PENDING,
+        )
+    )
+    optimizer._resolve_windows = Mock(  # type: ignore[method-assign]
+        return_value=[_scenario_window(idx) for idx in range(1, 4)]
+    )
+    optimizer._run_gepa = Mock(side_effect=AssertionError("GEPA should not run"))  # type: ignore[method-assign]
+
+    result = optimizer.optimize(target)
+
+    assert result == "skipped"
+    optimizer._run_gepa.assert_not_called()  # type: ignore[attr-defined]
+    jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
+    assert jobs == []
+
+
+def test_optimizer_runs_single_window_when_commit_threshold_is_one(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            enabled=True,
+            optimize_agent_playbooks=True,
+            webhook_url="https://assistant.example.test/rollout",
+            min_commit_windows=1,
+            min_commit_score=0.1,
+            min_commit_likert=1,
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    optimizer._load_incumbent = Mock(  # type: ignore[method-assign]
+        return_value=AgentPlaybook(
+            agent_playbook_id=1,
+            playbook_name="support",
+            agent_version="v1",
+            content="incumbent",
+            playbook_status=PlaybookStatus.PENDING,
+        )
+    )
+    window = _scenario_window(1)
+    optimizer._resolve_windows = Mock(return_value=[window])  # type: ignore[method-assign]
+
+    def fake_run_gepa(config, seed_content, train_windows, validation_windows, adapter):  # noqa: ARG001
+        candidate = adapter._ensure_candidate("candidate content")  # noqa: SLF001
+        storage.insert_playbook_optimization_evaluation(
+            PlaybookOptimizationEvaluation(
+                job_id=adapter.job_id,
+                candidate_id=candidate.candidate_id,
+                target_kind="agent_playbook",
+                target_id=1,
+                scenario_user_playbook_id=window.user_playbook_id,
+                source_interaction_ids=window.source_interaction_ids,
+                score=0.9,
+                verdict="candidate",
+                likert=5,
+            )
+        )
+        return SimpleNamespace(
+            best_candidate={PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+            val_aggregate_scores=[0.9],
+            best_idx=0,
+            to_dict=lambda: {"best_idx": 0},
+        )
+
+    optimizer._run_gepa = Mock(side_effect=fake_run_gepa)  # type: ignore[method-assign]
+
+    result = optimizer.optimize(
+        PlaybookOptimizationTarget(kind="agent_playbook", target_id=1)
+    )
+
+    assert result == "completed"
+    optimizer._run_gepa.assert_called_once()  # type: ignore[attr-defined]
+    _, _, train_windows, validation_windows, _ = optimizer._run_gepa.call_args.args  # type: ignore[attr-defined]
+    assert train_windows == validation_windows == [window]
+    jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
+    assert jobs[0]["status"] == "completed"
+
+
+def test_run_gepa_reuses_trainset_for_single_window_validation(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(
+        enabled=True,
+        optimize_agent_playbooks=True,
+        webhook_url="https://assistant.example.test/rollout",
+    )
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+    adapter = Mock(job_id=123)
+    window = _scenario_window(1)
+    with patch("gepa.api.optimize") as gepa_optimize:
+        gepa_optimize.return_value = SimpleNamespace()
+
+        optimizer._run_gepa(config, "seed", [window], [window], adapter)  # noqa: SLF001
+
+    _, kwargs = gepa_optimize.call_args
+    assert kwargs["trainset"] == [window]
+    assert kwargs["valset"] is None
+    assert kwargs["cache_evaluation"] is True
+
+
+def test_run_gepa_keeps_distinct_validation_holdout(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(
+        enabled=True,
+        optimize_agent_playbooks=True,
+        webhook_url="https://assistant.example.test/rollout",
+    )
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+    adapter = Mock(job_id=123)
+    train_windows = [_scenario_window(2)]
+    validation_windows = [_scenario_window(1)]
+    with patch("gepa.api.optimize") as gepa_optimize:
+        gepa_optimize.return_value = SimpleNamespace()
+
+        optimizer._run_gepa(  # noqa: SLF001
+            config, "seed", train_windows, validation_windows, adapter
+        )
+
+    _, kwargs = gepa_optimize.call_args
+    assert kwargs["trainset"] == train_windows
+    assert kwargs["valset"] == validation_windows
+    assert kwargs["cache_evaluation"] is True
 
 
 def test_optimizer_runs_local_script_assistant_and_persists_evaluation(tmp_path):
@@ -483,8 +694,7 @@ json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys
             optimize_agent_playbooks=True,
             assistant_script_path=sys.executable,
             assistant_script_args=[str(script), str(record)],
-            allow_single_window_commit=True,
-            auto_update_pending_agent_playbooks=False,
+            auto_update_pending_agent_playbooks=True,
             min_commit_windows=1,
             min_commit_score=0.1,
             min_commit_likert=1,
@@ -544,7 +754,7 @@ def test_optimizer_passes_distinct_train_and_validation_sets_to_gepa(tmp_path):
             enabled=True,
             optimize_agent_playbooks=True,
             webhook_url="https://assistant.example.test/rollout",
-            auto_update_pending_agent_playbooks=False,
+            auto_update_pending_agent_playbooks=True,
             min_commit_windows=1,
             min_commit_score=0.1,
             min_commit_likert=1,
@@ -712,7 +922,6 @@ def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
             enabled=True,
             optimize_agent_playbooks=True,
             webhook_url="https://assistant.example.test/rollout",
-            allow_single_window_commit=True,
             min_commit_windows=1,
             min_commit_score=0.1,
             min_commit_likert=1,


### PR DESCRIPTION
## Summary

Cleanup pass on the GEPA-backed playbook optimizer:

- **Remove `allow_single_window_commit`.** It was never released, and single-window eligibility is now governed by `min_commit_windows` relative to the validation holdout size. One less knob to keep coherent.
- **Skip optimization runs upfront when there is no adoption path.** If the target kind has no auto-update path enabled (`auto_update_pending_agent_playbooks` for agent playbooks, `auto_update_user_playbooks` for user playbooks), the optimizer skips before creating a job row. Avoids producing winners that could never be adopted.
- **Always pass `cache_evaluation=True` to GEPA.** The same accepted candidate/window pair is no longer scored twice across iterations.
- **Single-window mode reuses the trainset as valset.** When train and validation windows are identical, pass `valset=None` so GEPA does not double-count the holdout.
- **Lower default GEPA budget.** `max_metric_calls` 40 → 20, `max_turns` 5 → 4. Cheaper nightly runs; raise these for deeper exploration.
- **Consolidate the per-kind adoption check** into `_can_adopt_winner`, used by both the upfront skip in `optimize()` and `_commit_if_allowed`.

## Behavior notes

- With the new defaults (`min_commit_windows=2`, `max_validation_windows=2`), the optimizer requires **≥3 source windows** to run — two held out for validation and at least one in the training pool. Targets with one or two source windows are skipped before any job is created. Lower `min_commit_windows` to 1 to opt into single-window or two-window optimization.
- Caching is now always on, not single-window-only — docs updated to match.

## Test plan
- [x] `pytest tests/server/services/playbook_optimizer/test_playbook_optimizer.py` — all green (27 tests)
- [x] `pytest tests/models/test_validators.py` — all green
- [x] `ruff check` clean on all changed files
- [x] `pyright` clean on all changed files