### PR TITLE
feat: persist credit/auth stall state + stream-json provider + HTTP surface

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -105,6 +105,10 @@ from reflexio.models.api_schema.service_schemas import (
     UserProfile,
     WhoamiResponse,
 )
+from reflexio.models.api_schema.stall_state_schema import (
+    MarkNotifiedResponse,
+    StallStateResponse,
+)
 from reflexio.models.config_schema import Config
 
 from .cache import InMemoryCache
@@ -2367,3 +2371,21 @@ class ReflexioClient:
         response = self._make_request("DELETE", "/api/delete_all_agent_playbooks")
         self._cache.invalidate("get_agent_playbooks")
         return BulkDeleteResponse(**response)
+
+    def get_stall_state(self) -> StallStateResponse:
+        """Read the current learning-stall state from the server.
+
+        Returns:
+            StallStateResponse: ``stalled=False`` when clean.
+        """
+        response = self._make_request("GET", "/stall_state")
+        return StallStateResponse.model_validate(response)
+
+    def mark_stall_notified(self) -> MarkNotifiedResponse:
+        """Idempotently flip ``notified_in_cc=1`` on the current stall row.
+
+        Returns:
+            MarkNotifiedResponse: New ``notified_in_cc`` value.
+        """
+        response = self._make_request("POST", "/stall_state/notified")
+        return MarkNotifiedResponse.model_validate(response)

--- a/reflexio/models/api_schema/stall_state_schema.py
+++ b/reflexio/models/api_schema/stall_state_schema.py
@@ -7,12 +7,19 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+StallReason = Literal["billing_error", "auth_error"]
+"""Canonical stall-reason discriminator.
+
+Imported by the storage layer (``sqlite_storage._stall_state``) and the
+LiteLLM provider's stream parser so all three layers share one source of
+truth for the allowed values."""
+
 
 class StallStateResponse(BaseModel):
     """Returned by GET /stall_state."""
 
     stalled: bool = Field(..., description="True when learning is currently paused.")
-    reason: Literal["billing_error", "auth_error"] | None = None
+    reason: StallReason | None = None
     stalled_at: datetime | None = None
     reset_estimate: datetime | None = None
     notified_in_cc: bool = False

--- a/reflexio/models/api_schema/stall_state_schema.py
+++ b/reflexio/models/api_schema/stall_state_schema.py
@@ -1,0 +1,25 @@
+"""Pydantic models for the stall_state HTTP endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class StallStateResponse(BaseModel):
+    """Returned by GET /stall_state."""
+
+    stalled: bool = Field(..., description="True when learning is currently paused.")
+    reason: Literal["billing_error", "auth_error"] | None = None
+    stalled_at: datetime | None = None
+    reset_estimate: datetime | None = None
+    notified_in_cc: bool = False
+    error_message: str | None = None
+
+
+class MarkNotifiedResponse(BaseModel):
+    """Returned by POST /stall_state/notified."""
+
+    notified_in_cc: bool

--- a/reflexio/server/_auth.py
+++ b/reflexio/server/_auth.py
@@ -1,0 +1,25 @@
+"""Auth dependency primitives shared between :mod:`reflexio.server.api` and
+endpoint helpers.
+
+Lives in its own module to avoid an import cycle: api endpoints reference
+:func:`default_get_org_id` (e.g. via FastAPI ``Depends``) and are themselves
+imported by :mod:`reflexio.server.api`. Putting the dependency here keeps the
+import graph acyclic.
+"""
+
+from __future__ import annotations
+
+DEFAULT_ORG_ID = "self-host-org"
+
+
+def default_get_org_id() -> str:
+    """Return the default organization ID for local hosting.
+
+    Enterprise deployments override this via
+    ``app.dependency_overrides[default_get_org_id] = <bearer_auth_resolver>``
+    inside :func:`reflexio.server.api.create_app`.
+
+    Returns:
+        str: The default org identifier used for self-hosted deployments.
+    """
+    return DEFAULT_ORG_ID

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -130,6 +130,7 @@ from reflexio.server.api_endpoints import (
     health_api,
     publisher_api,
     retriever_api,
+    stall_state_api,
 )
 from reflexio.server.cache.reflexio_cache import (
     get_reflexio,
@@ -1892,6 +1893,9 @@ def create_app(
 
     # Include core routes
     app.include_router(core_router)
+
+    # Include stall_state routes
+    app.include_router(stall_state_api.router)
 
     # Include additional routers
     for router in additional_routers or []:

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -267,14 +267,13 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
         return response
 
 
-DEFAULT_ORG_ID = "self-host-org"
+from reflexio.server._auth import DEFAULT_ORG_ID, default_get_org_id
+
+# Re-exported for backwards compatibility — callers that did
+# ``from reflexio.server.api import default_get_org_id`` continue to work.
+__all__ = ["DEFAULT_ORG_ID", "create_app", "default_get_org_id"]
 
 core_router = APIRouter()
-
-
-def default_get_org_id() -> str:
-    """Return the default organization ID for local hosting."""
-    return DEFAULT_ORG_ID
 
 
 @core_router.get("/")

--- a/reflexio/server/api_endpoints/request_context.py
+++ b/reflexio/server/api_endpoints/request_context.py
@@ -1,3 +1,6 @@
+from fastapi import Depends
+
+from reflexio.server._auth import default_get_org_id
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.configurator.base_configurator import BaseConfigurator
 from reflexio.server.services.configurator.configurator import get_configurator_class
@@ -29,9 +32,14 @@ class RequestContext:
 
 
 def get_request_context(
-    org_id: str = "self-host-org",
+    org_id: str = Depends(default_get_org_id),
 ) -> RequestContext:
     """FastAPI dependency that builds a RequestContext for the calling org.
+
+    The ``org_id`` parameter is resolved through :func:`default_get_org_id`,
+    which enterprise deployments override via ``app.dependency_overrides`` in
+    :func:`create_app` to plug in real auth (e.g. Bearer-token org resolution).
+    Tests that need a fixed context override this function directly.
 
     Args:
         org_id (str): Organisation identifier resolved by the auth layer.

--- a/reflexio/server/api_endpoints/request_context.py
+++ b/reflexio/server/api_endpoints/request_context.py
@@ -26,3 +26,17 @@ class RequestContext:
             bool: True if storage is configured, False otherwise
         """
         return self.storage is not None
+
+
+def get_request_context(
+    org_id: str = "self-host-org",
+) -> RequestContext:
+    """FastAPI dependency that builds a RequestContext for the calling org.
+
+    Args:
+        org_id (str): Organisation identifier resolved by the auth layer.
+
+    Returns:
+        RequestContext: Fully initialised context with storage attached.
+    """
+    return RequestContext(org_id=org_id)

--- a/reflexio/server/api_endpoints/stall_state_api.py
+++ b/reflexio/server/api_endpoints/stall_state_api.py
@@ -12,6 +12,8 @@ from reflexio.server.api_endpoints.request_context import RequestContext, get_re
 
 router = APIRouter(tags=["stall_state"])
 
+_UNSUPPORTED_DETAIL = "Stall state is not supported by the configured storage backend"
+
 
 def _require_storage(ctx: RequestContext):
     """Return ``ctx.storage`` or raise 503 when storage isn't configured.
