### PR TITLE
feat(api): add /api/get_playbook_application_stats endpoint

### DIFF
--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -75,7 +75,9 @@ When `REFLEXIO_EMBEDDING_PROVIDER=local_service` or
 `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1`, `services start --only backend` starts an
 `embedding` service dependency automatically. The daemon exposes
 `POST /v1/embeddings` and supports `local/nomic-embed-v1.5`,
-`local/nomic-embed-text-v1.5`, and `local/minilm-l6-v2`.
+`local/nomic-embed-text-v1.5`, and `local/minilm-l6-v2`. Local embedding
+requests allow extra time for model cold start; override with
+`REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS` when needed.
 
 ## Publishing interactions
 

--- a/reflexio/lib/_dashboard.py
+++ b/reflexio/lib/_dashboard.py
@@ -3,6 +3,8 @@ from reflexio.models.api_schema.retriever_schema import (
     DashboardStats,
     GetDashboardStatsRequest,
     GetDashboardStatsResponse,
+    GetPlaybookApplicationStatsRequest,
+    GetPlaybookApplicationStatsResponse,
     PeriodStats,
     TimeSeriesDataPoint,
 )
@@ -87,4 +89,43 @@ class DashboardMixin(ReflexioBase):
         except Exception as e:
             return GetDashboardStatsResponse(
                 success=False, msg=f"Failed to get dashboard stats: {str(e)}"
+            )
+
+    def get_playbook_application_stats(
+        self, request: GetPlaybookApplicationStatsRequest | dict
+    ) -> GetPlaybookApplicationStatsResponse:
+        """Get per-rule citation counts from the interactions table.
+
+        Aggregates the JSON citations column on interactions in the look-back
+        window and groups by (kind, real_id) so the dashboard can show how
+        often each individual playbook or profile has been applied.
+
+        Args:
+            request (Union[GetPlaybookApplicationStatsRequest, dict]): Request
+                containing days_back.
+
+        Returns:
+            GetPlaybookApplicationStatsResponse: Response containing the
+                aggregated stats sorted by applied_count descending.
+        """
+        if not self._is_storage_configured():
+            return GetPlaybookApplicationStatsResponse(
+                success=True, stats=[], msg=STORAGE_NOT_CONFIGURED_MSG
+            )
+        try:
+            if isinstance(request, dict):
+                request = GetPlaybookApplicationStatsRequest(**request)
+            stats = self._get_storage().get_playbook_application_stats(
+                days_back=request.days_back
+            )
+            return GetPlaybookApplicationStatsResponse(
+                success=True,
+                stats=stats,
+                msg="Retrieved playbook application stats successfully",
+            )
+        except Exception as e:
+            return GetPlaybookApplicationStatsResponse(
+                success=False,
+                stats=[],
+                msg=f"Failed to get playbook application stats: {str(e)}",
             )

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -492,6 +492,68 @@ class GetDashboardStatsResponse(BaseModel):
     msg: str | None = None
 
 
