### PR TITLE
feat(storage): generalize row-retention to many tables via RetentionMixin

### DIFF
--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -42,6 +42,10 @@ from reflexio.server.services.reflection.reflection_service import ReflectionSer
 from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionServiceRequest,
 )
+from reflexio.server.services.storage.retention import (
+    delete_count_for_retention,
+    get_row_retention_limits,
+)
 from reflexio.server.usage_metrics import record_usage_event
 
 if TYPE_CHECKING:
@@ -139,8 +143,8 @@ class GenerationService:
             logger.error("Received None user_id in publish_user_interaction_request")
             return result
 
-        # Check if cleanup is needed before adding new interactions
-        self._cleanup_old_interactions_if_needed()
+        # Check if cleanup is needed before adding new interactions.
+        self._cleanup_storage_tables_if_needed()
 
         publish_start = time.perf_counter()
         # Resolve agent_version: explicit > env var > default. Resolved here
@@ -431,49 +435,60 @@ class GenerationService:
                 type(exc).__name__,
             )
 
-    def _cleanup_old_interactions_if_needed(self) -> None:
-        """
-        Check total interaction count and cleanup oldest interactions if threshold exceeded.
-        Uses OperationStateManager simple lock to prevent race conditions.
-        """
-        from reflexio.server import (
-            INTERACTION_CLEANUP_DELETE_COUNT,
-            INTERACTION_CLEANUP_THRESHOLD,
-        )
-
-        if INTERACTION_CLEANUP_THRESHOLD <= 0:
-            return  # Cleanup disabled
+    def _cleanup_storage_tables_if_needed(self) -> None:
+        """Best-effort publish-boundary cleanup for capped storage tables."""
+        limits = {
+            target_name: limit
+            for target_name, limit in get_row_retention_limits().items()
+            if limit > 0
+        }
+        if not limits:
+            return
 
         try:
-            total_count = self.storage.count_all_interactions()  # type: ignore[reportOptionalMemberAccess]
-            if total_count < INTERACTION_CLEANUP_THRESHOLD:
-                return  # No cleanup needed
-
             mgr = OperationStateManager(
                 self.storage,  # type: ignore[reportArgumentType]
                 self.org_id,
-                "interaction_cleanup",  # type: ignore[reportArgumentType]
+                "storage_table_cleanup",  # type: ignore[reportArgumentType]
             )
             if not mgr.acquire_simple_lock(stale_seconds=CLEANUP_STALE_LOCK_SECONDS):
                 return
 
             try:
-                # Perform cleanup
-                deleted = self.storage.delete_oldest_interactions(  # type: ignore[reportOptionalMemberAccess]
-                    INTERACTION_CLEANUP_DELETE_COUNT
-                )
-                logger.info(
-                    "Cleaned up %d oldest interactions (total was %d, threshold %d)",
-                    deleted,
-                    total_count,
-                    INTERACTION_CLEANUP_THRESHOLD,
-                )
+                for target_name, limit in limits.items():
+                    # Isolate per-target failures so one bad table does not
+                    # short-circuit cleanup for every subsequent target.
+                    try:
+                        self._cleanup_retention_target(target_name, limit)
+                    except Exception as e:  # noqa: BLE001
+                        logger.error(
+                            "Failed to cleanup retention target %s: %s",
+                            target_name,
+                            e,
+                        )
             finally:
                 mgr.release_simple_lock()
 
         except Exception as e:
-            logger.error("Failed to cleanup old interactions: %s", e)
+            logger.error("Failed to cleanup storage tables: %s", e)
             # Don't raise - cleanup failure shouldn't block normal operation
+
+    def _cleanup_retention_target(self, target_name: str, limit: int) -> None:
+        total_count = self.storage.count_retention_target_rows(target_name)  # type: ignore[reportOptionalMemberAccess]
+        if total_count < limit:
+            return
+        delete_count = delete_count_for_retention(total_count)
+        deleted = self.storage.delete_oldest_retention_target_rows(  # type: ignore[reportOptionalMemberAccess]
+            target_name,
+            delete_count,
+        )
+        logger.info(
+            "Cleaned up %d oldest %s row(s) (total was %d, limit %d)",
+            deleted,
+            target_name,
+            total_count,
+            limit,
+        )
 
     # ===============================
     # static methods

--- a/reflexio/server/services/storage/disk_storage/_base.py
+++ b/reflexio/server/services/storage/disk_storage/_base.py
@@ -11,17 +11,29 @@ import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TypeVar, cast
+from typing import Any, TypeVar, cast
 
+import yaml
 from pydantic import BaseModel
 
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
+    AgentSuccessEvaluationResult,
+    Interaction,
+    PlaybookAggregationChangeLog,
+    PlaybookOptimizationCandidate,
+    PlaybookOptimizationEvaluation,
+    PlaybookOptimizationEvent,
+    PlaybookOptimizationJob,
+    ProfileChangeLog,
+    Request,
     UserPlaybook,
+    UserProfile,
 )
 from reflexio.models.config_schema import StorageConfigDisk
 from reflexio.server import LOCAL_STORAGE_PATH
 from reflexio.server.services.storage.error import StorageError
+from reflexio.server.services.storage.retention import RETENTION_TARGETS_BY_NAME
 from reflexio.server.services.storage.storage_base import BaseStorage
 
 from ._file_io import (
@@ -190,7 +202,15 @@ class DiskStorageBase(BaseStorage):
             raise StorageError(f"Unsupported file format: {path.suffix}")
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".tmp")
-        tmp.write_text(serializer(model), encoding="utf-8")
+        text = serializer(model)
+        if isinstance(model, UserProfile):
+            created_at = self._entity_metadata_value(path, "created_at")
+            if created_at is None:
+                created_at = int(datetime.now(UTC).timestamp())
+            text = self._with_entity_metadata(
+                text, path.suffix, {"created_at": created_at}
+            )
+        tmp.write_text(text, encoding="utf-8")
         tmp.rename(path)
 
     def _read_entity(self, path: Path, model_class: type[T]) -> T:
@@ -214,7 +234,7 @@ class DiskStorageBase(BaseStorage):
         if "embedding" in model_class.model_fields and (
             embedding := self._read_embedding(path)
         ):
-            entity.embedding = embedding
+            cast(Any, entity).embedding = embedding
         return entity  # type: ignore[return-value]
 
     def _list_entities(self, directory: Path, model_class: type[T]) -> list[T]:
@@ -298,6 +318,62 @@ class DiskStorageBase(BaseStorage):
         tmp = path.with_suffix(".tmp")
         tmp.write_text(json.dumps(data_dict, indent=2, default=str))
         tmp.rename(path)
+
+    def _entity_metadata_value(self, path: Path, key: str) -> Any | None:
+        """Read a metadata value directly from an entity file."""
+        if not path.exists():
+            return None
+        try:
+            if path.suffix == ".json":
+                data = json.loads(path.read_text(encoding="utf-8") or "{}")
+                return data.get(key) if isinstance(data, dict) else None
+            if path.suffix != ".md":
+                return None
+            frontmatter, _body = self._split_markdown_frontmatter(
+                path.read_text(encoding="utf-8")
+            )
+            return frontmatter.get(key)
+        except (OSError, json.JSONDecodeError, ValueError, yaml.YAMLError):
+            return None
+
+    def _with_entity_metadata(
+        self, text: str, suffix: str, metadata: dict[str, Any]
+    ) -> str:
+        """Return serialized entity text with extra metadata preserved."""
+        if suffix == ".json":
+            data = json.loads(text or "{}")
+            if isinstance(data, dict):
+                data.update(metadata)
+                return json.dumps(data, indent=2, default=str)
+            return text
+        if suffix != ".md":
+            return text
+        frontmatter, body = self._split_markdown_frontmatter(text)
+        frontmatter.update(metadata)
+        yaml_text = yaml.dump(
+            frontmatter,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+            width=120,
+        ).rstrip("\n")
+        return f"---\n{yaml_text}\n---{body}"
+
+    @staticmethod
+    def _split_markdown_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+        if not text.startswith("---"):
+            return {}, text
+        close_idx = text.find("\n---\n", 3)
+        if close_idx == -1:
+            if not text.endswith("\n---"):
+                return {}, text
+            close_idx = len(text) - 4
+            body = ""
+        else:
+            body = text[close_idx + 4 :]
+        yaml_text = text[3 : close_idx + 1]
+        data = yaml.safe_load(yaml_text) or {}
+        return data if isinstance(data, dict) else {}, body
 
     # ------------------------------------------------------------------
     # Embedding sidecar I/O
@@ -395,6 +471,286 @@ class DiskStorageBase(BaseStorage):
     def _current_timestamp(self) -> str:
         """Return a timezone-aware ISO timestamp."""
         return datetime.now(UTC).isoformat()
