### PR TITLE
feat(llm): claude-code provider tool-calling support

### DIFF
--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -22,6 +22,7 @@ import inspect
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess  # noqa: S404 — subprocess is the integration point; inputs are sanitised.
 import tempfile
@@ -34,7 +35,9 @@ from typing import Any
 import litellm
 from litellm.llms.custom_llm import CustomLLM
 from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
     Choices,
+    Function,
     Message,
     ModelResponse,
     Usage,
@@ -318,21 +321,65 @@ def _split_system_and_dialogue(
     for msg in messages:
         role = msg.get("role", "user")
         content = _flatten_content(msg.get("content"))
-        if not content:
+        tool_calls = msg.get("tool_calls") if role == "assistant" else None
+        if not content and not tool_calls:
             continue
         if role == "system":
             systems.append(content)
             continue
         non_system_roles += 1
         if role == "assistant":
-            turns.append(f"Assistant: {content}")
+            # When the assistant message carries tool_calls (content is
+            # typically None), serialise them as breadcrumbs so the CLI's
+            # next-turn context shows which tools were invoked. This is
+            # required for multi-turn tool loops to converge.
+            if tool_calls:
+                breadcrumbs = []
+                for tc in tool_calls:
+                    name = _tool_call_attr(tc, "name") or "?"
+                    args = _tool_call_attr(tc, "arguments") or "{}"
+                    breadcrumbs.append(f"called {name} with {args}")
+                prefix = "; ".join(breadcrumbs)
+                if content:
+                    turns.append(f"Assistant: {content}\n[tools: {prefix}]")
+                else:
+                    turns.append(f"Assistant: [tools: {prefix}]")
+            else:
+                turns.append(f"Assistant: {content}")
         elif role == "tool":
-            turns.append(f"Tool: {content}")
+            tcid = msg.get("tool_call_id") or "?"
+            turns.append(f"Tool[{tcid}]: {content}")
         else:
             turns.append(f"User: {content}")
     if non_system_roles > 1:
         _warn_multiturn_once()
     return "\n\n".join(systems), "\n\n".join(turns)
+
+
+def _tool_call_attr(tc: Any, attr: str) -> str | None:
+    """Read a tool-call field from either a LiteLLM object or a plain dict.
+
+    ``tool_calls`` entries may be ``ChatCompletionMessageToolCall`` objects
+    (each carrying a ``.function`` with ``.name`` / ``.arguments``) or
+    raw dicts (``{"function": {"name": ..., "arguments": ...}}``). Walk
+    both shapes.
+
+    Args:
+        tc: A single ``tool_calls`` entry (object or dict).
+        attr: The attribute to read (``"name"`` or ``"arguments"``).
+
+    Returns:
+        str | None: The attribute's string value, or ``None`` if absent.
+    """
+    if isinstance(tc, dict):
+        fn = tc.get("function") or {}
+        value = fn.get(attr) if isinstance(fn, dict) else getattr(fn, attr, None)
+    else:
+        fn = getattr(tc, "function", None)
+        value = getattr(fn, attr, None) if fn is not None else None
+    if value is None:
+        return None
+    return value if isinstance(value, str) else json.dumps(value)
 
 
 def _run_cli_stream(
@@ -537,6 +584,192 @@ def _build_model_response(
     return response
 
 
+_TOOL_USE_INSTRUCTION_TEMPLATE = (
+    "## EXTERNAL TOOL-CALLING MODE\n"
+    "\n"
+    "You are running as a non-interactive subprocess driven by an external "
+    "orchestrator. The orchestrator will execute tools on your behalf. You "
+    "MUST NOT use Read, Edit, Write, Bash, Glob, Grep, TodoWrite, Task, or "
+    "ANY of your built-in Claude Code tools. The tools listed below are "
+    "NOT real callable functions in this session — they are the external "
+    "tools the ORCHESTRATOR exposes, which YOU describe by emitting a "
+    "structured JSON request as your final text response.\n"
+    "\n"
+    "Your response MUST be EXACTLY one JSON object on a single line, with "
+    "this shape:\n"
+    '{{"tool": "<tool_name>", "args": {{...}} }}\n'
+    "\n"
+    "Hard rules — failing any of these will break the orchestrator:\n"
+    "1. Output ONLY the JSON object as plain text. No prose before or after.\n"
+    "2. No markdown. No ```json``` code fences.\n"
+    "3. Do NOT invoke any built-in tool. Do NOT search the codebase. Just "
+    "   emit the JSON.\n"
+    "4. ``tool`` must be exactly one of the names listed below.\n"
+    "5. ``args`` must be a JSON object matching that tool's parameters.\n"
+    "6. To terminate the orchestrator's loop, call the tool named "
+    "``{finish}`` with the appropriate args.\n"
+    "\n"
+    "Available orchestrator tools (each described by name + params schema):\n"
+    "{tool_specs}\n"
+    "\n"
+    "Now decide which tool to call and output ONLY the JSON object.\n"
+)
+
+
+def _render_tools_instruction(tools: list[Any], finish_tool: str = "finish") -> str:
+    """Render a LiteLLM tools spec into a system-prompt addendum.
+
+    Args:
+        tools: LiteLLM-style tools list. Each entry is a dict with
+            ``{"type": "function", "function": {"name", "description", "parameters"}}``.
+        finish_tool: The conventional finish tool name (echoed in the
+            instructions so the model has a recognised termination signal).
+
+    Returns:
+        str: The system-prompt block to append.
+    """
+    lines: list[str] = []
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") if isinstance(tool.get("function"), dict) else {}
+        name = fn.get("name") or "?"
+        desc = fn.get("description") or ""
+        params = fn.get("parameters") or {}
+        lines.append(
+            f"- {name}: {desc}\n  parameters: {json.dumps(params, separators=(',', ':'))}"
+        )
+    tool_specs = "\n".join(lines) if lines else "(no tools)"
+    return _TOOL_USE_INSTRUCTION_TEMPLATE.format(
+        finish=finish_tool, tool_specs=tool_specs
+    )
+
+
+def _maybe_append_tools_instruction(system_prompt: str, tools: list[Any] | None) -> str:
+    """Append the tool-use instructions when tools are present.
+
+    Args:
+        system_prompt: Existing system prompt (possibly empty).
+        tools: LiteLLM-style tools list, or None/empty.
+
+    Returns:
+        str: The (possibly-augmented) system prompt.
+    """
+    if not tools:
+        return system_prompt
+    instruction = _render_tools_instruction(tools)
+    if system_prompt:
+        return f"{system_prompt}\n\n{instruction}"
+    return instruction
+
+
+def _parse_tool_use(text: str, tool_names: set[str]) -> dict[str, Any] | None:
+    """Try to parse a ``{"tool": ..., "args": ...}`` block from claude's output.
+
+    Walks candidate JSON substrings (plain, code-fenced, first balanced
+    ``{...}``) in order, returning the first that parses to a dict with a
+    recognised ``tool`` name and a dict ``args``.
+
+    Args:
+        text: Raw text from claude's ``-p --output-format json`` ``result``.
+        tool_names: Set of tool names registered by the caller. The returned
+            ``tool`` must be in this set.
+
+    Returns:
+        dict | None: ``{"name": str, "args": dict}`` on success; ``None`` if
+            no valid tool-use JSON could be located.
+    """
+    stripped = (text or "").strip()
+    if not stripped:
+        return None
+    candidates: list[str] = [stripped]
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", stripped, re.DOTALL)
+    if fence:
+        candidates.append(fence.group(1))
+    # Find the first balanced ``{...}`` object via JSONDecoder.raw_decode
+    # instead of the greedy ``r"\{.*\}"`` regex. The greedy form swallows
+    # any trailing ``{...}`` on the same line and silently misses a valid
+    # tool-call when claude appends explanatory text after the JSON.
+    decoder = json.JSONDecoder()
+    for idx, ch in enumerate(stripped):
+        if ch != "{":
+            continue
+        try:
+            obj, end = decoder.raw_decode(stripped[idx:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict):
+            candidates.append(stripped[idx : idx + end])
+            break
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        name = parsed.get("tool")
+        args = parsed.get("args")
+        if name in tool_names and isinstance(args, dict):
+            return {"name": name, "args": args}
+    return None
+
+
+def _build_model_response_with_tool_call(
+    *,
+    model: str,
+    terminal_text: str,
+    elapsed_seconds: float,
+    tool_use: dict[str, Any],
+) -> ModelResponse:
+    """Wrap the CLI terminal text as a ``ModelResponse`` carrying one ``tool_calls`` entry.
+
+    The stream-json transport does not surface usage tokens at the terminal
+    event, so prompt/completion counts are reported as zero (same convention
+    as :func:`_build_model_response`). Downstream LiteLLM callers tolerate
+    this — usage is informational, not load-bearing.
+
+    Args:
+        model: Model string passed in by LiteLLM.
+        terminal_text: The terminal ``result`` text from the CLI (retained
+            for signature parity with the plain-text branch; surfaced via
+            logging only).
+        elapsed_seconds: Subprocess wall time, for logging only.
+        tool_use: Parsed ``{"name": str, "args": dict}`` from the model output.
+
+    Returns:
+        ModelResponse: A LiteLLM response with ``choices[0].message.tool_calls`` set
+            and ``content`` set to ``None`` — matches OpenAI/Anthropic tool-call shape.
+    """
+    del terminal_text  # retained for signature parity only
+    call_id = f"call_{int(time.time() * 1000)}"
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(
+            name=tool_use["name"],
+            arguments=json.dumps(tool_use["args"]),
+        ),
+    )
+    message = Message(role="assistant", content=None, tool_calls=[tool_call])
+    choice = Choices(index=0, message=message, finish_reason="tool_calls")
+    usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
+    response = ModelResponse(
+        id=f"claude-code-{int(time.time())}",
+        choices=[choice],
+        created=int(time.time()),
+        model=model,
+        object="chat.completion",
+        usage=usage,
+    )
+    _LOGGER.debug(
+        "claude-code provider: tool_call name=%s elapsed=%.2fs",
+        tool_use["name"],
+        elapsed_seconds,
+    )
+    return response
+
+
 def _maybe_append_schema(system_prompt: str, response_format: Any) -> str:
     """Return *system_prompt* extended with a JSON-schema instruction when applicable.
 
@@ -665,15 +898,27 @@ class ClaudeCodeLLM(CustomLLM):
         Raises:
             ClaudeCodeCLIError: On CLI failure or missing binary.
         """
-        del args, kwargs
+        del args
         messages = messages or []
         optional_params = optional_params or {}
+
+        # Tools may arrive in either ``optional_params["tools"]`` (LiteLLM's
+        # standard plumbing for custom providers) or as a top-level ``tools``
+        # kwarg. Read both before discarding kwargs.
+        tools = optional_params.get("tools") or kwargs.get("tools")
+        del kwargs
 
         _warn_on_ignored_params(optional_params)
 
         response_format = optional_params.get("response_format")
         system_prompt, dialogue = _split_system_and_dialogue(messages)
-        system_prompt = _maybe_append_schema(system_prompt, response_format)
+        # When ``tools`` is present, render the tools spec into the system
+        # prompt and ignore response_format (mutually exclusive with our
+        # tool_use JSON output contract).
+        if tools:
+            system_prompt = _maybe_append_tools_instruction(system_prompt, tools)
+        else:
+            system_prompt = _maybe_append_schema(system_prompt, response_format)
 
         started = time.perf_counter()
         result = _run_cli_stream(
@@ -685,10 +930,33 @@ class ClaudeCodeLLM(CustomLLM):
 
         if result.success:
             self._clear_stall_safely()
+            elapsed = time.perf_counter() - started
+
+            # When ``tools`` are provided, attempt to parse the model's
+            # terminal text as a ``{"tool": ..., "args": ...}`` JSON object.
+            # If parsing succeeds, return a tool-call ModelResponse; otherwise
+            # fall through to a plain-text response — the caller treats that
+            # as "no tool_calls" and terminates the tool loop.
+            if tools:
+                tool_names = {
+                    (tool.get("function") or {}).get("name")
+                    for tool in tools
+                    if isinstance(tool, dict)
+                }
+                tool_names.discard(None)
+                tool_use = _parse_tool_use(result.terminal_text, tool_names)
+                if tool_use is not None:
+                    return _build_model_response_with_tool_call(
+                        model=model,
+                        terminal_text=result.terminal_text,
+                        elapsed_seconds=elapsed,
+                        tool_use=tool_use,
+                    )
+
             return _build_model_response(
                 model=model,
                 terminal_text=result.terminal_text,
-                elapsed_seconds=time.perf_counter() - started,
+                elapsed_seconds=elapsed,
             )
 
         self._record_stall_safely(result)

--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -632,7 +632,8 @@ def _render_tools_instruction(tools: list[Any], finish_tool: str = "finish") -> 
     for tool in tools or []:
         if not isinstance(tool, dict):
             continue
-        fn = tool.get("function") if isinstance(tool.get("function"), dict) else {}
+        raw_fn = tool.get("function")
+        fn: dict[str, Any] = raw_fn if isinstance(raw_fn, dict) else {}
         name = fn.get("name") or "?"
         desc = fn.get("description") or ""
         params = fn.get("parameters") or {}
@@ -935,15 +936,18 @@ class ClaudeCodeLLM(CustomLLM):
             # When ``tools`` are provided, attempt to parse the model's
             # terminal text as a ``{"tool": ..., "args": ...}`` JSON object.
             # If parsing succeeds, return a tool-call ModelResponse; otherwise
-            # fall through to a plain-text response — the caller treats that
-            # as "no tool_calls" and terminates the tool loop.
+            # warn (so the silent fall-through is observable) and return a
+            # plain-text response, which the caller treats as "no tool_calls"
+            # and uses to terminate the tool loop.
             if tools:
-                tool_names = {
-                    (tool.get("function") or {}).get("name")
+                tool_names: set[str] = {
+                    name
                     for tool in tools
                     if isinstance(tool, dict)
+                    and isinstance(
+                        name := (tool.get("function") or {}).get("name"), str
+                    )
                 }
-                tool_names.discard(None)
                 tool_use = _parse_tool_use(result.terminal_text, tool_names)
                 if tool_use is not None:
                     return _build_model_response_with_tool_call(
@@ -952,6 +956,20 @@ class ClaudeCodeLLM(CustomLLM):
                         elapsed_seconds=elapsed,
                         tool_use=tool_use,
                     )
+                # Log a metadata-only warning (no raw payload) — the model
+                # output can carry user content / source code; deferring the
+                # body to a DEBUG fingerprint avoids turning a recoverable
+                # parse miss into a log-retention concern.
+                _LOGGER.warning(
+                    "claude-code provider: tools=%s were provided but no valid "
+                    "tool_use JSON was parsed from model output; the tool loop "
+                    "will terminate without a finish_tool call.",
+                    sorted(tool_names),
+                )
+                _LOGGER.debug(
+                    "claude-code provider: unparsable tool-use payload length=%d",
+                    len(result.terminal_text),
+                )
 
             return _build_model_response(
                 model=model,

--- a/reflexio/server/llm/tools.py
+++ b/reflexio/server/llm/tools.py
@@ -123,6 +123,13 @@ _TOOL_CALLING_OVERRIDES: tuple[str, ...] = (
     # tools=[...])` round-trip that returned a proper tool_call message.
     # litellm 1.80.x has 'minimax/MiniMax-M2' in model_cost but not 'MiniMax-M2.7'.
     "minimax/MiniMax-M2",
+    # claude-code/* models route through our local CLI provider
+    # (see providers/claude_code_provider.py). litellm has no registry
+    # entry for them, so it returns False. The provider handles tool
+    # calling explicitly by rendering tool specs into the system prompt
+    # and parsing the model's JSON output back into ChatCompletionMessageToolCall
+    # blocks. Verified end-to-end against the agentic ExtractionAgent loop.
+    "claude-code/",
 )
 
 

--- a/tests/server/llm/test_claude_code_provider.py
+++ b/tests/server/llm/test_claude_code_provider.py
@@ -99,11 +99,23 @@ class TestSplitSystemAndDialogue:
     def test_tool_role_prefixed(self) -> None:
         msgs = [
             {"role": "user", "content": "fetch"},
+            {"role": "tool", "tool_call_id": "call_abc", "content": "result: 42"},
+            {"role": "assistant", "content": "done"},
+        ]
+        _, dialogue = _split_system_and_dialogue(msgs)
+        # The Tool line includes the tool_call_id in brackets so multi-call
+        # context can be reconstructed: ``Tool[<id>]: <content>``.
+        assert "Tool[call_abc]: result: 42" in dialogue
+
+    def test_tool_role_without_id_uses_placeholder(self) -> None:
+        msgs = [
+            {"role": "user", "content": "fetch"},
             {"role": "tool", "content": "result: 42"},
             {"role": "assistant", "content": "done"},
         ]
         _, dialogue = _split_system_and_dialogue(msgs)
-        assert "Tool: result: 42" in dialogue
+        # Tool message with no tool_call_id falls back to ``?`` placeholder.
+        assert "Tool[?]: result: 42" in dialogue
 
     def test_image_blocks_dropped_with_single_warning(
         self, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Summary

Wire native function-calling through the `claude-code` custom LiteLLM provider so the agentic extraction pipeline (`AgenticExtractionRunner`) actually runs end-to-end against the locally-installed Claude Code CLI. Before this change, every `ExtractionAgent.run(...)` call against `claude-code/default` failed with `RuntimeError: Model claude-code/default lacks tool-calling and no fallback_schema provided`, so the agentic backend was effectively a no-op for users routing through Claude Code.

## What changed

Two layered fixes:

### 1. `tools.supports_tool_calling` — add `claude-code/` to `_TOOL_CALLING_OVERRIDES`

litellm has no registry entry for `claude-code/*` models, so `litellm.supports_function_calling(model=...)` returns False by default and the tool loop short-circuits with the "lacks tool-calling" error. Since the provider now handles tools explicitly (below), we override to True.

### 2. `claude_code_provider.completion` — implement tools plumbing end-to-end

- Read `tools` from `optional_params["tools"]` (LiteLLM's standard plumbing for custom providers) and from top-level `kwargs["tools"]` as fallback. Previously discarded by `del args, kwargs`.
- When tools are present, render the tools spec into the system prompt via `_render_tools_instruction`. The rendered prompt:
  - Tells the CLI subprocess it's in `EXTERNAL TOOL-CALLING MODE` — must NOT use its built-in `Read`/`Edit`/`Bash`/etc. tools.
  - Provides each tool's name + description + JSON parameters schema.
  - Instructs the model to respond with exactly one JSON object: `{"tool": "<name>", "args": {...}}` and nothing else.
- Parse the CLI's text response via `_parse_tool_use` (tries plain JSON, ```` ```json ```` code fences, and the first balanced `{...}` block). Validates the `tool` name against the registered tool set.
- Build a `ChatCompletionMessageToolCall` and return a `ModelResponse` with `tool_calls` + `finish_reason="tool_calls"` — matches the OpenAI/Anthropic-compatible shape `run_tool_loop` expects.

### Multi-turn context preservation

`_split_system_and_dialogue` now preserves assistant `tool_calls` (which previously had `content=None` and were dropped) as breadcrumbs in the flattened dialogue:

- Assistant turns with tool_calls render as `Assistant: [tools: called <name> with <args>; ...]`
- Tool result messages include their `tool_call_id`: `Tool[call_abc]: <result>`

This lets the CLI subprocess see the prior turns' tool invocations + results on its next turn so the loop can converge across multiple tool calls.

A small helper `_tool_call_attr` accepts both `ChatCompletionMessageToolCall` objects and raw dicts so the dialogue serializer works regardless of which shape upstream code passes.

## Verification

### Existing tests pass

`tests/server/llm/test_claude_code_provider.py` — 29 passed (one assertion updated to match the new `Tool[<id>]:` format, plus one new test for the no-id placeholder fallback).
`tests/server/llm/test_tools.py` — 19 passed.
`tests/server/llm/test_tools_multi_stage_integration.py` — 6 passed.

### End-to-end smoke

Ran the agentic `ExtractionAgent` loop against `claude-code/default` (model=`claude-haiku-4-5-20251001`, real Claude Code CLI). Backend log shows real multi-step tool-calling loops completing:

```
extraction_agent[default_profile_extractor] kind=UserProfile loop_done
  elapsed_ms=89405 turns=4/4
  tools={search_user_profiles:3, create_user_profile:1}
  outcome=max_steps plan_size=1
  usage={claude-code/default: 6325 tokens, $0.000000}

extraction_agent[default_profile_extractor] kind=UserProfileAgentRec loop_done
  elapsed_ms=28244 turns=2/4
  tools={search_user_profiles:1, finish:1}
  outcome=finish_tool plan_size=0

extraction_agent[default_playbook_extractor] kind=UserPlaybook loop_done
  elapsed_ms=23378 turns=1/4
  tools={finish:1}
  outcome=finish_tool plan_size=0
```

The `plan_size=1` line is the smoking gun — the agent executed `create_user_profile` and the operation was committed. Before this change, every such loop produced `outcome=error turns=0/4 tools={(none)}` because the provider raised before any tool call could happen.

Across the smoke runs **zero `lacks tool-calling` errors** appeared. Before the change, we observed 21 such errors across four prior attempts.

## Limitations

- The CLI's output format is plain text; if the model deviates from the JSON-only contract (extra prose, malformed JSON, picks a tool name not in the registry), `_parse_tool_use` returns `None` and the tool loop terminates as "no tool_calls" — a slightly weaker recovery than native function-calling providers. The very explicit instruction in `_TOOL_USE_INSTRUCTION_TEMPLATE` reduces this in practice; logs from the smoke didn't show parse failures across 50+ tool calls.
- Multi-turn tool_call_id pairing relies on the model honouring the `Tool[<id>]:` breadcrumb format the dialogue serializer produces. Anthropic models follow this reliably in our smoke.
- This change adds no support for streaming tool calls — the CLI is invoked as a single subprocess and the response is parsed once.

## Files

- `reflexio/server/llm/tools.py` — extend `_TOOL_CALLING_OVERRIDES`.
- `reflexio/server/llm/providers/claude_code_provider.py` — accept and translate `tools`, render system-prompt block, parse tool_use, build `ModelResponse.tool_calls`. Also preserve tool-call context in `_split_system_and_dialogue`.
- `tests/server/llm/test_claude_code_provider.py` — update one assertion, add one test for the no-id case.

282 insertions, 7 deletions across 3 files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code provider now supports tool-calling flows, emitting structured tool-invocation responses to trigger tools and recording breadcrumb text in conversations for clearer tool-loop context.
  * Improved handling when tool output can't be parsed, falling back to plain-text results and emitting a warning for visibility.

* **Tests**
  * Expanded tests to validate tool-call labeling in dialogues, including explicit and missing tool-call IDs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->