### PR TITLE
fix(regen-jobs): only block new regen while a job is actually running

### DIFF
--- a/reflexio/server/services/agent_success_evaluation/regen_jobs.py
+++ b/reflexio/server/services/agent_success_evaluation/regen_jobs.py
@@ -77,11 +77,19 @@ class RegenJobRegistry:
         to_ts: int,
         total: int,
     ) -> RegenJob:
-        """Register a new running job. Raises RuntimeError if (org, evaluator) is active."""
+        """Register a new running job. Raises RuntimeError when an actively-running
+        job exists for (org, evaluator).
+
+        Only *running* jobs block; a previous completed/cancelled/errored job for
+        the same key is replaced. Eviction by TTL is a separate cleanup concern —
+        we don't want users to wait an hour after a completed run before they can
+        regenerate again.
+        """
         with self._lock:
             self._evict_completed_locked(DEFAULT_TTL_SECONDS)
             key = (org_id, evaluation_name)
-            if key in self._by_org_evaluator:
+            active = self._active_job_for_locked(key)
+            if active is not None:
                 raise RuntimeError(
                     f"A regenerate is already running for evaluator '{evaluation_name}'"
                 )
@@ -112,7 +120,24 @@ class RegenJobRegistry:
     def has_active(self, org_id: str, evaluation_name: str) -> bool:
         with self._lock:
             self._evict_completed_locked(DEFAULT_TTL_SECONDS)
-            return (org_id, evaluation_name) in self._by_org_evaluator
+            return self._active_job_for_locked((org_id, evaluation_name)) is not None
+
+    def _active_job_for_locked(self, key: tuple[str, str]) -> RegenJob | None:
+        """Return the running job for (org, evaluator), or None when no live job exists.
+
+        A registry entry whose job has already finished
+        (``completed`` / ``cancelled`` / ``error``) is treated as having no active
+        job — the previous run finished and the user can start a new one. The
+        registry still holds the finished job until TTL eviction so status polls
+        keep working, but it doesn't block new submissions.
+        """
+        job_id = self._by_org_evaluator.get(key)
+        if job_id is None:
+            return None
+        job = self._jobs.get(job_id)
+        if job is None or job.status != "running":
+            return None
+        return job
 
     def evict_completed_older_than(self, ttl_seconds: int) -> None:
         with self._lock:

--- a/tests/server/services/agent_success_evaluation/test_regen_jobs.py
+++ b/tests/server/services/agent_success_evaluation/test_regen_jobs.py
@@ -154,3 +154,45 @@ def test_run_regen_observes_cancel_between_sessions():
 
     assert job.status == "cancelled"
     assert job.completed == 2
+
+
+def test_create_succeeds_after_previous_job_completed_within_ttl():
+    """Bug fix: a completed job in the registry must NOT block a new regen.
+
+    Pre-fix: ``has_active`` and ``create`` both checked
+    ``key in _by_org_evaluator``, which stayed populated until TTL eviction
+    (default 1h). That meant users couldn't regenerate again for an hour
+    after a successful run. After the fix, only a job whose ``status`` is
+    still ``"running"`` blocks new submissions.
+    """
+    from reflexio.server.services.agent_success_evaluation.regen_jobs import (
+        RegenJobRegistry,
+    )
+
+    reg = RegenJobRegistry()
+    first = reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=2)
+    first.status = "completed"
+    # Registry still holds the finished job (TTL hasn't run); has_active must
+    # report False because nothing is running anymore.
+    assert reg.has_active("o", "e") is False
+    # And a fresh create must succeed instead of raising.
+    second = reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=3)
+    assert second.job_id != first.job_id
+    assert second.status == "running"
+    assert reg.has_active("o", "e") is True
+    # The previous completed job is still fetchable until TTL eviction.
+    assert reg.get(first.job_id) is not None
+
+
+def test_create_still_blocks_when_previous_job_is_running():
+    """Sanity-check: the gate still fires when the previous job is actually running."""
+    from reflexio.server.services.agent_success_evaluation.regen_jobs import (
+        RegenJobRegistry,
+    )
+
+    reg = RegenJobRegistry()
+    reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=2)
+    import pytest
+
+    with pytest.raises(RuntimeError, match="already running"):
+        reg.create(org_id="o", evaluation_name="e", from_ts=0, to_ts=1, total=2)


### PR DESCRIPTION
## Summary

`RegenJobRegistry.has_active` and `.create` both keyed off `(org, evaluator) in _by_org_evaluator`, which stayed populated until TTL eviction (default 1 hour). That meant a user who finished a regenerate run couldn't start another one for an hour — UI returned 409 with "A regenerate is already running for evaluator '<name>'" even though nothing was actually running.

After the fix, the gate only fires when the previous job's `status == 'running'`. Completed / cancelled / errored jobs no longer block; the registry still holds them until TTL eviction so status polls keep working.

## What changed

- New private helper `_active_job_for_locked` resolves "is there a live job for this key?" by checking status, not just registry presence.
- `create` and `has_active` both use it.

## Test plan

- [x] New regression test: completed job in registry doesn't block new create
- [x] New sanity-check test: running job DOES still block (existing gate still fires)
- [x] All 10 `test_regen_jobs.py` tests pass; ruff + pyright clean