+
+    def count_retention_target_rows(self, target_name: str) -> int:
+        if target_name == "agent_playbook_source_user_playbooks":
+            with self._lock:
+                return len(self._source_map_rows())
+        spec = self._disk_retention_spec(target_name)
+        if spec is None:
+            return 0
+        directory, _model, recursive = spec
+        with self._lock:
+            return len(self._scan_entities(directory, recursive=recursive))
+
+    def delete_oldest_retention_target_rows(self, target_name: str, count: int) -> int:
+        if count <= 0:
+            return 0
+        if target_name == "agent_playbook_source_user_playbooks":
+            return self._delete_oldest_source_map_files(count)
+        spec = self._disk_retention_spec(target_name)
+        if spec is None:
+            return 0
+        directory, model, recursive = spec
+        target = RETENTION_TARGETS_BY_NAME[target_name]
+
+        with self._lock:
+            entries: list[tuple[Any, Path, Any]] = []
+            for path in self._scan_entities(directory, recursive=recursive):
+                entity = self._read_entity(path, model)
+                entries.append(
+                    (
+                        self._disk_retention_order_value(
+                            target_name, target.order_column, path, entity
+                        ),
+                        path,
+                        entity,
+                    )
+                )
+            entries.sort(key=lambda item: (item[0], item[1].name))
+            selected = entries[:count]
+            if not selected:
+                return 0
+            self._delete_disk_retention_dependencies(target_name, selected)
+            for _order, path, _entity in selected:
+                if path.exists():
+                    self._delete_embedding(path)
+                    path.unlink()
+        self._trigger_qmd_update()
+        return len(selected)
+
+    def _disk_retention_spec(
+        self, target_name: str
+    ) -> tuple[Path, type[BaseModel], bool] | None:
+        specs: dict[str, tuple[Path, type[BaseModel], bool]] = {
+            "profiles": (self._profiles_dir(), UserProfile, True),
+            "interactions": (self._interactions_dir(), Interaction, True),
+            "requests": (self._requests_dir(), Request, False),
+            "user_playbooks": (self._user_playbooks_dir(), UserPlaybook, False),
+            "agent_playbooks": (self._agent_playbooks_dir(), AgentPlaybook, False),
+            "agent_success_evaluation_result": (
+                self._evaluations_dir(),
+                AgentSuccessEvaluationResult,
+                False,
+            ),
+            "profile_change_logs": (
+                self._profile_change_logs_dir(),
+                ProfileChangeLog,
+                False,
+            ),
+            "playbook_aggregation_change_logs": (
+                self._playbook_agg_change_logs_dir(),
+                PlaybookAggregationChangeLog,
+                False,
+            ),
+            "playbook_optimization_jobs": (
+                self._playbook_opt_jobs_dir(),
+                PlaybookOptimizationJob,
+                False,
+            ),
+            "playbook_optimization_candidates": (
+                self._playbook_opt_candidates_dir(),
+                PlaybookOptimizationCandidate,
+                False,
+            ),
+            "playbook_optimization_evaluations": (
+                self._playbook_opt_evaluations_dir(),
+                PlaybookOptimizationEvaluation,
+                False,
+            ),
+            "playbook_optimization_events": (
+                self._playbook_opt_events_dir(),
+                PlaybookOptimizationEvent,
+                False,
+            ),
+        }
+        if target_name not in RETENTION_TARGETS_BY_NAME:
+            raise ValueError(f"Unknown retention target: {target_name}")
+        return specs.get(target_name)
+
+    def _disk_retention_order_value(
+        self,
+        target_name: str,
+        order_column: str,
+        path: Path,
+        entity: BaseModel,
+    ) -> float:
+        value = (
+            self._entity_metadata_value(path, order_column)
+            if target_name == "profiles"
+            else getattr(entity, order_column, None)
+        )
+        if value is None:
+            return path.stat().st_mtime
+        return self._normalize_retention_order_value(value)
+
+    @staticmethod
+    def _normalize_retention_order_value(value: Any) -> float:
+        if isinstance(value, int | float):
+            return float(value)
+        if isinstance(value, datetime):
+            return value.timestamp()
+        if isinstance(value, str):
+            try:
+                return float(value)
+            except ValueError:
+                pass
+            try:
+                return datetime.fromisoformat(value).timestamp()
+            except ValueError:
+                return 0.0
+        return 0.0
+
+    def _delete_disk_retention_dependencies(
+        self, target_name: str, entries: list[tuple[Any, Path, Any]]
+    ) -> None:
+        entities = [entity for _order, _path, entity in entries]
+        if target_name == "requests":
+            request_ids = {entity.request_id for entity in entities}
+            self._delete_interactions_for_request_ids(request_ids)
+        elif target_name == "user_playbooks":
+            user_playbook_ids = {int(entity.user_playbook_id) for entity in entities}
+            self._delete_source_windows_for_user_playbook_ids(user_playbook_ids)
+        elif target_name == "agent_playbooks":
+            agent_playbook_ids = {int(entity.agent_playbook_id) for entity in entities}
+            self._delete_source_map_files(agent_playbook_ids)
+        elif target_name == "playbook_optimization_jobs":
+            job_ids = {int(entity.job_id) for entity in entities}
+            self._delete_optimizer_files_for_job_ids(job_ids)
+        elif target_name == "playbook_optimization_candidates":
+            candidate_ids = {int(entity.candidate_id) for entity in entities}
+            self._delete_optimizer_evaluation_files_for_candidate_ids(candidate_ids)
+
+    def _delete_interactions_for_request_ids(self, request_ids: set[str]) -> None:
+        if not request_ids:
+            return
+        for path in self._scan_entities(self._interactions_dir(), recursive=True):
+            interaction = self._read_entity(path, Interaction)
+            if interaction.request_id in request_ids:
+                self._delete_embedding(path)
+                path.unlink()
+
+    def _delete_source_map_files(self, agent_playbook_ids: set[int]) -> None:
+        for agent_playbook_id in agent_playbook_ids:
+            path = self._entity_path(
+                self._agent_playbook_source_map_dir(), str(agent_playbook_id)
+            )
+            if path.exists():
+                path.unlink()
+
+    def _delete_source_windows_for_user_playbook_ids(
+        self, user_playbook_ids: set[int]
+    ) -> None:
+        if not user_playbook_ids:
+            return
+        for path in self._scan_entities(self._agent_playbook_source_map_dir()):
+            windows = self._read_source_windows_data(path)
+            filtered = [
+                item
+                for item in windows
+                if int(item.get("user_playbook_id", 0)) not in user_playbook_ids
+            ]
+            if filtered:
+                self._write_dict(path, {"source_windows": filtered})
+            else:
+                path.unlink()
+
+    def _delete_optimizer_files_for_job_ids(self, job_ids: set[int]) -> None:
+        if not job_ids:
+            return
+        for directory, model in (
+            (self._playbook_opt_evaluations_dir(), PlaybookOptimizationEvaluation),
+            (self._playbook_opt_events_dir(), PlaybookOptimizationEvent),
+            (self._playbook_opt_candidates_dir(), PlaybookOptimizationCandidate),
+        ):
+            for path in self._scan_entities(directory):
+                entity = self._read_entity(path, model)
+                if int(entity.job_id) in job_ids:
+                    path.unlink()
+
+    def _delete_optimizer_evaluation_files_for_candidate_ids(
+        self, candidate_ids: set[int]
+    ) -> None:
+        if not candidate_ids:
+            return
+        for path in self._scan_entities(self._playbook_opt_evaluations_dir()):
+            entity = self._read_entity(path, PlaybookOptimizationEvaluation)
+            if int(entity.candidate_id) in candidate_ids:
+                path.unlink()
+
+    def _delete_oldest_source_map_files(self, count: int) -> int:
+        return self._delete_oldest_source_map_rows(count)
+
+    def _source_map_rows(self) -> list[tuple[float, int, int, Path, dict[str, Any]]]:
+        rows: list[tuple[float, int, int, Path, dict[str, Any]]] = []
+        for path in self._scan_entities(self._agent_playbook_source_map_dir()):
+            try:
+                agent_playbook_id = int(path.stem)
+            except ValueError:
+                continue
+            fallback_created_at = path.stat().st_mtime
+            for window in self._read_source_windows_data(path):
+                user_playbook_id = int(window.get("user_playbook_id", 0))
+                created_at = self._normalize_retention_order_value(
+                    window.get("created_at", fallback_created_at)
+                )
+                rows.append(
+                    (created_at, agent_playbook_id, user_playbook_id, path, window)
+                )
+        return rows
+
+    def _read_source_windows_data(self, path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        try:
+            data = json.loads(path.read_text(encoding="utf-8") or "{}")
+        except json.JSONDecodeError:
+            return []
+        if isinstance(data, list):
+            return [
+                {
+                    "user_playbook_id": int(user_playbook_id),
+                    "source_interaction_ids": [],
+                    "created_at": path.stat().st_mtime,
+                }
+                for user_playbook_id in data
+            ]
+        if not isinstance(data, dict):
+            return []
+        windows = data.get("source_windows")
+        if isinstance(windows, list):
+            return [item for item in windows if isinstance(item, dict)]
+        user_playbook_ids = data.get("user_playbook_ids")
+        if isinstance(user_playbook_ids, list):
+            return [
+                {
+                    "user_playbook_id": int(user_playbook_id),
+                    "source_interaction_ids": [],
+                    "created_at": path.stat().st_mtime,
+                }
+                for user_playbook_id in user_playbook_ids
+            ]
+        return []
+
+    def _delete_oldest_source_map_rows(self, count: int) -> int:
+        with self._lock:
+            selected = self._source_map_rows()[:]
+            selected.sort(key=lambda row: (row[0], row[1], row[2]))
+            selected = selected[:count]
+            by_path: dict[Path, set[int]] = {}
+            for _created_at, _agent_id, user_playbook_id, path, _window in selected:
+                by_path.setdefault(path, set()).add(user_playbook_id)
+            for path, user_playbook_ids in by_path.items():
+                remaining = [
+                    window
+                    for window in self._read_source_windows_data(path)
+                    if int(window.get("user_playbook_id", 0)) not in user_playbook_ids
+                ]
+                if remaining:
+                    self._write_dict(path, {"source_windows": remaining})
+                elif path.exists():
+                    path.unlink()
+        return len(selected)
 
     # Directory accessors
     def _profiles_dir(self) -> Path:

--- a/reflexio/server/services/storage/disk_storage/_playbook.py
+++ b/reflexio/server/services/storage/disk_storage/_playbook.py
@@ -823,6 +823,15 @@ class PlaybookMixin:
         agent_playbook_id: int,
         source_windows: list[AgentPlaybookSourceWindow],
     ) -> None:
+        path = self._entity_path(
+            self._agent_playbook_source_map_dir(), str(agent_playbook_id)
+        )
+        existing_created_at = {
+            int(item["user_playbook_id"]): item.get("created_at")
+            for item in self._read_source_windows_data(path)
+            if item.get("user_playbook_id") is not None
+        }
+        now = int(time.time())
         by_id: dict[int, list[int]] = {}
         for window in source_windows:
             ids = by_id.setdefault(window.user_playbook_id, [])
@@ -831,9 +840,6 @@ class PlaybookMixin:
                 if source_id not in seen:
                     ids.append(source_id)
                     seen.add(source_id)
-        path = self._entity_path(
-            self._agent_playbook_source_map_dir(), str(agent_playbook_id)
-        )
         # Route through `_write_dict` so the write is atomic (tmp +
         # rename). Concurrent updates from multiple workers for the
         # same agent_playbook_id can otherwise race last-writer-wins
@@ -845,6 +851,7 @@ class PlaybookMixin:
                     {
                         "user_playbook_id": upid,
                         "source_interaction_ids": source_interaction_ids,
+                        "created_at": existing_created_at.get(upid, now),
                     }
                     for upid, source_interaction_ids in by_id.items()
                 ]

--- a/reflexio/server/services/storage/retention.py
+++ b/reflexio/server/services/storage/retention.py
@@ -1,0 +1,152 @@
+"""Shared row-retention policy for storage backends."""
+
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+
+DEFAULT_ROW_RETENTION_LIMIT = 250_000
+ROW_RETENTION_DELETE_FRACTION = 0.20
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionTarget:
+    """A physical storage target eligible for row-count retention."""
+
+    name: str
+    table_name: str
+    order_column: str
+    id_columns: tuple[str, ...]
+
+
+RETENTION_TARGETS: tuple[RetentionTarget, ...] = (
+    RetentionTarget("profiles", "profiles", "created_at", ("profile_id",)),
+    RetentionTarget("interactions", "interactions", "created_at", ("interaction_id",)),
+    RetentionTarget("requests", "requests", "created_at", ("request_id",)),
+    RetentionTarget(
+        "user_playbooks", "user_playbooks", "created_at", ("user_playbook_id",)
+    ),
+    RetentionTarget(
+        "agent_playbooks", "agent_playbooks", "created_at", ("agent_playbook_id",)
+    ),
+    RetentionTarget(
+        "agent_success_evaluation_result",
+        "agent_success_evaluation_result",
+        "created_at",
+        ("result_id",),
+    ),
+    RetentionTarget("profile_change_logs", "profile_change_logs", "created_at", ("id",)),
+    RetentionTarget(
+        "playbook_aggregation_change_logs",
+        "playbook_aggregation_change_logs",
+        "created_at",
+        ("id",),
+    ),
+    RetentionTarget("share_links", "share_links", "created_at", ("id",)),
+    RetentionTarget(
+        "agent_playbook_source_user_playbooks",
+        "agent_playbook_source_user_playbooks",
+        "created_at",
+        ("agent_playbook_id", "user_playbook_id"),
+    ),
+    RetentionTarget(
+        "playbook_optimization_jobs",
+        "playbook_optimization_jobs",
+        "created_at",
+        ("job_id",),
+    ),
+    RetentionTarget(
+        "playbook_optimization_candidates",
+        "playbook_optimization_candidates",
+        "created_at",
+        ("candidate_id",),
+    ),
+    RetentionTarget(
+        "playbook_optimization_evaluations",
+        "playbook_optimization_evaluations",
+        "created_at",
+        ("evaluation_id",),
+    ),
+    RetentionTarget(
+        "playbook_optimization_events",
+        "playbook_optimization_events",
+        "created_at",
+        ("event_id",),
+    ),
+    RetentionTarget("skills", "skills", "created_at", ("skill_id",)),
+)
+
+RETENTION_TARGETS_BY_NAME = {target.name: target for target in RETENTION_TARGETS}
+
+
+@dataclass(frozen=True, slots=True)
+class CascadeRef:
+    """A dependent table that must be cleaned when a retention target's rows
+    are deleted.
+
+    Attributes:
+        table_name (str): Table whose rows depend on the retention target.
+        fk_column (str): Column in ``table_name`` holding the parent target's
+            primary key. Always references the first column of the parent
+            target's ``id_columns`` (single-key parents only).
+    """
+
+    table_name: str
+    fk_column: str
+
+
+# Maps a retention target → its dependent tables that must be deleted first
+# when retention removes rows. Keep in sync with the storage backends that
+# rely on it (Postgres, Supabase, and the SQLite/Disk bespoke implementations).
+RETENTION_CASCADES: dict[str, tuple[CascadeRef, ...]] = {
+    "requests": (CascadeRef("interactions", "request_id"),),
+    "user_playbooks": (
+        CascadeRef("agent_playbook_source_user_playbooks", "user_playbook_id"),
+    ),
+    "agent_playbooks": (
+        CascadeRef("agent_playbook_source_user_playbooks", "agent_playbook_id"),
+    ),
+    "playbook_optimization_jobs": (
+        CascadeRef("playbook_optimization_evaluations", "job_id"),
+        CascadeRef("playbook_optimization_events", "job_id"),
+        CascadeRef("playbook_optimization_candidates", "job_id"),
+    ),
+    "playbook_optimization_candidates": (
+        CascadeRef("playbook_optimization_evaluations", "candidate_id"),
+    ),
+}
+
+
+def get_row_retention_limits() -> dict[str, int]:
+    """Return per-target row limits from env with code defaults.
+
+    ``REFLEXIO_ROW_LIMIT_<TARGET>`` takes precedence for every target.
+    ``INTERACTION_CLEANUP_THRESHOLD`` remains the legacy override for
+    interactions when the new variable is not present.
+    """
+    limits: dict[str, int] = {}
+    for target in RETENTION_TARGETS:
+        env_name = f"REFLEXIO_ROW_LIMIT_{target.name.upper()}"
+        default = DEFAULT_ROW_RETENTION_LIMIT
+        if target.name == "interactions":
+            default = _get_int_env("INTERACTION_CLEANUP_THRESHOLD", default)
+        limits[target.name] = _get_int_env(env_name, default)
+    return limits
+
+
+def delete_count_for_retention(current_count: int) -> int:
+    """Return how many rows to delete when a target exceeds its limit."""
+    if current_count <= 0:
+        return 0
+    return max(1, math.ceil(current_count * ROW_RETENTION_DELETE_FRACTION))
+
+
+def _get_int_env(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default

--- a/reflexio/server/services/storage/retention_mixin.py
+++ b/reflexio/server/services/storage/retention_mixin.py
@@ -1,0 +1,160 @@
+"""Shared scaffolding for SQL-backed row-retention cleanup.
+
+Concrete SQL backends (SQLite, Postgres, Supabase) mix in
+``RetentionMixin`` and implement a small set of hooks. The public surface
+``count_retention_target_rows`` / ``delete_oldest_retention_target_rows``
+lives here so the dispatch — limit lookup, key selection, cascade,
+delete — cannot drift across the three backends.
+
+Disk storage has a fundamentally different (file-based) implementation
+and does not use this mixin.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterator, Sequence
+from typing import Any
+
+from reflexio.server.services.storage.retention import (
+    RETENTION_TARGETS_BY_NAME,
+    RetentionTarget,
+)
+
+# Conservative chunk size for IN-list deletes. Picked to stay well under:
+#   - SQLite's SQLITE_MAX_VARIABLE_NUMBER (999 on builds before 3.32; 32766 after).
+#   - PostgREST URL length limits (gateway caps are commonly 8-16 KB).
+RETENTION_DELETE_CHUNK = 500
+
+
+def chunked(
+    values: Sequence[Any], chunk_size: int = RETENTION_DELETE_CHUNK
+) -> Iterator[list[Any]]:
+    """Yield consecutive ``chunk_size`` slices of ``values`` as lists.
+
+    Args:
+        values (Sequence[Any]): Items to split.
+        chunk_size (int): Maximum number of items per chunk.
+
+    Yields:
+        list[Any]: Successive non-empty chunks.
+    """
+    for start in range(0, len(values), chunk_size):
+        yield list(values[start : start + chunk_size])
+
+
+def get_retention_target(target_name: str) -> RetentionTarget:
+    """Resolve a retention target by name.
+
+    Args:
+        target_name (str): Registered name (e.g. ``"interactions"``).
+
+    Returns:
+        RetentionTarget: The matching target.
+
+    Raises:
+        ValueError: If ``target_name`` is not registered.
+    """
+    try:
+        return RETENTION_TARGETS_BY_NAME[target_name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown retention target: {target_name}") from exc
+
+
+class RetentionMixin(ABC):
+    """Backend-agnostic orchestration of row-retention cleanup.
+
+    SQL backends mix this in and implement the abstract hooks. The public
+    methods are intentionally defined once here so that the count/select/
+    cascade/delete ordering is identical across all three backends.
+    """
+
+    def count_retention_target_rows(self, target_name: str) -> int:
+        """Return the current row count for a retention target.
+
+        Args:
+            target_name (str): Registered retention target name.
+
+        Returns:
+            int: Row count, or 0 if the underlying table is missing.
+        """
+        target = get_retention_target(target_name)
+        if not self._retention_table_exists(target.table_name):
+            return 0
+        return self._retention_count_rows(target)
+
+    def delete_oldest_retention_target_rows(
+        self, target_name: str, count: int
+    ) -> int:
+        """Delete up to ``count`` oldest rows for a retention target.
+
+        Calls the dependency-cascade hook before the target-row delete so
+        backends with foreign-key constraints stay consistent.
+
+        Args:
+            target_name (str): Registered retention target name.
+            count (int): Maximum number of rows to delete.
+
+        Returns:
+            int: Number of rows actually selected for deletion.
+        """
+        if count <= 0:
+            return 0
+        target = get_retention_target(target_name)
+        if not self._retention_table_exists(target.table_name):
+            return 0
+        keys = self._retention_select_oldest_keys(target, count)
+        if not keys:
+            return 0
+        self._retention_perform_delete(target, keys)
+        return len(keys)
+
+    def _retention_perform_delete(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        """Run dependency cleanup then target-row delete.
+
+        Default implementation runs the hooks in sequence. Backends that
+        need both steps inside one transaction (notably SQLite) should
+        override this method.
+        """
+        self._retention_delete_dependencies(target, keys)
+        self._retention_delete_target_rows(target, keys)
+
+    # -- Backend hooks --
+
+    @abstractmethod
+    def _retention_table_exists(self, table_name: str) -> bool:
+        """Return whether ``table_name`` exists in the backing store."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _retention_count_rows(self, target: RetentionTarget) -> int:
+        """Return the live row count for ``target``'s table."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _retention_select_oldest_keys(
+        self, target: RetentionTarget, count: int
+    ) -> list[tuple[Any, ...]]:
+        """Return up to ``count`` oldest key tuples for ``target``.
+
+        Each key tuple contains values aligned with ``target.id_columns``.
+        Ordering is by ``target.order_column`` ascending with the id
+        columns as a stable tiebreaker.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def _retention_delete_dependencies(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        """Remove rows in tables that depend on ``target`` for ``keys``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _retention_delete_target_rows(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        """Remove the rows for ``keys`` from ``target``'s table."""
+        raise NotImplementedError

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -48,6 +48,12 @@ from reflexio.models.config_schema import (
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.services.storage.error import StorageError
+from reflexio.server.services.storage.retention import RetentionTarget
+from reflexio.server.services.storage.retention_mixin import (
+    RETENTION_DELETE_CHUNK,
+    RetentionMixin,
+    chunked,
+)
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.site_var.site_var_manager import SiteVarManager
 from ._stall_state import init_stall_state_table
@@ -516,7 +522,7 @@ def _row_to_playbook_aggregation_change_log(
 # ---------------------------------------------------------------------------
 
 
-class SQLiteStorageBase(BaseStorage):
+class SQLiteStorageBase(RetentionMixin, BaseStorage):
     """SQLite-backed storage base class for local/self-hosted deployments."""
 
     @staticmethod
@@ -618,6 +624,197 @@ class SQLiteStorageBase(BaseStorage):
         self._migrate_agent_playbook_source_windows()
         init_stall_state_table(self.conn)
         return True
+
+    # -- Retention hooks (see RetentionMixin) --
+
+    @handle_exceptions
+    def _retention_table_exists(self, table_name: str) -> bool:
+        row = self._fetchone(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        )
+        return row is not None
+
+    @handle_exceptions
+    def _retention_count_rows(self, target: RetentionTarget) -> int:
+        row = self._fetchone(f"SELECT COUNT(*) as cnt FROM {target.table_name}")  # noqa: S608
+        return int(row["cnt"]) if row else 0
+
+    @handle_exceptions
+    def _retention_select_oldest_keys(
+        self, target: RetentionTarget, count: int
+    ) -> list[tuple[Any, ...]]:
+        id_sql = ", ".join(target.id_columns)
+        tiebreak_sql = id_sql
+        rows = self._fetchall(
+            f"SELECT {id_sql} FROM {target.table_name} "  # noqa: S608
+            f"ORDER BY {target.order_column} ASC, {tiebreak_sql} ASC LIMIT ?",
+            (count,),
+        )
+        return [tuple(row[col] for col in target.id_columns) for row in rows]
+
+    @handle_exceptions
+    def _retention_perform_delete(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        # Wrap dependency + target deletes in a single critical section so
+        # concurrent writers see either both or neither.
+        with self._lock:
+            self._retention_delete_dependencies(target, keys)
+            self._retention_delete_target_rows(target, keys)
+            self.conn.commit()
+
+    def _retention_delete_dependencies(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        ids = [key[0] for key in keys]
+        target_name = target.name
+        if target_name == "requests":
+            self._delete_interactions_for_request_ids([str(v) for v in ids])
+        elif target_name == "interactions":
+            self._delete_interaction_search_rows([int(v) for v in ids])
+        elif target_name == "profiles":
+            self._delete_profile_search_rows([str(v) for v in ids])
+        elif target_name == "user_playbooks":
+            self._delete_source_windows_for_user_playbook_ids([int(v) for v in ids])
+            self._delete_playbook_search_rows("user", [int(v) for v in ids])
+        elif target_name == "agent_playbooks":
+            self._delete_source_windows_for_agent_playbook_ids([int(v) for v in ids])
+            self._delete_playbook_search_rows("agent", [int(v) for v in ids])
+        elif target_name == "playbook_optimization_jobs":
+            self._delete_optimizer_rows_for_job_ids([int(v) for v in ids])
+        elif target_name == "playbook_optimization_candidates":
+            self._delete_optimizer_evaluations_for_candidate_ids([int(v) for v in ids])
+
+    def _retention_delete_target_rows(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        if len(target.id_columns) == 1:
+            self._delete_in_chunks(
+                target.table_name,
+                target.id_columns[0],
+                [key[0] for key in keys],
+            )
+            return
+        # Composite-key delete: chunk by row to bound parameter count.
+        params_per_key = len(target.id_columns)
+        rows_per_chunk = max(1, RETENTION_DELETE_CHUNK // params_per_key)
+        for chunk in chunked(keys, rows_per_chunk):
+            where = " OR ".join(
+                "(" + " AND ".join(f"{column} = ?" for column in target.id_columns) + ")"
+                for _ in chunk
+            )
+            params = [value for key in chunk for value in key]
+            self.conn.execute(
+                f"DELETE FROM {target.table_name} WHERE {where}",  # noqa: S608
+                params,
+            )
+
+    # -- Chunked-delete primitives shared by the cascade helpers --
+
+    def _delete_in_chunks(
+        self, table_name: str, column_name: str, values: list[Any]
+    ) -> None:
+        """Chunked ``DELETE FROM table WHERE col IN (...)``.
+
+        Chunking keeps parameter count under ``SQLITE_MAX_VARIABLE_NUMBER``
+        on older sqlite builds (default 999) and avoids degenerate plans
+        on very large IN lists.
+        """
+        if not values:
+            return
+        for chunk in chunked(values):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"DELETE FROM {table_name} WHERE {column_name} IN ({placeholders})",  # noqa: S608
+                chunk,
+            )
+
+    def _select_in_chunks(
+        self, sql_template: str, values: list[Any]
+    ) -> list[Any]:
+        """Run ``sql_template`` (containing ``{placeholders}``) over chunks of
+        ``values`` and aggregate the result rows."""
+        results: list[Any] = []
+        for chunk in chunked(values):
+            placeholders = ",".join("?" for _ in chunk)
+            stmt = sql_template.format(placeholders=placeholders)
+            results.extend(self.conn.execute(stmt, chunk).fetchall())
+        return results
+
+    def _delete_interactions_for_request_ids(self, request_ids: list[str]) -> None:
+        if not request_ids:
+            return
+        rows = self._select_in_chunks(
+            "SELECT interaction_id FROM interactions WHERE request_id IN ({placeholders})",
+            request_ids,
+        )
+        self._delete_interaction_search_rows(
+            [int(row["interaction_id"]) for row in rows]
+        )
+        self._delete_in_chunks("interactions", "request_id", request_ids)
+
+    def _delete_interaction_search_rows(self, interaction_ids: list[int]) -> None:
+        if not interaction_ids:
+            return
+        self._delete_in_chunks("interactions_fts", "rowid", interaction_ids)
+        for interaction_id in interaction_ids:
+            self._vec_delete("interactions_vec", interaction_id)
+
+    def _delete_profile_search_rows(self, profile_ids: list[str]) -> None:
+        if not profile_ids:
+            return
+        rows = self._select_in_chunks(
+            "SELECT rowid, profile_id FROM profiles WHERE profile_id IN ({placeholders})",
+            profile_ids,
+        )
+        for row in rows:
+            self._fts_delete_profile(row["profile_id"])
+            self._vec_delete("profiles_vec", row["rowid"])
+
+    def _delete_playbook_search_rows(self, kind: str, ids: list[int]) -> None:
+        if not ids:
+            return
+        self._delete_in_chunks(f"{kind}_playbooks_fts", "rowid", ids)
+        for item_id in ids:
+            self._vec_delete(f"{kind}_playbooks_vec", item_id)
+
+    def _delete_source_windows_for_agent_playbook_ids(
+        self, agent_playbook_ids: list[int]
+    ) -> None:
+        self._delete_in_chunks(
+            "agent_playbook_source_user_playbooks",
+            "agent_playbook_id",
+            agent_playbook_ids,
+        )
+
+    def _delete_source_windows_for_user_playbook_ids(
+        self, user_playbook_ids: list[int]
+    ) -> None:
+        self._delete_in_chunks(
+            "agent_playbook_source_user_playbooks",
+            "user_playbook_id",
+            user_playbook_ids,
+        )
+
+    def _delete_optimizer_rows_for_job_ids(self, job_ids: list[int]) -> None:
+        if not job_ids:
+            return
+        for table in (
+            "playbook_optimization_evaluations",
+            "playbook_optimization_events",
+            "playbook_optimization_candidates",
+        ):
+            self._delete_in_chunks(table, "job_id", job_ids)
+
+    def _delete_optimizer_evaluations_for_candidate_ids(
+        self, candidate_ids: list[int]
+    ) -> None:
+        self._delete_in_chunks(
+            "playbook_optimization_evaluations",
+            "candidate_id",
+            candidate_ids,
+        )
 
     def _try_load_sqlite_vec(self) -> bool:
         """Attempt to load the sqlite-vec extension for native KNN search.

--- a/reflexio/server/services/storage/storage_base/_base.py
+++ b/reflexio/server/services/storage/storage_base/_base.py
@@ -60,3 +60,9 @@ class BaseStorageCore(ABC):  # noqa: B024
             bool: True if migration is needed, False otherwise
         """
         return False
+
+    # `count_retention_target_rows` and `delete_oldest_retention_target_rows`
+    # are provided by `RetentionMixin` for SQL backends and overridden in
+    # `DiskStorageBase` for file-based storage. They are intentionally not
+    # declared abstract here so that test doubles can subclass BaseStorage
+    # without implementing retention.

--- a/tests/server/services/storage/test_disk_storage_reflection_methods.py
+++ b/tests/server/services/storage/test_disk_storage_reflection_methods.py
@@ -8,6 +8,7 @@ be exercised without requiring the ``qmd`` CLI.
 
 from __future__ import annotations
 
+import json
 import tempfile
 from collections.abc import Generator
 from datetime import UTC, datetime
@@ -294,3 +295,101 @@ class TestDiskAgentPlaybookSourceWindows:
             AgentPlaybookSourceWindow(user_playbook_id=2, source_interaction_ids=[]),
             AgentPlaybookSourceWindow(user_playbook_id=3, source_interaction_ids=[]),
         ]
+
+
+class TestDiskRetention:
+    def test_profile_retention_uses_persisted_created_at(self, disk_storage):
+        disk_storage.add_user_profile(
+            "u1",
+            [
+                _make_profile("u1", "z-old", "old"),
+                _make_profile("u1", "m-mid", "mid"),
+                _make_profile("u1", "a-new", "new"),
+            ],
+        )
+        for profile_id, created_at in (
+            ("z-old", 1),
+            ("m-mid", 2),
+            ("a-new", 3),
+        ):
+            path = disk_storage._entity_path(  # noqa: SLF001
+                disk_storage._user_dir(  # noqa: SLF001
+                    disk_storage._profiles_dir(),  # noqa: SLF001
+                    "u1",
+                ),
+                profile_id,
+            )
+            path.write_text(
+                disk_storage._with_entity_metadata(  # noqa: SLF001
+                    path.read_text(encoding="utf-8"),
+                    path.suffix,
+                    {"created_at": created_at},
+                ),
+                encoding="utf-8",
+            )
+
+        deleted = disk_storage.delete_oldest_retention_target_rows("profiles", 2)
+
+        assert deleted == 2
+        remaining = disk_storage.get_all_profiles(limit=10)
+        assert {profile.profile_id for profile in remaining} == {"a-new"}
+
+    def test_source_map_retention_deletes_logical_rows(self, disk_storage):
+        disk_storage.set_source_windows_for_agent_playbook(
+            10,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=2, source_interaction_ids=[20]
+                ),
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=3, source_interaction_ids=[30]
+                ),
+            ],
+        )
+        disk_storage.set_source_windows_for_agent_playbook(
+            11,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=1, source_interaction_ids=[10]
+                )
+            ],
+        )
+        created_at_by_path = {
+            "10": {2: 1, 3: 3},
+            "11": {1: 2},
+        }
+        for agent_playbook_id, created_at_by_user_id in created_at_by_path.items():
+            path = disk_storage._entity_path(  # noqa: SLF001
+                disk_storage._agent_playbook_source_map_dir(),  # noqa: SLF001
+                agent_playbook_id,
+            )
+            data = json.loads(path.read_text(encoding="utf-8"))
+            for window in data["source_windows"]:
+                window["created_at"] = created_at_by_user_id[
+                    int(window["user_playbook_id"])
+                ]
+            path.write_text(json.dumps(data), encoding="utf-8")
+
+        assert (
+            disk_storage.count_retention_target_rows(
+                "agent_playbook_source_user_playbooks"
+            )
+            == 3
+        )
+
+        deleted = disk_storage.delete_oldest_retention_target_rows(
+            "agent_playbook_source_user_playbooks",
+            2,
+        )
+
+        assert deleted == 2
+        assert (
+            disk_storage.count_retention_target_rows(
+                "agent_playbook_source_user_playbooks"
+            )
+            == 1
+        )
+        assert disk_storage.get_source_windows_for_agent_playbook(10) == [
+            AgentPlaybookSourceWindow(user_playbook_id=3, source_interaction_ids=[30])
+        ]
+        assert disk_storage.get_source_windows_for_agent_playbook(11) == []

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -1,0 +1,101 @@
+"""Contract tests for generic row-retention storage methods."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    Interaction,
+    ProfileTimeToLive,
+    Request,
+    UserActionType,
+    UserProfile,
+)
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _make_request(request_id: str, created_at: int) -> Request:
+    return Request(
+        request_id=request_id,
+        user_id="u1",
+        created_at=created_at,
+        source="test",
+        agent_version="v1",
+    )
+
+
+def _make_interaction(interaction_id: int, request_id: str, created_at: int) -> Interaction:
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id="u1",
+        request_id=request_id,
+        content=f"interaction {interaction_id}",
+        created_at=created_at,
+        user_action=UserActionType.NONE,
+        user_action_description="",
+        interacted_image_url="",
+    )
+
+
+def _make_profile(profile_id: str) -> UserProfile:
+    return UserProfile(
+        user_id="u1",
+        profile_id=profile_id,
+        content=f"profile {profile_id}",
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        source="test",
+    )
+
+
+def test_retention_deletes_oldest_interactions(storage: BaseStorage) -> None:
+    now = int(datetime.now(UTC).timestamp())
+    for i in range(1, 6):
+        storage.add_user_interaction("u1", _make_interaction(i, f"req{i}", now + i))
+
+    assert storage.count_retention_target_rows("interactions") == 5
+
+    deleted = storage.delete_oldest_retention_target_rows("interactions", 2)
+
+    assert deleted == 2
+    remaining = storage.get_all_interactions(limit=10)
+    assert {interaction.interaction_id for interaction in remaining} == {3, 4, 5}
+
+
+def test_retention_deletes_oldest_profiles(storage: BaseStorage) -> None:
+    storage.add_user_profile("u1", [_make_profile("p1")])
+    storage.add_user_profile("u1", [_make_profile("p2")])
+    storage.add_user_profile("u1", [_make_profile("p3")])
+    conn = storage.conn  # type: ignore[attr-defined]
+    conn.execute("UPDATE profiles SET created_at = ? WHERE profile_id = ?", ("1", "p1"))
+    conn.execute("UPDATE profiles SET created_at = ? WHERE profile_id = ?", ("2", "p2"))
+    conn.execute("UPDATE profiles SET created_at = ? WHERE profile_id = ?", ("3", "p3"))
+    conn.commit()
+
+    deleted = storage.delete_oldest_retention_target_rows("profiles", 2)
+
+    assert deleted == 2
+    remaining = storage.get_all_profiles(limit=10, status_filter=[None])
+    assert {profile.profile_id for profile in remaining} == {"p3"}
+
+
+def test_retention_deletes_requests_before_orphaning_interactions(
+    storage: BaseStorage,
+) -> None:
+    now = int(datetime.now(UTC).timestamp())
+    for i in range(1, 4):
+        request_id = f"req{i}"
+        storage.add_request(_make_request(request_id, now + i))
+        storage.add_user_interaction("u1", _make_interaction(i, request_id, now + i))
+
+    deleted = storage.delete_oldest_retention_target_rows("requests", 2)
+
+    assert deleted == 2
+    assert storage.get_request("req1") is None
+    assert storage.get_request("req2") is None
+    assert storage.get_request("req3") is not None
+    remaining = storage.get_all_interactions(limit=10)
+    assert {interaction.request_id for interaction in remaining} == {"req3"}


### PR DESCRIPTION
## Summary
- Generalize per-table row-count retention into a reusable `RetentionMixin` shared by SQL backends (SQLite + the enterprise Postgres/Supabase implementations).
- Introduce `RetentionTarget` and `CascadeRef` configs covering profiles, interactions, requests, playbooks, evaluations, change logs, share links, optimization jobs/candidates/evaluations/events, and skills.
- Bespoke disk-storage implementation kept inline (file-based, no shared SQL ordering to enforce).
- Adds a parameterized contract test that runs against all backends.

## Behavior
- Each target's limit is configurable via `REFLEXIO_ROW_LIMIT_<TARGET>`; default `250_000`.
- Legacy `INTERACTION_CLEANUP_THRESHOLD` still honored as the interactions-specific override.
- On exceedance: delete `ceil(20% * current_count)` oldest rows in `RETENTION_DELETE_CHUNK`-sized IN-list chunks, with FK cascades applied first.

## Test plan
- [x] `tests/server/services/storage/test_storage_contract_retention.py` runs under all locally-testable backends.
- [x] Existing disk-storage reflection-method tests updated.
- [ ] Verify enterprise Postgres/Supabase implementations land alongside (see paired enterprise PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved data retention system with per-target deletion limits, configurable via environment variables
  * Enhanced reliability: retention cleanup failures are now isolated and logged without blocking operations
  * Creation timestamps are now preserved for stored entities, enabling smarter cleanup ordering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->