### PR TITLE
[codex] Route local provider through active host CLI

### DIFF
--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 # Env var opting into the Claude Code CLI provider (registered in
 # reflexio.server.llm.providers.claude_code_provider). When set to "1"
-# *and* the `claude` binary is on PATH, the provider is auto-detected
+# *and* the active host CLI is available, the provider is auto-detected
 # with highest priority — reflexio will route extraction/evaluation
 # calls through the local CLI instead of requiring an API key.
 _CLAUDE_CODE_ENABLE_ENV = "CLAUDE_SMART_USE_LOCAL_CLI"
@@ -292,6 +292,13 @@ GENERATION_CAPABLE_PROVIDERS: frozenset[str] = frozenset(
 )
 
 
+def _local_cli_provider_hint() -> str:
+    return (
+        f"or set {_CLAUDE_CODE_ENABLE_ENV}=1 with the active host CLI "
+        "(claude for Claude Code, codex for Codex) available."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Model role enum and resolution
 # ---------------------------------------------------------------------------
@@ -334,8 +341,7 @@ def _auto_detect_model(
         raise RuntimeError(
             "No LLM provider available. Set at least one of: "
             + ", ".join(sorted(_ENV_TO_PROVIDER))
-            + f" in your .env file, or set {_CLAUDE_CODE_ENABLE_ENV}=1 "
-            "with the `claude` CLI on PATH to use the local Claude Code provider."
+            + f" in your .env file, {_local_cli_provider_hint()}"
         )
 
     if role == ModelRole.EMBEDDING:
@@ -428,8 +434,7 @@ def validate_llm_availability(
         raise RuntimeError(
             "No LLM provider available. Set at least one of: "
             + ", ".join(sorted(_ENV_TO_PROVIDER))
-            + f" in your .env file, or set {_CLAUDE_CODE_ENABLE_ENV}=1 "
-            "with the `claude` CLI on PATH to use the local Claude Code provider."
+            + f" in your .env file, {_local_cli_provider_hint()}"
         )
 
     logger.info("Auto-detected LLM providers (priority order): %s", providers)
@@ -449,9 +454,7 @@ def validate_llm_availability(
             "No generation-capable LLM provider available. Set at least "
             "one of: "
             + ", ".join(sorted(_ENV_TO_PROVIDER))
-            + f" in your .env file, or set {_CLAUDE_CODE_ENABLE_ENV}=1 "
-            "with the `claude` CLI on PATH to use the local Claude Code "
-            "provider."
+            + f" in your .env file, {_local_cli_provider_hint()}"
         )
     logger.info("Primary provider for generation: %s", generation_provider)
 

--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -24,7 +24,9 @@ import logging
 import os
 import shutil
 import subprocess  # noqa: S404 — subprocess is the integration point; inputs are sanitised.
+import tempfile
 import time
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -51,8 +53,13 @@ _LOGGER = logging.getLogger(__name__)
 PROVIDER_KEY = "claude-code"
 ENV_ENABLE = "CLAUDE_SMART_USE_LOCAL_CLI"
 _ENV_CLI_PATH = "CLAUDE_SMART_CLI_PATH"
+_ENV_HOST = "CLAUDE_SMART_HOST"
+_ENV_CODEX_PATH = "CLAUDE_SMART_CODEX_PATH"
 _ENV_TIMEOUT = "CLAUDE_SMART_CLI_TIMEOUT"
 _ENV_MODEL = "CLAUDE_SMART_CLI_MODEL"
+_HOST_CODEX = "codex"
+_HOST_CLAUDE_CODE = "claude-code"
+_CODEX_COMPAT_SCRIPT = "codex-claude-compat.py"
 _DEFAULT_TIMEOUT_SECONDS = 120
 _DEFAULT_CLI_MODEL = "claude-sonnet-4-6"
 
@@ -76,11 +83,35 @@ def _env_enabled() -> bool:
     return bool(raw) and raw.lower() in _TRUTHY_ENV_VALUES
 
 
+def _host() -> str:
+    """Return the host that owns this backend process."""
+    return _HOST_CODEX if os.environ.get(_ENV_HOST) == _HOST_CODEX else _HOST_CLAUDE_CODE
+
+
+def _cli_name() -> str:
+    """Return the expected local CLI binary for the active host."""
+    return "codex" if _host() == _HOST_CODEX else "claude"
+
+
+def _candidate_codex_compat_path() -> Path | None:
+    """Return the Codex compatibility wrapper from plugin roots, if present."""
+    for env_var in ("PLUGIN_ROOT", "CLAUDE_PLUGIN_ROOT"):
+        root = os.environ.get(env_var)
+        if not root:
+            continue
+        candidate = Path(root) / "scripts" / _CODEX_COMPAT_SCRIPT
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def _resolve_cli_path() -> str | None:
-    """Return the path to the ``claude`` CLI binary, or None if unavailable.
+    """Return the path to the active host CLI, or None if unavailable.
 
     Honours the ``CLAUDE_SMART_CLI_PATH`` override before falling back to
-    ``shutil.which("claude")``.
+    host-specific defaults. Claude Code uses ``claude``. Codex prefers the
+    compatibility wrapper shipped with the plugin, then falls back to
+    ``codex`` directly.
 
     Returns:
         str | None: Absolute path to the CLI, or None if not found.
@@ -95,19 +126,23 @@ def _resolve_cli_path() -> str | None:
             _ENV_CLI_PATH,
             override,
         )
+    if _host() == _HOST_CODEX:
+        compat = _candidate_codex_compat_path()
+        if compat is not None:
+            return str(compat)
+        return os.environ.get(_ENV_CODEX_PATH) or shutil.which("codex")
     return shutil.which("claude")
 
 
 def is_claude_code_available() -> bool:
-    """Return True when the claude-code provider is usable right now.
+    """Return True when the local CLI provider is usable right now.
 
     Both the opt-in env var *and* a resolvable CLI path are required, so
     an unrelated env var can't silently redirect extraction traffic.
 
     Returns:
         bool: True iff ``CLAUDE_SMART_USE_LOCAL_CLI`` is truthy AND a
-            ``claude`` binary is resolvable (via PATH or
-            ``CLAUDE_SMART_CLI_PATH``).
+            host CLI is resolvable.
     """
     return _env_enabled() and _resolve_cli_path() is not None
 
@@ -300,10 +335,10 @@ def _run_cli_stream(
     dialogue: str,
     timeout_seconds: int,
 ) -> ParseResult:
-    """Invoke ``claude -p --output-format stream-json`` and return a ParseResult.
+    """Invoke the active host CLI and return a ParseResult.
 
     Args:
-        cli_path (str): Path to the ``claude`` executable.
+        cli_path (str): Path to the host executable or compatibility wrapper.
         system_prompt (str): Combined system prompt to append (may be empty).
         dialogue (str): Flattened user/assistant dialogue sent on stdin.
         timeout_seconds (int): Subprocess timeout.
@@ -315,6 +350,29 @@ def _run_cli_stream(
     Raises:
         ClaudeCodeCLIError: On timeout or missing binary.
     """
+    if _host() == _HOST_CODEX and Path(cli_path).name != _CODEX_COMPAT_SCRIPT:
+        return _run_codex_stream(
+            codex_path=cli_path,
+            system_prompt=system_prompt,
+            dialogue=dialogue,
+            timeout_seconds=timeout_seconds,
+        )
+    return _run_claude_stream(
+        cli_path=cli_path,
+        system_prompt=system_prompt,
+        dialogue=dialogue,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _run_claude_stream(
+    *,
+    cli_path: str,
+    system_prompt: str,
+    dialogue: str,
+    timeout_seconds: int,
+) -> ParseResult:
+    """Invoke ``claude -p --output-format stream-json`` and return a ParseResult."""
     model = os.environ.get(_ENV_MODEL) or _DEFAULT_CLI_MODEL
     cmd = [
         cli_path,
@@ -361,6 +419,77 @@ def _run_cli_stream(
     return parse_stream_json(
         proc.stdout, exit_code=proc.returncode, stderr_text=proc.stderr
     )
+
+
+def _run_codex_stream(
+    *,
+    codex_path: str,
+    system_prompt: str,
+    dialogue: str,
+    timeout_seconds: int,
+) -> ParseResult:
+    """Invoke ``codex exec`` and shape its output like a terminal stream result."""
+    output_path = _temporary_output_path()
+    cmd = [
+        codex_path,
+        "exec",
+        "--sandbox",
+        "read-only",
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "--ignore-rules",
+        "--output-last-message",
+        str(output_path),
+        "-",
+    ]
+
+    env = os.environ.copy()
+    env[_ENV_HOST] = _HOST_CODEX
+    env["CLAUDE_SMART_INTERNAL"] = "1"
+
+    try:
+        proc = subprocess.run(  # noqa: S603 — cmd is constructed from validated parts.
+            cmd,
+            input=_codex_prompt(prompt=dialogue, system_prompt=system_prompt),
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+            env=env,
+        )
+        try:
+            terminal_text = output_path.read_text(encoding="utf-8").strip()
+        except OSError:
+            terminal_text = ""
+    except subprocess.TimeoutExpired as exc:
+        raise ClaudeCodeCLIError(
+            f"codex CLI timed out after {timeout_seconds}s"
+        ) from exc
+    except FileNotFoundError as exc:
+        raise ClaudeCodeCLIError(f"codex CLI not found at {codex_path}") from exc
+    finally:
+        with suppress(OSError):
+            output_path.unlink()
+
+    return ParseResult(
+        success=proc.returncode == 0 and bool(terminal_text),
+        terminal_text=terminal_text,
+        stderr_text=proc.stderr,
+        raw_lines_parsed=1 if terminal_text else 0,
+    )
+
+
+def _temporary_output_path() -> Path:
+    with tempfile.NamedTemporaryFile(
+        prefix="claude-smart-codex-", delete=False
+    ) as handle:
+        return Path(handle.name)
+
+
+def _codex_prompt(*, prompt: str, system_prompt: str) -> str:
+    if not system_prompt:
+        return prompt
+    return f"{system_prompt}\n\n## Task\n{prompt}"
 
 
 def _build_model_response(
@@ -484,8 +613,8 @@ class ClaudeCodeLLM(CustomLLM):
         path = self._explicit_cli_path or _resolve_cli_path()
         if not path:
             raise ClaudeCodeCLIError(
-                "claude CLI not found. Install Claude Code or set "
-                f"{_ENV_CLI_PATH} to its absolute path."
+                f"{_cli_name()} CLI not found for {_host()}. Install the host "
+                f"CLI or set {_ENV_CLI_PATH} to an executable path."
             )
         return path
 
@@ -647,9 +776,11 @@ def register_if_enabled(storage: Any | None = None) -> bool:
     cli_path = _resolve_cli_path()
     if not cli_path:
         _LOGGER.warning(
-            "%s=1 is set but the claude CLI is not on PATH. "
-            "Install Claude Code or set %s; skipping provider registration.",
+            "%s=1 is set but the %s CLI is not available for %s. "
+            "Install the host CLI or set %s; skipping provider registration.",
             ENV_ENABLE,
+            _cli_name(),
+            _host(),
             _ENV_CLI_PATH,
         )
         return False

--- a/tests/server/llm/test_claude_code_provider.py
+++ b/tests/server/llm/test_claude_code_provider.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -419,6 +420,37 @@ class TestClaudeCodeLLMCompletion:
         )
         assert response.choices[0].message.content == "ok"  # type: ignore[union-attr]
 
+    def test_codex_host_uses_codex_exec(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex runs generation through ``codex exec`` instead of Claude flags."""
+
+        def fake_run(cmd, **kwargs):
+            out = Path(cmd[cmd.index("--output-last-message") + 1])
+            out.write_text("codex reply", encoding="utf-8")
+            return _fake_completed_process(stdout="", returncode=0)
+
+        mock_run = MagicMock(side_effect=fake_run)
+        monkeypatch.setenv("CLAUDE_SMART_HOST", "codex")
+        monkeypatch.setattr(ccp.subprocess, "run", mock_run)
+        monkeypatch.setattr(ccp, "_resolve_cli_path", lambda: "/usr/local/bin/codex")
+
+        response = ClaudeCodeLLM().completion(
+            model="claude-code/default",
+            messages=[
+                {"role": "system", "content": "Be terse."},
+                {"role": "user", "content": "ping"},
+            ],
+        )
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:2] == ["/usr/local/bin/codex", "exec"]
+        assert "-p" not in cmd
+        assert "--append-system-prompt" not in cmd
+        assert mock_run.call_args.kwargs["input"] == "Be terse.\n\n## Task\nUser: ping"
+        assert mock_run.call_args.kwargs["env"]["CLAUDE_SMART_HOST"] == "codex"
+        assert response.choices[0].message.content == "codex reply"  # type: ignore[union-attr]
+
 
 class TestIsClaudeCodeAvailable:
     def test_requires_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -448,6 +480,17 @@ class TestIsClaudeCodeAvailable:
         # Force PATH lookup to fail so the override is what matters.
         monkeypatch.setattr(ccp.shutil, "which", lambda _: None)
         assert is_claude_code_available() is True
+
+    def test_codex_host_resolves_codex_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLAUDE_SMART_USE_LOCAL_CLI", "1")
+        monkeypatch.setenv("CLAUDE_SMART_HOST", "codex")
+        monkeypatch.delenv("CLAUDE_SMART_CLI_PATH", raising=False)
+        monkeypatch.delenv("PLUGIN_ROOT", raising=False)
+        monkeypatch.delenv("CLAUDE_PLUGIN_ROOT", raising=False)
+        monkeypatch.setattr(ccp.shutil, "which", lambda name: f"/usr/local/bin/{name}")
+
+        assert is_claude_code_available() is True
+        assert ccp._resolve_cli_path() == "/usr/local/bin/codex"  # noqa: SLF001
 
 
 class TestRegisterIfEnabled:


### PR DESCRIPTION
## Summary
- make the local LiteLLM provider resolve the active host CLI instead of assuming Claude Code
- route Codex generation through codex exec when no compatibility wrapper is selected
- update provider availability messages and coverage for Codex host selection

## Validation
- uv run --project reflexio ruff check reflexio/server/llm/providers/claude_code_provider.py reflexio/server/llm/model_defaults.py tests/server/llm/test_claude_code_provider.py
- uv run --project reflexio pytest reflexio/tests/server/llm/test_claude_code_provider.py reflexio/tests/server/llm/test_model_defaults.py -n 0 --no-cov
- uv run --project reflexio pytest reflexio/tests/server/llm -n 0 --no-cov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex as an alternative local code execution provider alongside Claude, enabling flexible host configuration.

* **Improvements**
  * Enhanced error messaging to provide more consistent and clearer feedback when local CLI providers are unavailable or misconfigured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->