### PR TITLE
feat(eval): direct second-pass shadow grading + hero shadow_rate/delta_pp

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -358,6 +358,8 @@ class AgentSuccessEvaluationResult(BaseModel):
     number_of_correction_per_session: int = 0
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
+    shadow_is_success: bool | None = None
+    shadow_is_escalated: bool | None = None
     embedding: EmbeddingVector = []
 
 

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -653,6 +653,10 @@ class Config(BaseModel):
             "deduplicates internally."
         ),
     )
+    # When True, run a direct second-pass LLM grade on shadow_content alongside
+    # the combined regular-vs-shadow comparison, populating
+    # AgentSuccessEvaluationResult.shadow_is_success/shadow_is_escalated.
+    shadow_mode_enabled: bool = False
 
     @model_validator(mode="before")
     @classmethod

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -653,11 +653,6 @@ class Config(BaseModel):
             "deduplicates internally."
         ),
     )
-    # When True, run a direct second-pass LLM grade on shadow_content alongside
-    # the combined regular-vs-shadow comparison, populating
-    # AgentSuccessEvaluationResult.shadow_is_success/shadow_is_escalated.
-    shadow_mode_enabled: bool = False
-
     @model_validator(mode="before")
     @classmethod
     def _migrate_field_names(cls, data: Any) -> Any:

--- a/reflexio/server/api_endpoints/stall_state_api.py
+++ b/reflexio/server/api_endpoints/stall_state_api.py
@@ -12,13 +12,14 @@ from reflexio.server.api_endpoints.request_context import (
     RequestContext,
     get_request_context,
 )
+from reflexio.server.services.storage.storage_base import BaseStorage
 
 router = APIRouter(tags=["stall_state"])
 
 _UNSUPPORTED_DETAIL = "Stall state is not supported by the configured storage backend"
 
 
-def _require_storage(ctx: RequestContext):
+def _require_storage(ctx: RequestContext) -> BaseStorage:
     """Return ``ctx.storage`` or raise 503 when storage isn't configured.
 
     Cloud-mode deployments may run with ``ctx.storage is None`` until the
@@ -34,9 +35,8 @@ def _require_storage(ctx: RequestContext):
     Raises:
         HTTPException: 503 when storage is not configured.
     """
-    if not ctx.is_storage_configured():
+    if not ctx.is_storage_configured() or ctx.storage is None:
         raise HTTPException(status_code=503, detail="Storage not configured")
