### PR TITLE
[codex] Pause automatic extraction during provider stalls

### DIFF
--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -265,6 +265,13 @@ def publish(
             help="Bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors",
         ),
     ] = False,
+    override_learning_stall: Annotated[
+        bool,
+        typer.Option(
+            "--override-learning-stall",
+            help="Run extraction even when a provider auth/billing stall is recorded. Use only for explicit retries after reauth or limit reset.",
+        ),
+    ] = False,
 ) -> None:
     """Publish interaction data for a user.
 
@@ -316,6 +323,7 @@ def publish(
             wait_for_response=wait,
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
+            override_learning_stall=override_learning_stall,
         )
         if json_mode:
             render(result, json_mode=True)
@@ -372,6 +380,9 @@ def publish(
             wait_for_response=wait,
             skip_aggregation=payload.get("skip_aggregation", skip_aggregation),
             force_extraction=payload.get("force_extraction", force_extraction),
+            override_learning_stall=payload.get(
+                "override_learning_stall", override_learning_stall
+            ),
         )
         if json_mode:
             render(result, json_mode=True)

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -387,6 +387,7 @@ class ReflexioClient:
         wait_for_response: bool = False,
         skip_aggregation: bool = False,
         force_extraction: bool = False,
+        override_learning_stall: bool = False,
     ) -> PublishUserInteractionResponse:
         """Publish user interactions.
 
@@ -424,6 +425,10 @@ class ReflexioClient:
             force_extraction: If True, bypass all extraction gates
                 (stride_size, cheap pre-filter, LLM should_run) and
                 always run extractors.
+            override_learning_stall: If True, run extraction even when
+                Reflexio has recorded a provider auth/billing stall. Keep
+                this False for automatic hook publishes; use it only for an
+                explicit retry after reauth or limit reset.
 
         Returns:
             PublishUserInteractionResponse: Server response. In
@@ -449,6 +454,7 @@ class ReflexioClient:
             agent_version=agent_version,
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
+            override_learning_stall=override_learning_stall,
         )
         result = self._publish_interaction_sync(
             request, wait_for_response=wait_for_response

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -530,6 +530,7 @@ class PublishUserInteractionRequest(BaseModel):
         False  # when True, extract profiles/playbooks but skip aggregation
     )
     force_extraction: bool = False  # when True, bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors
+    override_learning_stall: bool = False  # when True, run extraction even if a provider auth/billing stall is recorded
 
 
 # publish user interaction response

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 CLEANUP_STALE_LOCK_SECONDS = 600
 # Timeout for the outer generation service parallel execution
 GENERATION_SERVICE_TIMEOUT_SECONDS = 600
+_STALL_WARNING_PREFIX = "Reflexio learning is paused"
 
 
 @dataclass
@@ -202,6 +203,28 @@ class GenerationService:
 
             # Extract source (empty string treated as None)
             source = publish_user_interaction_request.source or None
+
+            if (
+                not publish_user_interaction_request.override_learning_stall
+                and (stall_warning := self._active_learning_stall_warning()) is not None
+            ):
+                result.warnings.append(stall_warning)
+                logger.warning("%s; skipping automatic extraction", stall_warning)
+                record_usage_event(
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    session_id=new_request.session_id,
+                    source=source,
+                    agent_version=agent_version,
+                    event_name="publish_request_succeeded",
+                    event_category="publish",
+                    outcome="success",
+                    count_value=len(new_interactions),
+                    duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                    metadata={"warning_count": len(result.warnings)},
+                )
+                return result
 
             # Reflection runs as its own sliding-window step BEFORE the
             # extractor pool spins up, so any replacements it makes are
@@ -472,6 +495,36 @@ class GenerationService:
         except Exception as e:
             logger.error("Failed to cleanup storage tables: %s", e)
             # Don't raise - cleanup failure shouldn't block normal operation
+
+    def _active_learning_stall_warning(self) -> str | None:
+        """Return a warning when extraction should not auto-retry.
+
+        Plugin publishes should still store raw interactions while the local
+        LLM provider is blocked by auth or billing, but they
+        must not keep invoking extraction on every publish. Only callers that
+        pass ``override_learning_stall=True`` bypass this check so an explicit
+        retry after reauth can clear the stall state on a successful provider
+        call.
+        """
+        try:
+            stall_state = self.storage.get_stall_state()  # type: ignore[reportOptionalMemberAccess]
+        except (AttributeError, NotImplementedError):
+            return None
+        except Exception as exc:  # noqa: BLE001 - stall telemetry must not block publish.
+            logger.debug("Failed to read stall_state before extraction: %s", exc)
+            return None
+
+        if not getattr(stall_state, "stalled", False):
+            return None
+        reason = getattr(stall_state, "reason", None) or "unknown"
+        suffix = (
+            "reauthenticate the active coding-agent provider, then run an explicit "
+            "override retry to resume."
+            if reason == "auth_error"
+            else "wait for the limit/reset condition to clear, then run an explicit "
+            "override retry to resume."
+        )
+        return f"{_STALL_WARNING_PREFIX} ({reason}); {suffix}"
 
     def _cleanup_retention_target(self, target_name: str, limit: int) -> None:
         total_count = self.storage.count_retention_target_rows(target_name)  # type: ignore[reportOptionalMemberAccess]

