### PR TITLE
feat(eval): rubric editor backend — storage primitives, regen registry, /api/evaluations/regenerate

### DIFF
--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -180,15 +180,19 @@ class RegenerateStatusResponse(BaseModel):
     Args:
         job_id (str): Opaque job handle.
         status (Literal["running", "completed", "cancelled", "error"]):
-            Current lifecycle state.
+            Current lifecycle state. ``"completed"`` means the worker loop
+            finished iterating regardless of whether every session
+            succeeded — per-session pass/fail is in ``completed`` vs.
+            ``failed``. ``"error"`` means the worker itself crashed before
+            or during iteration.
         total (int): Total tuples queued at job creation.
         completed (int): Number of successfully replayed tuples.
         failed (int): Number of tuples that raised in the worker.
         failures (list[RegenerateFailure]): Per-session failure rows, capped
             inside the worker so the response stays small.
-        started_at (float): Monotonic timestamp at job creation.
-        finished_at (float | None): Monotonic timestamp at completion;
-            None while ``status == "running"``.
+        started_at (float): Unix-seconds wall-clock timestamp at job creation.
+        finished_at (float | None): Unix-seconds wall-clock timestamp at
+            worker exit; ``None`` while ``status == "running"``.
     """
 
     job_id: str

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from reflexio.models.api_schema.validators import NonEmptyStr
 
 HeroStateLiteral = Literal["full", "early", "shadow_off", "empty"]
 BucketLiteral = Literal["day", "week"]
@@ -117,3 +119,83 @@ class GetEvaluationOverviewResponse(BaseModel):
     rule_attribution: list[RuleAttributionRow]
     score_distribution: ScoreDistribution
     braintrust_tiles: list[BraintrustTileRow] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# /api/evaluations/regenerate — replay-the-judge endpoints
+# ---------------------------------------------------------------------------
+
+
+class RegenerateRequest(BaseModel):
+    """Input for POST /api/evaluations/regenerate.
+
+    Args:
+        evaluation_name (NonEmptyStr): Name of the evaluator to replay.
+            Must match one of the ``agent_success_configs[*].evaluation_name``
+            entries in the caller's config.
+        from_ts (int): Inclusive lower bound of the window (Unix seconds).
+        to_ts (int): Inclusive upper bound of the window (Unix seconds).
+            Must be strictly greater than ``from_ts``.
+    """
+
+    evaluation_name: NonEmptyStr
+    from_ts: int = Field(ge=0)
+    to_ts: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def _check_window(self) -> RegenerateRequest:
+        if self.from_ts >= self.to_ts:
+            raise ValueError("from_ts must be strictly before to_ts")
+        return self
+
+
+class RegenerateStartResponse(BaseModel):
+    """Returned by POST /api/evaluations/regenerate.
+
+    Args:
+        job_id (str): Opaque handle used to poll status or cancel.
+        total (int): Number of distinct (user, session, agent_version, source)
+            tuples the worker will replay.
+    """
+
+    job_id: str
+    total: int
+
+
+class RegenerateFailure(BaseModel):
+    """One failed session in a regenerate job's failure list.
+
+    Args:
+        session_id (str): The session whose replay failed.
+        reason (str): Truncated exception message (worker boundary).
+    """
+
+    session_id: str
+    reason: str
+
+
+class RegenerateStatusResponse(BaseModel):
+    """Returned by GET /api/evaluations/regenerate/{job_id}.
+
+    Args:
+        job_id (str): Opaque job handle.
+        status (Literal["running", "completed", "cancelled", "error"]):
+            Current lifecycle state.
+        total (int): Total tuples queued at job creation.
+        completed (int): Number of successfully replayed tuples.
+        failed (int): Number of tuples that raised in the worker.
+        failures (list[RegenerateFailure]): Per-session failure rows, capped
+            inside the worker so the response stays small.
+        started_at (float): Monotonic timestamp at job creation.
+        finished_at (float | None): Monotonic timestamp at completion;
+            None while ``status == "running"``.
+    """
+
+    job_id: str
+    status: Literal["running", "completed", "cancelled", "error"]
+    total: int
+    completed: int
+    failed: int
+    failures: list[RegenerateFailure]
+    started_at: float
+    finished_at: float | None

--- a/reflexio/models/api_schema/internal_schema.py
+++ b/reflexio/models/api_schema/internal_schema.py
@@ -25,4 +25,4 @@ class SessionDescriptor(NamedTuple):
     user_id: str
     session_id: str
     agent_version: str
-    source: str | None
+    source: str

--- a/reflexio/models/api_schema/internal_schema.py
+++ b/reflexio/models/api_schema/internal_schema.py
@@ -2,6 +2,8 @@
 # Internal data models
 # for only internal data representation
 # ==============================
+from typing import NamedTuple
+
 from pydantic import BaseModel
 
 from .service_schemas import Interaction, Request
@@ -11,3 +13,16 @@ class RequestInteractionDataModel(BaseModel):
     session_id: str
     request: Request
     interactions: list[Interaction]
+
+
+class SessionDescriptor(NamedTuple):
+    """Lightweight identifier for a session in a time window.
+
+    Used by regenerate workflows to enumerate sessions without loading
+    full Request/Interaction payloads.
+    """
+
+    user_id: str
+    session_id: str
+    agent_version: str
+    source: str | None

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -160,7 +160,7 @@ from reflexio.server.cache.reflexio_cache import (
 from reflexio.server.correlation import correlation_id_var, generate_correlation_id
 from reflexio.server.services.agent_success_evaluation.regen_jobs import (
     REGEN_JOBS,
-    _run_regen,
+    run_regen,
 )
 
 logger = logging.getLogger(__name__)
@@ -1728,8 +1728,6 @@ def start_regenerate(
             status_code=400,
             detail=f"Unknown evaluation_name '{payload.evaluation_name}'",
         )
-    if REGEN_JOBS.has_active(org_id, payload.evaluation_name):
-        raise HTTPException(status_code=409, detail="A regenerate is already running")
 
     storage = reflexio.request_context.storage
     if storage is None:
@@ -1737,15 +1735,18 @@ def start_regenerate(
     descriptors = storage.get_session_ids_in_window(
         from_ts=payload.from_ts, to_ts=payload.to_ts
     )
-    job = REGEN_JOBS.create(
-        org_id=org_id,
-        evaluation_name=payload.evaluation_name,
-        from_ts=payload.from_ts,
-        to_ts=payload.to_ts,
-        total=len(descriptors),
-    )
+    try:
+        job = REGEN_JOBS.create(
+            org_id=org_id,
+            evaluation_name=payload.evaluation_name,
+            from_ts=payload.from_ts,
+            to_ts=payload.to_ts,
+            total=len(descriptors),
+        )
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
     threading.Thread(
-        target=_run_regen,
+        target=run_regen,
         kwargs={
             "job": job,
             "request_context": reflexio.request_context,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 from collections.abc import Callable
 from typing import Any
 
@@ -30,6 +31,10 @@ from reflexio.models.api_schema.braintrust_schema import (
 from reflexio.models.api_schema.eval_overview_schema import (
     GetEvaluationOverviewRequest,
     GetEvaluationOverviewResponse,
+    RegenerateFailure,
+    RegenerateRequest,
+    RegenerateStartResponse,
+    RegenerateStatusResponse,
 )
 from reflexio.models.api_schema.retriever_schema import (
     GetAgentPlaybooksRequest,
@@ -153,6 +158,10 @@ from reflexio.server.cache.reflexio_cache import (
     invalidate_reflexio_cache,
 )
 from reflexio.server.correlation import correlation_id_var, generate_correlation_id
+from reflexio.server.services.agent_success_evaluation.regen_jobs import (
+    REGEN_JOBS,
+    _run_regen,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1676,6 +1685,143 @@ def get_evaluation_overview(
     """
     reflexio = get_reflexio(org_id=org_id)
     return reflexio.get_evaluation_overview(request)
