### PR TITLE
feat(playbook-optimizer): add early_stop_score to halt GEPA at threshold

### DIFF
--- a/docs/playbook_optimizer_assistant_backends.md
+++ b/docs/playbook_optimizer_assistant_backends.md
@@ -322,6 +322,7 @@ need deeper exploration.
 | `webhook_backoff_base_seconds` | `float >= 0` | 1.0 | Exponential base — both backends |
 | `max_metric_calls` | `int > 0` | 20 | GEPA metric-call budget per optimization run |
 | `max_turns` | `int > 0` | 4 | Maximum user turns replayed per source window rollout |
+| `early_stop_score` | `float [0, 1]` | 0.9 | Stops GEPA early once the current best validation score reaches this threshold |
 | `reflection_minibatch_size` | `int > 0` | 2 | Number of training windows GEPA samples for each reflection minibatch |
 
 ### 6.3 Validator

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -476,6 +476,7 @@ class PlaybookOptimizerConfig(BaseModel):
     # --- GEPA budget -------------------------------------------------------
     max_metric_calls: int = Field(default=20, gt=0)
     max_turns: int = Field(default=4, gt=0)
+    early_stop_score: float = Field(default=0.9, ge=0.0, le=1.0)
     reflection_minibatch_size: int = Field(default=2, gt=0)
     max_validation_windows: int = Field(default=2, gt=0)
     min_commit_windows: int = Field(default=2, gt=0)

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -270,6 +270,7 @@ class PlaybookOptimizer:
         adapter: ReflexioPlaybookGEPAAdapter,
     ) -> Any:
         from gepa.api import optimize as gepa_optimize
+        from gepa.utils.stop_condition import ScoreThresholdStopper
 
         reflection_lm = config.reflection_model or self.llm_client.config.model
         return gepa_optimize(
@@ -287,6 +288,7 @@ class PlaybookOptimizer:
             use_merge=config.use_merge,
             max_merge_invocations=config.max_merge_invocations,
             max_metric_calls=config.max_metric_calls,
+            stop_callbacks=[ScoreThresholdStopper(config.early_stop_score)],
             raise_on_exception=False,
             display_progress_bar=False,
             cache_evaluation=True,

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -748,7 +748,13 @@ class TestCrossFieldValidators:
         assert config.assistant_script_path is None
         assert config.max_metric_calls == 20
         assert config.max_turns == 4
+        assert config.early_stop_score == 0.9
         assert config.max_validation_windows == 2
+
+    def test_playbook_optimizer_rejects_invalid_early_stop_score(self):
+        """PlaybookOptimizerConfig: early stop score must be in [0, 1]."""
+        with pytest.raises(ValidationError):
+            PlaybookOptimizerConfig(early_stop_score=1.1)
 
     def test_playbook_optimizer_rejects_invalid_max_validation_windows(self):
         """PlaybookOptimizerConfig: validation window cap must be positive."""

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -592,6 +592,35 @@ def test_run_gepa_reuses_trainset_for_single_window_validation(tmp_path):
     assert kwargs["trainset"] == [window]
     assert kwargs["valset"] is None
     assert kwargs["cache_evaluation"] is True
+    [stopper] = kwargs["stop_callbacks"]
+    assert stopper.threshold == 0.9
+
+
+def test_run_gepa_forwards_configured_early_stop_score(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(
+        enabled=True,
+        optimize_agent_playbooks=True,
+        webhook_url="https://assistant.example.test/rollout",
+        early_stop_score=0.5,
+    )
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+    adapter = Mock(job_id=123)
+    window = _scenario_window(1)
+    with patch("gepa.api.optimize") as gepa_optimize:
+        gepa_optimize.return_value = SimpleNamespace()
+
+        optimizer._run_gepa(config, "seed", [window], [window], adapter)  # noqa: SLF001
+
+    _, kwargs = gepa_optimize.call_args
+    [stopper] = kwargs["stop_callbacks"]
+    assert stopper.threshold == 0.5
 
 
 def test_run_gepa_keeps_distinct_validation_holdout(tmp_path):


### PR DESCRIPTION
## Summary

- Add `early_stop_score` knob to `PlaybookOptimizerConfig` (default `0.9`, range `[0, 1]`) so optimization runs can halt as soon as the current best validation score reaches the threshold.
- Plumb the value into GEPA via `ScoreThresholdStopper`, saving metric-call budget on already-strong playbooks. Setting the value to `1.0` effectively disables early stopping.
- Document the new field in the assistant-backends doc.

## Changes

- `reflexio/models/config_schema.py`: new `early_stop_score: float = Field(default=0.9, ge=0.0, le=1.0)` field on `PlaybookOptimizerConfig`.
- `reflexio/server/services/playbook_optimizer/optimizer.py`: import `ScoreThresholdStopper` and pass `stop_callbacks=[ScoreThresholdStopper(config.early_stop_score)]` to `gepa_optimize`.
- `docs/playbook_optimizer_assistant_backends.md`: add a row in the budget-and-threshold table.
- Tests:
  - `tests/models/test_validators.py`: assert default value and reject out-of-range values.
  - `tests/server/services/playbook_optimizer/test_playbook_optimizer.py`: assert the default value flows through to GEPA, and a non-default `early_stop_score=0.5` is forwarded to the stopper.

## Test Plan

- [x] `uv run ruff check` and `uv run ruff format --check` on changed Python files
- [x] `uv run pyright` on changed source files
- [x] `uv run pytest tests/server/services/playbook_optimizer/test_playbook_optimizer.py tests/models/test_validators.py::TestCrossFieldValidators` (41 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added early stopping capability to the playbook optimizer with a configurable score threshold. You can now set an early_stop_score parameter (default: 0.9, valid range: 0.0–1.0) to automatically stop optimization runs when the target score is achieved.

* **Documentation**
  * Updated configuration documentation to document the new early_stop_score field.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->