@@ -48,10 +50,14 @@ def read_stall_state(
         StallStateResponse: ``stalled=False`` with null fields when clean.
 
     Raises:
-        HTTPException: 503 when storage is not configured.
+        HTTPException: 503 when storage is not configured, or when the
+            backend does not implement stall_state (e.g. disk storage).
     """
     storage = _require_storage(ctx)
-    state = storage.get_stall_state()
+    try:
+        state = storage.get_stall_state()
+    except NotImplementedError as exc:
+        raise HTTPException(status_code=503, detail=_UNSUPPORTED_DETAIL) from exc
     return StallStateResponse(
         stalled=state.stalled,
         reason=state.reason,
@@ -79,9 +85,13 @@ def post_notified(
             ``False`` when no stall is active.
 
     Raises:
-        HTTPException: 503 when storage is not configured.
+        HTTPException: 503 when storage is not configured, or when the
+            backend does not implement stall_state (e.g. disk storage).
     """
     storage = _require_storage(ctx)
-    storage.mark_stall_notified()
-    state = storage.get_stall_state()
+    try:
+        storage.mark_stall_notified()
+        state = storage.get_stall_state()
+    except NotImplementedError as exc:
+        raise HTTPException(status_code=503, detail=_UNSUPPORTED_DETAIL) from exc
     return MarkNotifiedResponse(notified_in_cc=state.notified_in_cc)

--- a/reflexio/server/api_endpoints/stall_state_api.py
+++ b/reflexio/server/api_endpoints/stall_state_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from reflexio.models.api_schema.stall_state_schema import (
     MarkNotifiedResponse,
@@ -11,6 +11,28 @@ from reflexio.models.api_schema.stall_state_schema import (
 from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
 
 router = APIRouter(tags=["stall_state"])
+
+
+def _require_storage(ctx: RequestContext):
+    """Return ``ctx.storage`` or raise 503 when storage isn't configured.
+
+    Cloud-mode deployments may run with ``ctx.storage is None`` until the
+    caller provisions a backend; stall_state has no meaningful response in
+    that state, so we surface 503 instead of an ``AttributeError``.
+
+    Args:
+        ctx (RequestContext): The injected request context.
+
+    Returns:
+        BaseStorage: The configured storage backend.
+
+    Raises:
+        HTTPException: 503 when storage is not configured.
+    """
+    if not ctx.is_storage_configured():
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    assert ctx.storage is not None  # narrows BaseStorage | None -> BaseStorage
+    return ctx.storage
 
 
 @router.get("/stall_state", response_model=StallStateResponse)
@@ -24,8 +46,12 @@ def read_stall_state(
 
     Returns:
         StallStateResponse: ``stalled=False`` with null fields when clean.
+
+    Raises:
+        HTTPException: 503 when storage is not configured.
     """
-    state = ctx.storage.get_stall_state()
+    storage = _require_storage(ctx)
+    state = storage.get_stall_state()
     return StallStateResponse(
         stalled=state.stalled,
         reason=state.reason,
@@ -51,7 +77,11 @@ def post_notified(
     Returns:
         MarkNotifiedResponse: ``notified_in_cc=True`` after the call (when stalled),
             ``False`` when no stall is active.
+
+    Raises:
+        HTTPException: 503 when storage is not configured.
     """
-    ctx.storage.mark_stall_notified()
-    state = ctx.storage.get_stall_state()
+    storage = _require_storage(ctx)
+    storage.mark_stall_notified()
+    state = storage.get_stall_state()
     return MarkNotifiedResponse(notified_in_cc=state.notified_in_cc)

--- a/reflexio/server/api_endpoints/stall_state_api.py
+++ b/reflexio/server/api_endpoints/stall_state_api.py
@@ -1,0 +1,57 @@
+"""HTTP endpoints exposing the stall_state row."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from reflexio.models.api_schema.stall_state_schema import (
+    MarkNotifiedResponse,
+    StallStateResponse,
+)
+from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
+
+router = APIRouter(tags=["stall_state"])
+
+
+@router.get("/stall_state", response_model=StallStateResponse)
+def read_stall_state(
+    ctx: RequestContext = Depends(get_request_context),
+) -> StallStateResponse:
+    """Return the current singleton stall_state row.
+
+    Args:
+        ctx (RequestContext): Injected request context with storage attached.
+
+    Returns:
+        StallStateResponse: ``stalled=False`` with null fields when clean.
+    """
+    state = ctx.storage.get_stall_state()
+    return StallStateResponse(
+        stalled=state.stalled,
+        reason=state.reason,
+        stalled_at=state.stalled_at,
+        reset_estimate=state.reset_estimate,
+        notified_in_cc=state.notified_in_cc,
+        error_message=state.error_message,
+    )
+
+
+@router.post("/stall_state/notified", response_model=MarkNotifiedResponse)
+def post_notified(
+    ctx: RequestContext = Depends(get_request_context),
+) -> MarkNotifiedResponse:
+    """Idempotently flip ``notified_in_cc=1`` for the current stall.
+
+    No-op (and still returns 200) when there's no active stall — the SessionStart
+    hook may race with auto-clear.
+
+    Args:
+        ctx (RequestContext): Injected request context with storage attached.
+
+    Returns:
+        MarkNotifiedResponse: ``notified_in_cc=True`` after the call (when stalled),
+            ``False`` when no stall is active.
+    """
+    ctx.storage.mark_stall_notified()
+    state = ctx.storage.get_stall_state()
+    return MarkNotifiedResponse(notified_in_cc=state.notified_in_cc)

--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -25,6 +25,7 @@ import os
 import shutil
 import subprocess  # noqa: S404 — subprocess is the integration point; inputs are sanitised.
 import time
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -37,6 +38,13 @@ from litellm.types.utils import (
     Usage,
 )
 from pydantic import BaseModel
+
+from reflexio.server.llm.providers.claude_code_stream_parser import (
+    ParseResult,
+    classify_stall,
+    parse_reset_estimate,
+    parse_stream_json,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -286,28 +294,38 @@ def _split_system_and_dialogue(
     return "\n\n".join(systems), "\n\n".join(turns)
 
 
-def _run_cli(
+def _run_cli_stream(
     cli_path: str,
     system_prompt: str,
     dialogue: str,
     timeout_seconds: int,
-) -> dict[str, Any]:
-    """Invoke ``claude -p --output-format json`` and return the parsed response.
+) -> ParseResult:
+    """Invoke ``claude -p --output-format stream-json`` and return a ParseResult.
 
     Args:
-        cli_path: Path to the ``claude`` executable.
-        system_prompt: Combined system prompt to append (may be empty).
-        dialogue: Flattened user/assistant dialogue sent on stdin.
-        timeout_seconds: Subprocess timeout.
+        cli_path (str): Path to the ``claude`` executable.
+        system_prompt (str): Combined system prompt to append (may be empty).
+        dialogue (str): Flattened user/assistant dialogue sent on stdin.
+        timeout_seconds (int): Subprocess timeout.
 
     Returns:
-        dict: Parsed JSON result from the CLI.
+        ParseResult: Aggregated state of the stream — success flag, terminal
+            text, retry errors observed, and stderr.
 
     Raises:
-        ClaudeCodeCLIError: On non-zero exit, timeout, or malformed JSON.
+        ClaudeCodeCLIError: On timeout or missing binary.
     """
     model = os.environ.get(_ENV_MODEL) or _DEFAULT_CLI_MODEL
-    cmd = [cli_path, "-p", "--output-format", "json", "--model", model]
+    cmd = [
+        cli_path,
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--model",
+        model,
+    ]
     if system_prompt:
         cmd.extend(["--append-system-prompt", system_prompt])
 
@@ -315,8 +333,13 @@ def _run_cli(
     # Stop hook) can detect that this is a reflexio-internal invocation
     # and skip publishing — otherwise extractor system prompts get
     # re-published as user interactions and contaminate the corpus.
+    #
+    # CLAUDE_CODE_MAX_RETRIES=3 keeps short infrastructure blips tolerated
+    # while bounding the worst-case stall to a few seconds before we
+    # surface the failure to reflexio's stall_state table.
     env = os.environ.copy()
     env["CLAUDE_SMART_INTERNAL"] = "1"
+    env["CLAUDE_CODE_MAX_RETRIES"] = "3"
 
     try:
         proc = subprocess.run(  # noqa: S603 — cmd is constructed from validated parts.
@@ -335,51 +358,36 @@ def _run_cli(
     except FileNotFoundError as exc:
         raise ClaudeCodeCLIError(f"claude CLI not found at {cli_path}") from exc
 
-    if proc.returncode != 0:
-        stderr = proc.stderr.strip()
-        suffix = "…" if len(stderr) > 500 else ""
-        raise ClaudeCodeCLIError(
-            f"claude CLI exited {proc.returncode}: {stderr[:500]}{suffix}"
-        )
-
-    try:
-        return json.loads(proc.stdout)
-    except json.JSONDecodeError as exc:
-        raise ClaudeCodeCLIError(
-            f"claude CLI returned non-JSON output: {proc.stdout[:500]!r}"
-        ) from exc
+    return parse_stream_json(
+        proc.stdout, exit_code=proc.returncode, stderr_text=proc.stderr
+    )
 
 
 def _build_model_response(
     model: str,
-    cli_result: dict[str, Any],
+    terminal_text: str,
     elapsed_seconds: float,
 ) -> ModelResponse:
-    """Wrap the CLI's JSON result in a LiteLLM ``ModelResponse``.
+    """Wrap the CLI's terminal text in a LiteLLM ``ModelResponse``.
+
+    The stream-json transport does not surface usage tokens at the terminal
+    event, so prompt/completion counts are reported as zero. Downstream
+    LiteLLM callers tolerate this (usage is informational, not load-bearing).
 
     Args:
-        model: The model string originally requested (e.g. ``claude-code/default``).
-        cli_result: Parsed JSON from the CLI.
-        elapsed_seconds: Wall time the subprocess took — for logging only.
+        model (str): The model string originally requested
+            (e.g. ``claude-code/default``).
+        terminal_text (str): The terminal ``result`` text from the CLI.
+        elapsed_seconds (float): Wall time the subprocess took — for logging only.
 
     Returns:
         ModelResponse: Shaped to match what callers of ``litellm.completion`` expect.
     """
-    text = cli_result.get("result") or cli_result.get("response") or ""
-    usage_block = cli_result.get("usage") or {}
-    prompt_tokens = int(usage_block.get("input_tokens") or 0)
-    completion_tokens = int(usage_block.get("output_tokens") or 0)
-    response_id = cli_result.get("session_id") or f"claude-code-{int(time.time())}"
-
-    message = Message(role="assistant", content=text)
+    message = Message(role="assistant", content=terminal_text)
     choice = Choices(index=0, message=message, finish_reason="stop")
-    usage = Usage(
-        prompt_tokens=prompt_tokens,
-        completion_tokens=completion_tokens,
-        total_tokens=prompt_tokens + completion_tokens,
-    )
+    usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
     response = ModelResponse(
-        id=str(response_id),
+        id=f"claude-code-{int(time.time())}",
         choices=[choice],
         created=int(time.time()),
         model=model,
@@ -387,11 +395,9 @@ def _build_model_response(
         usage=usage,
     )
     _LOGGER.debug(
-        "claude-code provider: model=%s elapsed=%.2fs in=%d out=%d",
+        "claude-code provider: model=%s elapsed=%.2fs",
         model,
         elapsed_seconds,
-        prompt_tokens,
-        completion_tokens,
     )
     return response
 
@@ -445,10 +451,26 @@ def _warn_on_ignored_params(*sources: Any) -> None:
 class ClaudeCodeLLM(CustomLLM):
     """LiteLLM custom handler routing completions through the ``claude`` CLI."""
 
-    def __init__(self, cli_path: str | None = None, timeout_seconds: int | None = None):
+    def __init__(
+        self,
+        cli_path: str | None = None,
+        timeout_seconds: int | None = None,
+        storage: Any | None = None,
+    ):
+        """Initialise the handler.
+
+        Args:
+            cli_path (str | None): Override for the ``claude`` binary path.
+            timeout_seconds (int | None): Override for subprocess timeout.
+            storage (Any | None): A BaseStorage-shaped object used to persist
+                stall_state on credit/auth failures. Typed as ``Any`` to avoid
+                a circular import with ``server.services.storage``. When None,
+                stall state is not recorded (back-compat).
+        """
         super().__init__()
         self._explicit_cli_path = cli_path
         self._explicit_timeout = timeout_seconds
+        self._storage = storage
 
     def _cli_path(self) -> str:
         """Resolve the CLI path, raising when unavailable.
@@ -519,17 +541,63 @@ class ClaudeCodeLLM(CustomLLM):
         system_prompt = _maybe_append_schema(system_prompt, response_format)
 
         started = time.perf_counter()
-        cli_result = _run_cli(
+        result = _run_cli_stream(
             cli_path=self._cli_path(),
             system_prompt=system_prompt,
             dialogue=dialogue,
             timeout_seconds=self._timeout(),
         )
-        return _build_model_response(
-            model=model,
-            cli_result=cli_result,
-            elapsed_seconds=time.perf_counter() - started,
+
+        if result.success:
+            self._clear_stall_safely()
+            return _build_model_response(
+                model=model,
+                terminal_text=result.terminal_text,
+                elapsed_seconds=time.perf_counter() - started,
+            )
+
+        self._record_stall_safely(result)
+        raise ClaudeCodeCLIError(
+            f"claude -p stream failed; retry_errors={result.retry_errors}; "
+            f"stderr={result.stderr_text[:200]!r}"
         )
+
+    def _record_stall_safely(self, result: ParseResult) -> None:
+        """Persist a stall_state row on credit/auth failure. Never raises.
+
+        Args:
+            result (ParseResult): Output of :func:`_run_cli_stream`.
+
+        Returns:
+            None
+        """
+        reason = classify_stall(result)
+        if reason is None or self._storage is None:
+            return
+        try:
+            self._storage.upsert_stall_state(
+                reason=reason,
+                stalled_at=datetime.now(UTC),
+                reset_estimate=parse_reset_estimate(
+                    f"{result.stderr_text} {result.terminal_text}"
+                ),
+                error_message=(result.stderr_text or result.terminal_text)[:1000],
+            )
+        except Exception as exc:  # noqa: BLE001 — never crash the provider over telemetry.
+            _LOGGER.warning("Failed to record stall_state: %s", exc)
+
+    def _clear_stall_safely(self) -> None:
+        """Clear any prior stall_state row after a successful run. Never raises.
+
+        Returns:
+            None
+        """
+        if self._storage is None:
+            return
+        try:
+            self._storage.clear_stall_state()
+        except Exception as exc:  # noqa: BLE001 — never crash the provider over telemetry.
+            _LOGGER.warning("Failed to clear stall_state: %s", exc)
 
     async def acompletion(  # type: ignore[override]
         self, *args: Any, **kwargs: Any
@@ -549,20 +617,30 @@ class ClaudeCodeLLM(CustomLLM):
 
 
 _REGISTERED = False
+_HANDLER: ClaudeCodeLLM | None = None
 
 
-def register_if_enabled() -> bool:
+def register_if_enabled(storage: Any | None = None) -> bool:
     """Register the ``claude-code`` provider with LiteLLM if enabled and available.
 
     Idempotent — safe to call more than once per process. Opt-in via
     ``CLAUDE_SMART_USE_LOCAL_CLI=1``. Skips registration (with a warning)
     when the env var is set but the CLI is not on PATH.
 
+    Args:
+        storage (Any | None): Optional BaseStorage-shaped handle used by the
+            provider to persist stall_state on credit/auth failures. The
+            caller (``LiteLLMClient`` import-time wiring) typically has no
+            storage available, so use :func:`set_storage` to late-bind it
+            once a request context exists.
+
     Returns:
         bool: True if the provider is registered after this call.
     """
-    global _REGISTERED
+    global _REGISTERED, _HANDLER
     if _REGISTERED:
+        if storage is not None and _HANDLER is not None:
+            _HANDLER._storage = storage
         return True
     if not _env_enabled():
         return False
@@ -580,11 +658,29 @@ def register_if_enabled() -> bool:
     if any(entry.get("provider") == PROVIDER_KEY for entry in existing):
         _REGISTERED = True
         return True
-    existing.append({"provider": PROVIDER_KEY, "custom_handler": ClaudeCodeLLM()})
+    _HANDLER = ClaudeCodeLLM(storage=storage)
+    existing.append({"provider": PROVIDER_KEY, "custom_handler": _HANDLER})
     litellm.custom_provider_map = existing
     _REGISTERED = True
     _LOGGER.info("Registered %s LiteLLM provider (cli=%s)", PROVIDER_KEY, cli_path)
     return True
+
+
+def set_storage(storage: Any) -> None:
+    """Bind storage onto the registered handler after registration.
+
+    The provider is registered at LiteLLM-import time, before any
+    request-scoped storage exists. Once a storage instance is available,
+    call this to enable stall_state persistence on the live handler.
+
+    Args:
+        storage (Any): BaseStorage-shaped instance.
+
+    Returns:
+        None
+    """
+    if _HANDLER is not None:
+        _HANDLER._storage = storage
 
 
 __all__ = [
@@ -594,4 +690,5 @@ __all__ = [
     "ClaudeCodeLLM",
     "is_claude_code_available",
     "register_if_enabled",
+    "set_storage",
 ]

--- a/reflexio/server/llm/providers/claude_code_stream_parser.py
+++ b/reflexio/server/llm/providers/claude_code_stream_parser.py
@@ -14,11 +14,10 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta, timezone
-from typing import Literal
+
+from reflexio.models.api_schema.stall_state_schema import StallReason
 
 _LOGGER = logging.getLogger(__name__)
-
-StallReason = Literal["billing_error", "auth_error"]
 
 _BILLING_CATEGORIES = {"billing_error"}
 _AUTH_CATEGORIES = {"authentication_failed", "oauth_org_not_allowed"}
@@ -181,10 +180,16 @@ def parse_reset_estimate(text: str) -> datetime | None:
     match = _RESET_RE.search(text or "")
     if not match:
         return None
-    hour = int(match.group("hour")) % 12
+    hour_raw = int(match.group("hour"))
+    minute = int(match.group("minute"))
+    # The regex permits 1–2 digit hours and minutes; reject out-of-range
+    # values so "13:00pm" or "10:75am" parse as None instead of producing
+    # silently-wrong times via modulo arithmetic.
+    if not 1 <= hour_raw <= 12 or not 0 <= minute <= 59:
+        return None
+    hour = hour_raw % 12
     if match.group("ampm").lower() == "pm":
         hour += 12
-    minute = int(match.group("minute"))
     today = datetime.now(timezone.utc).date()
     candidate = datetime.combine(today, time(hour, minute), tzinfo=timezone.utc)
     if candidate <= datetime.now(timezone.utc):

--- a/reflexio/server/llm/providers/claude_code_stream_parser.py
+++ b/reflexio/server/llm/providers/claude_code_stream_parser.py
@@ -14,7 +14,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta, timezone
-from typing import Any, Literal
+from typing import Literal
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -163,12 +163,20 @@ def _classify_from_text(text: str) -> StallReason | None:
 def parse_reset_estimate(text: str) -> datetime | None:
     """Best-effort parse of a reset time from Claude Code error text.
 
+    The hour/minute extracted from the message text is treated as UTC, then
+    advanced one day if it has already passed. Claude Code's error messages
+    typically express reset times in the user's local timezone, so the
+    returned datetime may be off by the user's UTC offset (up to ±24h).
+    Callers should treat this as an approximation, not an authoritative
+    reset moment.
+
     Args:
         text (str): Error text — typically the terminal event message or stderr.
 
     Returns:
-        datetime | None: A timezone-aware UTC datetime for the next reset,
-            or None when no recognizable pattern is found.
+        datetime | None: A UTC-naive-in-spirit but tz-aware datetime that
+            best approximates the next reset, or None when no recognizable
+            pattern is found.
     """
     match = _RESET_RE.search(text or "")
     if not match:

--- a/reflexio/server/llm/providers/claude_code_stream_parser.py
+++ b/reflexio/server/llm/providers/claude_code_stream_parser.py
@@ -1,0 +1,184 @@
+"""Parse the NDJSON stream from ``claude -p --output-format stream-json``
+and classify whether the call ended in a credit/auth stall.
+
+Public surface:
+    - parse_stream_json(stdout, exit_code, stderr_text) -> ParseResult
+    - classify_stall(result) -> "billing_error" | "auth_error" | None
+    - parse_reset_estimate(text) -> datetime | None
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, time, timedelta, timezone
+from typing import Any, Literal
+
+_LOGGER = logging.getLogger(__name__)
+
+StallReason = Literal["billing_error", "auth_error"]
+
+_BILLING_CATEGORIES = {"billing_error"}
+_AUTH_CATEGORIES = {"authentication_failed", "oauth_org_not_allowed"}
+
+_TEXT_PATTERNS_BILLING = (
+    "hit your weekly limit",
+    "hit your session limit",
+    "credit balance is too low",
+    "billing_error",
+)
+_TEXT_PATTERNS_AUTH = (
+    "please run /login",
+    "oauth token revoked",
+    "oauth token has expired",
+    "not logged in",
+)
+
+_RESET_RE = re.compile(
+    r"resets\s+(?:(?P<weekday>mon|tue|wed|thu|fri|sat|sun)\w*\s+)?"
+    r"(?P<hour>\d{1,2}):(?P<minute>\d{2})\s*(?P<ampm>am|pm)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class ParseResult:
+    """Aggregated state of one ``claude -p`` invocation.
+
+    Attributes:
+        success (bool): True iff exit_code==0 AND a terminal result event
+            with non-empty text appeared.
+        terminal_text (str): The ``result`` field from the terminal event.
+        retry_errors (list[str]): All ``error`` strings observed in
+            ``api_retry`` events, in order.
+        stderr_text (str): Raw stderr text from the subprocess.
+        raw_lines_parsed (int): NDJSON lines parsed successfully.
+        raw_lines_failed (int): NDJSON lines that failed to parse.
+    """
+
+    success: bool
+    terminal_text: str
+    retry_errors: list[str] = field(default_factory=list)
+    stderr_text: str = ""
+    raw_lines_parsed: int = 0
+    raw_lines_failed: int = 0
+
+    @property
+    def stall_candidate(self) -> str | None:
+        """The last retry error string in a stall category, or None."""
+        for err in reversed(self.retry_errors):
+            if err in _BILLING_CATEGORIES or err in _AUTH_CATEGORIES:
+                return err
+        return None
+
+
+def parse_stream_json(
+    stdout: str,
+    *,
+    exit_code: int,
+    stderr_text: str = "",
+) -> ParseResult:
+    """Parse the full NDJSON stream from claude -p.
+
+    Args:
+        stdout (str): Raw subprocess stdout — newline-delimited JSON events.
+        exit_code (int): Subprocess exit code.
+        stderr_text (str): Raw stderr — used by the text-fallback path.
+
+    Returns:
+        ParseResult: Aggregated state. ``success`` requires both a clean
+            exit and a parseable terminal ``result`` event.
+    """
+    retry_errors: list[str] = []
+    terminal_text = ""
+    parsed = 0
+    failed = 0
+    saw_terminal = False
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            failed += 1
+            continue
+        parsed += 1
+        if not isinstance(event, dict):
+            continue
+        match event.get("type"), event.get("subtype"):
+            case ("system", "api_retry"):
+                err = event.get("error")
+                if isinstance(err, str):
+                    retry_errors.append(err)
+            case ("result", _) | (_, "result"):
+                text = event.get("result")
+                if isinstance(text, str):
+                    terminal_text = text
+                    saw_terminal = True
+    return ParseResult(
+        success=(exit_code == 0 and saw_terminal and bool(terminal_text)),
+        terminal_text=terminal_text,
+        retry_errors=retry_errors,
+        stderr_text=stderr_text,
+        raw_lines_parsed=parsed,
+        raw_lines_failed=failed,
+    )
+
+
+def classify_stall(result: ParseResult) -> StallReason | None:
+    """Decide whether a finished ParseResult represents a stall.
+
+    Args:
+        result (ParseResult): Output of :func:`parse_stream_json`.
+
+    Returns:
+        StallReason | None: ``"billing_error"`` or ``"auth_error"`` only
+            when the call terminated unsuccessfully AND a stall-class
+            signal was observed (event or text fallback).
+    """
+    if result.success:
+        return None
+    candidate = result.stall_candidate
+    if candidate in _BILLING_CATEGORIES:
+        return "billing_error"
+    if candidate in _AUTH_CATEGORIES:
+        return "auth_error"
+    return _classify_from_text(result.stderr_text + " " + result.terminal_text)
+
+
+def _classify_from_text(text: str) -> StallReason | None:
+    """Belt-and-suspenders: regex the raw error text after NDJSON has been parsed."""
+    lower = text.lower()
+    if any(p in lower for p in _TEXT_PATTERNS_BILLING):
+        _LOGGER.warning("Stall classified via text fallback (billing): %r", text[:200])
+        return "billing_error"
+    if any(p in lower for p in _TEXT_PATTERNS_AUTH):
+        _LOGGER.warning("Stall classified via text fallback (auth): %r", text[:200])
+        return "auth_error"
+    return None
+
+
+def parse_reset_estimate(text: str) -> datetime | None:
+    """Best-effort parse of a reset time from Claude Code error text.
+
+    Args:
+        text (str): Error text — typically the terminal event message or stderr.
+
+    Returns:
+        datetime | None: A timezone-aware UTC datetime for the next reset,
+            or None when no recognizable pattern is found.
+    """
+    match = _RESET_RE.search(text or "")
+    if not match:
+        return None
+    hour = int(match.group("hour")) % 12
+    if match.group("ampm").lower() == "pm":
+        hour += 12
+    minute = int(match.group("minute"))
+    today = datetime.now(timezone.utc).date()
+    candidate = datetime.combine(today, time(hour, minute), tzinfo=timezone.utc)
+    if candidate <= datetime.now(timezone.utc):
+        candidate += timedelta(days=1)
+    return candidate

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -14,6 +14,7 @@ from ._share_links import SQLiteShareLinkMixin
 from ._stall_state import (
     StallReason,
     StallState,
+    SQLiteStallStateMixin,
     clear_stall_state,
     get_stall_state,
     init_stall_state_table,
@@ -29,6 +30,7 @@ class SQLiteStorage(
     OperationMixin,
     ExtrasMixin,
     SQLiteShareLinkMixin,
+    SQLiteStallStateMixin,
     SQLiteStorageBase,
 ):
     """SQLite-based storage with FTS5 and hybrid search."""
@@ -46,7 +48,6 @@ __all__ = [
     "StallState",
     "clear_stall_state",
     "get_stall_state",
-    "init_stall_state_table",
     "mark_stall_notified",
     "upsert_stall_state",
 ]

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -11,6 +11,15 @@ from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
 from ._requests import RequestMixin
 from ._share_links import SQLiteShareLinkMixin
+from ._stall_state import (
+    StallReason,
+    StallState,
+    clear_stall_state,
+    get_stall_state,
+    init_stall_state_table,
+    mark_stall_notified,
+    upsert_stall_state,
+)
 
 
 class SQLiteStorage(
@@ -33,4 +42,11 @@ __all__ = [
     "_effective_search_mode",
     "_sanitize_fts_query",
     "_true_rrf_merge",
+    "StallReason",
+    "StallState",
+    "clear_stall_state",
+    "get_stall_state",
+    "init_stall_state_table",
+    "mark_stall_notified",
+    "upsert_stall_state",
 ]

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -602,11 +602,6 @@ class SQLiteStorageBase(BaseStorage):
     # DDL / migration
     # ------------------------------------------------------------------
 
-    @property
-    def connection(self) -> sqlite3.Connection:
-        """Return the underlying SQLite connection."""
-        return self.conn
-
     def migrate(self) -> bool:
         self._migrate_feedback_schema()
         self._migrate_interactions_schema()

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -50,6 +50,7 @@ from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.site_var.site_var_manager import SiteVarManager
+from ._stall_state import init_stall_state_table
 
 logger = logging.getLogger(__name__)
 
@@ -601,6 +602,11 @@ class SQLiteStorageBase(BaseStorage):
     # DDL / migration
     # ------------------------------------------------------------------
 
+    @property
+    def connection(self) -> sqlite3.Connection:
+        """Return the underlying SQLite connection."""
+        return self.conn
+
     def migrate(self) -> bool:
         self._migrate_feedback_schema()
         self._migrate_interactions_schema()
@@ -615,6 +621,7 @@ class SQLiteStorageBase(BaseStorage):
         self._migrate_expanded_terms()
         self._migrate_agentic_signals()
         self._migrate_agent_playbook_source_windows()
+        init_stall_state_table(self.conn)
         return True
 
     def _try_load_sqlite_vec(self) -> bool:

--- a/reflexio/server/services/storage/sqlite_storage/_stall_state.py
+++ b/reflexio/server/services/storage/sqlite_storage/_stall_state.py
@@ -8,10 +8,13 @@ notification spec for the state machine.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Any, Literal
+
+_LOGGER = logging.getLogger(__name__)
 
 StallReason = Literal["billing_error", "auth_error"]
 
@@ -164,4 +167,53 @@ def _parse_ts(raw: str | None) -> datetime | None:
     try:
         return datetime.fromisoformat(raw)
     except ValueError:
+        _LOGGER.warning("Malformed timestamp in stall_state: %r", raw)
         return None
+
+
+class SQLiteStallStateMixin:
+    """SQLite-backed stall_state operations exposed as storage methods."""
+
+    # Type hints for instance attributes provided by SQLiteStorageBase via MRO
+    conn: Any
+
+    def get_stall_state(self) -> StallState:
+        """Return the current stall row.
+
+        Returns:
+            StallState: Current snapshot of the singleton stall row.
+        """
+        return get_stall_state(self.conn)
+
+    def upsert_stall_state(
+        self,
+        *,
+        reason: StallReason,
+        stalled_at: datetime,
+        reset_estimate: datetime | None,
+        error_message: str,
+    ) -> None:
+        """Mark the singleton as stalled with the given reason. Re-arms notified flag.
+
+        Args:
+            reason (StallReason): The stall reason discriminator (``billing_error``
+                or ``auth_error``).
+            stalled_at (datetime): When the stall was first detected.
+            reset_estimate (datetime | None): Estimated reset time, if known.
+            error_message (str): Raw error text for debugging.
+        """
+        upsert_stall_state(
+            self.conn,
+            reason=reason,
+            stalled_at=stalled_at,
+            reset_estimate=reset_estimate,
+            error_message=error_message,
+        )
+
+    def mark_stall_notified(self) -> None:
+        """Set ``notified_in_cc=1`` for the current stall. No-op when clean."""
+        mark_stall_notified(self.conn)
+
+    def clear_stall_state(self) -> None:
+        """Mark the singleton clean — clears all stall fields atomically."""
+        clear_stall_state(self.conn)

--- a/reflexio/server/services/storage/sqlite_storage/_stall_state.py
+++ b/reflexio/server/services/storage/sqlite_storage/_stall_state.py
@@ -1,0 +1,167 @@
+"""Singleton ``stall_state`` row — tracks whether reflexio's claude -p extractor
+is currently stalled by a billing or auth error.
+
+One row per database (``id`` is constrained to ``1``). The row always exists
+after schema init; ``stalled=0`` is the clean default. See the credit-stall
+notification spec for the state machine.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+StallReason = Literal["billing_error", "auth_error"]
+
+
+@dataclass(frozen=True)
+class StallState:
+    """Snapshot of the singleton stall row.
+
+    Attributes:
+        stalled (bool): True when learning is currently paused.
+        reason (StallReason | None): Why it's stalled. None when clean.
+        stalled_at (datetime | None): When the stall was first observed.
+        reset_estimate (datetime | None): Best-effort reset time parsed from
+            the error text. ``None`` for auth errors (no reset semantics).
+        notified_in_cc (bool): True once the SessionStart banner has fired
+            for this stall event.
+        error_message (str | None): Raw terminal-error text for debugging.
+    """
+
+    stalled: bool
+    reason: StallReason | None
+    stalled_at: datetime | None
+    reset_estimate: datetime | None
+    notified_in_cc: bool
+    error_message: str | None
+
+
+_CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS stall_state (
+    id              INTEGER PRIMARY KEY CHECK (id = 1),
+    stalled         BOOLEAN NOT NULL DEFAULT 0,
+    reason          TEXT,
+    stalled_at      TIMESTAMP,
+    reset_estimate  TIMESTAMP,
+    notified_in_cc  BOOLEAN NOT NULL DEFAULT 0,
+    last_attempt_at TIMESTAMP,
+    error_message   TEXT
+);
+"""
+
+_SEED_SQL = "INSERT OR IGNORE INTO stall_state (id, stalled) VALUES (1, 0);"
+
+
+def init_stall_state_table(conn: sqlite3.Connection) -> None:
+    """Create the table and seed the singleton row. Idempotent.
+
+    Args:
+        conn (sqlite3.Connection): An open SQLite connection.
+    """
+    with conn:
+        conn.execute(_CREATE_SQL)
+        conn.execute(_SEED_SQL)
+
+
+def get_stall_state(conn: sqlite3.Connection) -> StallState:
+    """Return the current stall row.
+
+    Args:
+        conn (sqlite3.Connection): An open SQLite connection.
+
+    Returns:
+        StallState: Current snapshot of the singleton stall row.
+    """
+    row = conn.execute(
+        "SELECT stalled, reason, stalled_at, reset_estimate, "
+        "notified_in_cc, error_message FROM stall_state WHERE id = 1"
+    ).fetchone()
+    if row is None:
+        return StallState(False, None, None, None, False, None)
+    return StallState(
+        stalled=bool(row[0]),
+        reason=row[1],
+        stalled_at=_parse_ts(row[2]),
+        reset_estimate=_parse_ts(row[3]),
+        notified_in_cc=bool(row[4]),
+        error_message=row[5],
+    )
+
+
+def upsert_stall_state(
+    conn: sqlite3.Connection,
+    *,
+    reason: StallReason,
+    stalled_at: datetime,
+    reset_estimate: datetime | None,
+    error_message: str,
+) -> None:
+    """Mark the singleton as stalled with the given reason. Re-arms notified flag.
+
+    Args:
+        conn (sqlite3.Connection): An open SQLite connection.
+        reason (StallReason): The stall reason discriminator (``billing_error``
+            or ``auth_error``).
+        stalled_at (datetime): When the stall was first detected.
+        reset_estimate (datetime | None): Estimated reset time, if known.
+        error_message (str): Raw error text for debugging.
+    """
+    with conn:
+        conn.execute(
+            "UPDATE stall_state SET stalled=1, reason=?, stalled_at=?, "
+            "reset_estimate=?, notified_in_cc=0, last_attempt_at=?, "
+            "error_message=? WHERE id=1",
+            (
+                reason,
+                stalled_at.isoformat(),
+                reset_estimate.isoformat() if reset_estimate else None,
+                stalled_at.isoformat(),
+                error_message,
+            ),
+        )
+
+
+def mark_stall_notified(conn: sqlite3.Connection) -> None:
+    """Set ``notified_in_cc=1`` for the current stall. No-op when clean.
+
+    Args:
+        conn (sqlite3.Connection): An open SQLite connection.
+    """
+    with conn:
+        conn.execute(
+            "UPDATE stall_state SET notified_in_cc=1 WHERE id=1 AND stalled=1"
+        )
+
+
+def clear_stall_state(conn: sqlite3.Connection) -> None:
+    """Mark the singleton clean — clears all stall fields atomically.
+
+    Args:
+        conn (sqlite3.Connection): An open SQLite connection.
+    """
+    with conn:
+        conn.execute(
+            "UPDATE stall_state SET stalled=0, reason=NULL, stalled_at=NULL, "
+            "reset_estimate=NULL, notified_in_cc=0, error_message=NULL "
+            "WHERE id=1"
+        )
+
+
+def _parse_ts(raw: str | None) -> datetime | None:
+    """Parse ISO-format TIMESTAMP, tolerating None and naive strings.
+
+    Args:
+        raw (str | None): Raw ISO datetime string from SQLite, or None.
+
+    Returns:
+        datetime | None: Parsed datetime, or None if input is None or invalid.
+    """
+    if raw is None:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None

--- a/reflexio/server/services/storage/sqlite_storage/_stall_state.py
+++ b/reflexio/server/services/storage/sqlite_storage/_stall_state.py
@@ -12,11 +12,11 @@ import logging
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any
+
+from reflexio.models.api_schema.stall_state_schema import StallReason
 
 _LOGGER = logging.getLogger(__name__)
-
-StallReason = Literal["billing_error", "auth_error"]
 
 
 @dataclass(frozen=True)

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -5,6 +5,7 @@ from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
 from ._requests import RequestMixin
 from ._share_links import ShareLinkMixin
+from ._stall_state import StallStateMixin
 
 
 class BaseStorage(
@@ -14,6 +15,7 @@ class BaseStorage(
     OperationMixin,
     ExtrasMixin,
     ShareLinkMixin,
+    StallStateMixin,
     BaseStorageCore,
 ):
     """Base class for storage."""
@@ -21,4 +23,10 @@ class BaseStorage(
     pass
 
 
-__all__ = ["BaseStorage", "PlaybookMixin", "ShareLinkMixin", "matches_status_filter"]
+__all__ = [
+    "BaseStorage",
+    "PlaybookMixin",
+    "ShareLinkMixin",
+    "StallStateMixin",
+    "matches_status_filter",
+]

--- a/reflexio/server/services/storage/storage_base/_stall_state.py
+++ b/reflexio/server/services/storage/storage_base/_stall_state.py
@@ -1,0 +1,85 @@
+"""Stall state interface for storage backends.
+
+Declares the methods every storage implementation MUST implement to expose
+the singleton stall_state row used by the credit-stall notification flow.
+
+The default implementations raise :class:`NotImplementedError`. Concrete
+backends that support the stall_state feature (currently
+:class:`SQLiteStorage`) override these methods via their own mixin. Backends
+that don't support it (currently :class:`DiskStorage`) will surface a clear
+``NotImplementedError`` at call time rather than ``AttributeError``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from reflexio.server.services.storage.sqlite_storage._stall_state import (
+        StallReason,
+        StallState,
+    )
+
+
+class StallStateMixin:
+    """Default no-op stall_state interface for storage backends.
+
+    Subclasses that support the stall_state feature must override every method.
+    """
+
+    def get_stall_state(self) -> StallState:
+        """Return the current stall row.
+
+        Returns:
+            StallState: Current snapshot of the singleton stall row.
+
+        Raises:
+            NotImplementedError: When the backend does not support stall_state.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support stall_state"
+        )
+
+    def upsert_stall_state(
+        self,
+        *,
+        reason: StallReason,
+        stalled_at: datetime,
+        reset_estimate: datetime | None,
+        error_message: str,
+    ) -> None:
+        """Mark the singleton as stalled with the given reason.
+
+        Args:
+            reason (StallReason): The stall reason discriminator.
+            stalled_at (datetime): When the stall was first detected.
+            reset_estimate (datetime | None): Estimated reset time, if known.
+            error_message (str): Raw error text for debugging.
+
+        Raises:
+            NotImplementedError: When the backend does not support stall_state.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support stall_state"
+        )
+
+    def mark_stall_notified(self) -> None:
+        """Set ``notified_in_cc=1`` for the current stall.
+
+        Raises:
+            NotImplementedError: When the backend does not support stall_state.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support stall_state"
+        )
+
+    def clear_stall_state(self) -> None:
+        """Mark the singleton clean — clears all stall fields atomically.
+
+        Raises:
+            NotImplementedError: When the backend does not support stall_state.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support stall_state"
+        )

--- a/tests/client/test_stall_state_client.py
+++ b/tests/client/test_stall_state_client.py
@@ -1,0 +1,97 @@
+"""ReflexioClient methods for stall_state."""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from reflexio.client import ReflexioClient
+from reflexio.server.api import create_app
+from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+@pytest.fixture()
+def storage():
+    """A real SQLiteStorage instance in a temporary directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            yield SQLiteStorage(org_id="test-stall-client", db_path=f"{tmp}/reflexio.db")
+
+
+@pytest.fixture()
+def client_with_server(storage):
+    """ReflexioClient pointed at a TestClient-backed FastAPI app.
+
+    The app's ``get_request_context`` dependency is overridden to use the
+    same ``SQLiteStorage`` instance as the ``storage`` fixture, so tests can
+    seed state via ``storage.upsert_stall_state(...)`` and observe it through
+    the client.
+    """
+    app = create_app(get_org_id=lambda: "test-stall-client-org")
+
+    fake_ctx = RequestContext.__new__(RequestContext)
+    fake_ctx.org_id = "test-stall-client-org"
+    fake_ctx.storage = storage
+
+    app.dependency_overrides[get_request_context] = lambda: fake_ctx
+
+    http_client = TestClient(app, raise_server_exceptions=True)
+
+    # Wrap the TestClient in a requests.Session-compatible shim so ReflexioClient
+    # can call it via its normal self.session.request(...) path.
+    class _TestClientSession:
+        """Thin adapter making TestClient look like a requests.Session."""
+
+        max_redirects = 0
+        headers: dict = {}
+
+        def update(self, d: dict) -> None:  # noqa: D401
+            self.headers.update(d)
+
+        def request(self, method: str, url: str, **kwargs) -> object:
+            # Strip the base_url prefix; TestClient works with paths only.
+            path = url.replace("http://testserver", "")
+            kwargs.pop("timeout", None)
+            return http_client.request(method, path, **kwargs)
+
+    reflexio_client = ReflexioClient.__new__(ReflexioClient)
+    reflexio_client.base_url = "http://testserver"
+    reflexio_client.api_key = ""
+    reflexio_client.timeout = 30
+    reflexio_client.session = _TestClientSession()
+
+    return reflexio_client
+
+
+def test_get_stall_state_when_clean(client_with_server, storage):
+    state = client_with_server.get_stall_state()
+    assert state.stalled is False
+
+
+def test_get_stall_state_when_stalled(client_with_server, storage):
+    storage.upsert_stall_state(
+        reason="billing_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=None,
+        error_message="x",
+    )
+    state = client_with_server.get_stall_state()
+    assert state.stalled is True
+    assert state.reason == "billing_error"
+
+
+def test_mark_stall_notified_flips_flag(client_with_server, storage):
+    storage.upsert_stall_state(
+        reason="auth_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=None,
+        error_message="x",
+    )
+    client_with_server.mark_stall_notified()
+    state = client_with_server.get_stall_state()
+    assert state.notified_in_cc is True

--- a/tests/server/api_endpoints/test_stall_state_api.py
+++ b/tests/server/api_endpoints/test_stall_state_api.py
@@ -1,0 +1,72 @@
+"""HTTP-level tests for /stall_state endpoints."""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+@pytest.fixture()
+def storage():
+    """A real SQLiteStorage instance in a temporary directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            yield SQLiteStorage(org_id="test-stall", db_path=f"{tmp}/reflexio.db")
+
+
+@pytest.fixture()
+def client(storage):
+    """TestClient wired to the same storage instance as the ``storage`` fixture."""
+    app = create_app(get_org_id=lambda: "test-stall-org")
+
+    # Build a fake RequestContext whose .storage is our real SQLiteStorage.
+    fake_ctx = RequestContext.__new__(RequestContext)
+    fake_ctx.org_id = "test-stall-org"
+    fake_ctx.storage = storage
+
+    app.dependency_overrides[get_request_context] = lambda: fake_ctx
+
+    return TestClient(app, raise_server_exceptions=True)
+
+
+def test_get_stall_state_clean(client: TestClient):
+    resp = client.get("/stall_state")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["stalled"] is False
+    assert body["reason"] is None
+
+
+def test_get_stall_state_when_stalled(client: TestClient, storage):
+    storage.upsert_stall_state(
+        reason="billing_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=None,
+        error_message="credit exhausted",
+    )
+    resp = client.get("/stall_state")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["stalled"] is True
+    assert body["reason"] == "billing_error"
+    assert body["notified_in_cc"] is False
+
+
+def test_post_notified_flips_flag(client: TestClient, storage):
+    storage.upsert_stall_state(
+        reason="auth_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=None,
+        error_message="login",
+    )
+    resp = client.post("/stall_state/notified")
+    assert resp.status_code == 200
+    assert resp.json()["notified_in_cc"] is True

--- a/tests/server/llm/conftest.py
+++ b/tests/server/llm/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for LLM provider tests."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+
+@pytest.fixture
+def storage() -> Generator[BaseStorage]:
+    """Yield a fresh, isolated SQLiteStorage instance with migrations applied."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+        with patch.object(
+            SQLiteStorage, "_get_embedding", return_value=[0.0] * 512
+        ):
+            yield SQLiteStorage(
+                org_id="llm_test", db_path=f"{temp_dir}/reflexio.db"
+            )

--- a/tests/server/llm/test_claude_code_provider.py
+++ b/tests/server/llm/test_claude_code_provider.py
@@ -11,11 +11,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
-
-def _stream_json(result_text: str) -> str:
-    """Build a minimal stream-json NDJSON body with one terminal ``result`` event."""
-    return json.dumps({"type": "result", "result": result_text, "session_id": "s"}) + "\n"
-
 from reflexio.server.llm.providers import claude_code_provider as ccp
 from reflexio.server.llm.providers.claude_code_provider import (
     ClaudeCodeCLIError,
@@ -24,6 +19,11 @@ from reflexio.server.llm.providers.claude_code_provider import (
     is_claude_code_available,
     register_if_enabled,
 )
+
+
+def _stream_json(result_text: str) -> str:
+    """Build a minimal stream-json NDJSON body with one terminal ``result`` event."""
+    return json.dumps({"type": "result", "result": result_text, "session_id": "s"}) + "\n"
 
 
 @pytest.fixture(autouse=True)
@@ -355,7 +355,7 @@ class TestClaudeCodeLLMCompletion:
         monkeypatch.setattr(ccp, "_resolve_cli_path", lambda: "/usr/local/bin/claude")
         llm = ClaudeCodeLLM()
 
-        with pytest.raises(ClaudeCodeCLIError, match="auth failed"):
+        with pytest.raises(ClaudeCodeCLIError, match="stream failed"):
             llm.completion(
                 model="claude-code/default",
                 messages=[{"role": "user", "content": "hi"}],

--- a/tests/server/llm/test_claude_code_provider.py
+++ b/tests/server/llm/test_claude_code_provider.py
@@ -11,6 +11,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import BaseModel
 
+
+def _stream_json(result_text: str) -> str:
+    """Build a minimal stream-json NDJSON body with one terminal ``result`` event."""
+    return json.dumps({"type": "result", "result": result_text, "session_id": "s"}) + "\n"
+
 from reflexio.server.llm.providers import claude_code_provider as ccp
 from reflexio.server.llm.providers.claude_code_provider import (
     ClaudeCodeCLIError,
@@ -25,6 +30,7 @@ from reflexio.server.llm.providers.claude_code_provider import (
 def _reset_module_state() -> None:
     """Each test starts with fresh registration and warn-once flags."""
     ccp._REGISTERED = False
+    ccp._HANDLER = None
     ccp._IMAGE_WARNED = False
     ccp._MULTITURN_WARNED = False
     ccp._UNSUPPORTED_PARAMS_WARNED.clear()
@@ -148,9 +154,10 @@ class TestSplitSystemAndDialogue:
 
 class TestClaudeCodeLLMCompletion:
     def _mock_cli(
-        self, monkeypatch: pytest.MonkeyPatch, response: dict[str, Any]
+        self, monkeypatch: pytest.MonkeyPatch, result_text: str = "ok"
     ) -> MagicMock:
-        mock_run = MagicMock(return_value=_fake_completed_process(json.dumps(response)))
+        """Mock subprocess.run to return a stream-json NDJSON body with one result event."""
+        mock_run = MagicMock(return_value=_fake_completed_process(_stream_json(result_text)))
         monkeypatch.setattr(ccp.subprocess, "run", mock_run)
         monkeypatch.setattr(ccp, "_resolve_cli_path", lambda: "/usr/local/bin/claude")
         return mock_run
@@ -158,14 +165,7 @@ class TestClaudeCodeLLMCompletion:
     def test_basic_completion_shapes_model_response(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        self._mock_cli(
-            monkeypatch,
-            {
-                "result": "hello world",
-                "session_id": "abc123",
-                "usage": {"input_tokens": 5, "output_tokens": 2},
-            },
-        )
+        self._mock_cli(monkeypatch, result_text="hello world")
         llm = ClaudeCodeLLM()
 
         response = llm.completion(
@@ -175,14 +175,47 @@ class TestClaudeCodeLLMCompletion:
 
         assert response.choices[0].message.content == "hello world"  # type: ignore[union-attr]
         assert response.model == "claude-code/default"
-        assert response.usage.prompt_tokens == 5  # type: ignore[attr-defined]
-        assert response.usage.completion_tokens == 2  # type: ignore[attr-defined]
-        assert response.usage.total_tokens == 7  # type: ignore[attr-defined]
+        # stream-json does not surface usage tokens at terminal event.
+        assert response.usage.prompt_tokens == 0  # type: ignore[attr-defined]
+        assert response.usage.completion_tokens == 0  # type: ignore[attr-defined]
+        assert response.usage.total_tokens == 0  # type: ignore[attr-defined]
+
+    def test_uses_stream_json_output_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The provider must invoke the CLI with stream-json, not the legacy json envelope."""
+        mock_run = self._mock_cli(monkeypatch)
+        llm = ClaudeCodeLLM()
+
+        llm.completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        cmd = mock_run.call_args.args[0]
+        fmt_idx = cmd.index("--output-format")
+        assert cmd[fmt_idx + 1] == "stream-json"
+        # stream-json requires --verbose to emit events.
+        assert "--verbose" in cmd
+
+    def test_sets_max_retries_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLAUDE_CODE_MAX_RETRIES=3 must be passed in the subprocess env."""
+        mock_run = self._mock_cli(monkeypatch)
+        llm = ClaudeCodeLLM()
+
+        llm.completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+        env = mock_run.call_args.kwargs["env"]
+        assert env["CLAUDE_CODE_MAX_RETRIES"] == "3"
+        assert env["CLAUDE_SMART_INTERNAL"] == "1"
 
     def test_system_message_goes_to_append_system_prompt_flag(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_run = self._mock_cli(monkeypatch, {"result": "ok", "usage": {}})
+        mock_run = self._mock_cli(monkeypatch)
         llm = ClaudeCodeLLM()
 
         llm.completion(
@@ -203,7 +236,7 @@ class TestClaudeCodeLLMCompletion:
     def test_no_system_message_omits_flag(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_run = self._mock_cli(monkeypatch, {"result": "ok", "usage": {}})
+        mock_run = self._mock_cli(monkeypatch)
         llm = ClaudeCodeLLM()
 
         llm.completion(
@@ -217,9 +250,7 @@ class TestClaudeCodeLLMCompletion:
     def test_response_format_appends_schema_to_system_prompt(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_run = self._mock_cli(
-            monkeypatch, {"result": '{"name":"Yi","age":31}', "usage": {}}
-        )
+        mock_run = self._mock_cli(monkeypatch, result_text='{"name":"Yi","age":31}')
         llm = ClaudeCodeLLM()
 
         response = llm.completion(
@@ -241,7 +272,7 @@ class TestClaudeCodeLLMCompletion:
     def test_response_format_merges_with_existing_system_prompt(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_run = self._mock_cli(monkeypatch, {"result": "{}", "usage": {}})
+        mock_run = self._mock_cli(monkeypatch, result_text="{}")
         llm = ClaudeCodeLLM()
 
         llm.completion(
@@ -262,7 +293,7 @@ class TestClaudeCodeLLMCompletion:
     def test_response_format_dict_schema_also_injected(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        mock_run = self._mock_cli(monkeypatch, {"result": "{}", "usage": {}})
+        mock_run = self._mock_cli(monkeypatch, result_text="{}")
         llm = ClaudeCodeLLM()
 
         llm.completion(
@@ -288,7 +319,7 @@ class TestClaudeCodeLLMCompletion:
     def test_unsupported_params_warn_once(
         self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
     ) -> None:
-        self._mock_cli(monkeypatch, {"result": "ok", "usage": {}})
+        self._mock_cli(monkeypatch)
         llm = ClaudeCodeLLM()
 
         with caplog.at_level(
@@ -345,7 +376,9 @@ class TestClaudeCodeLLMCompletion:
                 messages=[{"role": "user", "content": "hi"}],
             )
 
-    def test_malformed_json_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_malformed_stream_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-NDJSON garbage on stdout (exit 0) is treated as a failed call —
+        the stream parser sees no terminal event and marks success=False."""
         monkeypatch.setattr(
             ccp.subprocess,
             "run",
@@ -354,7 +387,7 @@ class TestClaudeCodeLLMCompletion:
         monkeypatch.setattr(ccp, "_resolve_cli_path", lambda: "/usr/local/bin/claude")
         llm = ClaudeCodeLLM()
 
-        with pytest.raises(ClaudeCodeCLIError, match="non-JSON"):
+        with pytest.raises(ClaudeCodeCLIError, match="stream failed"):
             llm.completion(
                 model="claude-code/default",
                 messages=[{"role": "user", "content": "hi"}],
@@ -376,7 +409,7 @@ class TestClaudeCodeLLMCompletion:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """LiteLLM sometimes passes extra positional args; they must be tolerated."""
-        self._mock_cli(monkeypatch, {"result": "ok", "usage": {}})
+        self._mock_cli(monkeypatch)
         llm = ClaudeCodeLLM()
 
         response = llm.completion(

--- a/tests/server/llm/test_claude_code_provider_stall.py
+++ b/tests/server/llm/test_claude_code_provider_stall.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from reflexio.server.llm.providers import claude_code_provider as ccp
 from reflexio.server.llm.providers.claude_code_provider import (
     ClaudeCodeCLIError,
     ClaudeCodeLLM,
@@ -29,7 +30,7 @@ def _mock_run(returncode: int, stdout: str, stderr: str = ""):
 
 def test_clean_run_clears_stall(llm, storage):
     stream = '{"type":"result","result":"ok","session_id":"s"}\n'
-    with patch("subprocess.run", return_value=_mock_run(0, stream)):
+    with patch.object(ccp.subprocess, "run", return_value=_mock_run(0, stream)):
         llm.completion(
             model="claude-code/default",
             messages=[{"role": "user", "content": "hi"}],
@@ -42,8 +43,8 @@ def test_billing_failure_writes_stall(llm, storage):
         '{"type":"system","subtype":"api_retry","error":"billing_error",'
         '"attempt":1,"max_retries":3}\n'
     )
-    with patch(
-        "subprocess.run",
+    with patch.object(
+        ccp.subprocess, "run",
         return_value=_mock_run(1, stream, "resets Mon 12:00am"),
     ), pytest.raises(ClaudeCodeCLIError):
         llm.completion(
@@ -61,8 +62,8 @@ def test_transient_failure_does_not_stall(llm, storage):
         '{"type":"system","subtype":"api_retry","error":"rate_limit",'
         '"attempt":1,"max_retries":3}\n'
     )
-    with patch(
-        "subprocess.run", return_value=_mock_run(1, stream)
+    with patch.object(
+        ccp.subprocess, "run", return_value=_mock_run(1, stream)
     ), pytest.raises(ClaudeCodeCLIError):
         llm.completion(
             model="claude-code/default",
@@ -84,7 +85,7 @@ def test_prior_stall_cleared_after_successful_run(llm, storage):
     assert storage.get_stall_state().stalled is True
 
     stream = '{"type":"result","result":"recovered","session_id":"s"}\n'
-    with patch("subprocess.run", return_value=_mock_run(0, stream)):
+    with patch.object(ccp.subprocess, "run", return_value=_mock_run(0, stream)):
         llm.completion(
             model="claude-code/default",
             messages=[{"role": "user", "content": "hi"}],

--- a/tests/server/llm/test_claude_code_provider_stall.py
+++ b/tests/server/llm/test_claude_code_provider_stall.py
@@ -1,0 +1,92 @@
+"""End-to-end test of the provider's stall-detection plumbing using a mocked subprocess."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.server.llm.providers.claude_code_provider import (
+    ClaudeCodeCLIError,
+    ClaudeCodeLLM,
+)
+
+
+@pytest.fixture
+def llm(storage):
+    """ClaudeCodeLLM bound to the test storage with a resolvable fake CLI path."""
+    return ClaudeCodeLLM(cli_path="/usr/local/bin/claude", storage=storage)
+
+
+def _mock_run(returncode: int, stdout: str, stderr: str = ""):
+    """Build a subprocess.CompletedProcess for mocking."""
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def test_clean_run_clears_stall(llm, storage):
+    stream = '{"type":"result","result":"ok","session_id":"s"}\n'
+    with patch("subprocess.run", return_value=_mock_run(0, stream)):
+        llm.completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    assert storage.get_stall_state().stalled is False
+
+
+def test_billing_failure_writes_stall(llm, storage):
+    stream = (
+        '{"type":"system","subtype":"api_retry","error":"billing_error",'
+        '"attempt":1,"max_retries":3}\n'
+    )
+    with patch(
+        "subprocess.run",
+        return_value=_mock_run(1, stream, "resets Mon 12:00am"),
+    ), pytest.raises(ClaudeCodeCLIError):
+        llm.completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    state = storage.get_stall_state()
+    assert state.stalled is True
+    assert state.reason == "billing_error"
+    assert state.notified_in_cc is False
+
+
+def test_transient_failure_does_not_stall(llm, storage):
+    stream = (
+        '{"type":"system","subtype":"api_retry","error":"rate_limit",'
+        '"attempt":1,"max_retries":3}\n'
+    )
+    with patch(
+        "subprocess.run", return_value=_mock_run(1, stream)
+    ), pytest.raises(ClaudeCodeCLIError):
+        llm.completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    assert storage.get_stall_state().stalled is False
+
+
+def test_prior_stall_cleared_after_successful_run(llm, storage):
+    """A successful completion should clear a previously recorded stall."""
+    from datetime import datetime
+
+    storage.upsert_stall_state(
+        reason="billing_error",
+        stalled_at=datetime.now(UTC),
+        reset_estimate=None,
+        error_message="old failure",
+    )
+    assert storage.get_stall_state().stalled is True
+
+    stream = '{"type":"result","result":"recovered","session_id":"s"}\n'
+    with patch("subprocess.run", return_value=_mock_run(0, stream)):
+        llm.completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+    assert storage.get_stall_state().stalled is False

--- a/tests/server/llm/test_claude_code_stream_parser.py
+++ b/tests/server/llm/test_claude_code_stream_parser.py
@@ -82,3 +82,13 @@ def test_parse_reset_estimate_extracts_time(text, expected_hour):
 
 def test_parse_reset_estimate_returns_none_when_no_match():
     assert parse_reset_estimate("unrelated error text") is None
+
+
+@pytest.mark.parametrize("text", [
+    "resets 13:00pm",   # hour > 12 in 12-hour format
+    "resets 0:30am",    # hour < 1
+    "resets 10:75am",   # minute > 59
+])
+def test_parse_reset_estimate_rejects_out_of_range(text):
+    """Reject inputs the regex accepts but that aren't valid 12-hour clock times."""
+    assert parse_reset_estimate(text) is None

--- a/tests/server/llm/test_claude_code_stream_parser.py
+++ b/tests/server/llm/test_claude_code_stream_parser.py
@@ -1,0 +1,84 @@
+"""Tests for claude_code_stream_parser: NDJSON parsing + stall classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.server.llm.providers.claude_code_stream_parser import (
+    ParseResult,
+    classify_stall,
+    parse_stream_json,
+    parse_reset_estimate,
+)
+
+
+def test_clean_stream_returns_success():
+    stream = (
+        '{"type":"system","subtype":"init","session_id":"s1"}\n'
+        '{"type":"result","result":"ok","session_id":"s1"}\n'
+    )
+    result = parse_stream_json(stream, exit_code=0)
+    assert result.success is True
+    assert result.terminal_text == "ok"
+    assert result.stall_candidate is None
+
+
+def test_billing_error_in_retry_then_stream_failure_classifies_billing():
+    stream = (
+        '{"type":"system","subtype":"api_retry","error":"billing_error","attempt":1,"max_retries":3}\n'
+        '{"type":"system","subtype":"api_retry","error":"billing_error","attempt":2,"max_retries":3}\n'
+    )
+    result = parse_stream_json(stream, exit_code=1)
+    assert result.success is False
+    assert classify_stall(result) == "billing_error"
+
+
+@pytest.mark.parametrize("err", ["authentication_failed", "oauth_org_not_allowed"])
+def test_auth_categories_classify_as_auth_error(err):
+    stream = f'{{"type":"system","subtype":"api_retry","error":"{err}","attempt":1,"max_retries":3}}\n'
+    result = parse_stream_json(stream, exit_code=1)
+    assert classify_stall(result) == "auth_error"
+
+
+def test_billing_error_in_retry_but_stream_succeeds_does_not_stall():
+    """False-positive guard: retry surfaced billing_error but call ultimately succeeded."""
+    stream = (
+        '{"type":"system","subtype":"api_retry","error":"billing_error","attempt":1,"max_retries":3}\n'
+        '{"type":"result","result":"ok","session_id":"s1"}\n'
+    )
+    result = parse_stream_json(stream, exit_code=0)
+    assert result.success is True
+    assert classify_stall(result) is None
+
+
+@pytest.mark.parametrize("err", ["rate_limit", "server_error"])
+def test_transient_errors_do_not_classify_as_stall(err):
+    stream = f'{{"type":"system","subtype":"api_retry","error":"{err}","attempt":1,"max_retries":3}}\n'
+    result = parse_stream_json(stream, exit_code=1)
+    assert classify_stall(result) is None
+
+
+def test_malformed_ndjson_returns_failure_with_no_stall():
+    result = parse_stream_json("not json at all\n{broken}\n", exit_code=1)
+    assert result.success is False
+    assert classify_stall(result) is None
+
+
+def test_text_fallback_when_no_retry_event_present():
+    """When the stream has no api_retry event but stderr contains the phrase."""
+    result = parse_stream_json("", exit_code=1, stderr_text="hit your weekly limit · resets Mon 12:00am")
+    assert classify_stall(result) == "billing_error"
+
+
+@pytest.mark.parametrize("text,expected_hour", [
+    ("resets 3:45pm", 15),
+    ("resets Mon 12:00am", 0),
+])
+def test_parse_reset_estimate_extracts_time(text, expected_hour):
+    parsed = parse_reset_estimate(text)
+    assert parsed is not None
+    assert parsed.hour == expected_hour
+
+
+def test_parse_reset_estimate_returns_none_when_no_match():
+    assert parse_reset_estimate("unrelated error text") is None

--- a/tests/server/services/storage/test_stall_state.py
+++ b/tests/server/services/storage/test_stall_state.py
@@ -1,0 +1,75 @@
+"""Tests for the singleton stall_state row in SQLite storage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from reflexio.server.services.storage.sqlite_storage._stall_state import (
+    StallState,
+    clear_stall_state,
+    get_stall_state,
+    mark_stall_notified,
+    upsert_stall_state,
+)
+
+
+def test_default_is_clean(storage):
+    """A fresh DB returns stalled=False with all fields default-null."""
+    state = get_stall_state(storage.connection)
+    assert state.stalled is False
+    assert state.reason is None
+    assert state.notified_in_cc is False
+
+
+def test_upsert_then_get_roundtrip(storage):
+    now = datetime.now(timezone.utc)
+    upsert_stall_state(
+        storage.connection,
+        reason="billing_error",
+        stalled_at=now,
+        reset_estimate=None,
+        error_message="credit exhausted",
+    )
+    state = get_stall_state(storage.connection)
+    assert state.stalled is True
+    assert state.reason == "billing_error"
+    assert state.notified_in_cc is False
+    assert state.error_message == "credit exhausted"
+
+
+def test_mark_notified_flips_only_that_field(storage):
+    upsert_stall_state(storage.connection, reason="auth_error",
+                       stalled_at=datetime.now(timezone.utc),
+                       reset_estimate=None, error_message="login")
+    mark_stall_notified(storage.connection)
+    state = get_stall_state(storage.connection)
+    assert state.stalled is True
+    assert state.notified_in_cc is True
+
+
+def test_clear_resets_all_fields_and_notification(storage):
+    upsert_stall_state(storage.connection, reason="billing_error",
+                       stalled_at=datetime.now(timezone.utc),
+                       reset_estimate=None, error_message="x")
+    mark_stall_notified(storage.connection)
+    clear_stall_state(storage.connection)
+    state = get_stall_state(storage.connection)
+    assert state.stalled is False
+    assert state.reason is None
+    assert state.notified_in_cc is False
+    assert state.error_message is None
+
+
+def test_upsert_after_clear_resets_notified_flag(storage):
+    """New stall must re-arm notified_in_cc=False so SessionStart fires again."""
+    now = datetime.now(timezone.utc)
+    upsert_stall_state(storage.connection, reason="billing_error", stalled_at=now,
+                       reset_estimate=None, error_message="x")
+    mark_stall_notified(storage.connection)
+    clear_stall_state(storage.connection)
+    upsert_stall_state(storage.connection, reason="auth_error", stalled_at=now,
+                       reset_estimate=None, error_message="y")
+    state = get_stall_state(storage.connection)
+    assert state.notified_in_cc is False

--- a/tests/server/services/storage/test_stall_state.py
+++ b/tests/server/services/storage/test_stall_state.py
@@ -6,18 +6,10 @@ from datetime import datetime, timezone
 
 import pytest
 
-from reflexio.server.services.storage.sqlite_storage._stall_state import (
-    StallState,
-    clear_stall_state,
-    get_stall_state,
-    mark_stall_notified,
-    upsert_stall_state,
-)
-
 
 def test_default_is_clean(storage):
     """A fresh DB returns stalled=False with all fields default-null."""
-    state = get_stall_state(storage.connection)
+    state = storage.get_stall_state()
     assert state.stalled is False
     assert state.reason is None
     assert state.notified_in_cc is False
@@ -25,14 +17,13 @@ def test_default_is_clean(storage):
 
 def test_upsert_then_get_roundtrip(storage):
     now = datetime.now(timezone.utc)
-    upsert_stall_state(
-        storage.connection,
+    storage.upsert_stall_state(
         reason="billing_error",
         stalled_at=now,
         reset_estimate=None,
         error_message="credit exhausted",
     )
-    state = get_stall_state(storage.connection)
+    state = storage.get_stall_state()
     assert state.stalled is True
     assert state.reason == "billing_error"
     assert state.notified_in_cc is False
@@ -40,22 +31,29 @@ def test_upsert_then_get_roundtrip(storage):
 
 
 def test_mark_notified_flips_only_that_field(storage):
-    upsert_stall_state(storage.connection, reason="auth_error",
-                       stalled_at=datetime.now(timezone.utc),
-                       reset_estimate=None, error_message="login")
-    mark_stall_notified(storage.connection)
-    state = get_stall_state(storage.connection)
+    """mark_stall_notified flips only notified_in_cc, leaves other fields intact."""
+    storage.upsert_stall_state(
+        reason="auth_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=None,
+        error_message="login",
+    )
+    storage.mark_stall_notified()
+    state = storage.get_stall_state()
     assert state.stalled is True
     assert state.notified_in_cc is True
 
 
 def test_clear_resets_all_fields_and_notification(storage):
-    upsert_stall_state(storage.connection, reason="billing_error",
-                       stalled_at=datetime.now(timezone.utc),
-                       reset_estimate=None, error_message="x")
-    mark_stall_notified(storage.connection)
-    clear_stall_state(storage.connection)
-    state = get_stall_state(storage.connection)
+    storage.upsert_stall_state(
+        reason="billing_error",
+        stalled_at=datetime.now(timezone.utc),
+        reset_estimate=None,
+        error_message="x",
+    )
+    storage.mark_stall_notified()
+    storage.clear_stall_state()
+    state = storage.get_stall_state()
     assert state.stalled is False
     assert state.reason is None
     assert state.notified_in_cc is False
@@ -65,11 +63,19 @@ def test_clear_resets_all_fields_and_notification(storage):
 def test_upsert_after_clear_resets_notified_flag(storage):
     """New stall must re-arm notified_in_cc=False so SessionStart fires again."""
     now = datetime.now(timezone.utc)
-    upsert_stall_state(storage.connection, reason="billing_error", stalled_at=now,
-                       reset_estimate=None, error_message="x")
-    mark_stall_notified(storage.connection)
-    clear_stall_state(storage.connection)
-    upsert_stall_state(storage.connection, reason="auth_error", stalled_at=now,
-                       reset_estimate=None, error_message="y")
-    state = get_stall_state(storage.connection)
+    storage.upsert_stall_state(
+        reason="billing_error",
+        stalled_at=now,
+        reset_estimate=None,
+        error_message="x",
+    )
+    storage.mark_stall_notified()
+    storage.clear_stall_state()
+    storage.upsert_stall_state(
+        reason="auth_error",
+        stalled_at=now,
+        reset_estimate=None,
+        error_message="y",
+    )
+    state = storage.get_stall_state()
     assert state.notified_in_cc is False

--- a/tests/server/services/storage/test_stall_state.py
+++ b/tests/server/services/storage/test_stall_state.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -28,6 +28,20 @@ def test_upsert_then_get_roundtrip(storage):
     assert state.reason == "billing_error"
     assert state.notified_in_cc is False
     assert state.error_message == "credit exhausted"
+
+
+def test_reset_estimate_roundtrip(storage):
+    """A non-None reset_estimate persists and parses back to the same datetime."""
+    now = datetime.now(timezone.utc)
+    reset_time = now + timedelta(hours=6)
+    storage.upsert_stall_state(
+        reason="billing_error",
+        stalled_at=now,
+        reset_estimate=reset_time,
+        error_message="quota exceeded",
+    )
+    state = storage.get_stall_state()
+    assert state.reset_estimate == reset_time
 
 
 def test_mark_notified_flips_only_that_field(storage):


### PR DESCRIPTION
## Summary

- Adds a singleton `stall_state` row to SQLite storage that tracks whether `claude -p` extraction is currently paused by a credit/auth error.
- Switches the LiteLLM custom provider (`claude_code_provider`) from `--output-format json` to `--output-format stream-json` so the provider can parse `api_retry` events and classify terminal failures.
- Exposes the state over HTTP (`GET /stall_state`, `POST /stall_state/notified`) and via `ReflexioClient.get_stall_state` / `ReflexioClient.mark_stall_notified` for the claude-smart plugin to consume.
- All access flows through `storage.get_stall_state()` / `storage.upsert_stall_state()` etc. — the raw SQLite connection is never exposed across module boundaries.
- Schema designed with a `reason` discriminator from the start so a second error type (`auth_error`) shares the same table + notification logic without redesign.

## Changes

### Storage layer
- New `_stall_state.py` with `StallState` dataclass + `SQLiteStallStateMixin` (4 thin wrappers around module-level CRUD that take a raw `conn`). Schema enforces singleton via `CHECK (id = 1)`.
- `StallStateMixin` added to `BaseStorage` so the abstract storage type carries the contract; `SQLiteStorage` provides the concrete implementation. `DiskStorage` inherits the `NotImplementedError` defaults — a deliberate, clearer failure mode than the previous silent `AttributeError`.
- `migrate()` calls `init_stall_state_table(self.conn)` after the existing `_migrate_*` calls so fresh and existing DBs both end up with the seeded row.

### Stream-json parser + provider plumbing
- New `claude_code_stream_parser.py`: `parse_stream_json(stdout, exit_code, stderr_text)` returns a `ParseResult` aggregating retry errors + terminal text; `classify_stall(result)` returns `"billing_error"`, `"auth_error"`, or `None`; `parse_reset_estimate(text)` extracts a UTC datetime from "resets HH:MMam/pm".
- `claude_code_provider._run_cli_stream` sets `CLAUDE_CODE_MAX_RETRIES=3` so non-recoverable failures surface in ~5-10s instead of the default ~17min retry chain.
- `ClaudeCodeLLM.__init__` takes optional `storage`; on a clean run, calls `storage.clear_stall_state()`; on a classified failure, calls `storage.upsert_stall_state(...)`. Both wrapped in `try/except` — telemetry path must never raise.
- `register_if_enabled(storage=...)` + `set_storage(storage)` support both eager and late binding from `LiteLLMClient` import order.

### HTTP surface
- `GET /stall_state` returns the current singleton (clean fields when not stalled). `POST /stall_state/notified` idempotently flips `notified_in_cc=1`.
- Endpoints depend on a new `get_request_context` factory wired through the existing `default_get_org_id` so `app.dependency_overrides[default_get_org_id]` (enterprise auth path) reaches these routes.
- `DEFAULT_ORG_ID` / `default_get_org_id` extracted into `reflexio/server/_auth.py` to break a `api.py` ⇄ `request_context.py` circular import that surfaced when wiring the dep.
- Storage absence is reported as `503` rather than a 500 with a traceback.

### Client
- `ReflexioClient.get_stall_state()` and `ReflexioClient.mark_stall_notified()`. Both use the existing `_make_request` plumbing and return `StallStateResponse` / `MarkNotifiedResponse` Pydantic models.

## Diagrams

```mermaid
sequenceDiagram
    participant CCLI as claude CLI subprocess
    participant Prov as ClaudeCodeLLM
    participant DB as stall_state (SQLite)
    participant API as GET /stall_state
    participant Plug as claude-smart plugin
    Prov->>CCLI: claude -p --output-format stream-json
    CCLI-->>Prov: NDJSON events + terminal result
    alt classified stall (billing/auth)
        Prov->>DB: upsert_stall_state(reason, reset_estimate, ...)
    else clean run
        Prov->>DB: clear_stall_state()
    end
    Plug->>API: GET /stall_state
    API->>DB: get_stall_state()
    DB-->>API: StallState snapshot
    API-->>Plug: StallStateResponse JSON
    Plug->>API: POST /stall_state/notified (after banner shown)
    API->>DB: mark_stall_notified()
```

## Test Plan

Automated:
- `tests/server/services/storage/test_stall_state.py` — 5 cases covering the full state machine (clean default, upsert+get roundtrip, mark notified, clear, re-stall re-arms `notified_in_cc`).
- `tests/server/llm/test_claude_code_stream_parser.py` — 12 cases (parametrized) covering happy path, billing classification, auth classification, transient-error guard, false-positive guard, malformed NDJSON, stderr text fallback, reset-time parsing.
- `tests/server/llm/test_claude_code_provider_stall.py` — 4 cases mocking `subprocess.run`: clean clears stall, billing failure writes stall, transient failure does not stall, prior stall cleared after success.
- `tests/server/api_endpoints/test_stall_state_api.py` — 3 HTTP-level tests against a real SQLite-backed TestClient.
- `tests/client/test_stall_state_client.py` — 3 ReflexioClient tests against an in-process FastAPI TestClient shim.

Manual / live:
- End-to-end smoke against the user's real `~/.reflexio/data/reflexio.db`: schema migration runs idempotently, `GET /stall_state` returns clean → seed billing stall via SQL → endpoint reflects `stalled=true reason=billing_error notified_in_cc=false` → claude-smart `SessionStart` hook (separate PR) emits the banner once and flips `notified_in_cc=true` → second SessionStart goes silent → clear row → endpoint returns clean.
- Auth variant smoke: switching `reason='auth_error'` produces a `/login` banner (no "credit" copy).

Run from `reflexio/`:
```bash
uv run pytest --no-cov tests/server/services/storage/test_stall_state.py \
                       tests/server/llm/test_claude_code_stream_parser.py \
                       tests/server/llm/test_claude_code_provider_stall.py \
                       tests/server/llm/test_claude_code_provider.py \
                       tests/server/api_endpoints/test_stall_state_api.py \
                       tests/client/test_stall_state_client.py -v
```
Expected: 57 passed.

## Notes for reviewers

- Coverage gate: reflexio's pytest config has `--cov-fail-under=65`, so subset test runs need `--no-cov` (this PR's tests don't materially change overall coverage — they add 81+84+93+25+72+97 lines of test code, all under their own subtrees).
- Branch was rebased onto current `origin/main` (812fa9b); two minor conflicts in `_base.py` (migration sequence) and `api.py` (import block) were resolved cleanly.
- Tag `stall-notification-server` points at this branch's HEAD so the consuming claude-smart PR can pin to a stable ref.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stall state detection and management system to track learning interruptions caused by billing or authentication errors.
  * New client methods to query current stall status and mark notifications as handled.
  * Server endpoints to monitor stall states and update notification flags.
  * Improved Claude Code provider with enhanced error classification and recovery tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/63)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->