### PR TITLE
feat(storage): /api/clear_user_data — per-user_id row deletion (3rd attempt onto main)

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -69,6 +69,8 @@ from reflexio.models.api_schema.service_schemas import (
     AddUserProfileResponse,
     AgentPlaybook,
     BulkDeleteResponse,
+    ClearUserDataRequest,
+    ClearUserDataResponse,
     DeleteAgentPlaybookRequest,
     DeleteAgentPlaybookResponse,
     DeleteAgentPlaybooksByIdsRequest,
@@ -2389,3 +2391,27 @@ class ReflexioClient:
         """
         response = self._make_request("POST", "/stall_state/notified")
         return MarkNotifiedResponse.model_validate(response)
+
+    def clear_user_data(self, user_id: str) -> ClearUserDataResponse:
+        """Delete all rows scoped to a single ``user_id``.
+
+        Wipes the user's interactions, user playbooks, profiles, and
+        requests on the server. Does NOT touch agent playbooks — they
+        are intentionally shared cross-project. Used by paired-protocol
+        harnesses (e.g. SWE-bench) to isolate per-task data on a shared
+        backend without one task's clear-all nuking another in-flight
+        task's rows.
+
+        Args:
+            user_id (str): The user id whose data should be cleared.
+
+        Returns:
+            ClearUserDataResponse: Per-entity deletion counts.
+        """
+        req = ClearUserDataRequest(user_id=user_id)
+        response = self._make_request(
+            "POST", "/api/clear_user_data", json=req.model_dump()
+        )
+        # Nuclear — clear everything that could reference this user.
+        self._cache.clear()
+        return ClearUserDataResponse(**response)

--- a/reflexio/lib/_interactions.py
+++ b/reflexio/lib/_interactions.py
@@ -14,6 +14,8 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.models.api_schema.service_schemas import (
     BulkDeleteResponse,
+    ClearUserDataRequest,
+    ClearUserDataResponse,
     DeleteRequestRequest,
     DeleteRequestResponse,
     DeleteRequestsByIdsRequest,
@@ -232,6 +234,37 @@ class InteractionsMixin(ReflexioBase):
         deleted = self._get_storage().delete_requests_by_ids(request.request_ids)
         return BulkDeleteResponse(
             success=True, deleted_count=deleted, message=f"Deleted {deleted} item(s)"
+        )
+
+    @_require_storage(ClearUserDataResponse)
+    def clear_user_data(
+        self,
+        request: ClearUserDataRequest | dict,
+    ) -> ClearUserDataResponse:
+        """Delete all rows scoped to a single ``user_id``.
+
+        Wipes the user's interactions, user playbooks, profiles, and
+        requests. Intentionally does NOT touch ``agent_playbooks`` —
+        those are the cross-project rollup of skills and have no
+        ``user_id`` column. Used by paired-protocol harnesses (e.g.
+        SWE-bench) to isolate per-task data on a shared backend without
+        nuking sibling tasks' rows.
+
+        Args:
+            request (ClearUserDataRequest | dict): Request containing
+                the ``user_id`` whose data should be cleared.
+
+        Returns:
+            ClearUserDataResponse: Per-entity deletion counts.
+        """
+        if isinstance(request, dict):
+            request = ClearUserDataRequest(**request)
+        deleted_counts = self._get_storage().clear_user_data(request.user_id)
+        total = sum(deleted_counts.values())
+        return ClearUserDataResponse(
+            success=True,
+            deleted_counts=deleted_counts,
+            message=f"Cleared {total} row(s) for user {request.user_id!r}",
         )
 
     def get_interactions(

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -58,6 +58,8 @@ __all__ = [
     "DeleteProfilesByIdsRequest",
     "DeleteAgentPlaybooksByIdsRequest",
     "DeleteUserPlaybooksByIdsRequest",
+    "ClearUserDataRequest",
+    "ClearUserDataResponse",
     "InteractionData",
     "PublishUserInteractionRequest",
     "PublishUserInteractionResponse",
@@ -478,6 +480,21 @@ class DeleteAgentPlaybooksByIdsRequest(BaseModel):
 
 class DeleteUserPlaybooksByIdsRequest(BaseModel):
     user_playbook_ids: list[int] = Field(min_length=1)
+
+
+# Clear all data scoped to a single user_id (interactions, requests, user
+# playbooks, profiles). Used by paired-protocol harnesses (e.g. SWE-bench) to
+# isolate per-task data on a shared storage backend without nuking sibling
+# tasks' rows. Intentionally does NOT touch agent_playbooks — they are the
+# cross-project rollup of skills and have no user_id column.
+class ClearUserDataRequest(BaseModel):
+    user_id: NonEmptyStr
+
+
+class ClearUserDataResponse(BaseModel):
+    success: bool
+    deleted_counts: dict[str, int] = Field(default_factory=dict)
+    message: str | None = None
 
 
 # user provided interaction data from the request

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -73,6 +73,8 @@ from reflexio.models.api_schema.service_schemas import (
     BulkDeleteResponse,
     CancelOperationRequest,
     CancelOperationResponse,
+    ClearUserDataRequest,
+    ClearUserDataResponse,
     DeleteAgentPlaybookRequest,
     DeleteAgentPlaybookResponse,
     DeleteAgentPlaybooksByIdsRequest,
@@ -915,6 +917,34 @@ def delete_all_agent_playbooks(
         BulkDeleteResponse: Response containing success status and deleted count
     """
     return publisher_api.delete_all_agent_playbooks_bulk(org_id=org_id)
+
+
+@core_router.post(
+    "/api/clear_user_data",
+    response_model=ClearUserDataResponse,
+    response_model_exclude_none=True,
+)
+def clear_user_data(
+    request: ClearUserDataRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> ClearUserDataResponse:
+    """Delete all rows scoped to a single ``user_id``.
+
+    Removes the user's interactions, user playbooks, profiles, and
+    requests. Does NOT touch ``agent_playbooks`` — they are
+    intentionally shared cross-project. Used by paired-protocol
+    harnesses (e.g. SWE-bench) to isolate per-task data on a shared
+    backend without one task's clear-all nuking another in-flight
+    task's rows.
+
+    Args:
+        request (ClearUserDataRequest): Request containing the target user_id
+        org_id (str): Organization ID
+
+    Returns:
+        ClearUserDataResponse: Response with per-entity deletion counts
+    """
+    return publisher_api.clear_user_data(org_id=org_id, request=request)
 
 
 @core_router.post(

--- a/reflexio/server/api_endpoints/publisher_api.py
+++ b/reflexio/server/api_endpoints/publisher_api.py
@@ -22,6 +22,8 @@ from reflexio.models.api_schema.service_schemas import (
     AddUserProfileRequest,
     AddUserProfileResponse,
     BulkDeleteResponse,
+    ClearUserDataRequest,
+    ClearUserDataResponse,
     DeleteAgentPlaybookRequest,
     DeleteAgentPlaybookResponse,
     DeleteAgentPlaybooksByIdsRequest,
@@ -384,6 +386,22 @@ def delete_user_playbooks_by_ids_bulk(
     """
     reflexio = get_reflexio(org_id=org_id)
     return reflexio.delete_user_playbooks_by_ids_bulk(request)
+
+
+def clear_user_data(
+    org_id: str, request: ClearUserDataRequest
+) -> ClearUserDataResponse:
+    """Delete all rows scoped to a single ``user_id``.
+
+    Args:
+        org_id (str): Organization ID
+        request (ClearUserDataRequest): Request containing the target user_id
+
+    Returns:
+        ClearUserDataResponse: Response with per-entity deletion counts
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.clear_user_data(request)
 
 
 # ==============================

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1319,6 +1319,113 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         ]
         return self._fetchall(sql, all_params)
 
+    # ------------------------------------------------------------------
+    # Per-user data clear
+    # ------------------------------------------------------------------
+
+    def clear_user_data(self, user_id: str) -> dict[str, int]:
+        """Atomic per-``user_id`` row deletion across all user-scoped tables.
+
+        Overrides the BaseStorage default with a single-transaction SQL
+        implementation. Removes interactions, user playbooks, profiles,
+        and requests scoped to the user. Intentionally does NOT touch
+        ``agent_playbooks`` — they are the cross-project rollup of
+        skills and have no ``user_id`` column.
+
+        Also cleans up FTS and vector sidecars for the user's rows so
+        subsequent searches don't surface deleted data.
+
+        Args:
+            user_id (str): The user id whose rows should be deleted.
+
+        Returns:
+            dict[str, int]: Per-entity deletion counts with keys
+                ``interactions``, ``user_playbooks``, ``profiles``, and
+                ``requests``.
+        """
+        with self._lock:
+            # Snapshot rowids/ids that need FTS or vector cleanup before
+            # the DELETE removes them from the main tables.
+            interaction_ids = [
+                r["interaction_id"]
+                for r in self.conn.execute(
+                    "SELECT interaction_id FROM interactions WHERE user_id = ?",
+                    (user_id,),
+                ).fetchall()
+            ]
+            user_playbook_ids = [
+                r["user_playbook_id"]
+                for r in self.conn.execute(
+                    "SELECT user_playbook_id FROM user_playbooks WHERE user_id = ?",
+                    (user_id,),
+                ).fetchall()
+            ]
+            profile_rows = self.conn.execute(
+                "SELECT rowid, profile_id FROM profiles WHERE user_id = ?",
+                (user_id,),
+            ).fetchall()
+            profile_rowids = [r["rowid"] for r in profile_rows]
+            profile_ids = [r["profile_id"] for r in profile_rows]
+
+            # FTS cleanup
+            if interaction_ids:
+                ph = ",".join("?" for _ in interaction_ids)
+                self.conn.execute(
+                    f"DELETE FROM interactions_fts WHERE rowid IN ({ph})",
+                    interaction_ids,
+                )
+            if user_playbook_ids:
+                ph = ",".join("?" for _ in user_playbook_ids)
+                self.conn.execute(
+                    f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
+                    user_playbook_ids,
+                )
+            if profile_ids:
+                ph = ",".join("?" for _ in profile_ids)
+                self.conn.execute(
+                    f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",
+                    profile_ids,
+                )
+
+            # Vector index cleanup (best-effort: only if sqlite-vec loaded)
+            if self._has_sqlite_vec:
+                vec_targets = (
+                    ("interactions_vec", interaction_ids),
+                    ("user_playbooks_vec", user_playbook_ids),
+                    ("profiles_vec", profile_rowids),
+                )
+                for vec_table, rowids in vec_targets:
+                    if rowids:
+                        ph = ",".join("?" for _ in rowids)
+                        self.conn.execute(
+                            f"DELETE FROM {vec_table} WHERE rowid IN ({ph})",
+                            rowids,
+                        )
+
+            # Main-table deletes. Order matters only for foreign key
+            # integrity; SQLite default has FK off for most tables here
+            # so order is chosen for readability.
+            interactions_cur = self.conn.execute(
+                "DELETE FROM interactions WHERE user_id = ?", (user_id,)
+            )
+            user_playbooks_cur = self.conn.execute(
+                "DELETE FROM user_playbooks WHERE user_id = ?", (user_id,)
+            )
+            profiles_cur = self.conn.execute(
+                "DELETE FROM profiles WHERE user_id = ?", (user_id,)
+            )
+            requests_cur = self.conn.execute(
+                "DELETE FROM requests WHERE user_id = ?", (user_id,)
+            )
+            self.conn.commit()
+
+            return {
+                "interactions": interactions_cur.rowcount,
+                "user_playbooks": user_playbooks_cur.rowcount,
+                "profiles": profiles_cur.rowcount,
+                "requests": requests_cur.rowcount,
+            }
+
 
 # ---------------------------------------------------------------------------
 # DDL — table and FTS definitions

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -1,3 +1,5 @@
+from reflexio.models.api_schema.domain.enums import Status
+
 from ._base import BaseStorageCore, matches_status_filter
 from ._extras import ExtrasMixin
 from ._operations import OperationMixin
@@ -20,7 +22,82 @@ class BaseStorage(
 ):
     """Base class for storage."""
 
-    pass
+    def clear_user_data(self, user_id: str) -> dict[str, int]:
+        """Delete all rows scoped to a single ``user_id``.
+
+        Removes the user's interactions, user playbooks, profiles, and
+        requests. Intentionally does NOT touch ``agent_playbooks`` — those
+        are the cross-project rollup of skills and have no ``user_id``
+        column. This is the data-isolation primitive used by paired
+        protocols (e.g. SWE-bench) that share a single backend across
+        parallel tasks without one task's clear-all nuking another
+        in-flight task's rows.
+
+        The default implementation composes existing per-user / by-ids
+        primitives so any backend that implements those (sqlite, disk,
+        supabase, postgres, ...) gets correct behaviour for free.
+        Subclasses MAY override for atomic / transactional efficiency.
+
+        Args:
+            user_id (str): The user id whose rows should be deleted.
+
+        Returns:
+            dict[str, int]: Per-entity deletion counts with keys
+                ``interactions``, ``user_playbooks``, ``profiles``, and
+                ``requests``. Counts reflect pre-deletion totals for the
+                user (i.e. how many rows existed for that user).
+        """
+        interaction_count = len(self.get_user_interaction(user_id))
+
+        # Snapshot user_playbook ids for the user so we can both count
+        # and delete via the existing bulk-by-ids primitive (no per-user
+        # playbook delete primitive exists at the mixin level).
+        user_playbook_ids = [
+            up.user_playbook_id
+            for up in self.get_user_playbooks(
+                user_id=user_id,
+                limit=1_000_000,
+                status_filter=[None, Status.ARCHIVED, Status.PENDING],
+            )
+            if up.user_playbook_id is not None
+        ]
+        profile_count = len(
+            self.get_user_profile(
+                user_id, status_filter=[None, Status.ARCHIVED, Status.PENDING]
+            )
+        )
+
+        # Snapshot request ids for the user so we can both count and
+        # delete via delete_requests_by_ids — there is no
+        # delete_all_requests_for_user primitive.
+        request_ids = [
+            session_item.request.request_id
+            for session_items in self.get_sessions(
+                user_id=user_id, top_k=1_000_000
+            ).values()
+            for session_item in session_items
+        ]
+
+        # Delete in dependency-safe order: interactions first (they
+        # reference requests), then user playbooks (also reference
+        # requests), then profiles, then the requests themselves.
+        self.delete_all_interactions_for_user(user_id)
+        deleted_user_playbooks = (
+            self.delete_user_playbooks_by_ids(user_playbook_ids)
+            if user_playbook_ids
+            else 0
+        )
+        self.delete_all_profiles_for_user(user_id)
+        deleted_requests = (
+            self.delete_requests_by_ids(request_ids) if request_ids else 0
+        )
+
+        return {
+            "interactions": interaction_count,
+            "user_playbooks": deleted_user_playbooks,
+            "profiles": profile_count,
+            "requests": deleted_requests,
+        }
 
 
 __all__ = [

--- a/tests/client/test_clear_user_data.py
+++ b/tests/client/test_clear_user_data.py
@@ -1,0 +1,97 @@
+"""Tests for ReflexioClient.clear_user_data — per-``user_id`` data clearing."""
+
+from unittest.mock import MagicMock, patch
+
+from reflexio.client import ReflexioClient
+
+
+class TestClearUserData:
+    @patch("reflexio.client.client.requests.Session")
+    def test_posts_user_id_to_clear_user_data_endpoint(
+        self, mock_session_class
+    ) -> None:
+        """Client must POST {"user_id": ...} to /api/clear_user_data."""
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "success": True,
+            "deleted_counts": {
+                "interactions": 3,
+                "user_playbooks": 1,
+                "profiles": 2,
+                "requests": 1,
+            },
+            "message": "Cleared 7 row(s) for user 'userA'",
+        }
+        mock_session.request.return_value = mock_response
+
+        client = ReflexioClient(api_key="test_key")
+        result = client.clear_user_data("userA")
+
+        # Right HTTP method and path.
+        call_args = mock_session.request.call_args
+        assert call_args.args[0] == "POST"
+        assert call_args.args[1].endswith("/api/clear_user_data")
+        # Right body shape — single user_id field.
+        assert call_args.kwargs["json"] == {"user_id": "userA"}
+
+        # Response is parsed into the typed model with intact counts.
+        assert result.success is True
+        assert result.deleted_counts == {
+            "interactions": 3,
+            "user_playbooks": 1,
+            "profiles": 2,
+            "requests": 1,
+        }
+        assert result.message and "userA" in result.message
+
+    @patch("reflexio.client.client.requests.Session")
+    def test_clear_user_data_invalidates_cache(self, mock_session_class) -> None:
+        """clear_user_data must clear the cache so stale per-user reads vanish."""
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [
+            # get_profiles
+            {"success": True, "user_profiles": [], "msg": None},
+            # clear_user_data
+            {
+                "success": True,
+                "deleted_counts": {
+                    "interactions": 0,
+                    "user_playbooks": 0,
+                    "profiles": 0,
+                    "requests": 0,
+                },
+                "message": "Cleared 0 row(s) for user 'userA'",
+            },
+            # get_profiles again (cache miss)
+            {"success": True, "user_profiles": [], "msg": None},
+        ]
+        mock_session.request.return_value = mock_response
+
+        client = ReflexioClient(api_key="test_key")
+        client.get_profiles(
+            {
+                "user_id": "userA",
+                "start_time": None,
+                "end_time": None,
+                "top_k": 30,
+            }
+        )
+        assert mock_session.request.call_count == 1
+
+        client.clear_user_data("userA")
+        assert mock_session.request.call_count == 2
+
+        # Cache cleared — next read hits the API again.
+        client.get_profiles(
+            {
+                "user_id": "userA",
+                "start_time": None,
+                "end_time": None,
+                "top_k": 30,
+            }
+        )
+        assert mock_session.request.call_count == 3

--- a/tests/server/api_endpoints/test_publisher_api.py
+++ b/tests/server/api_endpoints/test_publisher_api.py
@@ -13,6 +13,7 @@ from reflexio.server.api_endpoints.publisher_api import (
     add_user_interaction,
     add_user_playbook,
     add_user_profile,
+    clear_user_data,
     delete_agent_playbook,
     delete_agent_playbooks_by_ids_bulk,
     delete_all_interactions_bulk,
@@ -340,6 +341,16 @@ class TestBulkDeletes:
         result = delete_user_playbooks_by_ids_bulk(ORG_ID, request)
 
         mock_reflexio.delete_user_playbooks_by_ids_bulk.assert_called_once_with(request)
+        assert result is expected
+
+    def test_clear_user_data(self, mock_reflexio):
+        request = MagicMock()
+        expected = MagicMock()
+        mock_reflexio.clear_user_data.return_value = expected
+
+        result = clear_user_data(ORG_ID, request)
+
+        mock_reflexio.clear_user_data.assert_called_once_with(request)
         assert result is expected
 
 

--- a/tests/server/services/storage/test_disk_storage_clear_user_data.py
+++ b/tests/server/services/storage/test_disk_storage_clear_user_data.py
@@ -1,0 +1,165 @@
+"""Disk-storage coverage for ``clear_user_data`` (BaseStorage default impl).
+
+The shared ``storage`` fixture in conftest.py only exercises SQLite
+(QMD-binary dependency keeps disk out of the parametrized fixture).
+This file mocks out ``QMDClient`` so the default ``BaseStorage``
+``clear_user_data`` composition can be verified end-to-end on the disk
+backend without requiring the ``qmd`` CLI.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Generator
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    Interaction,
+    ProfileTimeToLive,
+    Request,
+    UserActionType,
+    UserPlaybook,
+    UserProfile,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def disk_storage() -> Generator:
+    """Yield a DiskStorage instance with QMDClient stubbed out."""
+    from reflexio.server.services.storage.disk_storage import DiskStorage
+
+    with (
+        tempfile.TemporaryDirectory() as temp_dir,
+        patch(
+            "reflexio.server.services.storage.disk_storage._base.QMDClient",
+            return_value=MagicMock(),
+        ),
+    ):
+        yield DiskStorage(org_id="contract_test_disk", base_dir=temp_dir)
+
+
+def _make_request(request_id: str, user_id: str) -> Request:
+    return Request(
+        request_id=request_id,
+        user_id=user_id,
+        created_at=int(datetime.now(UTC).timestamp()),
+        source="test",
+        agent_version="v1",
+        session_id=f"sess_{request_id}",
+    )
+
+
+def _make_interaction(
+    user_id: str, interaction_id: int, request_id: str
+) -> Interaction:
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id=user_id,
+        request_id=request_id,
+        content=f"content-{interaction_id}",
+        created_at=int(datetime.now(UTC).timestamp()),
+        user_action=UserActionType.NONE,
+        user_action_description="",
+        interacted_image_url="",
+    )
+
+
+def _make_profile(user_id: str, profile_id: str) -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=f"prefs-{profile_id}",
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        source="test",
+    )
+
+
+def _make_user_playbook(
+    user_playbook_id: int, user_id: str, request_id: str
+) -> UserPlaybook:
+    return UserPlaybook(
+        user_playbook_id=user_playbook_id,
+        user_id=user_id,
+        playbook_name="fb",
+        agent_version="v1",
+        request_id=request_id,
+        content=f"playbook-{user_playbook_id}",
+        created_at=1_700_000_000 + user_playbook_id,
+        source="test",
+        source_interaction_ids=[],
+    )
+
+
+def _make_agent_playbook(agent_playbook_id: int) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=agent_playbook_id,
+        playbook_name="fb",
+        agent_version="v1",
+        content=f"agent-pb-{agent_playbook_id}",
+        created_at=1_700_000_000 + agent_playbook_id,
+    )
+
+
+def _seed_user(storage, user_id: str, suffix: str) -> None:
+    storage.add_request(_make_request(f"req_{suffix}", user_id))
+    storage.add_user_interaction(
+        user_id, _make_interaction(user_id, 1000 + ord(suffix[0]), f"req_{suffix}")
+    )
+    storage.save_user_playbooks(
+        [_make_user_playbook(2000 + ord(suffix[0]), user_id, f"req_{suffix}")]
+    )
+    storage.add_user_profile(user_id, [_make_profile(user_id, f"pid_{suffix}")])
+
+
+class TestClearUserDataDisk:
+    def test_clears_only_target_user_rows(self, disk_storage) -> None:
+        _seed_user(disk_storage, "userA", "a")
+        _seed_user(disk_storage, "userB", "b")
+        disk_storage.save_agent_playbooks([_make_agent_playbook(9001)])
+
+        counts = disk_storage.clear_user_data("userA")
+
+        for key in ("interactions", "user_playbooks", "profiles", "requests"):
+            assert key in counts
+            assert counts[key] >= 1
+
+        assert disk_storage.get_user_interaction("userA") == []
+        assert disk_storage.get_user_profile("userA") == []
+        assert disk_storage.get_user_playbooks(user_id="userA") == []
+        assert disk_storage.get_request("req_a") is None
+
+        assert len(disk_storage.get_user_interaction("userB")) == 1
+        assert len(disk_storage.get_user_profile("userB")) == 1
+        assert len(disk_storage.get_user_playbooks(user_id="userB")) == 1
+        assert disk_storage.get_request("req_b") is not None
+
+    def test_agent_playbooks_unchanged(self, disk_storage) -> None:
+        _seed_user(disk_storage, "userA", "a")
+        disk_storage.save_agent_playbooks(
+            [_make_agent_playbook(9001), _make_agent_playbook(9002)]
+        )
+        before = disk_storage.get_agent_playbooks(limit=1000)
+        assert len(before) == 2
+
+        disk_storage.clear_user_data("userA")
+
+        after = disk_storage.get_agent_playbooks(limit=1000)
+        assert {p.agent_playbook_id for p in after} == {
+            p.agent_playbook_id for p in before
+        }
+
+    def test_clear_unknown_user_is_noop(self, disk_storage) -> None:
+        _seed_user(disk_storage, "userA", "a")
+
+        counts = disk_storage.clear_user_data("does_not_exist")
+
+        assert all(v == 0 for v in counts.values()), counts
+        assert len(disk_storage.get_user_interaction("userA")) == 1

--- a/tests/server/services/storage/test_storage_contract_clear_user_data.py
+++ b/tests/server/services/storage/test_storage_contract_clear_user_data.py
@@ -1,0 +1,195 @@
+"""Contract tests for clear_user_data — per-``user_id`` row deletion.
+
+The method is the data-isolation primitive used by paired-protocol
+harnesses (e.g. SWE-bench) to share a single backend across parallel
+tasks without one task's clear-all nuking another in-flight task's
+rows. These tests pin the cross-entity invariants every storage backend
+must satisfy.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    Interaction,
+    ProfileTimeToLive,
+    Request,
+    UserActionType,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _make_request(request_id: str, user_id: str) -> Request:
+    return Request(
+        request_id=request_id,
+        user_id=user_id,
+        created_at=int(datetime.now(UTC).timestamp()),
+        source="test",
+        agent_version="v1",
+        session_id=f"sess_{request_id}",
+    )
+
+
+def _make_interaction(
+    user_id: str, interaction_id: int, request_id: str
+) -> Interaction:
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id=user_id,
+        request_id=request_id,
+        content=f"content-{interaction_id}",
+        created_at=int(datetime.now(UTC).timestamp()),
+        user_action=UserActionType.NONE,
+        user_action_description="",
+        interacted_image_url="",
+    )
+
+
+def _make_profile(user_id: str, profile_id: str) -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=f"prefs-{profile_id}",
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        source="test",
+    )
+
+
+def _make_user_playbook(
+    user_playbook_id: int, user_id: str, request_id: str
+) -> UserPlaybook:
+    return UserPlaybook(
+        user_playbook_id=user_playbook_id,
+        user_id=user_id,
+        playbook_name="fb",
+        agent_version="v1",
+        request_id=request_id,
+        content=f"playbook-{user_playbook_id}",
+        created_at=1_700_000_000 + user_playbook_id,
+        source="test",
+        source_interaction_ids=[],
+    )
+
+
+def _make_agent_playbook(agent_playbook_id: int) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=agent_playbook_id,
+        playbook_name="fb",
+        agent_version="v1",
+        content=f"agent-pb-{agent_playbook_id}",
+        created_at=1_700_000_000 + agent_playbook_id,
+    )
+
+
+def _seed_user(storage: BaseStorage, user_id: str, suffix: str) -> None:
+    """Seed one user's worth of cross-entity data.
+
+    Adds a request, an interaction, a user playbook, and a profile for
+    ``user_id``. ``suffix`` namespaces the row keys so two users can be
+    seeded into the same backend without primary-key collisions.
+    """
+    storage.add_request(_make_request(f"req_{suffix}", user_id))
+    storage.add_user_interaction(
+        user_id, _make_interaction(user_id, 1000 + ord(suffix[0]), f"req_{suffix}")
+    )
+    storage.save_user_playbooks(
+        [_make_user_playbook(2000 + ord(suffix[0]), user_id, f"req_{suffix}")]
+    )
+    storage.add_user_profile(user_id, [_make_profile(user_id, f"pid_{suffix}")])
+
+
+class TestClearUserData:
+    def test_clears_only_target_user_rows(self, storage: BaseStorage) -> None:
+        """Sibling user data must survive clear_user_data on another user."""
+        _seed_user(storage, "userA", "a")
+        _seed_user(storage, "userB", "b")
+        # Shared cross-project agent playbook — must survive.
+        storage.save_agent_playbooks([_make_agent_playbook(9001)])
+
+        counts = storage.clear_user_data("userA")
+
+        # All four user-scoped entity types report at least one deletion.
+        for key in ("interactions", "user_playbooks", "profiles", "requests"):
+            assert key in counts, f"missing {key} in deleted_counts"
+            assert counts[key] >= 1, (
+                f"expected {key} deletion >= 1 for userA, got {counts[key]}"
+            )
+
+        # userA fully wiped.
+        assert storage.get_user_interaction("userA") == []
+        assert storage.get_user_profile("userA") == []
+        assert storage.get_user_playbooks(user_id="userA") == []
+        assert storage.get_request("req_a") is None
+
+        # userB completely untouched.
+        assert len(storage.get_user_interaction("userB")) == 1
+        assert len(storage.get_user_profile("userB")) == 1
+        assert len(storage.get_user_playbooks(user_id="userB")) == 1
+        assert storage.get_request("req_b") is not None
+
+    def test_agent_playbooks_unchanged(self, storage: BaseStorage) -> None:
+        """agent_playbooks have no user_id column and must never be touched."""
+        _seed_user(storage, "userA", "a")
+        storage.save_agent_playbooks(
+            [_make_agent_playbook(9001), _make_agent_playbook(9002)]
+        )
+        before = storage.get_agent_playbooks(limit=1000)
+        assert len(before) == 2
+
+        storage.clear_user_data("userA")
+
+        after = storage.get_agent_playbooks(limit=1000)
+        assert len(after) == len(before)
+        assert {p.agent_playbook_id for p in after} == {
+            p.agent_playbook_id for p in before
+        }
+
+    def test_clear_unknown_user_is_noop(self, storage: BaseStorage) -> None:
+        """Clearing an unknown user_id returns zero counts and does not raise."""
+        _seed_user(storage, "userA", "a")
+
+        counts = storage.clear_user_data("does_not_exist")
+
+        # No rows removed for the unknown user.
+        assert all(v == 0 for v in counts.values()), counts
+        # userA still intact.
+        assert len(storage.get_user_interaction("userA")) == 1
+        assert len(storage.get_user_profile("userA")) == 1
+        assert len(storage.get_user_playbooks(user_id="userA")) == 1
+        assert storage.get_request("req_a") is not None
+
+    def test_returned_counts_match_seeded_rows(self, storage: BaseStorage) -> None:
+        """Per-entity counts must reflect actual seeded row counts for the user."""
+        # Seed userA with two of each.
+        storage.add_request(_make_request("ra1", "userA"))
+        storage.add_request(_make_request("ra2", "userA"))
+        storage.add_user_interaction("userA", _make_interaction("userA", 5001, "ra1"))
+        storage.add_user_interaction("userA", _make_interaction("userA", 5002, "ra2"))
+        storage.save_user_playbooks(
+            [
+                _make_user_playbook(6001, "userA", "ra1"),
+                _make_user_playbook(6002, "userA", "ra2"),
+            ]
+        )
+        storage.add_user_profile(
+            "userA",
+            [
+                _make_profile("userA", "pa1"),
+                _make_profile("userA", "pa2"),
+            ],
+        )
+
+        counts = storage.clear_user_data("userA")
+
+        assert counts["interactions"] == 2
+        assert counts["user_playbooks"] == 2
+        assert counts["profiles"] == 2
+        assert counts["requests"] == 2


### PR DESCRIPTION
## Summary

Third (and hopefully final) attempt to land `/api/clear_user_data` on `main`.

History of how this got tangled:

| PR | State on GitHub | Where the squash actually landed |
|---|---|---|
| #74 | MERGED | `feat/log-vector-search-scores` (not main) — original stacked-PR merge problem |
| #77 | MERGED | `feat/vector-rank-score-logging-v2` (not main) — re-do PR, also stacked-merged |
| **#this** | OPEN, base = `main` | `main`, no stacking |

The previous re-do (#77) merged 13 seconds after its parent #76 — GitHub didn't have time to auto-retarget the base from `feat/vector-rank-score-logging-v2` to `main`, so the squash merge landed on the now-defunct parent branch. This PR base is locked to `main` from the start: no stacking, no retarget, no race.

## What lands

```
POST /api/clear_user_data       — request:  {"user_id": "<id>"}
                                  response: {"success": bool,
                                             "deleted_counts": {
                                               "interactions": int,
                                               "user_playbooks": int,
                                               "profiles": int,
                                               "requests": int,
                                             },
                                             "message": str}
```

- `BaseStorage.clear_user_data(user_id) -> dict[str, int]` — default impl composes existing primitives; SQLite override uses one transaction for the fast path.
- `ReflexioClient.clear_user_data(user_id) -> ClearUserDataResponse` — invalidates the local read cache.
- 10 new tests across storage contract, disk storage, client, and endpoint.

Used by the SWE-bench paired-protocol harness in `reflexio-enterprise` to give per-task data isolation on a shared backend (so parallel paired runs don't trample each other's mid-flight playbooks).

## Test plan

- [x] Full storage suite (incl. 3 new contract/disk/integration tests): 245 passed
- [x] Cherry-pick from `b92f10756` (the orphaned squash from #77) applies cleanly onto current `main` (`9eab478`)

## Merge policy

**Merge this PR alone.** Do not stack anything else on it, do not enable any merge queue. Just click Squash and merge. This is the path that's been failing every time we deviated from it.
