### PR TITLE
feat(eval-overview): expose cited_session_ids on rule attribution rows

### DIFF
--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -69,6 +69,11 @@ class RuleAttributionRow(BaseModel):
     successes_with: int = Field(ge=0)
     failures_with: int = Field(ge=0)
     net_sessions: int
+    cited_session_ids: list[str] = Field(default_factory=list)
+    """Session IDs (within the trend window) that cited this rule. The
+    frontend uses this to filter the detail band to the sessions where the
+    rule actually fired — answering 'which sessions did this rule help or
+    hurt?' without a second roundtrip."""
 
 
 class ScoreDistribution(BaseModel):

--- a/reflexio/server/services/evaluation_overview/rule_attribution.py
+++ b/reflexio/server/services/evaluation_overview/rule_attribution.py
@@ -22,6 +22,12 @@ class RuleAttribution:
     title: str
     successes_with: int
     failures_with: int
+    cited_session_ids: tuple[str, ...] = ()
+    """Session IDs (within the trend window) that cited this rule. Tuple so
+    the dataclass stays hashable / frozen. The frontend uses this to filter
+    the /evaluations detail band to show only sessions where the rule
+    actually fired — answering 'which sessions did this rule help/hurt?'
+    without a second roundtrip."""
 
     @property
     def net_sessions(self) -> int:
@@ -50,9 +56,15 @@ def compute_net_sessions(
 
     Returns:
         list[RuleAttribution]: At most `top_n` rows in the order described.
+        Each row carries the session ids that cited the rule so the
+        frontend can drill from a rule into the sessions it fired in.
     """
     successes: dict[CitationKey, int] = {}
     failures: dict[CitationKey, int] = {}
+    # Map (kind, real_id) -> ordered list of session_ids that cited this rule.
+    # Ordering preserves caller-provided iteration order; the frontend sorts
+    # the detail band by created_at when displaying.
+    sessions_by_rule: dict[CitationKey, list[str]] = {}
     for session_id, citations in citations_by_session.items():
         outcome = is_success_by_session.get(session_id)
         if outcome is None:
@@ -64,6 +76,7 @@ def compute_net_sessions(
                 successes[key] = successes.get(key, 0) + 1
             else:
                 failures[key] = failures.get(key, 0) + 1
+            sessions_by_rule.setdefault(key, []).append(session_id)
 
     all_keys = set(successes) | set(failures)
     rows = [
@@ -73,6 +86,7 @@ def compute_net_sessions(
             title=rule_titles.get((kind, real_id), ""),
             successes_with=successes.get((kind, real_id), 0),
             failures_with=failures.get((kind, real_id), 0),
+            cited_session_ids=tuple(sessions_by_rule.get((kind, real_id), [])),
         )
         for (kind, real_id) in all_keys
     ]

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -175,6 +175,7 @@ class EvaluationOverviewService:
                 successes_with=r.successes_with,
                 failures_with=r.failures_with,
                 net_sessions=r.net_sessions,
+                cited_session_ids=list(r.cited_session_ids),
             )
             for r in rows
         ]

--- a/tests/server/services/evaluation_overview/test_rule_attribution.py
+++ b/tests/server/services/evaluation_overview/test_rule_attribution.py
@@ -92,3 +92,77 @@ def test_session_missing_from_success_map_is_skipped() -> None:
     assert a.successes_with == 1
     assert a.failures_with == 0
     assert a.net_sessions == 1
+
+
+def test_cited_session_ids_populated_for_each_rule() -> None:
+    """Each RuleAttribution row carries the session ids that cited the rule."""
+    citations_by_session = {
+        "sess_alpha": [("playbook", "rule_a"), ("playbook", "rule_b")],
+        "sess_beta": [("playbook", "rule_a")],
+        "sess_gamma": [("playbook", "rule_b")],
+    }
+    is_success_by_session = {"sess_alpha": True, "sess_beta": False, "sess_gamma": True}
+    rule_titles = {("playbook", "rule_a"): "A", ("playbook", "rule_b"): "B"}
+
+    rows = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles=rule_titles,
+        top_n=5,
+    )
+    rows_by_id = {r.rule_id: r for r in rows}
+
+    # rule_a was cited in alpha (success) and beta (failure)
+    assert set(rows_by_id["rule_a"].cited_session_ids) == {"sess_alpha", "sess_beta"}
+    # rule_b was cited in alpha (success) and gamma (success)
+    assert set(rows_by_id["rule_b"].cited_session_ids) == {"sess_alpha", "sess_gamma"}
+
+
+def test_cited_session_ids_excludes_sessions_with_no_outcome() -> None:
+    """Sessions absent from is_success_by_session are skipped on both sides."""
+    citations_by_session = {
+        "graded": [("playbook", "rule_x")],
+        "ungraded": [("playbook", "rule_x")],
+    }
+    is_success_by_session = {"graded": True}  # 'ungraded' not present
+
+    rows = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles={},
+        top_n=5,
+    )
+    assert len(rows) == 1
+    assert rows[0].cited_session_ids == ("graded",)
+    assert "ungraded" not in rows[0].cited_session_ids
+
+
+def test_cited_session_ids_dedupes_within_same_session() -> None:
+    """A rule cited multiple times in the same session yields a single session entry."""
+    citations_by_session = {
+        "sess_a": [
+            ("playbook", "rule_x"),
+            ("playbook", "rule_x"),
+            ("playbook", "rule_x"),
+        ],
+    }
+    is_success_by_session = {"sess_a": True}
+
+    rows = compute_net_sessions(
+        citations_by_session=citations_by_session,
+        is_success_by_session=is_success_by_session,
+        rule_titles={},
+        top_n=5,
+    )
+    assert rows[0].cited_session_ids == ("sess_a",)
+    assert rows[0].successes_with == 1
+
+
+def test_default_cited_session_ids_is_empty_tuple() -> None:
+    """Backward-compat: the field defaults to () and the dataclass is hashable."""
+    attrib = RuleAttribution(
+        rule_id="r", kind="playbook", title="t", successes_with=0, failures_with=0,
+    )
+    assert attrib.cited_session_ids == ()
+    # Frozen + tuple-typed default keeps it hashable
+    assert hash(attrib) == hash(attrib)


### PR DESCRIPTION
## Summary

Adds `cited_session_ids: list[str]` to each `RuleAttributionRow` returned by `POST /api/get_evaluation_overview`. The data was already computed server-side inside `compute_net_sessions` — this just propagates the inverse mapping (`rule -> sessions that cited it`) out to the API so the frontend can drill from a rule into the sessions where it fired.

## Why

The /evaluations 'Rules that moved the needle' panel only showed aggregate wins/misses per rule. New users asked 'which sessions did this rule help/hurt?' — answering required a second roundtrip or a separate endpoint. Now the panel can filter the detail band locally on click.

## Changes

- `rule_attribution.py` `RuleAttribution` dataclass gets `cited_session_ids: tuple[str, ...]` (tuple keeps it frozen + hashable). `compute_net_sessions` populates it from the same `citations_by_session` mapping it already iterates.
- `eval_overview_schema.py` `RuleAttributionRow` gets matching `cited_session_ids: list[str]`, defaults to `[]`.
- `service.py` builder passes the field through.

## Test plan

- [x] 4 new unit tests in `test_rule_attribution.py`: populated per rule, excludes ungraded sessions, dedupes within same session, default-empty for back-compat
- [x] All `test_rule_attribution.py` tests pass (existing + new)
- [x] Ruff + pyright clean

Pairs with the enterprise frontend PR that consumes the new field.