### PR TITLE
fix(storage): suppress fallback warning for empty-query searches

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -154,21 +154,26 @@ def _cosine_similarity(a: list[float], b: list[float]) -> float:
 def _effective_search_mode(
     mode: SearchMode,
     query_embedding: list[float] | None,
+    query: str | None,
 ) -> SearchMode:
     """Downgrade search mode when the required embedding is unavailable.
 
     Args:
         mode: Requested search mode.
         query_embedding: Pre-computed query embedding, or None.
+        query: Original query text. The fallback warning is suppressed when
+            this is falsy, since an empty-query HYBRID/VECTOR request has no
+            semantic intent to lose.
 
     Returns:
         The effective SearchMode — falls back to FTS when HYBRID/VECTOR lacks an embedding.
     """
     if mode in (SearchMode.HYBRID, SearchMode.VECTOR) and not query_embedding:
-        logger.warning(
-            "Search mode '%s' requested but no query embedding provided — falling back to FTS",
-            mode,
-        )
+        if query:
+            logger.warning(
+                "Search mode '%s' requested but no query embedding provided — falling back to FTS",
+                mode,
+            )
         return SearchMode.FTS
     return mode
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -441,7 +441,9 @@ class PlaybookMixin:
         status_filter = request.status_filter
         match_count = request.top_k or 10
         query_embedding = options.query_embedding if options else None
-        mode = _effective_search_mode(request.search_mode, query_embedding)
+        mode = _effective_search_mode(
+            request.search_mode, query_embedding, request.query
+        )
         rrf_k = options.rrf_k if options else 60
         vector_weight = options.vector_weight if options else 1.0
         fts_weight = options.fts_weight if options else 1.0
@@ -1170,7 +1172,9 @@ class PlaybookMixin:
         playbook_status_filter = request.playbook_status_filter
         match_count = request.top_k or 10
         query_embedding = options.query_embedding if options else None
-        mode = _effective_search_mode(request.search_mode, query_embedding)
+        mode = _effective_search_mode(
+            request.search_mode, query_embedding, request.query
+        )
         rrf_k = options.rrf_k if options else 60
         vector_weight = options.vector_weight if options else 1.0
         fts_weight = options.fts_weight if options else 1.0

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -525,7 +525,7 @@ class ProfileMixin:
         req = search_interaction_request
         has_query = bool(req.query)
         match_count = req.most_recent_k or 10
-        mode = _effective_search_mode(req.search_mode, query_embedding)
+        mode = _effective_search_mode(req.search_mode, query_embedding, req.query)
 
         conditions: list[str] = ["i.user_id = ?"]
         params: list[str | int | float] = [req.user_id]
@@ -616,7 +616,7 @@ class ProfileMixin:
         match_count = req.top_k or 10
         current_ts = _epoch_now()
         has_query = bool(req.query)
