### PR TITLE
feat(cli): centralize ~/.reflexio resolution behind reflexio_home() helper

### DIFF
--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import typer
 
+from .paths import reflexio_home
+
 logger = logging.getLogger(__name__)
 
 _VALID_STORAGE_BACKENDS = frozenset({"sqlite", "supabase", "postgres", "disk"})
@@ -48,7 +50,7 @@ def _config_dir(base_dir: str | None = None) -> Path:
     """Return the config directory path."""
     if base_dir:
         return Path(base_dir) / "configs"
-    return Path.home() / ".reflexio" / "configs"
+    return reflexio_home() / "configs"
 
 
 def default_config_path(base_dir: str | None = None) -> Path:

--- a/reflexio/cli/codex_auth.py
+++ b/reflexio/cli/codex_auth.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlencode, urlparse
 
+from .paths import reflexio_home
+
 logger = logging.getLogger(__name__)
 
 # OAuth client + endpoints used by the Codex CLI. Values verified by
@@ -54,7 +56,7 @@ CODEX_SCOPES = "openid profile email offline_access"
 # downstream call doesn't cross the boundary mid-flight.
 _REFRESH_LEAD_SECONDS = 60
 
-REFLEXIO_AUTH_DIR = Path.home() / ".reflexio" / "auth"
+REFLEXIO_AUTH_DIR = reflexio_home() / "auth"
 REFLEXIO_CODEX_TOKENS_PATH = REFLEXIO_AUTH_DIR / "openai-codex.json"
 
 

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -666,7 +666,9 @@ def _uninstall_openclaw() -> None:
         typer.echo("Warning: openclaw CLI not found on PATH, skipping plugin removal")
 
     # Remove setup markers
-    reflexio_dir = Path.home() / ".reflexio"
+    from reflexio.cli.paths import reflexio_home
+
+    reflexio_dir = reflexio_home()
     if reflexio_dir.exists():
         for marker in reflexio_dir.glob(".setup_complete_*"):
             marker.unlink(missing_ok=True)

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -17,7 +17,9 @@ _logger = logging.getLogger(__name__)
 
 from dotenv import load_dotenv
 
-_USER_ENV_DIR = Path.home() / ".reflexio"
+from .paths import reflexio_home
+
+_USER_ENV_DIR = reflexio_home()
 _USER_ENV_FILE = _USER_ENV_DIR / ".env"
 
 

--- a/reflexio/cli/log_format.py
+++ b/reflexio/cli/log_format.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import itertools
 import logging
-import os
 import re
 import sys
 import threading
