### PR TITLE
chore: rename /test-all skill to /check-and-test for clarity

### DIFF
--- a/.claude/commands/check-and-test/SKILL.md
+++ b/.claude/commands/check-and-test/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: check-and-test
-description: Run lint checks (ruff for Python, Biome for TS/JS), type checks (pyright for Python, tsc for TS/JS), and all tests including e2e tests and tests skipped during pre-commit. Investigates failures to determine if they are application bugs or test issues, and fixes application bugs rather than weakening tests.
+description: Run lint checks (ruff for Python, Biome for TS/JS), type checks (pyright for Python, tsc for TS/JS), and the standard pytest tiers (unit + e2e + tests skipped during pre-commit). Investigates failures to determine if they are application bugs or test issues, and fixes application bugs rather than weakening tests. Does not run paid-LLM real-API tests or scenario probes from the test-* command family.
 ---
 
 # Check and Test
 
-Run the complete test suite including tests that are normally skipped during pre-commit hooks.
+Run the standard check-and-test flow (lint + type-check + pytest tiers), including tests normally skipped during pre-commit hooks.
 
 ## Overview
 
-This command runs all tests in the repository:
+This command runs the standard check-and-test tiers:
 - **Python lint checks** via ruff (code quality, security, complexity)
 - **Python type checks** via pyright (type safety)
 - **TypeScript/JavaScript lint checks** via Biome (code quality, formatting, import sorting)

--- a/.claude/commands/check-and-test/SKILL.md
+++ b/.claude/commands/check-and-test/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: test-all
+name: check-and-test
 description: Run lint checks (ruff for Python, Biome for TS/JS), type checks (pyright for Python, tsc for TS/JS), and all tests including e2e tests and tests skipped during pre-commit. Investigates failures to determine if they are application bugs or test issues, and fixes application bugs rather than weakening tests.
 ---
 
-# Test All
+# Check and Test
 
 Run the complete test suite including tests that are normally skipped during pre-commit hooks.
 

--- a/reflexio/benchmarks/retrieval_latency/README.md
+++ b/reflexio/benchmarks/retrieval_latency/README.md
@@ -90,7 +90,7 @@ Sanity checks to run on any report:
 `tests/benchmarks/test_retrieval_latency_smoke.py` runs a tiny version of
 this benchmark at `N=50, trials=10, sqlite + service only` and asserts that
 p95 has not regressed past 3× the committed baseline. It's marked
-`skip_in_precommit`, so it runs in `test-all` but not on every commit. To
+`skip_in_precommit`, so it runs in `check-and-test` but not on every commit. To
 regenerate the baseline after an intentional perf change:
 
 ```bash

--- a/tests/benchmarks/test_retrieval_latency_smoke.py
+++ b/tests/benchmarks/test_retrieval_latency_smoke.py
@@ -9,7 +9,7 @@ precise measurement — a p95 that's 3× slower on an unchanged baseline
 almost certainly indicates a real regression (e.g. an accidental per-row
 LLM call, a missing index, a broken query plan).
 
-Marked ``skip_in_precommit`` so it runs in ``test-all`` but not on every
+Marked ``skip_in_precommit`` so it runs in ``check-and-test`` but not on every
 commit; seeding 150 rows and running 40 timed retrievals still takes a
 few seconds.
 """


### PR DESCRIPTION
## Why
The old `/test-all` name claimed completeness ("-all") but excluded real-API tests, stress tests, and paid-LLM tiers. Renamed for accuracy: `check-and-test` = lint + format + type-check (the "check" half) + the standard pytest tiers (the "test" half). No completeness claim.

## Scope
- Renamed `.claude/commands/test-all/` -> `check-and-test/`.
- Updated `name:` frontmatter and `# Title` heading in `SKILL.md`.
- Rewrote the `description:`, subtitle line, and Overview lead-in to drop "complete test suite" / "all tests in the repository" wording (commit 0ba061c, in response to CodeRabbit feedback on the sibling claude-smart PR). Added an explicit exclusion sentence listing what `check-and-test` does NOT cover: paid-LLM real-API tests, and scenario-probe skills from the `test-*` command family (`test-e2e-cli`, `test-ui`, `test-backend-pipeline`, ...).
- Updated doc mentions in `reflexio/benchmarks/retrieval_latency/README.md` and `tests/benchmarks/test_retrieval_latency_smoke.py`.

Companion PRs: ReflexioAI/reflexio-enterprise#56 (bundles the enterprise rename + a separate nightly-CI fix) and ReflexioAI/claude-smart#19 (cross-fork rename PR). They land independently — no submodule pointer bump needed here.