### PR TITLE
[codex] fix config only after persistence succeeds

### DIFF
--- a/reflexio/server/services/configurator/base_configurator.py
+++ b/reflexio/server/services/configurator/base_configurator.py
@@ -88,8 +88,8 @@ class BaseConfigurator(ABC):
         return context.strip()
 
     def set_config(self, config: Config) -> None:
-        self.config = config
         self.config_storage.save_config(config=config)
+        self.config = config
 
     def set_config_by_name(
         self,


### PR DESCRIPTION
## Summary
- update shared configurator state only after config storage save succeeds

## Why
If a storage adapter fails or no-ops during save, updating the in-memory config first can make the current request look successful while the next fresh read reloads the old persisted config.

## Validation
- `uv run pytest reflexio_ext/tests/server/services/configurator/test_supabase_config_storage.py reflexio_ext/tests/server/services/storage/test_supabase_storage_utils.py -q --no-cov`
- `uv run ruff check ...`
- `uv run python -c "import reflexio"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration save reliability by ensuring changes are persisted before being applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->