### PR TITLE
feat(eval-overview): Plan C-overview — Braintrust tiles in /api/get_evaluation_overview

### DIFF
--- a/reflexio/lib/_dashboard.py
+++ b/reflexio/lib/_dashboard.py
@@ -1,4 +1,13 @@
 from reflexio.lib._base import STORAGE_NOT_CONFIGURED_MSG, ReflexioBase
+from reflexio.models.api_schema.eval_overview_schema import (
+    ContextTile,
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+    HeroBlock,
+    NumberWithDelta,
+    PercentWithDelta,
+    ScoreDistribution,
+)
 from reflexio.models.api_schema.retriever_schema import (
     DashboardStats,
     GetDashboardStatsRequest,
@@ -129,3 +138,59 @@ class DashboardMixin(ReflexioBase):
                 stats=[],
                 msg=f"Failed to get playbook application stats: {str(e)}",
             )
+
+    def get_evaluation_overview(
+        self, request: GetEvaluationOverviewRequest | dict
+    ) -> GetEvaluationOverviewResponse:
+        """Build the /evaluations overview payload (hero + tiles + attribution + distribution).
+
+        Args:
+            request (GetEvaluationOverviewRequest | dict): Window, bucket
+                granularity, and shadow-inclusion flag.
+
+        Returns:
+            GetEvaluationOverviewResponse: Full payload — the redesigned
+                /evaluations page is expected to render directly from this.
+        """
+        if isinstance(request, dict):
+            request = GetEvaluationOverviewRequest(**request)
+        if not self._is_storage_configured():
+            return _empty_overview_response()
+        from reflexio.server.services.evaluation_overview.service import (
+            EvaluationOverviewService,
+        )
+
+        service = EvaluationOverviewService(
+            storage=self._get_storage(),
+            config=self.request_context.configurator.get_config(),
+        )
+        return service.run(request)
+
+
+def _empty_overview_response() -> GetEvaluationOverviewResponse:
+    """Return a default response when storage is not configured.
+
+    Used by lib wrappers to keep the endpoint stable even before storage is
+    wired up (matches the defensive pattern used by other dashboard methods).
+    """
+    return GetEvaluationOverviewResponse(
+        hero=HeroBlock(
+            state="empty",
+            regular_success_rate_pp=0.0,
+            shadow_success_rate_pp=None,
+            delta_pp=None,
+            buckets=[],
+        ),
+        context_tiles=ContextTile(
+            success=PercentWithDelta(current=0.0, delta_pp=0.0),
+            corrections=NumberWithDelta(current=0.0, delta=0.0),
+            turns=NumberWithDelta(current=0.0, delta=0.0),
+            escalation=PercentWithDelta(current=0.0, delta_pp=0.0),
+        ),
+        rule_attribution=[],
+        score_distribution=ScoreDistribution(
+            current_bins=[0, 0, 0, 0, 0, 0],
+            baseline_bins=[0, 0, 0, 0, 0, 0],
+            labels=["0", "1", "2", "3", "4", "5+"],
+        ),
+    )

--- a/reflexio/lib/_dashboard.py
+++ b/reflexio/lib/_dashboard.py
@@ -250,4 +250,5 @@ def _empty_overview_response() -> GetEvaluationOverviewResponse:
             baseline_bins=[0, 0, 0, 0, 0, 0],
             labels=["0", "1", "2", "3", "4", "5+"],
         ),
+        braintrust_tiles=[],
     )

--- a/reflexio/lib/_dashboard.py
+++ b/reflexio/lib/_dashboard.py
@@ -1,4 +1,14 @@
+from typing import TYPE_CHECKING
+
 from reflexio.lib._base import STORAGE_NOT_CONFIGURED_MSG, ReflexioBase
+from reflexio.models.api_schema.braintrust_schema import (
+    BraintrustStatusResponse,
+    ConnectBraintrustRequest,
+    ConnectBraintrustResponse,
+    SelectProjectsRequest,
+    SelectProjectsResponse,
+    SyncBraintrustResponse,
+)
 from reflexio.models.api_schema.eval_overview_schema import (
     ContextTile,
     GetEvaluationOverviewRequest,
@@ -17,6 +27,11 @@ from reflexio.models.api_schema.retriever_schema import (
     PeriodStats,
     TimeSeriesDataPoint,
 )
+
+if TYPE_CHECKING:
+    from reflexio.server.services.braintrust.service import (
+        BraintrustConnectorService,
+    )
 
 
 class DashboardMixin(ReflexioBase):
@@ -138,6 +153,48 @@ class DashboardMixin(ReflexioBase):
                 stats=[],
                 msg=f"Failed to get playbook application stats: {str(e)}",
             )