+
+
+# ---------------------------------------------------------------------------
+# /api/evaluations/regenerate — replay the LLM judge over a window
+# ---------------------------------------------------------------------------
+
+
+@core_router.post(
+    "/api/evaluations/regenerate",
+    response_model=RegenerateStartResponse,
+    response_model_exclude_none=True,
+)
+def start_regenerate(
+    payload: RegenerateRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> RegenerateStartResponse:
+    """Start a regenerate job for one evaluator over a time window.
+
+    Args:
+        payload (RegenerateRequest): Evaluator name + window bounds.
+        org_id (str): Organization ID resolved by the auth dependency.
+
+    Returns:
+        RegenerateStartResponse: ``job_id`` to poll/cancel and ``total``
+            tuples queued.
+
+    Raises:
+        HTTPException: 400 when ``evaluation_name`` is not configured for
+            the org. 409 when a regenerate for the same (org, evaluator)
+            is already running. 503 when storage is not configured.
+    """
+    reflexio = get_reflexio(org_id=org_id)
+    config = reflexio.request_context.configurator.get_config()
+    known = (
+        {c.evaluation_name for c in (config.agent_success_configs or [])}
+        if config is not None
+        else set()
+    )
+    if payload.evaluation_name not in known:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown evaluation_name '{payload.evaluation_name}'",
+        )
+    if REGEN_JOBS.has_active(org_id, payload.evaluation_name):
+        raise HTTPException(status_code=409, detail="A regenerate is already running")
+
+    storage = reflexio.request_context.storage
+    if storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    descriptors = storage.get_session_ids_in_window(
+        from_ts=payload.from_ts, to_ts=payload.to_ts
+    )
+    job = REGEN_JOBS.create(
+        org_id=org_id,
+        evaluation_name=payload.evaluation_name,
+        from_ts=payload.from_ts,
+        to_ts=payload.to_ts,
+        total=len(descriptors),
+    )
+    threading.Thread(
+        target=_run_regen,
+        kwargs={
+            "job": job,
+            "request_context": reflexio.request_context,
+            "llm_client": reflexio.llm_client,
+        },
+        daemon=True,
+    ).start()
+    return RegenerateStartResponse(job_id=job.job_id, total=job.total)
+
+
+@core_router.get(
+    "/api/evaluations/regenerate/{job_id}",
+    response_model=RegenerateStatusResponse,
+    response_model_exclude_none=True,
+)
+def get_regenerate_status(
+    job_id: str,
+    org_id: str = Depends(default_get_org_id),
+) -> RegenerateStatusResponse:
+    """Poll the status of a regenerate job.
+
+    Args:
+        job_id (str): Opaque handle returned by POST /api/evaluations/regenerate.
+        org_id (str): Organization ID resolved by the auth dependency.
+
+    Returns:
+        RegenerateStatusResponse: Counters, status, and failure list.
+
+    Raises:
+        HTTPException: 404 when ``job_id`` is unknown or belongs to a
+            different org.
+    """
+    job = REGEN_JOBS.get(job_id)
+    if job is None or job.org_id != org_id:
+        raise HTTPException(status_code=404, detail="Unknown job_id")
+    return RegenerateStatusResponse(
+        job_id=job.job_id,
+        status=job.status,
+        total=job.total,
+        completed=job.completed,
+        failed=job.failed,
+        failures=[
+            RegenerateFailure(session_id=f.session_id, reason=f.reason)
+            for f in job.failures
+        ],
+        started_at=job.started_at,
+        finished_at=job.finished_at,
+    )
+
+
+@core_router.delete("/api/evaluations/regenerate/{job_id}")
+def cancel_regenerate(
+    job_id: str,
+    org_id: str = Depends(default_get_org_id),
+) -> dict[str, str]:
+    """Request cancellation of a running regenerate job.
+
+    Sets the worker's cancel event; the worker checks the flag between
+    sessions and transitions to ``"cancelled"`` on its next iteration.
+
+    Args:
+        job_id (str): Opaque handle returned by POST /api/evaluations/regenerate.
+        org_id (str): Organization ID resolved by the auth dependency.
+
+    Returns:
+        dict[str, str]: ``{"status": "cancelled"}`` on successful flag set.
+
+    Raises:
+        HTTPException: 404 when ``job_id`` is unknown or belongs to a
+            different org.
+    """
+    job = REGEN_JOBS.get(job_id)
+    if job is None or job.org_id != org_id:
+        raise HTTPException(status_code=404, detail="Unknown job_id")
+    REGEN_JOBS.cancel(job_id)
+    return {"status": "cancelled"}
 
 
 @core_router.post(

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
@@ -27,12 +27,16 @@ class AgentSuccessGenerationServiceConfig:
         agent_version: The agent version
         request_interaction_data_models: The interactions to evaluate
         source: Source of the interactions
+        evaluation_name_filter: Optional evaluator-name filter. When set,
+            _load_extractor_configs narrows to the single AgentSuccessConfig
+            whose evaluation_name matches; all others are skipped.
     """
 
     session_id: str
     agent_version: str
     request_interaction_data_models: list[RequestInteractionDataModel]
     source: str | None = None
+    evaluation_name_filter: str | None = None
 
 
 class AgentSuccessEvaluationService(
@@ -81,16 +85,26 @@ class AgentSuccessEvaluationService(
             agent_version=request.agent_version,
             request_interaction_data_models=request.request_interaction_data_models,
             source=request.source,
+            evaluation_name_filter=request.evaluation_name_filter,
         )
 
     def _load_extractor_configs(self) -> list[AgentSuccessConfig]:
         """
         Load agent success configs from configurator.
 
+        When the active service_config carries an evaluation_name_filter
+        (set by run_group_evaluation in regenerate mode), skip every config
+        whose evaluation_name does not match — so the regenerate flow only
+        re-runs the targeted evaluator instead of every configured rubric.
+
         Returns:
-            list[AgentSuccessConfig]: List of agent success configuration objects from YAML
+            list[AgentSuccessConfig]: Agent success configurations to execute.
         """
-        return self.configurator.get_config().agent_success_configs  # type: ignore[reportReturnType]
+        configs = self.configurator.get_config().agent_success_configs  # type: ignore[reportOptionalMemberAccess]
+        name_filter = getattr(self.service_config, "evaluation_name_filter", None)
+        if name_filter is None:
+            return configs  # type: ignore[reportReturnType]
+        return [c for c in configs if c.evaluation_name == name_filter]  # type: ignore[reportReturnType]
 
     def _create_extractor(
         self,

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
@@ -24,6 +24,11 @@ class AgentSuccessEvaluationRequest(BaseModel):
     agent_version: str
     request_interaction_data_models: list[RequestInteractionDataModel]
     source: str | None = None
+    # When set, AgentSuccessEvaluationService.run skips every evaluator whose
+    # AgentSuccessConfig.evaluation_name doesn't match this string. Used by the
+    # regenerate flow so a prompt edit re-evaluates only its own evaluator
+    # instead of every config configured for the org.
+    evaluation_name_filter: str | None = None
 
 
 def construct_agent_success_evaluation_messages_from_sessions(

--- a/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
+++ b/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
@@ -51,13 +51,16 @@ def run_group_evaluation(
     source: str | None,
     request_context: RequestContext,
     llm_client: LiteLLMClient,
+    *,
+    force_regenerate: bool = False,
+    evaluation_name: str | None = None,
 ) -> None:
     """Run agent success evaluation for an entire session.
 
     Steps:
-    1. Check if already evaluated via operation state
+    1. Check if already evaluated via operation state (skipped when force_regenerate)
     2. Fetch all requests for the session
-    3. Verify completion (latest request created_at >= delay ago)
+    3. Verify completion (latest request created_at >= delay ago; skipped when force_regenerate)
     4. Fetch interactions and build data models
     5. Run evaluation service
     6. Mark as evaluated in operation state
@@ -70,18 +73,29 @@ def run_group_evaluation(
         source: Source of the interactions
         request_context: Request context with storage and configurator
         llm_client: LLM client for evaluation
+        force_regenerate: When True, bypass the already-evaluated short-circuit
+            and the completeness delay gate so the regenerate worker can
+            re-evaluate sessions of any age regardless of prior state.
+        evaluation_name: When set, narrow the evaluation to a single
+            AgentSuccessConfig.evaluation_name. Propagated to the service via
+            AgentSuccessEvaluationRequest.evaluation_name_filter. When combined
+            with force_regenerate, any prior result rows for
+            (session_id, evaluation_name, agent_version) are deleted before
+            the new run so the re-evaluation cleanly replaces the old verdict.
     """
     storage = request_context.storage
     state_key = _build_state_key(org_id, user_id, session_id)
 
-    # 1. Check if already evaluated
-    existing_state = storage.get_operation_state(state_key)  # type: ignore[reportOptionalMemberAccess]
-    if existing_state and isinstance(existing_state.get("operation_state"), dict):
-        op_state = existing_state["operation_state"]
-        if op_state.get("evaluated"):
-            _eval_health.record_skip(SkipReason.ALREADY_EVALUATED)
-            logger.info("Session %s already evaluated, skipping", session_id)
-            return
+    # 1. Check if already evaluated — skipped in force_regenerate mode so the
+    # regenerate worker can re-evaluate a session that's already been marked.
+    if not force_regenerate:
+        existing_state = storage.get_operation_state(state_key)  # type: ignore[reportOptionalMemberAccess]
+        if existing_state and isinstance(existing_state.get("operation_state"), dict):
+            op_state = existing_state["operation_state"]
+            if op_state.get("evaluated"):
+                _eval_health.record_skip(SkipReason.ALREADY_EVALUATED)
+                logger.info("Session %s already evaluated, skipping", session_id)
+                return
 
     # 2. Fetch all requests for the session
     requests = storage.get_requests_by_session(user_id, session_id)  # type: ignore[reportOptionalMemberAccess]
@@ -90,19 +104,21 @@ def run_group_evaluation(
         logger.info("No requests found for session %s, skipping", session_id)
         return
 
-    # 3. Verify completion: latest request must be >= delay ago
-    latest_created_at = max(r.created_at for r in requests)
-    now = int(datetime.now(UTC).timestamp())
-    elapsed = now - latest_created_at
-    if elapsed < _EFFECTIVE_DELAY_SECONDS:
-        _eval_health.record_skip(SkipReason.NOT_YET_COMPLETE)
-        logger.info(
-            "Session %s not yet complete (latest request %ds ago, need %ds), skipping",
-            session_id,
-            elapsed,
-            _EFFECTIVE_DELAY_SECONDS,
-        )
-        return
+    # 3. Verify completion: latest request must be >= delay ago — skipped in
+    # force_regenerate mode so the operator can re-evaluate any session.
+    if not force_regenerate:
+        latest_created_at = max(r.created_at for r in requests)
+        now = int(datetime.now(UTC).timestamp())
+        elapsed = now - latest_created_at
+        if elapsed < _EFFECTIVE_DELAY_SECONDS:
+            _eval_health.record_skip(SkipReason.NOT_YET_COMPLETE)
+            logger.info(
+                "Session %s not yet complete (latest request %ds ago, need %ds), skipping",
+                session_id,
+                elapsed,
+                _EFFECTIVE_DELAY_SECONDS,
+            )
+            return
 
     # 4. Fetch interactions for all requests
     request_ids = [r.request_id for r in requests]
@@ -142,11 +158,25 @@ def run_group_evaluation(
         return
 
     # 5. Run evaluation
+    # When regenerating a single evaluator, clear any prior result rows for
+    # this (session, evaluation_name, agent_version) so the new run cleanly
+    # replaces the previous verdict instead of leaving stale rows alongside
+    # the regenerated ones.
+    if force_regenerate and evaluation_name is not None:
+        storage.delete_agent_success_evaluation_results_for_session(  # type: ignore[reportOptionalMemberAccess]
+            session_id=session_id,
+            evaluation_name=evaluation_name,
+            agent_version=agent_version,
+        )
+
     logger.info(
-        "Running group evaluation for session=%s with %d requests and %d interactions",
+        "Running group evaluation for session=%s with %d requests and %d interactions"
+        " (force_regenerate=%s, evaluation_name=%s)",
         session_id,
         len(request_interaction_data_models),
         len(all_interactions),
+        force_regenerate,
+        evaluation_name,
     )
 
     evaluation_request = AgentSuccessEvaluationRequest(
@@ -154,6 +184,7 @@ def run_group_evaluation(
         agent_version=agent_version,
         source=source,
         request_interaction_data_models=request_interaction_data_models,
+        evaluation_name_filter=evaluation_name,
     )
 
     evaluation_service = AgentSuccessEvaluationService(

--- a/reflexio/server/services/agent_success_evaluation/regen_jobs.py
+++ b/reflexio/server/services/agent_success_evaluation/regen_jobs.py
@@ -22,6 +22,14 @@ from reflexio.server.services.agent_success_evaluation.group_evaluation_runner i
 logger = logging.getLogger(__name__)
 
 JobStatus = Literal["running", "completed", "cancelled", "error"]
+"""Lifecycle states for a regenerate job.
+
+``"completed"`` means the worker loop finished iterating, regardless of whether
+every session succeeded — per-session pass/fail counts are in the ``completed``
+and ``failed`` counters. ``"error"`` means the worker itself crashed before or
+during iteration (e.g. storage was unavailable). ``"cancelled"`` means a caller
+set the cancel event and the worker observed it between sessions.
+"""
 
 DEFAULT_TTL_SECONDS = 3600
 _FAILURE_CAP = 50
@@ -46,8 +54,10 @@ class RegenJob:
     failed: int = 0
     failures: list[JobFailure] = field(default_factory=list)
     cancel_event: threading.Event = field(default_factory=threading.Event)
-    started_at: float = field(default_factory=time.monotonic)
+    started_at: float = field(default_factory=time.time)
+    """Unix seconds (wall clock) at job creation — returned to API clients."""
     finished_at: float | None = None
+    """Unix seconds (wall clock) when the worker exited; ``None`` while running."""
 
 
 class RegenJobRegistry:
@@ -109,7 +119,7 @@ class RegenJobRegistry:
             self._evict_completed_locked(ttl_seconds)
 
     def _evict_completed_locked(self, ttl_seconds: int) -> None:
-        now = time.monotonic()
+        now = time.time()
         drop = [
             jid
             for jid, j in self._jobs.items()
@@ -126,13 +136,29 @@ class RegenJobRegistry:
 REGEN_JOBS = RegenJobRegistry()
 
 
-def _run_regen(
+def run_regen(
     *,
     job: RegenJob,
     request_context: RequestContext,
     llm_client: LiteLLMClient,
 ) -> None:
-    """Worker body. Drives run_group_evaluation per session in the window."""
+    """Worker body. Drives run_group_evaluation per session in the window.
+
+    On normal completion of the session loop, sets ``job.status = "completed"``
+    even if individual sessions raised — per-session failures are recorded in
+    ``job.failed`` and ``job.failures``. Sets ``job.status = "error"`` only if
+    the worker itself crashes (e.g. storage misconfigured). Sets
+    ``job.status = "cancelled"`` if the cancel event is observed between
+    sessions.
+
+    Args:
+        job (RegenJob): Pre-registered job whose counters and status this
+            worker mutates in place.
+        request_context (RequestContext): Carrier for storage, config, and
+            prompt manager.
+        llm_client (LiteLLMClient): Shared LLM client used by
+            ``run_group_evaluation`` per session.
+    """
     try:
         storage = request_context.storage
         if storage is None:
@@ -170,4 +196,4 @@ def _run_regen(
         job.status = "error"
         logger.exception("Regen worker crashed for job=%s", job.job_id)
     finally:
-        job.finished_at = time.monotonic()
+        job.finished_at = time.time()

--- a/reflexio/server/services/agent_success_evaluation/regen_jobs.py
+++ b/reflexio/server/services/agent_success_evaluation/regen_jobs.py
@@ -1,0 +1,173 @@
+"""Regenerate job registry + worker for replaying the LLM judge.
+
+In-memory only; process-local. Survives the worker thread but not a
+backend restart. v2 will move job state to storage.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.agent_success_evaluation.group_evaluation_runner import (
+    run_group_evaluation,
+)
+
+logger = logging.getLogger(__name__)
+
+JobStatus = Literal["running", "completed", "cancelled", "error"]
+
+DEFAULT_TTL_SECONDS = 3600
+_FAILURE_CAP = 50
+
+
+@dataclass
+class JobFailure:
+    session_id: str
+    reason: str
+
+
+@dataclass
+class RegenJob:
+    job_id: str
+    org_id: str
+    evaluation_name: str
+    from_ts: int
+    to_ts: int
+    status: JobStatus
+    total: int
+    completed: int = 0
+    failed: int = 0
+    failures: list[JobFailure] = field(default_factory=list)
+    cancel_event: threading.Event = field(default_factory=threading.Event)
+    started_at: float = field(default_factory=time.monotonic)
+    finished_at: float | None = None
+
+
+class RegenJobRegistry:
+    """Process-local job registry. One active job per (org_id, evaluation_name)."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, RegenJob] = {}
+        self._by_org_evaluator: dict[tuple[str, str], str] = {}
+        self._lock = threading.Lock()
+
+    def create(
+        self,
+        *,
+        org_id: str,
+        evaluation_name: str,
+        from_ts: int,
+        to_ts: int,
+        total: int,
+    ) -> RegenJob:
+        """Register a new running job. Raises RuntimeError if (org, evaluator) is active."""
+        with self._lock:
+            self._evict_completed_locked(DEFAULT_TTL_SECONDS)
+            key = (org_id, evaluation_name)
+            if key in self._by_org_evaluator:
+                raise RuntimeError(
+                    f"A regenerate is already running for evaluator '{evaluation_name}'"
+                )
+            job = RegenJob(
+                job_id=uuid.uuid4().hex,
+                org_id=org_id,
+                evaluation_name=evaluation_name,
+                from_ts=from_ts,
+                to_ts=to_ts,
+                status="running",
+                total=total,
+            )
+            self._jobs[job.job_id] = job
+            self._by_org_evaluator[key] = job.job_id
+            return job
+
+    def get(self, job_id: str) -> RegenJob | None:
+        with self._lock:
+            self._evict_completed_locked(DEFAULT_TTL_SECONDS)
+            return self._jobs.get(job_id)
+
+    def cancel(self, job_id: str) -> None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+        if job is not None:
+            job.cancel_event.set()
+
+    def has_active(self, org_id: str, evaluation_name: str) -> bool:
+        with self._lock:
+            self._evict_completed_locked(DEFAULT_TTL_SECONDS)
+            return (org_id, evaluation_name) in self._by_org_evaluator
+
+    def evict_completed_older_than(self, ttl_seconds: int) -> None:
+        with self._lock:
+            self._evict_completed_locked(ttl_seconds)
+
+    def _evict_completed_locked(self, ttl_seconds: int) -> None:
+        now = time.monotonic()
+        drop = [
+            jid
+            for jid, j in self._jobs.items()
+            if j.status in ("completed", "cancelled", "error")
+            and j.finished_at is not None
+            and (now - j.finished_at) > ttl_seconds
+        ]
+        for jid in drop:
+            j = self._jobs.pop(jid)
+            self._by_org_evaluator.pop((j.org_id, j.evaluation_name), None)
+
+
+# Single process-local instance.
+REGEN_JOBS = RegenJobRegistry()
+
+
+def _run_regen(
+    *,
+    job: RegenJob,
+    request_context: RequestContext,
+    llm_client: LiteLLMClient,
+) -> None:
+    """Worker body. Drives run_group_evaluation per session in the window."""
+    try:
+        storage = request_context.storage
+        if storage is None:
+            raise RuntimeError("storage is not configured")
+        descriptors = storage.get_session_ids_in_window(
+            from_ts=job.from_ts, to_ts=job.to_ts
+        )
+        for sd in descriptors:
+            if job.cancel_event.is_set():
+                job.status = "cancelled"
+                break
+            try:
+                run_group_evaluation(
+                    org_id=job.org_id,
+                    user_id=sd.user_id,
+                    session_id=sd.session_id,
+                    agent_version=sd.agent_version,
+                    source=sd.source,
+                    request_context=request_context,
+                    llm_client=llm_client,
+                    force_regenerate=True,
+                    evaluation_name=job.evaluation_name,
+                )
+                job.completed += 1
+            except Exception as e:  # noqa: BLE001 — worker boundary
+                job.failed += 1
+                if len(job.failures) < _FAILURE_CAP:
+                    job.failures.append(
+                        JobFailure(session_id=sd.session_id, reason=str(e)[:200])
+                    )
+                logger.warning("Regen failed for session=%s: %s", sd.session_id, e)
+        else:
+            job.status = "completed"
+    except Exception:  # noqa: BLE001 — worker boundary
+        job.status = "error"
+        logger.exception("Regen worker crashed for job=%s", job.job_id)
+    finally:
+        job.finished_at = time.monotonic()

--- a/reflexio/server/services/storage/disk_storage/_playbook.py
+++ b/reflexio/server/services/storage/disk_storage/_playbook.py
@@ -1046,3 +1046,36 @@ class PlaybookMixin:
     def delete_all_agent_success_evaluation_results(self) -> None:
         with self._lock:
             self._clear_dir(self._evaluations_dir())
+
+    def delete_agent_success_evaluation_results_for_session(
+        self,
+        session_id: str,
+        evaluation_name: str,
+        agent_version: str,
+    ) -> int:
+        """Delete results scoped to (session_id, evaluation_name, agent_version).
+
+        Iterates the per-file evaluation directory, reads each entity, and
+        unlinks (with its embedding sidecar) any that match the triple.
+
+        Args:
+            session_id (str): Session whose results to clear.
+            evaluation_name (str): Which evaluator's results to clear.
+            agent_version (str): Agent version scope.
+
+        Returns:
+            int: Number of files deleted.
+        """
+        deleted = 0
+        with self._lock:
+            for path in self._scan_entities(self._evaluations_dir()):
+                result = self._read_entity(path, AgentSuccessEvaluationResult)
+                if (
+                    result.session_id == session_id
+                    and result.evaluation_name == evaluation_name
+                    and result.agent_version == agent_version
+                ):
+                    self._delete_embedding(path)
+                    path.unlink()
+                    deleted += 1
+        return deleted

--- a/reflexio/server/services/storage/disk_storage/_requests.py
+++ b/reflexio/server/services/storage/disk_storage/_requests.py
@@ -1,6 +1,9 @@
 import logging
 
-from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
+from reflexio.models.api_schema.internal_schema import (
+    RequestInteractionDataModel,
+    SessionDescriptor,
+)
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
     Request,
@@ -214,3 +217,25 @@ class RequestMixin:
             user_ids.add(req.user_id)
 
         return sorted(user_ids)
+
+    def get_session_ids_in_window(
+        self, from_ts: int, to_ts: int
+    ) -> list[SessionDescriptor]:
+        with self._lock:
+            all_requests = self._list_entities(self._requests_dir(), Request)
+
+        seen: dict[tuple[str, str], SessionDescriptor] = {}
+        for req in all_requests:
+            if req.session_id is None:
+                continue
+            if not (from_ts <= req.created_at <= to_ts):
+                continue
+            key = (req.user_id, req.session_id)
+            if key not in seen:
+                seen[key] = SessionDescriptor(
+                    user_id=req.user_id,
+                    session_id=req.session_id,
+                    agent_version=req.agent_version,
+                    source=req.source,
+                )
+        return sorted(seen.values(), key=lambda d: d.session_id)

--- a/reflexio/server/services/storage/disk_storage/_requests.py
+++ b/reflexio/server/services/storage/disk_storage/_requests.py
@@ -224,13 +224,13 @@ class RequestMixin:
         with self._lock:
             all_requests = self._list_entities(self._requests_dir(), Request)
 
-        seen: dict[tuple[str, str], SessionDescriptor] = {}
+        seen: dict[tuple[str, str, str, str], SessionDescriptor] = {}
         for req in all_requests:
             if req.session_id is None:
                 continue
             if not (from_ts <= req.created_at <= to_ts):
                 continue
-            key = (req.user_id, req.session_id)
+            key = (req.user_id, req.session_id, req.agent_version, req.source)
             if key not in seen:
                 seen[key] = SessionDescriptor(
                     user_id=req.user_id,
@@ -238,4 +238,6 @@ class RequestMixin:
                     agent_version=req.agent_version,
                     source=req.source,
                 )
-        return sorted(seen.values(), key=lambda d: d.session_id)
+        return sorted(
+            seen.values(), key=lambda d: (d.session_id, d.user_id, d.agent_version)
+        )

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1330,3 +1330,27 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_success_evaluation_results(self) -> None:
         self._execute("DELETE FROM agent_success_evaluation_result")
+
+    @SQLiteStorageBase.handle_exceptions
+    def delete_agent_success_evaluation_results_for_session(
+        self,
+        session_id: str,
+        evaluation_name: str,
+        agent_version: str,
+    ) -> int:
+        """Delete results scoped to (session_id, evaluation_name, agent_version).
+
+        Args:
+            session_id (str): Session whose results to clear.
+            evaluation_name (str): Which evaluator's results to clear.
+            agent_version (str): Agent version scope.
+
+        Returns:
+            int: Number of rows deleted.
+        """
+        cur = self._execute(
+            """DELETE FROM agent_success_evaluation_result
+               WHERE session_id = ? AND evaluation_name = ? AND agent_version = ?""",
+            (session_id, evaluation_name, agent_version),
+        )
+        return cur.rowcount

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -243,12 +243,11 @@ class RequestMixin:
         from_iso = _epoch_to_iso(from_ts)
         to_iso = _epoch_to_iso(to_ts)
         rows = self._fetchall(
-            """SELECT user_id, session_id, agent_version, source
+            """SELECT DISTINCT user_id, session_id, agent_version, source
                FROM requests
                WHERE session_id IS NOT NULL
                  AND created_at BETWEEN ? AND ?
-               GROUP BY user_id, session_id
-               ORDER BY session_id""",
+               ORDER BY session_id, user_id, agent_version""",
             (from_iso, to_iso),
         )
         return [

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -3,7 +3,10 @@
 import sqlite3
 from typing import Any
 
-from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
+from reflexio.models.api_schema.internal_schema import (
+    RequestInteractionDataModel,
+    SessionDescriptor,
+)
 from reflexio.models.api_schema.service_schemas import (
     Request,
 )
@@ -232,3 +235,28 @@ class RequestMixin:
             (user_id, session_id),
         )
         return [_row_to_request(r) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_session_ids_in_window(
+        self, from_ts: int, to_ts: int
+    ) -> list[SessionDescriptor]:
+        from_iso = _epoch_to_iso(from_ts)
+        to_iso = _epoch_to_iso(to_ts)
+        rows = self._fetchall(
+            """SELECT user_id, session_id, agent_version, source
+               FROM requests
+               WHERE session_id IS NOT NULL
+                 AND created_at BETWEEN ? AND ?
+               GROUP BY user_id, session_id
+               ORDER BY session_id""",
+            (from_iso, to_iso),
+        )
+        return [
+            SessionDescriptor(
+                user_id=r["user_id"],
+                session_id=r["session_id"],
+                agent_version=r["agent_version"],
+                source=r["source"],
+            )
+            for r in rows
+        ]

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -638,3 +638,22 @@ class PlaybookMixin:
     def delete_all_agent_success_evaluation_results(self) -> None:
         """Delete all agent success evaluation results from storage."""
         raise NotImplementedError
+
+    @abstractmethod
+    def delete_agent_success_evaluation_results_for_session(
+        self,
+        session_id: str,
+        evaluation_name: str,
+        agent_version: str,
+    ) -> int:
+        """Delete stored results for (session_id, evaluation_name, agent_version).
+
+        Args:
+            session_id (str): Session whose results to clear.
+            evaluation_name (str): Which evaluator's results to clear.
+            agent_version (str): Agent version scope.
+
+        Returns:
+            int: Number of rows deleted.
+        """
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -1,7 +1,10 @@
 from abc import abstractmethod
 
 from reflexio.models.api_schema.domain import Request
-from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
+from reflexio.models.api_schema.internal_schema import (
+    RequestInteractionDataModel,
+    SessionDescriptor,
+)
 
 
 class RequestMixin:
@@ -126,5 +129,20 @@ class RequestMixin:
 
         Returns:
             list[Request]: List of Request objects in the session
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_session_ids_in_window(
+        self, from_ts: int, to_ts: int
+    ) -> list[SessionDescriptor]:
+        """Return one descriptor per distinct (user_id, session_id) with any request in window.
+
+        Args:
+            from_ts (int): Inclusive lower bound (Unix seconds).
+            to_ts (int): Inclusive upper bound (Unix seconds).
+
+        Returns:
+            list[SessionDescriptor]: Deduped descriptors ordered by session_id.
         """
         raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -136,7 +136,13 @@ class RequestMixin:
     def get_session_ids_in_window(
         self, from_ts: int, to_ts: int
     ) -> list[SessionDescriptor]:
-        """Return one descriptor per distinct (user_id, session_id) with any request in window.
+        """Return one descriptor per distinct (user_id, session_id, agent_version, source) tuple with at least one request whose ``created_at`` falls inside ``[from_ts, to_ts]``.
+
+        A session that records requests under multiple ``agent_version`` or
+        ``source`` values within the window yields one descriptor per distinct
+        combination, so regen workers can invoke ``run_group_evaluation`` once
+        per (user, session, agent_version, source) tuple without conflating
+        runs from different agent versions.
 
         Args:
             from_ts (int): Inclusive lower bound (Unix seconds).

--- a/tests/models/test_regenerate_schema.py
+++ b/tests/models/test_regenerate_schema.py
@@ -1,0 +1,40 @@
+"""Unit tests for the RegenerateRequest pydantic model."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from reflexio.models.api_schema.eval_overview_schema import RegenerateRequest
+
+
+def test_valid_request() -> None:
+    """Happy path: well-formed window with non-empty evaluator name."""
+    r = RegenerateRequest(evaluation_name="overall_success", from_ts=100, to_ts=200)
+    assert r.from_ts == 100
+    assert r.to_ts == 200
+    assert r.evaluation_name == "overall_success"
+
+
+def test_from_ts_equal_to_to_ts_rejected() -> None:
+    """An empty window (from == to) is rejected — no sessions could be in it."""
+    with pytest.raises(ValidationError, match="strictly before"):
+        RegenerateRequest(evaluation_name="overall", from_ts=100, to_ts=100)
+
+
+def test_from_ts_after_to_ts_rejected() -> None:
+    """A reversed window is rejected so callers don't silently get zero sessions."""
+    with pytest.raises(ValidationError, match="strictly before"):
+        RegenerateRequest(evaluation_name="overall", from_ts=200, to_ts=100)
+
+
+def test_empty_evaluation_name_rejected() -> None:
+    """An empty evaluator name is rejected via NonEmptyStr."""
+    with pytest.raises(ValidationError):
+        RegenerateRequest(evaluation_name="", from_ts=0, to_ts=10)
+
+
+def test_negative_ts_rejected() -> None:
+    """Negative timestamps are rejected (ge=0 on the Field)."""
+    with pytest.raises(ValidationError):
+        RegenerateRequest(evaluation_name="overall", from_ts=-1, to_ts=10)

--- a/tests/server/api_endpoints/conftest.py
+++ b/tests/server/api_endpoints/conftest.py
@@ -1,11 +1,17 @@
 """Shared fixtures for API endpoint tests."""
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from reflexio.models.config_schema import AgentSuccessConfig
 from reflexio.server.api import create_app
+from reflexio.server.cache.reflexio_cache import (
+    get_reflexio,
+    invalidate_reflexio_cache,
+)
 
 
 @pytest.fixture
@@ -40,3 +46,59 @@ def patched_reflexio(mock_reflexio):
         ),
     ):
         yield mock_get