-    assert ctx.storage is not None  # narrows BaseStorage | None -> BaseStorage
     return ctx.storage
 
 

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
@@ -38,6 +38,7 @@ def construct_agent_success_evaluation_messages_from_sessions(
     success_definition_prompt: str,
     tool_can_use: str,
     metadata_definition_prompt: str | None = None,
+    use_shadow: bool = False,
 ) -> list[dict]:
     """
     Construct LLM messages for agent success evaluation from request interaction groups.
@@ -52,6 +53,9 @@ def construct_agent_success_evaluation_messages_from_sessions(
         success_definition_prompt: Definition of what constitutes agent success
         tool_can_use: Description of tools available to the agent
         metadata_definition_prompt: Optional additional metadata definition
+        use_shadow: When True, render assistant turns using shadow_content instead of
+            content, enabling a symmetric second-pass grade of the shadow response.
+            Defaults to False so all existing callers are unaffected.
 
     Returns:
         list[dict]: List of messages ready for agent success evaluation
@@ -66,7 +70,8 @@ def construct_agent_success_evaluation_messages_from_sessions(
             "tool_can_use": tool_can_use,
             "metadata_definition_prompt": metadata_definition_prompt or "",
             "interactions": format_sessions_to_history_string(
-                request_interaction_data_models
+                request_interaction_data_models,
+                use_shadow=use_shadow,
             ),
         },
     )

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
@@ -183,17 +183,34 @@ class AgentSuccessEvaluator:
         )
 
         # Check if any interaction has shadow content
-        if has_shadow_content(all_interactions):
-            return self._evaluate_with_shadow_comparison(
+        shadow_present = has_shadow_content(all_interactions)
+        shadow_grade_enabled = (
+            root_config is not None
+            and getattr(root_config, "shadow_mode_enabled", False)
+            and shadow_present
+        )
+
+        if shadow_present:
+            # Existing combined-comparison path still runs (populates regular_vs_shadow)
+            result = self._evaluate_with_shadow_comparison(
+                request_interaction_data_models,
+                tool_can_use_str,
+            )
+        else:
+            # No shadow content — use existing single evaluation prompt
+            result = self._evaluate_regular(
                 request_interaction_data_models,
                 tool_can_use_str,
             )
 
-        # No shadow content - use existing evaluation prompt
-        return self._evaluate_regular(
-            request_interaction_data_models,
-            tool_can_use_str,
-        )
+        if shadow_grade_enabled and result is not None:
+            s_is_success, s_is_escalated = self._run_direct_shadow_grade(
+                request_interaction_data_models, tool_can_use_str
+            )
+            result.shadow_is_success = s_is_success
+            result.shadow_is_escalated = s_is_escalated
+
+        return result
 
     def _evaluate_regular(
         self,
@@ -271,6 +288,79 @@ class AgentSuccessEvaluator:
             evaluation_response=evaluation_response,
             request_interaction_data_models=request_interaction_data_models,
         )
+
+    def _run_direct_shadow_grade(
+        self,
+        request_interaction_data_models: list[RequestInteractionDataModel],
+        tool_can_use_str: str,
+    ) -> tuple[bool | None, bool | None]:
+        """Run a second-pass grade against shadow_content using the same rubric.
+
+        Reuses the agent_success_evaluation/v1.0.0 prompt — but with assistant
+        content substituted for shadow_content via the ``use_shadow=True``
+        flag threaded through ``construct_agent_success_evaluation_messages_from_sessions``.
+
+        Returns the outcome tuple ``(is_success, is_escalated)``. Returns
+        ``(None, None)`` when the underlying LLM call fails — callers
+        should not surface a failed shadow grade as ``False``.
+
+        Args:
+            request_interaction_data_models: All request interaction data models in the group
+            tool_can_use_str: Formatted string of available tools
+
+        Returns:
+            tuple[bool | None, bool | None]: ``(is_success, is_escalated)`` outcome pair,
+                or ``(None, None)`` on LLM failure.
+        """
+        messages = construct_agent_success_evaluation_messages_from_sessions(
+            prompt_manager=self.request_context.prompt_manager,
+            request_interaction_data_models=request_interaction_data_models,
+            agent_context_prompt=self.agent_context,
+            success_definition_prompt=(
+                self.config.success_definition_prompt.strip()
+                if self.config.success_definition_prompt
+                else ""
+            ),
+            tool_can_use=tool_can_use_str,
+            metadata_definition_prompt=(
+                self.config.metadata_definition_prompt.strip()
+                if self.config.metadata_definition_prompt
+                else None
+            ),
+            use_shadow=True,
+        )
+
+        log_llm_messages(logger, "Shadow second-pass evaluation", messages)
+
+        try:
+            evaluation_response = self.client.generate_chat_response(
+                messages=messages,
+                model=self.default_evaluate_model_name,
+                response_format=AgentSuccessEvaluationOutput,
+            )
+        except Exception:
+            logger.exception("Shadow second-pass grade failed; leaving outcome None")
+            return (None, None)
+
+        if not evaluation_response:
+            logger.info(
+                "No shadow evaluation can be generated for session %s",
+                self.service_config.session_id,
+            )
+            return (None, None)
+
+        log_model_response(
+            logger, "Shadow second-pass evaluation response", evaluation_response
+        )
+
+        if not isinstance(evaluation_response, AgentSuccessEvaluationOutput):
+            logger.warning(
+                "Unexpected response type from shadow evaluation LLM: %s",
+                type(evaluation_response),
+            )
+            return (None, None)
+
+        return (evaluation_response.is_success, evaluation_response.is_escalated)
 
     def _evaluate_with_shadow_comparison(
         self,

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
@@ -186,7 +186,7 @@ class AgentSuccessEvaluator:
         shadow_present = has_shadow_content(all_interactions)
         shadow_grade_enabled = (
             root_config is not None
-            and getattr(root_config, "shadow_mode_enabled", False)
+            and root_config.shadow_mode_enabled
             and shadow_present
         )
 
@@ -331,6 +331,14 @@ class AgentSuccessEvaluator:
         )
 
         log_llm_messages(logger, "Shadow second-pass evaluation", messages)
+
+        logger.info(
+            "event=agent_success_eval_shadow_llm_start session_id=%s evaluation_name=%s "
+            "model=%s",
+            self.service_config.session_id,
+            self.config.evaluation_name,
+            self.default_evaluate_model_name,
+        )
 
         try:
             evaluation_response = self.client.generate_chat_response(

--- a/reflexio/server/services/evaluation_overview/hero_state.py
+++ b/reflexio/server/services/evaluation_overview/hero_state.py
@@ -39,8 +39,12 @@ def compute_hero_state(
         shadow_enabled (bool): Value of `Config.shadow_mode_enabled`.
         days_since_first_eval (int | None): Wall-clock days since the first
             ever evaluated session for this org. None when no results exist.
-        n_shadow_in_window (int): Count of sessions with non-empty shadow
-            content inside the trend window (last 8 weeks).
+        n_shadow_in_window (int): Count of evaluation results with a non-null
+            shadow_is_success grade inside the trend window. Caller is
+            responsible for filtering; this function only consumes the count.
+            Why graded-only: prevents the FULL gate from tripping mid-window-
+            flag-flip when sessions exist with shadow_content but no shadow
+            grade.
         total_results (int): Total AgentSuccessEvaluationResult rows in the
             trend window (used only to differentiate EMPTY from SHADOW_OFF).
 
@@ -51,7 +55,10 @@ def compute_hero_state(
     if total_results == 0:
         return HeroState.EMPTY
     if not shadow_enabled:
-        if days_since_first_eval is not None and days_since_first_eval >= _SHADOW_OFF_MIN_DAYS:
+        if (
+            days_since_first_eval is not None
+            and days_since_first_eval >= _SHADOW_OFF_MIN_DAYS
+        ):
             return HeroState.SHADOW_OFF
         # <7 days since first eval AND shadow off → still onboarding;
         # render as EMPTY so the frontend shows onboarding rather than a

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -71,7 +71,7 @@ class EvaluationOverviewService:
         prev_from = max(0, prev_to - _WEEK_SECONDS)
         results_prev = [r for r in all_results if prev_from <= r.created_at < prev_to]
 
-        hero = self._build_hero(request, results)
+        hero = self._build_hero(results)
         tiles = self._build_tiles(results, results_prev)
         attribution = self._build_attribution(results)
         distribution = self._build_distribution(results, results_prev)
@@ -89,9 +89,35 @@ class EvaluationOverviewService:
 
     # --- private helpers ---
 
+    @staticmethod
+    def _compute_shadow_rate_and_delta(
+        results: list[AgentSuccessEvaluationResult],
+        regular_rate: float,
+    ) -> tuple[float | None, float | None]:
+        """Compute shadow_success_rate_pp and delta_pp from already-loaded results.
+
+        Returns (None, None) when no row in ``results`` has a non-null
+        shadow_is_success — i.e. shadow mode was off, no shadow_content was
+        published, or the shadow grade failed for every session in the window.
+
+        Args:
+            results: Evaluation results for the current window.
+            regular_rate: The regular success rate in percentage points (0–100).
+
+        Returns:
+            A tuple of (shadow_rate_pp, delta_pp), both None when no shadow
+            grades are present.
+        """
+        graded = [r for r in results if r.shadow_is_success is not None]
+        if not graded:
+            return (None, None)
+        shadow_rate = (
+            sum(1 for r in graded if r.shadow_is_success) / len(graded)
+        ) * 100
+        return (shadow_rate, shadow_rate - regular_rate)
+
     def _build_hero(
         self,
-        request: GetEvaluationOverviewRequest,
         results: list[AgentSuccessEvaluationResult],
     ) -> HeroBlock:
         if not results:
@@ -99,23 +125,15 @@ class EvaluationOverviewService:
         else:
             earliest = min(r.created_at for r in results)
             days_since = (int(datetime.now(UTC).timestamp()) - earliest) // 86_400
-        n_shadow = self.storage.count_sessions_with_shadow_content(  # type: ignore[attr-defined]
-            request.from_ts, request.to_ts
-        )
+        n_shadow_graded = sum(1 for r in results if r.shadow_is_success is not None)
         state = compute_hero_state(
             shadow_enabled=self.config.shadow_mode_enabled,
             days_since_first_eval=days_since,
-            n_shadow_in_window=n_shadow,
+            n_shadow_in_window=n_shadow_graded,
             total_results=len(results),
         )
         success_rate = _success_rate(results) * 100
-        # shadow_rate and delta are None until real shadow-content evaluations
-        # exist. When count_sessions_with_shadow_content > 0 AND a future
-        # storage method exposes shadow-side outcomes, populate from there.
-        # Today both stay None and the frontend renders state-1 vs state-3
-        # purely from the `state` enum.
-        shadow_rate: float | None = None
-        delta: float | None = None
+        shadow_rate, delta = self._compute_shadow_rate_and_delta(results, success_rate)
         return HeroBlock(
             state=state.value,  # type: ignore[arg-type]
             regular_success_rate_pp=success_rate,
@@ -314,14 +332,23 @@ def _weekly_buckets(
         buckets[week_start].append(r)
     out: list[HeroBucket] = []
     for ts in sorted(buckets):
-        bucket = buckets[ts]
+        week_results = buckets[ts]
+        shadow_graded = [r for r in week_results if r.shadow_is_success is not None]
+        if shadow_graded:
+            shadow_rate: float | None = sum(
+                1 for r in shadow_graded if r.shadow_is_success
+            ) / len(shadow_graded)
+            shadow_n = len(shadow_graded)
+        else:
+            shadow_rate = None
+            shadow_n = 0
         out.append(
             HeroBucket(
                 ts=ts,
-                regular_rate=_success_rate(bucket),
-                shadow_rate=None,
-                regular_n=len(bucket),
-                shadow_n=0,
+                regular_rate=_success_rate(week_results),
+                shadow_rate=shadow_rate,
+                regular_n=len(week_results),
+                shadow_n=shadow_n,
             )
         )
     return out

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -1,6 +1,6 @@
 """Aggregator that composes hero, tiles, rule attribution, and distribution.
 
