### PR TITLE
feat(eval): pipeline diagnostic & retry hardening

### DIFF
--- a/reflexio/server/api_endpoints/health_api.py
+++ b/reflexio/server/api_endpoints/health_api.py
@@ -15,6 +15,8 @@ from typing import Any
 
 from fastapi import FastAPI, Request, Response
 
+from reflexio.server.services.agent_success_evaluation import _eval_health
+
 _STARTED_AT = time.monotonic()
 _REQUEST_COUNT = 0
 
@@ -30,6 +32,30 @@ def _read_rss_mb() -> float | None:
     except ImportError:
         return None
     return psutil.Process().memory_info().rss / 1024.0 / 1024.0
+
+
+_AMBER_SECONDS = 5 * 60
+_RED_SECONDS = 30 * 60
+
+
+def _liveness_from_tick(last_tick_monotonic: float | None) -> str:
+    """Map scheduler-tick age to a green/amber/red liveness color.
+
+    Args:
+        last_tick_monotonic (float | None): The last recorded scheduler tick,
+            from `time.monotonic()`; None if the scheduler has not yet ticked.
+
+    Returns:
+        str: One of "green", "amber", "red".
+    """
+    if last_tick_monotonic is None:
+        return "red"
+    age = time.monotonic() - last_tick_monotonic
+    if age > _RED_SECONDS:
+        return "red"
+    if age > _AMBER_SECONDS:
+        return "amber"
+    return "green"
 
 
 def install(app: FastAPI) -> None:
@@ -53,4 +79,13 @@ def install(app: FastAPI) -> None:
             "uptime_sec": time.monotonic() - _STARTED_AT,
             "request_count": _REQUEST_COUNT,
             "rss_mb": _read_rss_mb(),
+        }
+
+    @app.get("/healthz/eval")
+    def healthz_eval() -> dict[str, Any]:
+        """Return evaluation-pipeline health: skip counts, failure counts, liveness."""
+        status = _eval_health.get_status()
+        return {
+            **status,
+            "liveness": _liveness_from_tick(status["last_tick_monotonic"]),
         }