-        mode = _effective_search_mode(req.search_mode, query_embedding)
+        mode = _effective_search_mode(req.search_mode, query_embedding, req.query)
         has_embedding = query_embedding is not None
         logger.info(
             "Profile search: requested_mode=%s, effective_mode=%s, has_query=%s, has_embedding=%s, user_id=%s",

--- a/tests/server/services/storage/test_sqlite_storage.py
+++ b/tests/server/services/storage/test_sqlite_storage.py
@@ -351,22 +351,52 @@ class TestCosineSimilarity:
 
 class TestEffectiveSearchMode:
     def test_fts_always_honored(self):
-        assert _effective_search_mode(SearchMode.FTS, [1.0]) == SearchMode.FTS
+        assert _effective_search_mode(SearchMode.FTS, [1.0], "q") == SearchMode.FTS
 
     def test_hybrid_with_embedding(self):
-        assert _effective_search_mode(SearchMode.HYBRID, [1.0]) == SearchMode.HYBRID
+        assert (
+            _effective_search_mode(SearchMode.HYBRID, [1.0], "q") == SearchMode.HYBRID
+        )
 
     def test_vector_with_embedding(self):
-        assert _effective_search_mode(SearchMode.VECTOR, [1.0]) == SearchMode.VECTOR
+        assert (
+            _effective_search_mode(SearchMode.VECTOR, [1.0], "q") == SearchMode.VECTOR
+        )
 
     def test_hybrid_falls_back_to_fts_without_embedding(self):
-        assert _effective_search_mode(SearchMode.HYBRID, None) == SearchMode.FTS
+        assert _effective_search_mode(SearchMode.HYBRID, None, "q") == SearchMode.FTS
 
     def test_vector_falls_back_to_fts_without_embedding(self):
-        assert _effective_search_mode(SearchMode.VECTOR, None) == SearchMode.FTS
+        assert _effective_search_mode(SearchMode.VECTOR, None, "q") == SearchMode.FTS
 
     def test_fts_without_embedding(self):
-        assert _effective_search_mode(SearchMode.FTS, None) == SearchMode.FTS
+        assert _effective_search_mode(SearchMode.FTS, None, "q") == SearchMode.FTS
+
+    def test_hybrid_fallback_with_query_warns(self, caplog):
+        with caplog.at_level("WARNING"):
+            result = _effective_search_mode(SearchMode.HYBRID, None, "hello")
+        assert result == SearchMode.FTS
+        assert any("falling back to FTS" in rec.message for rec in caplog.records)
+
+    def test_vector_fallback_with_query_warns(self, caplog):
+        with caplog.at_level("WARNING"):
+            result = _effective_search_mode(SearchMode.VECTOR, None, "hello")
+        assert result == SearchMode.FTS
+        assert any("falling back to FTS" in rec.message for rec in caplog.records)
+
+    @pytest.mark.parametrize("query", [None, ""])
+    def test_hybrid_fallback_without_query_is_silent(self, caplog, query):
+        with caplog.at_level("WARNING"):
+            result = _effective_search_mode(SearchMode.HYBRID, None, query)
+        assert result == SearchMode.FTS
+        assert not any("falling back to FTS" in rec.message for rec in caplog.records)
+
+    @pytest.mark.parametrize("query", [None, ""])
+    def test_vector_fallback_without_query_is_silent(self, caplog, query):
+        with caplog.at_level("WARNING"):
+            result = _effective_search_mode(SearchMode.VECTOR, None, query)
+        assert result == SearchMode.FTS
+        assert not any("falling back to FTS" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_effective_search_mode` logs a warning every time a `HYBRID`/`VECTOR` request without an embedding is downgraded to `FTS`. When the request also has no query text (a common pattern for "list latest" callers that reuse the search path), there is no semantic intent being lost — the warning is noise.
- Thread the original request `query` into the helper and only log when `query` is truthy.
- Make `query` a required parameter so future callers can't silently disable the warning by omission.

## Changes
**`reflexio/server/services/storage/sqlite_storage/_base.py`**
- `_effective_search_mode(mode, query_embedding, query)` — `query` is now required (no default). Warning fires only when `query` is truthy.

**Call sites updated to pass `request.query` / `req.query`:**
- `_playbook.py:444` (`SearchAgentPlaybookRequest`)
- `_playbook.py:1175` (`SearchUserPlaybookRequest`)
- `_profiles.py:528` (search interactions)
- `_profiles.py:619` (search profiles)

**Tests (`tests/server/services/storage/test_sqlite_storage.py`):**
- Existing `TestEffectiveSearchMode` cases updated to pass `query` explicitly.
- New cases covering the warning branch:
  - `test_hybrid_fallback_with_query_warns`
  - `test_vector_fallback_with_query_warns`
  - `test_hybrid_fallback_without_query_is_silent` (parametrized: `None`, `""`)
  - `test_vector_fallback_without_query_is_silent` (parametrized: `None`, `""`)

## Test Plan
- [x] `uv run pytest tests/server/services/storage/test_sqlite_storage.py::TestEffectiveSearchMode -x` → 12 passed
- [x] `ruff check` + `ruff format` clean on all four files
- [ ] Manual: confirm no warning log when issuing an empty-query playbook/profile search; confirm warning still fires for non-empty queries that lack an embedding