-The service does four reads (results, citations, playbook stats, shadow count)
+The service does three reads (results, citations, playbook stats)
 and returns a GetEvaluationOverviewResponse. It's invoked from the FastAPI
 route handler; the storage is the same BaseStorage the rest of the server
 uses, so the same instance is reused via request_context.
@@ -50,7 +50,7 @@ class EvaluationOverviewService:
     """Builds the full /api/get_evaluation_overview payload.
 
     The service holds a storage handle and the org's current Config. Each
-    call to `run` performs the four reads and returns a fresh response.
+    call to `run` performs the three reads and returns a fresh response.
     Stateless across calls — safe to reuse the instance across requests.
     """
 

--- a/reflexio/server/services/service_utils.py
+++ b/reflexio/server/services/service_utils.py
@@ -163,7 +163,9 @@ class MessageConstructionConfig:
     user_prompt_config: PromptConfig | None = None
 
 
-def format_interactions_to_history_string(interactions: list[Interaction]) -> str:
+def format_interactions_to_history_string(
+    interactions: list[Interaction], use_shadow: bool = False
+) -> str:
     """
     Format a list of interactions into a single string representing the interaction history.
 
@@ -173,6 +175,9 @@ def format_interactions_to_history_string(interactions: list[Interaction]) -> st
 
     Args:
         interactions (list[Interaction]): List of interactions to format
+        use_shadow (bool): When True, substitute shadow_content for content on assistant
+            turns that have it. Falls back to content when shadow_content is empty (e.g.
+            user turns always have an empty shadow_content). Defaults to False.
 
     Returns:
         str: A formatted string representing the interaction history, with interactions separated by newlines.
@@ -190,20 +195,25 @@ def format_interactions_to_history_string(interactions: list[Interaction]) -> st
     """
     formatted_interactions = []
     for interaction in interactions:
+        # Resolve which content field to render, with shadow fallback
+        content = (
+            interaction.shadow_content
+            if (use_shadow and interaction.shadow_content)
+            else interaction.content
+        )
+
         # Add text content with tools_used prefix if present
-        if interaction.content:
+        if content:
             if interaction.tools_used:
                 tool_prefix = " ".join(
                     f"[used tool: {t.tool_name}({json.dumps(t.tool_data)})]"
                     for t in interaction.tools_used
                 )
                 formatted_interactions.append(
-                    f"{interaction.role}: ```{tool_prefix} {interaction.content}```"
+                    f"{interaction.role}: ```{tool_prefix} {content}```"
                 )
             else:
-                formatted_interactions.append(
-                    f"{interaction.role}: ```{interaction.content}```"
-                )
+                formatted_interactions.append(f"{interaction.role}: ```{content}```")
 
         # Add user action
         if interaction.user_action != UserActionType.NONE:
@@ -216,6 +226,7 @@ def format_interactions_to_history_string(interactions: list[Interaction]) -> st
 
 def format_sessions_to_history_string(
     sessions: list[RequestInteractionDataModel],
+    use_shadow: bool = False,
 ) -> str:
     """
     Format interactions grouped by session into a string.
@@ -226,6 +237,9 @@ def format_sessions_to_history_string(
 
     Args:
         sessions (list[RequestInteractionDataModel]): List of request interaction data models to format
+        use_shadow (bool): When True, pass use_shadow=True to the underlying
+            format_interactions_to_history_string call so assistant turns with
+            shadow_content are rendered using that field. Defaults to False.
 
     Returns:
         str: A formatted string with interactions grouped by session.
@@ -309,7 +323,9 @@ def format_sessions_to_history_string(
         all_interactions = sorted(all_interactions, key=lambda i: i.interaction_id)
 
         # Format combined interactions
-        group_interactions = format_interactions_to_history_string(all_interactions)
+        group_interactions = format_interactions_to_history_string(
+            all_interactions, use_shadow=use_shadow
+        )
 
         # Combine header and interactions
         formatted_groups.append(f"{group_header}\n{group_interactions}")

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -494,6 +494,16 @@ def _row_to_eval_result(row: sqlite3.Row) -> AgentSuccessEvaluationResult:
         number_of_correction_per_session=d.get("number_of_correction_per_session") or 0,
         user_turns_to_resolution=d.get("user_turns_to_resolution"),
         is_escalated=bool(d.get("is_escalated", False)),
+        shadow_is_success=(
+            bool(d["shadow_is_success"])
+            if d.get("shadow_is_success") is not None
+            else None
+        ),
+        shadow_is_escalated=(
+            bool(d["shadow_is_escalated"])
+            if d.get("shadow_is_escalated") is not None
+            else None
+        ),
         embedding=[],
     )
 
@@ -652,6 +662,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_expanded_terms()
         self._migrate_agentic_signals()
         self._migrate_agent_playbook_source_windows()
+        self._migrate_evaluation_result_shadow_columns()
         init_stall_state_table(self.conn)
         return True
 
@@ -1136,6 +1147,36 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         )
         self.conn.commit()
 
+    def _migrate_evaluation_result_shadow_columns(self) -> None:
+        """Add shadow_is_success and shadow_is_escalated columns to evaluation results."""
+        cols = {
+            row["name"]
+            for row in self.conn.execute(
+                "PRAGMA table_info(agent_success_evaluation_result)"
+            ).fetchall()
+        }
+        if not cols:
+            return
+        if "shadow_is_success" not in cols:
+            with self._lock:
+                self.conn.execute(
+                    "ALTER TABLE agent_success_evaluation_result "
+                    "ADD COLUMN shadow_is_success INTEGER"
+                )
+                logger.info(
+                    "Added shadow_is_success column to agent_success_evaluation_result"
+                )
+        if "shadow_is_escalated" not in cols:
+            with self._lock:
+                self.conn.execute(
+                    "ALTER TABLE agent_success_evaluation_result "
+                    "ADD COLUMN shadow_is_escalated INTEGER"
+                )
+                logger.info(
+                    "Added shadow_is_escalated column to agent_success_evaluation_result"
+                )
+        self.conn.commit()
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
@@ -1555,6 +1596,8 @@ CREATE TABLE IF NOT EXISTS agent_success_evaluation_result (
     number_of_correction_per_session INTEGER NOT NULL DEFAULT 0,
     user_turns_to_resolution INTEGER,
     is_escalated INTEGER NOT NULL DEFAULT 0,
+    shadow_is_success INTEGER,
+    shadow_is_escalated INTEGER,
     embedding TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_eval_agent_version ON agent_success_evaluation_result(agent_version);

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -30,7 +30,6 @@ class OperationMixin:
     _fetchone: Any
     _fetchall: Any
     _current_timestamp: Any
-    get_operation_state: Any
 
     # ------------------------------------------------------------------
     # Operation State methods

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1293,8 +1293,9 @@ class PlaybookMixin:
                    (session_id, agent_version, evaluation_name, is_success,
                     failure_type, failure_reason, regular_vs_shadow,
                     number_of_correction_per_session, user_turns_to_resolution,
-                    is_escalated, embedding, created_at)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    is_escalated, embedding, created_at,
+                    shadow_is_success, shadow_is_escalated)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     result.session_id,
                     result.agent_version,
@@ -1310,6 +1311,12 @@ class PlaybookMixin:
                     int(result.is_escalated),
                     _json_dumps(result.embedding) if result.embedding else None,
                     created_at_iso,
+                    int(result.shadow_is_success)
+                    if result.shadow_is_success is not None
+                    else None,
+                    int(result.shadow_is_escalated)
+                    if result.shadow_is_escalated is not None
+                    else None,
                 ),
             )
 

--- a/tests/client/test_stall_state_client.py
+++ b/tests/client/test_stall_state_client.py
@@ -21,11 +21,11 @@ from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 @pytest.fixture()
 def storage():
     """A real SQLiteStorage instance in a temporary directory."""
-    with tempfile.TemporaryDirectory() as tmp:
-        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
-            yield SQLiteStorage(
-                org_id="test-stall-client", db_path=f"{tmp}/reflexio.db"
-            )
+    with (
+        tempfile.TemporaryDirectory() as tmp,
+        patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
+    ):
+        yield SQLiteStorage(org_id="test-stall-client", db_path=f"{tmp}/reflexio.db")
 
 
 @pytest.fixture()

--- a/tests/models/test_agent_success_evaluation_result.py
+++ b/tests/models/test_agent_success_evaluation_result.py
@@ -1,0 +1,29 @@
+from reflexio.models.api_schema.domain import AgentSuccessEvaluationResult
+
+
+def test_shadow_fields_default_to_none():
+    r = AgentSuccessEvaluationResult(
+        session_id="s",
+        agent_version="v",
+        evaluation_name="overall_success",
+        is_success=True,
+    )
+    assert r.shadow_is_success is None
+    assert r.shadow_is_escalated is None
+
+
+def test_shadow_fields_round_trip_through_model_dump():
+    r = AgentSuccessEvaluationResult(
+        session_id="s",
+        agent_version="v",
+        evaluation_name="overall_success",
+        is_success=True,
+        shadow_is_success=False,
+        shadow_is_escalated=True,
+    )
+    payload = r.model_dump()
+    assert payload["shadow_is_success"] is False
+    assert payload["shadow_is_escalated"] is True
+    r2 = AgentSuccessEvaluationResult(**payload)
+    assert r2.shadow_is_success is False
+    assert r2.shadow_is_escalated is True

--- a/tests/server/api_endpoints/test_stall_state_api.py
+++ b/tests/server/api_endpoints/test_stall_state_api.py
@@ -20,9 +20,11 @@ from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 @pytest.fixture()
 def storage():
     """A real SQLiteStorage instance in a temporary directory."""
-    with tempfile.TemporaryDirectory() as tmp:
-        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
-            yield SQLiteStorage(org_id="test-stall", db_path=f"{tmp}/reflexio.db")
+    with (
+        tempfile.TemporaryDirectory() as tmp,
+        patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
+    ):
+        yield SQLiteStorage(org_id="test-stall", db_path=f"{tmp}/reflexio.db")
 
 
 @pytest.fixture()

--- a/tests/server/services/agent_success_evaluation/test_shadow_grading_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_shadow_grading_integration.py
@@ -15,7 +15,7 @@ Fixture adaptations vs the plan template:
 """
 
 import tempfile
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -195,6 +195,82 @@ def test_shadow_grade_skipped_when_flag_off(temp_dir):
         results = evaluator.run()
 
     assert not mock_shadow.called