+
+
+@pytest.fixture
+def client_with_org():
+    """A TestClient bound to a fresh unique org_id with SQLite storage.
+
+    The org is generated per-test so the in-process per-org Reflexio cache
+    doesn't bleed configuration between tests. We also stub
+    ``storage.get_session_ids_in_window`` to return an empty list — the
+    regenerate endpoint queries it synchronously to size the job, and
+    we don't want the test outcome to depend on whatever happens to live
+    in the developer's local SQLite DB. The cache entry is evicted on
+    teardown.
+
+    Returns:
+        tuple[TestClient, str]: ``(client, org_id)`` pair.
+    """
+    org_id = f"test-regen-{uuid.uuid4().hex[:12]}"
+    app = create_app(get_org_id=lambda: org_id)
+    client = TestClient(app, raise_server_exceptions=False)
+    # Warm the cache so subsequent get_reflexio() calls inside the
+    # endpoint hand back the same instance the test can inspect.
+    reflexio = get_reflexio(org_id=org_id)
+    storage = reflexio.request_context.storage
+    assert storage is not None  # SQLite default — should never be None here.
+    with patch.object(storage, "get_session_ids_in_window", return_value=[]):
+        try:
+            yield client, org_id
+        finally:
+            invalidate_reflexio_cache(org_id=org_id)
+
+
+@pytest.fixture
+def client_with_org_and_evaluator(client_with_org):
+    """Same as ``client_with_org`` but with one configured AgentSuccessConfig.
+
+    Adds a single ``overall_success`` evaluator entry so the /regenerate
+    POST passes the "known evaluation_name" gate.
+
+    Returns:
+        tuple[TestClient, str]: ``(client, org_id)`` pair.
+    """
+    client, org_id = client_with_org
+    reflexio = get_reflexio(org_id=org_id)
+    reflexio.request_context.configurator.set_config_by_name(
+        "agent_success_configs",
+        [
+            AgentSuccessConfig(
+                evaluation_name="overall_success",
+                success_definition_prompt=(
+                    "Evaluate whether the agent successfully completed the task."
+                ),
+            )
+        ],
+    )
+    return client, org_id

