### PR TITLE
fix(litellm): make temperature=0 override opt-in via explicit REFLEXIO_LLM_SEED

### DIFF
--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -763,22 +763,23 @@ class LiteLLMClient:
         else:
             params["temperature"] = temperature
 
-        # Determinism knob: if REFLEXIO_LLM_SEED is set in the environment,
-        # inject it as seed + force temperature=0 on non-restricted models so
-        # repeated extraction calls produce stable outputs on providers that
-        # honor `seed`. Default to "42" so LongMemEval rounds are reproducible
-        # without requiring the env var to be set. Current-gen reasoning models
-        # (gpt-5-*) do not honor seed or temperature; the knob is best-effort.
-        seed_env = os.environ.get("REFLEXIO_LLM_SEED") or "42"
-        if seed_env:
-            try:
-                params["seed"] = int(seed_env)
-            except ValueError:
-                self.logger.warning(
-                    "REFLEXIO_LLM_SEED=%r is not an int; ignoring", seed_env
-                )
-            if not self._is_temperature_restricted_model(actual_model):
-                params["temperature"] = 0.0
+        # Determinism knob: `seed` is always injected (defaulting to 42) on
+        # providers that honor it, since seed alone is cheap and harmless.
+        # The companion temperature=0 override is opt-in via an explicit
+        # REFLEXIO_LLM_SEED env var so that caller-configured temperature
+        # flows through by default — silently clobbering a user's configured
+        # temperature was surprising. Current-gen reasoning models (gpt-5-*)
+        # ignore both knobs; the seed is best-effort.
+        seed_explicit = "REFLEXIO_LLM_SEED" in os.environ
+        seed_raw = os.environ.get("REFLEXIO_LLM_SEED", "42")
+        try:
+            params["seed"] = int(seed_raw)
+        except ValueError:
+            self.logger.warning(
+                "REFLEXIO_LLM_SEED=%r is not an int; ignoring", seed_raw
+            )
+        if seed_explicit and not self._is_temperature_restricted_model(actual_model):
+            params["temperature"] = 0.0
 
         max_tokens = kwargs.pop("max_tokens", self.config.max_tokens)
         if max_tokens:

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -770,14 +770,18 @@ class LiteLLMClient:
         # flows through by default — silently clobbering a user's configured
         # temperature was surprising. Current-gen reasoning models (gpt-5-*)
         # ignore both knobs; the seed is best-effort.
+        default_seed = 42
         seed_explicit = "REFLEXIO_LLM_SEED" in os.environ
-        seed_raw = os.environ.get("REFLEXIO_LLM_SEED", "42")
+        seed_raw = os.environ.get("REFLEXIO_LLM_SEED", str(default_seed))
         try:
             params["seed"] = int(seed_raw)
         except ValueError:
             self.logger.warning(
-                "REFLEXIO_LLM_SEED=%r is not an int; ignoring", seed_raw
+                "REFLEXIO_LLM_SEED=%r is not an int; falling back to default seed=%d",
+                seed_raw,
+                default_seed,
             )
