### PR TITLE
[codex] Fix Windows local service prerequisites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     # ``sentence-transformers`` transitively, but we depend on it directly
     # so the CrossEncoder/SentenceTransformer surface is guaranteed.
     "sentence-transformers>=3.0",
+    "einops>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/reflexio/cli/utils.py
+++ b/reflexio/cli/utils.py
@@ -10,6 +10,7 @@ import os
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections.abc import Callable
@@ -116,7 +117,7 @@ def get_pidfile_path(ports: dict[str, int]) -> Path:
     """Get a unique pidfile path based on the port combination."""
     port_str = json.dumps(ports, sort_keys=True)
     port_hash = hashlib.md5(port_str.encode()).hexdigest()[:8]  # noqa: S324
-    return Path(f"/tmp/reflexio_services_{port_hash}.json")  # noqa: S108
+    return Path(tempfile.gettempdir()) / f"reflexio_services_{port_hash}.json"
 
 
 def write_pidfile(pidfile: Path, service_pids: dict[str, int]) -> None:

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -46,7 +46,10 @@ from reflexio.models.config_schema import (
     SearchMode,
 )
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
-from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
+from reflexio.server.llm.model_defaults import (
+    ModelRole,
+    resolve_model_name,
+)
 from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.retention import RetentionTarget
 from reflexio.server.services.storage.retention_mixin import (
@@ -56,6 +59,7 @@ from reflexio.server.services.storage.retention_mixin import (
 )
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.site_var.site_var_manager import SiteVarManager
+
 from ._stall_state import init_stall_state_table
 
 logger = logging.getLogger(__name__)
@@ -701,7 +705,9 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         rows_per_chunk = max(1, RETENTION_DELETE_CHUNK // params_per_key)
         for chunk in chunked(keys, rows_per_chunk):
             where = " OR ".join(
-                "(" + " AND ".join(f"{column} = ?" for column in target.id_columns) + ")"
+                "("
+                + " AND ".join(f"{column} = ?" for column in target.id_columns)
+                + ")"
                 for _ in chunk
             )
             params = [value for key in chunk for value in key]
@@ -730,9 +736,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 chunk,
             )
 
-    def _select_in_chunks(
-        self, sql_template: str, values: list[Any]
-    ) -> list[Any]:
+    def _select_in_chunks(self, sql_template: str, values: list[Any]) -> list[Any]:
         """Run ``sql_template`` (containing ``{placeholders}``) over chunks of
         ``values`` and aggregate the result rows."""
         results: list[Any] = []

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -1,0 +1,16 @@
+"""Tests for service process utility helpers."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from reflexio.cli import utils
+
+
+def test_pidfile_path_uses_platform_temp_dir() -> None:
+    path = utils.get_pidfile_path({"backend": 8071})
+
+    assert path.parent == Path(tempfile.gettempdir())
+    assert str(path).startswith(tempfile.gettempdir())
+    assert path.name.startswith("reflexio_services_")

--- a/uv.lock
+++ b/uv.lock
@@ -1237,6 +1237,15 @@ wheels = [
 ]
 
 [[package]]
+name = "einops"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/77/850bef8d72ffb9219f0b1aac23fbc1bf7d038ee6ea666f331fa273031aa2/einops-0.8.2.tar.gz", hash = "sha256:609da665570e5e265e27283aab09e7f279ade90c4f01bcfca111f3d3e13f2827", size = 56261, upload-time = "2026-01-26T04:13:17.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/09/f8d8f8f31e4483c10a906437b4ce31bdf3d6d417b73fe33f1a8b59e34228/einops-0.8.2-py3-none-any.whl", hash = "sha256:54058201ac7087911181bfec4af6091bb59380360f069276601256a76af08193", size = 65638, upload-time = "2026-01-26T04:13:18.546Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5084,6 +5093,7 @@ dependencies = [
     { name = "chromadb" },
     { name = "colorlog" },
     { name = "duckduckgo-search" },
+    { name = "einops" },
     { name = "fastapi" },
     { name = "gepa" },
     { name = "hdbscan" },
@@ -5174,6 +5184,7 @@ requires-dist = [
     { name = "colorlog", specifier = ">=6.10.1" },
     { name = "datasets", marker = "extra == 'benchmark'", specifier = ">=4.8.4" },
     { name = "duckduckgo-search", specifier = ">=7.0.1" },
+    { name = "einops", specifier = ">=0.8.0" },
     { name = "fastapi", specifier = ">=0.111.1" },
     { name = "fire", marker = "extra == 'benchmark'", specifier = ">=0.7.1" },
     { name = "fpdf2", marker = "extra == 'benchmark'", specifier = ">=2.8.7" },


### PR DESCRIPTION
## Summary

- use the platform temp directory for Reflexio service PID files instead of hard-coded `/tmp`
- add the missing `einops` dependency required by the Nomic local embedding model
- keep SQLite embedding helper behavior explicit when embeddings are unavailable

## Why

claude-smart Codex installs should configure a real generation provider through the Codex compatibility wrapper. This PR does not add a capture-only fallback; if provider setup is broken, the install should fail visibly instead of silently storing turns without learning.

## Validation

- `uv run ruff format ...` on changed Python files
- `uv run ruff check ...` on changed Python files/tests
- `uv run pytest tests/server/services/test_generation_service.py tests/cli/test_utils.py tests/cli/test_services_first_run.py -q -o 'addopts='`