--- a/tests/server/api_endpoints/test_evaluations_regenerate_api.py
+++ b/tests/server/api_endpoints/test_evaluations_regenerate_api.py
@@ -1,0 +1,97 @@
+"""Integration tests for the three regenerate endpoints.
+
+The fixtures (see conftest.py) wire a fresh-per-test FastAPI app to a
+unique SQLite-backed Reflexio org and tear down both the cache entry
+and any registry state created during the test.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_post_400_when_evaluation_name_unknown(client_with_org):
+    """An evaluator name absent from the config returns 400."""
+    client, _org_id = client_with_org
+    resp = client.post(
+        "/api/evaluations/regenerate",
+        json={
+            "evaluation_name": "does_not_exist",
+            "from_ts": 0,
+            "to_ts": 9_999_999_999,
+        },
+    )
+    assert resp.status_code == 400
+
+
+def test_get_unknown_job_id_returns_404(client_with_org):
+    """GET on an unknown job_id returns 404."""
+    client, _ = client_with_org
+    resp = client.get("/api/evaluations/regenerate/nonexistent")
+    assert resp.status_code == 404
+
+
+def test_post_409_when_job_already_running(client_with_org_and_evaluator):
+    """A second POST while a job is still running returns 409."""
+    client, _ = client_with_org_and_evaluator
+    body = {
+        "evaluation_name": "overall_success",
+        "from_ts": 0,
+        "to_ts": 9_999_999_999,
+    }
+    # Patch threading.Thread so the worker never starts and the first job
+    # stays "running" — otherwise the empty-storage worker would finish
+    # immediately and the second POST would succeed.
+    with patch("reflexio.server.api.threading.Thread") as thread_cls:
+        thread_cls.return_value.start = lambda: None
+        first = client.post("/api/evaluations/regenerate", json=body)
+        assert first.status_code == 200, first.text
+        second = client.post("/api/evaluations/regenerate", json=body)
+        assert second.status_code == 409
+
+
+def test_full_lifecycle_running_then_completed(client_with_org_and_evaluator):
+    """POST then poll GET until status transitions out of "running"."""
+    client, _ = client_with_org_and_evaluator
+    body = {
+        "evaluation_name": "overall_success",
+        "from_ts": 0,
+        "to_ts": 9_999_999_999,
+    }
+    resp = client.post("/api/evaluations/regenerate", json=body)
+    assert resp.status_code == 200, resp.text
+    job_id = resp.json()["job_id"]
+
+    deadline = time.time() + 30
+    last_status = None
+    while time.time() < deadline:
+        r = client.get(f"/api/evaluations/regenerate/{job_id}")
+        assert r.status_code == 200
+        last_status = r.json()["status"]
+        if last_status in ("completed", "cancelled", "error"):
+            break
+        time.sleep(0.3)
+    # Empty storage → no descriptors → worker exits cleanly via the for-else.
+    assert last_status == "completed"
+
+
+def test_delete_cancels_running_job(client_with_org_and_evaluator):
+    """DELETE sets the cancel flag and returns {"status": "cancelled"}."""
+    client, _ = client_with_org_and_evaluator
+    body = {
+        "evaluation_name": "overall_success",
+        "from_ts": 0,
+        "to_ts": 9_999_999_999,
+    }
+    resp = client.post("/api/evaluations/regenerate", json=body)
+    assert resp.status_code == 200, resp.text
+    job_id = resp.json()["job_id"]
+
+    delete_resp = client.delete(f"/api/evaluations/regenerate/{job_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["status"] == "cancelled"

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
@@ -1,0 +1,275 @@
+"""Tests for force_regenerate + evaluation_name on run_group_evaluation.
+
+These cover the regenerate flow's behavior at the runner layer:
+- force_regenerate=True bypasses both the operation-state "already evaluated"
+  short-circuit and the completeness-delay gate so an operator can re-evaluate
+  any session.
+- evaluation_name propagates into AgentSuccessEvaluationRequest.evaluation_name_filter
+  so the downstream service narrows to a single evaluator instead of running
+  every configured rubric.
+- When both kwargs are set, prior result rows for that
+  (session_id, evaluation_name, agent_version) tuple are deleted before the new
+  run so the regenerated verdict cleanly replaces the old one.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+from reflexio.models.api_schema.service_schemas import Interaction, Request
+from reflexio.server.services.agent_success_evaluation.group_evaluation_runner import (
+    run_group_evaluation,
+)
+
+
+def _make_request(request_id: str, user_id: str, session_id: str) -> Request:
+    """Create a request old enough to pass the completion delay gate.
+
+    Args:
+        request_id (str): Request identifier.
+        user_id (str): Owner user identifier.
+        session_id (str): Session identifier.
+
+    Returns:
+        Request: A Request with created_at well in the past.
+    """
+    now = int(datetime.now(UTC).timestamp())
+    return Request(
+        request_id=request_id,
+        user_id=user_id,
+        session_id=session_id,
+        created_at=now - 10000,
+    )
+
+
+def _make_interaction(request_id: str, user_id: str) -> Interaction:
+    """Create a minimal interaction tied to a request.
+
+    Args:
+        request_id (str): Owning request identifier.
+        user_id (str): Owner user identifier.
+
+    Returns:
+        Interaction: A populated Interaction instance.
+    """
+    now = int(datetime.now(UTC).timestamp())
+    return Interaction(
+        interaction_id=1,
+        user_id=user_id,
+        request_id=request_id,
+        content="test content",
+        role="user",
+        created_at=now - 9999,
+    )
+
+
+def _make_storage(*, with_evaluated_marker: bool) -> MagicMock:
+    """Build a storage mock seeded with one request + one interaction.
+
+    Args:
+        with_evaluated_marker (bool): When True, get_operation_state returns a
+            payload whose operation_state.evaluated is True — simulating a
+            session that's already been evaluated.
+
+    Returns:
+        MagicMock: A storage stub wired with the standard return values.
+    """
+    storage = MagicMock()
+    if with_evaluated_marker:
+        storage.get_operation_state.return_value = {
+            "operation_state": {"evaluated": True, "evaluated_at": 1}
+        }
+    else:
+        storage.get_operation_state.return_value = None
+    storage.get_requests_by_session.return_value = [
+        _make_request("req_1", "user_a", "session_a")
+    ]
+    storage.get_interactions_by_request_ids.return_value = [
+        _make_interaction("req_1", "user_a")
+    ]
+    storage.delete_agent_success_evaluation_results_for_session.return_value = 1
+    return storage
+
+
+def test_force_regenerate_bypasses_already_evaluated_short_circuit() -> None:
+    """force_regenerate=True must still invoke the service on a marked session."""
+    storage = _make_storage(with_evaluated_marker=True)
+    request_context = MagicMock()
+    request_context.storage = storage
+    llm_client = MagicMock()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation"
+        ".group_evaluation_runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=llm_client,
+            force_regenerate=True,
+        )
+
+    # Service was constructed and invoked despite the existing evaluated marker.
+    service.run.assert_called_once()
+
+
+def test_evaluation_name_propagates_into_evaluation_request() -> None:
+    """evaluation_name kwarg must flow into AgentSuccessEvaluationRequest.evaluation_name_filter."""
+    storage = _make_storage(with_evaluated_marker=False)
+    request_context = MagicMock()
+    request_context.storage = storage
+    llm_client = MagicMock()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation"
+        ".group_evaluation_runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=llm_client,
+            force_regenerate=True,
+            evaluation_name="overall_success",
+        )
+
+    service.run.assert_called_once()
+    eval_request = service.run.call_args.args[0]
+    assert eval_request.evaluation_name_filter == "overall_success"
+    assert eval_request.session_id == "session_a"
+    assert eval_request.agent_version == "1.0.0"
+
+
+def test_force_regenerate_with_evaluation_name_deletes_prior_results() -> None:
+    """Both kwargs set => prior result rows deleted before re-running."""
+    storage = _make_storage(with_evaluated_marker=True)
+    request_context = MagicMock()
+    request_context.storage = storage
+    llm_client = MagicMock()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation"
+        ".group_evaluation_runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=llm_client,
+            force_regenerate=True,
+            evaluation_name="overall_success",
+        )
+
+    # Scoped delete called exactly once with the targeted tuple.
+    storage.delete_agent_success_evaluation_results_for_session.assert_called_once_with(
+        session_id="session_a",
+        evaluation_name="overall_success",
+        agent_version="1.0.0",
+    )
+
+
+def test_force_regenerate_without_evaluation_name_does_not_delete() -> None:
+    """force_regenerate alone (no evaluator name) must NOT call the scoped delete.
+
+    Deletion is scoped to a single evaluation_name. A regenerate run that
+    re-runs every configured evaluator should leave the storage layer to
+    overwrite (or accumulate) results as it normally does, rather than
+    silently wipe rows belonging to evaluators the caller didn't target.
+    """
+    storage = _make_storage(with_evaluated_marker=True)
+    request_context = MagicMock()
+    request_context.storage = storage
+    llm_client = MagicMock()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation"
+        ".group_evaluation_runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=llm_client,
+            force_regenerate=True,
+        )
+
+    storage.delete_agent_success_evaluation_results_for_session.assert_not_called()
+    service.run.assert_called_once()
+    eval_request = service.run.call_args.args[0]
+    assert eval_request.evaluation_name_filter is None
+
+
+def test_force_regenerate_bypasses_completeness_delay_gate() -> None:
+    """force_regenerate=True must skip the delay check even for a fresh session."""
+    # Build a request just a moment old — would normally trip the delay gate.
+    storage = MagicMock()
+    storage.get_operation_state.return_value = None
+    now = int(datetime.now(UTC).timestamp())
+    fresh_request = Request(
+        request_id="req_fresh",
+        user_id="user_a",
+        session_id="session_a",
+        created_at=now,
+    )
+    storage.get_requests_by_session.return_value = [fresh_request]
+    storage.get_interactions_by_request_ids.return_value = [
+        _make_interaction("req_fresh", "user_a")
+    ]
+
+    request_context = MagicMock()
+    request_context.storage = storage
+    llm_client = MagicMock()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation"
+        ".group_evaluation_runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=llm_client,
+            force_regenerate=True,
+        )
+
+    service.run.assert_called_once()