+    assert len(results) == 1
+    result = results[0]
+    assert result.shadow_is_success is None
+    assert result.shadow_is_escalated is None
+
+
+def test_shadow_grade_calls_use_shadow_true_and_populates_result(temp_dir):
+    """_run_direct_shadow_grade body executes and threads use_shadow=True through."""
+    evaluator = _make_evaluator(temp_dir, shadow_mode_enabled=True, with_shadow=True)
+
+    captured: dict[str, object] = {}
+
+    real_construct = (
+        "reflexio.server.services.agent_success_evaluation"
+        ".agent_success_evaluator"
+        ".construct_agent_success_evaluation_messages_from_sessions"
+    )
+
+    def capture_construct(*args: object, **kwargs: object) -> list[dict[str, str]]:
+        captured["use_shadow"] = kwargs.get("use_shadow")
+        return [{"role": "user", "content": "test"}]
+
+    # call 1 — _evaluate_with_shadow_comparison (uses AgentSuccessEvaluationWithComparisonOutput)
+    # call 2 — _run_direct_shadow_grade (uses AgentSuccessEvaluationOutput)
+    valid_comparison = AgentSuccessEvaluationWithComparisonOutput(
+        is_success=True,
+        better_request="1",
+        is_significantly_better=False,
+    )
+    valid_output = AgentSuccessEvaluationOutput(is_success=True, is_escalated=False)
+    call_count: dict[str, int] = {"n": 0}
+
+    def llm_side_effect(*args: object, **kwargs: object) -> object:
+        call_count["n"] += 1
+        response_format = kwargs.get("response_format")
+        if response_format is AgentSuccessEvaluationWithComparisonOutput:
+            return valid_comparison
+        return valid_output
+
+    evaluator.client.generate_chat_response = Mock(side_effect=llm_side_effect)
+
+    with patch(real_construct, side_effect=capture_construct):
+        results = evaluator.run()
+
+    assert captured.get("use_shadow") is True
+    assert len(results) == 1
+    result = results[0]
+    assert result.shadow_is_success is True
+    assert result.shadow_is_escalated is False
+
+
+def test_shadow_grade_returns_none_when_llm_raises(temp_dir):
+    """_run_direct_shadow_grade returns (None, None) when the LLM call raises."""
+    evaluator = _make_evaluator(temp_dir, shadow_mode_enabled=True, with_shadow=True)
+
+    valid_comparison = AgentSuccessEvaluationWithComparisonOutput(
+        is_success=True,
+        better_request="1",
+        is_significantly_better=False,
+    )
+    call_count: dict[str, int] = {"n": 0}
+
+    def side_effect(*args: object, **kwargs: object) -> object:
+        call_count["n"] += 1
+        response_format = kwargs.get("response_format")
+        if response_format is AgentSuccessEvaluationWithComparisonOutput:
+            # First call — regular combined comparison — succeeds
+            return valid_comparison
+        # Second call — shadow grade — fails
+        raise RuntimeError("simulated provider failure")
+
+    evaluator.client.generate_chat_response = Mock(side_effect=side_effect)
+
+    results = evaluator.run()
+
+    assert results is not None
     assert len(results) == 1
     result = results[0]
     assert result.shadow_is_success is None