+            params["seed"] = default_seed
         if seed_explicit and not self._is_temperature_restricted_model(actual_model):
             params["temperature"] = 0.0
 

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1276,9 +1276,13 @@ class TestTemperatureRestriction:
         assert call_kwargs["temperature"] == 1.0
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_non_restricted_model_defaults_to_deterministic_temperature(
-        self, mock_completion
+    def test_non_restricted_model_default_injects_seed_only(
+        self, mock_completion, monkeypatch
     ):
+        """Default behavior: seed=42 is injected, but caller-configured
+        temperature flows through unchanged (the temperature override is
+        opt-in via an explicit REFLEXIO_LLM_SEED env var)."""
+        monkeypatch.delenv("REFLEXIO_LLM_SEED", raising=False)
         mock_completion.return_value = _make_completion_response("ok")
         config = LiteLLMConfig(model="gpt-4o", temperature=0.3)
         client = LiteLLMClient(config)
@@ -1287,6 +1291,23 @@ class TestTemperatureRestriction:
 
         call_kwargs = mock_completion.call_args.kwargs
         assert call_kwargs["seed"] == 42
+        assert call_kwargs["temperature"] == 0.3
+
+    @patch("reflexio.server.llm.litellm_client.litellm.completion")
+    def test_explicit_seed_env_forces_temperature_zero(
+        self, mock_completion, monkeypatch
+    ):
+        """Explicit REFLEXIO_LLM_SEED opt-in: seed is injected AND temperature
+        is forced to 0.0 on non-restricted models for reproducible sampling."""
+        monkeypatch.setenv("REFLEXIO_LLM_SEED", "7")
+        mock_completion.return_value = _make_completion_response("ok")
+        config = LiteLLMConfig(model="gpt-4o", temperature=0.3)
+        client = LiteLLMClient(config)
+
+        client.generate_response("hi")
+
+        call_kwargs = mock_completion.call_args.kwargs
+        assert call_kwargs["seed"] == 7
         assert call_kwargs["temperature"] == 0.0
 
 

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1310,6 +1310,22 @@ class TestTemperatureRestriction:
         assert call_kwargs["seed"] == 7
         assert call_kwargs["temperature"] == 0.0
 
+    @patch("reflexio.server.llm.litellm_client.litellm.completion")
+    def test_invalid_seed_env_falls_back_to_default(self, mock_completion, monkeypatch):
+        """A non-integer REFLEXIO_LLM_SEED falls back to seed=42 so the
+        'always inject a seed' contract holds; the temperature override still
+        fires because the operator explicitly opted into determinism."""
+        monkeypatch.setenv("REFLEXIO_LLM_SEED", "not-an-int")
+        mock_completion.return_value = _make_completion_response("ok")
+        config = LiteLLMConfig(model="gpt-4o", temperature=0.3)
+        client = LiteLLMClient(config)
+
+        client.generate_response("hi")
+
+        call_kwargs = mock_completion.call_args.kwargs
+        assert call_kwargs["seed"] == 42
+        assert call_kwargs["temperature"] == 0.0
+
 
 # ===================================================================
 # Config management tests

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -1173,6 +1173,10 @@ def test_should_run_before_extraction_combines_all_extractor_criteria():
                 "_collect_scoped_interactions_for_precheck",
                 return_value=([session_data], extractor_configs),
             ),
+            patch(
+                "reflexio.server.services.base_generation_service._cheap_should_run_reject",
+                return_value=None,
+            ),
             patch.object(
                 service.client,
                 "generate_chat_response",


### PR DESCRIPTION
## Summary

The seed-injection block in `litellm_client.py` was silently overriding any caller-configured `temperature` with `0.0` on every non-restricted model. The fallback `seed_env = os.environ.get("REFLEXIO_LLM_SEED") or "42"` meant the override always fired — `LiteLLMConfig(temperature=0.3)` and friends never reached the provider.

## Behavior change

- `seed=42` is still injected by default. Cheap, harmless on providers that ignore it, helpful on providers that honor it.
- The companion `temperature=0.0` override now fires **only** when the operator explicitly opts in via `REFLEXIO_LLM_SEED=<int>`. Caller-configured temperature flows through unchanged otherwise.

To restore the prior "always deterministic" behavior in a deployment, set `REFLEXIO_LLM_SEED=42` in the environment.

## Tests

- Renamed `test_non_restricted_model_defaults_to_deterministic_temperature` → `test_non_restricted_model_default_injects_seed_only`; asserts seed is injected but configured temperature flows through.
- Added `test_explicit_seed_env_forces_temperature_zero` to cover the opt-in path with `monkeypatch.setenv("REFLEXIO_LLM_SEED", "7")`.
- Patched `_cheap_should_run_reject` in `test_should_run_before_extraction_combines_all_extractor_criteria` so the new cheap pre-filter short-circuit doesn't pre-empt the mocked LLM call.

## Test plan

- [x] `uv run pytest tests/server/llm/test_litellm_client_unit.py::TestTemperatureRestriction` — all 13 pass.
- [x] `uv run pytest tests/server/services/test_profile_generation_service.py::test_should_run_before_extraction_combines_all_extractor_criteria` — passes.
- [x] Verified the pre-existing 44 unit-tier failures on `main` are unchanged by this PR (orthogonal — same count, same names, with or without the diff applied).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic behavior for LLM requests: client now always supplies an integer seed (defaulting to 42 when unset or invalid) and only forces temperature to zero when an explicit seed is present and the model allows it.

* **Tests**
  * Updated and expanded unit tests to cover seed defaults, explicit seed handling, invalid seed fallback, and related prompt/response behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->