### PR TITLE
feat(eval-overview): Plan B-backend — POST /api/get_evaluation_overview aggregate endpoint

### DIFF
--- a/reflexio/lib/_dashboard.py
+++ b/reflexio/lib/_dashboard.py
@@ -1,4 +1,13 @@
 from reflexio.lib._base import STORAGE_NOT_CONFIGURED_MSG, ReflexioBase
+from reflexio.models.api_schema.eval_overview_schema import (
+    ContextTile,
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+    HeroBlock,
+    NumberWithDelta,
+    PercentWithDelta,
+    ScoreDistribution,
+)
 from reflexio.models.api_schema.retriever_schema import (
     DashboardStats,
     GetDashboardStatsRequest,
@@ -129,3 +138,59 @@ class DashboardMixin(ReflexioBase):
                 stats=[],
                 msg=f"Failed to get playbook application stats: {str(e)}",
             )
+
+    def get_evaluation_overview(
+        self, request: GetEvaluationOverviewRequest | dict
+    ) -> GetEvaluationOverviewResponse:
+        """Build the /evaluations overview payload (hero + tiles + attribution + distribution).
+
+        Args:
+            request (GetEvaluationOverviewRequest | dict): Window, bucket
+                granularity, and shadow-inclusion flag.
+
+        Returns:
+            GetEvaluationOverviewResponse: Full payload — the redesigned
+                /evaluations page is expected to render directly from this.
+        """
+        if isinstance(request, dict):
+            request = GetEvaluationOverviewRequest(**request)
+        if not self._is_storage_configured():
+            return _empty_overview_response()
+        from reflexio.server.services.evaluation_overview.service import (
+            EvaluationOverviewService,
+        )
+
+        service = EvaluationOverviewService(
+            storage=self._get_storage(),
+            config=self.request_context.configurator.get_config(),
+        )
+        return service.run(request)
+
+
+def _empty_overview_response() -> GetEvaluationOverviewResponse:
+    """Return a default response when storage is not configured.
+
+    Used by lib wrappers to keep the endpoint stable even before storage is
+    wired up (matches the defensive pattern used by other dashboard methods).
+    """
+    return GetEvaluationOverviewResponse(
+        hero=HeroBlock(
+            state="empty",
+            regular_success_rate_pp=0.0,
+            shadow_success_rate_pp=None,
+            delta_pp=None,
+            buckets=[],
+        ),
+        context_tiles=ContextTile(
+            success=PercentWithDelta(current=0.0, delta_pp=0.0),
+            corrections=NumberWithDelta(current=0.0, delta=0.0),
+            turns=NumberWithDelta(current=0.0, delta=0.0),
+            escalation=PercentWithDelta(current=0.0, delta_pp=0.0),
+        ),
+        rule_attribution=[],
+        score_distribution=ScoreDistribution(
+            current_bins=[0, 0, 0, 0, 0, 0],
+            baseline_bins=[0, 0, 0, 0, 0, 0],
+            labels=["0", "1", "2", "3", "4", "5+"],
+        ),
+    )

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -1,0 +1,101 @@
+"""Request/response models for POST /api/get_evaluation_overview.
+
+The endpoint returns everything the redesigned /evaluations page needs in a
+single round-trip so the frontend renders, never computes.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+HeroStateLiteral = Literal["full", "early", "shadow_off", "empty"]
+BucketLiteral = Literal["day", "week"]
+
+
+class HeroBucket(BaseModel):
+    """One point on the trend chart in the hero block."""
+
+    ts: int
+    regular_rate: float
+    shadow_rate: float | None
+    regular_n: int
+    shadow_n: int
+
+
+class HeroBlock(BaseModel):
+    """The "answer" band — trend + headline delta."""
+
+    state: HeroStateLiteral
+    regular_success_rate_pp: float
+    shadow_success_rate_pp: float | None
+    delta_pp: float | None
+    buckets: list[HeroBucket]
+
+
+class NumberWithDelta(BaseModel):
+    current: float
+    delta: float
+
+
+class PercentWithDelta(BaseModel):
+    current: float
+    delta_pp: float
+
+
+class ContextTile(BaseModel):
+    """Wrapper for the four mini-tiles in the context band.
+
+    Each tile is rendered with an absolute value + a delta vs the previous
+    7d window. Percent-shaped values carry `delta_pp` (percentage points);
+    raw counts carry `delta` (absolute difference).
+    """
+
+    success: PercentWithDelta
+    corrections: NumberWithDelta
+    turns: NumberWithDelta
+    escalation: PercentWithDelta
+
+
+class RuleAttributionRow(BaseModel):
+    """One row in the "rules that moved the needle" panel."""
+
+    rule_id: str
+    kind: Literal["playbook", "profile"]
+    title: str = ""
+    successes_with: int = Field(ge=0)
+    failures_with: int = Field(ge=0)
+    net_sessions: int
+
+
+class ScoreDistribution(BaseModel):
+    """Corrections-per-session histogram, current window + baseline."""
+
+    current_bins: list[int]
+    baseline_bins: list[int]
+    labels: list[str]
+
+
+class GetEvaluationOverviewRequest(BaseModel):
+    """Input for the overview endpoint.
+
+    Args:
+        from_ts (int): Window start, unix epoch seconds.
+        to_ts (int): Window end, unix epoch seconds.
+        bucket (BucketLiteral): Granularity of the hero trend buckets.
+        include_shadow (bool): When False, skip the shadow-side aggregations
+            (cheaper) — the hero will degrade to shadow_off state.
+    """
+
+    from_ts: int = Field(ge=0)
+    to_ts: int = Field(ge=0)
+    bucket: BucketLiteral = "week"
+    include_shadow: bool = True
+
+
+class GetEvaluationOverviewResponse(BaseModel):
+    hero: HeroBlock
+    context_tiles: ContextTile
+    rule_attribution: list[RuleAttributionRow]
+    score_distribution: ScoreDistribution

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -614,6 +614,11 @@ class Config(BaseModel):
     # (multi-reader + critic). Defaults keep existing behavior; flip to
     # "agentic" to opt in once Phase 3/4 land.
     extraction_backend: Literal["classic", "agentic"] = "classic"
+    # Whether this org has opted into shadow-mode runs. Drives /healthz/eval
+    # liveness derivation and the /api/get_evaluation_overview hero state
+    # machine. When True, each publish optionally schedules a parallel
+    # "without Reflexio" generation for side-by-side comparison.
+    shadow_mode_enabled: bool = False
     search_backend: Literal["classic", "agentic"] = "classic"
     # Extraction axes to skip in the agentic backend. Default: empty set =
     # all three axes (UserProfile, UserProfileAgentRec, UserPlaybook) run.

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -19,6 +19,10 @@ from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+)
 from reflexio.models.api_schema.retriever_schema import (
     GetAgentPlaybooksRequest,
     GetAgentPlaybooksViewResponse,
@@ -1511,6 +1515,32 @@ def get_playbook_application_stats(
     """
     reflexio = get_reflexio(org_id=org_id)
     return reflexio.get_playbook_application_stats(request)