--- a/tests/server/services/agent_success_evaluation/test_regen_jobs.py
+++ b/tests/server/services/agent_success_evaluation/test_regen_jobs.py
@@ -1,0 +1,156 @@
+"""Unit tests for RegenJobRegistry and _run_regen."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.internal_schema import SessionDescriptor
+from reflexio.server.services.agent_success_evaluation.regen_jobs import (
+    RegenJob,
+    RegenJobRegistry,
+    _run_regen,
+)
+
+
+def test_registry_create_returns_job_and_records_active():
+    reg = RegenJobRegistry()
+    job = reg.create(
+        org_id="org1", evaluation_name="overall", from_ts=0, to_ts=100, total=5
+    )
+    assert isinstance(job, RegenJob)
+    assert job.total == 5 and job.status == "running"
+    assert reg.has_active("org1", "overall")
+    assert reg.get(job.job_id) is job
+
+
+def test_registry_rejects_second_active_for_same_org_evaluator():
+    reg = RegenJobRegistry()
+    reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=0)
+    with pytest.raises(RuntimeError, match="already running"):
+        reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=0)
+
+
+def test_registry_allows_different_evaluator():
+    reg = RegenJobRegistry()
+    reg.create(org_id="o", evaluation_name="e1", from_ts=0, to_ts=1, total=0)
+    reg.create(org_id="o", evaluation_name="e2", from_ts=0, to_ts=1, total=0)
+
+
+def test_cancel_sets_event_and_status():
+    reg = RegenJobRegistry()
+    job = reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=0)
+    reg.cancel(job.job_id)
+    assert job.cancel_event.is_set()
+
+
+def test_evict_completed_older_than_drops_old_jobs():
+    reg = RegenJobRegistry()
+    job = reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=0)
+    job.status = "completed"
+    job.finished_at = time.monotonic() - 7200
+    reg.evict_completed_older_than(3600)
+    assert reg.get(job.job_id) is None
+    assert not reg.has_active("o", "e")
+
+
+def test_run_regen_processes_sessions_and_marks_completed():
+    descriptors = [
+        SessionDescriptor("u1", "s1", "v1", "src"),
+        SessionDescriptor("u1", "s2", "v1", "src"),
+    ]
+    storage = MagicMock()
+    storage.get_session_ids_in_window.return_value = descriptors
+    rc = MagicMock(storage=storage)
+    llm = MagicMock()
+    job = RegenJob(
+        job_id="j1",
+        org_id="o",
+        evaluation_name="e",
+        from_ts=0,
+        to_ts=1,
+        status="running",
+        total=2,
+    )
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation.regen_jobs.run_group_evaluation"
+    ) as runner:
+        _run_regen(job=job, request_context=rc, llm_client=llm)
+        assert runner.call_count == 2
+        first_call = runner.call_args_list[0]
+        assert first_call.kwargs["force_regenerate"] is True
+        assert first_call.kwargs["evaluation_name"] == "e"
+
+    assert job.status == "completed"
+    assert job.completed == 2
+    assert job.failed == 0
+
+
+def test_run_regen_records_failures_and_continues():
+    storage = MagicMock()
+    storage.get_session_ids_in_window.return_value = [
+        SessionDescriptor("u", "good", "v1", ""),
+        SessionDescriptor("u", "bad", "v1", ""),
+        SessionDescriptor("u", "good2", "v1", ""),
+    ]
+    rc = MagicMock(storage=storage)
+    job = RegenJob(
+        job_id="j",
+        org_id="o",
+        evaluation_name="e",
+        from_ts=0,
+        to_ts=1,
+        status="running",
+        total=3,
+    )
+
+    def runner(**kwargs):
+        if kwargs["session_id"] == "bad":
+            raise RuntimeError("LLM timeout")
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation.regen_jobs.run_group_evaluation",
+        side_effect=runner,
+    ):
+        _run_regen(job=job, request_context=rc, llm_client=MagicMock())
+
+    assert job.status == "completed"
+    assert job.completed == 2
+    assert job.failed == 1
+    assert job.failures[0].session_id == "bad"
+    assert "LLM timeout" in job.failures[0].reason
+
+
+def test_run_regen_observes_cancel_between_sessions():
+    storage = MagicMock()
+    storage.get_session_ids_in_window.return_value = [
+        SessionDescriptor("u", f"s{i}", "v1", "") for i in range(5)
+    ]
+    rc = MagicMock(storage=storage)
+    job = RegenJob(
+        job_id="j",
+        org_id="o",
+        evaluation_name="e",
+        from_ts=0,
+        to_ts=1,
+        status="running",
+        total=5,
+    )
+    call_count = {"n": 0}
+
+    def runner(**kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            job.cancel_event.set()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation.regen_jobs.run_group_evaluation",
+        side_effect=runner,
+    ):
+        _run_regen(job=job, request_context=rc, llm_client=MagicMock())
+
+    assert job.status == "cancelled"
+    assert job.completed == 2

--- a/tests/server/services/agent_success_evaluation/test_regen_jobs.py
+++ b/tests/server/services/agent_success_evaluation/test_regen_jobs.py
@@ -1,4 +1,4 @@
-"""Unit tests for RegenJobRegistry and _run_regen."""
+"""Unit tests for RegenJobRegistry and run_regen."""
 
 from __future__ import annotations
 
@@ -11,7 +11,7 @@ from reflexio.models.api_schema.internal_schema import SessionDescriptor
 from reflexio.server.services.agent_success_evaluation.regen_jobs import (
     RegenJob,
     RegenJobRegistry,
-    _run_regen,
+    run_regen,
 )
 
 
@@ -78,7 +78,7 @@ def test_run_regen_processes_sessions_and_marks_completed():
     with patch(
         "reflexio.server.services.agent_success_evaluation.regen_jobs.run_group_evaluation"
     ) as runner:
-        _run_regen(job=job, request_context=rc, llm_client=llm)
+        run_regen(job=job, request_context=rc, llm_client=llm)
         assert runner.call_count == 2
         first_call = runner.call_args_list[0]
         assert first_call.kwargs["force_regenerate"] is True
@@ -115,7 +115,7 @@ def test_run_regen_records_failures_and_continues():
         "reflexio.server.services.agent_success_evaluation.regen_jobs.run_group_evaluation",
         side_effect=runner,
     ):
-        _run_regen(job=job, request_context=rc, llm_client=MagicMock())
+        run_regen(job=job, request_context=rc, llm_client=MagicMock())
 
     assert job.status == "completed"
     assert job.completed == 2
@@ -150,7 +150,7 @@ def test_run_regen_observes_cancel_between_sessions():
         "reflexio.server.services.agent_success_evaluation.regen_jobs.run_group_evaluation",
         side_effect=runner,
     ):
-        _run_regen(job=job, request_context=rc, llm_client=MagicMock())
+        run_regen(job=job, request_context=rc, llm_client=MagicMock())
 
     assert job.status == "cancelled"
     assert job.completed == 2

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -1,0 +1,89 @@
+"""Contract tests for get_session_ids_in_window across storage backends.
+
+This file defines its own parametrized ``storage`` fixture (shadowing the
+conftest one) so the new method is exercised against BOTH SQLite and
+Disk backends without enrolling pre-existing contract tests against the
+Disk backend (which currently has unrelated failures in retention and
+stall_state).
+"""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.internal_schema import SessionDescriptor
+from reflexio.models.api_schema.service_schemas import (
+    Request,
+)
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(params=["sqlite", "disk"])
+def storage(request: pytest.FixtureRequest) -> Generator[BaseStorage]:
+    """Yield a fresh, isolated storage instance for each backend."""
+    backend = request.param
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        if backend == "sqlite":
+            from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+            with patch.object(
+                SQLiteStorage, "_get_embedding", return_value=[0.0] * 512
+            ):
+                yield SQLiteStorage(
+                    org_id="contract_test_session_window",
+                    db_path=f"{temp_dir}/reflexio.db",
+                )
+        elif backend == "disk":
+            from reflexio.server.services.storage.disk_storage import DiskStorage
+
+            yield DiskStorage(
+                org_id="contract_test_session_window", base_dir=temp_dir
+            )
+
+
+def _seed_request(storage: BaseStorage, user_id: str, session_id: str, ts: int) -> str:
+    """Insert one Request at ``ts`` and return its request_id."""
+    req = Request(
+        request_id=f"req_{session_id}_{ts}",
+        user_id=user_id,
+        created_at=ts,
+        source="test",
+        agent_version="v1",
+        session_id=session_id,
+    )
+    storage.add_request(req)
+    return req.request_id
+
+
+def test_returns_distinct_sessions_in_window(storage: BaseStorage) -> None:
+    _seed_request(storage, "u1", "s1", ts=1000)
+    _seed_request(storage, "u1", "s1", ts=1005)
+    _seed_request(storage, "u2", "s2", ts=2000)
+    _seed_request(storage, "u3", "s3", ts=9999)
+
+    out = storage.get_session_ids_in_window(from_ts=500, to_ts=5000)
+
+    assert isinstance(out, list)
+    assert all(isinstance(d, SessionDescriptor) for d in out)
+    session_ids = {d.session_id for d in out}
+    assert session_ids == {"s1", "s2"}
+    assert sum(1 for d in out if d.session_id == "s1") == 1
+
+
+def test_empty_window_returns_empty_list(storage: BaseStorage) -> None:
+    out = storage.get_session_ids_in_window(from_ts=0, to_ts=1)
+    assert out == []
+
+
+def test_window_boundaries_are_inclusive(storage: BaseStorage) -> None:
+    _seed_request(storage, "u1", "edge_low", ts=100)
+    _seed_request(storage, "u1", "edge_high", ts=200)
+    out = storage.get_session_ids_in_window(from_ts=100, to_ts=200)
+    assert {d.session_id for d in out} == {"edge_low", "edge_high"}

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -43,9 +43,7 @@ def storage(request: pytest.FixtureRequest) -> Generator[BaseStorage]:
         elif backend == "disk":
             from reflexio.server.services.storage.disk_storage import DiskStorage
 
-            yield DiskStorage(
-                org_id="contract_test_session_window", base_dir=temp_dir
-            )
+            yield DiskStorage(org_id="contract_test_session_window", base_dir=temp_dir)
 
 
 def _seed_request(storage: BaseStorage, user_id: str, session_id: str, ts: int) -> str:
@@ -76,6 +74,12 @@ def test_returns_distinct_sessions_in_window(storage: BaseStorage) -> None:
     assert session_ids == {"s1", "s2"}
     assert sum(1 for d in out if d.session_id == "s1") == 1
 
+    # Verify full descriptor identity for a seeded row, not just session_id.
+    expected_s1 = SessionDescriptor(
+        user_id="u1", session_id="s1", agent_version="v1", source="test"
+    )
+    assert expected_s1 in out
+
 
 def test_empty_window_returns_empty_list(storage: BaseStorage) -> None:
     out = storage.get_session_ids_in_window(from_ts=0, to_ts=1)
@@ -87,3 +91,50 @@ def test_window_boundaries_are_inclusive(storage: BaseStorage) -> None:
     _seed_request(storage, "u1", "edge_high", ts=200)
     out = storage.get_session_ids_in_window(from_ts=100, to_ts=200)
     assert {d.session_id for d in out} == {"edge_low", "edge_high"}
+
+
+def test_null_session_excluded(storage: BaseStorage) -> None:
+    """Requests with session_id=None must be excluded from the result."""
+    _seed_request(storage, "u1", "s1", ts=1000)
+    req = Request(
+        request_id="req_null",
+        user_id="u1",
+        created_at=1000,
+        source="test",
+        agent_version="v1",
+        session_id=None,
+    )
+    storage.add_request(req)
+
+    out = storage.get_session_ids_in_window(from_ts=0, to_ts=5000)
+    assert {d.session_id for d in out} == {"s1"}
+
+
+def test_distinct_agent_versions_split_into_separate_descriptors(
+    storage: BaseStorage,
+) -> None:
+    """Two requests with same (user_id, session_id) but different agent_version produce two descriptors."""
+    storage.add_request(
+        Request(
+            request_id="r1",
+            user_id="u1",
+            created_at=1000,
+            source="test",
+            agent_version="v1",
+            session_id="s1",
+        )
+    )
+    storage.add_request(
+        Request(
+            request_id="r2",
+            user_id="u1",
+            created_at=1100,
+            source="test",
+            agent_version="v2",
+            session_id="s1",
+        )
+    )
+
+    out = storage.get_session_ids_in_window(from_ts=0, to_ts=5000)
+    versions = {d.agent_version for d in out if d.session_id == "s1"}
+    assert versions == {"v1", "v2"}

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -17,6 +17,7 @@ import pytest
 
 from reflexio.models.api_schema.internal_schema import SessionDescriptor
 from reflexio.models.api_schema.service_schemas import (
+    AgentSuccessEvaluationResult,
     Request,
 )
 from reflexio.server.services.storage.storage_base import BaseStorage
@@ -138,3 +139,63 @@ def test_distinct_agent_versions_split_into_separate_descriptors(
     out = storage.get_session_ids_in_window(from_ts=0, to_ts=5000)
     versions = {d.agent_version for d in out if d.session_id == "s1"}
     assert versions == {"v1", "v2"}
+
+
+def _seed_eval_result(
+    storage: BaseStorage,
+    session_id: str,
+    evaluation_name: str,
+    agent_version: str = "v1",
+) -> None:
+    """Save one ``AgentSuccessEvaluationResult`` row with minimal fields set."""
+    result = AgentSuccessEvaluationResult(
+        session_id=session_id,
+        agent_version=agent_version,
+        evaluation_name=evaluation_name,
+        is_success=True,
+        failure_type=None,
+        failure_reason=None,
+        regular_vs_shadow=None,
+        number_of_correction_per_session=0,
+        user_turns_to_resolution=None,
+        is_escalated=False,
+        embedding=[],
+        created_at=1000,
+    )
+    storage.save_agent_success_evaluation_results([result])
+
+
+def test_delete_scoped_to_session_and_name(storage: BaseStorage) -> None:
+    _seed_eval_result(storage, "s1", "overall_success")
+    _seed_eval_result(storage, "s1", "safety")
+    _seed_eval_result(storage, "s2", "overall_success")
+
+    n = storage.delete_agent_success_evaluation_results_for_session(
+        session_id="s1", evaluation_name="overall_success", agent_version="v1"
+    )
+
+    assert n == 1
+    remaining = storage.get_agent_success_evaluation_results(limit=100)
+    sessions_and_names = {(r.session_id, r.evaluation_name) for r in remaining}
+    assert sessions_and_names == {("s1", "safety"), ("s2", "overall_success")}
+
+
+def test_delete_unknown_session_returns_zero(storage: BaseStorage) -> None:
+    n = storage.delete_agent_success_evaluation_results_for_session(
+        session_id="does_not_exist",
+        evaluation_name="overall_success",
+        agent_version="v1",
+    )
+    assert n == 0
+
+
+def test_delete_respects_agent_version_scope(storage: BaseStorage) -> None:
+    _seed_eval_result(storage, "s1", "overall_success", agent_version="v1")
+    _seed_eval_result(storage, "s1", "overall_success", agent_version="v2")
+    n = storage.delete_agent_success_evaluation_results_for_session(
+        session_id="s1", evaluation_name="overall_success", agent_version="v1"
+    )
+    assert n == 1
+    remaining = storage.get_agent_success_evaluation_results(limit=100)
+    versions = {r.agent_version for r in remaining if r.session_id == "s1"}
+    assert versions == {"v2"}


### PR DESCRIPTION
## Summary

Backend half of the **Evaluation rubric editor + Regenerate** feature, stacked on the consolidated PR (#91). Adds the storage primitives, service-layer flags, in-memory regen job registry/worker, and three new HTTP endpoints that the enterprise frontend (paired PR) consumes.

**Stacks on**: ReflexioAI/reflexio#91. Do not merge this PR into `main` until #91 lands.

**Diffstat**: 19 files, +1512 / −30

## What's in this PR, by commit

| Commit | Topic |
|---|---|
| `b630697` + `e33ff58` | `get_session_ids_in_window(from_ts, to_ts)` storage primitive; dedupes by the 4-tuple `(user_id, session_id, agent_version, source)` for deterministic cross-backend behavior |
| `2b9d2b9` | `delete_agent_success_evaluation_results_for_session(session_id, evaluation_name, agent_version)` for clearing prior results before regenerating |
| `0672a5a` | `force_regenerate` + `evaluation_name` kwargs on `run_group_evaluation`. Bypasses operation-state + completeness gates and filters which evaluator runs |
| `9eb05bf` | `RegenJobRegistry` + `run_regen` worker. Process-local in-memory dict; one job per (org, evaluator); 1h TTL eviction |
| `9a43791` | `POST/GET/DELETE /api/evaluations/regenerate{/<job_id>}`. Background-thread orchestration; org-scoped job ownership |
| `8288d5d` | Fix-up: TOCTOU race on `has_active`→`create` returns 409 not 500; `started_at`/`finished_at` switched to wall clock; `_run_regen` renamed `run_regen` (no longer private) |

## Highlights from the review loop

Two reviewer rounds caught real bugs before this got published:

- **Pre-fix:** SQLite `GROUP BY user_id, session_id` without aggregating `agent_version`/`source` was implementation-defined; would pick different rows than Disk. **Fix:** `SELECT DISTINCT` over the full 4-tuple.
- **Pre-fix:** TOCTOU on `has_active(...)` → `create(...)` could return 500 instead of 409 under concurrent POSTs. **Fix:** removed the precheck, rely on `create`'s lock-protected duplicate guard.

## Test plan

- [x] `uv run pytest tests/server/services/agent_success_evaluation/ tests/server/services/storage/test_session_window_contract.py tests/server/api_endpoints/test_evaluations_regenerate_api.py tests/models/test_regenerate_schema.py -o 'addopts=' -q` — all pass
- [x] `uv run ruff check reflexio/` — clean (2 pre-existing warnings in `stall_state_api.py` unrelated to this work)
- [x] `uv run pyright reflexio/server/api.py reflexio/server/services/agent_success_evaluation/regen_jobs.py reflexio/models/api_schema/eval_overview_schema.py` — 0 errors
- [ ] Live agent-browser e2e walkthrough on the paired enterprise PR
