### PR TITLE
feat(storage): configurable Postgres pool size and acquire-timeout

### DIFF
--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import Any
 
 import typer
 
@@ -154,13 +155,25 @@ def save_storage_to_config(
             db_url = os.environ.get("REFLEXIO_POSTGRES_DB_URL", "")
             schema = os.environ.get("REFLEXIO_POSTGRES_SCHEMA", "").strip()
             pool_size_raw = os.environ.get("REFLEXIO_POSTGRES_POOL_SIZE", "").strip()
-            pool_size = int(pool_size_raw) if pool_size_raw.isdigit() else 5
+            pool_size = int(pool_size_raw) if pool_size_raw.isdigit() else 10
+            timeout_raw = os.environ.get(
+                "REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT", ""
+            ).strip()
+            postgres_kwargs: dict[str, Any] = {
+                "db_url": db_url,
+                "schema": schema or None,
+                "pool_size": pool_size,
+            }
+            if timeout_raw:
+                try:
+                    postgres_kwargs["pool_acquire_timeout"] = float(timeout_raw)
+                except ValueError:
+                    logger.warning(
+                        "Invalid REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT=%r; using default",
+                        timeout_raw,
+                    )
             if db_url:
-                config.storage_config = StorageConfigPostgres(
-                    db_url=db_url,
-                    schema=schema or None,
-                    pool_size=pool_size,
-                )
+                config.storage_config = StorageConfigPostgres(**postgres_kwargs)
             else:
                 logger.warning(
                     "Postgres storage requested but REFLEXIO_POSTGRES_DB_URL "

--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -156,6 +156,12 @@ def save_storage_to_config(
             schema = os.environ.get("REFLEXIO_POSTGRES_SCHEMA", "").strip()
             pool_size_raw = os.environ.get("REFLEXIO_POSTGRES_POOL_SIZE", "").strip()
             pool_size = int(pool_size_raw) if pool_size_raw.isdigit() else 10
+            if pool_size < 1:
+                logger.warning(
+                    "Invalid REFLEXIO_POSTGRES_POOL_SIZE=%r (must be >= 1); using default",
+                    pool_size_raw,
+                )
+                pool_size = 10
             timeout_raw = os.environ.get(
                 "REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT", ""
             ).strip()
@@ -166,12 +172,21 @@ def save_storage_to_config(
             }
             if timeout_raw:
                 try:
-                    postgres_kwargs["pool_acquire_timeout"] = float(timeout_raw)
+                    timeout = float(timeout_raw)
                 except ValueError:
                     logger.warning(
                         "Invalid REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT=%r; using default",
                         timeout_raw,
                     )
+                else:
+                    if timeout > 0:
+                        postgres_kwargs["pool_acquire_timeout"] = timeout
+                    else:
+                        logger.warning(
+                            "Invalid REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT=%r "
+                            "(must be > 0); using default",
+                            timeout_raw,
+                        )
             if db_url:
                 config.storage_config = StorageConfigPostgres(**postgres_kwargs)
             else:

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -175,7 +175,10 @@ class StorageConfigPostgres(BaseModel):
     storage_type: Literal["postgres"] = Field(default="postgres", alias="type")
     db_url: NonEmptyStr
     schema_name: str | None = Field(default=None, alias="schema")
-    pool_size: int = Field(default=5, ge=1)
+    pool_size: int = Field(default=10, ge=1)
+    # Seconds a query waits for a free pooled connection before failing. Bounds the
+    # back-pressure applied when concurrent queries exceed pool_size.
+    pool_acquire_timeout: float = Field(default=30.0, gt=0)
 
 
 class StorageConfigManagedSupabase(BaseModel):


### PR DESCRIPTION
## Summary

Makes the native Postgres storage connection pool tunable so deployments can apply back-pressure under concurrent load instead of failing.

- Raise `StorageConfigPostgres.pool_size` default from **5 → 10**.
- Add `pool_acquire_timeout: float` (default **30.0s**) — bounds how long a query waits for a free pooled connection before failing.
- Wire `REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT` into the CLI bootstrap alongside the existing `REFLEXIO_POSTGRES_POOL_SIZE`.
- Range-check both env vars in `save_storage_to_config` before constructing the model: `POOL_SIZE` must be `>= 1` and `POOL_ACQUIRE_TIMEOUT` must be `> 0`. Out-of-range-but-parseable values (e.g. `POOL_SIZE=0`, `TIMEOUT=0`) now log a warning and fall back to defaults instead of crashing bootstrap with a `ValidationError`.

## Why

The enterprise repo's `PostgresStorageBase` uses these fields to gate connection acquisition with a blocking semaphore (see the paired enterprise PR). Without a configurable timeout and a larger default, concurrent generation fan-out exhausts the pool and raises `psycopg2.pool.PoolError` instead of queueing.

The bounds-validation hardening keeps env-var parsing consistent: format errors and range violations both degrade gracefully to defaults rather than failing only for one and crashing for the other.

## Testing

- `ruff` + `pyright` clean on changed files.
- Defaults verified: `StorageConfigPostgres(db_url=...).pool_size == 10`, `pool_acquire_timeout == 30.0`.
- Out-of-range env values (`POOL_SIZE=0`, `TIMEOUT=0`/negative) fall back to defaults with a warning instead of raising.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pool acquire timeout for PostgreSQL connections. New environment variable REFLEXIO_POSTGRES_POOL_ACQUIRE_TIMEOUT (default: 30s) lets you control how long queries wait for an available connection.

* **Improvements**
  * Increased default PostgreSQL connection pool size from 5 to 10 to better handle concurrent database activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
