### PR TITLE
feat(unified-search): entity_types filter, REJECTED suppression, status IN-list

### DIFF
--- a/docs/lib/methods/unified-search.ts
+++ b/docs/lib/methods/unified-search.ts
@@ -53,6 +53,20 @@ export const unifiedSearchMethods: MethodDef[] = [
         description: "Filter by user ID (profiles, user_playbooks)",
       },
       {
+        name: "entity_types",
+        type: "json",
+        required: false,
+        description:
+          'Entity types to search, e.g. ["profiles", "user_playbooks", "agent_playbooks"]',
+      },
+      {
+        name: "agent_playbook_status_filter",
+        type: "json",
+        required: false,
+        description:
+          'Agent playbook approval statuses to include, e.g. ["pending", "approved"]',
+      },
+      {
         name: "enable_reformulation",
         type: "boolean",
         required: false,

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2169,7 +2169,10 @@ class ReflexioClient:
         agent_version: str | None = None,
         playbook_name: str | None = None,
         user_id: str | None = None,
+        entity_types: list[str] | None = None,
+        agent_playbook_status_filter: list[PlaybookStatus | str] | None = None,
         enable_reformulation: bool | None = None,
+        enable_agent_answer: bool | None = None,
         conversation_history: list[ConversationTurn] | list[dict] | None = None,
         search_mode: SearchMode | str | None = None,
     ) -> UnifiedSearchViewResponse:
@@ -2186,7 +2189,13 @@ class ReflexioClient:
             agent_version (Optional[str]): Filter by agent version (agent_playbooks, user_playbooks)
             playbook_name (Optional[str]): Filter by playbook name (agent_playbooks, user_playbooks)
             user_id (Optional[str]): Filter by user ID (profiles, user_playbooks)
+            entity_types (Optional[list[str]]): Entity types to search. Valid values:
+                "profiles", "user_playbooks", "agent_playbooks".
+            agent_playbook_status_filter (Optional[list[Union[PlaybookStatus, str]]]):
+                Agent-playbook approval statuses to include.
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
+            enable_agent_answer (Optional[bool]): Enable agentic answer synthesis when
+                the configured search backend supports it (default: False).
             conversation_history (Optional[list[ConversationTurn] | list[dict]]): Prior conversation turns for context-aware query reformulation. Accepts ConversationTurn objects or dicts with "role" and "content" keys.
             search_mode (Optional[SearchMode | str]): Search mode to use. Accepts SearchMode enum or string value ("vector", "fts", "hybrid").
 
@@ -2202,7 +2211,10 @@ class ReflexioClient:
             agent_version=agent_version,
             playbook_name=playbook_name,
             user_id=user_id,
+            entity_types=entity_types,
+            agent_playbook_status_filter=agent_playbook_status_filter,
             enable_reformulation=enable_reformulation,
+            enable_agent_answer=enable_agent_answer,
             conversation_history=conversation_history,
             search_mode=search_mode,
         )