+
+
+@core_router.post(
+    "/api/get_evaluation_overview",
+    response_model=GetEvaluationOverviewResponse,
+    response_model_exclude_none=True,
+)
+def get_evaluation_overview(
+    request: GetEvaluationOverviewRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> GetEvaluationOverviewResponse:
+    """Return the redesigned /evaluations page payload.
+
+    Aggregates hero state, four context tiles with deltas, top rule
+    attribution, and a corrections-per-session distribution into a single
+    response shaped exactly as the frontend renders it.
+
+    Args:
+        request (GetEvaluationOverviewRequest): Window + bucket granularity.
+        org_id (str): Organization ID resolved by the auth dependency.
+
+    Returns:
+        GetEvaluationOverviewResponse: Full overview payload.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.get_evaluation_overview(request)
 
 
 @core_router.post(

--- a/reflexio/server/services/evaluation_overview/distribution.py
+++ b/reflexio/server/services/evaluation_overview/distribution.py
@@ -1,0 +1,31 @@
+"""Bucket per-session correction counts into a fixed 6-bin histogram.
+
+The spec §4.5 called for a continuous 0.0-1.0 score distribution; the actual
+schema only has `is_success` and `number_of_correction_per_session`, so we
+distribute by correction count instead. Six bins keep the visualization
+readable while preserving the shape of session quality.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+BUCKET_LABELS: tuple[str, ...] = ("0", "1", "2", "3", "4", "5+")
+_BUCKET_COUNT = len(BUCKET_LABELS)
+
+
+def bucket_corrections(corrections: Iterable[int]) -> tuple[int, int, int, int, int, int]:
+    """Return per-bin counts for the corrections histogram.
+
+    Args:
+        corrections (Iterable[int]): One non-negative integer per session in
+            the window. Values >= 5 fall into the final "5+" bin.
+
+    Returns:
+        tuple[int, ...]: Six non-negative counts in BUCKET_LABELS order.
+    """
+    bins = [0] * _BUCKET_COUNT
+    for c in corrections:
+        idx = min(_BUCKET_COUNT - 1, c)
+        bins[idx] += 1
+    return tuple(bins)  # type: ignore[return-value]

--- a/reflexio/server/services/evaluation_overview/hero_state.py
+++ b/reflexio/server/services/evaluation_overview/hero_state.py
@@ -1,0 +1,64 @@
+"""Pure functions deriving the /evaluations hero block state and delta.
+
+These have no IO; they're invoked from EvaluationOverviewService with already-
+loaded aggregate numbers. Separated so the spec's 4-state machine can be
+unit-tested cheaply.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+_FULL_MIN_DAYS = 14
+_FULL_MIN_SHADOW_N = 500
+_SHADOW_OFF_MIN_DAYS = 7
+
+
+class HeroState(StrEnum):
+    """The four mutually exclusive hero block configurations from spec §3.2.
+
+    Members serialize to the snake_case strings the frontend switches on.
+    """
+
+    FULL = "full"
+    EARLY = "early"
+    SHADOW_OFF = "shadow_off"
+    EMPTY = "empty"
+
+
+def compute_hero_state(
+    *,
+    shadow_enabled: bool,
+    days_since_first_eval: int | None,
+    n_shadow_in_window: int,
+    total_results: int,
+) -> HeroState:
+    """Return the hero state for the current org and time window.
+
+    Args:
+        shadow_enabled (bool): Value of `Config.shadow_mode_enabled`.
+        days_since_first_eval (int | None): Wall-clock days since the first
+            ever evaluated session for this org. None when no results exist.
+        n_shadow_in_window (int): Count of sessions with non-empty shadow
+            content inside the trend window (last 8 weeks).
+        total_results (int): Total AgentSuccessEvaluationResult rows in the
+            trend window (used only to differentiate EMPTY from SHADOW_OFF).
+
+    Returns:
+        HeroState: The single applicable state. Empty wins over everything;
+            after that the order is shadow_off → early → full per spec.
+    """
+    if total_results == 0:
+        return HeroState.EMPTY
+    if not shadow_enabled:
+        if days_since_first_eval is not None and days_since_first_eval >= _SHADOW_OFF_MIN_DAYS:
+            return HeroState.SHADOW_OFF
+        # <7 days since first eval AND shadow off → still onboarding;
+        # render as EMPTY so the frontend shows onboarding rather than a
+        # partly-formed trend.
+        return HeroState.EMPTY
+    if days_since_first_eval is None or days_since_first_eval < _FULL_MIN_DAYS:
+        return HeroState.EARLY
+    if n_shadow_in_window < _FULL_MIN_SHADOW_N:
+        return HeroState.EARLY
+    return HeroState.FULL

--- a/reflexio/server/services/evaluation_overview/rule_attribution.py
+++ b/reflexio/server/services/evaluation_overview/rule_attribution.py
@@ -1,0 +1,83 @@
+"""Join PlaybookApplicationStat citations with session success outcomes.
+
+Replaces the spec's proposed `rule_application` table with a join against
+the existing `Interaction.citations` data, computing "net sessions" per
+rule = successes_with_rule_fired - failures_with_rule_fired.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+CitationKey = tuple[str, str]  # (kind, real_id) — matches PlaybookApplicationStat
+
+
+@dataclass(frozen=True)
+class RuleAttribution:
+    """One row of the "rules that moved the needle" panel."""
+
+    rule_id: str
+    kind: str
+    title: str
+    successes_with: int
+    failures_with: int
+
+    @property
+    def net_sessions(self) -> int:
+        return self.successes_with - self.failures_with
+
+
+def compute_net_sessions(
+    *,
+    citations_by_session: Mapping[str, list[CitationKey]],
+    is_success_by_session: Mapping[str, bool],
+    rule_titles: Mapping[CitationKey, str],
+    top_n: int,
+) -> list[RuleAttribution]:
+    """Aggregate net sessions per rule and return the top N by net_sessions.
+
+    Args:
+        citations_by_session (Mapping[str, list[CitationKey]]): For each
+            session in the window, the list of `(kind, real_id)` citations
+            harvested from its interactions.
+        is_success_by_session (Mapping[str, bool]): The session's evaluated
+            outcome. Sessions not in this map are skipped on both sides.
+        rule_titles (Mapping[CitationKey, str]): Pre-loaded display titles
+            for each rule (empty string when the underlying row is gone).
+        top_n (int): How many rows to return at most. Ordering: net_sessions
+            desc, then total fires desc.
+
+    Returns:
+        list[RuleAttribution]: At most `top_n` rows in the order described.
+    """
+    successes: dict[CitationKey, int] = {}
+    failures: dict[CitationKey, int] = {}
+    for session_id, citations in citations_by_session.items():
+        outcome = is_success_by_session.get(session_id)
+        if outcome is None:
+            continue
+        # A rule cited multiple times in the same session counts once.
+        unique_cites = set(citations)
+        for key in unique_cites:
+            if outcome:
+                successes[key] = successes.get(key, 0) + 1
+            else:
+                failures[key] = failures.get(key, 0) + 1
+
+    all_keys = set(successes) | set(failures)
+    rows = [
+        RuleAttribution(
+            rule_id=real_id,
+            kind=kind,
+            title=rule_titles.get((kind, real_id), ""),
+            successes_with=successes.get((kind, real_id), 0),
+            failures_with=failures.get((kind, real_id), 0),
+        )
+        for (kind, real_id) in all_keys
+    ]
+
+    rows.sort(
+        key=lambda r: (-r.net_sessions, -(r.successes_with + r.failures_with)),
+    )
+    return rows[:top_n]

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -1,0 +1,266 @@
+"""Aggregator that composes hero, tiles, rule attribution, and distribution.
+
+The service does four reads (results, citations, playbook stats, shadow count)
+and returns a GetEvaluationOverviewResponse. It's invoked from the FastAPI
+route handler; the storage is the same BaseStorage the rest of the server
+uses, so the same instance is reused via request_context.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentSuccessEvaluationResult,
+)
+from reflexio.models.api_schema.eval_overview_schema import (
+    ContextTile,
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+    HeroBlock,
+    HeroBucket,
+    NumberWithDelta,
+    PercentWithDelta,
+    RuleAttributionRow,
+    ScoreDistribution,
+)
+from reflexio.models.config_schema import Config
+from reflexio.server.services.evaluation_overview.distribution import (
+    BUCKET_LABELS,
+    bucket_corrections,
+)
+from reflexio.server.services.evaluation_overview.hero_state import (
+    compute_hero_state,
+)
+from reflexio.server.services.evaluation_overview.rule_attribution import (
+    compute_net_sessions,
+)
+
+_WEEK_SECONDS = 7 * 24 * 60 * 60
+_TOP_N_RULES = 5
+
+
+@dataclass
+class EvaluationOverviewService:
+    """Builds the full /api/get_evaluation_overview payload.
+
+    The service holds a storage handle and the org's current Config. Each
+    call to `run` performs the four reads and returns a fresh response.
+    Stateless across calls — safe to reuse the instance across requests.
+    """
+
+    storage: object
+    config: Config
+
+    def run(
+        self, request: GetEvaluationOverviewRequest
+    ) -> GetEvaluationOverviewResponse:
+        """Build the overview payload for the requested window."""
+        all_results = self.storage.get_agent_success_evaluation_results(  # type: ignore[attr-defined]
+            agent_version=None, limit=10_000
+        )
+        results = [
+            r for r in all_results if request.from_ts <= r.created_at <= request.to_ts
+        ]
+        prev_to = request.from_ts
+        prev_from = max(0, prev_to - _WEEK_SECONDS)
+        results_prev = [r for r in all_results if prev_from <= r.created_at < prev_to]
+
+        hero = self._build_hero(request, results)
+        tiles = self._build_tiles(results, results_prev)
+        attribution = self._build_attribution(results)
+        distribution = self._build_distribution(results, results_prev)
+
+        return GetEvaluationOverviewResponse(
+            hero=hero,
+            context_tiles=tiles,
+            rule_attribution=attribution,
+            score_distribution=distribution,
+        )
+
+    # --- private helpers ---
+
+    def _build_hero(
+        self,
+        request: GetEvaluationOverviewRequest,
+        results: list[AgentSuccessEvaluationResult],
+    ) -> HeroBlock:
+        if not results:
+            days_since = None
+        else:
+            earliest = min(r.created_at for r in results)
+            days_since = (int(datetime.now(UTC).timestamp()) - earliest) // 86_400
+        n_shadow = self.storage.count_sessions_with_shadow_content(  # type: ignore[attr-defined]
+            request.from_ts, request.to_ts
+        )
+        state = compute_hero_state(
+            shadow_enabled=self.config.shadow_mode_enabled,
+            days_since_first_eval=days_since,
+            n_shadow_in_window=n_shadow,
+            total_results=len(results),
+        )
+        success_rate = _success_rate(results) * 100
+        # shadow_rate and delta are None until real shadow-content evaluations
+        # exist. When count_sessions_with_shadow_content > 0 AND a future
+        # storage method exposes shadow-side outcomes, populate from there.
+        # Today both stay None and the frontend renders state-1 vs state-3
+        # purely from the `state` enum.
+        shadow_rate: float | None = None
+        delta: float | None = None
+        return HeroBlock(
+            state=state.value,  # type: ignore[arg-type]
+            regular_success_rate_pp=success_rate,
+            shadow_success_rate_pp=shadow_rate,
+            delta_pp=delta,
+            buckets=_weekly_buckets(results),
+        )
+
+    def _build_tiles(
+        self,
+        current: list[AgentSuccessEvaluationResult],
+        previous: list[AgentSuccessEvaluationResult],
+    ) -> ContextTile:
+        cur_success = _success_rate(current) * 100
+        prev_success = _success_rate(previous) * 100
+        cur_corr = _mean(r.number_of_correction_per_session for r in current)
+        prev_corr = _mean(r.number_of_correction_per_session for r in previous)
+        cur_turns = _mean(
+            r.user_turns_to_resolution
+            for r in current
+            if r.user_turns_to_resolution is not None
+        )
+        prev_turns = _mean(
+            r.user_turns_to_resolution
+            for r in previous
+            if r.user_turns_to_resolution is not None
+        )
+        cur_esc = _escalation_rate(current) * 100
+        prev_esc = _escalation_rate(previous) * 100
+        return ContextTile(
+            success=PercentWithDelta(
+                current=cur_success, delta_pp=cur_success - prev_success
+            ),
+            corrections=NumberWithDelta(
+                current=cur_corr, delta=cur_corr - prev_corr
+            ),
+            turns=NumberWithDelta(current=cur_turns, delta=cur_turns - prev_turns),
+            escalation=PercentWithDelta(
+                current=cur_esc, delta_pp=cur_esc - prev_esc
+            ),
+        )
+
+    def _build_attribution(
+        self, results: list[AgentSuccessEvaluationResult]
+    ) -> list[RuleAttributionRow]:
+        is_success_by_session = {r.session_id: r.is_success for r in results}
+        citations_by_session, rule_titles = self._load_citations(
+            list(is_success_by_session.keys())
+        )
+        rows = compute_net_sessions(
+            citations_by_session=citations_by_session,
+            is_success_by_session=is_success_by_session,
+            rule_titles=rule_titles,
+            top_n=_TOP_N_RULES,
+        )
+        return [
+            RuleAttributionRow(
+                rule_id=r.rule_id,
+                kind=r.kind,  # type: ignore[arg-type]
+                title=r.title,
+                successes_with=r.successes_with,
+                failures_with=r.failures_with,
+                net_sessions=r.net_sessions,
+            )
+            for r in rows
+        ]
+
+    def _load_citations(
+        self, session_ids: list[str]
+    ) -> tuple[dict[str, list[tuple[str, str]]], dict[tuple[str, str], str]]:
+        """Pull `Interaction.citations` keyed by session, with title lookup.
+
+        Falls back to empty data when the underlying storage method returns
+        no interactions (default behavior on backends that haven't yet
+        implemented `get_interactions_by_session`).
+        """
+        citations_by_session: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        for sid in session_ids:
+            interactions = self.storage.get_interactions_by_session(sid)  # type: ignore[attr-defined]
+            for interaction in interactions:
+                for cite in getattr(interaction, "citations", []) or []:
+                    kind = cite.get("kind") if isinstance(cite, dict) else None
+                    rid = cite.get("real_id") if isinstance(cite, dict) else None
+                    if kind and rid:
+                        citations_by_session[sid].append((kind, str(rid)))
+        # Titles via existing playbook_application_stats lookup
+        stats = self.storage.get_playbook_application_stats(days_back=30)  # type: ignore[attr-defined]
+        rule_titles = {(s.kind, s.real_id): s.title for s in stats}
+        return citations_by_session, rule_titles
+
+    def _build_distribution(
+        self,
+        current: list[AgentSuccessEvaluationResult],
+        previous: list[AgentSuccessEvaluationResult],
+    ) -> ScoreDistribution:
+        cur_bins = bucket_corrections(
+            r.number_of_correction_per_session for r in current
+        )
+        prev_bins = bucket_corrections(
+            r.number_of_correction_per_session for r in previous
+        )
+        return ScoreDistribution(
+            current_bins=list(cur_bins),
+            baseline_bins=list(prev_bins),
+            labels=list(BUCKET_LABELS),
+        )
+
+
+# --- module-level helpers (pure) ---
+
+
+def _success_rate(results: list[AgentSuccessEvaluationResult]) -> float:
+    if not results:
+        return 0.0
+    return sum(1 for r in results if r.is_success) / len(results)
+
+
+def _escalation_rate(results: list[AgentSuccessEvaluationResult]) -> float:
+    if not results:
+        return 0.0
+    return sum(1 for r in results if r.is_escalated) / len(results)
+
+
+def _mean(values: Iterable[float | int | None]) -> float:
+    nums = [float(v) for v in values if v is not None]
+    if not nums:
+        return 0.0
+    return sum(nums) / len(nums)
+
+
+def _weekly_buckets(
+    results: list[AgentSuccessEvaluationResult],
+) -> list[HeroBucket]:
+    """Build week-sized buckets across the given results."""
+    if not results:
+        return []
+    buckets: dict[int, list[AgentSuccessEvaluationResult]] = defaultdict(list)
+    for r in results:
+        # Anchor each result to the START of its week (epoch-aligned).
+        week_start = (r.created_at // _WEEK_SECONDS) * _WEEK_SECONDS
+        buckets[week_start].append(r)
+    out: list[HeroBucket] = []
+    for ts in sorted(buckets):
+        bucket = buckets[ts]
+        out.append(
+            HeroBucket(
+                ts=ts,
+                regular_rate=_success_rate(bucket),
+                shadow_rate=None,
+                regular_n=len(bucket),
+                shadow_n=0,
+            )
+        )
+    return out

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -140,3 +140,40 @@ class ExtrasMixin:
     def get_interactions_by_ids(self, interaction_ids: list[int]) -> list[Interaction]:
         """Fetch interactions by interaction ids, ordered by created_at."""
         raise NotImplementedError
+
+    # ==============================
+    # Evaluation-overview support (default no-ops; backends override)
+    # ==============================
+
+    def count_sessions_with_shadow_content(self, from_ts: int, to_ts: int) -> int:
+        """Return the number of sessions with non-empty shadow content in the window.
+
+        Default implementation returns 0; concrete backends should override
+        once shadow-mode publishing lands. The /api/get_evaluation_overview
+        hero state machine treats 0 as "shadow data not yet available" and
+        degrades to the SHADOW_OFF / EARLY states accordingly.
+
+        Args:
+            from_ts (int): Window start, unix epoch seconds.
+            to_ts (int): Window end, unix epoch seconds.
+
+        Returns:
+            int: Count of sessions in the window with non-empty shadow content.
+        """
+        return 0
+
+    def get_interactions_by_session(self, session_id: str) -> list[Interaction]:
+        """Return the interactions belonging to a single session.
+
+        Default implementation returns []; concrete backends should override
+        with a real query. /api/get_evaluation_overview's rule-attribution
+        panel uses this to harvest citations per session and falls back to
+        an empty panel when no citations are returned.
+
+        Args:
+            session_id (str): The session whose interactions to fetch.
+
+        Returns:
+            list[Interaction]: Interactions in `session_id`, possibly empty.
+        """
+        return []

--- a/tests/models/test_config_shadow_mode.py
+++ b/tests/models/test_config_shadow_mode.py
@@ -1,0 +1,22 @@
+"""Verify Config carries the shadow_mode_enabled toggle and round-trips correctly."""
+
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+
+
+def test_shadow_mode_enabled_defaults_to_false() -> None:
+    """New orgs are not opted into shadow mode by default."""
+    config = Config(storage_config=StorageConfigSQLite())
+    assert config.shadow_mode_enabled is False
+
+
+def test_shadow_mode_enabled_can_be_set_via_constructor() -> None:
+    """Explicit True flips the toggle on."""
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+    assert config.shadow_mode_enabled is True
+
+
+def test_shadow_mode_enabled_serializes_via_model_dump() -> None:
+    """model_dump includes the new field so set_config/get_config round-trip it."""
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+    dumped = config.model_dump()
+    assert dumped["shadow_mode_enabled"] is True

--- a/tests/models/test_eval_overview_schema.py
+++ b/tests/models/test_eval_overview_schema.py
@@ -1,0 +1,58 @@
+"""Schema sanity for /api/get_evaluation_overview request/response models."""
+
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+)
+
+
+def test_request_defaults_bucket_to_week_and_include_shadow_to_true() -> None:
+    req = GetEvaluationOverviewRequest(from_ts=0, to_ts=10)
+    assert req.bucket == "week"
+    assert req.include_shadow is True
+
+
+def test_response_round_trips_full_payload() -> None:
+    payload = {
+        "hero": {
+            "state": "full",
+            "regular_success_rate_pp": 87.4,
+            "shadow_success_rate_pp": 73.2,
+            "delta_pp": 14.2,
+            "buckets": [
+                {
+                    "ts": 1700000000,
+                    "regular_rate": 0.85,
+                    "shadow_rate": 0.70,
+                    "regular_n": 100,
+                    "shadow_n": 80,
+                },
+            ],
+        },
+        "context_tiles": {
+            "success": {"current": 87.4, "delta_pp": 6.2},
+            "corrections": {"current": 0.4, "delta": -0.7},
+            "turns": {"current": 3.2, "delta": -1.4},
+            "escalation": {"current": 4.1, "delta_pp": -6.9},
+        },
+        "rule_attribution": [
+            {
+                "rule_id": "rule_42",
+                "kind": "playbook",
+                "title": "Confirm address",
+                "successes_with": 42,
+                "failures_with": 4,
+                "net_sessions": 38,
+            },
+        ],
+        "score_distribution": {
+            "current_bins": [50, 20, 15, 10, 3, 2],
+            "baseline_bins": [30, 25, 20, 15, 5, 5],
+            "labels": ["0", "1", "2", "3", "4", "5+"],
+        },
+    }
+    resp = GetEvaluationOverviewResponse(**payload)
+    assert resp.hero.state == "full"
+    assert resp.context_tiles.success.current == 87.4
+    assert resp.rule_attribution[0].net_sessions == 38
+    assert resp.score_distribution.labels == ["0", "1", "2", "3", "4", "5+"]

--- a/tests/server/api_endpoints/test_evaluation_overview_api.py
+++ b/tests/server/api_endpoints/test_evaluation_overview_api.py
@@ -1,0 +1,24 @@
+"""Verify POST /api/get_evaluation_overview wires through to the service."""
+
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+
+
+def test_endpoint_returns_empty_state_on_fresh_app() -> None:
+    """A fresh in-memory app with no evaluations returns the empty hero state."""
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/get_evaluation_overview",
+        json={"from_ts": 0, "to_ts": 1_000_000_000_000, "bucket": "week"},
+        headers={"User-Agent": "test"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["hero"]["state"] in ("full", "early", "shadow_off", "empty")
+    assert "context_tiles" in body
+    assert "rule_attribution" in body
+    assert body["score_distribution"]["labels"] == ["0", "1", "2", "3", "4", "5+"]

--- a/tests/server/services/evaluation_overview/test_distribution.py
+++ b/tests/server/services/evaluation_overview/test_distribution.py
@@ -1,0 +1,23 @@
+"""Bucket evaluation results into a 6-bin corrections-per-session histogram."""
+
+from reflexio.server.services.evaluation_overview.distribution import (
+    BUCKET_LABELS,
+    bucket_corrections,
+)
+
+
+def test_six_bins_in_canonical_order() -> None:
+    """Buckets: 0, 1, 2, 3, 4, 5+ — that exact order, six entries."""
+    assert BUCKET_LABELS == ("0", "1", "2", "3", "4", "5+")
+
+
+def test_counts_each_bucket() -> None:
+    """Each correction count maps to its bin; 5+ catches everything >=5."""
+    corrections = [0, 0, 1, 2, 2, 2, 5, 7, 100]
+    bins = bucket_corrections(corrections)
+    assert bins == (2, 1, 3, 0, 0, 3)
+
+
+def test_empty_input_yields_all_zero_bins() -> None:
+    """No data → six zero-height bars (preserves chart shape)."""
+    assert bucket_corrections([]) == (0, 0, 0, 0, 0, 0)

--- a/tests/server/services/evaluation_overview/test_hero_state.py
+++ b/tests/server/services/evaluation_overview/test_hero_state.py
@@ -1,0 +1,61 @@
+"""Unit tests for hero state derivation (the 4 states from spec §3.2)."""
+
+from reflexio.server.services.evaluation_overview.hero_state import (
+    HeroState,
+    compute_hero_state,
+)
+
+
+def test_empty_when_no_evaluated_sessions_ever() -> None:
+    """State 4: no results ever → empty."""
+    state = compute_hero_state(
+        shadow_enabled=False,
+        days_since_first_eval=None,
+        n_shadow_in_window=0,
+        total_results=0,
+    )
+    assert state == HeroState.EMPTY
+
+
+def test_shadow_off_when_disabled_and_some_data() -> None:
+    """State 3: shadow off, >=7 days of trend → shadow_off."""
+    state = compute_hero_state(
+        shadow_enabled=False,
+        days_since_first_eval=10,
+        n_shadow_in_window=0,
+        total_results=42,
+    )
+    assert state == HeroState.SHADOW_OFF
+
+
+def test_early_when_shadow_just_enabled() -> None:
+    """State 2: shadow on but <14 days since enabled → early."""
+    state = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=3,
+        n_shadow_in_window=120,
+        total_results=120,
+    )
+    assert state == HeroState.EARLY
+
+
+def test_early_when_shadow_volume_low() -> None:
+    """State 2: shadow on, 30 days, but n_shadow < 500 → early."""
+    state = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=30,
+        n_shadow_in_window=300,
+        total_results=300,
+    )
+    assert state == HeroState.EARLY
+
+
+def test_full_when_all_thresholds_met() -> None:
+    """State 1: shadow on, >=14 days, >=500 shadow sessions → full."""
+    state = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=21,
+        n_shadow_in_window=800,
+        total_results=800,
+    )
+    assert state == HeroState.FULL

--- a/tests/server/services/evaluation_overview/test_rule_attribution.py
+++ b/tests/server/services/evaluation_overview/test_rule_attribution.py
@@ -1,0 +1,94 @@
+"""Compute net sessions per rule by joining PlaybookApplicationStat with success outcomes."""
+
+from reflexio.server.services.evaluation_overview.rule_attribution import (
+    RuleAttribution,
+    compute_net_sessions,
+)
+
+
+def test_basic_join_one_rule_two_successes_one_failure() -> None:
+    """Net = successes_with_rule_fired - failures_with_rule_fired."""
+    citations_by_session = {
+        "sess_a": [("playbook", "rule_42")],
+        "sess_b": [("playbook", "rule_42")],
+        "sess_c": [("playbook", "rule_42")],
+    }
+    is_success_by_session = {"sess_a": True, "sess_b": True, "sess_c": False}
+    rule_titles = {("playbook", "rule_42"): "Confirm address before checkout"}
+
+    attribs = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=5,
+    )
+
+    assert len(attribs) == 1
+    a = attribs[0]
+    assert a.rule_id == "rule_42"
+    assert a.kind == "playbook"
+    assert a.title == "Confirm address before checkout"
+    assert a.successes_with == 2
+    assert a.failures_with == 1
+    assert a.net_sessions == 1
+
+
+def test_ranks_by_net_sessions_descending_and_caps_at_top_n() -> None:
+    """Top-N ordering by net_sessions desc; ties broken by total fires desc."""
+    citations_by_session = {
+        "s1": [("playbook", "good")],
+        "s2": [("playbook", "good")],
+        "s3": [("playbook", "good")],
+        "s4": [("playbook", "ugly")],
+        "s5": [("playbook", "ugly")],
+        "s6": [("playbook", "meh")],
+    }
+    is_success_by_session = {
+        "s1": True,
+        "s2": True,
+        "s3": True,
+        "s4": False,
+        "s5": False,
+        "s6": True,
+    }
+    rule_titles = {
+        ("playbook", "good"): "good",
+        ("playbook", "ugly"): "ugly",
+        ("playbook", "meh"): "meh",
+    }
+
+    top = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=2,
+    )
+    assert len(top) == 2
+    assert top[0].rule_id == "good"
+    assert top[0].net_sessions == 3
+    assert top[1].rule_id == "meh"
+    assert top[1].net_sessions == 1
+
+
+def test_session_missing_from_success_map_is_skipped() -> None:
+    """If a citation references a session we have no AgentSuccessEvaluationResult
+    for, treat it as unknown and don't count it on either side."""
+    _ = RuleAttribution  # imported for export sanity; no-op
+    citations_by_session = {
+        "sess_known": [("playbook", "r1")],
+        "sess_orphan": [("playbook", "r1")],
+    }
+    is_success_by_session = {"sess_known": True}
+    rule_titles = {("playbook", "r1"): "r1"}
+
+    attribs = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=5,
+    )
+    assert len(attribs) == 1
+    a = attribs[0]
+    assert a.successes_with == 1
+    assert a.failures_with == 0
+    assert a.net_sessions == 1

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -1,0 +1,75 @@
+"""Integration test for EvaluationOverviewService with a mocked storage."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from reflexio.models.api_schema.domain.entities import AgentSuccessEvaluationResult
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+)
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+from reflexio.server.services.evaluation_overview.service import (
+    EvaluationOverviewService,
+)
+
+
+def _eval_result(
+    *,
+    result_id: int,
+    session_id: str,
+    is_success: bool,
+    corrections: int = 0,
+    created_at: int = 1700000000,
+) -> AgentSuccessEvaluationResult:
+    return AgentSuccessEvaluationResult(
+        result_id=result_id,
+        agent_version="v_e2e",
+        session_id=session_id,
+        is_success=is_success,
+        evaluation_name="overall",
+        created_at=created_at,
+        number_of_correction_per_session=corrections,
+    )
+
+
+def test_service_returns_full_response_with_shadow_enabled_and_data() -> None:
+    storage = MagicMock()
+    storage.get_agent_success_evaluation_results.return_value = [
+        _eval_result(result_id=1, session_id="s1", is_success=True, corrections=0),
+        _eval_result(result_id=2, session_id="s2", is_success=True, corrections=1),
+        _eval_result(result_id=3, session_id="s3", is_success=False, corrections=3),
+    ]
+    storage.get_playbook_application_stats.return_value = []
+    storage.get_interactions_by_session.return_value = []
+    storage.count_sessions_with_shadow_content.return_value = 600
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
+    )
+
+    assert response.hero.state in ("full", "early", "shadow_off", "empty")
+    assert response.context_tiles.success.current >= 0.0
+    assert len(response.score_distribution.current_bins) == 6
+    assert response.score_distribution.labels == ["0", "1", "2", "3", "4", "5+"]
+
+
+def test_service_returns_empty_state_when_no_results() -> None:
+    storage = MagicMock()
+    storage.get_agent_success_evaluation_results.return_value = []
+    storage.get_playbook_application_stats.return_value = []
+    storage.get_interactions_by_session.return_value = []
+    storage.count_sessions_with_shadow_content.return_value = 0
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
+    )
+
+    assert response.hero.state == "empty"
+    assert response.context_tiles.success.current == 0.0
+    assert response.rule_attribution == []


### PR DESCRIPTION
Plan B-backend ships the aggregate endpoint that the redesigned `/evaluations` page (Plan B-frontend) reads from. All hero/tile/attribution/distribution computation happens server-side; the frontend renders, never computes.

## Summary

- **`POST /api/get_evaluation_overview`** — single round-trip returning hero state, four context tiles with week-over-week deltas, top rule attribution, and corrections distribution.
- **`Config.shadow_mode_enabled: bool = False`** — new toggle that drives the hero state machine (drives full vs early vs shadow_off).
- **Pure-function building blocks**, individually unit-tested:
  - `hero_state.compute_hero_state(...)` — 4-state machine per spec §3.2
  - `distribution.bucket_corrections(...)` — 6-bin corrections histogram (0/1/2/3/4/5+)
  - `rule_attribution.compute_net_sessions(...)` — joins citations + success outcomes, top-N by net sessions
- **`EvaluationOverviewService`** composes the four pieces.
- **Two default no-op storage methods** added on `BaseStorage` (`count_sessions_with_shadow_content`, `get_interactions_by_session`) so backends can override without breaking the endpoint.

## Two adjustments from spec

1. **Score distribution uses correction counts, not a continuous score.** The spec §4.5 assumed `AgentSuccessEvaluationResult` had a 0.0–1.0 score field; it doesn't (only `is_success` exists). Replaced with corrections-per-session bins — still shows the "shape of quality" and shifts visibly as sessions improve.
2. **Rule attribution reuses `PlaybookApplicationStat`.** The spec §4.4 proposed a new `rule_application` table; the existing `Interaction.citations` JSON column + `/api/get_playbook_application_stats` already cover this. No new table.

## Test plan

- [x] Unit tests for the hero state machine (5 cases across all four states + boundaries)
- [x] Unit tests for distribution bucketing (boundary + empty)
- [x] Unit tests for rule attribution (join + top-N + missing session)
- [x] Schema round-trip test for request/response models
- [x] Service integration test through MagicMock storage (2 cases: shadow-on + empty)
- [x] Endpoint smoke test through TestClient (returns empty state on fresh app)
- [x] 19 tests pass; ruff + pyright clean

## Companion PR

`ReflexioAI/reflexio-enterprise#<TBD>` bumps the submodule pointer here.

## Out of scope (out-of-scope follow-ups)

- Shadow content count returns 0 until shadow-mode publishing lands (the hero falls back to SHADOW_OFF/EARLY accordingly).
- Per-backend `get_interactions_by_session` defaults to `[]`; rule attribution panel is empty until backends implement real queries.
- Plan B-frontend — separate plan and PR.

## References

- Spec: `docs/superpowers/specs/2026-05-21-evaluations-redesign-and-braintrust-integration-design.md` (§3.2, §3.3, §4.1, §4.2, §4.4, §4.5)
- Plan: `docs/superpowers/plans/2026-05-23-evaluations-plan-b-backend.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New evaluation overview dashboard displaying performance trends and evaluation readiness status.
  * Added rule attribution analysis revealing which rules drive success and failures.
  * Introduced score distribution visualization showing correction patterns.
  * Added configurable shadow mode to enable parallel evaluation runs for comparison.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->