### PR TITLE
feat(storage): log per-call cosine-similarity scores in _vector_rank_rows

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -4,6 +4,7 @@ from ._base import (
     _effective_search_mode,
     _sanitize_fts_query,
     _true_rrf_merge,
+    _vector_rank_rows,
 )
 from ._extras import ExtrasMixin
 from ._operations import OperationMixin
@@ -44,6 +45,7 @@ __all__ = [
     "_effective_search_mode",
     "_sanitize_fts_query",
     "_true_rrf_merge",
+    "_vector_rank_rows",
     "StallReason",
     "StallState",
     "clear_stall_state",

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -202,6 +202,22 @@ def _vector_rank_rows(
             scored.append((row, sim))
 
     scored.sort(key=lambda x: x[1], reverse=True)
+    # Diagnostic: log the full pre-cut score distribution so retrieval
+    # misses are debuggable. Without this, the only signal callers see is
+    # "K results returned" with no way to tell whether a relevant row
+    # scored 0.39 (close, just below an upstream threshold filter) vs
+    # 0.05 (semantic mismatch, no threshold tuning will save it). Top 10
+    # is sufficient context; logs at INFO so it shows up in production
+    # backend.log without an explicit debug flag. Cost is one log line
+    # per vector search call (~200 bytes).
+    if scored:
+        top = [round(s, 3) for _, s in scored[:10]]
+        logger.info(
+            "vector_rank: candidates=%d match_count=%d top_scores=%s",
+            len(scored),
+            match_count,
+            top,
+        )
     return [row for row, _ in scored[:match_count]]
 
 

--- a/tests/server/services/storage/test_sqlite_storage.py
+++ b/tests/server/services/storage/test_sqlite_storage.py
@@ -24,6 +24,7 @@ from reflexio.server.services.storage.sqlite_storage import (
     _effective_search_mode,
     _sanitize_fts_query,
     _true_rrf_merge,
+    _vector_rank_rows,
 )
 
 # ---------------------------------------------------------------------------
@@ -347,6 +348,67 @@ class TestCosineSimilarity:
 
     def test_zero_vector(self):
         assert _cosine_similarity([0.0, 0.0], [1.0, 2.0]) == 0.0
+
+
+class TestVectorRankRowsLogging:
+    """Logging of cosine-similarity scores in ``_vector_rank_rows``.
+
+    Validates the diagnostic that gives retrieval misses a paper trail
+    in ``backend.log``. Without it, a caller-side "0 hits" is
+    indistinguishable from "candidate scored 0.39 but was just below
+    threshold" vs "candidate scored 0.05, semantic mismatch."
+    """
+
+    def _row(self, embedding: list[float]) -> dict:
+        # The function only touches ``row["embedding"]`` so a dict
+        # mock suffices — no need for a real sqlite3.Row.
+        return {"embedding": json.dumps(embedding), "id": 1}
+
+    def test_emits_top_scores_when_candidates_exist(self, caplog) -> None:
+        rows = [
+            self._row([1.0, 0.0, 0.0]),
+            self._row([0.5, 0.5, 0.0]),
+            self._row([0.0, 0.0, 1.0]),
+        ]
+        with caplog.at_level(
+            "INFO",
+            logger="reflexio.server.services.storage.sqlite_storage._base",
+        ):
+            _vector_rank_rows(rows, [1.0, 0.0, 0.0], match_count=2)
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("vector_rank:" in m for m in msgs)
+        # The log line must include candidate count and the ranked scores.
+        line = next(m for m in msgs if "vector_rank:" in m)
+        assert "candidates=3" in line
+        assert "match_count=2" in line
+        assert "top_scores=" in line
+
+    def test_no_log_when_no_candidates(self, caplog) -> None:
+        """Empty candidate set produces no log line so noise stays bounded."""
+        with caplog.at_level(
+            "INFO",
+            logger="reflexio.server.services.storage.sqlite_storage._base",
+        ):
+            _vector_rank_rows([], [1.0, 0.0, 0.0], match_count=5)
+        assert not any("vector_rank:" in r.getMessage() for r in caplog.records)
+
+    def test_top_scores_truncated_to_10(self, caplog) -> None:
+        """Long candidate lists must not flood the log."""
+        rows = [self._row([1.0, 0.0] + [0.0] * 510) for _ in range(50)]
+        with caplog.at_level(
+            "INFO",
+            logger="reflexio.server.services.storage.sqlite_storage._base",
+        ):
+            _vector_rank_rows(rows, [1.0, 0.0] + [0.0] * 510, match_count=3)
+        line = next(
+            r.getMessage()
+            for r in caplog.records
+            if "vector_rank:" in r.getMessage()
+        )
+        # The log shows candidates=50 but only ~10 scores in top_scores=.
+        assert "candidates=50" in line
+        # Score list portion should not contain 50 entries.
+        assert line.count(",") <= 12  # ~10 entries plus commas in candidates/match_count
 
 
 class TestEffectiveSearchMode:


### PR DESCRIPTION
## Summary

One-line diagnostic — `_vector_rank_rows` now logs candidate count, requested match_count, and the top-10 cosine-similarity scores per call. Makes retrieval misses debuggable from `backend.log`.

```
INFO  reflexio.server.services.storage.sqlite_storage._base:
  vector_rank: candidates=12 match_count=3 top_scores=[0.41, 0.33, 0.28, 0.27, 0.21, ...]
```

## Why

Caller-side observability of vector search today is "K results returned, ranked by relevance" — but nothing about the actual scores. A document scoring 0.39 (close to a 0.4 threshold) looks identical to one scoring 0.05 (semantic mismatch). This makes "retrieval-miss" debugging a guessing game.

**Concrete motivating case** (from the SWE-bench paired-protocol flask run):

Run A produced a playbook whose `trigger` field was literally _"Patching a validation guard in a Python class `__init__` method to raise ValueError on invalid input"_. Run B's task: _"Require a non-empty name for Blueprints … raise a ValueError"_. A perfect match by content. Yet Run B fired 28+ retrieval queries during its session and **every single one returned zero hits** (`cs_injections_count: 0` in `metrics.json`, no `[cs:...]` markers in the pane log).

The existing backend log gave no signal whether:

- The playbook scored 0.39 (close, blocked by upstream threshold)
- The playbook scored 0.05 (semantic mismatch — no threshold tuning would help)
- The query embedding never got generated at all

With this PR's log line, the answer would have been in `backend.log` immediately.

## Cost / noise

One INFO line per vector search, ~200 bytes. Top-10 truncation prevents flood on long candidate lists. No log line when there are zero candidates so empty-DB queries stay quiet. Disabled by sub-INFO log level filtering if a user wants to suppress it; INFO is the right default for an observability hook.

## Test plan

- [x] 3 new tests in `TestVectorRankRowsLogging`: emits-on-candidates, no-log-on-empty, truncated-to-10
- [x] Full storage suite green
- [x] Ruff + pyright clean

## Companion PRs

- claude-smart [#30](https://github.com/ReflexioAI/claude-smart/pull/30) — paired-protocol learning loop fixes
- reflexio-enterprise [#74](https://github.com/ReflexioAI/reflexio-enterprise/pull/74) — SWE-bench harness fixes

Neither depends on this PR for merge order — this is a pure diagnostic add. Bumping the enterprise's reflexio submodule pointer here will let the next paired flask run produce the score data we need to disambiguate the retrieval miss.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool-calling support for Claude code models with JSON-based tool specification routing.

* **Improvements**
  * Enhanced logging for vector ranking operations with candidate metadata and top similarity scores.

* **Tests**
  * Added unit tests for tool message formatting and vector ranking operation logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->