--- a/tests/server/services/agent_success_evaluation/test_shadow_grading_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_shadow_grading_integration.py
@@ -1,0 +1,201 @@
+"""Integration tests for direct shadow-content grading.
+
+Verifies the evaluator runs a second-pass LLM call when shadow_mode_enabled
+is True and the session has shadow_content, and populates the new outcome
+fields without disturbing the regular evaluation path.
+
+Fixture adaptations vs the plan template:
+- AgentSuccessEvaluator.__init__ requires positional args ``extractor_config``
+  (AgentSuccessConfig) and ``service_config`` (AgentSuccessGenerationServiceConfig)
+  plus ``agent_context: str``.  A real RequestContext is constructed with a
+  temp dir and a mocked storage layer (same pattern as test_agent_success_evaluator.py).
+- Config.shadow_mode_enabled is a plain bool field on Config — no setattr tricks needed.
+- AgentSuccessEvaluator.run() is the public entrypoint; the shadow grade fires
+  inside _evaluate_group which run() calls.
+"""
+
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
+from reflexio.models.api_schema.service_schemas import Interaction, Request
+from reflexio.models.config_schema import AgentSuccessConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_constants import (
+    AgentSuccessEvaluationOutput,
+    AgentSuccessEvaluationWithComparisonOutput,
+)
+from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service import (
+    AgentSuccessGenerationServiceConfig,
+)
+from reflexio.server.services.agent_success_evaluation.agent_success_evaluator import (
+    AgentSuccessEvaluator,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request_with_shadow(
+    *, with_shadow: bool
+) -> list[RequestInteractionDataModel]:
+    """Build a single-session request list, optionally with shadow_content on the assistant turn."""
+    return [
+        RequestInteractionDataModel(
+            session_id="s1",
+            request=Request(request_id="r1", user_id="u1", created_at=1000),
+            interactions=[
+                Interaction(
+                    interaction_id=1,
+                    user_id="u1",
+                    request_id="r1",
+                    role="user",
+                    content="hi",
+                    created_at=1000,
+                ),
+                Interaction(
+                    interaction_id=2,
+                    user_id="u1",
+                    request_id="r1",
+                    role="assistant",
+                    content="hello (regular)",
+                    shadow_content="hello (shadow)" if with_shadow else "",
+                    created_at=1001,
+                ),
+            ],
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+def _make_evaluator(
+    temp_dir: str,
+    *,
+    shadow_mode_enabled: bool = True,
+    with_shadow: bool = True,
+) -> AgentSuccessEvaluator:
+    """
+    Build a fully-wired AgentSuccessEvaluator.
+
+    The RequestContext uses a real temp dir (so the configurator initialises)
+    but its storage is replaced with a MagicMock so no DB I/O happens.
+    The LLM client is mocked to return a successful evaluation for both the
+    regular path and (when needed) the combined comparison path.
+    """
+    request_interaction_data_models = _make_request_with_shadow(with_shadow=with_shadow)
+
+    context = RequestContext(org_id="test_org_shadow", storage_base_dir=temp_dir)
+    context.storage = MagicMock()
+    context.storage.count_user_playbooks_by_session.return_value = 0
+
+    # Patch get_config so it returns a Config with shadow_mode_enabled as requested
+    mock_config = MagicMock()
+    mock_config.shadow_mode_enabled = shadow_mode_enabled
+    mock_config.tool_can_use = None
+    context.configurator = MagicMock()
+    context.configurator.get_config.return_value = mock_config
+
+    extractor_config = AgentSuccessConfig(
+        evaluation_name="overall_success",
+        success_definition_prompt="any non-empty answer is success",
+    )
+
+    service_config = AgentSuccessGenerationServiceConfig(
+        agent_version="v1",
+        session_id="s1",
+        request_interaction_data_models=request_interaction_data_models,
+        source="test",
+    )
+
+    # The mock LLM client returns valid outputs for all three call types
+    mock_client = MagicMock(spec=LiteLLMClient)
+    mock_client.generate_chat_response.side_effect = _llm_side_effect
+
+    return AgentSuccessEvaluator(
+        request_context=context,
+        llm_client=mock_client,
+        extractor_config=extractor_config,
+        service_config=service_config,
+        agent_context="test agent",
+    )
+
+
+def _llm_side_effect(*args, **kwargs):
+    """Return the right mock output based on response_format."""
+    response_format = kwargs.get("response_format")
+    if response_format is AgentSuccessEvaluationWithComparisonOutput:
+        return AgentSuccessEvaluationWithComparisonOutput(
+            is_success=True,
+            better_request="1",
+            is_significantly_better=False,
+        )
+    # Default: AgentSuccessEvaluationOutput
+    return AgentSuccessEvaluationOutput(is_success=True, is_escalated=False)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_shadow_grade_runs_when_enabled_and_shadow_present(temp_dir):
+    """run() triggers _run_direct_shadow_grade when flag on + shadow_content present."""
+    evaluator = _make_evaluator(temp_dir, shadow_mode_enabled=True, with_shadow=True)
+
+    with patch.object(
+        evaluator,
+        "_run_direct_shadow_grade",
+        return_value=(False, True),
+    ) as mock_shadow:
+        results = evaluator.run()
+
+    assert mock_shadow.called
+    assert len(results) == 1
+    result = results[0]
+    assert result.shadow_is_success is False
+    assert result.shadow_is_escalated is True
+
+
+def test_shadow_grade_skipped_when_no_shadow_content(temp_dir):
+    """run() does not call _run_direct_shadow_grade when no interaction has shadow_content."""
+    evaluator = _make_evaluator(temp_dir, shadow_mode_enabled=True, with_shadow=False)
+
+    with patch.object(evaluator, "_run_direct_shadow_grade") as mock_shadow:
+        results = evaluator.run()
+
+    assert not mock_shadow.called
+    assert len(results) == 1
+    result = results[0]
+    assert result.shadow_is_success is None
+    assert result.shadow_is_escalated is None
+
+
+def test_shadow_grade_skipped_when_flag_off(temp_dir):
+    """run() does not call _run_direct_shadow_grade when shadow_mode_enabled=False."""
+    evaluator = _make_evaluator(temp_dir, shadow_mode_enabled=False, with_shadow=True)
+
+    with patch.object(evaluator, "_run_direct_shadow_grade") as mock_shadow:
+        results = evaluator.run()
+
+    assert not mock_shadow.called
+    assert len(results) == 1
+    result = results[0]
+    assert result.shadow_is_success is None
+    assert result.shadow_is_escalated is None

--- a/tests/server/services/evaluation_overview/test_braintrust_tiles.py
+++ b/tests/server/services/evaluation_overview/test_braintrust_tiles.py
@@ -56,13 +56,10 @@ def test_service_returns_empty_braintrust_tiles_with_no_imported_scores() -> Non
     storage.org_id = "org_t"
     storage.get_agent_success_evaluation_results.return_value = []
     storage.get_imported_scores.return_value = []
-    storage.count_sessions_with_shadow_content.return_value = 0
     config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
 
     svc = EvaluationOverviewService(storage=storage, config=config)
-    response = svc.run(
-        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
-    )
+    response = svc.run(GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time())))
 
     assert response.braintrust_tiles == []
 
@@ -72,7 +69,6 @@ def test_service_emits_braintrust_tiles_with_delta() -> None:
     storage = MagicMock()
     storage.org_id = "org_t"
     storage.get_agent_success_evaluation_results.return_value = []
-    storage.count_sessions_with_shadow_content.return_value = 0
 
     # Storage returns different score sets per (from_ts, to_ts) window
     def get_imported_scores_router(
@@ -93,9 +89,7 @@ def test_service_emits_braintrust_tiles_with_delta() -> None:
     config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
 
     svc = EvaluationOverviewService(storage=storage, config=config)
-    response = svc.run(
-        GetEvaluationOverviewRequest(from_ts=1_000_000, to_ts=2_000_000)
-    )
+    response = svc.run(GetEvaluationOverviewRequest(from_ts=1_000_000, to_ts=2_000_000))
 
     tiles_by_name = {t.scorer_name: t for t in response.braintrust_tiles}
     assert tiles_by_name["hallucination"].current == 0.2

--- a/tests/server/services/evaluation_overview/test_hero_state.py
+++ b/tests/server/services/evaluation_overview/test_hero_state.py
@@ -59,3 +59,29 @@ def test_full_when_all_thresholds_met() -> None:
         total_results=800,
     )
     assert state == HeroState.FULL
+
+
+def test_full_gate_threshold_499_vs_500_graded_shadow_rows() -> None:
+    """Pin the 500-graded-shadow-rows boundary.
+
+    Why: the n_shadow_in_window semantics changed from "sessions with
+    shadow_content" (storage call) to "rows with non-null shadow_is_success"
+    (in-memory count). A future caller change that reverts the filter would
+    silently push orgs into FULL state on ungraded shadow rows. The 499/500
+    threshold is the load-bearing gate; pin both sides explicitly.
+    """
+    below = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=30,
+        n_shadow_in_window=499,
+        total_results=499,
+    )
+    assert below == HeroState.EARLY
+
+    at = compute_hero_state(
+        shadow_enabled=True,
+        days_since_first_eval=30,
+        n_shadow_in_window=500,
+        total_results=500,
+    )
+    assert at == HeroState.FULL