@@ -42,30 +41,24 @@ _LEVEL_RE = re.compile(r"^(?:\[)?(ERROR|CRITICAL|WARNING|WARN)(?:\])?(?::|\s+-\s
 # Canonical log file paths.
 # Default: ~/.reflexio/logs/. The REFLEXIO_LOG_DIR env var overrides only the
 # base directory (the ~ part) — the .reflexio/logs suffix is preserved so the
-# on-disk layout stays consistent regardless of where the base points.
+# on-disk layout stays consistent regardless of where the base points. Base
+# resolution is delegated to ``reflexio_home`` so every ``~/.reflexio/*`` path
+# honors the env var identically.
 def _resolve_log_dir() -> Path:
     """Return the directory log files are written to.
 
-    The ``REFLEXIO_LOG_DIR`` env var overrides the base directory only — the
-    ``.reflexio/logs`` suffix is preserved so the on-disk layout matches the
-    default home-relative layout. Resolved at module import time so the
-    public ``DEV_LOG_FILE`` / ``LLM_IO_LOG_FILE`` constants are stable across
-    a server's lifetime — change requires a restart.
+    Resolved at module import time so the public ``DEV_LOG_FILE`` /
+    ``LLM_IO_LOG_FILE`` constants are stable across a server's lifetime —
+    change requires a restart.
 
     Returns:
         Path: Resolved log directory. Not created here — callers must
             ``mkdir(parents=True, exist_ok=True)`` before opening any
             file handler against ``DEV_LOG_FILE`` / ``LLM_IO_LOG_FILE``.
     """
-    base = os.environ.get("REFLEXIO_LOG_DIR")
-    if base:
-        base_path = Path(base).expanduser()
-        if not base_path.is_absolute():
-            base_path = Path.home() / base_path
-        base_path = base_path.resolve()
-    else:
-        base_path = Path.home()
-    return base_path / ".reflexio" / "logs"
+    from .paths import reflexio_home
+
+    return reflexio_home() / "logs"
 
 
 LOG_DIR: Path = _resolve_log_dir()

--- a/reflexio/cli/paths.py
+++ b/reflexio/cli/paths.py
@@ -1,0 +1,41 @@
+"""Canonical filesystem paths for reflexio runtime data.
+
+Centralizes the resolution of the ``.reflexio`` base directory so every
+caller honors the ``REFLEXIO_LOG_DIR`` env var consistently. When the env
+var is set, the ``.reflexio`` tree is rooted at that path instead of
+``Path.home()``; the ``.reflexio/<subdir>`` suffix is always preserved
+so the on-disk layout stays identical regardless of where the base
+points.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def reflexio_home() -> Path:
+    """Return the canonical ``.reflexio`` directory.
+
+    Resolution:
+        - If ``REFLEXIO_LOG_DIR`` is set, the base is that path (with
+          ``~`` expanded; resolved to an absolute path, anchored to
+          ``Path.home()`` if relative).
+        - Otherwise the base is ``Path.home()``.
+
+    The ``.reflexio`` suffix is appended to the base in both cases. The
+    directory is **not** created here — callers must
+    ``mkdir(parents=True, exist_ok=True)`` at point of use.
+
+    Returns:
+        Path: Absolute path to the resolved ``.reflexio`` directory.
+    """
+    base = os.environ.get("REFLEXIO_LOG_DIR")
+    if base:
+        base_path = Path(base).expanduser()
+        if not base_path.is_absolute():
+            base_path = Path.home() / base_path
+        base_path = base_path.resolve()
+    else:
+        base_path = Path.home()
+    return base_path / ".reflexio"

--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -3,7 +3,6 @@ import logging.handlers
 import os
 import sys
 import time
-from pathlib import Path
 
 import colorlog
 
@@ -14,12 +13,13 @@ import openai  # noqa: F401
 import openai.resources  # noqa: F401
 
 from reflexio.cli.env_loader import load_reflexio_env
+from reflexio.cli.paths import reflexio_home
 
 # Load environment variables using shared discovery logic
 load_reflexio_env()
 
-# Default user data directory: ~/.reflexio/data/
-_DEFAULT_DATA_DIR = str(Path.home() / ".reflexio" / "data")
+# Default user data directory: ~/.reflexio/data/ (or REFLEXIO_LOG_DIR/.reflexio/data/).
+_DEFAULT_DATA_DIR = str(reflexio_home() / "data")
 
 # OpenAI related
 OPENAI_API_KEY = os.environ.get(

--- a/reflexio/server/services/configurator/local_file_config_storage.py
+++ b/reflexio/server/services/configurator/local_file_config_storage.py
@@ -6,6 +6,7 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+from reflexio.cli.paths import reflexio_home
 from reflexio.models.config_schema import (
     Config,
     PlaybookConfig,
@@ -36,7 +37,7 @@ class LocalFileConfigStorage(ConfigStorage):
                 f"LocalFileConfigStorage will save config for {org_id} to a local file at {self.config_file}"
             )
         else:
-            self.base_dir = str(Path.home() / ".reflexio" / "configs")
+            self.base_dir = str(reflexio_home() / "configs")
             self.config_file = str(Path(self.base_dir) / f"config_{org_id}.json")
 
     def _default_storage_config(self) -> StorageConfigSQLite | StorageConfigDisk:

--- a/tests/server/services/storage/test_storage_defaults.py
+++ b/tests/server/services/storage/test_storage_defaults.py
@@ -16,7 +16,9 @@ from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 def test_local_storage_path_defaults_to_home_reflexio_data() -> None:
     """With LOCAL_STORAGE_PATH unset, reflexio.server.LOCAL_STORAGE_PATH
     resolves to ~/.reflexio/data."""
-    expected = str(Path.home() / ".reflexio" / "data")
+    from reflexio.cli.paths import reflexio_home
+
+    expected = str(reflexio_home() / "data")
 
     env = {k: v for k, v in os.environ.items() if k != "LOCAL_STORAGE_PATH"}
     import reflexio.server as server_module
@@ -34,7 +36,9 @@ def test_local_storage_path_defaults_to_home_reflexio_data() -> None:
 def test_local_storage_path_empty_string_falls_back_to_default() -> None:
     """LOCAL_STORAGE_PATH='' (blank) also falls back to ~/.reflexio/data
     rather than resolving to an empty path."""
-    expected = str(Path.home() / ".reflexio" / "data")
+    from reflexio.cli.paths import reflexio_home
+
+    expected = str(reflexio_home() / "data")
 
     import reflexio.server as server_module
 
@@ -57,6 +61,24 @@ def test_sqlite_storage_uses_local_storage_path_when_db_path_none() -> None:
     ):
         storage = SQLiteStorage(org_id="0", db_path=None)
         assert storage.db_path == str(Path(temp_dir) / "reflexio.db")
+
+
+def test_local_storage_path_honors_reflexio_log_dir_override(tmp_path: Path) -> None:
+    """When ``REFLEXIO_LOG_DIR`` is set, the default ``LOCAL_STORAGE_PATH``
+    rebases off it: ``<REFLEXIO_LOG_DIR>/.reflexio/data`` instead of
+    ``~/.reflexio/data``."""
+    expected = str(tmp_path / ".reflexio" / "data")
+
+    import reflexio.server as server_module
+
+    try:
+        env = {k: v for k, v in os.environ.items() if k != "LOCAL_STORAGE_PATH"}
+        env["REFLEXIO_LOG_DIR"] = str(tmp_path)
+        with patch.dict(os.environ, env, clear=True):
+            reloaded = importlib.reload(server_module)
+            assert expected == reloaded.LOCAL_STORAGE_PATH
+    finally:
+        importlib.reload(server_module)
 
 
 def test_sqlite_storage_explicit_db_path_overrides_env() -> None:


### PR DESCRIPTION
## Summary

- Add ``reflexio/cli/paths.py::reflexio_home()`` — single helper that resolves the ``.reflexio`` base directory, honoring ``REFLEXIO_LOG_DIR`` if set (otherwise ``Path.home()``). The ``.reflexio/<subdir>`` suffix is always preserved.
- Refactor ``log_format._resolve_log_dir`` to delegate to it, then sweep every other ``Path.home() / \".reflexio\"`` call site: ``env_loader``, ``codex_auth``, ``bootstrap_config``, ``commands/setup_cmd``, ``server/__init__`` (data dir), ``server/services/configurator/local_file_config_storage`` (configs dir).
- Default behavior is unchanged. With ``REFLEXIO_LOG_DIR=/foo``, the entire tree rebases to ``/foo/.reflexio/{.env, configs, data, auth, logs, ...}`` instead of only ``logs/``.

## Why

Previously only ``logs/`` honored ``REFLEXIO_LOG_DIR``. An isolated workspace (e.g. parallel test runs, sandboxed dev envs) couldn't fully avoid writing under ``~/.reflexio/`` because env, configs, data, and auth paths were each hardcoded with ``Path.home()``.

## Test plan

- [x] ``uv run pytest tests/server/services/storage/test_storage_defaults.py`` — 5 passed (incl. new ``test_local_storage_path_honors_reflexio_log_dir_override``)
- [x] ``uv run ruff check`` + ``uv run pyright`` on every changed file — 0 errors
- [x] Runtime smoke: with env var unset, paths default to ``~/.reflexio/...``; with ``REFLEXIO_LOG_DIR=/tmp/iso``, they rebase to ``/tmp/iso/.reflexio/...``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added `REFLEXIO_LOG_DIR` environment variable support to override the default Reflexio data and configuration directory location.

* **Chores**
  - Improved path resolution consistency across Reflexio components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->