### PR TITLE
[codex] Recognize Node Codex compatibility wrapper

### DIFF
--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -59,7 +59,12 @@ _ENV_TIMEOUT = "CLAUDE_SMART_CLI_TIMEOUT"
 _ENV_MODEL = "CLAUDE_SMART_CLI_MODEL"
 _HOST_CODEX = "codex"
 _HOST_CLAUDE_CODE = "claude-code"
-_CODEX_COMPAT_SCRIPT = "codex-claude-compat.py"
+_CODEX_COMPAT_SCRIPT_NAMES = (
+    ("codex-claude-compat.cmd", "codex-claude-compat")
+    if os.name == "nt"
+    else ("codex-claude-compat", "codex-claude-compat.cmd")
+)
+_CODEX_COMPAT_SCRIPT_NAME_SET = set(_CODEX_COMPAT_SCRIPT_NAMES)
 _DEFAULT_TIMEOUT_SECONDS = 120
 _DEFAULT_CLI_MODEL = "claude-sonnet-4-6"
 
@@ -99,9 +104,10 @@ def _candidate_codex_compat_path() -> Path | None:
         root = os.environ.get(env_var)
         if not root:
             continue
-        candidate = Path(root) / "scripts" / _CODEX_COMPAT_SCRIPT
-        if candidate.is_file() and os.access(candidate, os.X_OK):
-            return candidate
+        for name in _CODEX_COMPAT_SCRIPT_NAMES:
+            candidate = Path(root) / "scripts" / name
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                return candidate
     return None
 
 
@@ -350,7 +356,7 @@ def _run_cli_stream(
     Raises:
         ClaudeCodeCLIError: On timeout or missing binary.
     """
-    if _host() == _HOST_CODEX and Path(cli_path).name != _CODEX_COMPAT_SCRIPT:
+    if _host() == _HOST_CODEX and Path(cli_path).name not in _CODEX_COMPAT_SCRIPT_NAME_SET:
         return _run_codex_stream(
             codex_path=cli_path,
             system_prompt=system_prompt,

--- a/tests/server/llm/test_claude_code_provider.py
+++ b/tests/server/llm/test_claude_code_provider.py
@@ -451,6 +451,57 @@ class TestClaudeCodeLLMCompletion:
         assert mock_run.call_args.kwargs["env"]["CLAUDE_SMART_HOST"] == "codex"
         assert response.choices[0].message.content == "codex reply"  # type: ignore[union-attr]
 
+    def test_codex_host_uses_compat_wrapper_with_claude_flags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The bundled Codex compatibility wrapper keeps the Claude CLI contract."""
+        mock_run = MagicMock(return_value=_fake_completed_process(_stream_json("ok")))
+        monkeypatch.setenv("CLAUDE_SMART_HOST", "codex")
+        monkeypatch.setattr(ccp.subprocess, "run", mock_run)
+        monkeypatch.setattr(
+            ccp,
+            "_resolve_cli_path",
+            lambda: "/plugin/scripts/codex-claude-compat",
+        )
+
+        response = ClaudeCodeLLM().completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "ping"}],
+        )
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == [
+            "/plugin/scripts/codex-claude-compat",
+            "-p",
+            "--output-format",
+        ]
+        assert "exec" not in cmd
+        assert "--include-partial-messages" in cmd
+        assert response.choices[0].message.content == "ok"  # type: ignore[union-attr]
+
+    def test_codex_host_uses_windows_compat_wrapper_with_claude_flags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows .cmd wrapper is also treated as a Claude-compatible shim."""
+        mock_run = MagicMock(return_value=_fake_completed_process(_stream_json("ok")))
+        monkeypatch.setenv("CLAUDE_SMART_HOST", "codex")
+        monkeypatch.setattr(ccp.subprocess, "run", mock_run)
+        monkeypatch.setattr(
+            ccp,
+            "_resolve_cli_path",
+            lambda: "/plugin/scripts/codex-claude-compat.cmd",
+        )
+
+        ClaudeCodeLLM().completion(
+            model="claude-code/default",
+            messages=[{"role": "user", "content": "ping"}],
+        )
+
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "/plugin/scripts/codex-claude-compat.cmd"
+        assert "-p" in cmd
+        assert "exec" not in cmd
+
 
 class TestIsClaudeCodeAvailable:
     def test_requires_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Detect Node-based Codex compatibility wrappers as valid local CLI provider commands.
- Add tests covering wrapper detection for the Claude Code provider.

## Rebase Update

- Rebased `codex/node-compat-wrapper-detection` onto latest `origin/main` (`1fb86ee`).
- Force-pushed the rebased branch with lease.

## Validation

- `git diff --check origin/main..HEAD`
- `uv run ruff check reflexio/server/llm/providers/claude_code_provider.py tests/server/llm/test_claude_code_provider.py`
- `uv run pytest -q -o 'addopts=' tests/server/llm/test_claude_code_provider.py`

Note: the earlier default single-file pytest run executed 34 tests successfully but failed the global coverage threshold because it was run under default addopts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility for Codex wrapper detection, now properly handles both Windows and non-Windows script filenames.
  * Enhanced host routing for Codex to correctly identify and use compatibility wrapper executables across different operating systems.

* **Tests**
  * Added test cases verifying proper Codex compatibility wrapper execution and response parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->