--- a/tests/server/services/evaluation_overview/test_service.py
+++ b/tests/server/services/evaluation_overview/test_service.py
@@ -7,6 +7,7 @@ import pytest
 from reflexio.models.api_schema.domain.entities import AgentSuccessEvaluationResult
 from reflexio.server.services.evaluation_overview.service import (
     EvaluationOverviewService,
+    _weekly_buckets,
 )
 
 
@@ -84,3 +85,48 @@ def test_compute_shadow_rate_partial_graded() -> None:
     )
     assert rate == pytest.approx(50.0)
     assert delta == pytest.approx(50.0 - 66.7)
+
+
+def test_weekly_buckets_pin_shadow_rate_in_ratio_form() -> None:
+    """HeroBucket.shadow_rate must be a ratio (0.0-1.0), not pp.
+
+    The hero-level shadow_success_rate_pp uses 0-100 (per its name),
+    but HeroBucket.shadow_rate uses 0-1 to match the existing
+    HeroBucket.regular_rate convention. Pin both fields with concrete
+    values so a future refactor that adds `* 100` to either side
+    breaks loudly.
+    """
+    # Three graded shadow results in the same week, 2 success + 1 failure.
+    # Pick a fixed timestamp that all 3 share so they bucket together.
+    ts = 1700000000
+    results = [
+        _shadow_result(True, shadow_is_success=True, created_at=ts),
+        _shadow_result(True, shadow_is_success=True, created_at=ts),
+        _shadow_result(False, shadow_is_success=False, created_at=ts),
+        # Plus one ungraded — must NOT contribute to shadow_rate or shadow_n
+        _shadow_result(True, shadow_is_success=None, created_at=ts),
+    ]
+    buckets = _weekly_buckets(results)
+    # Expect at least one bucket containing all 4 results
+    bucket = next(b for b in buckets if b.regular_n == 4)
+    assert bucket.shadow_n == 3
+    assert bucket.shadow_rate == pytest.approx(2 / 3)
+    # Crucial: shadow_rate is a ratio, NOT pp — i.e. NOT 66.67
+    assert bucket.shadow_rate is not None and bucket.shadow_rate <= 1.0
+
+
+def test_n_shadow_in_window_excludes_ungraded_rows() -> None:
+    """Ensure rows with shadow_is_success=None do not count toward the
+    FULL-gate threshold. This is the spec's semantics tightening — without
+    it, orgs that publish shadow_content but flip the flag mid-window
+    would prematurely hit FULL state.
+    """
+    results = [
+        _shadow_result(True, shadow_is_success=True),  # counts
+        _shadow_result(True, shadow_is_success=False),  # counts
+        _shadow_result(True, shadow_is_success=None),  # excluded
+        _shadow_result(True, shadow_is_success=None),  # excluded
+    ]
+    # Compute n_shadow_in_window the same way _build_hero does
+    n_shadow_graded = sum(1 for r in results if r.shadow_is_success is not None)
+    assert n_shadow_graded == 2  # not 4