--- a/reflexio/server/services/agent_success_evaluation/_eval_health.py
+++ b/reflexio/server/services/agent_success_evaluation/_eval_health.py
@@ -1,0 +1,131 @@
+"""Process-wide health singleton for the agent-success evaluation pipeline.
+
+Tracks three signals that the operator-facing healthcheck surfaces:
+
+1. Scheduler liveness — last tick timestamp (monotonic).
+2. Per-reason skip counts — why a session was skipped during evaluation.
+3. Producer failure counts in a rolling 24h window.
+
+This is intentionally a global singleton, not a per-request object — the
+healthcheck endpoint needs to read counts that accumulate across the
+process lifetime, and the scheduler / runner / service all need to write
+to the same store.
+"""
+
+from __future__ import annotations
+
+import enum
+import threading
+import time
+from collections import Counter, deque
+from typing import Any
+
+
+class SkipReason(enum.StrEnum):
+    """Why a session evaluation was skipped.
+
+    Members are the exact string the healthcheck exposes; do not rename
+    casually.
+    """
+
+    ALREADY_EVALUATED = "already_evaluated"
+    NO_REQUESTS = "no_requests"
+    NOT_YET_COMPLETE = "not_yet_complete"
+    NO_INTERACTIONS = "no_interactions"
+    NO_DATA_MODELS = "no_data_models"
+
+
+_FAILURE_WINDOW_SECONDS = 24 * 60 * 60
+
+
+class EvalHealth:
+    """Thread-safe counter store for evaluation-pipeline diagnostics.
+
+    A module-level singleton is exposed as `_HEALTH`; the public helpers
+    `record_skip`, `record_producer_failure`, `record_tick`, and
+    `get_status` proxy to it.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._skip_counts: Counter[SkipReason] = Counter()
+        self._failures: deque[float] = deque()
+        self._last_tick_monotonic: float | None = None
+
+    def record_skip(self, reason: SkipReason) -> None:
+        """Bump the counter for `reason` by one.
+
+        Args:
+            reason (SkipReason): The reason the runner skipped a session.
+        """
+        with self._lock:
+            self._skip_counts[reason] += 1
+
+    def record_producer_failure(self, at_ts: float | None = None) -> None:
+        """Record a producer failure (LLM error or persistent save failure).
+
+        Args:
+            at_ts (float | None): Wall-clock unix timestamp; defaults to now.
+        """
+        ts = time.time() if at_ts is None else at_ts
+        with self._lock:
+            self._failures.append(ts)
+            self._trim_locked(ts)
+
+    def record_tick(self, monotonic_ts: float | None = None) -> None:
+        """Record that the scheduler loop ticked.
+
+        Args:
+            monotonic_ts (float | None): Monotonic clock reading; defaults to now.
+        """
+        ts = time.monotonic() if monotonic_ts is None else monotonic_ts
+        with self._lock:
+            self._last_tick_monotonic = ts
+
+    def get_status(self, now_ts: float | None = None) -> dict[str, Any]:
+        """Return a snapshot of all health counters.
+
+        Args:
+            now_ts (float | None): Unix wall-clock used for the failure window;
+                defaults to now.
+
+        Returns:
+            dict[str, Any]: Snapshot suitable for the /healthz/eval payload.
+        """
+        ts = time.time() if now_ts is None else now_ts
+        with self._lock:
+            self._trim_locked(ts)
+            return {
+                "skip_counts": {r.value: self._skip_counts[r] for r in SkipReason},
+                "producer_failures_24h": len(self._failures),
+                "last_tick_monotonic": self._last_tick_monotonic,
+            }
+
+    def _trim_locked(self, now_ts: float) -> None:
+        """Drop failure timestamps older than the 24h window (caller holds lock)."""
+        cutoff = now_ts - _FAILURE_WINDOW_SECONDS
+        while self._failures and self._failures[0] < cutoff:
+            self._failures.popleft()
+
+
+_HEALTH = EvalHealth()
+
+
+def record_skip(reason: SkipReason) -> None:
+    """Module-level proxy to the singleton."""
+    _HEALTH.record_skip(reason)
+
+
+def record_producer_failure(at_ts: float | None = None) -> None:
+    """Module-level proxy to the singleton."""
+    _HEALTH.record_producer_failure(at_ts=at_ts)
+
+
+def record_tick(monotonic_ts: float | None = None) -> None:
+    """Module-level proxy to the singleton."""
+    _HEALTH.record_tick(monotonic_ts=monotonic_ts)
+
+
+def get_status(now_ts: float | None = None) -> dict[str, Any]:
+    """Module-level proxy to the singleton."""
+    return _HEALTH.get_status(now_ts=now_ts)

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
@@ -1,10 +1,12 @@
 import logging
+import time
 from dataclasses import dataclass
 
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.models.config_schema import AgentSuccessConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.agent_success_evaluation import _eval_health
 from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_utils import (
     AgentSuccessEvaluationRequest,
 )
@@ -134,24 +136,46 @@ class AgentSuccessEvaluationService(
             self.service_config.session_id,  # type: ignore[reportOptionalMemberAccess]
         )
 
-        # Save results
+        # Save results with retry+backoff. After the final attempt the producer
+        # failure is recorded into EvalHealth so the operator-facing healthcheck
+        # surfaces persistent storage problems.
         if all_results:
-            try:
-                self.storage.save_agent_success_evaluation_results(all_results)  # type: ignore[reportOptionalMemberAccess]
-                self.last_run_saved_result_count = len(all_results)
-                logger.info(
-                    "Saved %d agent success evaluation results for session: %s",
-                    len(all_results),
-                    self.service_config.session_id,  # type: ignore[reportOptionalMemberAccess]
-                )
-            except Exception as e:
+            backoffs = [1, 4]
+            attempt = 0
+            saved = False
+            while True:
+                attempt += 1
+                try:
+                    self.storage.save_agent_success_evaluation_results(all_results)  # type: ignore[reportOptionalMemberAccess]
+                    self.last_run_saved_result_count = len(all_results)
+                    logger.info(
+                        "Saved %d agent success evaluation results for session: %s (attempt %d)",
+                        len(all_results),
+                        self.service_config.session_id,  # type: ignore[reportOptionalMemberAccess]
+                        attempt,
+                    )
+                    saved = True
+                    break
+                except Exception as e:
+                    logger.warning(
+                        "Save attempt %d/%d failed for session %s: %s",
+                        attempt,
+                        len(backoffs) + 1,
+                        self.service_config.session_id,  # type: ignore[reportOptionalMemberAccess]
+                        e,
+                    )
+                    if attempt > len(backoffs):
+                        break
+                    time.sleep(backoffs[attempt - 1])
+
+            if not saved:
                 self.last_run_save_failed = True
+                _eval_health.record_producer_failure()
                 logger.error(
-                    "Failed to save %s results for session: %s due to %s, exception type: %s",
+                    "Failed to save %s results for session %s after %d attempts",
                     self._get_service_name(),
                     self.service_config.session_id,  # type: ignore[reportOptionalMemberAccess]
-                    str(e),
-                    type(e).__name__,
+                    attempt,
                 )
 
     def has_run_failures(self) -> bool:

--- a/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
@@ -14,6 +14,8 @@ import threading
 import time
 from collections.abc import Callable
 
+from reflexio.server.services.agent_success_evaluation import _eval_health
+
 logger = logging.getLogger(__name__)
 
 # Delay in seconds before evaluating a group after the last request
@@ -89,6 +91,7 @@ class GroupEvaluationScheduler:
         """
         while True:
             try:
+                _eval_health.record_tick()
                 with self._mutex:
                     next_fire_time = self._heap[0][0] if self._heap else None
 

--- a/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
+++ b/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
@@ -11,6 +11,8 @@ from datetime import UTC, datetime
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.agent_success_evaluation import _eval_health
+from reflexio.server.services.agent_success_evaluation._eval_health import SkipReason
 from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service import (
     AgentSuccessEvaluationService,
 )
@@ -77,12 +79,14 @@ def run_group_evaluation(
     if existing_state and isinstance(existing_state.get("operation_state"), dict):
         op_state = existing_state["operation_state"]
         if op_state.get("evaluated"):
+            _eval_health.record_skip(SkipReason.ALREADY_EVALUATED)
             logger.info("Session %s already evaluated, skipping", session_id)
             return
 
     # 2. Fetch all requests for the session
     requests = storage.get_requests_by_session(user_id, session_id)  # type: ignore[reportOptionalMemberAccess]
     if not requests:
+        _eval_health.record_skip(SkipReason.NO_REQUESTS)
         logger.info("No requests found for session %s, skipping", session_id)
         return
 
@@ -91,6 +95,7 @@ def run_group_evaluation(
     now = int(datetime.now(UTC).timestamp())
     elapsed = now - latest_created_at
     if elapsed < _EFFECTIVE_DELAY_SECONDS:
+        _eval_health.record_skip(SkipReason.NOT_YET_COMPLETE)
         logger.info(
             "Session %s not yet complete (latest request %ds ago, need %ds), skipping",
             session_id,
@@ -103,6 +108,7 @@ def run_group_evaluation(
     request_ids = [r.request_id for r in requests]
     all_interactions = storage.get_interactions_by_request_ids(request_ids)  # type: ignore[reportOptionalMemberAccess]
     if not all_interactions:
+        _eval_health.record_skip(SkipReason.NO_INTERACTIONS)
         logger.info("No interactions found for session %s, skipping", session_id)
         return
 
@@ -128,6 +134,7 @@ def run_group_evaluation(
             )
 
     if not request_interaction_data_models:
+        _eval_health.record_skip(SkipReason.NO_DATA_MODELS)
         logger.info(
             "No request interaction data models built for session %s, skipping",
             session_id,

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -237,6 +237,15 @@ class GenerationService:
                         config=root_config,
                     )
                 )
+                # Schedule delayed group evaluation — must run for the agentic
+                # backend too, otherwise no AgentSuccessEvaluationResult records
+                # ever get produced and /evaluations stays empty.
+                self._schedule_group_evaluation_if_needed(
+                    new_request=new_request,
+                    user_id=user_id,
+                    agent_version=agent_version,
+                    source=source,
+                )
                 record_usage_event(
                     org_id=self.org_id,
                     user_id=user_id,
@@ -323,45 +332,12 @@ class GenerationService:
                 executor.shutdown(wait=False, cancel_futures=True)
 
             # Schedule delayed group evaluation if session_id is present
-            session_id = new_request.session_id
-            if session_id:
-                scheduler = GroupEvaluationScheduler.get_instance()
-                key = (self.org_id, user_id, session_id)
-
-                def make_callback(
-                    _org_id: str,
-                    _user_id: str,
-                    _sid: str,
-                    _av: str,
-                    _src: str | None,
-                    _rc: RequestContext,
-                    _llm: LiteLLMClient,
-                ) -> Callable[[], None]:
-                    def callback() -> None:
-                        run_group_evaluation(
-                            org_id=_org_id,
-                            user_id=_user_id,
-                            session_id=_sid,
-                            agent_version=_av,
-                            source=_src,
-                            request_context=_rc,
-                            llm_client=_llm,
-                        )
-
-                    return callback
-
-                scheduler.schedule(
-                    key,
-                    make_callback(
-                        self.org_id,
-                        user_id,
-                        session_id,
-                        agent_version,
-                        source,
-                        self.request_context,
-                        self.client,
-                    ),
-                )
+            self._schedule_group_evaluation_if_needed(
+                new_request=new_request,
+                user_id=user_id,
+                agent_version=agent_version,
+                source=source,
+            )
 
             record_usage_event(
                 org_id=self.org_id,
@@ -406,6 +382,70 @@ class GenerationService:
     # ===============================
     # private methods
     # ===============================
+
+    def _schedule_group_evaluation_if_needed(
+        self,
+        *,
+        new_request: Request,
+        user_id: str,
+        agent_version: str,
+        source: str | None,
+    ) -> None:
+        """Enqueue agent-success evaluation for this session, if session_id is set.
+
+        Must be called once per publish — from BOTH the classic and the agentic
+        extraction code paths — so that ``AgentSuccessEvaluationResult`` records
+        get produced regardless of which backend is in use. Skipping this for
+        the agentic path was the silent root cause of empty /evaluations tiles.
+
+        Args:
+            new_request (Request): The just-stored request whose session is being
+                published into. ``new_request.session_id`` gates scheduling.
+            user_id (str): The user owning the session.
+            agent_version (str): Agent version string carried into the evaluator.
+            source (str | None): Optional source label.
+        """
+        session_id = new_request.session_id
+        if not session_id:
+            return
+
+        scheduler = GroupEvaluationScheduler.get_instance()
+        key = (self.org_id, user_id, session_id)
+
+        def make_callback(
+            _org_id: str,
+            _user_id: str,
+            _sid: str,
+            _av: str,
+            _src: str | None,
+            _rc: RequestContext,
+            _llm: LiteLLMClient,
+        ) -> Callable[[], None]:
+            def callback() -> None:
+                run_group_evaluation(
+                    org_id=_org_id,
+                    user_id=_user_id,
+                    session_id=_sid,
+                    agent_version=_av,
+                    source=_src,
+                    request_context=_rc,
+                    llm_client=_llm,
+                )
+
+            return callback
+
+        scheduler.schedule(
+            key,
+            make_callback(
+                self.org_id,
+                user_id,
+                session_id,
+                agent_version,
+                source,
+                self.request_context,
+                self.client,
+            ),
+        )
 
     def _maybe_run_reflection(
         self, *, user_id: str, agent_version: str, source: str | None

--- a/tests/server/api_endpoints/test_health_api_eval.py
+++ b/tests/server/api_endpoints/test_health_api_eval.py
@@ -1,0 +1,50 @@
+"""Verify /healthz/eval returns the EvalHealth snapshot + liveness color."""
+
+import time
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from reflexio.server.api_endpoints import health_api
+from reflexio.server.services.agent_success_evaluation import _eval_health
+from reflexio.server.services.agent_success_evaluation._eval_health import SkipReason
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    health_api.install(app)
+    return TestClient(app)
+
+
+def test_eval_health_returns_skip_counts_and_failures() -> None:
+    _eval_health._HEALTH.__init__()
+    _eval_health.record_skip(SkipReason.ALREADY_EVALUATED)
+    _eval_health.record_producer_failure()
+    _eval_health.record_tick(monotonic_ts=time.monotonic())
+
+    response = _client().get("/healthz/eval")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["skip_counts"]["already_evaluated"] == 1
+    assert body["producer_failures_24h"] == 1
+    assert body["last_tick_monotonic"] is not None
+    assert body["liveness"] == "green"
+
+
+def test_eval_health_returns_red_when_scheduler_silent_for_30_min() -> None:
+    _eval_health._HEALTH.__init__()
+    _eval_health.record_tick(monotonic_ts=time.monotonic() - 31 * 60)
+
+    response = _client().get("/healthz/eval")
+
+    assert response.json()["liveness"] == "red"
+
+
+def test_eval_health_returns_amber_when_scheduler_silent_for_5_min() -> None:
+    _eval_health._HEALTH.__init__()
+    _eval_health.record_tick(monotonic_ts=time.monotonic() - 6 * 60)
+
+    response = _client().get("/healthz/eval")
+
+    assert response.json()["liveness"] == "amber"

--- a/tests/server/services/agent_success_evaluation/test_eligibility_logging.py
+++ b/tests/server/services/agent_success_evaluation/test_eligibility_logging.py
@@ -1,0 +1,36 @@
+"""Verify each skip path in run_group_evaluation bumps the matching counter."""
+
+from unittest.mock import MagicMock
+
+from reflexio.server.services.agent_success_evaluation import _eval_health
+from reflexio.server.services.agent_success_evaluation.group_evaluation_runner import (
+    run_group_evaluation,
+)
+
+
+def _make_mock_context(*, get_op_state=None, get_requests=None, get_interactions=None):
+    ctx = MagicMock()
+    ctx.storage.get_operation_state.return_value = get_op_state
+    ctx.storage.get_requests_by_session.return_value = get_requests or []
+    ctx.storage.get_interactions_by_request_ids.return_value = get_interactions or []
+    return ctx
+
+
+def test_already_evaluated_path_bumps_counter() -> None:
+    _eval_health._HEALTH.__init__()
+    ctx = _make_mock_context(
+        get_op_state={"operation_state": {"evaluated": True}},
+    )
+
+    run_group_evaluation("org", "user", "sess", "v0", None, ctx, MagicMock())
+
+    assert _eval_health.get_status()["skip_counts"]["already_evaluated"] == 1
+
+
+def test_no_requests_path_bumps_counter() -> None:
+    _eval_health._HEALTH.__init__()
+    ctx = _make_mock_context(get_requests=[])
+
+    run_group_evaluation("org", "user", "sess", "v0", None, ctx, MagicMock())
+
+    assert _eval_health.get_status()["skip_counts"]["no_requests"] == 1

--- a/tests/server/services/agent_success_evaluation/test_eval_health.py
+++ b/tests/server/services/agent_success_evaluation/test_eval_health.py
@@ -1,0 +1,43 @@
+"""Unit tests for the EvalHealth singleton — counters and serialization."""
+
+from reflexio.server.services.agent_success_evaluation._eval_health import (
+    EvalHealth,
+    SkipReason,
+)
+
+
+def test_skip_reason_counts_aggregate_per_reason() -> None:
+    """EvalHealth aggregates skip counts by reason."""
+    health = EvalHealth()
+    health.record_skip(SkipReason.ALREADY_EVALUATED)
+    health.record_skip(SkipReason.ALREADY_EVALUATED)
+    health.record_skip(SkipReason.NO_REQUESTS)
+
+    status = health.get_status()
+
+    assert status["skip_counts"]["already_evaluated"] == 2
+    assert status["skip_counts"]["no_requests"] == 1
+    assert status["skip_counts"].get("no_interactions", 0) == 0
+
+
+def test_producer_failure_24h_count_decays() -> None:
+    """Producer failures older than 24h fall off the rolling window."""
+    health = EvalHealth()
+    health.record_producer_failure(at_ts=0)
+    health.record_producer_failure(at_ts=1000)
+    health.record_producer_failure(at_ts=1000)
+
+    status = health.get_status(now_ts=86_900)
+
+    assert status["producer_failures_24h"] == 2
+
+
+def test_tick_timestamp_records_latest() -> None:
+    """`record_tick` overwrites with the newest monotonic time."""
+    health = EvalHealth()
+    health.record_tick(monotonic_ts=10.0)
+    health.record_tick(monotonic_ts=42.5)
+
+    status = health.get_status()
+
+    assert status["last_tick_monotonic"] == 42.5

--- a/tests/server/services/agent_success_evaluation/test_save_retry.py
+++ b/tests/server/services/agent_success_evaluation/test_save_retry.py
@@ -1,0 +1,68 @@
+"""Verify the producer retries save_agent_success_evaluation_results with backoff
+and records a failure into EvalHealth when retries are exhausted."""
+
+from unittest.mock import MagicMock
+
+from reflexio.server.services.agent_success_evaluation import _eval_health
+from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service import (
+    AgentSuccessEvaluationService,
+)
+
+
+def _make_service_with_storage(storage_mock):
+    """Build the service with internals stubbed enough to exercise _process_results."""
+    svc = AgentSuccessEvaluationService.__new__(AgentSuccessEvaluationService)
+    svc.last_run_result_count = 0
+    svc.last_run_saved_result_count = 0
+    svc.last_run_save_failed = False
+    svc._last_extractor_run_stats = {"failed": 0}
+    svc.storage = storage_mock
+    svc.service_config = MagicMock(session_id="sess_test")
+    return svc
+
+
+def test_save_retried_three_times_with_backoff(monkeypatch) -> None:
+    _eval_health._HEALTH.__init__()
+    storage = MagicMock()
+    storage.save_agent_success_evaluation_results.side_effect = RuntimeError("nope")
+
+    slept: list[float] = []
+    monkeypatch.setattr(
+        "reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service.time.sleep",
+        lambda s: slept.append(s),
+    )
+
+    svc = _make_service_with_storage(storage)
+    fake_result = MagicMock()
+    svc._process_results([[fake_result]])
+
+    assert storage.save_agent_success_evaluation_results.call_count == 3
+    assert slept == [1, 4]  # backoffs *between* attempts (no sleep after final)
+    assert svc.last_run_save_failed is True
+    assert _eval_health.get_status()["producer_failures_24h"] == 1
+
+
+def test_save_succeeds_on_second_attempt(monkeypatch) -> None:
+    _eval_health._HEALTH.__init__()
+    calls = {"n": 0}
+
+    def flaky(_results):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("flake")
+
+    storage = MagicMock()
+    storage.save_agent_success_evaluation_results.side_effect = flaky
+    monkeypatch.setattr(
+        "reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service.time.sleep",
+        lambda _: None,
+    )
+
+    svc = _make_service_with_storage(storage)
+    fake_result = MagicMock()
+    svc._process_results([[fake_result]])
+
+    assert calls["n"] == 2
+    assert svc.last_run_save_failed is False
+    assert svc.last_run_saved_result_count == 1
+    assert _eval_health.get_status()["producer_failures_24h"] == 0

--- a/tests/server/services/agent_success_evaluation/test_scheduler_tick.py
+++ b/tests/server/services/agent_success_evaluation/test_scheduler_tick.py
@@ -1,0 +1,21 @@
+"""Verify the scheduler records ticks into EvalHealth."""
+
+import time
+
+from reflexio.server.services.agent_success_evaluation import _eval_health
+from reflexio.server.services.agent_success_evaluation.delayed_group_evaluator import (
+    GroupEvaluationScheduler,
+)
+
+
+def test_scheduler_records_tick_within_one_second() -> None:
+    """After getting the scheduler, the loop ticks at least once promptly."""
+    _eval_health._HEALTH.__init__()  # reset for isolation
+    scheduler = GroupEvaluationScheduler.get_instance()
+
+    # Wake the scheduler to force a loop iteration
+    scheduler._wake_event.set()
+    time.sleep(0.5)
+
+    status = _eval_health.get_status()
+    assert status["last_tick_monotonic"] is not None

--- a/tests/server/services/test_generation_service_scheduling.py
+++ b/tests/server/services/test_generation_service_scheduling.py
@@ -1,0 +1,75 @@
+"""Tests for `_schedule_group_evaluation_if_needed` in GenerationService.
+
+Guards against regression of the bug where the agentic extraction backend
+silently bypassed the scheduler call, leaving /evaluations permanently empty.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.server.services.generation_service import GenerationService
+
+
+@pytest.fixture
+def service() -> GenerationService:
+    """Build a bare GenerationService with the attributes the helper reads.
+
+    Bypasses __init__ entirely because the helper only reads three instance
+    attributes: org_id, request_context, and client. The full constructor would
+    require a configurator + storage + LLM client that aren't needed here.
+    """
+    svc = GenerationService.__new__(GenerationService)
+    svc.org_id = "org_test"
+    svc.request_context = MagicMock(name="request_context")
+    svc.client = MagicMock(name="llm_client")
+    return svc
+
+
+def test_no_schedule_when_session_id_is_none(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When new_request.session_id is None, the helper short-circuits."""
+    scheduler = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
+        lambda: scheduler,
+    )
+    request_with_no_session = MagicMock(session_id=None)
+
+    service._schedule_group_evaluation_if_needed(
+        new_request=request_with_no_session,
+        user_id="user_test",
+        agent_version="v_test",
+        source=None,
+    )
+
+    scheduler.schedule.assert_not_called()
+
+
+def test_schedules_with_correct_key_when_session_id_present(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The helper schedules with key=(org_id, user_id, session_id)."""
+    scheduler = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
+        lambda: scheduler,
+    )
+    request_with_session = MagicMock(session_id="sess_42")
+
+    service._schedule_group_evaluation_if_needed(
+        new_request=request_with_session,
+        user_id="user_test",
+        agent_version="v_test",
+        source="ide",
+    )
+
+    scheduler.schedule.assert_called_once()
+    call_args = scheduler.schedule.call_args
+    key = call_args[0][0] if call_args[0] else call_args.kwargs.get("key")
+    callback = call_args[0][1] if len(call_args[0]) > 1 else call_args.kwargs.get("callback")
+    assert key == ("org_test", "user_test", "sess_42")
+    assert callable(callback)


### PR DESCRIPTION
Plan A of the /evaluations redesign work. Makes the existing evaluation pipeline observable and self-healing — AND fixes a silent product bug discovered during live e2e verification.

## Summary

- **EvalHealth singleton** tracks scheduler ticks, per-reason skip counts, and rolling 24h producer-failure counts in one process-wide store.
- **Producer retries** `save_agent_success_evaluation_results` with backoff (1s / 4s, 3 total attempts); records final failures into EvalHealth instead of silently dropping them.
- **Scheduler loop** records its tick into EvalHealth on every iteration.
- **All five skip paths** in `run_group_evaluation` bump matching `SkipReason` counters so the operator can see why sessions are dropping.
- **New `/healthz/eval` endpoint** surfaces all three signals with a green/amber/red liveness derivation (>5min silent = amber, >30min = red).
- **Bug fix — agentic-path scheduler bypass.** The agentic extraction backend hit `return result` before reaching the scheduler invocation in the classic path, so no AgentSuccessEvaluationResult records were ever produced for any org running with `extraction_backend=agentic`. This was the silent root cause of empty /evaluations tiles. Extracted into a shared `_schedule_group_evaluation_if_needed` helper called from both code paths.

## Live verification

Discovered and fixed during local e2e testing — published 10 substantive sessions to a backend running this branch, observed:
- Before the agentic fix: `last_tick_monotonic: null`, `liveness: red`, no scheduler logs.
- After the fix: `Scheduled group evaluation for key=...` → `Firing group evaluation` → `Running group evaluation for session=...` in logs; `/healthz/eval` reports `liveness: green` with populated tick.

## Commits

1. `EvalHealth singleton for pipeline diagnostics`
2. `scheduler records tick into EvalHealth`
3. `bump SkipReason counters in each skip path`
4. `retry save with backoff and record producer failures`
5. `/healthz/eval exposes pipeline diagnostics`
6. `schedule group evaluation from the agentic path too` *(discovered via e2e)*

## Test plan

- [x] Unit tests for EvalHealth counters, 24h decay window, tick recording
- [x] Skip-reason counter tests for `run_group_evaluation`
- [x] Save-retry tests: 3 attempts with backoff = [1s, 4s], success on attempt 2
- [x] `/healthz/eval` route tests for green/amber/red liveness derivation
- [x] Regression test for `_schedule_group_evaluation_if_needed`
- [x] Full submodule regression: 127 tests pass
- [x] Live e2e against running backend: scheduler fires through to runner; /healthz/eval reports green

## Companion PR

ReflexioAI/reflexio-enterprise#100 bumps the submodule pointer here.

## Operational follow-up (out of scope for Plan A)

During live e2e, the runner logged `No agent_success_evaluation extractor configs found` — the deployed config has `agent_success_configs: null`, so even when the scheduler fires correctly, the evaluator produces no records. This is a config gap, not a code bug, and is separate from Plan A.