### PR TITLE
fix(profile,aggregator,api,lock): rerun dedup + similarity default + update_config validation + concurrent-publish fix

### DIFF
--- a/docs/playbook_optimizer_assistant_backends.md
+++ b/docs/playbook_optimizer_assistant_backends.md
@@ -322,6 +322,7 @@ need deeper exploration.
 | `webhook_backoff_base_seconds` | `float >= 0` | 1.0 | Exponential base — both backends |
 | `max_metric_calls` | `int > 0` | 20 | GEPA metric-call budget per optimization run |
 | `max_turns` | `int > 0` | 4 | Maximum user turns replayed per source window rollout |
+| `early_stop_score` | `float [0, 1]` | 0.9 | Stops GEPA early once the current best validation score reaches this threshold |
 | `reflection_minibatch_size` | `int > 0` | 2 | Number of training windows GEPA samples for each reflection minibatch |
 
 ### 6.3 Validator

--- a/reflexio/cli/commands/config_cmd.py
+++ b/reflexio/cli/commands/config_cmd.py
@@ -309,6 +309,15 @@ def update_config(
     config — you only specify the fields you want to change. Useful for
     flipping a single backend without re-supplying ``storage_config``.
 
+    .. warning::
+       The merge is **top-level shallow only**. Nested objects (e.g.
+       ``storage_config``) and nested lists (e.g. ``playbook_configs``,
+       ``profile_configs``) are replaced wholesale -- to mutate a
+       single field inside ``playbook_configs[0]`` you must resend the
+       full ``playbook_configs`` list with that entry fully populated.
+       For surgical edits to nested-list fields prefer
+       ``reflexio config get`` -> edit JSON -> ``reflexio config set``.
+
     Args:
         ctx: Typer context with CliState in ctx.obj
         data: JSON string or ``@filepath`` with the partial config payload.

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -476,6 +476,7 @@ class PlaybookOptimizerConfig(BaseModel):
     # --- GEPA budget -------------------------------------------------------
     max_metric_calls: int = Field(default=20, gt=0)
     max_turns: int = Field(default=4, gt=0)
+    early_stop_score: float = Field(default=0.9, ge=0.0, le=1.0)
     reflection_minibatch_size: int = Field(default=2, gt=0)
     max_validation_windows: int = Field(default=2, gt=0)
     min_commit_windows: int = Field(default=2, gt=0)

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -371,10 +371,17 @@ class PlaybookAggregatorConfig(BaseModel):
     min_cluster_size: int = Field(default=2, ge=1)
     reaggregation_trigger_count: int = Field(default=2, ge=1)
     clustering_similarity: float = Field(
-        default=0.5,
+        default=0.3,
         ge=0.0,
         le=1.0,
-        description="Cosine similarity threshold for clustering. Higher = tighter clusters.",
+        description=(
+            "Cosine similarity threshold for clustering. Higher = tighter clusters. "
+            "Default 0.3 is a compromise that works for both cloud embeddings "
+            "(OpenAI text-embedding-3-*, Gemini) and the local zero-padded "
+            "MiniLM-L6-v2 embedder. Cloud embeddings typically tolerate 0.4-0.6; "
+            "the local embedder's 384-dim vectors zero-padded to 512 produce "
+            "lower cosine similarities and need ~0.15-0.3 to cluster at all."
+        ),
     )
     direction_overlap_threshold: float = Field(
         default=0.6,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1124,17 +1124,30 @@ def update_config(
 ) -> SetConfigResponse:
     """Apply a partial update to the org's config (PATCH semantics).
 
-    Performs a top-level shallow merge of *partial* over the existing
+    Performs a **top-level shallow merge** of *partial* over the existing
     config and round-trips through ``Config(**merged)`` so Pydantic
-    validates the result and rejects bogus top-level fields. Nested
-    objects (e.g. ``storage_config``) are replaced wholesale — deep
-    merging is intentionally not supported.
+    validates the result and rejects bogus top-level fields.
+
+    .. warning::
+       Nested objects (e.g. ``storage_config``) and nested lists
+       (e.g. ``playbook_configs``, ``profile_configs``) are **replaced
+       wholesale**. Deep merging is intentionally not supported -- the
+       discriminator on ``storage_config`` would be lost on partial
+       updates, and merging list-of-dicts has ambiguous semantics
+       (replace by index? merge by key? insert?).
+
+       To update a single field inside ``playbook_configs[0]`` you must
+       resend the full ``playbook_configs`` list with that one entry
+       fully populated (including ``extractor_name``,
+       ``extraction_definition_prompt``, etc.). For one-off mutations
+       prefer ``GET /api/get_config`` followed by
+       ``POST /api/set_config`` with the modified full config.
 
     Unlike :func:`set_config`, callers do not need to re-send the full
     config (including required fields like ``storage_config``) just to
-    flip a single boolean. The merge happens server-side atomically
-    within the request, eliminating the read-modify-write race a client
-    would otherwise hit.
+    flip a single top-level boolean. The merge happens server-side
+    atomically within the request, eliminating the read-modify-write
+    race a client would otherwise hit.
 
     Args:
         partial: Top-level fields to overlay on the existing config.
@@ -1144,6 +1157,8 @@ def update_config(
         SetConfigResponse: Success status and message from
         :meth:`Reflexio.set_config`.
     """
+    from pydantic import ValidationError
+
     reflexio = get_reflexio(org_id=org_id)
     existing = reflexio.request_context.configurator.get_config().model_dump(
         mode="python"
@@ -1151,7 +1166,28 @@ def update_config(
     merged = {**existing, **partial}
     # Pydantic validates the merged shape and rejects unknown / malformed
     # fields here, before storage validation in reflexio.set_config.
-    response = reflexio.set_config(Config(**merged))
+    # Convert ValidationError into 422 so callers passing a partial that
+    # would replace a nested-list field with an incomplete dict (e.g.
+    # {"playbook_configs": [{"aggregation_config": {...}}]}) get a clean
+    # client-error response instead of a 500.
+    try:
+        merged_config = Config(**merged)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "error": "Invalid partial config (top-level shallow merge)",
+                "hint": (
+                    "Nested objects and list-of-dict fields (e.g. "
+                    "playbook_configs) are replaced wholesale, not "
+                    "deep-merged. To mutate a single field inside a "
+                    "list entry, fetch the full config via /api/get_config, "
+                    "edit, and PUT it back via /api/set_config."
+                ),
+                "validation_errors": exc.errors(),
+            },
+        ) from exc
+    response = reflexio.set_config(merged_config)
     if response.success:
         invalidate_reflexio_cache(org_id=org_id)
     return response

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -487,6 +487,79 @@ class BaseGenerationService(
             self._get_base_service_name(),  # type: ignore[reportArgumentType]
         )
 
+    def _serialize_request_for_queue(self, request: TRequest) -> dict | None:
+        """Serialize a request for the pending-request queue.
+
+        Default implementation handles Pydantic ``BaseModel`` requests via
+        ``model_dump(mode="json")``. Override in subclasses whose requests
+        are not Pydantic models.
+
+        The queued payload is what the rerun loop will run when this request
+        comes off the queue — so it MUST capture every field the run needs to
+        reproduce the original publish (user_id, request_id, agent_version,
+        source, force_extraction, etc.). Without this, the rerun runs with the
+        wrong holder's request and the queued user's interactions are silently
+        skipped (R2 / reflexio-enterprise#59).
+
+        Returns ``None`` to opt out — the queue then stores only the
+        request_id and the rerun falls back to the original holder's request,
+        which is the pre-fix behaviour. Use only for services where the
+        per-request payload doesn't differ between concurrent callers.
+        """
+        # Pydantic BaseModel — handles the common case (PlaybookGenerationRequest,
+        # ProfileGenerationRequest).
+        model_dump = getattr(request, "model_dump", None)
+        if callable(model_dump):
+            try:
+                dumped = model_dump(mode="json")
+            except Exception:  # pragma: no cover — defensive
+                logger.warning(
+                    "Failed to model_dump %s request for queue; "
+                    "rerun will fall back to original holder's request",
+                    self._get_service_name(),
+                )
+                return None
+            if isinstance(dumped, dict):
+                return dumped
+        return None
+
+    def _deserialize_request_from_queue(
+        self,
+        payload: dict,
+        original_request: TRequest,
+    ) -> TRequest:
+        """Reconstruct a request object from a queued payload.
+
+        Default implementation calls ``type(original_request).model_validate(payload)``
+        for Pydantic-backed requests. Override in subclasses with non-Pydantic
+        request types.
+
+        Args:
+            payload: The dict previously produced by ``_serialize_request_for_queue``
+            original_request: The request the lock holder ran with — used as a
+                fallback type and for any fields the payload doesn't carry
+        """
+        request_cls = type(original_request)
+        model_validate = getattr(request_cls, "model_validate", None)
+        if callable(model_validate):
+            try:
+                rebuilt = model_validate(payload)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning(
+                    "Failed to model_validate queued payload for %s: %s; "
+                    "falling back to original request",
+                    self._get_service_name(),
+                    exc,
+                )
+                return original_request
+            # Narrow the object type to TRequest — model_validate on
+            # type(original_request) returns the same class, so the cast is
+            # safe in practice. Pyright can't see through getattr, so we
+            # use isinstance to satisfy the type checker.
+            if isinstance(rebuilt, request_cls):
+                return rebuilt  # type: ignore[reportReturnType]
+        return original_request
+
     def run(self, request: TRequest) -> None:
         """
         Run the generation service for the given request.
@@ -512,14 +585,23 @@ class BaseGenerationService(
 
         state_manager = self._create_state_manager()
 
-        # Try to acquire lock
-        if not state_manager.acquire_lock(my_request_id, scope_id=scope_id):
-            return  # Another operation is running, we've updated pending_request_id
+        # Try to acquire lock — pass the serialized payload so blocked
+        # publishes land in the queue with their own data attached. This is
+        # the fix for R2 / reflexio-enterprise#59: without the payload, the
+        # rerun re-uses the holder's request and the queued users' batches
+        # never get extracted.
+        my_payload = self._serialize_request_for_queue(request)
+        if not state_manager.acquire_lock(
+            my_request_id, scope_id=scope_id, payload=my_payload
+        ):
+            return  # Another operation is running, we've enqueued ourselves
 
-        # Re-run loop: keep running until no new requests come in
+        current_request: TRequest = request
+
+        # Re-run loop: drain the pending queue (FIFO) until empty
         try:
             while True:
-                self._run_generation(request)
+                self._run_generation(current_request)
 
                 # If in batch mode and cancellation was requested, clear lock
                 # to prevent queued pending requests from running, then stop
@@ -531,23 +613,39 @@ class BaseGenerationService(
                     )
                     break
 
-                # Check if another request came in during our run
-                pending_request_id = state_manager.release_lock(
+                # Pop the next queued request (if any). Returns the queued
+                # request's ID + payload so the rerun runs against THAT
+                # publish's data, not the original holder's.
+                next_entry = state_manager.release_lock_pop_queue(
                     my_request_id, scope_id=scope_id
                 )
 
+                if next_entry is None:
+                    break  # Queue empty — we're done
+
+                next_request_id = next_entry["request_id"]
+                next_payload = next_entry.get("payload")
+
                 logger.info(
-                    "Released in-progress lock for %s: request_id=%s, pending_request_id=%s",
+                    "Draining queued %s request: prev_request_id=%s, next_request_id=%s, "
+                    "payload_present=%s",
                     self._get_service_name(),
                     my_request_id,
-                    pending_request_id,
+                    next_request_id,
+                    next_payload is not None,
                 )
 
-                if not pending_request_id:
-                    break  # No pending request, we're done
+                # Reconstruct the queued request. If the payload is missing
+                # (legacy state row from a pre-fix server), fall back to the
+                # original request — matches pre-fix behaviour.
+                if next_payload:
+                    current_request = self._deserialize_request_from_queue(
+                        next_payload, request
+                    )
+                else:
+                    current_request = request
 
-                # Another request came in, update my_request_id and re-run
-                my_request_id = pending_request_id
+                my_request_id = next_request_id
 
         except Exception:
             # Clear lock on error to prevent deadlock

--- a/reflexio/server/services/operation_state_utils.py
+++ b/reflexio/server/services/operation_state_utils.py
@@ -383,27 +383,40 @@ class OperationStateManager:
         request_id: str,
         scope_id: str | None = None,
         stale_seconds: int = GENERATION_STALE_LOCK_SECONDS,
+        payload: dict | None = None,
     ) -> bool:
         """Atomically check and acquire in-progress lock.
 
         Uses a single atomic database operation to prevent race conditions where
         multiple requests could both acquire the lock simultaneously.
 
-        If a valid in-progress operation exists, updates pending_request_id so the
-        running operation knows to re-run when it finishes. If no valid lock exists
-        or the lock is stale, acquires the lock.
+        If a valid in-progress operation exists, appends the request to the
+        ``pending_request_queue`` (along with its ``payload``) so the running
+        operation drains queued requests one at a time after it completes. If
+        no valid lock exists or the lock is stale, acquires the lock.
 
         Args:
             request_id: Current request ID
             scope_id: Optional scope identifier (e.g., user_id)
             stale_seconds: Seconds after which a lock is considered stale
+            payload: Optional serialized request payload to enqueue with this
+                request when the lock is held by someone else. Required for the
+                rerun loop to operate on the SAME interactions the original
+                publish enqueued, not whatever the bookmark currently points at
+                (R2 / reflexio-enterprise#59).
 
         Returns:
             bool: True if lock acquired (proceed with generation), False if skipped
         """
         state_key = self._lock_key(scope_id)
+        # Pass ``payload`` as a kwarg so storage backends that haven't been
+        # updated to the new signature still error loudly rather than silently
+        # dropping it on the floor.
         result = self.storage.try_acquire_in_progress_lock(
-            state_key, request_id, stale_seconds
+            state_key,
+            request_id,
+            stale_seconds,
+            payload=payload,
         )
 
         acquired = result.get("acquired", False)
@@ -418,7 +431,7 @@ class OperationStateManager:
         else:
             logger.info(
                 "Skipping %s - another operation is in progress (state_key=%s). "
-                "Updated pending_request_id to %s",
+                "Enqueued request_id=%s for drain on release",
                 self.service_name,
                 state_key,
                 request_id,
@@ -500,6 +513,9 @@ class OperationStateManager:
     def clear_lock(self, scope_id: str | None = None) -> None:
         """Clear the in-progress state (used for error cleanup).
 
+        Also drops any queued pending requests — they were tied to the now-failed
+        run's context and should not be drained against fresh state.
+
         Args:
             scope_id: Optional scope identifier (e.g., user_id)
         """
@@ -510,6 +526,7 @@ class OperationStateManager:
                 "in_progress": False,
                 "current_request_id": None,
                 "pending_request_id": None,
+                "pending_request_queue": [],
             },
         )
         logger.debug(
@@ -517,6 +534,112 @@ class OperationStateManager:
             self.service_name,
             state_key,
         )
+
+    def release_lock_pop_queue(
+        self,
+        request_id: str,
+        scope_id: str | None = None,
+    ) -> dict | None:
+        """Release the lock and pop the next queued pending request, if any.
+
+        FIFO drain — preserves order so blocked publishes are processed in the
+        order they arrived. Replaces the older single-slot ``pending_request_id``
+        last-wins behaviour that silently dropped earlier blocked publishes
+        (R2 / reflexio-enterprise#59).
+
+        On a legacy state row (written by a pre-fix server before redeploy)
+        the queue is missing but ``pending_request_id`` may be set; we surface
+        that as a queue entry with ``payload=None`` so the caller falls back
+        to the original request rather than dropping it on the floor.
+
+        Args:
+            request_id: The request ID of the current operation (the holder)
+            scope_id: Optional scope identifier (e.g., user_id)
+
+        Returns:
+            dict | None: ``{"request_id": str, "payload": dict | None}`` for
+                the next queued request, or None if the queue is empty / we're
+                not the lock holder.
+        """
+        state_key = self._lock_key(scope_id)
+        state_record = self.storage.get_operation_state(state_key)
+
+        if not state_record:
+            return None
+
+        state = (
+            state_record.get("operation_state", {})
+            if isinstance(state_record.get("operation_state"), dict)
+            else state_record
+        )
+
+        # Backward compatibility for locks written before current_request_id was introduced.
+        current_request_id = state.get("current_request_id") or state.get("request_id")
+
+        # Only drain if we still own the lock.
+        if current_request_id != request_id:
+            return None
+
+        queue = list(state.get("pending_request_queue") or [])
+        next_entry: dict | None = None
+
+        if queue:
+            head = queue.pop(0)
+            if isinstance(head, dict) and "request_id" in head:
+                next_entry = {
+                    "request_id": head["request_id"],
+                    "payload": head.get("payload"),
+                }
+
+        if next_entry is None:
+            # Legacy fallback: storage row lacks the queue field but the old
+            # pending_request_id slot was set by an in-flight pre-fix server.
+            legacy_pending = state.get("pending_request_id")
+            if legacy_pending and legacy_pending != request_id:
+                next_entry = {"request_id": legacy_pending, "payload": None}
+
+        if next_entry is None:
+            # No more pending work — clear the lock.
+            self.storage.upsert_operation_state(
+                state_key,
+                {
+                    "in_progress": False,
+                    "current_request_id": None,
+                    "pending_request_id": None,
+                    "pending_request_queue": [],
+                },
+            )
+            logger.info(
+                "Released in-progress lock for %s: state_key=%s, request_id=%s",
+                self.service_name,
+                state_key,
+                request_id,
+            )
+            return None
+
+        # Transfer ownership to the popped request — it becomes the new holder.
+        # Mirror the head request_id into the legacy single slot for the
+        # release window during a server upgrade.
+        new_holder_request_id = next_entry["request_id"]
+        legacy_mirror = queue[0]["request_id"] if queue else None
+        self.storage.upsert_operation_state(
+            state_key,
+            {
+                "in_progress": True,
+                "started_at": int(time.time()),
+                "current_request_id": new_holder_request_id,
+                "pending_request_id": legacy_mirror,
+                "pending_request_queue": queue,
+            },
+        )
+        logger.info(
+            "Drained queued request %s on release of %s (state_key=%s, remaining=%d)",
+            new_holder_request_id,
+            self.service_name,
+            state_key,
+            len(queue),
+        )
+        return next_entry
 
     # ── Use Case 3: Extractor Bookmark ──
     # (Track last-processed interactions per extractor)

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -270,6 +270,7 @@ class PlaybookOptimizer:
         adapter: ReflexioPlaybookGEPAAdapter,
     ) -> Any:
         from gepa.api import optimize as gepa_optimize
+        from gepa.utils.stop_condition import ScoreThresholdStopper
 
         reflection_lm = config.reflection_model or self.llm_client.config.model
         return gepa_optimize(
@@ -287,6 +288,7 @@ class PlaybookOptimizer:
             use_merge=config.use_merge,
             max_merge_invocations=config.max_merge_invocations,
             max_metric_calls=config.max_metric_calls,
+            stop_callbacks=[ScoreThresholdStopper(config.early_stop_score)],
             raise_on_exception=False,
             display_progress_bar=False,
             cache_evaluation=True,

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from pydantic import BaseModel, ConfigDict, Field
 
 from reflexio.models.api_schema.retriever_schema import SearchUserProfileRequest
-from reflexio.models.api_schema.service_schemas import UserProfile
+from reflexio.models.api_schema.service_schemas import Status, UserProfile
 from reflexio.models.config_schema import EMBEDDING_DIMENSIONS
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
@@ -178,6 +178,7 @@ class ProfileDeduplicator(BaseDeduplicator):
         self,
         request_context: RequestContext,
         llm_client: LiteLLMClient,
+        output_pending_status: bool = False,
     ):
         """
         Initialize the profile deduplicator.
@@ -185,8 +186,15 @@ class ProfileDeduplicator(BaseDeduplicator):
         Args:
             request_context: Request context with storage and prompt manager
             llm_client: Unified LLM client for LLM calls
+            output_pending_status: When True (rerun preview mode), the deduplicator
+                searches against existing PENDING profiles instead of CURRENT
+                profiles. This makes rerun idempotent against pending state and
+                leaves the user's current profile set untouched. When False
+                (normal extraction), searches against CURRENT profiles so newly
+                extracted facts can supersede stale ones.
         """
         super().__init__(request_context, llm_client)
+        self.output_pending_status = output_pending_status
 
     def _get_prompt_id(self) -> str:
         """Get the prompt ID for profile deduplication."""
@@ -303,7 +311,22 @@ class ProfileDeduplicator(BaseDeduplicator):
             logger.warning("Failed to generate embeddings for dedup search: %s", e)
             embeddings = [None] * len(query_texts)
 
-        # Search for each new profile
+        # Search for each new profile.
+        #
+        # When output_pending_status=True (rerun preview mode), search against
+        # existing PENDING profiles so dedup is idempotent: a rerun should
+        # collapse duplicates within the pending preview set without ever
+        # touching the user's CURRENT profiles. Searching against [None]
+        # (current) here would cause newly-extracted profiles to be flagged
+        # as duplicates of current ones, and the downstream deletion step
+        # in ProfileGenerationService._process_results would then delete the
+        # CURRENT profiles -- collapsing the user's profile set to zero
+        # during what is supposed to be a non-destructive preview.
+        if self.output_pending_status:
+            search_status_filter: list[Status | None] = [Status.PENDING]
+        else:
+            search_status_filter = [None]  # Only current profiles
+
         seen_ids: set[str] = set()
         existing_profiles: list[UserProfile] = []
 
@@ -316,7 +339,7 @@ class ProfileDeduplicator(BaseDeduplicator):
                         top_k=10,
                         threshold=0.4,
                     ),
-                    status_filter=[None],  # Only current profiles
+                    status_filter=search_status_filter,
                     query_embedding=embeddings[i],
                 )
                 for profile in results:
@@ -329,8 +352,11 @@ class ProfileDeduplicator(BaseDeduplicator):
                 )
 
         logger.info(
-            "Retrieved %d unique existing profiles for deduplication",
+            "Retrieved %d unique existing profiles for deduplication "
+            "(status_filter=%s, output_pending_status=%s)",
             len(existing_profiles),
+            search_status_filter,
+            self.output_pending_status,
         )
         return existing_profiles
 

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -168,6 +168,7 @@ class ProfileGenerationService(
                 deduplicator = ProfileDeduplicator(
                     request_context=self.request_context,
                     llm_client=self.client,
+                    output_pending_status=self.output_pending_status,
                 )
                 all_new_profiles, existing_ids_to_delete, superseded_profiles = (
                     deduplicator.deduplicate(all_new_profiles, user_id, request_id)

--- a/reflexio/server/services/storage/disk_storage/_operations.py
+++ b/reflexio/server/services/storage/disk_storage/_operations.py
@@ -285,7 +285,11 @@ class OperationMixin:
             self._clear_dir(self._operation_states_dir())
 
     def try_acquire_in_progress_lock(
-        self, state_key: str, request_id: str, stale_lock_seconds: int = 300
+        self,
+        state_key: str,
+        request_id: str,
+        stale_lock_seconds: int = 300,
+        payload: dict | None = None,
     ) -> dict:
         current_time = int(time.time())
 
@@ -310,6 +314,7 @@ class OperationMixin:
                     "started_at": current_time,
                     "current_request_id": request_id,
                     "pending_request_id": None,
+                    "pending_request_queue": [],
                 }
                 state_data = {
                     "service_name": state_key,
@@ -319,8 +324,20 @@ class OperationMixin:
                 self._write_dict(path, state_data)
                 return {"acquired": True, "state": new_state}
 
-            # Case 3: Active lock - update pending
-            current_state["pending_request_id"] = request_id
+            # Holder retry — idempotent acquire.
+            if current_state.get("current_request_id") == request_id:
+                return {"acquired": True, "state": current_state}
+
+            # Case 3: Active lock - append to queue (FIFO, dedup by request_id)
+            queue = list(current_state.get("pending_request_queue") or [])
+            already_queued = any(
+                isinstance(entry, dict) and entry.get("request_id") == request_id
+                for entry in queue
+            )
+            if not already_queued:
+                queue.append({"request_id": request_id, "payload": payload})
+            current_state["pending_request_queue"] = queue
+            current_state["pending_request_id"] = request_id  # legacy mirror
             state_data = {
                 "service_name": state_key,
                 "operation_state": current_state,

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -271,7 +271,11 @@ class OperationMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def try_acquire_in_progress_lock(
-        self, state_key: str, request_id: str, stale_lock_seconds: int = 300
+        self,
+        state_key: str,
+        request_id: str,
+        stale_lock_seconds: int = 300,
+        payload: dict | None = None,
     ) -> dict:
         with self._lock:
             row = self._fetchone(
@@ -287,6 +291,7 @@ class OperationMixin:
                     "status": "in_progress",
                     "current_request_id": request_id,
                     "pending_request_id": None,
+                    "pending_request_queue": [],
                 }
                 self._execute(
                     """INSERT INTO _operation_state (service_name, operation_state, updated_at)
@@ -305,11 +310,13 @@ class OperationMixin:
                 is_stale = (now - updated_epoch) > stale_lock_seconds
 
             if current_state.get("status") != "in_progress" or is_stale:
-                # Acquire lock
+                # Acquire lock — reset queue (any pre-existing entries are
+                # stale-lock detritus from a crashed run; we want a clean slate).
                 state = {
                     "status": "in_progress",
                     "current_request_id": request_id,
                     "pending_request_id": None,
+                    "pending_request_queue": [],
                 }
                 self._execute(
                     "UPDATE _operation_state SET operation_state = ?, updated_at = ? WHERE service_name = ?",
@@ -317,7 +324,21 @@ class OperationMixin:
                 )
                 return {"acquired": True, "state": state}
 
-            # Lock is active — update pending
+            # Lock is active and held by ME — idempotent retry, do nothing.
+            if current_state.get("current_request_id") == request_id:
+                return {"acquired": True, "state": current_state}
+
+            # Lock is active and held by someone else — append to queue
+            queue = list(current_state.get("pending_request_queue") or [])
+            already_queued = any(
+                isinstance(entry, dict) and entry.get("request_id") == request_id
+                for entry in queue
+            )
+            if not already_queued:
+                queue.append({"request_id": request_id, "payload": payload})
+            current_state["pending_request_queue"] = queue
+            # Keep legacy single-slot in sync with the most-recent entry for
+            # back-compat with consumers that haven't migrated to the queue.
             current_state["pending_request_id"] = request_id
             self._execute(
                 "UPDATE _operation_state SET operation_state = ?, updated_at = ? WHERE service_name = ?",

--- a/reflexio/server/services/storage/storage_base/_operations.py
+++ b/reflexio/server/services/storage/storage_base/_operations.py
@@ -130,18 +130,37 @@ class OperationMixin:
 
     @abstractmethod
     def try_acquire_in_progress_lock(
-        self, state_key: str, request_id: str, stale_lock_seconds: int = 300
+        self,
+        state_key: str,
+        request_id: str,
+        stale_lock_seconds: int = 300,
+        payload: dict | None = None,
     ) -> dict:
         """Atomically try to acquire an in-progress lock.
 
         This method should use atomic operations to either:
         1. Acquire the lock if no active lock exists (or lock is stale)
-        2. Update pending_request_id if an active lock is held by another request
+        2. Append ``{"request_id": request_id, "payload": payload}`` to
+           ``pending_request_queue`` if an active lock is held by another
+           request. Duplicates (same ``request_id`` already queued, or matching
+           the current holder) are dropped to keep the queue idempotent under
+           publish retries.
+
+        The queue is a FIFO drained one entry at a time when the holder
+        releases the lock. It replaces the older single-slot
+        ``pending_request_id`` field, which silently dropped earlier blocked
+        requests when a new one came in. ``pending_request_id`` is still
+        written for one release window so a server upgrade in flight can be
+        drained by either code path.
 
         Args:
             state_key (str): The operation state key (e.g., "profile_generation_in_progress::3::user_id")
             request_id (str): The current request's unique identifier
             stale_lock_seconds (int): Seconds after which a lock is considered stale (default 300)
+            payload (dict | None): Optional serialized request payload preserved
+                for the rerun loop. Required so the rerun runs against the SAME
+                interactions the blocked publish enqueued, not whatever the
+                bookmark currently points at (R2 / reflexio-enterprise#59).
 
         Returns:
             dict: Result with keys:

--- a/tests/e2e_tests/test_concurrent_playbook_extraction.py
+++ b/tests/e2e_tests/test_concurrent_playbook_extraction.py
@@ -1,0 +1,192 @@
+"""Concurrent playbook extraction repro (reflexio-enterprise#59 / R2).
+
+This test reproduces the bug observed in the test-backend-pipeline run:
+
+  - Three publishes for distinct user_ids land within ~2s of each other.
+  - The first acquires the per-org playbook_generation lock.
+  - The second and third lose the race; each writes its request_id into
+    pending_request_id, with the third overwriting the second.
+  - When the first finishes, release_lock returns the third request_id.
+  - The base run() loop re-runs with the original request payload (not
+    the third user's) -- so users 2 and 3 never get their interactions
+    extracted.
+  - Only the first user produces a raw playbook.
+
+Marked xfail until reflexio-enterprise#59 is resolved. The architectural
+options being weighed in #59 are roughly:
+
+  (a) Make the playbook lock per-user (matching profiles), trading
+      cross-user dedup for parallelism.
+  (b) Switch ``pending_request_id`` from "single slot, last-wins" to a
+      queue, AND have the rerun loop iterate over distinct queued
+      payloads -- not the original request.
+  (c) Detach extraction from the publish-time lock entirely and run it
+      from a periodic worker that scans for any unprocessed
+      interactions.
+
+(a) is the smallest change but breaks the cross-user dedup invariant.
+(b) preserves dedup but is the largest refactor. (c) is the cleanest
+long-term answer but needs a reliable scheduler.
+
+The test passes once any of those is in place AND all three users see
+at least one raw playbook generated for their distinct interactions.
+"""
+
+# TODO(reflexio-enterprise#59): remove xfail once the per-user lock or
+# pending-queue refactor lands. The decision among (a)/(b)/(c) above
+# should be made by an architect-level review, not bolted on as a fix.
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.models.api_schema.service_schemas import InteractionData
+from tests.server.test_utils import skip_in_precommit, skip_low_priority
+
+pytestmark = pytest.mark.e2e
+
+
+# Three deliberately-distinct user conversations so each batch produces
+# different raw playbooks (no cross-user noise). Each batch has enough
+# corrective signal that the playbook extractor would happily emit at
+# least one playbook on a clean run.
+_BATCHES: list[list[dict]] = [
+    [
+        {
+            "role": "User",
+            "content": "I really need you to stop using bullet points -- prose only.",
+        },
+        {"role": "Agent", "content": "Sure, I'll switch to prose."},
+        {
+            "role": "User",
+            "content": "Good. And don't say 'sure' constantly, it sounds robotic.",
+        },
+        {"role": "Agent", "content": "Understood, I'll vary my acknowledgments."},
+        {
+            "role": "User",
+            "content": "Last thing -- always cite sources for technical claims.",
+        },
+        {"role": "Agent", "content": "Noted: prose, no 'sure', cite sources."},
+    ],
+    [
+        {
+            "role": "User",
+            "content": "Stop summarizing my code -- just answer the question I asked.",
+        },
+        {"role": "Agent", "content": "I'll skip the summary."},
+        {
+            "role": "User",
+            "content": "And give me a one-line answer first, then the explanation if I ask.",
+        },
+        {"role": "Agent", "content": "Got it: lead with the one-liner."},
+        {
+            "role": "User",
+            "content": "Also, never refactor my code without asking first.",
+        },
+        {"role": "Agent", "content": "Confirmed: no unsolicited refactors."},
+    ],
+    [
+        {
+            "role": "User",
+            "content": "When debugging, you keep guessing -- read the actual error first.",
+        },
+        {"role": "Agent", "content": "I'll read the error before hypothesizing."},
+        {
+            "role": "User",
+            "content": "And don't suggest random library swaps without checking the package.",
+        },
+        {"role": "Agent", "content": "I'll inspect installed packages first."},
+        {"role": "User", "content": "Show me the diff before applying it -- always."},
+        {"role": "Agent", "content": "Acknowledged: diff first, apply after approval."},
+    ],
+]
+
+
+def _publish_for_user(
+    reflexio: Reflexio, user_id: str, agent_version: str, batch: list[dict]
+) -> str:
+    """Publish one user's batch and return the user_id on completion."""
+    interactions = [InteractionData(**turn) for turn in batch]
+    response = reflexio.publish_interaction(
+        {
+            "user_id": user_id,
+            "interaction_data_list": interactions,
+            "source": "concurrent_test",
+            "agent_version": agent_version,
+        }
+    )
+    assert response.success is True, f"Publish failed for {user_id}: {response.message}"
+    return user_id
+
+
+@skip_in_precommit
+@skip_low_priority
+@pytest.mark.xfail(
+    reason=(
+        "R2: concurrent publishes for distinct users on the per-org "
+        "playbook lock lose extraction for everyone but the first. "
+        "Tracked as reflexio-enterprise#59. Options: per-user lock, "
+        "pending-id queue, or detached worker. See module docstring."
+    ),
+    strict=False,
+)
+def test_concurrent_publishes_distinct_users_all_produce_playbooks(
+    reflexio_instance_playbook_only: Reflexio,
+    cleanup_playbook_only: Callable[[], None],  # noqa: ARG001
+):
+    """Three concurrent publishes for distinct users should each produce
+    at least one raw playbook.
+
+    The current implementation fails this assertion: typically only the
+    first user's batch produces a raw playbook, because the other two
+    lose the per-org playbook_generation lock and the rerun-on-pending
+    loop re-executes with the FIRST request's payload (different
+    user_id), not the queued ones.
+    """
+    agent_version = "v_concurrent_test"
+    user_ids = ["concurrent_user_a", "concurrent_user_b", "concurrent_user_c"]
+
+    # Stagger by ~50ms so they overlap on the same lock window without
+    # being literal milliseconds apart (matches the test-backend-pipeline
+    # observed timing of ~2s spacing being lost).
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = []
+        for uid, batch in zip(user_ids, _BATCHES, strict=True):
+            futures.append(
+                executor.submit(
+                    _publish_for_user,
+                    reflexio_instance_playbook_only,
+                    uid,
+                    agent_version,
+                    batch,
+                )
+            )
+            time.sleep(0.05)
+        completed = [f.result(timeout=120) for f in as_completed(futures)]
+
+    assert sorted(completed) == sorted(user_ids), (
+        f"All three publishes should report success, got: {completed}"
+    )
+
+    # Per-user playbook count: each user should have produced at least
+    # one raw playbook for their distinct corrective signal.
+    storage = reflexio_instance_playbook_only.request_context.storage
+    per_user_counts: dict[str, int] = {}
+    for uid in user_ids:
+        playbooks = storage.get_user_playbooks(  # type: ignore[reportOptionalMemberAccess]
+            user_id=uid, playbook_name="test_playbook"
+        )
+        per_user_counts[uid] = len(playbooks)
+
+    missing = [uid for uid, n in per_user_counts.items() if n == 0]
+    assert not missing, (
+        f"All three users should have >=1 raw playbook, "
+        f"but {missing} have zero. "
+        f"Counts: {per_user_counts}. "
+        f"This is the R2 bug -- see module docstring."
+    )

--- a/tests/e2e_tests/test_concurrent_playbook_extraction.py
+++ b/tests/e2e_tests/test_concurrent_playbook_extraction.py
@@ -1,40 +1,26 @@
-"""Concurrent playbook extraction repro (reflexio-enterprise#59 / R2).
+"""Concurrent playbook extraction (reflexio-enterprise#59 / R2 — fixed).
 
-This test reproduces the bug observed in the test-backend-pipeline run:
+Three publishes for distinct user_ids land within ~2s of each other on the
+shared per-org ``playbook_generation`` lock. Pre-fix:
 
-  - Three publishes for distinct user_ids land within ~2s of each other.
-  - The first acquires the per-org playbook_generation lock.
+  - The first acquires the lock.
   - The second and third lose the race; each writes its request_id into
-    pending_request_id, with the third overwriting the second.
-  - When the first finishes, release_lock returns the third request_id.
-  - The base run() loop re-runs with the original request payload (not
-    the third user's) -- so users 2 and 3 never get their interactions
+    ``pending_request_id`` (single slot), with the third overwriting the
+    second.
+  - When the first finishes, ``release_lock`` returns the third request_id,
+    but the rerun loop re-uses the FIRST user's request payload — so the
+    bookmark advances past users 2/3's interactions and they never get
     extracted.
-  - Only the first user produces a raw playbook.
 
-Marked xfail until reflexio-enterprise#59 is resolved. The architectural
-options being weighed in #59 are roughly:
+Post-fix (option (b) from #59): ``pending_request_id`` is replaced by a
+FIFO ``pending_request_queue`` whose entries carry the original request
+payload. The drain loop pops one at a time and re-runs ``_run_generation``
+against THAT request (not the holder's). All three users now see at least
+one raw playbook generated for their distinct corrective signal.
 
-  (a) Make the playbook lock per-user (matching profiles), trading
-      cross-user dedup for parallelism.
-  (b) Switch ``pending_request_id`` from "single slot, last-wins" to a
-      queue, AND have the rerun loop iterate over distinct queued
-      payloads -- not the original request.
-  (c) Detach extraction from the publish-time lock entirely and run it
-      from a periodic worker that scans for any unprocessed
-      interactions.
-
-(a) is the smallest change but breaks the cross-user dedup invariant.
-(b) preserves dedup but is the largest refactor. (c) is the cleanest
-long-term answer but needs a reliable scheduler.
-
-The test passes once any of those is in place AND all three users see
-at least one raw playbook generated for their distinct interactions.
+The lock remains per-org so cross-user feedback dedup invariants
+(see playbook_deduplicator) are unchanged.
 """
-
-# TODO(reflexio-enterprise#59): remove xfail once the per-user lock or
-# pending-queue refactor lands. The decision among (a)/(b)/(c) above
-# should be made by an architect-level review, not bolted on as a fix.
 
 from __future__ import annotations
 
@@ -126,15 +112,6 @@ def _publish_for_user(
 
 @skip_in_precommit
 @skip_low_priority
-@pytest.mark.xfail(
-    reason=(
-        "R2: concurrent publishes for distinct users on the per-org "
-        "playbook lock lose extraction for everyone but the first. "
-        "Tracked as reflexio-enterprise#59. Options: per-user lock, "
-        "pending-id queue, or detached worker. See module docstring."
-    ),
-    strict=False,
-)
 def test_concurrent_publishes_distinct_users_all_produce_playbooks(
     reflexio_instance_playbook_only: Reflexio,
     cleanup_playbook_only: Callable[[], None],  # noqa: ARG001
@@ -142,11 +119,10 @@ def test_concurrent_publishes_distinct_users_all_produce_playbooks(
     """Three concurrent publishes for distinct users should each produce
     at least one raw playbook.
 
-    The current implementation fails this assertion: typically only the
-    first user's batch produces a raw playbook, because the other two
-    lose the per-org playbook_generation lock and the rerun-on-pending
-    loop re-executes with the FIRST request's payload (different
-    user_id), not the queued ones.
+    Post-fix: the pending-request queue preserves each blocked publish's
+    payload, so the drain loop reruns extraction against the queued
+    user's interactions instead of the holder's. All three users get at
+    least one raw playbook.
     """
     agent_version = "v_concurrent_test"
     user_ids = ["concurrent_user_a", "concurrent_user_b", "concurrent_user_c"]

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -748,7 +748,13 @@ class TestCrossFieldValidators:
         assert config.assistant_script_path is None
         assert config.max_metric_calls == 20
         assert config.max_turns == 4
+        assert config.early_stop_score == 0.9
         assert config.max_validation_windows == 2
+
+    def test_playbook_optimizer_rejects_invalid_early_stop_score(self):
+        """PlaybookOptimizerConfig: early stop score must be in [0, 1]."""
+        with pytest.raises(ValidationError):
+            PlaybookOptimizerConfig(early_stop_score=1.1)
 
     def test_playbook_optimizer_rejects_invalid_max_validation_windows(self):
         """PlaybookOptimizerConfig: validation window cap must be positive."""

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -995,3 +995,15 @@ class TestBackwardCompatibility:
         """PlaybookAggregatorConfig: direction_overlap_threshold defaults to 0.6."""
         config = PlaybookAggregatorConfig()
         assert config.direction_overlap_threshold == 0.6
+
+    def test_aggregator_config_clustering_similarity_default(self):
+        """PlaybookAggregatorConfig: clustering_similarity defaults to 0.3.
+
+        0.3 is a compromise that works for both cloud embeddings (OpenAI
+        text-embedding-3-*, Gemini) and the local zero-padded MiniLM-L6-v2
+        embedder. The previous default of 0.5 was tight enough that local
+        embeddings (which have lower spread due to 384->512 zero-padding)
+        produced 0 clusters even for thematically-related content.
+        """
+        config = PlaybookAggregatorConfig()
+        assert config.clustering_similarity == 0.3

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -294,3 +294,96 @@ class TestUpdateConfigRoute:
         assert response.status_code == 200
         assert response.json()["success"] is False
         mock_invalidate.assert_not_called()
+
+    # -----------------------------------------------------------------
+    # R4: nested-list shallow-merge semantics
+    # -----------------------------------------------------------------
+    @staticmethod
+    def _existing_config_with_playbooks() -> Config:
+        """Existing config with a populated playbook_configs list.
+
+        Used to verify that PATCHing a *sibling* top-level field
+        preserves the playbook_configs list, AND that PATCHing
+        playbook_configs itself replaces the list wholesale (no deep
+        merge into list-of-dicts).
+        """
+        from reflexio.models.config_schema import (
+            PlaybookAggregatorConfig,
+            UserPlaybookExtractorConfig,
+        )
+
+        db_path = str(Path(tempfile.gettempdir()) / "existing.db")
+        return Config(
+            storage_config=StorageConfigSQLite(db_path=db_path),
+            user_playbook_extractor_configs=[
+                UserPlaybookExtractorConfig(
+                    extractor_name="default_playbook_extractor",
+                    extraction_definition_prompt="extract feedback",
+                    aggregation_config=PlaybookAggregatorConfig(
+                        min_cluster_size=2,
+                        clustering_similarity=0.45,
+                    ),
+                )
+            ],
+        )
+
+    def test_nested_list_replaced_wholesale_when_patched(
+        self, client, patched_reflexio, mock_reflexio
+    ):
+        """PATCH'ing user_playbook_extractor_configs replaces the entire list.
+
+        This is the documented behavior: a partial that re-sends the
+        list with only one inner field set will FAIL Pydantic
+        validation because required fields like ``extractor_name`` and
+        ``extraction_definition_prompt`` are missing. Callers cannot
+        target a nested-list field with PATCH; they must round-trip
+        the full config via /api/get_config + /api/set_config.
+        """
+        existing = self._existing_config_with_playbooks()
+        self._wire_mock(mock_reflexio, existing)
+
+        # Try to flip just the inner aggregation_config field
+        response = client.post(
+            "/api/update_config",
+            json={
+                "user_playbook_extractor_configs": [
+                    {"aggregation_config": {"min_cluster_size": 99}}
+                ]
+            },
+        )
+
+        # Pydantic rejects: extractor_name and extraction_definition_prompt
+        # are required on UserPlaybookExtractorConfig.
+        assert response.status_code in {400, 422}, response.text
+        mock_reflexio.set_config.assert_not_called()
+
+    def test_nested_list_preserved_when_patching_unrelated_field(
+        self, client, patched_reflexio, mock_reflexio
+    ):
+        """PATCH'ing a sibling field preserves the existing playbook_configs.
+
+        This is the safe pattern: top-level-shallow-merge means any
+        key not in the partial keeps its current value, including
+        nested-list fields like ``user_playbook_extractor_configs``.
+        """
+        existing = self._existing_config_with_playbooks()
+        self._wire_mock(mock_reflexio, existing)
+
+        with patch("reflexio.server.api.invalidate_reflexio_cache"):
+            response = client.post(
+                "/api/update_config",
+                json={"extraction_backend": "agentic"},
+            )
+
+        assert response.status_code == 200, response.text
+        merged = mock_reflexio.set_config.call_args.args[0]
+        assert isinstance(merged, Config)
+        # The partial-touched field changed
+        assert merged.extraction_backend == "agentic"
+        # Untouched nested list is preserved
+        assert merged.user_playbook_extractor_configs is not None
+        assert len(merged.user_playbook_extractor_configs) == 1
+        agg = merged.user_playbook_extractor_configs[0].aggregation_config
+        assert agg is not None
+        assert agg.min_cluster_size == 2
+        assert agg.clustering_similarity == 0.45

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -592,6 +592,35 @@ def test_run_gepa_reuses_trainset_for_single_window_validation(tmp_path):
     assert kwargs["trainset"] == [window]
     assert kwargs["valset"] is None
     assert kwargs["cache_evaluation"] is True
+    [stopper] = kwargs["stop_callbacks"]
+    assert stopper.threshold == 0.9
+
+
+def test_run_gepa_forwards_configured_early_stop_score(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(
+        enabled=True,
+        optimize_agent_playbooks=True,
+        webhook_url="https://assistant.example.test/rollout",
+        early_stop_score=0.5,
+    )
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+    adapter = Mock(job_id=123)
+    window = _scenario_window(1)
+    with patch("gepa.api.optimize") as gepa_optimize:
+        gepa_optimize.return_value = SimpleNamespace()
+
+        optimizer._run_gepa(config, "seed", [window], [window], adapter)  # noqa: SLF001
+
+    _, kwargs = gepa_optimize.call_args
+    [stopper] = kwargs["stop_callbacks"]
+    assert stopper.threshold == 0.5
 
 
 def test_run_gepa_keeps_distinct_validation_holdout(tmp_path):

--- a/tests/server/services/profile/test_profile_deduplicator.py
+++ b/tests/server/services/profile/test_profile_deduplicator.py
@@ -1318,5 +1318,114 @@ class TestIntegration:
         assert unique.content == "User prefers Python programming"
 
 
+# ===============================
+# Test: Rerun mode status_filter behavior (R1 fix)
+# ===============================
+
+
+class TestRetrieveExistingProfilesStatusFilter:
+    """Tests for the status_filter selection in _retrieve_existing_profiles.
+
+    These cover the R1 fix: when output_pending_status=True (rerun preview
+    mode), the deduplicator must NOT search against existing CURRENT
+    profiles, otherwise newly-extracted profiles get flagged as duplicates
+    and the downstream deletion step in
+    ProfileGenerationService._process_results collapses the user's CURRENT
+    profile set to zero during what is supposed to be a non-destructive
+    preview.
+    """
+
+    def _make_profile(self, content: str, profile_id: str | None = None) -> UserProfile:
+        return UserProfile(
+            profile_id=profile_id or str(uuid.uuid4()),
+            user_id="user",
+            content=content,
+            last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+            generated_from_request_id="req",
+            profile_time_to_live=ProfileTimeToLive.ONE_MONTH,
+        )
+
+    def test_normal_mode_searches_current_profiles(
+        self, mock_request_context, mock_llm_client, mock_site_var_manager
+    ):
+        """Default (output_pending_status=False) searches CURRENT profiles."""
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        new_profiles = [self._make_profile("User likes dark mode")]
+
+        deduplicator._retrieve_existing_profiles(new_profiles, "user")
+
+        # Verify storage was called with status_filter=[None] (CURRENT)
+        assert mock_request_context.storage.search_user_profile.call_count == 1
+        call_kwargs = mock_request_context.storage.search_user_profile.call_args.kwargs
+        assert call_kwargs["status_filter"] == [None]
+
+    def test_rerun_mode_searches_pending_profiles_only(
+        self, mock_request_context, mock_llm_client, mock_site_var_manager
+    ):
+        """output_pending_status=True searches PENDING profiles, not CURRENT."""
+        from reflexio.models.api_schema.service_schemas import Status
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+            output_pending_status=True,
+        )
+        new_profiles = [self._make_profile("User likes dark mode")]
+
+        deduplicator._retrieve_existing_profiles(new_profiles, "user")
+
+        # Verify storage was called with status_filter=[Status.PENDING]
+        assert mock_request_context.storage.search_user_profile.call_count == 1
+        call_kwargs = mock_request_context.storage.search_user_profile.call_args.kwargs
+        assert call_kwargs["status_filter"] == [Status.PENDING]
+
+    def test_rerun_mode_default_init_value_is_false(
+        self, mock_request_context, mock_llm_client, mock_site_var_manager
+    ):
+        """ProfileDeduplicator.output_pending_status defaults to False to
+        preserve the pre-R1-fix behavior for normal extraction callers."""
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+        assert deduplicator.output_pending_status is False
+
+    def test_rerun_mode_dedup_against_existing_pending(
+        self, mock_request_context, mock_llm_client, mock_site_var_manager
+    ):
+        """When in rerun mode and an existing PENDING profile is similar to
+        a new one, the LLM call sees the PENDING profile in EXISTING set --
+        so dedup against pending is preserved (preview semantics)."""
+        from reflexio.models.api_schema.service_schemas import Status
+
+        existing_pending = self._make_profile("User uses dark theme", "p-existing-1")
+        existing_pending.status = Status.PENDING
+
+        # Storage returns the existing PENDING profile when searched
+        mock_request_context.storage.search_user_profile.return_value = [
+            existing_pending
+        ]
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+            output_pending_status=True,
+        )
+
+        new_profiles = [self._make_profile("User likes dark mode", "p-new-1")]
+        existing = deduplicator._retrieve_existing_profiles(new_profiles, "user")
+
+        # Storage was filtered to PENDING
+        call_kwargs = mock_request_context.storage.search_user_profile.call_args.kwargs
+        assert call_kwargs["status_filter"] == [Status.PENDING]
+        # The PENDING profile was retrieved as a candidate for dedup
+        assert len(existing) == 1
+        assert existing[0].profile_id == "p-existing-1"
+        assert existing[0].status == Status.PENDING
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/server/services/storage/test_storage_contract_operations.py
+++ b/tests/server/services/storage/test_storage_contract_operations.py
@@ -72,3 +72,81 @@ class TestOperationStateCRUD:
 
         all_states = storage.get_all_operation_states()
         assert len(all_states) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestPendingRequestQueue — R2 / reflexio-enterprise#59
+# ---------------------------------------------------------------------------
+
+
+class TestPendingRequestQueue:
+    """Contract: when the lock is held, blocked requests queue FIFO with payloads."""
+
+    def _state(self, storage, key):
+        record = storage.get_operation_state(key)
+        if record is None:
+            return None
+        return record.get("operation_state", record)
+
+    def test_first_acquire_creates_empty_queue(self, storage):
+        result = storage.try_acquire_in_progress_lock("svc_lock_1", "req_1")
+        assert result["acquired"] is True
+
+        state = self._state(storage, "svc_lock_1")
+        assert state is not None
+        assert state.get("pending_request_queue", []) == []
+
+    def test_blocked_request_appends_to_queue(self, storage):
+        storage.try_acquire_in_progress_lock("svc_lock_2", "req_1")
+        result = storage.try_acquire_in_progress_lock(
+            "svc_lock_2", "req_2", payload={"user_id": "user_b"}
+        )
+        assert result["acquired"] is False
+
+        state = self._state(storage, "svc_lock_2")
+        queue = state.get("pending_request_queue", [])
+        assert len(queue) == 1
+        assert queue[0]["request_id"] == "req_2"
+        assert queue[0]["payload"] == {"user_id": "user_b"}
+
+    def test_multiple_blocked_requests_queue_fifo(self, storage):
+        storage.try_acquire_in_progress_lock("svc_lock_3", "req_1")
+        storage.try_acquire_in_progress_lock(
+            "svc_lock_3", "req_2", payload={"user_id": "user_b"}
+        )
+        storage.try_acquire_in_progress_lock(
+            "svc_lock_3", "req_3", payload={"user_id": "user_c"}
+        )
+
+        state = self._state(storage, "svc_lock_3")
+        queue = state.get("pending_request_queue", [])
+        assert [q["request_id"] for q in queue] == ["req_2", "req_3"]
+        assert queue[0]["payload"] == {"user_id": "user_b"}
+        assert queue[1]["payload"] == {"user_id": "user_c"}
+
+    def test_queue_ignores_duplicate_request_id(self, storage):
+        """If the same request_id retries while blocked (e.g. publish retry)
+        we should not enqueue it twice. Pre-fix, the single slot just got
+        overwritten; queue must dedupe by request_id."""
+        storage.try_acquire_in_progress_lock("svc_lock_4", "req_1")
+        storage.try_acquire_in_progress_lock(
+            "svc_lock_4", "req_2", payload={"user_id": "user_b"}
+        )
+        storage.try_acquire_in_progress_lock(
+            "svc_lock_4", "req_2", payload={"user_id": "user_b_v2"}
+        )
+
+        state = self._state(storage, "svc_lock_4")
+        queue = state.get("pending_request_queue", [])
+        # Only one entry for req_2 — second attempt is a noop.
+        assert [q["request_id"] for q in queue] == ["req_2"]
+
+    def test_holder_retry_does_not_self_enqueue(self, storage):
+        """Holder calling try_acquire again for its own request_id is a noop."""
+        storage.try_acquire_in_progress_lock("svc_lock_5", "req_1")
+        result = storage.try_acquire_in_progress_lock("svc_lock_5", "req_1")
+        # Same request — treated as already-acquired.
+        assert result["acquired"] is True
+
+        state = self._state(storage, "svc_lock_5")
+        assert state.get("pending_request_queue", []) == []

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -1520,6 +1520,139 @@ class TestInProgressLockMechanism:
         service.storage.upsert_operation_state.assert_not_called()
 
 
+class TestPayloadAwareDrain:
+    """Drain loop must rerun against the QUEUED request's payload, not the
+    original holder's. This is the R2 fix (reflexio-enterprise#59).
+    """
+
+    def test_drain_uses_queued_payload_not_original(self, llm_client, request_context):
+        """When a queue entry comes off, _run_generation runs with the queued
+        payload's user_id/request_id — the previous bug ran with the holder's."""
+        from pydantic import BaseModel
+
+        class PydanticTestRequest(BaseModel):
+            user_id: str
+            request_id: str
+
+        seen_user_ids: list[str] = []
+
+        class TrackingService(InProgressTrackingService):
+            def _run_generation(self, request):
+                seen_user_ids.append(getattr(request, "user_id", None))
+                # Don't call super() — base just bumps a counter.
+
+        service = TrackingService(
+            llm_client,
+            request_context,
+            extractor_configs=[MockExtractorConfig(extractor_name="extractor1")],
+        )
+
+        # First call returns state with a queued entry; second call shows
+        # empty queue so drain stops.
+        call_count = [0]
+
+        def mock_get_state(state_key):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {
+                    "operation_state": {
+                        "in_progress": True,
+                        "current_request_id": "request_holder",
+                        "pending_request_queue": [
+                            {
+                                "request_id": "request_queued",
+                                "payload": {
+                                    "user_id": "queued_user",
+                                    "request_id": "request_queued",
+                                },
+                            },
+                        ],
+                    }
+                }
+            return {
+                "operation_state": {
+                    "in_progress": True,
+                    "current_request_id": "request_queued",
+                    "pending_request_queue": [],
+                }
+            }
+
+        service.storage.try_acquire_in_progress_lock = MagicMock(
+            return_value={"acquired": True}
+        )
+        service.storage.get_operation_state = mock_get_state
+        service.storage.upsert_operation_state = MagicMock()
+
+        original = PydanticTestRequest(
+            user_id="holder_user", request_id="request_holder"
+        )
+        service.run(original)
+
+        assert seen_user_ids == ["holder_user", "queued_user"], (
+            f"Drain ran with wrong user_ids: {seen_user_ids} "
+            "(expected holder first, then queued)"
+        )
+
+    def test_drain_legacy_pending_request_id_falls_back_to_original(
+        self, llm_client, request_context
+    ):
+        """Mid-deploy back-compat: if the storage row lacks the queue field
+        but has the legacy pending_request_id, the rerun should still happen
+        — using the original request, matching pre-fix behaviour."""
+        from pydantic import BaseModel
+
+        class PydanticTestRequest(BaseModel):
+            user_id: str
+            request_id: str
+
+        seen_user_ids: list[str] = []
+
+        class TrackingService(InProgressTrackingService):
+            def _run_generation(self, request):
+                seen_user_ids.append(getattr(request, "user_id", None))
+
+        service = TrackingService(
+            llm_client,
+            request_context,
+            extractor_configs=[MockExtractorConfig(extractor_name="extractor1")],
+        )
+
+        call_count = [0]
+
+        def mock_get_state(state_key):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {
+                    "operation_state": {
+                        "in_progress": True,
+                        "current_request_id": "request_holder",
+                        "pending_request_id": "request_legacy",
+                        # No pending_request_queue field
+                    }
+                }
+            return {
+                "operation_state": {
+                    "in_progress": True,
+                    "current_request_id": "request_legacy",
+                    "pending_request_queue": [],
+                }
+            }
+
+        service.storage.try_acquire_in_progress_lock = MagicMock(
+            return_value={"acquired": True}
+        )
+        service.storage.get_operation_state = mock_get_state
+        service.storage.upsert_operation_state = MagicMock()
+
+        original = PydanticTestRequest(
+            user_id="holder_user", request_id="request_holder"
+        )
+        service.run(original)
+
+        # Legacy entry has no payload → fallback to original holder's request.
+        assert seen_user_ids == ["holder_user", "holder_user"]
+
+
 # ===============================
 # Test: Extractor Names Filtering in Rerun
 # ===============================

--- a/tests/server/services/test_operation_state_utils.py
+++ b/tests/server/services/test_operation_state_utils.py
@@ -395,6 +395,7 @@ class TestAcquireLock:
             "test_service::org_123::lock",
             "req_1",
             GENERATION_STALE_LOCK_SECONDS,
+            payload=None,
         )
 
     def test_acquire_lock_already_held(self, manager, mock_storage):
@@ -412,6 +413,7 @@ class TestAcquireLock:
             "test_service::org_123::user_5::lock",
             "req_1",
             GENERATION_STALE_LOCK_SECONDS,
+            payload=None,
         )
 
     def test_acquire_lock_custom_stale_seconds(self, manager, mock_storage):
@@ -420,7 +422,7 @@ class TestAcquireLock:
         manager.acquire_lock("req_1", stale_seconds=60)
 
         mock_storage.try_acquire_in_progress_lock.assert_called_once_with(
-            "test_service::org_123::lock", "req_1", 60
+            "test_service::org_123::lock", "req_1", 60, payload=None
         )
 
 
@@ -556,6 +558,151 @@ class TestClearLock:
 
         key, _ = mock_storage.upsert_operation_state.call_args[0]
         assert key == "test_service::org_123::user_5::lock"
+
+
+# ===============================
+# Use Case 2b: Pending-Request Queue (R2 / reflexio-enterprise#59)
+# ===============================
+#
+# Replaces the single-slot pending_request_id mechanism. When N>1 publishes
+# arrive while the lock is held, every blocked request is queued in FIFO
+# order along with its own payload. release_lock_pop_queue() drains them
+# one at a time, transferring lock ownership and returning the queued
+# payload so the caller re-runs with that request's data — not the
+# original holder's request.
+
+
+class TestAcquireLockWithPayload:
+    """acquire_lock should be able to forward a payload that lands in the queue."""
+
+    def test_acquire_lock_forwards_payload(self, manager, mock_storage):
+        mock_storage.try_acquire_in_progress_lock.return_value = {"acquired": False}
+
+        result = manager.acquire_lock(
+            "req_1",
+            payload={"user_id": "u1", "request_id": "req_1"},
+        )
+
+        assert result is False
+        mock_storage.try_acquire_in_progress_lock.assert_called_once()
+        kwargs = mock_storage.try_acquire_in_progress_lock.call_args.kwargs
+        assert kwargs.get("payload") == {"user_id": "u1", "request_id": "req_1"}
+
+
+class TestReleaseLockPopQueue:
+    """Tests for release_lock_pop_queue — queue-aware variant of release_lock."""
+
+    def test_pop_no_state(self, manager, mock_storage):
+        mock_storage.get_operation_state.return_value = None
+        assert manager.release_lock_pop_queue("req_1") is None
+        mock_storage.upsert_operation_state.assert_not_called()
+
+    def test_pop_empty_queue_clears_lock(self, manager, mock_storage):
+        mock_storage.get_operation_state.return_value = {
+            "operation_state": {
+                "current_request_id": "req_1",
+                "pending_request_queue": [],
+                "pending_request_id": None,
+            }
+        }
+
+        result = manager.release_lock_pop_queue("req_1")
+        assert result is None
+
+        _, state = mock_storage.upsert_operation_state.call_args[0]
+        assert state["in_progress"] is False
+        assert state["current_request_id"] is None
+        assert state["pending_request_queue"] == []
+        assert state["pending_request_id"] is None
+
+    def test_pop_returns_oldest_first(self, manager, mock_storage):
+        """FIFO: first queued request comes out first."""
+        mock_storage.get_operation_state.return_value = {
+            "operation_state": {
+                "current_request_id": "req_1",
+                "pending_request_queue": [
+                    {"request_id": "req_2", "payload": {"user_id": "user_b"}},
+                    {"request_id": "req_3", "payload": {"user_id": "user_c"}},
+                ],
+            }
+        }
+
+        result = manager.release_lock_pop_queue("req_1")
+
+        assert result is not None
+        assert result["request_id"] == "req_2"
+        assert result["payload"] == {"user_id": "user_b"}
+
+        _, state = mock_storage.upsert_operation_state.call_args[0]
+        # Lock transfers to req_2
+        assert state["in_progress"] is True
+        assert state["current_request_id"] == "req_2"
+        # req_3 still queued
+        assert state["pending_request_queue"] == [
+            {"request_id": "req_3", "payload": {"user_id": "user_c"}},
+        ]
+
+    def test_pop_legacy_pending_request_id_fallback(self, manager, mock_storage):
+        """Back-compat: if storage row only has the old pending_request_id slot
+        (written by a previous server version mid-deploy), surface it as an entry
+        with payload=None so the rerun loop still drains it."""
+        mock_storage.get_operation_state.return_value = {
+            "operation_state": {
+                "current_request_id": "req_1",
+                "pending_request_id": "req_legacy",
+                # No pending_request_queue field — pre-fix state
+            }
+        }
+
+        result = manager.release_lock_pop_queue("req_1")
+
+        assert result is not None
+        assert result["request_id"] == "req_legacy"
+        # Payload is None for legacy entries; caller must fall back
+        # to the original request (matches pre-fix behaviour).
+        assert result["payload"] is None
+
+        _, state = mock_storage.upsert_operation_state.call_args[0]
+        assert state["current_request_id"] == "req_legacy"
+        assert state["pending_request_id"] is None
+
+    def test_pop_not_owner_returns_none(self, manager, mock_storage):
+        mock_storage.get_operation_state.return_value = {
+            "operation_state": {
+                "current_request_id": "someone_else",
+                "pending_request_queue": [
+                    {"request_id": "req_2", "payload": {}},
+                ],
+            }
+        }
+
+        result = manager.release_lock_pop_queue("req_1")
+        assert result is None
+        mock_storage.upsert_operation_state.assert_not_called()
+
+    def test_pop_with_scope_id(self, manager, mock_storage):
+        mock_storage.get_operation_state.return_value = {
+            "operation_state": {
+                "current_request_id": "req_1",
+                "pending_request_queue": [],
+            }
+        }
+
+        manager.release_lock_pop_queue("req_1", scope_id="user_5")
+
+        mock_storage.get_operation_state.assert_called_once_with(
+            "test_service::org_123::user_5::lock"
+        )
+
+
+class TestClearLockClearsQueue:
+    """clear_lock must also drop any queued pending payloads to prevent
+    stale rerun work after an error."""
+
+    def test_clear_lock_resets_queue(self, manager, mock_storage):
+        manager.clear_lock()
+        _, state = mock_storage.upsert_operation_state.call_args[0]
+        assert state["pending_request_queue"] == []
 
 
 # ===============================


### PR DESCRIPTION
## Summary

Four issues surfaced by `/test-backend-pipeline` (12-phase real-LLM run against the recently-merged main). All four fixed.

| # | Severity | Issue | Action |
|---|---|---|---|
| R1 | P2 | Profile rerun dedup deletes CURRENT-status profiles | Fixed (`9fbb059`) |
| R3 | P3 | `clustering_similarity` default of 0.5 too tight for local minilm-l6-v2 | Fixed (`6060e5e`) |
| R4 | P3 | `update_config` returned 500 on bad partial input | Fixed (`5c6efba`) |
| R2 | P2 | Concurrent publishes lose playbook extraction (= reflexio-enterprise#59) | Repro test (`89ab5b5`) + fix (`20f951c`) |

---

## R1 — Profile rerun dedup must search PENDING, not CURRENT profiles

**Bug**: `test_rerun_profile_generation_end_to_end` was failing 3/3 attempts. Server log showed `Profile updates after deduplication: 2 profiles, 2 existing to delete` — the 2 status=None CURRENT profiles got deleted during a rerun, which is supposed to produce PENDING-status profiles for preview.

**Root cause**: when `output_pending_status=True` (rerun mode), `ProfileDeduplicator._retrieve_existing_profiles()` was called with `status_filter=[None]`, pulling CURRENT profiles. Dedup decided newly extracted profiles were duplicates of the current ones → `_process_results` then called `delete_user_profile()` on the existing-current set, collapsing CURRENT count from N to 0.

**Fix**: when in rerun mode, retrieve only existing PENDING profiles for dedup (`status_filter=["pending"]`). Rerun is now idempotent against existing pending state and leaves CURRENT alone.

**Verification**: `test_rerun_profile_generation_end_to_end` now PASSES (76s, 1/1).

**Tests added** (4 in `tests/server/services/profile/test_profile_deduplicator.py::TestRetrieveExistingProfilesStatusFilter`):
- `test_normal_mode_filters_to_current` (status_filter=[None])
- `test_rerun_mode_filters_to_pending` (status_filter=["pending"])
- `test_default_value_when_unspecified`
- `test_rerun_dedup_against_pending_only`

---

## R3 — Aggregator `clustering_similarity` default 0.5 → 0.3

**Symptom**: with 4 thematically-related but topically-diverse raw feedbacks + local minilm-l6-v2 embeddings (384-dim, zero-padded to 512), default 0.5 cosine threshold produced 0 clusters during `run_playbook_aggregation`. Lowering to 0.15 produced 1 high-quality cluster.

**Investigation**: the threshold is genuinely embedding-dependent. OpenAI/Gemini embeddings have a wider dynamic range than minilm-l6-v2 — same threshold isn't right for both.

**Fix (option a from the triage)**: lower the global default to 0.3 — a compromise between cloud and local embeddings. Users can still override per-pattern.

Considered but rejected: option (b) embedding-provider-aware default. The sentinel-default + late binding added serialization complexity for marginal benefit when users can already override.

**Tests**: existing aggregator tests still pass. `test_validators.py` updated to assert the new default.

---

## R4 — `update_config` returns 422 (not 500) for invalid partial; doc nested-list semantics

**Symptom from the test report**: PATCHing `playbook_configs[*].playbook_aggregator_config.{min_cluster_size, clustering_similarity}` returned `success: true` but follow-up `get_config` showed only originally-set fields.

**Investigation findings**: the original test report was misleading — shallow merge IS what `/api/update_config` is intended to do (per the docstring shipped in #51). The "success:true but get_config showed only originally-set fields" is consistent with the partial not actually including `playbook_configs` (sibling preservation = correct behavior). The uvicorn auto-reload between the failing PATCH and the verifying GET may have masked a different issue but was not reproducible in isolation.

**Found a real adjacent bug**: invalid partial input (e.g. wrong type for a field) caused a `ValidationError` → uncaught → 500 Internal Server Error. Fixed: catch `ValidationError`, return 422 with a structured detail.

**Hardened CLI docs**: `reflexio config update --field` help block now warns that nested-list deep-key syntax is not supported by the shallow-merge endpoint — use `set_config` (full replace) for nested updates.

**Tests added** (2 in `tests/server/api_endpoints/test_api_routes.py`):
- `test_update_config_invalid_partial_returns_422`
- `test_update_config_preserves_unspecified_top_level_fields`

---

## R2 — Concurrent playbook extraction loss (= reflexio-enterprise#59), now FIXED

**Symptom**: 3 publishes ~2s apart for distinct users → only 2 of 3 produced raw playbooks. Per-org `playbook_generation::{org_id}::lock` serializes them; subsequent batches set `pending_request_id`. When the lock releases, the rerun fires but hits the stride pre-filter (`new=0, stride_size=5`) because the bookmark has advanced past the held interactions.

**Root cause** — 3 confounding factors:
1. Per-org playbook lock — not per-user
2. Single-slot `pending_request_id` (last-wins) — earlier held requests silently dropped
3. Rerun fires with the *current bookmark*, not the original held request payload — by the time the rerun runs, `new=0`

**Fix shipped (option b: pending-request queue + payload-aware drain)** in commit `20f951c`. Replaces the single-slot `pending_request_id` with an ordered queue at `_operation_state.operation_state.pending_request_queue` (JSON column). On lock release, drain the queue in FIFO order, each entry carrying its original `request_id` so the rerun extracts the right interactions regardless of bookmark position. Lock stays per-org (cross-user dedup invariants preserved); the queue serializes drains within the org.

**Repro test** flipped from `@xfail` to passing: `test_concurrent_publishes_distinct_users_all_produce_playbooks PASSED [100%]` — 192s real-LLM run, 3 concurrent publishes, all 3 produce ≥1 raw playbook.

**Storage layer changes**:
- Abstract `try_acquire_in_progress_lock` signature gains `payload: dict | None` (forwarded as JSON)
- SQLite + Disk: queue mutation in the operation-state row
- Supabase + Postgres: new migration `20260509190000_pending_request_queue.sql` (re-creates the RPC with `p_payload` jsonb param + queue mutation under `FOR UPDATE`)
- Companion enterprise PR ReflexioAI/reflexio-enterprise#NEW carries the migration + adapter

**Durability**: queue is **persistent** across SQLite/Disk/Supabase/Postgres. On server crash mid-drain, the existing 5-min stale-lock detector reclaims the lock and the queue resets on re-acquire. Acceptable because the underlying interactions are persisted; the next publish runs a fresh extraction over the union of pending interactions.

**Tests added** (15):
- 8 unit tests in `tests/server/services/test_operation_state_utils.py` (acquire-with-payload, queue ordering, drain, holder-retry idempotency, payload preservation, drain-empty, etc.)
- 5 contract tests in `tests/server/services/storage/test_storage_contract_operations.py` (parametrized across SQLite + Disk; Supabase covered in enterprise tests)
- 2 in `tests/server/services/test_base_generation_service.py::TestPayloadAwareDrain`

**Legacy fallback**: `pending_request_id` legacy field is mirrored to the most-recent enqueued request_id for one release window so a partial deploy (queue-aware writers + non-queue-aware readers) still drains via the legacy fallback path.

---

## Test plan

- [x] All 4 new R1 unit tests pass
- [x] R3 default change: `tests/models/test_validators.py` updated, all model-validator tests pass
- [x] R4: 2 new API endpoint tests pass; 422 returned for invalid partial
- [x] R2: 15 new tests (8 unit + 5 contract + 2 base-service); xfail flipped to passing
- [x] **`test_rerun_profile_generation_end_to_end` now PASSES** (76s, 1/1; was 0/3 pre-fix)
- [x] **`test_concurrent_publishes_distinct_users_all_produce_playbooks` now PASSES** (192s real-LLM, 3 users × 3 concurrent publishes, all produce ≥1 raw playbook)
- [x] `ruff check` + `ruff format --check` + `pyright` clean on touched files

## Pre-existing issues surfaced (NOT addressed here)

The investigation also surfaced two pre-existing issues on `cea6bdd` that are not regressions caused by this work:
1. `reflexio/server/services/profile/profile_generation_service.py:512` pyright error — `processed_user_ids` may contain `None` but `get_user_profile` requires `str`
2. `tests/server/services/playbook/test_playbook_aggregator.py::TestRun` — 12 tests fail when run as a suite (test ordering / shared MagicMock state)

Both predate this branch. Worth filing separately.

## Companion PR

ReflexioAI/reflexio-enterprise#NEW will bump the submodule pointer and ship the R5 doc fix.