+
+    # ==============================
+    # Braintrust connector (Plan C-backend)
+    # ==============================
+
+    def braintrust_connect(
+        self, request: ConnectBraintrustRequest | dict
+    ) -> ConnectBraintrustResponse:
+        """Step 1 of the Braintrust connect flow — validate key, list workspaces."""
+        if isinstance(request, dict):
+            request = ConnectBraintrustRequest(**request)
+        return self._braintrust_service().connect(request)
+
+    def braintrust_select_projects(
+        self, request: SelectProjectsRequest | dict
+    ) -> SelectProjectsResponse:
+        """Step 2 — persist the connection with selected projects (key encrypted)."""
+        if isinstance(request, dict):
+            request = SelectProjectsRequest(**request)
+        return self._braintrust_service().select_projects(request)
+
+    def braintrust_status(self) -> BraintrustStatusResponse:
+        """Return whether this org is connected to Braintrust + sync state."""
+        return self._braintrust_service().status()
+
+    def braintrust_disconnect(self) -> None:
+        """Delete the persisted Braintrust connection."""
+        self._braintrust_service().disconnect()
+
+    def braintrust_sync(self) -> SyncBraintrustResponse:
+        """Manual one-shot sync (cron-driven sync is a follow-up)."""
+        return self._braintrust_service().sync_once()
+
+    def _braintrust_service(self) -> "BraintrustConnectorService":
+        from reflexio.server.services.braintrust.service import (
+            BraintrustConnectorService,
+        )
+
+        return BraintrustConnectorService(
+            storage=self._get_storage(),
+            org_id=self.request_context.org_id,
+        )
 
     def get_evaluation_overview(
         self, request: GetEvaluationOverviewRequest | dict

--- a/reflexio/models/api_schema/braintrust_schema.py
+++ b/reflexio/models/api_schema/braintrust_schema.py
@@ -1,0 +1,141 @@
+"""Pydantic models for the Braintrust connector (Plan C-backend).
+
+The connector imports per-scorer outputs from a customer's Braintrust
+workspace and surfaces them next to Reflexio's own evaluation results.
+This module owns the schemas; the orchestration lives in
+`reflexio.server.services.braintrust.service`.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# ===============================
+# Stored entities
+# ===============================
+
+
+class BraintrustConnection(BaseModel):
+    """A persisted Braintrust workspace connection for one Reflexio org.
+
+    The `api_key_enc` field carries the Fernet-encrypted API key. Storage
+    layers MUST not log or echo this field.
+
+    Args:
+        org_id (str): Reflexio org owning the connection.
+        api_key_enc (str): Fernet-encrypted Braintrust API key.
+        workspace_id (str): Braintrust workspace (organization) id.
+        workspace_name (str): Human-readable workspace name (cached).
+        project_ids (list[str]): Selected Braintrust project ids to sync.
+        last_sync_ts (int | None): Unix epoch of last successful sync.
+        last_error (str | None): Last sync error message, if any.
+    """
+
+    org_id: str
+    api_key_enc: str
+    workspace_id: str
+    workspace_name: str = ""
+    project_ids: list[str] = Field(default_factory=list)
+    last_sync_ts: int | None = None
+    last_error: str | None = None
+
+
+class ImportedScore(BaseModel):
+    """One scorer output imported from an external eval tool.
+
+    Source is generic to enable future LangSmith / Patronus imports
+    against the same table.
+
+    Args:
+        org_id (str): Reflexio org owning the score.
+        source (Literal["braintrust"]): Provider — extensible.
+        source_run_id (str): Provider-side span/run id (unique per source).
+        session_id (str | None): Reflexio session this score attaches to
+            when matched via `span.metadata.reflexio_session_id`; None
+            until the customer instruments their Braintrust spans.
+        scorer_name (str): Provider-side scorer name.
+        value (float): Scorer output value; range is provider-specific.
+        ts (int): Unix epoch of the span's creation in the provider.
+    """
+
+    org_id: str
+    source: Literal["braintrust"] = "braintrust"
+    source_run_id: str
+    session_id: str | None = None
+    scorer_name: str
+    value: float
+    ts: int
+
+
+# ===============================
+# Requests / responses
+# ===============================
+
+
+class BraintrustWorkspaceSummary(BaseModel):
+    """One workspace + its projects as returned by Braintrust."""
+
+    workspace_id: str
+    workspace_name: str
+    projects: list[BraintrustProjectSummary] = Field(default_factory=list)
+
+
+class BraintrustProjectSummary(BaseModel):
+    project_id: str
+    project_name: str
+
+
+class ConnectBraintrustRequest(BaseModel):
+    """Step 1 of the connect flow: validate the API key + list workspaces.
+
+    The key is NOT persisted here; only after `select_projects` does it
+    land in storage (encrypted).
+    """
+
+    api_key: str = Field(min_length=1)
+
+
+class ConnectBraintrustResponse(BaseModel):
+    success: bool
+    workspaces: list[BraintrustWorkspaceSummary] = Field(default_factory=list)
+    msg: str = ""
+
+
+class SelectProjectsRequest(BaseModel):
+    """Step 2 of the connect flow: commit the connection."""
+
+    api_key: str = Field(min_length=1)
+    workspace_id: str = Field(min_length=1)
+    workspace_name: str = ""
+    project_ids: list[str] = Field(default_factory=list)
+
+
+class SelectProjectsResponse(BaseModel):
+    success: bool
+    msg: str = ""
+
+
+class BraintrustStatusResponse(BaseModel):
+    """Returned by GET /api/braintrust/status.
+
+    Connected reflects whether a row exists in storage; sensitive fields
+    (the API key) are never serialized.
+    """
+
+    connected: bool
+    workspace_id: str = ""
+    workspace_name: str = ""
+    project_count: int = 0
+    last_sync_ts: int | None = None
+    last_error: str | None = None
+
+
+class SyncBraintrustResponse(BaseModel):
+    success: bool
+    scored_count: int = 0
+    msg: str = ""
+
+
+BraintrustWorkspaceSummary.model_rebuild()

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -1,0 +1,101 @@
+"""Request/response models for POST /api/get_evaluation_overview.
+
+The endpoint returns everything the redesigned /evaluations page needs in a
+single round-trip so the frontend renders, never computes.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+HeroStateLiteral = Literal["full", "early", "shadow_off", "empty"]
+BucketLiteral = Literal["day", "week"]
+
+
+class HeroBucket(BaseModel):
+    """One point on the trend chart in the hero block."""
+
+    ts: int
+    regular_rate: float
+    shadow_rate: float | None
+    regular_n: int
+    shadow_n: int
+
+
+class HeroBlock(BaseModel):
+    """The "answer" band — trend + headline delta."""
+
+    state: HeroStateLiteral
+    regular_success_rate_pp: float
+    shadow_success_rate_pp: float | None
+    delta_pp: float | None
+    buckets: list[HeroBucket]
+
+
+class NumberWithDelta(BaseModel):
+    current: float
+    delta: float
+
+
+class PercentWithDelta(BaseModel):
+    current: float
+    delta_pp: float
+
+
+class ContextTile(BaseModel):
+    """Wrapper for the four mini-tiles in the context band.
+
+    Each tile is rendered with an absolute value + a delta vs the previous
+    7d window. Percent-shaped values carry `delta_pp` (percentage points);
+    raw counts carry `delta` (absolute difference).
+    """
+
+    success: PercentWithDelta
+    corrections: NumberWithDelta
+    turns: NumberWithDelta
+    escalation: PercentWithDelta
+
+
+class RuleAttributionRow(BaseModel):
+    """One row in the "rules that moved the needle" panel."""
+
+    rule_id: str
+    kind: Literal["playbook", "profile"]
+    title: str = ""
+    successes_with: int = Field(ge=0)
+    failures_with: int = Field(ge=0)
+    net_sessions: int
+
+
+class ScoreDistribution(BaseModel):
+    """Corrections-per-session histogram, current window + baseline."""
+
+    current_bins: list[int]
+    baseline_bins: list[int]
+    labels: list[str]
+
+
+class GetEvaluationOverviewRequest(BaseModel):
+    """Input for the overview endpoint.
+
+    Args:
+        from_ts (int): Window start, unix epoch seconds.
+        to_ts (int): Window end, unix epoch seconds.
+        bucket (BucketLiteral): Granularity of the hero trend buckets.
+        include_shadow (bool): When False, skip the shadow-side aggregations
+            (cheaper) — the hero will degrade to shadow_off state.
+    """
+
+    from_ts: int = Field(ge=0)
+    to_ts: int = Field(ge=0)
+    bucket: BucketLiteral = "week"
+    include_shadow: bool = True
+
+
+class GetEvaluationOverviewResponse(BaseModel):
+    hero: HeroBlock
+    context_tiles: ContextTile
+    rule_attribution: list[RuleAttributionRow]
+    score_distribution: ScoreDistribution

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -94,8 +94,26 @@ class GetEvaluationOverviewRequest(BaseModel):
     include_shadow: bool = True
 
 
+class BraintrustTileRow(BaseModel):
+    """One imported-scorer aggregate for the context band (Plan C-overview).
+
+    Args:
+        scorer_name (str): The Braintrust scorer name.
+        current (float): Mean value across the current window.
+        n (int): Number of imported scores backing `current`.
+        delta (float): Mean current − mean prior-window. Equals `current`
+            when no baseline (the frontend renders "no baseline").
+    """
+
+    scorer_name: str
+    current: float
+    n: int = Field(ge=0)
+    delta: float
+
+
 class GetEvaluationOverviewResponse(BaseModel):
     hero: HeroBlock
     context_tiles: ContextTile
     rule_attribution: list[RuleAttributionRow]
     score_distribution: ScoreDistribution
+    braintrust_tiles: list[BraintrustTileRow] = Field(default_factory=list)

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -614,6 +614,11 @@ class Config(BaseModel):
     # (multi-reader + critic). Defaults keep existing behavior; flip to
     # "agentic" to opt in once Phase 3/4 land.
     extraction_backend: Literal["classic", "agentic"] = "classic"
+    # Whether this org has opted into shadow-mode runs. Drives /healthz/eval
+    # liveness derivation and the /api/get_evaluation_overview hero state
+    # machine. When True, each publish optionally schedules a parallel
+    # "without Reflexio" generation for side-by-side comparison.
+    shadow_mode_enabled: bool = False
     search_backend: Literal["classic", "agentic"] = "classic"
     # Extraction axes to skip in the agentic backend. Default: empty set =
     # all three axes (UserProfile, UserProfileAgentRec, UserPlaybook) run.

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -19,6 +19,14 @@ from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
+from reflexio.models.api_schema.braintrust_schema import (
+    BraintrustStatusResponse,
+    ConnectBraintrustRequest,
+    ConnectBraintrustResponse,
+    SelectProjectsRequest,
+    SelectProjectsResponse,
+    SyncBraintrustResponse,
+)
 from reflexio.models.api_schema.eval_overview_schema import (
     GetEvaluationOverviewRequest,
     GetEvaluationOverviewResponse,
@@ -1515,6 +1523,101 @@ def get_playbook_application_stats(
     """
     reflexio = get_reflexio(org_id=org_id)
     return reflexio.get_playbook_application_stats(request)
+
+
+# ============================================================================
+# Braintrust connector (Plan C-backend)
+# ============================================================================
+
+
+@core_router.post(
+    "/api/braintrust/connect",
+    response_model=ConnectBraintrustResponse,
+    response_model_exclude_none=True,
+)
+def braintrust_connect(
+    request: ConnectBraintrustRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> ConnectBraintrustResponse:
+    """Step 1: validate the Braintrust API key and list workspaces/projects.
+
+    Persists nothing — call `/api/braintrust/select_projects` to commit.
+
+    Args:
+        request (ConnectBraintrustRequest): Customer's Braintrust API key.
+        org_id (str): Resolved by auth dependency.
+
+    Returns:
+        ConnectBraintrustResponse: Workspaces tree on success; `success=False`
+            with a message when the key is rejected.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.braintrust_connect(request)
+
+
+@core_router.post(
+    "/api/braintrust/select_projects",
+    response_model=SelectProjectsResponse,
+    response_model_exclude_none=True,
+)
+def braintrust_select_projects(
+    request: SelectProjectsRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> SelectProjectsResponse:
+    """Step 2: commit the Braintrust connection with selected projects.
+
+    The API key is encrypted at rest. Subsequent syncs use the persisted
+    connection until the customer calls DELETE /api/braintrust/connection.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.braintrust_select_projects(request)
+
+
+@core_router.get(
+    "/api/braintrust/status",
+    response_model=BraintrustStatusResponse,
+    response_model_exclude_none=True,
+)
+def braintrust_status(
+    org_id: str = Depends(default_get_org_id),
+) -> BraintrustStatusResponse:
+    """Return Braintrust connection state. Never echoes the API key."""
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.braintrust_status()
+
+
+@core_router.delete("/api/braintrust/connection")
+def braintrust_disconnect(
+    org_id: str = Depends(default_get_org_id),
+) -> dict:
+    """Delete the persisted Braintrust connection for the org.
+
+    Args:
+        org_id (str): Resolved by auth dependency.
+
+    Returns:
+        dict: ``{"success": True}`` on completion.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    reflexio.braintrust_disconnect()
+    return {"success": True}
+
+
+@core_router.post(
+    "/api/braintrust/sync",
+    response_model=SyncBraintrustResponse,
+    response_model_exclude_none=True,
+)
+def braintrust_sync(
+    org_id: str = Depends(default_get_org_id),
+) -> SyncBraintrustResponse:
+    """Trigger a one-shot sync of Braintrust scorer outputs.
+
+    Scheduled (cron) sync is a follow-up; for now the endpoint exists so
+    operators can drive a manual import.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.braintrust_sync()
 
 
 @core_router.post(

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -19,6 +19,10 @@ from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
 
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+)
 from reflexio.models.api_schema.retriever_schema import (
     GetAgentPlaybooksRequest,
     GetAgentPlaybooksViewResponse,
@@ -1511,6 +1515,32 @@ def get_playbook_application_stats(
     """
     reflexio = get_reflexio(org_id=org_id)
     return reflexio.get_playbook_application_stats(request)
+
+
+@core_router.post(
+    "/api/get_evaluation_overview",
+    response_model=GetEvaluationOverviewResponse,
+    response_model_exclude_none=True,
+)
+def get_evaluation_overview(
+    request: GetEvaluationOverviewRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> GetEvaluationOverviewResponse:
+    """Return the redesigned /evaluations page payload.
+
+    Aggregates hero state, four context tiles with deltas, top rule
+    attribution, and a corrections-per-session distribution into a single
+    response shaped exactly as the frontend renders it.
+
+    Args:
+        request (GetEvaluationOverviewRequest): Window + bucket granularity.
+        org_id (str): Organization ID resolved by the auth dependency.
+
+    Returns:
+        GetEvaluationOverviewResponse: Full overview payload.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    return reflexio.get_evaluation_overview(request)
 
 
 @core_router.post(

--- a/reflexio/server/api_endpoints/stall_state_api.py
+++ b/reflexio/server/api_endpoints/stall_state_api.py
@@ -8,7 +8,10 @@ from reflexio.models.api_schema.stall_state_schema import (
     MarkNotifiedResponse,
     StallStateResponse,
 )
-from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
+from reflexio.server.api_endpoints.request_context import (
+    RequestContext,
+    get_request_context,
+)
 
 router = APIRouter(tags=["stall_state"])
 

--- a/reflexio/server/llm/providers/claude_code_stream_parser.py
+++ b/reflexio/server/llm/providers/claude_code_stream_parser.py
@@ -13,7 +13,7 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 
 from reflexio.models.api_schema.stall_state_schema import StallReason
 
@@ -190,8 +190,8 @@ def parse_reset_estimate(text: str) -> datetime | None:
     hour = hour_raw % 12
     if match.group("ampm").lower() == "pm":
         hour += 12
-    today = datetime.now(timezone.utc).date()
-    candidate = datetime.combine(today, time(hour, minute), tzinfo=timezone.utc)
-    if candidate <= datetime.now(timezone.utc):
+    today = datetime.now(UTC).date()
+    candidate = datetime.combine(today, time(hour, minute), tzinfo=UTC)
+    if candidate <= datetime.now(UTC):
         candidate += timedelta(days=1)
     return candidate

--- a/reflexio/server/services/braintrust/_encryption.py
+++ b/reflexio/server/services/braintrust/_encryption.py
@@ -1,0 +1,100 @@
+"""Minimal Fernet encryption helper for the Braintrust connector.
+
+Reads `REFLEXIO_FERNET_KEYS` (comma-separated) from the environment. When
+the env var is unset, both `encrypt` and `decrypt` return the value
+unchanged — matching the existing `EncryptManager` behavior in
+`reflexio_ext.utils` and keeping OS dev mode workable without rotation
+infrastructure.
+
+In enterprise deployments, the env var IS set and the API key is stored
+ciphertext-only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from cryptography import fernet
+from cryptography.fernet import Fernet, MultiFernet
+
+logger = logging.getLogger(__name__)
+
+
+_ENV_KEY = "REFLEXIO_FERNET_KEYS"
+_MULTI: MultiFernet | None = None
+_LOADED = False
+
+
+def _load() -> MultiFernet | None:
+    """Lazy-load the MultiFernet from env on first use."""
+    global _MULTI, _LOADED
+    if _LOADED:
+        return _MULTI
+    _LOADED = True
+    raw = os.environ.get(_ENV_KEY, "").strip()
+    if not raw:
+        logger.info(
+            "%s is unset — Braintrust connector storing API keys in plaintext "
+            "(suitable only for local development).",
+            _ENV_KEY,
+        )
+        return None
+    fernets = []
+    for k in raw.split(","):
+        k = k.strip()
+        if not k:
+            continue
+        try:
+            fernets.append(Fernet(k.encode("utf-8")))
+        except Exception:  # noqa: BLE001
+            logger.warning("Discarding invalid Fernet key in %s", _ENV_KEY)
+    if not fernets:
+        return None
+    _MULTI = MultiFernet(fernets)
+    return _MULTI
+
+
+def encrypt(value: str) -> str:
+    """Encrypt `value` if Fernet keys are configured; otherwise return as-is.
+
+    Args:
+        value (str): The plaintext (e.g., a Braintrust API key).
+
+    Returns:
+        str: Ciphertext, or `value` unchanged when no keys are configured.
+    """
+    m = _load()
+    if m is None:
+        return value
+    return m.encrypt(value.encode("utf-8")).decode("utf-8")
+
+
+def decrypt(value: str) -> str:
+    """Decrypt `value` if Fernet keys are configured; otherwise return as-is.
+
+    Args:
+        value (str): The (possibly ciphertext) value from storage.
+
+    Returns:
+        str: Plaintext.
+
+    Raises:
+        InvalidToken: When the token cannot be decoded by any registered key.
+    """
+    m = _load()
+    if m is None:
+        return value
+    try:
+        return m.decrypt(value.encode("utf-8")).decode("utf-8")
+    except fernet.InvalidToken:
+        # Storage may contain plaintext from a pre-encryption deployment.
+        # Caller decides whether to surface the issue.
+        raise
+
+
+def _reset_for_test() -> None:
+    """Reset the cached MultiFernet — for tests only."""
+    global _MULTI, _LOADED
+    _MULTI = None
+    _LOADED = False

--- a/reflexio/server/services/braintrust/client.py
+++ b/reflexio/server/services/braintrust/client.py
@@ -1,0 +1,166 @@
+"""HTTP client for the Braintrust REST API.
+
+Pure HTTP wrapper — no storage, no encryption, no orchestration. The
+service layer composes this with storage to build the connector.
+
+The exact endpoint paths (`/v1/api_key`, `/v1/organization`, etc.) follow
+the spec §5.1; if Braintrust evolves the API, only this file needs to
+change — call sites use the typed methods.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_BASE_URL = "https://api.braintrust.dev"
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class BraintrustAuthError(RuntimeError):
+    """Raised when the Braintrust API rejects the key (401 / 403)."""
+
+
+class BraintrustHTTPError(RuntimeError):
+    """Raised on non-2xx, non-auth-error responses from Braintrust."""
+
+    def __init__(self, status_code: int, body: str) -> None:
+        super().__init__(f"Braintrust HTTP {status_code}: {body[:200]}")
+        self.status_code = status_code
+        self.body = body
+
+
+class BraintrustClient:
+    """Thin wrapper around the Braintrust REST API.
+
+    All methods are synchronous; they use a per-client `httpx.Client`
+    with a fixed timeout so tests can monkey-patch the client.
+
+    Args:
+        api_key (str): Customer-supplied Braintrust API key.
+        base_url (str): Override for testing.
+        timeout (float): Per-request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self._client = httpx.Client(
+            timeout=timeout,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Accept": "application/json",
+                "User-Agent": "reflexio-braintrust-connector/1.0",
+            },
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    # ------------------------------------------------------------------
+    # API methods
+    # ------------------------------------------------------------------
+
+    def validate_key(self) -> bool:
+        """Return True iff the API key is valid.
+
+        Returns:
+            bool: True on 2xx, False on 401/403. Other errors raise.
+        """
+        try:
+            self._get("/v1/api_key")
+        except BraintrustAuthError:
+            return False
+        return True
+
+    def list_organizations(self) -> list[dict[str, Any]]:
+        """List workspaces (Braintrust calls these "organizations").
+
+        Returns:
+            list[dict]: Each item has at least `id` and `name`.
+        """
+        return self._unwrap(self._get("/v1/organization"))
+
+    def list_projects(self, workspace_id: str) -> list[dict[str, Any]]:
+        """List projects in a workspace.
+
+        Args:
+            workspace_id (str): Braintrust organization id.
+
+        Returns:
+            list[dict]: Each item has at least `id` and `name`.
+        """
+        return self._unwrap(
+            self._get("/v1/project", params={"org_id": workspace_id})
+        )
+
+    def list_experiments(
+        self, project_id: str, since_ts: int | None = None
+    ) -> list[dict[str, Any]]:
+        """List experiments in a project.
+
+        Args:
+            project_id (str): Braintrust project id.
+            since_ts (int | None): Optional unix-epoch lower bound on
+                `experiment.created_at`.
+
+        Returns:
+            list[dict]: Each item has at least `id`, `name`, `created_at`.
+        """
+        params: dict[str, Any] = {"project_id": project_id}
+        if since_ts is not None:
+            params["since"] = since_ts
+        return self._unwrap(self._get("/v1/experiment", params=params))
+
+    def list_spans(self, experiment_id: str) -> list[dict[str, Any]]:
+        """List spans for an experiment.
+
+        Returns:
+            list[dict]: Each item has at least `id`, `metadata`, `scores`,
+                `created_at`. Other fields are ignored by the caller.
+        """
+        return self._unwrap(
+            self._get("/v1/span", params={"experiment_id": experiment_id})
+        )
+
+    # ------------------------------------------------------------------
+    # internals
+    # ------------------------------------------------------------------
+
+    def _get(
+        self, path: str, *, params: dict[str, Any] | None = None
+    ) -> httpx.Response:
+        url = f"{self.base_url}{path}"
+        response = self._client.get(url, params=params)
+        if response.status_code in (401, 403):
+            raise BraintrustAuthError(
+                f"Braintrust rejected the API key (HTTP {response.status_code})"
+            )
+        if not (200 <= response.status_code < 300):
+            raise BraintrustHTTPError(response.status_code, response.text)
+        return response
+
+    @staticmethod
+    def _unwrap(response: httpx.Response) -> list[dict[str, Any]]:
+        """Pull the list payload from Braintrust's standard envelope.
+
+        Braintrust wraps list responses in `{"objects": [...]}`. We
+        accept either the wrapped form or a bare list (some endpoints).
+        """
+        data = response.json()
+        if isinstance(data, dict) and "objects" in data:
+            return data["objects"]
+        if isinstance(data, list):
+            return data
+        return []

--- a/reflexio/server/services/braintrust/service.py
+++ b/reflexio/server/services/braintrust/service.py
@@ -1,0 +1,267 @@
+"""Orchestrates the Braintrust connector: connect, select-projects, sync, status.
+
+The service is stateless across requests; it loads the connection from
+storage on each call. API keys are encrypted in storage and decrypted
+only when needed for a Braintrust HTTP call.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from reflexio.models.api_schema.braintrust_schema import (
+    BraintrustConnection,
+    BraintrustProjectSummary,
+    BraintrustStatusResponse,
+    BraintrustWorkspaceSummary,
+    ConnectBraintrustRequest,
+    ConnectBraintrustResponse,
+    ImportedScore,
+    SelectProjectsRequest,
+    SelectProjectsResponse,
+    SyncBraintrustResponse,
+)
+from reflexio.server.services.braintrust._encryption import decrypt, encrypt
+from reflexio.server.services.braintrust.client import (
+    BraintrustAuthError,
+    BraintrustClient,
+    BraintrustHTTPError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_METADATA_SESSION_KEY = "reflexio_session_id"
+
+
+@dataclass
+class BraintrustConnectorService:
+    """Top-level orchestrator for the Braintrust connector.
+
+    Args:
+        storage: BaseStorage-like; uses save/get/delete_braintrust_connection
+            and save_imported_scores. Default no-op storage methods keep
+            this workable until per-backend implementations land.
+        org_id (str): The Reflexio org for which the connector operates.
+        client_factory (Callable[[str], BraintrustClient]): Factory that
+            takes an API key and returns a BraintrustClient. Injectable so
+            tests can pass mocks.
+    """
+
+    storage: object
+    org_id: str
+    client_factory: Callable[[str], BraintrustClient] = BraintrustClient
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def connect(
+        self, request: ConnectBraintrustRequest
+    ) -> ConnectBraintrustResponse:
+        """Step 1: validate the API key and return the workspace/project tree.
+
+        Persists nothing — the caller chooses which projects to sync and
+        then calls `select_projects` with the same key.
+        """
+        client = self.client_factory(request.api_key)
+        try:
+            if not client.validate_key():
+                return ConnectBraintrustResponse(
+                    success=False, msg="Braintrust rejected the API key."
+                )
+            workspaces = self._fetch_workspace_tree(client)
+        except BraintrustAuthError:
+            return ConnectBraintrustResponse(
+                success=False, msg="Braintrust rejected the API key."
+            )
+        except BraintrustHTTPError as e:
+            return ConnectBraintrustResponse(
+                success=False, msg=f"Braintrust HTTP error: {e}"
+            )
+
+        return ConnectBraintrustResponse(
+            success=True, workspaces=workspaces, msg=""
+        )
+
+    def select_projects(
+        self, request: SelectProjectsRequest
+    ) -> SelectProjectsResponse:
+        """Step 2: persist the connection with the selected projects.
+
+        Stores the API key encrypted. Overwrites any existing connection
+        for the org.
+        """
+        connection = BraintrustConnection(
+            org_id=self.org_id,
+            api_key_enc=encrypt(request.api_key),
+            workspace_id=request.workspace_id,
+            workspace_name=request.workspace_name,
+            project_ids=request.project_ids,
+            last_sync_ts=None,
+            last_error=None,
+        )
+        self._save_connection(connection)
+        return SelectProjectsResponse(success=True, msg="Connected.")
+
+    def status(self) -> BraintrustStatusResponse:
+        """Return whether the org is connected + sync state. Never echoes the key."""
+        connection = self._load_connection()
+        if connection is None:
+            return BraintrustStatusResponse(connected=False)
+        return BraintrustStatusResponse(
+            connected=True,
+            workspace_id=connection.workspace_id,
+            workspace_name=connection.workspace_name,
+            project_count=len(connection.project_ids),
+            last_sync_ts=connection.last_sync_ts,
+            last_error=connection.last_error,
+        )
+
+    def disconnect(self) -> None:
+        """Delete the persisted connection."""
+        self.storage.delete_braintrust_connection(self.org_id)  # type: ignore[attr-defined]
+
+    def sync_once(self, backfill_days: int = 90) -> SyncBraintrustResponse:
+        """One-shot sync: walk projects → experiments → spans → write scores.
+
+        Updates `last_sync_ts` and `last_error` on the persisted connection.
+        Idempotent at the storage layer (per-backend overrides should
+        upsert by (source, source_run_id, scorer_name)).
+        """
+        connection = self._load_connection()
+        if connection is None:
+            return SyncBraintrustResponse(
+                success=False, msg="Not connected to Braintrust."
+            )
+
+        try:
+            api_key = decrypt(connection.api_key_enc)
+        except Exception as e:  # noqa: BLE001
+            return SyncBraintrustResponse(
+                success=False, msg=f"Failed to decrypt API key: {e}"
+            )
+
+        client = self.client_factory(api_key)
+        since_ts = max(0, int(time.time()) - backfill_days * 24 * 60 * 60)
+
+        all_scores: list[ImportedScore] = []
+        try:
+            for project_id in connection.project_ids:
+                experiments = client.list_experiments(project_id, since_ts=since_ts)
+                for exp in experiments:
+                    spans = client.list_spans(exp["id"])
+                    all_scores.extend(_scores_from_spans(spans, self.org_id))
+        except BraintrustAuthError:
+            self._persist_sync_outcome(connection, error="API key invalid.")
+            return SyncBraintrustResponse(
+                success=False, msg="API key invalid; halting sync."
+            )
+        except BraintrustHTTPError as e:
+            self._persist_sync_outcome(connection, error=str(e))
+            return SyncBraintrustResponse(success=False, msg=str(e))
+
+        self.storage.save_imported_scores(all_scores)  # type: ignore[attr-defined]
+        self._persist_sync_outcome(connection, error=None)
+        return SyncBraintrustResponse(
+            success=True, scored_count=len(all_scores), msg=""
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _fetch_workspace_tree(
+        self, client: BraintrustClient
+    ) -> list[BraintrustWorkspaceSummary]:
+        """Pull workspaces + their projects in one shot for the connect UX."""
+        result: list[BraintrustWorkspaceSummary] = []
+        for ws in client.list_organizations():
+            workspace_id = str(ws.get("id", ""))
+            workspace_name = str(ws.get("name", ""))
+            if not workspace_id:
+                continue
+            projects_raw = client.list_projects(workspace_id)
+            projects = [
+                BraintrustProjectSummary(
+                    project_id=str(p.get("id", "")),
+                    project_name=str(p.get("name", "")),
+                )
+                for p in projects_raw
+                if p.get("id")
+            ]
+            result.append(
+                BraintrustWorkspaceSummary(
+                    workspace_id=workspace_id,
+                    workspace_name=workspace_name,
+                    projects=projects,
+                )
+            )
+        return result
+
+    def _load_connection(self) -> BraintrustConnection | None:
+        return self.storage.get_braintrust_connection(self.org_id)  # type: ignore[attr-defined]
+
+    def _save_connection(self, connection: BraintrustConnection) -> None:
+        self.storage.save_braintrust_connection(connection)  # type: ignore[attr-defined]
+
+    def _persist_sync_outcome(
+        self, connection: BraintrustConnection, *, error: str | None
+    ) -> None:
+        updated = connection.model_copy(
+            update={
+                "last_sync_ts": int(time.time()),
+                "last_error": error,
+            }
+        )
+        self._save_connection(updated)
+
+
+def _scores_from_spans(
+    spans: list[dict],
+    org_id: str,
+) -> list[ImportedScore]:
+    """Extract ImportedScore rows from a list of Braintrust spans.
+
+    A single span may carry multiple scorers — one row per scorer.
+    `session_id` is pulled from `span.metadata.reflexio_session_id` when
+    present (the progressive-matching upgrade path).
+    """
+    out: list[ImportedScore] = []
+    for span in spans:
+        span_id = str(span.get("id", ""))
+        if not span_id:
+            continue
+        ts_raw = span.get("created_at", 0)
+        try:
+            ts = int(ts_raw)
+        except (TypeError, ValueError):
+            ts = 0
+        metadata = span.get("metadata") or {}
+        session_id: str | None = None
+        if isinstance(metadata, dict):
+            v = metadata.get(_METADATA_SESSION_KEY)
+            if isinstance(v, str) and v:
+                session_id = v
+        scores = span.get("scores") or {}
+        if not isinstance(scores, dict):
+            continue
+        for scorer_name, value in scores.items():
+            try:
+                fvalue = float(value)
+            except (TypeError, ValueError):
+                continue
+            out.append(
+                ImportedScore(
+                    org_id=org_id,
+                    source_run_id=span_id,
+                    session_id=session_id,
+                    scorer_name=str(scorer_name),
+                    value=fvalue,
+                    ts=ts,
+                )
+            )
+    return out

--- a/reflexio/server/services/evaluation_overview/distribution.py
+++ b/reflexio/server/services/evaluation_overview/distribution.py
@@ -1,0 +1,31 @@
+"""Bucket per-session correction counts into a fixed 6-bin histogram.
+
+The spec §4.5 called for a continuous 0.0-1.0 score distribution; the actual
+schema only has `is_success` and `number_of_correction_per_session`, so we
+distribute by correction count instead. Six bins keep the visualization
+readable while preserving the shape of session quality.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+BUCKET_LABELS: tuple[str, ...] = ("0", "1", "2", "3", "4", "5+")
+_BUCKET_COUNT = len(BUCKET_LABELS)
+
+
+def bucket_corrections(corrections: Iterable[int]) -> tuple[int, int, int, int, int, int]:
+    """Return per-bin counts for the corrections histogram.
+
+    Args:
+        corrections (Iterable[int]): One non-negative integer per session in
+            the window. Values >= 5 fall into the final "5+" bin.
+
+    Returns:
+        tuple[int, ...]: Six non-negative counts in BUCKET_LABELS order.
+    """
+    bins = [0] * _BUCKET_COUNT
+    for c in corrections:
+        idx = min(_BUCKET_COUNT - 1, c)
+        bins[idx] += 1
+    return tuple(bins)  # type: ignore[return-value]

--- a/reflexio/server/services/evaluation_overview/hero_state.py
+++ b/reflexio/server/services/evaluation_overview/hero_state.py
@@ -1,0 +1,64 @@
+"""Pure functions deriving the /evaluations hero block state and delta.
+
+These have no IO; they're invoked from EvaluationOverviewService with already-
+loaded aggregate numbers. Separated so the spec's 4-state machine can be
+unit-tested cheaply.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+_FULL_MIN_DAYS = 14
+_FULL_MIN_SHADOW_N = 500
+_SHADOW_OFF_MIN_DAYS = 7
+
+
+class HeroState(StrEnum):
+    """The four mutually exclusive hero block configurations from spec §3.2.
+
+    Members serialize to the snake_case strings the frontend switches on.
+    """
+
+    FULL = "full"
+    EARLY = "early"
+    SHADOW_OFF = "shadow_off"
+    EMPTY = "empty"
+
+
+def compute_hero_state(
+    *,
+    shadow_enabled: bool,
+    days_since_first_eval: int | None,
+    n_shadow_in_window: int,
+    total_results: int,
+) -> HeroState:
+    """Return the hero state for the current org and time window.
+
+    Args:
+        shadow_enabled (bool): Value of `Config.shadow_mode_enabled`.
+        days_since_first_eval (int | None): Wall-clock days since the first
+            ever evaluated session for this org. None when no results exist.
+        n_shadow_in_window (int): Count of sessions with non-empty shadow
+            content inside the trend window (last 8 weeks).
+        total_results (int): Total AgentSuccessEvaluationResult rows in the
+            trend window (used only to differentiate EMPTY from SHADOW_OFF).
+
+    Returns:
+        HeroState: The single applicable state. Empty wins over everything;
+            after that the order is shadow_off → early → full per spec.
+    """
+    if total_results == 0:
+        return HeroState.EMPTY
+    if not shadow_enabled:
+        if days_since_first_eval is not None and days_since_first_eval >= _SHADOW_OFF_MIN_DAYS:
+            return HeroState.SHADOW_OFF
+        # <7 days since first eval AND shadow off → still onboarding;
+        # render as EMPTY so the frontend shows onboarding rather than a
+        # partly-formed trend.
+        return HeroState.EMPTY
+    if days_since_first_eval is None or days_since_first_eval < _FULL_MIN_DAYS:
+        return HeroState.EARLY
+    if n_shadow_in_window < _FULL_MIN_SHADOW_N:
+        return HeroState.EARLY
+    return HeroState.FULL

--- a/reflexio/server/services/evaluation_overview/rule_attribution.py
+++ b/reflexio/server/services/evaluation_overview/rule_attribution.py
@@ -1,0 +1,83 @@
+"""Join PlaybookApplicationStat citations with session success outcomes.
+
+Replaces the spec's proposed `rule_application` table with a join against
+the existing `Interaction.citations` data, computing "net sessions" per
+rule = successes_with_rule_fired - failures_with_rule_fired.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+CitationKey = tuple[str, str]  # (kind, real_id) — matches PlaybookApplicationStat
+
+
+@dataclass(frozen=True)
+class RuleAttribution:
+    """One row of the "rules that moved the needle" panel."""
+
+    rule_id: str
+    kind: str
+    title: str
+    successes_with: int
+    failures_with: int
+
+    @property
+    def net_sessions(self) -> int:
+        return self.successes_with - self.failures_with
+
+
+def compute_net_sessions(
+    *,
+    citations_by_session: Mapping[str, list[CitationKey]],
+    is_success_by_session: Mapping[str, bool],
+    rule_titles: Mapping[CitationKey, str],
+    top_n: int,
+) -> list[RuleAttribution]:
+    """Aggregate net sessions per rule and return the top N by net_sessions.
+
+    Args:
+        citations_by_session (Mapping[str, list[CitationKey]]): For each
+            session in the window, the list of `(kind, real_id)` citations
+            harvested from its interactions.
+        is_success_by_session (Mapping[str, bool]): The session's evaluated
+            outcome. Sessions not in this map are skipped on both sides.
+        rule_titles (Mapping[CitationKey, str]): Pre-loaded display titles
+            for each rule (empty string when the underlying row is gone).
+        top_n (int): How many rows to return at most. Ordering: net_sessions
+            desc, then total fires desc.
+
+    Returns:
+        list[RuleAttribution]: At most `top_n` rows in the order described.
+    """
+    successes: dict[CitationKey, int] = {}
+    failures: dict[CitationKey, int] = {}
+    for session_id, citations in citations_by_session.items():
+        outcome = is_success_by_session.get(session_id)
+        if outcome is None:
+            continue
+        # A rule cited multiple times in the same session counts once.
+        unique_cites = set(citations)
+        for key in unique_cites:
+            if outcome:
+                successes[key] = successes.get(key, 0) + 1
+            else:
+                failures[key] = failures.get(key, 0) + 1
+
+    all_keys = set(successes) | set(failures)
+    rows = [
+        RuleAttribution(
+            rule_id=real_id,
+            kind=kind,
+            title=rule_titles.get((kind, real_id), ""),
+            successes_with=successes.get((kind, real_id), 0),
+            failures_with=failures.get((kind, real_id), 0),
+        )
+        for (kind, real_id) in all_keys
+    ]
+
+    rows.sort(
+        key=lambda r: (-r.net_sessions, -(r.successes_with + r.failures_with)),
+    )
+    return rows[:top_n]

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -1,0 +1,266 @@
+"""Aggregator that composes hero, tiles, rule attribution, and distribution.
+
+The service does four reads (results, citations, playbook stats, shadow count)
+and returns a GetEvaluationOverviewResponse. It's invoked from the FastAPI
+route handler; the storage is the same BaseStorage the rest of the server
+uses, so the same instance is reused via request_context.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentSuccessEvaluationResult,
+)
+from reflexio.models.api_schema.eval_overview_schema import (
+    ContextTile,
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+    HeroBlock,
+    HeroBucket,
+    NumberWithDelta,
+    PercentWithDelta,
+    RuleAttributionRow,
+    ScoreDistribution,
+)
+from reflexio.models.config_schema import Config
+from reflexio.server.services.evaluation_overview.distribution import (
+    BUCKET_LABELS,
+    bucket_corrections,
+)
+from reflexio.server.services.evaluation_overview.hero_state import (
+    compute_hero_state,
+)
+from reflexio.server.services.evaluation_overview.rule_attribution import (
+    compute_net_sessions,
+)
+
+_WEEK_SECONDS = 7 * 24 * 60 * 60
+_TOP_N_RULES = 5
+
+
+@dataclass
+class EvaluationOverviewService:
+    """Builds the full /api/get_evaluation_overview payload.
+
+    The service holds a storage handle and the org's current Config. Each
+    call to `run` performs the four reads and returns a fresh response.
+    Stateless across calls — safe to reuse the instance across requests.
+    """
+
+    storage: object
+    config: Config
+
+    def run(
+        self, request: GetEvaluationOverviewRequest
+    ) -> GetEvaluationOverviewResponse:
+        """Build the overview payload for the requested window."""
+        all_results = self.storage.get_agent_success_evaluation_results(  # type: ignore[attr-defined]
+            agent_version=None, limit=10_000
+        )
+        results = [
+            r for r in all_results if request.from_ts <= r.created_at <= request.to_ts
+        ]
+        prev_to = request.from_ts
+        prev_from = max(0, prev_to - _WEEK_SECONDS)
+        results_prev = [r for r in all_results if prev_from <= r.created_at < prev_to]
+
+        hero = self._build_hero(request, results)
+        tiles = self._build_tiles(results, results_prev)
+        attribution = self._build_attribution(results)
+        distribution = self._build_distribution(results, results_prev)
+
+        return GetEvaluationOverviewResponse(
+            hero=hero,
+            context_tiles=tiles,
+            rule_attribution=attribution,
+            score_distribution=distribution,
+        )
+
+    # --- private helpers ---
+
+    def _build_hero(
+        self,
+        request: GetEvaluationOverviewRequest,
+        results: list[AgentSuccessEvaluationResult],
+    ) -> HeroBlock:
+        if not results:
+            days_since = None
+        else:
+            earliest = min(r.created_at for r in results)
+            days_since = (int(datetime.now(UTC).timestamp()) - earliest) // 86_400
+        n_shadow = self.storage.count_sessions_with_shadow_content(  # type: ignore[attr-defined]
+            request.from_ts, request.to_ts
+        )
+        state = compute_hero_state(
+            shadow_enabled=self.config.shadow_mode_enabled,
+            days_since_first_eval=days_since,
+            n_shadow_in_window=n_shadow,
+            total_results=len(results),
+        )
+        success_rate = _success_rate(results) * 100
+        # shadow_rate and delta are None until real shadow-content evaluations
+        # exist. When count_sessions_with_shadow_content > 0 AND a future
+        # storage method exposes shadow-side outcomes, populate from there.
+        # Today both stay None and the frontend renders state-1 vs state-3
+        # purely from the `state` enum.
+        shadow_rate: float | None = None
+        delta: float | None = None
+        return HeroBlock(
+            state=state.value,  # type: ignore[arg-type]
+            regular_success_rate_pp=success_rate,
+            shadow_success_rate_pp=shadow_rate,
+            delta_pp=delta,
+            buckets=_weekly_buckets(results),
+        )
+
+    def _build_tiles(
+        self,
+        current: list[AgentSuccessEvaluationResult],
+        previous: list[AgentSuccessEvaluationResult],
+    ) -> ContextTile:
+        cur_success = _success_rate(current) * 100
+        prev_success = _success_rate(previous) * 100
+        cur_corr = _mean(r.number_of_correction_per_session for r in current)
+        prev_corr = _mean(r.number_of_correction_per_session for r in previous)
+        cur_turns = _mean(
+            r.user_turns_to_resolution
+            for r in current
+            if r.user_turns_to_resolution is not None
+        )
+        prev_turns = _mean(
+            r.user_turns_to_resolution
+            for r in previous
+            if r.user_turns_to_resolution is not None
+        )
+        cur_esc = _escalation_rate(current) * 100
+        prev_esc = _escalation_rate(previous) * 100
+        return ContextTile(
+            success=PercentWithDelta(
+                current=cur_success, delta_pp=cur_success - prev_success
+            ),
+            corrections=NumberWithDelta(
+                current=cur_corr, delta=cur_corr - prev_corr
+            ),
+            turns=NumberWithDelta(current=cur_turns, delta=cur_turns - prev_turns),
+            escalation=PercentWithDelta(
+                current=cur_esc, delta_pp=cur_esc - prev_esc
+            ),
+        )
+
+    def _build_attribution(
+        self, results: list[AgentSuccessEvaluationResult]
+    ) -> list[RuleAttributionRow]:
+        is_success_by_session = {r.session_id: r.is_success for r in results}
+        citations_by_session, rule_titles = self._load_citations(
+            list(is_success_by_session.keys())
+        )
+        rows = compute_net_sessions(
+            citations_by_session=citations_by_session,
+            is_success_by_session=is_success_by_session,
+            rule_titles=rule_titles,
+            top_n=_TOP_N_RULES,
+        )
+        return [
+            RuleAttributionRow(
+                rule_id=r.rule_id,
+                kind=r.kind,  # type: ignore[arg-type]
+                title=r.title,
+                successes_with=r.successes_with,
+                failures_with=r.failures_with,
+                net_sessions=r.net_sessions,
+            )
+            for r in rows
+        ]
+
+    def _load_citations(
+        self, session_ids: list[str]
+    ) -> tuple[dict[str, list[tuple[str, str]]], dict[tuple[str, str], str]]:
+        """Pull `Interaction.citations` keyed by session, with title lookup.
+
+        Falls back to empty data when the underlying storage method returns
+        no interactions (default behavior on backends that haven't yet
+        implemented `get_interactions_by_session`).
+        """
+        citations_by_session: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        for sid in session_ids:
+            interactions = self.storage.get_interactions_by_session(sid)  # type: ignore[attr-defined]
+            for interaction in interactions:
+                for cite in getattr(interaction, "citations", []) or []:
+                    kind = cite.get("kind") if isinstance(cite, dict) else None
+                    rid = cite.get("real_id") if isinstance(cite, dict) else None
+                    if kind and rid:
+                        citations_by_session[sid].append((kind, str(rid)))
+        # Titles via existing playbook_application_stats lookup
+        stats = self.storage.get_playbook_application_stats(days_back=30)  # type: ignore[attr-defined]
+        rule_titles = {(s.kind, s.real_id): s.title for s in stats}
+        return citations_by_session, rule_titles
+
+    def _build_distribution(
+        self,
+        current: list[AgentSuccessEvaluationResult],
+        previous: list[AgentSuccessEvaluationResult],
+    ) -> ScoreDistribution:
+        cur_bins = bucket_corrections(
+            r.number_of_correction_per_session for r in current
+        )
+        prev_bins = bucket_corrections(
+            r.number_of_correction_per_session for r in previous
+        )
+        return ScoreDistribution(
+            current_bins=list(cur_bins),
+            baseline_bins=list(prev_bins),
+            labels=list(BUCKET_LABELS),
+        )
+
+
+# --- module-level helpers (pure) ---
+
+
+def _success_rate(results: list[AgentSuccessEvaluationResult]) -> float:
+    if not results:
+        return 0.0
+    return sum(1 for r in results if r.is_success) / len(results)
+
+
+def _escalation_rate(results: list[AgentSuccessEvaluationResult]) -> float:
+    if not results:
+        return 0.0
+    return sum(1 for r in results if r.is_escalated) / len(results)
+
+
+def _mean(values: Iterable[float | int | None]) -> float:
+    nums = [float(v) for v in values if v is not None]
+    if not nums:
+        return 0.0
+    return sum(nums) / len(nums)
+
+
+def _weekly_buckets(
+    results: list[AgentSuccessEvaluationResult],
+) -> list[HeroBucket]:
+    """Build week-sized buckets across the given results."""
+    if not results:
+        return []
+    buckets: dict[int, list[AgentSuccessEvaluationResult]] = defaultdict(list)
+    for r in results:
+        # Anchor each result to the START of its week (epoch-aligned).
+        week_start = (r.created_at // _WEEK_SECONDS) * _WEEK_SECONDS
+        buckets[week_start].append(r)
+    out: list[HeroBucket] = []
+    for ts in sorted(buckets):
+        bucket = buckets[ts]
+        out.append(
+            HeroBucket(
+                ts=ts,
+                regular_rate=_success_rate(bucket),
+                shadow_rate=None,
+                regular_n=len(bucket),
+                shadow_n=0,
+            )
+        )
+    return out

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -13,10 +13,12 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from reflexio.models.api_schema.braintrust_schema import ImportedScore
 from reflexio.models.api_schema.domain.entities import (
     AgentSuccessEvaluationResult,
 )
 from reflexio.models.api_schema.eval_overview_schema import (
+    BraintrustTileRow,
     ContextTile,
     GetEvaluationOverviewRequest,
     GetEvaluationOverviewResponse,
@@ -73,12 +75,16 @@ class EvaluationOverviewService:
         tiles = self._build_tiles(results, results_prev)
         attribution = self._build_attribution(results)
         distribution = self._build_distribution(results, results_prev)
+        braintrust_tiles = self._build_braintrust_tiles(
+            request.from_ts, request.to_ts, prev_from, prev_to
+        )
 
         return GetEvaluationOverviewResponse(
             hero=hero,
             context_tiles=tiles,
             rule_attribution=attribution,
             score_distribution=distribution,
+            braintrust_tiles=braintrust_tiles,
         )
 
     # --- private helpers ---
@@ -200,6 +206,48 @@ class EvaluationOverviewService:
         rule_titles = {(s.kind, s.real_id): s.title for s in stats}
         return citations_by_session, rule_titles
 
+    def _build_braintrust_tiles(
+        self, from_ts: int, to_ts: int, prev_from: int, prev_to: int
+    ) -> list[BraintrustTileRow]:
+        """Aggregate imported_score rows per scorer_name for current + prior windows.
+
+        Returns [] when the org has no Braintrust connection (default no-op
+        storage returns []). The frontend treats an empty list as "not
+        connected" and hides the Braintrust strip entirely.
+        """
+        org_id = self._org_id()
+        if not org_id:
+            return []
+        current = self.storage.get_imported_scores(org_id, from_ts, to_ts)  # type: ignore[attr-defined]
+        if not current:
+            return []
+        prior = self.storage.get_imported_scores(org_id, prev_from, prev_to)  # type: ignore[attr-defined]
+        cur_agg = _aggregate_imported_scores(current)
+        prior_agg = _aggregate_imported_scores(prior)
+        rows: list[BraintrustTileRow] = []
+        for scorer_name, (mean, n) in sorted(cur_agg.items()):
+            # No prior data → set delta = current so the frontend's
+            # `delta == current` check renders "no baseline" honestly.
+            # With prior data → real difference.
+            prior_entry = prior_agg.get(scorer_name)
+            delta = mean if prior_entry is None else mean - prior_entry[0]
+            rows.append(
+                BraintrustTileRow(
+                    scorer_name=scorer_name,
+                    current=mean,
+                    n=n,
+                    delta=delta,
+                )
+            )
+        return rows
+
+    def _org_id(self) -> str:
+        """Resolve org_id from request_context when available; else empty string."""
+        # The service is constructed with `storage` + `config`; org_id isn't a
+        # direct attribute. For Plan C-overview, we read it via the storage
+        # instance's org_id when present (every BaseStorage carries one).
+        return str(getattr(self.storage, "org_id", "") or "")
+
     def _build_distribution(
         self,
         current: list[AgentSuccessEvaluationResult],
@@ -238,6 +286,16 @@ def _mean(values: Iterable[float | int | None]) -> float:
     if not nums:
         return 0.0
     return sum(nums) / len(nums)
+
+
+def _aggregate_imported_scores(
+    scores: list[ImportedScore],
+) -> dict[str, tuple[float, int]]:
+    """Group imported scores by scorer_name → (mean, count)."""
+    bucket: dict[str, list[float]] = defaultdict(list)
+    for s in scores:
+        bucket[s.scorer_name].append(s.value)
+    return {name: (sum(vs) / len(vs), len(vs)) for name, vs in bucket.items() if vs}
 
 
 def _weekly_buckets(

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -13,9 +13,9 @@ from ._profiles import ProfileMixin
 from ._requests import RequestMixin
 from ._share_links import SQLiteShareLinkMixin
 from ._stall_state import (
+    SQLiteStallStateMixin,
     StallReason,
     StallState,
-    SQLiteStallStateMixin,
     clear_stall_state,
     get_stall_state,
     init_stall_state_table,

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -220,3 +220,16 @@ class ExtrasMixin:
         Args:
             scores (list[ImportedScore]): Scores to persist.
         """
+
+    def get_imported_scores(
+        self,
+        org_id: str,  # noqa: ARG002
+        from_ts: int,  # noqa: ARG002
+        to_ts: int,  # noqa: ARG002
+    ) -> list[ImportedScore]:
+        """Return imported scores for the org in `[from_ts, to_ts]` (default []).
+
+        Default implementation returns []; concrete backends override.
+        Used by EvaluationOverviewService to surface Braintrust tiles.
+        """
+        return []

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -1,5 +1,9 @@
 from abc import abstractmethod
 
+from reflexio.models.api_schema.braintrust_schema import (
+    BraintrustConnection,
+    ImportedScore,
+)
 from reflexio.models.api_schema.domain import (
     Interaction,
     PlaybookAggregationChangeLog,
@@ -145,35 +149,74 @@ class ExtrasMixin:
     # Evaluation-overview support (default no-ops; backends override)
     # ==============================
 
-    def count_sessions_with_shadow_content(self, from_ts: int, to_ts: int) -> int:
+    def count_sessions_with_shadow_content(
+        self,
+        from_ts: int,  # noqa: ARG002
+        to_ts: int,  # noqa: ARG002
+    ) -> int:
         """Return the number of sessions with non-empty shadow content in the window.
 
         Default implementation returns 0; concrete backends should override
-        once shadow-mode publishing lands. The /api/get_evaluation_overview
-        hero state machine treats 0 as "shadow data not yet available" and
-        degrades to the SHADOW_OFF / EARLY states accordingly.
-
-        Args:
-            from_ts (int): Window start, unix epoch seconds.
-            to_ts (int): Window end, unix epoch seconds.
-
-        Returns:
-            int: Count of sessions in the window with non-empty shadow content.
+        once shadow-mode publishing lands.
         """
         return 0
 
-    def get_interactions_by_session(self, session_id: str) -> list[Interaction]:
-        """Return the interactions belonging to a single session.
+    def get_interactions_by_session(
+        self,
+        session_id: str,  # noqa: ARG002
+    ) -> list[Interaction]:
+        """Return the interactions belonging to a single session (default []).
 
-        Default implementation returns []; concrete backends should override
-        with a real query. /api/get_evaluation_overview's rule-attribution
-        panel uses this to harvest citations per session and falls back to
-        an empty panel when no citations are returned.
-
-        Args:
-            session_id (str): The session whose interactions to fetch.
-
-        Returns:
-            list[Interaction]: Interactions in `session_id`, possibly empty.
+        Default implementation returns []; concrete backends should override.
         """
         return []
+
+    # ==============================
+    # Braintrust connector (default no-ops; backends override)
+    # ==============================
+
+    def save_braintrust_connection(self, connection: BraintrustConnection) -> None:
+        """Persist a Braintrust connection (default no-op).
+
+        Concrete backends should upsert by `org_id`. The default no-op
+        keeps tests and dev mode workable until per-backend implementations
+        land.
+
+        Args:
+            connection (BraintrustConnection): Encrypted connection record.
+        """
+
+    def get_braintrust_connection(
+        self,
+        org_id: str,  # noqa: ARG002 — default no-op; concrete backends use it
+    ) -> BraintrustConnection | None:
+        """Fetch the persisted Braintrust connection for an org.
+
+        Args:
+            org_id (str): The Reflexio org.
+
+        Returns:
+            BraintrustConnection | None: The stored record, or None if the
+                org has not connected (or no backend override yet).
+        """
+        return None
+
+    def delete_braintrust_connection(
+        self,
+        org_id: str,  # noqa: ARG002 — default no-op; concrete backends use it
+    ) -> None:
+        """Delete the org's Braintrust connection (default no-op).
+
+        Args:
+            org_id (str): The Reflexio org to disconnect.
+        """
+
+    def save_imported_scores(self, scores: list[ImportedScore]) -> None:
+        """Persist a batch of imported scorer outputs (default no-op).
+
+        Concrete backends should upsert by `(source, source_run_id,
+        scorer_name)` so re-syncs are idempotent.
+
+        Args:
+            scores (list[ImportedScore]): Scores to persist.
+        """

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -140,3 +140,40 @@ class ExtrasMixin:
     def get_interactions_by_ids(self, interaction_ids: list[int]) -> list[Interaction]:
         """Fetch interactions by interaction ids, ordered by created_at."""
         raise NotImplementedError
+
+    # ==============================
+    # Evaluation-overview support (default no-ops; backends override)
+    # ==============================
+
+    def count_sessions_with_shadow_content(self, from_ts: int, to_ts: int) -> int:
+        """Return the number of sessions with non-empty shadow content in the window.
+
+        Default implementation returns 0; concrete backends should override
+        once shadow-mode publishing lands. The /api/get_evaluation_overview
+        hero state machine treats 0 as "shadow data not yet available" and
+        degrades to the SHADOW_OFF / EARLY states accordingly.
+
+        Args:
+            from_ts (int): Window start, unix epoch seconds.
+            to_ts (int): Window end, unix epoch seconds.
+
+        Returns:
+            int: Count of sessions in the window with non-empty shadow content.
+        """
+        return 0
+
+    def get_interactions_by_session(self, session_id: str) -> list[Interaction]:
+        """Return the interactions belonging to a single session.
+
+        Default implementation returns []; concrete backends should override
+        with a real query. /api/get_evaluation_overview's rule-attribution
+        panel uses this to harvest citations per session and falls back to
+        an empty panel when no citations are returned.
+
+        Args:
+            session_id (str): The session whose interactions to fetch.
+
+        Returns:
+            list[Interaction]: Interactions in `session_id`, possibly empty.
+        """
+        return []

--- a/tests/client/test_stall_state_client.py
+++ b/tests/client/test_stall_state_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +11,10 @@ from fastapi.testclient import TestClient
 
 from reflexio.client import ReflexioClient
 from reflexio.server.api import create_app
-from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
+from reflexio.server.api_endpoints.request_context import (
+    RequestContext,
+    get_request_context,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 
@@ -76,7 +79,7 @@ def test_get_stall_state_when_clean(client_with_server, storage):
 def test_get_stall_state_when_stalled(client_with_server, storage):
     storage.upsert_stall_state(
         reason="billing_error",
-        stalled_at=datetime.now(timezone.utc),
+        stalled_at=datetime.now(UTC),
         reset_estimate=None,
         error_message="x",
     )
@@ -88,7 +91,7 @@ def test_get_stall_state_when_stalled(client_with_server, storage):
 def test_mark_stall_notified_flips_flag(client_with_server, storage):
     storage.upsert_stall_state(
         reason="auth_error",
-        stalled_at=datetime.now(timezone.utc),
+        stalled_at=datetime.now(UTC),
         reset_estimate=None,
         error_message="x",
     )

--- a/tests/models/test_braintrust_schema.py
+++ b/tests/models/test_braintrust_schema.py
@@ -1,0 +1,96 @@
+"""Round-trip tests for the Braintrust connector Pydantic models."""
+
+from reflexio.models.api_schema.braintrust_schema import (
+    BraintrustConnection,
+    BraintrustProjectSummary,
+    BraintrustStatusResponse,
+    BraintrustWorkspaceSummary,
+    ConnectBraintrustRequest,
+    ConnectBraintrustResponse,
+    ImportedScore,
+    SelectProjectsRequest,
+    SelectProjectsResponse,
+    SyncBraintrustResponse,
+)
+
+
+def test_braintrust_connection_defaults() -> None:
+    """A minimal BraintrustConnection round-trips and defaults sensibly."""
+    c = BraintrustConnection(
+        org_id="org_test",
+        api_key_enc="enc_value",
+        workspace_id="ws_42",
+    )
+    assert c.workspace_name == ""
+    assert c.project_ids == []
+    assert c.last_sync_ts is None
+    assert c.last_error is None
+
+
+def test_imported_score_defaults_source_to_braintrust() -> None:
+    s = ImportedScore(
+        org_id="org_test",
+        source_run_id="span_1",
+        scorer_name="hallucination",
+        value=0.25,
+        ts=1700000000,
+    )
+    assert s.source == "braintrust"
+    assert s.session_id is None
+
+
+def test_connect_request_rejects_empty_key() -> None:
+    """Empty API key fails validation (min_length=1)."""
+    try:
+        ConnectBraintrustRequest(api_key="")
+    except ValueError:
+        return
+    raise AssertionError("Expected ValidationError for empty api_key")
+
+
+def test_workspace_summary_roundtrips() -> None:
+    w = BraintrustWorkspaceSummary(
+        workspace_id="ws_1",
+        workspace_name="My Workspace",
+        projects=[
+            BraintrustProjectSummary(project_id="p_1", project_name="Production"),
+            BraintrustProjectSummary(project_id="p_2", project_name="Staging"),
+        ],
+    )
+    dumped = w.model_dump()
+    restored = BraintrustWorkspaceSummary(**dumped)
+    assert restored.workspace_name == "My Workspace"
+    assert len(restored.projects) == 2
+    assert restored.projects[0].project_id == "p_1"
+
+
+def test_status_response_defaults_to_disconnected() -> None:
+    s = BraintrustStatusResponse(connected=False)
+    assert s.workspace_id == ""
+    assert s.project_count == 0
+    assert s.last_sync_ts is None
+
+
+def test_select_projects_response_round_trip() -> None:
+    r = SelectProjectsResponse(success=True, msg="ok")
+    assert r.success is True
+    assert r.msg == "ok"
+    # Also exercise SelectProjectsRequest validation
+    req = SelectProjectsRequest(
+        api_key="sk_test",
+        workspace_id="ws_1",
+        workspace_name="WS",
+        project_ids=["p_1", "p_2"],
+    )
+    assert req.project_ids == ["p_1", "p_2"]
+
+
+def test_connect_response_default_lists() -> None:
+    r = ConnectBraintrustResponse(success=False, msg="invalid key")
+    assert r.workspaces == []
+
+
+def test_sync_response_defaults() -> None:
+    r = SyncBraintrustResponse(success=True, scored_count=42)
+    assert r.msg == ""
+    assert r.scored_count == 42

--- a/tests/models/test_config_shadow_mode.py
+++ b/tests/models/test_config_shadow_mode.py
@@ -1,0 +1,22 @@
+"""Verify Config carries the shadow_mode_enabled toggle and round-trips correctly."""
+
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+
+
+def test_shadow_mode_enabled_defaults_to_false() -> None:
+    """New orgs are not opted into shadow mode by default."""
+    config = Config(storage_config=StorageConfigSQLite())
+    assert config.shadow_mode_enabled is False
+
+
+def test_shadow_mode_enabled_can_be_set_via_constructor() -> None:
+    """Explicit True flips the toggle on."""
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+    assert config.shadow_mode_enabled is True
+
+
+def test_shadow_mode_enabled_serializes_via_model_dump() -> None:
+    """model_dump includes the new field so set_config/get_config round-trip it."""
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+    dumped = config.model_dump()
+    assert dumped["shadow_mode_enabled"] is True

--- a/tests/models/test_eval_overview_schema.py
+++ b/tests/models/test_eval_overview_schema.py
@@ -1,0 +1,58 @@
+"""Schema sanity for /api/get_evaluation_overview request/response models."""
+
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+    GetEvaluationOverviewResponse,
+)
+
+
+def test_request_defaults_bucket_to_week_and_include_shadow_to_true() -> None:
+    req = GetEvaluationOverviewRequest(from_ts=0, to_ts=10)
+    assert req.bucket == "week"
+    assert req.include_shadow is True
+
+
+def test_response_round_trips_full_payload() -> None:
+    payload = {
+        "hero": {
+            "state": "full",
+            "regular_success_rate_pp": 87.4,
+            "shadow_success_rate_pp": 73.2,
+            "delta_pp": 14.2,
+            "buckets": [
+                {
+                    "ts": 1700000000,
+                    "regular_rate": 0.85,
+                    "shadow_rate": 0.70,
+                    "regular_n": 100,
+                    "shadow_n": 80,
+                },
+            ],
+        },
+        "context_tiles": {
+            "success": {"current": 87.4, "delta_pp": 6.2},
+            "corrections": {"current": 0.4, "delta": -0.7},
+            "turns": {"current": 3.2, "delta": -1.4},
+            "escalation": {"current": 4.1, "delta_pp": -6.9},
+        },
+        "rule_attribution": [
+            {
+                "rule_id": "rule_42",
+                "kind": "playbook",
+                "title": "Confirm address",
+                "successes_with": 42,
+                "failures_with": 4,
+                "net_sessions": 38,
+            },
+        ],
+        "score_distribution": {
+            "current_bins": [50, 20, 15, 10, 3, 2],
+            "baseline_bins": [30, 25, 20, 15, 5, 5],
+            "labels": ["0", "1", "2", "3", "4", "5+"],
+        },
+    }
+    resp = GetEvaluationOverviewResponse(**payload)
+    assert resp.hero.state == "full"
+    assert resp.context_tiles.success.current == 87.4
+    assert resp.rule_attribution[0].net_sessions == 38
+    assert resp.score_distribution.labels == ["0", "1", "2", "3", "4", "5+"]

--- a/tests/server/api_endpoints/test_braintrust_api.py
+++ b/tests/server/api_endpoints/test_braintrust_api.py
@@ -1,0 +1,58 @@
+"""Smoke tests for the Braintrust connector endpoints.
+
+Validates only that the routes are registered with the expected
+shape — service-level behavior is covered by tests/server/services/braintrust/.
+"""
+
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+
+
+def _client() -> TestClient:
+    app = create_app()
+    return TestClient(app)
+
+
+def test_braintrust_status_returns_disconnected_on_fresh_app() -> None:
+    """A fresh in-memory app reports `connected=False`."""
+    response = _client().get(
+        "/api/braintrust/status", headers={"User-Agent": "test"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["connected"] is False
+    # Sensitive fields never appear
+    assert "api_key" not in body
+    assert "api_key_enc" not in body
+
+
+def test_braintrust_sync_returns_failure_when_not_connected() -> None:
+    """POST /sync against a disconnected org returns success=False with a message."""
+    response = _client().post(
+        "/api/braintrust/sync", headers={"User-Agent": "test"}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert "Not connected" in body["msg"]
+    assert body["scored_count"] == 0
+
+
+def test_braintrust_disconnect_returns_success() -> None:
+    """DELETE on a disconnected org is a no-op that still returns success."""
+    response = _client().delete(
+        "/api/braintrust/connection", headers={"User-Agent": "test"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+
+
+def test_braintrust_connect_validates_api_key_field() -> None:
+    """An empty api_key fails Pydantic validation (422)."""
+    response = _client().post(
+        "/api/braintrust/connect",
+        json={"api_key": ""},
+        headers={"User-Agent": "test"},
+    )
+    assert response.status_code == 422

--- a/tests/server/api_endpoints/test_evaluation_overview_api.py
+++ b/tests/server/api_endpoints/test_evaluation_overview_api.py
@@ -1,0 +1,24 @@
+"""Verify POST /api/get_evaluation_overview wires through to the service."""
+
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+
+
+def test_endpoint_returns_empty_state_on_fresh_app() -> None:
+    """A fresh in-memory app with no evaluations returns the empty hero state."""
+    app = create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/api/get_evaluation_overview",
+        json={"from_ts": 0, "to_ts": 1_000_000_000_000, "bucket": "week"},
+        headers={"User-Agent": "test"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["hero"]["state"] in ("full", "early", "shadow_off", "empty")
+    assert "context_tiles" in body
+    assert "rule_attribution" in body
+    assert body["score_distribution"]["labels"] == ["0", "1", "2", "3", "4", "5+"]

--- a/tests/server/api_endpoints/test_stall_state_api.py
+++ b/tests/server/api_endpoints/test_stall_state_api.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
 from reflexio.server.api import create_app
-from reflexio.server.api_endpoints.request_context import RequestContext, get_request_context
+from reflexio.server.api_endpoints.request_context import (
+    RequestContext,
+    get_request_context,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 
@@ -48,7 +51,7 @@ def test_get_stall_state_clean(client: TestClient):
 def test_get_stall_state_when_stalled(client: TestClient, storage):
     storage.upsert_stall_state(
         reason="billing_error",
-        stalled_at=datetime.now(timezone.utc),
+        stalled_at=datetime.now(UTC),
         reset_estimate=None,
         error_message="credit exhausted",
     )
@@ -63,7 +66,7 @@ def test_get_stall_state_when_stalled(client: TestClient, storage):
 def test_post_notified_flips_flag(client: TestClient, storage):
     storage.upsert_stall_state(
         reason="auth_error",
-        stalled_at=datetime.now(timezone.utc),
+        stalled_at=datetime.now(UTC),
         reset_estimate=None,
         error_message="login",
     )

--- a/tests/server/llm/test_claude_code_stream_parser.py
+++ b/tests/server/llm/test_claude_code_stream_parser.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import pytest
 
 from reflexio.server.llm.providers.claude_code_stream_parser import (
-    ParseResult,
     classify_stall,
-    parse_stream_json,
     parse_reset_estimate,
+    parse_stream_json,
 )
 
 

--- a/tests/server/services/braintrust/test_client.py
+++ b/tests/server/services/braintrust/test_client.py
@@ -1,0 +1,113 @@
+"""Tests for the BraintrustClient HTTP wrapper.
+
+Replaces the underlying `httpx.Client` so we can simulate Braintrust
+responses without hitting the network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from reflexio.server.services.braintrust.client import (
+    BraintrustAuthError,
+    BraintrustClient,
+    BraintrustHTTPError,
+)
+
+
+def _stub_client(*, status: int, payload: Any) -> httpx.Client:
+    """Build a fake httpx.Client that returns the same response for every GET."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=payload, request=request)
+
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_validate_key_returns_true_on_2xx(monkeypatch) -> None:
+    c = BraintrustClient("sk-test")
+    c._client = _stub_client(status=200, payload={"ok": True})
+    assert c.validate_key() is True
+
+
+def test_validate_key_returns_false_on_401() -> None:
+    c = BraintrustClient("sk-bad")
+    c._client = _stub_client(status=401, payload={"error": "Unauthorized"})
+    assert c.validate_key() is False
+
+
+def test_list_organizations_unwraps_objects_envelope() -> None:
+    c = BraintrustClient("sk")
+    c._client = _stub_client(
+        status=200,
+        payload={"objects": [{"id": "ws_1", "name": "My WS"}]},
+    )
+    orgs = c.list_organizations()
+    assert orgs == [{"id": "ws_1", "name": "My WS"}]
+
+
+def test_list_projects_unwraps_bare_list() -> None:
+    """Some endpoints return a bare list; we accept either shape."""
+    c = BraintrustClient("sk")
+    c._client = _stub_client(
+        status=200,
+        payload=[{"id": "p_1", "name": "Prod"}],
+    )
+    assert c.list_projects("ws_1") == [{"id": "p_1", "name": "Prod"}]
+
+
+def test_list_experiments_passes_since_param() -> None:
+    """The `since` query param is included only when provided."""
+    seen_params: list[dict[str, list[str]]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_params.append(dict(request.url.params.multi_items()))
+        return httpx.Response(200, json={"objects": []}, request=request)
+
+    c = BraintrustClient("sk")
+    c._client = httpx.Client(transport=httpx.MockTransport(handler))
+    c.list_experiments("p_1", since_ts=1700000000)
+    c.list_experiments("p_2", since_ts=None)
+
+    assert ("since", "1700000000") in seen_params[0].items()
+    assert "since" not in seen_params[1]
+
+
+def test_http_error_raises_with_status_and_body() -> None:
+    c = BraintrustClient("sk")
+    c._client = _stub_client(status=500, payload={"error": "boom"})
+    with pytest.raises(BraintrustHTTPError) as exc:
+        c.list_organizations()
+    assert exc.value.status_code == 500
+    assert "boom" in exc.value.body
+
+
+def test_auth_error_is_raised_on_403_for_list_methods() -> None:
+    c = BraintrustClient("sk-bad")
+    c._client = _stub_client(status=403, payload={"error": "Forbidden"})
+    with pytest.raises(BraintrustAuthError):
+        c.list_organizations()
+
+
+def test_authorization_header_is_set() -> None:
+    """Sanity: the client sends `Authorization: Bearer ...`.
+
+    Because we replace `_client` with a fresh one that doesn't inherit
+    the constructor headers, we re-attach them on the replacement.
+    """
+    seen_headers: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(request.headers.get("authorization", ""))
+        return httpx.Response(200, json={"objects": []}, request=request)
+
+    c = BraintrustClient("sk-customer")
+    c._client = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        headers={"Authorization": f"Bearer {c.api_key}"},
+    )
+    c.list_organizations()
+    assert seen_headers == ["Bearer sk-customer"]

--- a/tests/server/services/braintrust/test_encryption.py
+++ b/tests/server/services/braintrust/test_encryption.py
@@ -1,0 +1,46 @@
+"""Tests for the Braintrust encryption helper.
+
+Exercises both branches: env-var unset (passthrough) and env-var set
+(actual Fernet roundtrip).
+"""
+
+import os
+
+from cryptography.fernet import Fernet
+
+from reflexio.server.services.braintrust import _encryption
+
+
+def test_passthrough_when_env_key_unset(monkeypatch) -> None:
+    """With no Fernet keys configured, encrypt/decrypt return the value untouched."""
+    monkeypatch.delenv("REFLEXIO_FERNET_KEYS", raising=False)
+    _encryption._reset_for_test()
+    assert _encryption.encrypt("sk-secret") == "sk-secret"
+    assert _encryption.decrypt("sk-secret") == "sk-secret"
+
+
+def test_roundtrip_with_fernet_key(monkeypatch) -> None:
+    """With a Fernet key set, encrypt produces ciphertext, decrypt recovers it."""
+    key = Fernet.generate_key().decode("utf-8")
+    monkeypatch.setenv("REFLEXIO_FERNET_KEYS", key)
+    _encryption._reset_for_test()
+
+    plaintext = "sk-customer-braintrust-key"
+    ciphertext = _encryption.encrypt(plaintext)
+    assert ciphertext != plaintext
+    assert _encryption.decrypt(ciphertext) == plaintext
+
+
+def test_invalid_key_in_env_is_discarded(monkeypatch) -> None:
+    """A malformed Fernet key is dropped; passthrough behavior remains."""
+    monkeypatch.setenv("REFLEXIO_FERNET_KEYS", "not-a-real-fernet-key")
+    _encryption._reset_for_test()
+    # No valid keys → passthrough.
+    assert _encryption.encrypt("v") == "v"
+    assert _encryption.decrypt("v") == "v"
+
+
+def test_finalize_env_cleanup() -> None:
+    """Reset module state so other tests aren't affected."""
+    os.environ.pop("REFLEXIO_FERNET_KEYS", None)
+    _encryption._reset_for_test()

--- a/tests/server/services/braintrust/test_service.py
+++ b/tests/server/services/braintrust/test_service.py
@@ -1,0 +1,277 @@
+"""Service-level tests for the Braintrust connector orchestrator.
+
+Uses an in-memory fake storage and a stub client to exercise the full
+connect → select_projects → sync → status → disconnect flow without HTTP.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from reflexio.models.api_schema.braintrust_schema import (
+    BraintrustConnection,
+    ConnectBraintrustRequest,
+    ImportedScore,
+    SelectProjectsRequest,
+)
+from reflexio.server.services.braintrust import _encryption
+from reflexio.server.services.braintrust.client import BraintrustAuthError
+from reflexio.server.services.braintrust.service import (
+    BraintrustConnectorService,
+    _scores_from_spans,
+)
+
+
+class _InMemoryStorage:
+    """Tiny in-memory replacement for BaseStorage with just the methods we use."""
+
+    def __init__(self) -> None:
+        self.connections: dict[str, BraintrustConnection] = {}
+        self.scores: list[ImportedScore] = []
+
+    def save_braintrust_connection(self, connection: BraintrustConnection) -> None:
+        self.connections[connection.org_id] = connection
+
+    def get_braintrust_connection(self, org_id: str) -> BraintrustConnection | None:
+        return self.connections.get(org_id)
+
+    def delete_braintrust_connection(self, org_id: str) -> None:
+        self.connections.pop(org_id, None)
+
+    def save_imported_scores(self, scores: list[ImportedScore]) -> None:
+        self.scores.extend(scores)
+
+
+def _stub_client_factory(*, valid: bool = True, payload: dict[str, Any] | None = None):
+    """Build a `client_factory` callable returning a configured MagicMock client.
+
+    `payload` lets a test override per-method results. Defaults model a tiny
+    workspace with one project containing one experiment + two spans.
+    """
+    payload = payload or {}
+    orgs = payload.get(
+        "organizations", [{"id": "ws_1", "name": "My Workspace"}]
+    )
+    projects = payload.get(
+        "projects", [{"id": "p_1", "name": "Production"}]
+    )
+    experiments = payload.get(
+        "experiments", [{"id": "exp_1", "name": "v1", "created_at": 1700000000}]
+    )
+    spans = payload.get(
+        "spans",
+        [
+            {
+                "id": "span_a",
+                "created_at": 1700000010,
+                "metadata": {"reflexio_session_id": "sess_42"},
+                "scores": {"hallucination": 0.05, "factuality": 0.95},
+            },
+            {
+                "id": "span_b",
+                "created_at": 1700000020,
+                "metadata": {},
+                "scores": {"hallucination": 0.30},
+            },
+        ],
+    )
+
+    def make_client(api_key: str) -> MagicMock:  # noqa: ARG001
+        client = MagicMock()
+        if valid:
+            client.validate_key.return_value = True
+        else:
+            client.validate_key.return_value = False
+        client.list_organizations.return_value = orgs
+        client.list_projects.return_value = projects
+        client.list_experiments.return_value = experiments
+        client.list_spans.return_value = spans
+        return client
+
+    return make_client
+
+
+def test_connect_returns_workspaces_for_valid_key() -> None:
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=_stub_client_factory()
+    )
+    response = svc.connect(ConnectBraintrustRequest(api_key="sk-valid"))
+    assert response.success is True
+    assert len(response.workspaces) == 1
+    assert response.workspaces[0].workspace_id == "ws_1"
+    assert response.workspaces[0].projects[0].project_id == "p_1"
+    # Nothing persisted yet
+    assert storage.connections == {}
+
+
+def test_connect_returns_failure_for_invalid_key() -> None:
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage,
+        org_id="org_t",
+        client_factory=_stub_client_factory(valid=False),
+    )
+    response = svc.connect(ConnectBraintrustRequest(api_key="sk-bad"))
+    assert response.success is False
+    assert "rejected" in response.msg.lower()
+
+
+def test_connect_returns_failure_on_auth_error_during_org_listing() -> None:
+    """If list_organizations raises BraintrustAuthError, fail gracefully."""
+    storage = _InMemoryStorage()
+
+    def factory(_key: str) -> MagicMock:
+        c = MagicMock()
+        c.validate_key.return_value = True
+        c.list_organizations.side_effect = BraintrustAuthError("nope")
+        return c
+
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=factory
+    )
+    response = svc.connect(ConnectBraintrustRequest(api_key="sk"))
+    assert response.success is False
+
+
+def test_select_projects_persists_encrypted_connection(monkeypatch) -> None:
+    """select_projects writes a BraintrustConnection; API key is encrypted."""
+    monkeypatch.delenv("REFLEXIO_FERNET_KEYS", raising=False)
+    _encryption._reset_for_test()
+
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=_stub_client_factory()
+    )
+    response = svc.select_projects(
+        SelectProjectsRequest(
+            api_key="sk-customer",
+            workspace_id="ws_1",
+            workspace_name="My Workspace",
+            project_ids=["p_1"],
+        )
+    )
+    assert response.success is True
+    stored = storage.connections["org_t"]
+    # No Fernet key configured → passthrough; the stored value equals the input
+    assert stored.api_key_enc == "sk-customer"
+    assert stored.project_ids == ["p_1"]
+    assert stored.workspace_name == "My Workspace"
+
+
+def test_status_reports_disconnected_when_no_row() -> None:
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=_stub_client_factory()
+    )
+    s = svc.status()
+    assert s.connected is False
+    assert s.project_count == 0
+
+
+def test_status_reflects_persisted_connection(monkeypatch) -> None:
+    monkeypatch.delenv("REFLEXIO_FERNET_KEYS", raising=False)
+    _encryption._reset_for_test()
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=_stub_client_factory()
+    )
+    svc.select_projects(
+        SelectProjectsRequest(
+            api_key="sk", workspace_id="ws_1", workspace_name="WS",
+            project_ids=["p_1", "p_2"],
+        )
+    )
+    s = svc.status()
+    assert s.connected is True
+    assert s.workspace_id == "ws_1"
+    assert s.project_count == 2
+
+
+def test_disconnect_removes_the_row(monkeypatch) -> None:
+    monkeypatch.delenv("REFLEXIO_FERNET_KEYS", raising=False)
+    _encryption._reset_for_test()
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=_stub_client_factory()
+    )
+    svc.select_projects(
+        SelectProjectsRequest(api_key="sk", workspace_id="ws_1")
+    )
+    svc.disconnect()
+    assert svc.status().connected is False
+
+
+def test_sync_once_writes_imported_scores(monkeypatch) -> None:
+    monkeypatch.delenv("REFLEXIO_FERNET_KEYS", raising=False)
+    _encryption._reset_for_test()
+    storage = _InMemoryStorage()
+    svc = BraintrustConnectorService(
+        storage=storage, org_id="org_t", client_factory=_stub_client_factory()
+    )
+    svc.select_projects(
+        SelectProjectsRequest(
+            api_key="sk", workspace_id="ws_1", project_ids=["p_1"]
+        )
+    )
+
+    response = svc.sync_once()
+
+    # 2 scores from span_a (hallucination, factuality) + 1 from span_b
+    assert response.success is True
+    assert response.scored_count == 3
+    assert len(storage.scores) == 3
+    # Matched session_id for span_a (metadata contains reflexio_session_id)
+    matched = [s for s in storage.scores if s.session_id == "sess_42"]
+    assert len(matched) == 2
+    # Unmatched span_b → session_id is None
+    unmatched = [s for s in storage.scores if s.session_id is None]
+    assert len(unmatched) == 1
+    # last_sync_ts persisted
+    assert storage.connections["org_t"].last_sync_ts is not None
+
+
+def test_sync_once_returns_failure_when_not_connected() -> None:
+    svc = BraintrustConnectorService(
+        storage=_InMemoryStorage(), org_id="org_t",
+        client_factory=_stub_client_factory(),
+    )
+    response = svc.sync_once()
+    assert response.success is False
+
+
+def test_scores_from_spans_extracts_session_id_only_when_metadata_string() -> None:
+    """The reflexio_session_id metadata key must be a non-empty string."""
+    spans = [
+        {
+            "id": "s1",
+            "created_at": 1,
+            "metadata": {"reflexio_session_id": "sess_ok"},
+            "scores": {"a": 0.1},
+        },
+        {
+            "id": "s2",
+            "created_at": 2,
+            "metadata": {"reflexio_session_id": ""},
+            "scores": {"a": 0.2},
+        },
+        {
+            "id": "s3",
+            "created_at": 3,
+            "metadata": {},
+            "scores": {"a": 0.3},
+        },
+        {
+            "id": "s4",
+            "created_at": 4,
+            "scores": {"a": 0.4},  # no metadata at all
+        },
+    ]
+    out = _scores_from_spans(spans, org_id="org_t")
+    assert len(out) == 4
+    by_id = {s.source_run_id: s for s in out}
+    assert by_id["s1"].session_id == "sess_ok"
+    assert by_id["s2"].session_id is None
+    assert by_id["s3"].session_id is None
+    assert by_id["s4"].session_id is None

--- a/tests/server/services/evaluation_overview/test_braintrust_tiles.py
+++ b/tests/server/services/evaluation_overview/test_braintrust_tiles.py
@@ -1,0 +1,107 @@
+"""Tests for the Braintrust-tile aggregation in EvaluationOverviewService.
+
+Plan C-overview: when imported_score rows exist, the response now carries a
+`braintrust_tiles` list — one row per scorer with current mean + count +
+delta vs prior window.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from reflexio.models.api_schema.braintrust_schema import ImportedScore
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+)
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+from reflexio.server.services.evaluation_overview.service import (
+    EvaluationOverviewService,
+    _aggregate_imported_scores,
+)
+
+
+def _score(
+    *,
+    scorer_name: str,
+    value: float,
+    ts: int,
+    session_id: str | None = None,
+) -> ImportedScore:
+    return ImportedScore(
+        org_id="org_t",
+        source_run_id=f"span_{scorer_name}_{ts}",
+        session_id=session_id,
+        scorer_name=scorer_name,
+        value=value,
+        ts=ts,
+    )
+
+
+def test_aggregate_groups_by_scorer_name() -> None:
+    """`_aggregate_imported_scores` returns {scorer_name: (mean, count)}."""
+    scores = [
+        _score(scorer_name="hallucination", value=0.1, ts=100),
+        _score(scorer_name="hallucination", value=0.3, ts=200),
+        _score(scorer_name="factuality", value=0.9, ts=150),
+    ]
+    out = _aggregate_imported_scores(scores)
+    assert out["hallucination"] == (0.2, 2)
+    assert out["factuality"] == (0.9, 1)
+
+
+def test_service_returns_empty_braintrust_tiles_with_no_imported_scores() -> None:
+    """Default no-op storage returns []; tiles are empty."""
+    storage = MagicMock()
+    storage.org_id = "org_t"
+    storage.get_agent_success_evaluation_results.return_value = []
+    storage.get_imported_scores.return_value = []
+    storage.count_sessions_with_shadow_content.return_value = 0
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
+    )
+
+    assert response.braintrust_tiles == []
+
+
+def test_service_emits_braintrust_tiles_with_delta() -> None:
+    """When imported_score rows exist, tiles report current mean, n, and delta."""
+    storage = MagicMock()
+    storage.org_id = "org_t"
+    storage.get_agent_success_evaluation_results.return_value = []
+    storage.count_sessions_with_shadow_content.return_value = 0
+
+    # Storage returns different score sets per (from_ts, to_ts) window
+    def get_imported_scores_router(
+        _org_id: str, from_ts: int, _to_ts: int
+    ) -> list[ImportedScore]:
+        if from_ts >= 1_000_000:  # current window
+            return [
+                _score(scorer_name="hallucination", value=0.1, ts=1_000_010),
+                _score(scorer_name="hallucination", value=0.3, ts=1_000_020),
+                _score(scorer_name="factuality", value=0.9, ts=1_000_030),
+            ]
+        # prior window
+        return [
+            _score(scorer_name="hallucination", value=0.5, ts=900_010),
+        ]
+
+    storage.get_imported_scores.side_effect = get_imported_scores_router
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=1_000_000, to_ts=2_000_000)
+    )
+
+    tiles_by_name = {t.scorer_name: t for t in response.braintrust_tiles}
+    assert tiles_by_name["hallucination"].current == 0.2
+    assert tiles_by_name["hallucination"].n == 2
+    # prior mean was 0.5 → delta = 0.2 - 0.5 = -0.3
+    assert abs(tiles_by_name["hallucination"].delta - (-0.3)) < 1e-9
+    # factuality has no prior data → delta equals current (signals "no baseline")
+    assert tiles_by_name["factuality"].current == 0.9
+    assert tiles_by_name["factuality"].delta == 0.9

--- a/tests/server/services/evaluation_overview/test_distribution.py
+++ b/tests/server/services/evaluation_overview/test_distribution.py
@@ -1,0 +1,23 @@
+"""Bucket evaluation results into a 6-bin corrections-per-session histogram."""
+
+from reflexio.server.services.evaluation_overview.distribution import (
+    BUCKET_LABELS,
+    bucket_corrections,
+)
+
+
+def test_six_bins_in_canonical_order() -> None:
+    """Buckets: 0, 1, 2, 3, 4, 5+ — that exact order, six entries."""
+    assert BUCKET_LABELS == ("0", "1", "2", "3", "4", "5+")
+
+
+def test_counts_each_bucket() -> None:
+    """Each correction count maps to its bin; 5+ catches everything >=5."""
+    corrections = [0, 0, 1, 2, 2, 2, 5, 7, 100]
+    bins = bucket_corrections(corrections)
+    assert bins == (2, 1, 3, 0, 0, 3)
+
+
+def test_empty_input_yields_all_zero_bins() -> None:
+    """No data → six zero-height bars (preserves chart shape)."""
+    assert bucket_corrections([]) == (0, 0, 0, 0, 0, 0)

--- a/tests/server/services/evaluation_overview/test_hero_state.py
+++ b/tests/server/services/evaluation_overview/test_hero_state.py
@@ -1,0 +1,61 @@
+"""Unit tests for hero state derivation (the 4 states from spec §3.2)."""
+
+from reflexio.server.services.evaluation_overview.hero_state import (
+    HeroState,
+    compute_hero_state,
+)
+
+
+def test_empty_when_no_evaluated_sessions_ever() -> None:
+    """State 4: no results ever → empty."""
+    state = compute_hero_state(
+        shadow_enabled=False,
+        days_since_first_eval=None,
+        n_shadow_in_window=0,
+        total_results=0,
+    )
+    assert state == HeroState.EMPTY
+
+
+def test_shadow_off_when_disabled_and_some_data() -> None:
+    """State 3: shadow off, >=7 days of trend → shadow_off."""
+    state = compute_hero_state(
+        shadow_enabled=False,
+        days_since_first_eval=10,
+        n_shadow_in_window=0,
+        total_results=42,
+    )
+    assert state == HeroState.SHADOW_OFF
+
+
+def test_early_when_shadow_just_enabled() -> None:
+    """State 2: shadow on but <14 days since enabled → early."""
+    state = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=3,
+        n_shadow_in_window=120,
+        total_results=120,
+    )
+    assert state == HeroState.EARLY
+
+
+def test_early_when_shadow_volume_low() -> None:
+    """State 2: shadow on, 30 days, but n_shadow < 500 → early."""
+    state = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=30,
+        n_shadow_in_window=300,
+        total_results=300,
+    )
+    assert state == HeroState.EARLY
+
+
+def test_full_when_all_thresholds_met() -> None:
+    """State 1: shadow on, >=14 days, >=500 shadow sessions → full."""
+    state = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=21,
+        n_shadow_in_window=800,
+        total_results=800,
+    )
+    assert state == HeroState.FULL