+class PlaybookApplicationStat(BaseModel):
+    """Per-rule application stats derived from interaction citations.
+
+    Aggregates the JSON ``citations`` column on interactions to surface how
+    often each individual playbook or profile has been cited by the agent in
+    a given time window. Used by the claude-smart dashboard to show users a
+    "track record" for each rule so the impact of a learning is visible
+    rather than abstract.
+
+    Args:
+        real_id (str): Stable id of the cited item — ``user_playbook_id``,
+            ``agent_playbook_id``, or ``profile_id`` (always serialized as a
+            string).
+        kind (str): ``"playbook"`` or ``"profile"`` — the citation kind, as
+            recorded on ``Interaction.citations``.
+        title (str): Human-readable label for the rule. Empty string when
+            the underlying row has been deleted but old citations remain.
+        applied_count (int): Number of interactions in the window whose
+            citations referenced this ``(kind, real_id)``.
+        last_applied_at (int | None): Unix epoch seconds of the most recent
+            interaction citing this rule. ``None`` when no citation matches.
+            Matches the int-epoch convention used elsewhere in the dashboard
+            (e.g. ``Interaction.created_at``).
+        last_interaction_id (int | None): ``interaction_id`` of the most
+            recent citing interaction; useful for deep-linking from the
+            dashboard.
+    """
+
+    real_id: str
+    kind: Literal["playbook", "profile"]
+    title: str = ""
+    applied_count: int = Field(ge=0)
+    last_applied_at: int | None = None
+    last_interaction_id: int | None = None
+
+
+class GetPlaybookApplicationStatsRequest(BaseModel):
+    """Request for per-rule application stats.
+
+    Args:
+        days_back (int): Look-back window in days. Defaults to 30; must be
+            positive.
+    """
+
+    days_back: int = Field(default=30, gt=0)
+
+
+class GetPlaybookApplicationStatsResponse(BaseModel):
+    """Response containing per-rule application stats.
+
+    Args:
+        success (bool): Whether the call succeeded.
+        stats (list[PlaybookApplicationStat]): One row per cited rule, sorted
+            by ``applied_count`` descending.
+        msg (str | None): Optional error message when ``success`` is False.
+    """
+
+    success: bool
+    stats: list[PlaybookApplicationStat] = Field(default_factory=list)
+    msg: str | None = None
+
+
 # ===============================
 # Query Reformulation Models
 # ===============================

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -28,6 +28,8 @@ from reflexio.models.api_schema.retriever_schema import (
     GetEvaluationResultsViewResponse,
     GetInteractionsRequest,
     GetInteractionsViewResponse,
+    GetPlaybookApplicationStatsRequest,
+    GetPlaybookApplicationStatsResponse,
     GetProfileStatisticsResponse,
     GetProfilesViewResponse,
     GetRequestsRequest,
@@ -1480,6 +1482,35 @@ def get_dashboard_stats(
 
     # Get dashboard stats using Reflexio's method
     return reflexio.get_dashboard_stats(request)
+
+
+@core_router.post(
+    "/api/get_playbook_application_stats",
+    response_model=GetPlaybookApplicationStatsResponse,
+    response_model_exclude_none=True,
+)
+def get_playbook_application_stats(
+    request: GetPlaybookApplicationStatsRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> GetPlaybookApplicationStatsResponse:
+    """Get per-rule citation counts aggregated from interactions.
+
+    Returns one row per cited (kind, real_id) over the look-back window,
+    sorted by applied_count descending. Lets the dashboard show users a
+    per-rule "track record" — how often each playbook or profile has been
+    applied and when it last fired.
+
+    Args:
+        request (GetPlaybookApplicationStatsRequest): Request containing
+            days_back.
+        org_id (str): Organization ID.
+
+    Returns:
+        GetPlaybookApplicationStatsResponse: Response containing aggregated
+            stats.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.get_playbook_application_stats(request)
 
 
 @core_router.post(

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -27,7 +27,8 @@ _ENV_TIMEOUT_MS = "REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS"
 _ENV_EMBEDDING_PORT = "EMBEDDING_PORT"
 _ENV_CLAUDE_SMART_LOCAL = "CLAUDE_SMART_USE_LOCAL_EMBEDDING"
 _DEFAULT_LOCAL_PORT = 8072
-_DEFAULT_TIMEOUT_MS = 2_000
+_DEFAULT_INTERNAL_SERVICE_TIMEOUT_MS = 2_000
+_DEFAULT_LOCAL_SERVICE_TIMEOUT_MS = 30_000
 _SERVICE_MODES = {"local_service", "internal_service"}
 _VALID_MODES = {"cloud", *_SERVICE_MODES, "inprocess", "off"}
 
@@ -59,10 +60,15 @@ def embedding_service_url(mode: EmbeddingProviderMode | None = None) -> str:
     )
 
 
-def embedding_service_timeout_seconds() -> float:
+def embedding_service_timeout_seconds(
+    mode: EmbeddingProviderMode | None = None,
+) -> float:
     raw = os.environ.get(_ENV_TIMEOUT_MS)
     if raw is None:
-        return _DEFAULT_TIMEOUT_MS / 1000
+        resolved = mode or embedding_provider_mode()
+        if resolved == "local_service":
+            return _DEFAULT_LOCAL_SERVICE_TIMEOUT_MS / 1000
+        return _DEFAULT_INTERNAL_SERVICE_TIMEOUT_MS / 1000
     try:
         timeout_ms = int(raw)
     except ValueError as exc:
@@ -184,7 +190,7 @@ def get_service_embeddings(
     if dimensions:
         payload["dimensions"] = dimensions
 
-    timeout = embedding_service_timeout_seconds()
+    timeout = embedding_service_timeout_seconds(mode)
     last_error: Exception | None = None
     for attempt in range(2):
         try:

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -1,8 +1,10 @@
 """Analytics and change log methods for SQLite storage."""
 
 import sqlite3
-from typing import Any
+from collections import defaultdict
+from typing import Any, Literal, cast
 
+from reflexio.models.api_schema.retriever_schema import PlaybookApplicationStat
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
     PlaybookAggregationChangeLog,
@@ -15,10 +17,13 @@ from ._base import (
     _epoch_to_iso,
     _iso_to_epoch,
     _json_dumps,
+    _json_loads,
     _row_to_interaction,
     _row_to_playbook_aggregation_change_log,
     _row_to_profile_change_log,
 )
+
+type _CitationKind = Literal["playbook", "profile"]
 
 
 class ExtrasMixin:
@@ -190,6 +195,97 @@ class ExtrasMixin:
                 for r in evals_ts
             ],
         }
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_playbook_application_stats(
+        self, days_back: int = 30
+    ) -> list[PlaybookApplicationStat]:
+        """Return per-rule citation counts from the ``interactions`` table.
+
+        Aggregates the JSON ``citations`` column over the look-back window and
+        groups by ``(kind, real_id)``. Iteration is done in Python (rather
+        than pushing into SQL via ``json_each``) because volumes are bounded
+        per org and the resulting code is easier to maintain. Titles come
+        from the citation rows themselves — they are captured at injection
+        time when the rule is rendered into context.
+
+        Args:
+            days_back (int): Look-back window in days. Must be positive.
+
+        Returns:
+            list[PlaybookApplicationStat]: One row per cited ``(kind,
+                real_id)``, sorted by ``applied_count`` descending and then
+                by ``last_applied_at`` descending. Empty when no interactions
+                in the window carry citations.
+        """
+        if days_back <= 0:
+            return []
+
+        current_time = _epoch_now()
+        start_iso = _epoch_to_iso(current_time - days_back * 24 * 60 * 60)
+        rows = self._fetchall(
+            "SELECT interaction_id, created_at, citations FROM interactions "
+            "WHERE created_at >= ? "
+            "AND citations IS NOT NULL AND citations != '' AND citations != '[]' "
+            "ORDER BY created_at DESC, interaction_id DESC",
+            (start_iso,),
+        )
+        if not rows:
+            return []
+
+        aggregates: dict[tuple[_CitationKind, str], dict[str, Any]] = defaultdict(
+            lambda: {
+                "applied_count": 0,
+                "title": "",
+                "last_applied_at": None,
+                "last_interaction_id": None,
+            }
+        )
+        for row in rows:
+            citations = _json_loads(row["citations"])
+            if not isinstance(citations, list):
+                continue
+            for c in citations:
+                if not isinstance(c, dict):
+                    continue
+                kind = c.get("kind")
+                real_id = c.get("real_id")
+                if kind not in ("playbook", "profile") or not real_id:
+                    continue
+                key: tuple[_CitationKind, str] = (
+                    cast(_CitationKind, kind),
+                    str(real_id),
+                )
+                agg = aggregates[key]
+                agg["applied_count"] += 1
+                if agg["last_applied_at"] is None:
+                    # rows ordered DESC, so the first time we see this key
+                    # is the most recent occurrence
+                    agg["last_applied_at"] = _iso_to_epoch(row["created_at"])
+                    agg["last_interaction_id"] = row["interaction_id"]
+                if not agg["title"]:
+                    title = c.get("title") or ""
+                    if isinstance(title, str) and title.strip():
+                        agg["title"] = title.strip()
+
+        stats = [
+            PlaybookApplicationStat(
+                real_id=real_id,
+                kind=kind,
+                title=agg["title"],
+                applied_count=agg["applied_count"],
+                last_applied_at=agg["last_applied_at"],
+                last_interaction_id=agg["last_interaction_id"],
+            )
+            for (kind, real_id), agg in aggregates.items()
+        ]
+        stats.sort(
+            key=lambda s: (
+                -s.applied_count,
+                -(s.last_applied_at if s.last_applied_at is not None else 0),
+            )
+        )
+        return stats
 
     # ------------------------------------------------------------------
     # Statistics methods

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -245,6 +245,7 @@ class ExtrasMixin:
             citations = _json_loads(row["citations"])
             if not isinstance(citations, list):
                 continue
+            seen_keys_in_interaction: set[tuple[_CitationKind, str]] = set()
             for c in citations:
                 if not isinstance(c, dict):
                     continue
@@ -256,6 +257,9 @@ class ExtrasMixin:
                     cast(_CitationKind, kind),
                     str(real_id),
                 )
+                if key in seen_keys_in_interaction:
+                    continue
+                seen_keys_in_interaction.add(key)
                 agg = aggregates[key]
                 agg["applied_count"] += 1
                 if agg["last_applied_at"] is None:

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -5,6 +5,7 @@ from reflexio.models.api_schema.domain import (
     PlaybookAggregationChangeLog,
     ProfileChangeLog,
 )
+from reflexio.models.api_schema.retriever_schema import PlaybookApplicationStat
 
 
 class ExtrasMixin:
@@ -31,6 +32,32 @@ class ExtrasMixin:
                 - evaluations_time_series: List of time series data points (raw, ungrouped)
         """
         raise NotImplementedError
+
+    def get_playbook_application_stats(
+        self, days_back: int = 30
+    ) -> list[PlaybookApplicationStat]:
+        """Return per-rule citation counts derived from interaction citations.
+
+        Aggregates the JSON ``citations`` column on ``interactions`` over the
+        last ``days_back`` days and groups by ``(kind, real_id)``. Joins with
+        the playbook / profile tables to populate human-readable titles.
+
+        Concrete default returns ``[]`` so backends that do not yet implement
+        this method degrade gracefully (the dashboard simply shows no stats)
+        rather than raising 500s. Storage backends should override with a
+        real implementation — see ``sqlite_storage._extras`` for the
+        reference implementation.
+
+        Args:
+            days_back (int): Look-back window in days. Must be positive.
+
+        Returns:
+            list[PlaybookApplicationStat]: One row per cited ``(kind,
+                real_id)``, sorted by ``applied_count`` descending. Empty
+                when the backend has no implementation.
+        """
+        del days_back
+        return []
 
     @abstractmethod
     def get_profile_statistics(self) -> dict:

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -8,6 +8,7 @@ from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
     embedding_provider_mode,
+    embedding_service_timeout_seconds,
     get_service_embeddings,
 )
 
@@ -34,6 +35,25 @@ def test_local_model_without_opt_in_preserves_inprocess_mode(monkeypatch) -> Non
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
 
     assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+
+
+def test_local_service_default_timeout_allows_cold_start(monkeypatch) -> None:
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS", raising=False)
+
+    assert embedding_service_timeout_seconds("local_service") == 30
+
+
+def test_internal_service_keeps_fast_default_timeout(monkeypatch) -> None:
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS", raising=False)
+
+    assert embedding_service_timeout_seconds("internal_service") == 2
+
+
+def test_embedding_service_timeout_env_overrides_mode_default(monkeypatch) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS", "7500")
+
+    assert embedding_service_timeout_seconds("local_service") == 7.5
+    assert embedding_service_timeout_seconds("internal_service") == 7.5
 
 
 def test_litellm_client_routes_local_service_embeddings(monkeypatch) -> None:
@@ -77,6 +97,7 @@ def test_service_response_is_sorted_by_index(monkeypatch) -> None:
 
     class _Client:
         def __init__(self, timeout: float) -> None:
+            assert timeout == 30
             self.timeout = timeout
 
         def __enter__(self) -> _Client:

--- a/tests/server/services/storage/test_storage_contract_extras.py
+++ b/tests/server/services/storage/test_storage_contract_extras.py
@@ -1,8 +1,13 @@
 """Contract tests for ExtrasMixin — run against every local storage backend."""
 
+from datetime import UTC, datetime
+
 import pytest
 
+from reflexio.models.api_schema.domain.enums import UserActionType
 from reflexio.models.api_schema.service_schemas import (
+    Citation,
+    Interaction,
     ProfileChangeLog,
     UserProfile,
 )
@@ -66,3 +71,109 @@ class TestProfileChangeLogs:
 
         storage.delete_all_profile_change_logs()
         assert storage.get_profile_change_logs() == []
+
+
+# ---------------------------------------------------------------------------
+# TestPlaybookApplicationStats
+# ---------------------------------------------------------------------------
+
+
+def _make_interaction(
+    request_id: str,
+    created_at: int,
+    citations: list[Citation],
+) -> Interaction:
+    return Interaction(
+        interaction_id=0,
+        user_id="u1",
+        request_id=request_id,
+        created_at=created_at,
+        role="Assistant",
+        content="answer",
+        user_action=UserActionType.NONE,
+        user_action_description="",
+        interacted_image_url="",
+        shadow_content="",
+        expert_content="",
+        tools_used=[],
+        citations=citations,
+    )
+
+
+class TestPlaybookApplicationStats:
+    def test_empty_when_no_citations(self, storage):
+        # Backends that have no implementation return [] from the default; SQLite
+        # returns [] when no interactions carry citations. Either way: empty.
+        assert storage.get_playbook_application_stats(days_back=30) == []
+
+    def test_aggregates_by_kind_and_real_id(self, storage):
+        if not _backend_supports_application_stats(storage):
+            pytest.skip("Backend does not implement get_playbook_application_stats")
+        now = int(datetime.now(tz=UTC).timestamp())
+        # Two interactions cite playbook 42; one also cites profile p-99.
+        storage._insert_interaction(
+            _make_interaction(
+                "r1",
+                now - 100,
+                [
+                    Citation(
+                        kind="playbook", real_id="42", tag="s1-2a", title="timeline"
+                    ),
+                    Citation(
+                        kind="profile", real_id="p-99", tag="p1-99", title="terse"
+                    ),
+                ],
+            )
+        )
+        storage._insert_interaction(
+            _make_interaction(
+                "r2",
+                now,
+                [Citation(kind="playbook", real_id="42", tag="s1-2a", title="timeline")],
+            )
+        )
+
+        stats = storage.get_playbook_application_stats(days_back=30)
+        assert len(stats) == 2
+
+        # Most-applied row sorts first.
+        top = stats[0]
+        assert top.kind == "playbook"
+        assert top.real_id == "42"
+        assert top.applied_count == 2
+        assert top.title == "timeline"
+        # last_applied_at should be the LATER of the two interactions.
+        assert top.last_applied_at == now
+
+        profile_row = stats[1]
+        assert profile_row.kind == "profile"
+        assert profile_row.real_id == "p-99"
+        assert profile_row.applied_count == 1
+
+    def test_respects_days_back_window(self, storage):
+        if not _backend_supports_application_stats(storage):
+            pytest.skip("Backend does not implement get_playbook_application_stats")
+        now = int(datetime.now(tz=UTC).timestamp())
+        old = now - 60 * 24 * 60 * 60  # 60 days ago
+        storage._insert_interaction(
+            _make_interaction(
+                "r_old",
+                old,
+                [Citation(kind="playbook", real_id="42", tag="s1-2a", title="old")],
+            )
+        )
+        # 30-day window excludes the 60-day-old citation.
+        assert storage.get_playbook_application_stats(days_back=30) == []
+        # 90-day window includes it.
+        stats = storage.get_playbook_application_stats(days_back=90)
+        assert len(stats) == 1 and stats[0].applied_count == 1
+
+
+def _backend_supports_application_stats(storage) -> bool:
+    """True when the storage backend has a real (non-default) implementation.
+
+    The default in ``ExtrasMixin`` returns ``[]`` for any input — backends
+    that haven't been wired up yet (disk, supabase, postgres) hit that path
+    and have nothing to test. The SQLite backend has the real implementation.
+    """
+    return type(storage).__name__ == "SQLiteStorage"

--- a/tests/server/services/storage/test_storage_contract_extras.py
+++ b/tests/server/services/storage/test_storage_contract_extras.py
@@ -11,6 +11,7 @@ from reflexio.models.api_schema.service_schemas import (
     ProfileChangeLog,
     UserProfile,
 )
+from reflexio.server.services.storage.storage_base._extras import ExtrasMixin
 
 pytestmark = pytest.mark.integration
 
@@ -129,7 +130,11 @@ class TestPlaybookApplicationStats:
             _make_interaction(
                 "r2",
                 now,
-                [Citation(kind="playbook", real_id="42", tag="s1-2a", title="timeline")],
+                [
+                    Citation(
+                        kind="playbook", real_id="42", tag="s1-2a", title="timeline"
+                    )
+                ],
             )
         )
 
@@ -168,12 +173,39 @@ class TestPlaybookApplicationStats:
         stats = storage.get_playbook_application_stats(days_back=90)
         assert len(stats) == 1 and stats[0].applied_count == 1
 
+    def test_counts_duplicate_citations_once_per_interaction(self, storage):
+        if not _backend_supports_application_stats(storage):
+            pytest.skip("Backend does not implement get_playbook_application_stats")
+        now = int(datetime.now(tz=UTC).timestamp())
+        storage._insert_interaction(
+            _make_interaction(
+                "r_duplicate",
+                now,
+                [
+                    Citation(
+                        kind="playbook", real_id="42", tag="s1-2a", title="timeline"
+                    ),
+                    Citation(
+                        kind="playbook", real_id="42", tag="s1-2a", title="timeline"
+                    ),
+                ],
+            )
+        )
+
+        stats = storage.get_playbook_application_stats(days_back=30)
+
+        assert len(stats) == 1
+        assert stats[0].applied_count == 1
+
 
 def _backend_supports_application_stats(storage) -> bool:
     """True when the storage backend has a real (non-default) implementation.
 
     The default in ``ExtrasMixin`` returns ``[]`` for any input — backends
     that haven't been wired up yet (disk, supabase, postgres) hit that path
-    and have nothing to test. The SQLite backend has the real implementation.
+    and have nothing to test.
     """
-    return type(storage).__name__ == "SQLiteStorage"
+    return (
+        storage.__class__.get_playbook_application_stats
+        is not ExtrasMixin.get_playbook_application_stats
+    )


### PR DESCRIPTION
## Why

This PR adds backend support for aggregating per-rule citation/application stats from stored Reflexio interactions. That remains useful as backend groundwork for server-side analytics, cross-machine dashboards, or future hosted deployments.

The paired claude-smart dashboard has since moved its immediate **Most used claude-smart learnings** widget to local session-buffer aggregation from `~/.claude-smart/sessions/*.jsonl`, so this endpoint is no longer required for the current local dashboard UX.

## What

New endpoint: `POST /api/get_playbook_application_stats { days_back: int }`

Returns a list of `PlaybookApplicationStat` rows — one per cited `(kind, real_id)` in the window — sorted by `applied_count` descending. Each row carries `title`, `applied_count`, `last_applied_at` (epoch seconds, matching dashboard convention), and `last_interaction_id`.

Layers:

- `PlaybookApplicationStat` + request/response schemas in `models/api_schema/retriever_schema.py`
- `ExtrasMixin.get_playbook_application_stats` default returns `[]` so backends without the real implementation degrade gracefully rather than 500
- SQLite implementation in `sqlite_storage/_extras.py`: time-windowed scan of `interactions`, Python-side aggregation grouped by `(kind, real_id)`, ordering preserves "first seen = most recent" by `ORDER BY created_at DESC`
- `Reflexio.get_playbook_application_stats` wrapper in `lib/_dashboard.py`
- FastAPI handler in `server/api.py`

## Test plan

- [x] `pytest tests/server/services/storage/test_storage_contract_extras.py` — 6 passed (3 new: empty case, aggregation+sort+last-applied, days_back window).
- [x] Ad-hoc Python smoke: insert two interactions with citations into a temp SQLite, call the new method, assert counts/timestamps/last_interaction_id are correct.
- [x] `pyright` + `ruff` clean on all changed files when this PR was prepared.
- [ ] Other storage backends (disk, supabase, postgres) deliberately fall through to the default empty implementation for v1; can be implemented incrementally.

## Paired work

- claude-smart PR: https://github.com/ReflexioAI/claude-smart/pull/22
- enterprise submodule pointer PR: https://github.com/ReflexioAI/reflexio-enterprise/pull/67

## Current integration status

The claude-smart local dashboard no longer calls this endpoint. It now computes applied-learning counts directly from local session `cited_items`. This PR can still be merged as optional backend analytics groundwork, or deferred if we want to keep the backend surface smaller until hosted/cross-machine usage needs it.

## Out of scope

- SQL-side aggregation via `json_each` — Python-side is fine at current volumes and simpler. The migration path (materialized `citation_events` table or a generated column) is documented in the SQLite docstring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New API to retrieve playbook/application usage statistics (per-rule application counts and recent activity) over a configurable lookback window.

* **Improved Behavior**
  * Local embedding requests now allow a longer default timeout to accommodate model cold starts, still overridable via env var.

* **Documentation**
  * CLI docs updated with additional supported local embedding models and timeout guidance.

* **Tests**
  * Added tests covering embedding timeout defaults and playbook-stats behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->