--- a/tests/server/services/evaluation_overview/test_service.py
+++ b/tests/server/services/evaluation_overview/test_service.py
@@ -1,0 +1,86 @@
+"""Unit tests for EvaluationOverviewService static helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import AgentSuccessEvaluationResult
+from reflexio.server.services.evaluation_overview.service import (
+    EvaluationOverviewService,
+)
+
+
+def _shadow_result(
+    is_success: bool,
+    shadow_is_success: bool | None = None,
+    created_at: int = 0,
+) -> AgentSuccessEvaluationResult:
+    return AgentSuccessEvaluationResult(
+        session_id=f"s_{id(object())}",
+        agent_version="v",
+        evaluation_name="overall_success",
+        is_success=is_success,
+        is_escalated=False,
+        shadow_is_success=shadow_is_success,
+        shadow_is_escalated=False,
+        created_at=created_at,
+    )
+
+
+def test_compute_shadow_rate_excludes_ungraded_rows() -> None:
+    results = [
+        _shadow_result(True, shadow_is_success=True),
+        _shadow_result(False, shadow_is_success=True),
+        _shadow_result(True, shadow_is_success=None),  # excluded
+    ]
+    rate, delta = EvaluationOverviewService._compute_shadow_rate_and_delta(
+        results, regular_rate=2 / 3 * 100
+    )
+    assert rate == 100.0
+    assert delta == pytest.approx(100.0 - 2 / 3 * 100)
+
+
+def test_compute_shadow_rate_is_none_when_no_graded_rows() -> None:
+    results = [
+        _shadow_result(True, shadow_is_success=None),
+        _shadow_result(False, shadow_is_success=None),
+    ]
+    rate, delta = EvaluationOverviewService._compute_shadow_rate_and_delta(
+        results, regular_rate=50.0
+    )
+    assert rate is None
+    assert delta is None
+
+
+def test_compute_shadow_rate_handles_all_false_shadow() -> None:
+    results = [
+        _shadow_result(True, shadow_is_success=False),
+        _shadow_result(True, shadow_is_success=False),
+    ]
+    rate, delta = EvaluationOverviewService._compute_shadow_rate_and_delta(
+        results, regular_rate=100.0
+    )
+    assert rate == 0.0
+    assert delta == -100.0
+
+
+def test_compute_shadow_rate_empty_results() -> None:
+    rate, delta = EvaluationOverviewService._compute_shadow_rate_and_delta(
+        [], regular_rate=50.0
+    )
+    assert rate is None
+    assert delta is None
+
+
+def test_compute_shadow_rate_partial_graded() -> None:
+    """50% shadow success rate from a mix of graded and ungraded results."""
+    results = [
+        _shadow_result(True, shadow_is_success=True),
+        _shadow_result(True, shadow_is_success=False),
+        _shadow_result(False, shadow_is_success=None),  # ungraded, excluded
+    ]
+    rate, delta = EvaluationOverviewService._compute_shadow_rate_and_delta(
+        results, regular_rate=66.7
+    )
+    assert rate == pytest.approx(50.0)
+    assert delta == pytest.approx(50.0 - 66.7)

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -22,6 +22,7 @@ def _eval_result(
     is_success: bool,
     corrections: int = 0,
     created_at: int = 1700000000,
+    shadow_is_success: bool | None = None,
 ) -> AgentSuccessEvaluationResult:
     return AgentSuccessEvaluationResult(
         result_id=result_id,
@@ -31,6 +32,7 @@ def _eval_result(
         evaluation_name="overall",
         created_at=created_at,
         number_of_correction_per_session=corrections,
+        shadow_is_success=shadow_is_success,
     )
 
 
@@ -43,13 +45,10 @@ def test_service_returns_full_response_with_shadow_enabled_and_data() -> None:
     ]
     storage.get_playbook_application_stats.return_value = []
     storage.get_interactions_by_session.return_value = []
-    storage.count_sessions_with_shadow_content.return_value = 600
     config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
 
     svc = EvaluationOverviewService(storage=storage, config=config)
-    response = svc.run(
-        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
-    )
+    response = svc.run(GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time())))
 
     assert response.hero.state in ("full", "early", "shadow_off", "empty")
     assert response.context_tiles.success.current >= 0.0
@@ -57,18 +56,48 @@ def test_service_returns_full_response_with_shadow_enabled_and_data() -> None:
     assert response.score_distribution.labels == ["0", "1", "2", "3", "4", "5+"]
 
 
+def test_service_hero_shadow_rate_non_null_when_shadow_graded() -> None:
+    """When results include shadow_is_success grades, hero exposes non-null shadow data."""
+    storage = MagicMock()
+    storage.get_agent_success_evaluation_results.return_value = [
+        # 2 shadow-graded successes, 1 shadow-graded failure, 1 ungraded
+        _eval_result(
+            result_id=1, session_id="s1", is_success=True, shadow_is_success=True
+        ),
+        _eval_result(
+            result_id=2, session_id="s2", is_success=True, shadow_is_success=True
+        ),
+        _eval_result(
+            result_id=3, session_id="s3", is_success=False, shadow_is_success=False
+        ),
+        _eval_result(
+            result_id=4, session_id="s4", is_success=True, shadow_is_success=None
+        ),
+    ]
+    storage.get_playbook_application_stats.return_value = []
+    storage.get_interactions_by_session.return_value = []
+    config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time())))
+
+    # 2/3 shadow-graded are successes → 66.67%
+    assert response.hero.shadow_success_rate_pp is not None
+    assert abs(response.hero.shadow_success_rate_pp - 200 / 3) < 0.01
+    assert response.hero.delta_pp is not None
+    # regular is 3/4 → 75%; shadow is 66.67%; delta ≈ −8.33
+    assert abs(response.hero.delta_pp - (200 / 3 - 75.0)) < 0.01
+
+
 def test_service_returns_empty_state_when_no_results() -> None:
     storage = MagicMock()
     storage.get_agent_success_evaluation_results.return_value = []
     storage.get_playbook_application_stats.return_value = []
     storage.get_interactions_by_session.return_value = []
-    storage.count_sessions_with_shadow_content.return_value = 0
     config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
 
     svc = EvaluationOverviewService(storage=storage, config=config)
-    response = svc.run(
-        GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time()))
-    )
+    response = svc.run(GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time())))
 
     assert response.hero.state == "empty"
     assert response.context_tiles.success.current == 0.0

--- a/tests/server/services/search/test_agentic_search_service.py
+++ b/tests/server/services/search/test_agentic_search_service.py
@@ -199,7 +199,7 @@ def test_agentic_fetch_entities_excludes_rejected_by_default():
     )
 
     storage = SimpleNamespace(
-        get_agent_playbooks=lambda agent_version: [
+        get_agent_playbooks=lambda _agent_version: [
             AgentPlaybook(
                 agent_playbook_id=1,
                 agent_version="v1",

--- a/tests/server/services/storage/test_sqlite_storage_evaluation_results.py
+++ b/tests/server/services/storage/test_sqlite_storage_evaluation_results.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain import AgentSuccessEvaluationResult
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    db = tmp_path / "test.db"
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="test_org", db_path=str(db))
+        yield s
+
+
+@pytest.mark.parametrize(
+    "shadow_is_success,shadow_is_escalated",
+    [(True, False), (False, True), (None, None)],
+)
+def test_shadow_outcome_roundtrip(storage, shadow_is_success, shadow_is_escalated):
+    storage.save_agent_success_evaluation_results(
+        [
+            AgentSuccessEvaluationResult(
+                session_id="s1",
+                agent_version="v1",
+                evaluation_name="overall_success",
+                is_success=True,
+                is_escalated=False,
+                shadow_is_success=shadow_is_success,
+                shadow_is_escalated=shadow_is_escalated,
+            )
+        ]
+    )
+    [result] = storage.get_agent_success_evaluation_results(limit=1)
+    assert result.shadow_is_success == shadow_is_success
+    assert result.shadow_is_escalated == shadow_is_escalated

--- a/tests/server/services/test_service_utils_shadow.py
+++ b/tests/server/services/test_service_utils_shadow.py
@@ -1,0 +1,75 @@
+"""Unit tests for the use_shadow parameter in format_interactions_to_history_string."""
+
+from reflexio.models.api_schema.domain.entities import Interaction
+from reflexio.models.api_schema.domain.enums import UserActionType
+from reflexio.server.services.service_utils import format_interactions_to_history_string
+
+_UID = "u1"
+_RID = "r1"
+
+
+def _interaction(**kwargs) -> Interaction:
+    """Build an Interaction with required fields pre-filled."""
+    defaults = {"user_id": _UID, "request_id": _RID, "user_action": UserActionType.NONE}
+    return Interaction(**{**defaults, **kwargs})
+
+
+def test_use_shadow_renders_shadow_content_for_assistant():
+    """When use_shadow=True, assistant turns with shadow_content render shadow text."""
+    interactions = [
+        _interaction(role="user", content="hi"),
+        _interaction(
+            role="assistant",
+            content="hello (regular)",
+            shadow_content="hello (shadow)",
+        ),
+    ]
+    out_regular = format_interactions_to_history_string(interactions, use_shadow=False)
+    assert "hello (regular)" in out_regular
+    assert "hello (shadow)" not in out_regular
+
+    out_shadow = format_interactions_to_history_string(interactions, use_shadow=True)
+    assert "hello (shadow)" in out_shadow
+    assert "hello (regular)" not in out_shadow
+    # User turn always renders original content regardless of use_shadow
+    assert "hi" in out_shadow
+
+
+def test_use_shadow_falls_back_to_content_when_shadow_empty():
+    """When use_shadow=True but shadow_content is empty, fall back to content."""
+    interactions = [
+        _interaction(role="assistant", content="only regular", shadow_content=""),
+    ]
+    out_shadow = format_interactions_to_history_string(interactions, use_shadow=True)
+    assert "only regular" in out_shadow
+
+
+def test_default_use_shadow_is_false():
+    """Default call (no use_shadow arg) renders regular content."""
+    interactions = [
+        _interaction(role="assistant", content="regular", shadow_content="shadow"),
+    ]
+    out = format_interactions_to_history_string(interactions)
+    assert "regular" in out
+    assert "shadow" not in out
+
+
+def test_use_shadow_multiple_turns():
+    """All assistant turns with shadow_content are substituted when use_shadow=True."""
+    interactions = [
+        _interaction(role="user", content="q1"),
+        _interaction(
+            role="assistant", content="a1_regular", shadow_content="a1_shadow"
+        ),
+        _interaction(role="user", content="q2"),
+        _interaction(
+            role="assistant", content="a2_regular", shadow_content="a2_shadow"
+        ),
+    ]
+    out = format_interactions_to_history_string(interactions, use_shadow=True)
+    assert "a1_shadow" in out
+    assert "a2_shadow" in out
+    assert "a1_regular" not in out
+    assert "a2_regular" not in out
+    assert "q1" in out
+    assert "q2" in out


### PR DESCRIPTION
## Summary

Direct second-pass grading of `shadow_content` against the same rubric as the regular response. Lights up `shadow_success_rate_pp`, `delta_pp`, and per-bucket shadow data on the `/evaluations` hero block.

**Built on top of `feat/evaluations-consolidated`** (ReflexioAI/reflexio#91). This PR's diff is *additive* on top of that base — review accordingly. When the consolidated PR lands, this one should rebase cleanly onto main.

## What's in this PR

### Data model
- `AgentSuccessEvaluationResult.shadow_is_success: bool | None`, `shadow_is_escalated: bool | None` — default `None` (means "shadow not graded for this row").
- SQLite schema + idempotent inline migration + read/write paths.

### Evaluator
- `_run_direct_shadow_grade(...)` — a near-copy of `_evaluate_regular`, but invokes the same `agent_success_evaluation/v1.0.0` prompt with `use_shadow=True` substituted into the assistant turns via a parameter threaded through `construct_agent_success_evaluation_messages_from_sessions` → `format_sessions_to_history_string` → `format_interactions_to_history_string`. All three default to `False`, so every existing call site is unchanged.
- Wired into `_evaluate_group` so that when `Config.shadow_mode_enabled=True` AND `has_shadow_content(...)`, the new direct grade runs in addition to (not instead of) the existing combined-comparison path that still populates `regular_vs_shadow`.
- Net cost when both conditions met: 3 LLM calls per session (regular eval + combined comparison + direct shadow grade). 1 call otherwise (unchanged).
- Failures in the second pass return `(None, None)` so a failed shadow grade does not surface as `False`. Structured-log event `agent_success_eval_shadow_llm_start` for observability.

### Hero aggregator
- `EvaluationOverviewService._compute_shadow_rate_and_delta(results, regular_rate)` — pure-function helper. Returns `(None, None)` when no row has a non-null `shadow_is_success`; otherwise computes rate from the graded subset + delta.
- `_build_hero` wires the helper; old hard-coded `shadow_rate = None; delta = None` stub is gone.
- `_weekly_buckets` populates `HeroBucket.shadow_rate` (ratio form, 0-1) and `shadow_n` from the graded subset of each week.
- `n_shadow_in_window` semantics tightened: was "sessions with non-empty `shadow_content`" (storage round-trip), now "rows with non-null `shadow_is_success`" (in-memory count over the loaded `results` list). Prevents the FULL gate from tripping mid-window-flag-flip when sessions exist with shadow_content but no shadow grade.
- Side effect: the overview no longer reads `count_sessions_with_shadow_content`. The storage method itself is preserved (still on the storage interface) but is now unused by the overview — follow-up PR can remove it cleanly.

### Tests
- `tests/models/test_agent_success_evaluation_result.py` — defaults + round-trip for the two new fields.
- `tests/server/services/storage/test_sqlite_storage_evaluation_results.py` — parametrized roundtrip for `(True, False)`, `(False, True)`, `(None, None)`.
- `tests/server/services/test_service_utils_shadow.py` — formatter `use_shadow=True` and the empty-shadow fallback.
- `tests/server/services/agent_success_evaluation/test_shadow_grading_integration.py` — 5 tests covering shadow-on + content present, shadow-on + no content, shadow-off + content present, end-to-end success path (no patching of the method under test), and LLM-raise path.
- `tests/server/services/evaluation_overview/test_service.py` — 5 unit tests pinning `_compute_shadow_rate_and_delta` math + one pinning per-bucket `shadow_rate` scale (ratio, not pp) + one pinning `n_shadow_in_window` semantics excludes ungraded.
- `tests/server/services/evaluation_overview/test_hero_state.py` — explicit 499/500 boundary guard.
- `tests/server/services/evaluation_overview/test_service_integration.py` — extended to assert non-null hero shadow fields when graded rows are present.

### Drive-by cleanup
- `sqlite_storage/_operations.py`: removed a dead `get_operation_state: Any` forward-declaration that was causing a pyright `reportRedeclaration` error (the actual method is defined a few lines below).
- Tightened a couple of integration-test mocks that referenced the now-unused `count_sessions_with_shadow_content` storage call.

## Test plan
- [x] Submodule unit + integration: `uv run pytest tests/models/test_agent_success_evaluation_result.py tests/server/services/storage/test_sqlite_storage_evaluation_results.py tests/server/services/test_service_utils_shadow.py tests/server/services/agent_success_evaluation/ tests/server/services/evaluation_overview/ -o 'addopts=' -q` → 97 passed
- [x] `uv run ruff check reflexio/ tests/` → clean
- [x] `uv run pyright` on changed packages → 0 errors

## Notes
- The frontend needs **no changes** — `hero-block.tsx` already has `EARLY` and `FULL` variants that render `shadow_success_rate_pp` / `delta_pp` when non-null, and per-bucket `shadow_rate` is consumed by the trend chart's shadow-band overlay.
- Spec: `docs/superpowers/specs/2026-05-27-shadow-mode-counterfactual-grading-design.md` (lives in the paired enterprise PR).

## Follow-ups (separate PRs)
- Remove `count_sessions_with_shadow_content` from `BaseStorage` and its implementations (dead since this PR).
- Optional: backfill job that regrades sessions with `shadow_content` but `shadow_is_success IS NULL` for orgs that flipped the flag mid-window.
- Optional: add `shadow_failure_type` / `shadow_failure_reason` columns (deferred per spec Q1).
