### PR TITLE
feat(playbook-optimizer): cache evaluations per scenario window

### DIFF
--- a/reflexio/server/services/playbook_optimizer/gepa_adapter.py
+++ b/reflexio/server/services/playbook_optimizer/gepa_adapter.py
@@ -26,6 +26,17 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 PLAYBOOK_CONTENT_COMPONENT = "playbook_content"
+_EvaluationCacheKey = tuple[str, int | None, tuple[int, ...]]
+
+
+def _evaluation_cache_key(
+    candidate_content: str, window: ScenarioWindow
+) -> _EvaluationCacheKey:
+    return (
+        candidate_content,
+        window.user_playbook_id,
+        tuple(window.source_interaction_ids),
+    )
 
 
 class ReflexioPlaybookGEPAAdapter:
@@ -74,6 +85,9 @@ class ReflexioPlaybookGEPAAdapter:
         self.max_turns = max_turns
         self.propose_new_texts: ProposalFn | None = None
         self._candidate_ids_by_content: dict[str, int] = {}
+        self._evaluation_cache: dict[
+            _EvaluationCacheKey, CandidateEvaluationOutput
+        ] = {}
 
     def evaluate(
         self,
@@ -90,7 +104,48 @@ class ReflexioPlaybookGEPAAdapter:
         trajectories: list[EvaluationTrajectory] = []
 
         for window in batch:
-            output = self._evaluate_one(window, candidate_content)
+            cache_key = _evaluation_cache_key(candidate_content, window)
+            cached = self._evaluation_cache.get(cache_key)
+            if cached is not None:
+                output = cached
+                logger.info(
+                    "event=playbook_optimization_evaluation_cache_hit job_id=%d "
+                    "candidate_id=%d scenario_user_playbook_id=%s verdict=%s",
+                    self.job_id,
+                    persisted_candidate.candidate_id,
+                    window.user_playbook_id,
+                    output.verdict,
+                )
+            else:
+                output = self._evaluate_one(window, candidate_content)
+                self._evaluation_cache[cache_key] = output
+                self.storage.insert_playbook_optimization_evaluation(
+                    PlaybookOptimizationEvaluation(
+                        job_id=self.job_id,
+                        candidate_id=persisted_candidate.candidate_id,
+                        target_kind=self.target_kind,  # type: ignore[arg-type]
+                        target_id=self.target_id,
+                        scenario_user_playbook_id=window.user_playbook_id,
+                        source_interaction_ids=window.source_interaction_ids,
+                        score=output.score,
+                        verdict=output.verdict,
+                        likert=output.likert,
+                        rationale=output.rationale,
+                        asi_json=output.asi.model_dump_json(),
+                        incumbent_rollout_json=output.incumbent_rollout.model_dump_json(),
+                        candidate_rollout_json=output.candidate_rollout.model_dump_json(),
+                    )
+                )
+                logger.info(
+                    "event=playbook_optimization_evaluation job_id=%d candidate_id=%d "
+                    "scenario_user_playbook_id=%s verdict=%s score=%.3f likert=%d",
+                    self.job_id,
+                    persisted_candidate.candidate_id,
+                    window.user_playbook_id,
+                    output.verdict,
+                    output.score,
+                    output.likert,
+                )
             outputs.append(output)
             scores.append(output.score)
             if capture_traces:
@@ -101,33 +156,6 @@ class ReflexioPlaybookGEPAAdapter:
                         output=output,
                     )
                 )
-            self.storage.insert_playbook_optimization_evaluation(
-                PlaybookOptimizationEvaluation(
-                    job_id=self.job_id,
-                    candidate_id=persisted_candidate.candidate_id,
-                    target_kind=self.target_kind,  # type: ignore[arg-type]
-                    target_id=self.target_id,
-                    scenario_user_playbook_id=window.user_playbook_id,
-                    source_interaction_ids=window.source_interaction_ids,
-                    score=output.score,
-                    verdict=output.verdict,
-                    likert=output.likert,
-                    rationale=output.rationale,
-                    asi_json=output.asi.model_dump_json(),
-                    incumbent_rollout_json=output.incumbent_rollout.model_dump_json(),
-                    candidate_rollout_json=output.candidate_rollout.model_dump_json(),
-                )
-            )
-            logger.info(
-                "event=playbook_optimization_evaluation job_id=%d candidate_id=%d "
-                "scenario_user_playbook_id=%s verdict=%s score=%.3f likert=%d",
-                self.job_id,
-                persisted_candidate.candidate_id,
-                window.user_playbook_id,
-                output.verdict,
-                output.score,
-                output.likert,
-            )
 
         return EvaluationBatch(
             outputs=outputs,

--- a/reflexio/server/services/playbook_optimizer/gepa_adapter.py
+++ b/reflexio/server/services/playbook_optimizer/gepa_adapter.py
@@ -118,7 +118,6 @@ class ReflexioPlaybookGEPAAdapter:
                 )
             else:
                 output = self._evaluate_one(window, candidate_content)