--- a/tests/server/services/extraction/test_agentic_v2_e2e.py
+++ b/tests/server/services/extraction/test_agentic_v2_e2e.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 from reflexio.models.api_schema.service_schemas import (
@@ -270,6 +271,132 @@ def test_e2e_agentic_v2_extraction_agent_not_invoked_for_trivial_session(tmp_pat
 
     # Result must not have raised (warnings may be empty or trivial).
     assert result.request_id is not None
+
+
+def test_e2e_publish_stores_interactions_but_skips_extraction_when_stalled(tmp_path):
+    """An auth/billing stall pauses automatic learning retries, not raw storage."""
+    user_id = "stalled_user"
+    org_id = "stalled_org"
+
+    with tempfile.TemporaryDirectory() as temp_dir, patch.dict(
+        os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False
+    ):
+        request_context = RequestContext(org_id=org_id, storage_base_dir=temp_dir)
+        assert request_context.storage is not None
+        request_context.storage.llm_client.get_embeddings = MagicMock(  # type: ignore[method-assign]
+            return_value=[[], []]
+        )
+        request_context.storage.upsert_stall_state(
+            reason="auth_error",
+            stalled_at=datetime.now(UTC),
+            reset_estimate=None,
+            error_message="401 Invalid authentication credentials",
+        )
+
+        gs = GenerationService(
+            llm_client=_make_scripted_client([]),
+            request_context=request_context,
+        )
+        gs.configurator.get_config = MagicMock(return_value=_make_agentic_config())  # type: ignore[method-assign]
+
+        request = PublishUserInteractionRequest(
+            user_id=user_id,
+            interaction_data_list=[
+                InteractionData(
+                    role="User",
+                    content=(
+                        "I prefer implementation work to pause automatic learning "
+                        "when provider authentication is broken."
+                    ),
+                ),
+                InteractionData(
+                    role="Assistant",
+                    content="I will surface the authentication issue instead.",
+                ),
+            ],
+            session_id="stalled_sid",
+            force_extraction=True,
+        )
+
+        with (
+            patch(
+                "reflexio.server.services.generation_service.ReflectionService.run"
+            ) as mock_reflection_run,
+            patch(
+                "reflexio.server.services.extraction.agentic_adapter."
+                "AgenticExtractionRunner.run"
+            ) as mock_agentic_run,
+        ):
+            result = gs.run(request)
+
+        assert result.request_id is not None
+        assert result.warnings
+        assert "auth_error" in result.warnings[0]
+        assert "paused" in result.warnings[0]
+        assert mock_reflection_run.call_count == 0
+        assert mock_agentic_run.call_count == 0
+
+        stored = request_context.storage.get_user_interaction(user_id)
+        assert len(stored) == 2
+        assert {item.role for item in stored} == {"User", "Assistant"}
+
+
+def test_e2e_stalled_forced_publish_runs_with_explicit_override(tmp_path):
+    """A forced publish can retry a stall only with the explicit override flag."""
+    user_id = "stalled_override_user"
+    org_id = "stalled_override_org"
+
+    with tempfile.TemporaryDirectory() as temp_dir, patch.dict(
+        os.environ, {"OPENAI_API_KEY": "test-key"}, clear=False
+    ):
+        request_context = RequestContext(org_id=org_id, storage_base_dir=temp_dir)
+        assert request_context.storage is not None
+        request_context.storage.llm_client.get_embeddings = MagicMock(  # type: ignore[method-assign]
+            return_value=[[], []]
+        )
+        request_context.storage.upsert_stall_state(
+            reason="auth_error",
+            stalled_at=datetime.now(UTC),
+            reset_estimate=None,
+            error_message="401 Invalid authentication credentials",
+        )
+
+        gs = GenerationService(
+            llm_client=_make_scripted_client([]),
+            request_context=request_context,
+        )
+        gs.configurator.get_config = MagicMock(return_value=_make_agentic_config())  # type: ignore[method-assign]
+
+        request = PublishUserInteractionRequest(
+            user_id=user_id,
+            interaction_data_list=[
+                InteractionData(
+                    role="User",
+                    content="Retry extraction explicitly after fixing provider authentication.",
+                ),
+                InteractionData(role="Assistant", content="Retrying extraction now."),
+            ],
+            session_id="stalled_override_sid",
+            force_extraction=True,
+            override_learning_stall=True,
+        )
+
+        with (
+            patch(
+                "reflexio.server.services.generation_service.ReflectionService.run"
+            ) as mock_reflection_run,
+            patch(
+                "reflexio.server.services.extraction.agentic_adapter."
+                "AgenticExtractionRunner.run",
+                return_value=[],
+            ) as mock_agentic_run,
+        ):
+            result = gs.run(request)
+
+        assert result.request_id is not None
+        assert result.warnings == []
+        assert mock_reflection_run.call_count == 1
+        assert mock_agentic_run.call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- record provider auth/billing stalls and pause automatic profile/playbook extraction retries while still storing raw interactions
- add an explicit `override_learning_stall` API/CLI flag so manual retry flows can bypass a recorded stall after reauth or limit reset
- keep `force_extraction` from bypassing stalls, including forced automatic hook publishes
- cover stalled forced publishes and explicit override retry behavior in extraction tests

## Testing
- uv run ruff check open_source/reflexio/reflexio/models/api_schema/domain/entities.py open_source/reflexio/reflexio/client/client.py open_source/reflexio/reflexio/cli/commands/interactions.py open_source/reflexio/reflexio/server/services/generation_service.py open_source/reflexio/tests/server/services/extraction/test_agentic_v2_e2e.py
- uv run pytest --no-cov open_source/reflexio/tests/server/services/extraction/test_agentic_v2_e2e.py::test_e2e_publish_stores_interactions_but_skips_extraction_when_stalled open_source/reflexio/tests/server/services/extraction/test_agentic_v2_e2e.py::test_e2e_stalled_forced_publish_runs_with_explicit_override
- uv run python -c "import reflexio"

Follow-up integration: ReflexioAI/claude-smart#39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `--override-learning-stall` option to the publish command, enabling users to force extraction and publish interactions even when a learning stall due to provider authentication or billing issues is detected.
* The system now automatically detects stall conditions and notifies users with clear warning messages when learning is paused.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->