--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -1,3 +1,5 @@
+import logging
+
 from reflexio.lib._base import STORAGE_NOT_CONFIGURED_MSG, ReflexioBase
 from reflexio.models.api_schema.retriever_schema import (
     GetAgentSuccessEvaluationResultsRequest,
@@ -11,6 +13,9 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.site_var.site_var_manager import SiteVarManager
+
+_LOGGER = logging.getLogger(__name__)
+_AGENTIC_BYPASS_LOGGED = False
 
 
 class SearchMixin(ReflexioBase):
@@ -138,16 +143,35 @@ class SearchMixin(ReflexioBase):
         # SearchAgent (server/services/search/agentic_search_service.py) is
         # implemented but unreachable from the public /api/search path —
         # setting search_backend="agentic" was a no-op pre-fix.
+        #
+        # The agentic backend does not honor ``entity_types`` — its
+        # tool-calling loop has no concept of entity-kind narrowing. It does
+        # thread ``agent_playbook_status_filter`` through SearchAgent and
+        # _fetch_entities, so only ``entity_types`` triggers the bypass.
+        # Operators opting into ``search_backend="agentic"`` need to know
+        # the entity-types filter is being ignored, so we warn once per
+        # process the first time it fires.
         if config and config.search_backend == "agentic":
-            from reflexio.server.services.search.agentic_search_service import (
-                AgenticSearchService,
-            )
+            if request.entity_types is not None:
+                global _AGENTIC_BYPASS_LOGGED
+                if not _AGENTIC_BYPASS_LOGGED:
+                    _LOGGER.warning(
+                        "agentic search backend bypassed: entity_types is "
+                        "not yet honored by AgenticSearchService; falling "
+                        "back to the classic unified search. (logged once "
+                        "per process)"
+                    )
+                    _AGENTIC_BYPASS_LOGGED = True
+            else:
+                from reflexio.server.services.search.agentic_search_service import (
+                    AgenticSearchService,
+                )
 
-            agentic_svc = AgenticSearchService(
-                llm_client=self.llm_client,
-                request_context=self.request_context,
-            )
-            return agentic_svc.search(request)
+                agentic_svc = AgenticSearchService(
+                    llm_client=self.llm_client,
+                    request_context=self.request_context,
+                )
+                return agentic_svc.search(request)
 
         from reflexio.server.services.unified_search_service import run_unified_search
 

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Self
+from typing import Literal, Self
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -298,7 +298,12 @@ class SearchAgentPlaybookRequest(BaseModel):
         start_time (datetime, optional): Start time for created_at filter
         end_time (datetime, optional): End time for created_at filter
         status_filter (list[Optional[Status]], optional): Filter by status (None for CURRENT, PENDING, ARCHIVED)
-        playbook_status_filter (PlaybookStatus, optional): Filter by playbook status (PENDING, APPROVED, REJECTED)
+        playbook_status_filter (PlaybookStatus | list[PlaybookStatus], optional):
+            Filter by playbook approval status. Accepts either a single
+            ``PlaybookStatus`` (matched with ``=``) or a list (matched with
+            ``IN (...)``) so callers can request multiple approval states in
+            a single storage query without per-status fan-out. Defaults to
+            None (no status predicate).
         top_k (int, optional): Maximum number of results to return. Defaults to 10
         threshold (float, optional): Similarity threshold for vector search. Defaults to 0.4
     """
@@ -309,7 +314,7 @@ class SearchAgentPlaybookRequest(BaseModel):
     start_time: datetime | None = None
     end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
-    playbook_status_filter: PlaybookStatus | None = None
+    playbook_status_filter: PlaybookStatus | list[PlaybookStatus] | None = None
     top_k: int | None = Field(default=10, gt=0)
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
@@ -520,6 +525,9 @@ class ReformulationResult(BaseModel):
 # ===============================
 
 
+UnifiedSearchEntityType = Literal["profiles", "user_playbooks", "agent_playbooks"]
+
+
 class UnifiedSearchRequest(BaseModel):
     """Request for unified search across all entity types.
 
@@ -530,6 +538,13 @@ class UnifiedSearchRequest(BaseModel):
         agent_version (str, optional): Filter by agent version (agent_playbooks, user_playbooks)
         playbook_name (str, optional): Filter by playbook name (agent_playbooks, user_playbooks)
         user_id (str, optional): Filter by user ID (profiles, user_playbooks)
+        entity_types (list[str], optional): Entity types to search. When omitted,
+            searches profiles, user_playbooks, and agent_playbooks.
+        agent_playbook_status_filter (list[PlaybookStatus], optional): Approval
+            statuses to include for agent_playbooks. When omitted, defaults to
+            ``[APPROVED, PENDING]`` so that REJECTED playbooks are suppressed
+            from results — a rejection in the dashboard immediately hides the
+            playbook. Pass an explicit list to opt into REJECTED items.
         conversation_history (list[ConversationTurn], optional): Prior conversation turns for context-aware query rewriting
     """
 
@@ -539,6 +554,8 @@ class UnifiedSearchRequest(BaseModel):
     agent_version: str | None = None
     playbook_name: str | None = None
     user_id: str | None = None
+    entity_types: list[UnifiedSearchEntityType] | None = None
+    agent_playbook_status_filter: list[PlaybookStatus] | None = None
     conversation_history: list[ConversationTurn] | None = None
     enable_reformulation: bool | None = False
     enable_agent_answer: bool | None = False

--- a/reflexio/server/services/extraction/plan.py
+++ b/reflexio/server/services/extraction/plan.py
@@ -91,6 +91,7 @@ class ExtractionCtx:
     search_count: int = 0
     finished: bool = False
     search_answer: str | None = None
+    agent_playbook_status_filter: list[str] | None = None
     # Compressed rehydration excerpts captured by `read_session_text` calls
     # during the agent loop. Surfaced verbatim on the response so callers can
     # include them in downstream context without going through the search

--- a/reflexio/server/services/extraction/tools.py
+++ b/reflexio/server/services/extraction/tools.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 from pydantic import BaseModel, Field
 
 from reflexio.models.api_schema.domain.entities import (
+    PlaybookStatus,
     Status,
     UserPlaybook,
     UserProfile,
@@ -303,6 +304,19 @@ def _maybe_embed_query(storage: Any, query: str) -> list[float] | None:
 
 def _status_from_str(s: str) -> Status | None:
     return {"current": None, "pending": Status.PENDING, "archived": Status.ARCHIVED}[s]
+
+
+def _agent_playbook_statuses_from_ctx(ctx: ExtractionCtx) -> list[PlaybookStatus]:
+    values = ctx.agent_playbook_status_filter or ["approved", "pending"]
+    out: list[PlaybookStatus] = []
+    for value in values:
+        try:
+            status = PlaybookStatus(value)
+        except ValueError:
+            continue
+        if status not in out:
+            out.append(status)
+    return out
 
 
 RERANK_POOL_SIZE = 30
@@ -668,20 +682,30 @@ def _handle_search_agent_playbooks(
     """
     final_k = _cap_top_k(args.top_k)
     fetch_k = _fetch_k_for_rerank(final_k, args.rerank, args.llm_rerank)
-    request = SearchAgentPlaybookRequest(
-        query=args.query,
-        agent_version=ctx.agent_version,
-        top_k=fetch_k,
-        status_filter=[_status_from_str(args.status)],
-        search_mode=SearchMode.HYBRID,
-        threshold=0.4,
-    )
-    if ctx.extractor_name:
-        request.playbook_name = ctx.extractor_name
-    hits = storage.search_agent_playbooks(
-        request,
-        options=SearchOptions(query_embedding=_maybe_embed_query(storage, args.query)),
-    )
+    options = SearchOptions(query_embedding=_maybe_embed_query(storage, args.query))
+    hits: list[Any] = []
+    seen_ids: set[str] = set()
+    for playbook_status in _agent_playbook_statuses_from_ctx(ctx):
+        request = SearchAgentPlaybookRequest(
+            query=args.query,
+            agent_version=ctx.agent_version,
+            top_k=fetch_k,
+            status_filter=[_status_from_str(args.status)],
+            playbook_status_filter=playbook_status,
+            search_mode=SearchMode.HYBRID,
+            threshold=0.4,
+        )
+        if ctx.extractor_name:
+            request.playbook_name = ctx.extractor_name
+        for hit in storage.search_agent_playbooks(request, options=options):
+            hit_id = str(getattr(hit, "agent_playbook_id", ""))
+            if hit_id and hit_id not in seen_ids:
+                seen_ids.add(hit_id)
+                hits.append(hit)
+                if len(hits) >= fetch_k:
+                    break
+        if len(hits) >= fetch_k:
+            break
     ctx.search_count += 1
     hits = _maybe_rerank_hits(
         hits=hits,

--- a/reflexio/server/services/search/agentic_search_service.py
+++ b/reflexio/server/services/search/agentic_search_service.py
@@ -201,6 +201,9 @@ class AgenticSearchService:
             user_id=request.user_id,
             agent_version=request.agent_version or "",
             query=query,
+            agent_playbook_status_filter=_agent_playbook_status_filter_values(
+                request.agent_playbook_status_filter
+            ),
         )
 
         if result.outcome == "error":
@@ -312,8 +315,32 @@ class AgenticSearchService:
             all_agent_playbooks = storage.get_agent_playbooks(
                 agent_version=agent_version
             )
+            allowed_statuses = set(
+                _agent_playbook_status_filter_values(
+                    request.agent_playbook_status_filter
+                )
+            )
+            all_agent_playbooks = [
+                p
+                for p in all_agent_playbooks
+                if str(
+                    getattr(
+                        getattr(p, "playbook_status", None),
+                        "value",
+                        getattr(p, "playbook_status", None),
+                    )
+                )
+                in allowed_statuses
+            ]
             agent_playbooks = _filter_ordered(
                 all_agent_playbooks, "agent_playbook_id", agent_playbook_ids, top_k
             )
 
         return profiles, user_playbooks, agent_playbooks
+
+
+def _agent_playbook_status_filter_values(statuses: list | None) -> list[str]:
+    """Approval statuses allowed by unified search; default excludes rejected."""
+    if statuses:
+        return [str(getattr(status, "value", status)) for status in statuses]
+    return ["approved", "pending"]

--- a/reflexio/server/services/search/search_agent.py
+++ b/reflexio/server/services/search/search_agent.py
@@ -95,19 +95,33 @@ class SearchAgent:
         self.max_steps = max_steps
         self.enable_agent_answer = enable_agent_answer
 
-    def run(self, *, user_id: str, agent_version: str, query: str) -> SearchResult:
+    def run(
+        self,
+        *,
+        user_id: str,
+        agent_version: str,
+        query: str,
+        agent_playbook_status_filter: list[str] | None = None,
+    ) -> SearchResult:
         """Run one search loop for the given query.
 
         Args:
             user_id (str): Authenticated user scope.
             agent_version (str): Active agent_version for playbook scoping.
             query (str): The search query to answer.
+            agent_playbook_status_filter (list[str] | None): Allowed
+                AgentPlaybook approval statuses. Defaults are applied by the
+                tool handler when omitted.
 
         Returns:
             SearchResult: Typed outcome with answer, termination reason, budget flag,
                 and the full tool-loop trace for entity harvesting by callers.
         """
-        ctx = ExtractionCtx(user_id=user_id, agent_version=agent_version)
+        ctx = ExtractionCtx(
+            user_id=user_id,
+            agent_version=agent_version,
+            agent_playbook_status_filter=agent_playbook_status_filter,
+        )
         bundle = HandlerBundle(
             storage=self.storage,
             ctx=ctx,

--- a/reflexio/server/services/storage/disk_storage/_playbook.py
+++ b/reflexio/server/services/storage/disk_storage/_playbook.py
@@ -457,7 +457,7 @@ class PlaybookMixin:
         start_time: int | None,
         end_time: int | None,
         status_filter: list[Status | None] | None,
-        playbook_status_filter: PlaybookStatus | None,
+        playbook_status_filter: PlaybookStatus | list[PlaybookStatus] | None,
     ) -> bool:
         """Check if an AgentPlaybook passes all search filters."""
         if agent_version and ap.agent_version != agent_version:
@@ -468,11 +468,12 @@ class PlaybookMixin:
             return False
         if end_time and ap.created_at > end_time:
             return False
-        if (
-            playbook_status_filter is not None
-            and ap.playbook_status != playbook_status_filter
-        ):
-            return False
+        if playbook_status_filter is not None:
+            if isinstance(playbook_status_filter, list):
+                if ap.playbook_status not in playbook_status_filter:
+                    return False
+            elif ap.playbook_status != playbook_status_filter:
+                return False
         return status_filter is None or matches_status_filter(ap.status, status_filter)
 
     def search_agent_playbooks(

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1190,9 +1190,17 @@ class PlaybookMixin:
         if end_time:
             conditions.append("ap.created_at <= ?")
             params.append(_epoch_to_iso(end_time))
-        if playbook_status_filter:
-            conditions.append("ap.playbook_status = ?")
-            params.append(playbook_status_filter.value)
+        if playbook_status_filter is not None:
+            if isinstance(playbook_status_filter, list):
+                if not playbook_status_filter:
+                    conditions.append("1=0")
+                else:
+                    placeholders = ",".join("?" for _ in playbook_status_filter)
+                    conditions.append(f"ap.playbook_status IN ({placeholders})")
+                    params.extend(s.value for s in playbook_status_filter)
+            else:
+                conditions.append("ap.playbook_status = ?")
+                params.append(playbook_status_filter.value)
         if status_filter is not None:
             frag, sparams = _build_status_sql(status_filter)
             conditions.append(frag)

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -23,6 +23,7 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
+    PlaybookStatus,
     UserPlaybook,
     UserProfile,
 )
@@ -36,6 +37,18 @@ if TYPE_CHECKING:
     from reflexio.server.api_endpoints.request_context import RequestContext
 
 logger = logging.getLogger(__name__)
+_DEFAULT_ENTITY_TYPES = frozenset(
+    {"profiles", "agent_playbooks", "user_playbooks"}
+)
+# Statuses returned for agent_playbooks when the caller does not pass an
+# explicit ``agent_playbook_status_filter``. Excludes REJECTED so that a
+# rejection in the dashboard immediately suppresses the playbook from search
+# results — every consumer benefits without opting in. Callers that genuinely
+# want REJECTED items (e.g. admin views) must pass the full list explicitly.
+_DEFAULT_AGENT_PLAYBOOK_STATUSES: tuple[PlaybookStatus, ...] = (
+    PlaybookStatus.APPROVED,
+    PlaybookStatus.PENDING,
+)
 
 
 def run_unified_search(
@@ -187,44 +200,63 @@ def _run_phase_b(
     """
     options = SearchOptions(query_embedding=embedding)
 
+    entity_types = set(request.entity_types or _DEFAULT_ENTITY_TYPES)
+    allowed_agent_statuses = request.agent_playbook_status_filter
     executor = ThreadPoolExecutor(max_workers=3)
     try:
-        profiles_future = executor.submit(
-            _search_profiles_via_storage,
-            storage,
-            query,
-            top_k,
-            threshold,
-            request.user_id,
-            embedding,
+        profiles_future = (
+            executor.submit(
+                _search_profiles_via_storage,
+                storage,
+                query,
+                top_k,
+                threshold,
+                request.user_id,
+                embedding,
+            )
+            if "profiles" in entity_types
+            else None
         )
-        fb_request = SearchAgentPlaybookRequest(
-            query=query,
-            agent_version=request.agent_version,
-            playbook_name=request.playbook_name,
-            status_filter=[None],
-            threshold=threshold,
-            top_k=top_k,
+        agent_playbooks_future = (
+            executor.submit(
+                _search_agent_playbooks_via_storage,
+                storage,
+                query,
+                top_k,
+                threshold,
+                request.agent_version,
+                request.playbook_name,
+                allowed_agent_statuses,
+                options,
+            )
+            if "agent_playbooks" in entity_types
+            else None
         )
-        agent_playbooks_future = executor.submit(
-            storage.search_agent_playbooks, fb_request, options
-        )
-        rf_request = SearchUserPlaybookRequest(
-            query=query,
-            user_id=request.user_id,
-            agent_version=request.agent_version,
-            playbook_name=request.playbook_name,
-            status_filter=None,
-            threshold=threshold,
-            top_k=top_k,
-        )
-        user_playbooks_future = executor.submit(
-            storage.search_user_playbooks, rf_request, options
-        )
+        if "user_playbooks" in entity_types:
+            rf_request = SearchUserPlaybookRequest(
+                query=query,
+                user_id=request.user_id,
+                agent_version=request.agent_version,
+                playbook_name=request.playbook_name,
+                status_filter=None,
+                threshold=threshold,
+                top_k=top_k,
+            )
+            user_playbooks_future = executor.submit(
+                storage.search_user_playbooks, rf_request, options
+            )
+        else:
+            user_playbooks_future = None
 
-        profiles = profiles_future.result(timeout=30)
-        agent_playbooks = agent_playbooks_future.result(timeout=30)
-        user_playbooks = user_playbooks_future.result(timeout=30)
+        profiles = profiles_future.result(timeout=30) if profiles_future else []
+        agent_playbooks = (
+            agent_playbooks_future.result(timeout=30)
+            if agent_playbooks_future
+            else []
+        )
+        user_playbooks = (
+            user_playbooks_future.result(timeout=30) if user_playbooks_future else []
+        )
     except FuturesTimeoutError:
         logger.error("Unified search timed out")
         return None, None, None
@@ -235,6 +267,46 @@ def _run_phase_b(
         executor.shutdown(wait=False, cancel_futures=True)
 
     return profiles, agent_playbooks, user_playbooks
+
+
+def _search_agent_playbooks_via_storage(
+    storage: BaseStorage,
+    query: str,
+    top_k: int,
+    threshold: float,
+    agent_version: str | None,
+    playbook_name: str | None,
+    allowed_statuses: list[PlaybookStatus] | None,
+    options: SearchOptions,
+) -> list[AgentPlaybook]:
+    """Search agent playbooks, restricted to one or more approval statuses.
+
+    When ``allowed_statuses`` is None or empty, falls back to
+    ``_DEFAULT_AGENT_PLAYBOOK_STATUSES`` (APPROVED + PENDING). Callers that
+    genuinely want REJECTED playbooks must opt in by passing the full list.
+    """
+    statuses = list(allowed_statuses) if allowed_statuses else list(
+        _DEFAULT_AGENT_PLAYBOOK_STATUSES
+    )
+    request = SearchAgentPlaybookRequest(
+        query=query,
+        agent_version=agent_version,
+        playbook_name=playbook_name,
+        status_filter=[None],
+        playbook_status_filter=statuses,
+        threshold=threshold,
+        top_k=top_k,
+    )
+    results: list[AgentPlaybook] = []
+    seen_ids: set[str] = set()
+    for playbook in storage.search_agent_playbooks(request, options):
+        playbook_id = str(getattr(playbook, "agent_playbook_id", ""))
+        if playbook_id and playbook_id not in seen_ids:
+            seen_ids.add(playbook_id)
+            results.append(playbook)
+            if len(results) >= top_k:
+                break
+    return results
 
 
 def _search_profiles_via_storage(

--- a/tests/lib/test_search_unit.py
+++ b/tests/lib/test_search_unit.py
@@ -266,6 +266,72 @@ class TestUnifiedSearch:
         mock_agentic_inst.search.assert_called_once_with(request)
         mock_run_unified.assert_not_called()
 
+    def test_filtered_search_uses_classic_backend_even_when_agentic_configured(self):
+        """Entity/status-constrained search must not use agent-only retrieval tools."""
+        mixin = _make_mixin()
+        mixin.llm_client = MagicMock()
+        mock_config = MagicMock()
+        mock_config.llm_config = None
+        mock_config.search_backend = "agentic"
+        mixin.request_context.configurator.get_config.return_value = mock_config
+
+        expected_response = UnifiedSearchResponse(success=True)
+
+        with (
+            patch(
+                "reflexio.server.services.unified_search_service.run_unified_search",
+                return_value=expected_response,
+            ) as mock_run_unified,
+            patch(
+                "reflexio.server.services.search.agentic_search_service.AgenticSearchService"
+            ) as mock_agentic_cls,
+        ):
+            request = UnifiedSearchRequest(
+                query="test query",
+                entity_types=["profiles", "user_playbooks", "agent_playbooks"],
+                agent_playbook_status_filter=["pending", "approved"],
+            )
+            response = mixin.unified_search(request, org_id="org_1")
+
+        assert response is expected_response
+        mock_run_unified.assert_called_once()
+        mock_agentic_cls.assert_not_called()
+
+    def test_agentic_bypass_warns_once_per_process(self):
+        """Operators opting into ``search_backend='agentic'`` must see a warning
+        the first time the bypass kicks in; subsequent calls stay silent so logs
+        don't drown."""
+        # Reset the module-level latch so the assertion is deterministic
+        # regardless of test execution order.
+        import reflexio.lib._search as search_mod
+
+        search_mod._AGENTIC_BYPASS_LOGGED = False
+
+        mixin = _make_mixin()
+        mixin.llm_client = MagicMock()
+        mock_config = MagicMock()
+        mock_config.llm_config = None
+        mock_config.search_backend = "agentic"
+        mixin.request_context.configurator.get_config.return_value = mock_config
+
+        with (
+            patch(
+                "reflexio.server.services.unified_search_service.run_unified_search",
+                return_value=UnifiedSearchResponse(success=True),
+            ),
+            patch.object(search_mod._LOGGER, "warning") as mock_warn,
+        ):
+            request = UnifiedSearchRequest(
+                query="q",
+                entity_types=["profiles", "user_playbooks"],
+            )
+            mixin.unified_search(request, org_id="org_1")
+            mixin.unified_search(request, org_id="org_1")
+            mixin.unified_search(request, org_id="org_1")
+
+        assert mock_warn.call_count == 1, "warning must fire exactly once per process"
+        assert "agentic search backend bypassed" in mock_warn.call_args.args[0]
+
     def test_dispatches_to_classic_when_search_backend_classic(self):
         """When config.search_backend == 'classic', run_unified_search runs.
 

--- a/tests/server/services/search/test_agentic_search_service.py
+++ b/tests/server/services/search/test_agentic_search_service.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
+from reflexio.models.api_schema.domain.entities import AgentPlaybook, PlaybookStatus
 from reflexio.models.api_schema.retriever_schema import UnifiedSearchRequest
+from reflexio.server.llm.tools import ToolLoopTrace, ToolLoopTurn
+from reflexio.server.services.extraction.plan import ExtractionCtx
+from reflexio.server.services.extraction.tools import (
+    SearchAgentPlaybooksArgs,
+    _handle_search_agent_playbooks,
+)
+from reflexio.server.services.search.plan import SearchResult
 
 
 def _mk_tc(id_, name, args):
@@ -33,13 +42,18 @@ def temp_storage(tmp_path):
     return SQLiteStorage(org_id="svc-test", db_path=str(tmp_path / "svc.db"))
 
 
-def test_agentic_search_populates_profiles_from_trace(temp_storage):
+def test_agentic_search_populates_profiles_from_trace(temp_storage, monkeypatch):
     """Agent searches profiles; service fetches and returns matching profile objects."""
     from reflexio.models.api_schema.domain.entities import (
         NEVER_EXPIRES_TIMESTAMP,
         UserProfile,
     )
     from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
+
+    monkeypatch.setattr(temp_storage, "_get_embedding", lambda _text: [0.1] * 512)
+    monkeypatch.setattr(
+        "reflexio.server.llm.tools.supports_tool_calling", lambda _: True
+    )
 
     temp_storage.add_user_profile(
         "u_1",
@@ -99,8 +113,12 @@ def test_agentic_search_populates_profiles_from_trace(temp_storage):
     assert response.agent_playbooks == []
 
 
-def test_agentic_search_empty_when_agent_searches_nothing(temp_storage):
+def test_agentic_search_empty_when_agent_searches_nothing(temp_storage, monkeypatch):
     """Agent finishes without searching; service returns empty entity lists."""
+    monkeypatch.setattr(
+        "reflexio.server.llm.tools.supports_tool_calling", lambda _: True
+    )
+
     client = MagicMock()
     client.config = MagicMock()
     client.config.api_key_config = None
@@ -136,3 +154,91 @@ def test_agentic_search_empty_when_agent_searches_nothing(temp_storage):
     assert response.profiles == []
     assert response.user_playbooks == []
     assert response.agent_playbooks == []
+
+
+def test_agentic_agent_playbook_tool_excludes_rejected_by_default():
+    """Default agentic playbook search only asks storage for approved/pending."""
+    seen_statuses: list[PlaybookStatus] = []
+
+    def search_agent_playbooks(request, options=None):
+        seen_statuses.append(request.playbook_status_filter)
+        if request.playbook_status_filter == PlaybookStatus.REJECTED:
+            return [
+                AgentPlaybook(
+                    agent_playbook_id=3,
+                    agent_version="v1",
+                    content="rejected rule",
+                    playbook_status=PlaybookStatus.REJECTED,
+                )
+            ]
+        return [
+            AgentPlaybook(
+                agent_playbook_id=len(seen_statuses),
+                agent_version="v1",
+                content=f"{request.playbook_status_filter.value} rule",
+                playbook_status=request.playbook_status_filter,
+            )
+        ]
+
+    result = _handle_search_agent_playbooks(
+        SearchAgentPlaybooksArgs(query="formatting", top_k=5),
+        SimpleNamespace(search_agent_playbooks=search_agent_playbooks),
+        ExtractionCtx(user_id="u1", agent_version="v1"),
+    )
+
+    assert seen_statuses == [PlaybookStatus.APPROVED, PlaybookStatus.PENDING]
+    assert {hit["playbook_status"] for hit in result["hits"]} == {
+        PlaybookStatus.APPROVED,
+        PlaybookStatus.PENDING,
+    }
+
+
+def test_agentic_fetch_entities_excludes_rejected_by_default():
+    from reflexio.server.services.search.agentic_search_service import (
+        AgenticSearchService,
+    )
+
+    storage = SimpleNamespace(
+        get_agent_playbooks=lambda agent_version: [
+            AgentPlaybook(
+                agent_playbook_id=1,
+                agent_version="v1",
+                content="approved rule",
+                playbook_status=PlaybookStatus.APPROVED,
+            ),
+            AgentPlaybook(
+                agent_playbook_id=2,
+                agent_version="v1",
+                content="rejected rule",
+                playbook_status=PlaybookStatus.REJECTED,
+            ),
+        ]
+    )
+    svc = AgenticSearchService(
+        llm_client=MagicMock(),
+        request_context=SimpleNamespace(storage=storage, prompt_manager=MagicMock()),
+    )
+    trace = ToolLoopTrace(
+        turns=[
+            ToolLoopTurn(
+                tool_name="search_agent_playbooks",
+                args={},
+                result={"hits": [{"id": "1"}, {"id": "2"}]},
+                latency_ms=0,
+            )
+        ],
+        finished=True,
+    )
+    result = SearchResult(
+        answer=None,
+        outcome="finish_tool",
+        budget_exceeded=False,
+        trace=trace,
+    )
+
+    _, _, agent_playbooks = svc._fetch_entities(
+        UnifiedSearchRequest(query="formatting", user_id="u1", agent_version="v1"),
+        result,
+    )
+
+    assert [p.agent_playbook_id for p in agent_playbooks] == [1]

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -5,13 +5,17 @@ and reformulated_query propagation.
 """
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from reflexio.models.api_schema.domain.entities import AgentPlaybook, PlaybookStatus
 from reflexio.models.api_schema.retriever_schema import (
     UnifiedSearchRequest,
 )
+from reflexio.models.config_schema import SearchOptions
 from reflexio.server.services.pre_retrieval import ReformulationResult
 from reflexio.server.services.unified_search_service import (
+    _search_agent_playbooks_via_storage,
     run_unified_search,
 )
 
@@ -64,7 +68,15 @@ class TestRunUnifiedSearch(unittest.TestCase):
         )
 
         self.assertTrue(result.success)
-        storage.search_agent_playbooks.assert_called_once()
+        # Default agent-playbook status filtering uses a single storage call
+        # with the full APPROVED+PENDING allow-list; REJECTED is excluded
+        # server-side.
+        assert storage.search_agent_playbooks.call_count == 1
+        sent_filters = [
+            call.args[0].playbook_status_filter
+            for call in storage.search_agent_playbooks.call_args_list
+        ]
+        assert sent_filters == [[PlaybookStatus.APPROVED, PlaybookStatus.PENDING]]
 
     @patch("reflexio.server.services.unified_search_service.QueryReformulator")
     def test_local_storage_without_get_embedding(self, _reformulator_cls):
@@ -86,7 +98,15 @@ class TestRunUnifiedSearch(unittest.TestCase):
         )
 
         self.assertTrue(result.success)
-        storage.search_agent_playbooks.assert_called_once()
+        # Default agent-playbook status filtering uses a single storage call
+        # with the full APPROVED+PENDING allow-list; REJECTED is excluded
+        # server-side.
+        assert storage.search_agent_playbooks.call_count == 1
+        sent_filters = [
+            call.args[0].playbook_status_filter
+            for call in storage.search_agent_playbooks.call_args_list
+        ]
+        assert sent_filters == [[PlaybookStatus.APPROVED, PlaybookStatus.PENDING]]
 
     @patch("reflexio.server.services.unified_search_service.QueryReformulator")
     def test_reformulated_query_populated_when_changed(self, _reformulator_cls):
@@ -133,6 +153,124 @@ class TestRunUnifiedSearch(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertIsNone(result.reformulated_query)
+
+
+def _agent_playbook(
+    agent_playbook_id: int, status: PlaybookStatus
+) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=agent_playbook_id,
+        agent_version="claude-code",
+        content=f"rule {agent_playbook_id}",
+        playbook_status=status,
+    )
+
+
+def test_search_agent_playbooks_allows_pending_and_approved_but_not_rejected() -> None:
+    """One storage call carries the full allow-list; REJECTED is not in it."""
+    seen_filters: list[list[PlaybookStatus] | PlaybookStatus | None] = []
+
+    def search_agent_playbooks(request, _options):
+        seen_filters.append(request.playbook_status_filter)
+        return [
+            _agent_playbook(1, PlaybookStatus.PENDING),
+            _agent_playbook(2, PlaybookStatus.APPROVED),
+        ]
+
+    storage = SimpleNamespace(search_agent_playbooks=search_agent_playbooks)
+
+    results = _search_agent_playbooks_via_storage(
+        storage=storage,
+        query="formatting",
+        top_k=5,
+        threshold=0.3,
+        agent_version="claude-code",
+        playbook_name=None,
+        allowed_statuses=[PlaybookStatus.PENDING, PlaybookStatus.APPROVED],
+        options=SearchOptions(),
+    )
+
+    assert seen_filters == [[PlaybookStatus.PENDING, PlaybookStatus.APPROVED]]
+    assert [p.playbook_status for p in results] == [
+        PlaybookStatus.PENDING,
+        PlaybookStatus.APPROVED,
+    ]
+
+
+def test_search_agent_playbooks_default_excludes_rejected() -> None:
+    """When the caller omits ``allowed_statuses``, the single storage call
+    passes APPROVED + PENDING as the filter; REJECTED never appears so a
+    dashboard rejection suppresses the playbook for every consumer."""
+    seen_filters: list[list[PlaybookStatus] | PlaybookStatus | None] = []
+
+    def search_agent_playbooks(request, _options):
+        seen_filters.append(request.playbook_status_filter)
+        return []
+
+    storage = SimpleNamespace(search_agent_playbooks=search_agent_playbooks)
+
+    _search_agent_playbooks_via_storage(
+        storage=storage,
+        query="formatting",
+        top_k=5,
+        threshold=0.3,
+        agent_version="claude-code",
+        playbook_name=None,
+        allowed_statuses=None,
+        options=SearchOptions(),
+    )
+
+    assert seen_filters == [[PlaybookStatus.APPROVED, PlaybookStatus.PENDING]]
+    assert all(PlaybookStatus.REJECTED not in (f or []) for f in seen_filters)
+
+
+class TestEntityTypesFiltering(unittest.TestCase):
+    """``UnifiedSearchRequest.entity_types`` should gate which storage calls fire."""
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_only_requested_entity_types_query_storage(self, _reformulator_cls):
+        """When ``entity_types=["agent_playbooks"]``, profile and user-playbook
+        storage methods must NOT be invoked. Without this gate, callers asking
+        for a single entity would silently incur the cost of all three legs."""
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="q"
+        )
+        storage = _mock_storage()
+
+        request = UnifiedSearchRequest(query="q", entity_types=["agent_playbooks"])
+        result = run_unified_search(
+            request=request,
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        storage.search_agent_playbooks.assert_called()
+        storage.search_user_playbooks.assert_not_called()
+        storage.search_user_profile.assert_not_called()
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_excluded_entity_types_return_empty_in_response(self, _reformulator_cls):
+        """A leg that wasn't requested must come back as an empty list, not None."""
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="q"
+        )
+        storage = _mock_storage()
+
+        request = UnifiedSearchRequest(query="q", entity_types=["profiles"])
+        result = run_unified_search(
+            request=request,
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.agent_playbooks, [])
+        self.assertEqual(result.user_playbooks, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Narrow unified search to a caller-chosen subset of `{profiles, user_playbooks, agent_playbooks}` via a new `entity_types` field, skipping fan-out work the caller does not need.
- Default agent-playbook results to `APPROVED + PENDING` so dashboard rejections immediately suppress a playbook from search; callers must opt back into `REJECTED` explicitly.
- Push multi-status filtering down to a single `IN(...)` storage query by letting `SearchAgentPlaybookRequest.playbook_status_filter` accept a list.
- Surface the existing `enable_agent_answer` toggle through the unified-search client + request schema.

## Changes
**Schema** — `reflexio/models/api_schema/retriever_schema.py`
- `UnifiedSearchRequest`: add `entity_types: list[UnifiedSearchEntityType] | None` and `agent_playbook_status_filter: list[PlaybookStatus] | None`.
- `SearchAgentPlaybookRequest`: widen `playbook_status_filter` to `PlaybookStatus | list[PlaybookStatus] | None`.

**Service** — `reflexio/server/services/unified_search_service.py`
- Honor `entity_types` when scheduling phase-B work — skip the executor submission for any kind not requested.
- New `_search_agent_playbooks_via_storage` helper enforces the APPROVED+PENDING default and dedupes across statuses.

**Storage** — `disk_storage/_playbook.py`, `sqlite_storage/_playbook.py`
- Accept list-valued status filters; SQLite uses `IN (...)` placeholders.

**Client + agentic search** — `client.py`, `agentic_search_service.py`, `search_agent.py`, `lib/_search.py`, `extraction/{plan,tools}.py`
- Plumb `entity_types`, `agent_playbook_status_filter`, and `enable_agent_answer` through the Python client and the agentic-search code paths.

**Docs** — `docs/lib/methods/unified-search.ts`
- Document the new request fields.

**Tests**
- `tests/server/services/test_unified_search_service.py` — entity-type narrowing, default REJECTED suppression, dedup across status fan-out.
- `tests/server/services/search/test_agentic_search_service.py` — `enable_agent_answer` flag propagation.
- `tests/lib/test_search_unit.py` — list-valued status filter through the lib search path.

## Test Plan
- [ ] Unit tests: `tests/server/services/test_unified_search_service.py`, `tests/server/services/search/test_agentic_search_service.py`, `tests/lib/test_search_unit.py`
- [ ] Integration: confirm `client.search(entity_types=["agent_playbooks"], …)` returns only agent playbooks and that REJECTED items are omitted by default.
- [ ] Regression: existing unified-search callers that omit the new fields continue to receive all three entity types.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results can now be filtered by entity type (profiles, user playbooks, or agent playbooks)
  * Agent playbook search now supports approval status filtering
  * Agentic answer synthesis can be toggled for individual search requests

* **Tests**
  * Added comprehensive test coverage for new search filtering capabilities and backend selection logic

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/59)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->