-                self._evaluation_cache[cache_key] = output
                 self.storage.insert_playbook_optimization_evaluation(
                     PlaybookOptimizationEvaluation(
                         job_id=self.job_id,
@@ -136,6 +135,11 @@ class ReflexioPlaybookGEPAAdapter:
                         candidate_rollout_json=output.candidate_rollout.model_dump_json(),
                     )
                 )
+                # Persist before caching so a failed insert does not leave a
+                # phantom result behind; skip caching transient assistant-
+                # backend aborts so the next iteration retries the rollout.
+                if output.verdict != "aborted":
+                    self._evaluation_cache[cache_key] = output
                 logger.info(
                     "event=playbook_optimization_evaluation job_id=%d candidate_id=%d "
                     "scenario_user_playbook_id=%s verdict=%s score=%.3f likert=%d",

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -41,6 +41,7 @@ from reflexio.server.services.playbook_optimizer.gepa_adapter import (
 )
 from reflexio.server.services.playbook_optimizer.judge import JudgeOutput
 from reflexio.server.services.playbook_optimizer.models import (
+    CandidateEvaluationOutput,
     ChatMessage,
     JudgeASI,
     ScenarioWindow,
@@ -350,6 +351,72 @@ def test_adapter_cache_distinguishes_windows_with_same_playbook_id(tmp_path):
     assert [evaluation.verdict for evaluation in evaluations] == [
         "candidate",
         "incumbent",
+    ]
+
+
+def test_adapter_does_not_cache_aborted_evaluations(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    job = storage.create_playbook_optimization_job(
+        PlaybookOptimizationJob(target_kind="agent_playbook", target_id=1)
+    )
+    incumbent = AgentPlaybook(
+        agent_playbook_id=1,
+        playbook_name="support",
+        agent_version="v1",
+        content="incumbent content",
+    )
+    adapter = ReflexioPlaybookGEPAAdapter(
+        storage=storage,
+        job_id=job.job_id,
+        target_kind="agent_playbook",
+        target_id=1,
+        incumbent=incumbent,
+        rollout=MultiTurnRollout(Mock(return_value="assistant response")),
+        judge=Mock(),
+        max_turns=1,
+    )
+    aborted = CandidateEvaluationOutput(
+        verdict="aborted",
+        score=0.0,
+        likert=1,
+        rationale="assistant subprocess timed out",
+    )
+    succeeded = CandidateEvaluationOutput(
+        verdict="candidate",
+        score=0.9,
+        likert=5,
+        rationale="retry succeeded",
+        asi=JudgeASI(winning_behaviors=["clearer response"]),
+    )
+    adapter._evaluate_one = Mock(side_effect=[aborted, succeeded])  # type: ignore[method-assign]
+    window = ScenarioWindow(
+        user_playbook_id=11,
+        source_interaction_ids=[101],
+        interactions=[
+            Interaction(
+                interaction_id=101,
+                user_id="u1",
+                request_id="r1",
+                role="User",
+                content="Please summarize this.",
+            )
+        ],
+    )
+
+    first = adapter.evaluate(
+        [window], {PLAYBOOK_CONTENT_COMPONENT: "candidate content"}
+    )
+    second = adapter.evaluate(
+        [window], {PLAYBOOK_CONTENT_COMPONENT: "candidate content"}
+    )
+
+    assert first.outputs[0].verdict == "aborted"
+    assert second.outputs[0].verdict == "candidate"
+    assert adapter._evaluate_one.call_count == 2
+    evaluations = storage.list_playbook_optimization_evaluations(job.job_id)
+    assert [evaluation.verdict for evaluation in evaluations] == [
+        "aborted",
+        "candidate",
     ]
 
 

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -266,6 +266,93 @@ def test_adapter_calls_assistant_with_same_seed_and_different_content(tmp_path):
     assert evaluations[0].verdict == "candidate"
 
 
+def test_adapter_cache_distinguishes_windows_with_same_playbook_id(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    job = storage.create_playbook_optimization_job(
+        PlaybookOptimizationJob(target_kind="agent_playbook", target_id=1)
+    )
+    incumbent = AgentPlaybook(
+        agent_playbook_id=1,
+        playbook_name="support",
+        agent_version="v1",
+        content="incumbent content",
+    )
+    assistant = Mock(return_value="assistant response")
+    judge = Mock()
+    judge.judge.side_effect = [
+        JudgeOutput(
+            verdict="candidate",
+            score=0.9,
+            likert=5,
+            rationale="first window",
+            asi=JudgeASI(winning_behaviors=["clearer response"]),
+        ),
+        JudgeOutput(
+            verdict="incumbent",
+            score=0.1,
+            likert=1,
+            rationale="second window",
+            asi=JudgeASI(failure_modes=["missed context"]),
+        ),
+    ]
+    adapter = ReflexioPlaybookGEPAAdapter(
+        storage=storage,
+        job_id=job.job_id,
+        target_kind="agent_playbook",
+        target_id=1,
+        incumbent=incumbent,
+        rollout=MultiTurnRollout(assistant),
+        judge=judge,
+        max_turns=1,
+    )
+    windows = [
+        ScenarioWindow(
+            user_playbook_id=11,
+            source_interaction_ids=[101],
+            interactions=[
+                Interaction(
+                    interaction_id=101,
+                    user_id="u1",
+                    request_id="r1",
+                    role="User",
+                    content="Please summarize this.",
+                )
+            ],
+        ),
+        ScenarioWindow(
+            user_playbook_id=11,
+            source_interaction_ids=[202],
+            interactions=[
+                Interaction(
+                    interaction_id=202,
+                    user_id="u1",
+                    request_id="r2",
+                    role="User",
+                    content="Please expand this.",
+                )
+            ],
+        ),
+    ]
+
+    batch = adapter.evaluate(
+        windows,
+        {PLAYBOOK_CONTENT_COMPONENT: "candidate content"},
+        capture_traces=True,
+    )
+
+    assert batch.scores == [0.9, 0.1]
+    assert assistant.call_count == 4
+    evaluations = storage.list_playbook_optimization_evaluations(job.job_id)
+    assert [evaluation.source_interaction_ids for evaluation in evaluations] == [
+        [101],
+        [202],
+    ]
+    assert [evaluation.verdict for evaluation in evaluations] == [
+        "candidate",
+        "incumbent",
+    ]
+
+
 def test_optimizer_skips_approved_agent_playbooks(tmp_path):
     storage = _sqlite_storage(tmp_path)
     saved = storage.save_agent_playbooks(


### PR DESCRIPTION
## Summary

- Memoize `ReflexioPlaybookGEPAAdapter._evaluate_one` by `(candidate_content, user_playbook_id, source_interaction_ids)` so the GEPA loop skips redundant rollouts + judging when a candidate revisits the same window (minibatch resampling into the seed valset, pareto re-evaluation).
- Cache misses still persist a `PlaybookOptimizationEvaluation` row and emit the existing evaluation log line; cache hits emit a new `playbook_optimization_evaluation_cache_hit` log line so call-savings are observable in `dev_server.log` without DB row duplicates.
- Cache key intentionally includes `source_interaction_ids` — a single `user_playbook_id` can host multiple distinct windows that differ only in which interactions seed the rollout, so collapsing on `user_playbook_id` alone would silently merge unrelated scenarios.

## Changes

- `reflexio/server/services/playbook_optimizer/gepa_adapter.py` — adds `_EvaluationCacheKey`, `_evaluation_cache_key`, `self._evaluation_cache` dict, and the cache-hit/miss split inside `evaluate()`. DB insert + log line move into the miss branch only.
- `tests/server/services/playbook_optimizer/test_playbook_optimizer.py` — `test_adapter_cache_distinguishes_windows_with_same_playbook_id` asserts two windows with the same `user_playbook_id` but different `source_interaction_ids` each run rollout+judge and persist distinct evaluation rows.

## Test Plan

- [x] `uv run pytest tests/server/services/playbook_optimizer/test_playbook_optimizer.py` — 29 passed locally.
- [ ] CI green on the broader suite.
- [ ] Manual: run an end-to-end optimization in a dev stack and confirm `playbook_optimization_evaluation_cache_hit` lines appear in `~/.reflexio/logs/dev_server.log` when minibatches revisit prior windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Playbook evaluation results are now cached during batch evaluation, eliminating redundant computations when assessing identical playbook-scenario combinations.

* **Bug Fixes**
  * Enhanced cache logic to properly distinguish scenario windows sharing the same playbook ID but originating from different interaction sources, ensuring evaluation isolation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->