--- a/tests/server/services/evaluation_overview/test_rule_attribution.py
+++ b/tests/server/services/evaluation_overview/test_rule_attribution.py
@@ -1,0 +1,94 @@
+"""Compute net sessions per rule by joining PlaybookApplicationStat with success outcomes."""
+
+from reflexio.server.services.evaluation_overview.rule_attribution import (
+    RuleAttribution,
+    compute_net_sessions,
+)
+
+
+def test_basic_join_one_rule_two_successes_one_failure() -> None:
+    """Net = successes_with_rule_fired - failures_with_rule_fired."""
+    citations_by_session = {
+        "sess_a": [("playbook", "rule_42")],
+        "sess_b": [("playbook", "rule_42")],
+        "sess_c": [("playbook", "rule_42")],
+    }
+    is_success_by_session = {"sess_a": True, "sess_b": True, "sess_c": False}
+    rule_titles = {("playbook", "rule_42"): "Confirm address before checkout"}
+
+    attribs = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=5,
+    )
+
+    assert len(attribs) == 1
+    a = attribs[0]
+    assert a.rule_id == "rule_42"
+    assert a.kind == "playbook"
+    assert a.title == "Confirm address before checkout"
+    assert a.successes_with == 2
+    assert a.failures_with == 1
+    assert a.net_sessions == 1
+
+
+def test_ranks_by_net_sessions_descending_and_caps_at_top_n() -> None:
+    """Top-N ordering by net_sessions desc; ties broken by total fires desc."""
+    citations_by_session = {
+        "s1": [("playbook", "good")],
+        "s2": [("playbook", "good")],
+        "s3": [("playbook", "good")],
+        "s4": [("playbook", "ugly")],
+        "s5": [("playbook", "ugly")],
+        "s6": [("playbook", "meh")],
+    }
+    is_success_by_session = {
+        "s1": True,
+        "s2": True,
+        "s3": True,
+        "s4": False,
+        "s5": False,
+        "s6": True,
+    }
+    rule_titles = {
+        ("playbook", "good"): "good",
+        ("playbook", "ugly"): "ugly",
+        ("playbook", "meh"): "meh",
+    }
+
+    top = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=2,
+    )
+    assert len(top) == 2
+    assert top[0].rule_id == "good"
+    assert top[0].net_sessions == 3
+    assert top[1].rule_id == "meh"
+    assert top[1].net_sessions == 1
+
+
+def test_session_missing_from_success_map_is_skipped() -> None:
+    """If a citation references a session we have no AgentSuccessEvaluationResult
+    for, treat it as unknown and don't count it on either side."""
+    _ = RuleAttribution  # imported for export sanity; no-op
+    citations_by_session = {
+        "sess_known": [("playbook", "r1")],
+        "sess_orphan": [("playbook", "r1")],
+    }
+    is_success_by_session = {"sess_known": True}
+    rule_titles = {("playbook", "r1"): "r1"}
+
+    attribs = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=5,
+    )
+    assert len(attribs) == 1
+    a = attribs[0]
+    assert a.successes_with == 1
+    assert a.failures_with == 0
+    assert a.net_sessions == 1

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -1,0 +1,75 @@
+"""Integration test for EvaluationOverviewService with a mocked storage."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from reflexio.models.api_schema.domain.entities import AgentSuccessEvaluationResult
+from reflexio.models.api_schema.eval_overview_schema import (
+    GetEvaluationOverviewRequest,
+)
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+from reflexio.server.services.evaluation_overview.service import (
+    EvaluationOverviewService,
+)
+
+
+def _eval_result(
+    *,
+    result_id: int,
+    session_id: str,
+    is_success: bool,
+    corrections: int = 0,
+    created_at: int = 1700000000,
+) -> AgentSuccessEvaluationResult:
+    return AgentSuccessEvaluationResult(
+        result_id=result_id,
+        agent_version="v_e2e",
+        session_id=session_id,
+        is_success=is_success,
+        evaluation_name="overall",
+        created_at=created_at,
+        number_of_correction_per_session=corrections,
+    )
+
+
+def test_service_returns_full_response_with_shadow_enabled_and_data() -> None:
+    storage = MagicMock()
+    storage.get_agent_success_evaluation_results.return_value = [
+        _eval_result(result_id=1, session_id="s1", is_success=True, corrections=0),
+        _eval_result(result_id=2, session_id="s2", is_success=True, corrections=1),
+        _eval_result(result_id=3, session_id="s3", is_success=False, corrections=3),
+    ]
+    storage.get_playbook_application_stats.return_value = []
+    storage.get_interactions_by_session.return_value = []
+    storage.count_sessions_with_shadow_content.return_value = 600
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
+    )
+
+    assert response.hero.state in ("full", "early", "shadow_off", "empty")
+    assert response.context_tiles.success.current >= 0.0
+    assert len(response.score_distribution.current_bins) == 6
+    assert response.score_distribution.labels == ["0", "1", "2", "3", "4", "5+"]
+
+
+def test_service_returns_empty_state_when_no_results() -> None:
+    storage = MagicMock()
+    storage.get_agent_success_evaluation_results.return_value = []
+    storage.get_playbook_application_stats.return_value = []
+    storage.get_interactions_by_session.return_value = []
+    storage.count_sessions_with_shadow_content.return_value = 0
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
+    )
+
+    assert response.hero.state == "empty"
+    assert response.context_tiles.success.current == 0.0
+    assert response.rule_attribution == []

--- a/tests/server/services/storage/test_stall_state.py
+++ b/tests/server/services/storage/test_stall_state.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
-
-import pytest
+from datetime import UTC, datetime, timedelta
 
 
 def test_default_is_clean(storage):
@@ -16,7 +14,7 @@ def test_default_is_clean(storage):
 
 
 def test_upsert_then_get_roundtrip(storage):
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     storage.upsert_stall_state(
         reason="billing_error",
         stalled_at=now,
@@ -32,7 +30,7 @@ def test_upsert_then_get_roundtrip(storage):
 
 def test_reset_estimate_roundtrip(storage):
     """A non-None reset_estimate persists and parses back to the same datetime."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     reset_time = now + timedelta(hours=6)
     storage.upsert_stall_state(
         reason="billing_error",
@@ -48,7 +46,7 @@ def test_mark_notified_flips_only_that_field(storage):
     """mark_stall_notified flips only notified_in_cc, leaves other fields intact."""
     storage.upsert_stall_state(
         reason="auth_error",
-        stalled_at=datetime.now(timezone.utc),
+        stalled_at=datetime.now(UTC),
         reset_estimate=None,
         error_message="login",
     )
@@ -61,7 +59,7 @@ def test_mark_notified_flips_only_that_field(storage):
 def test_clear_resets_all_fields_and_notification(storage):
     storage.upsert_stall_state(
         reason="billing_error",
-        stalled_at=datetime.now(timezone.utc),
+        stalled_at=datetime.now(UTC),
         reset_estimate=None,
         error_message="x",
     )
@@ -76,7 +74,7 @@ def test_clear_resets_all_fields_and_notification(storage):
 
 def test_upsert_after_clear_resets_notified_flag(storage):
     """New stall must re-arm notified_in_cc=False so SessionStart fires again."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     storage.upsert_stall_state(
         reason="billing_error",
         stalled_at=now,


### PR DESCRIPTION
Plan C-overview — surfaces `imported_score` rows as a `braintrust_tiles` field on `/api/get_evaluation_overview`. Each tile is one scorer: `current` mean, `n` count, `delta` vs prior 7d window.

## Summary
- New `BraintrustTileRow` Pydantic model; `braintrust_tiles: list[]` (default empty) added to the response.
- Default no-op `get_imported_scores(org_id, from_ts, to_ts)` on `BaseStorage`; per-backend implementations are the Plan C-backends follow-up.
- New `EvaluationOverviewService._build_braintrust_tiles` aggregates by scorer_name.
- When no prior window data exists, `delta == current` so frontend can detect "no baseline" identically to how it does for the existing tiles.

## Tests
3 new (aggregator, empty case, deltas). 53 tests pass total. Ruff + pyright clean.

## Dependency
Depends on **both** `reflexio#86` (Plan B-backend — eval overview endpoint) AND `reflexio#87` (Plan C-backend — Braintrust connector). Both must merge before this rebases cleanly onto main.

## Out of scope
- Per-backend `get_imported_scores` implementations — Plan C-backends.
- Frontend rendering of the Braintrust tile strip — Plan C-frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Braintrust connector integration with connect/disconnect, project selection, sync, and status management.
  * Introduced evaluation overview dashboard with hero metrics, success trends, context tiles, rule attribution, and score distribution.
  * Added shadow mode configuration for side-by-side evaluation comparison.
  * Imported scores from Braintrust now aggregate in evaluation overview.

* **Tests**
  * Added comprehensive test coverage for Braintrust API, encryption, and service layer.
  * Added evaluation overview service and schema validation tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/88?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->