### PR TITLE
Refactor generation services for single configured extractor

### DIFF
--- a/docs/components/configure/config-editor.tsx
+++ b/docs/components/configure/config-editor.tsx
@@ -5,7 +5,6 @@ import { Settings, AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSettings } from "@/hooks/use-settings";
 import {
-  AgentSuccessConfig,
   ReflexioConfig,
   defaultConfig,
   serializeConfig,
@@ -35,16 +34,11 @@ type Status =
 function hydrate(raw: unknown): ReflexioConfig {
   const base = defaultConfig();
   if (!raw || typeof raw !== "object") return base;
-  const incoming = raw as Partial<ReflexioConfig> & {
-    agent_success_configs?: AgentSuccessConfig[] | null;
-  };
+  const incoming = raw as Partial<ReflexioConfig>;
   return {
     ...base,
     ...incoming,
-    agent_success_config:
-      "agent_success_config" in incoming
-        ? (incoming.agent_success_config ?? null)
-        : (incoming.agent_success_configs?.[0] ?? null),
+    agent_success_config: incoming.agent_success_config ?? null,
   };
 }
 
@@ -137,11 +131,11 @@ export function ConfigEditor() {
           <APIKeysSection value={config.api_key_config} setConfig={setConfig} />
           <LLMModelsSection value={config.llm_config} setConfig={setConfig} />
           <ProfileExtractorsSection
-            value={config.profile_extractor_configs}
+            value={config.profile_extractor_config}
             setConfig={setConfig}
           />
           <PlaybookExtractorsSection
-            value={config.user_playbook_extractor_configs}
+            value={config.user_playbook_extractor_config}
             setConfig={setConfig}
           />
           <AgentSuccessSection

--- a/docs/components/configure/config-editor.tsx
+++ b/docs/components/configure/config-editor.tsx
@@ -5,6 +5,7 @@ import { Settings, AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useSettings } from "@/hooks/use-settings";
 import {
+  AgentSuccessConfig,
   ReflexioConfig,
   defaultConfig,
   serializeConfig,
@@ -34,7 +35,17 @@ type Status =
 function hydrate(raw: unknown): ReflexioConfig {
   const base = defaultConfig();
   if (!raw || typeof raw !== "object") return base;
-  return { ...base, ...(raw as Partial<ReflexioConfig>) };
+  const incoming = raw as Partial<ReflexioConfig> & {
+    agent_success_configs?: AgentSuccessConfig[] | null;
+  };
+  return {
+    ...base,
+    ...incoming,
+    agent_success_config:
+      "agent_success_config" in incoming
+        ? (incoming.agent_success_config ?? null)
+        : (incoming.agent_success_configs?.[0] ?? null),
+  };
 }
 
 function errorMessage(err: unknown): string {
@@ -134,7 +145,7 @@ export function ConfigEditor() {
             setConfig={setConfig}
           />
           <AgentSuccessSection
-            value={config.agent_success_configs}
+            value={config.agent_success_config}
             setConfig={setConfig}
           />
           <ToolsSection value={config.tool_can_use} setConfig={setConfig} />

--- a/docs/components/configure/sections.tsx
+++ b/docs/components/configure/sections.tsx
@@ -665,31 +665,23 @@ export function AgentSuccessSection({
   value,
   setConfig,
 }: {
-  value: AgentSuccessConfig[] | null;
+  value: AgentSuccessConfig | null;
   setConfig: SetConfig;
 }) {
-  const items = value ?? [];
-  const updateAt = (idx: number, patch: Partial<AgentSuccessConfig>) => {
+  const enabled = value !== null;
+  const current = value ?? defaultAgentSuccess();
+  const update = (patch: Partial<AgentSuccessConfig>) => {
     setConfig((prev) => {
-      const next = [...(prev.agent_success_configs ?? [])];
-      next[idx] = { ...next[idx], ...patch };
-      return { ...prev, agent_success_configs: next };
+      const existing = prev.agent_success_config ?? defaultAgentSuccess();
+      return { ...prev, agent_success_config: { ...existing, ...patch } };
     });
   };
-  const removeAt = (idx: number) => {
-    setConfig((prev) => {
-      const next = [...(prev.agent_success_configs ?? [])];
-      next.splice(idx, 1);
-      return { ...prev, agent_success_configs: next.length ? next : null };
-    });
-  };
-  const add = () => {
+  const setEnabled = (checked: boolean) => {
     setConfig((prev) => ({
       ...prev,
-      agent_success_configs: [
-        ...(prev.agent_success_configs ?? []),
-        defaultAgentSuccess(),
-      ],
+      agent_success_config: checked
+        ? (prev.agent_success_config ?? defaultAgentSuccess())
+        : null,
     }));
   };
 
@@ -699,34 +691,31 @@ export function AgentSuccessSection({
       description="Define what 'success' means for the agent so Reflexio can score interactions."
       defaultOpen={false}
     >
-      {items.length === 0 && (
-        <p className="text-xs text-muted-foreground italic">
-          No evaluations configured.
-        </p>
-      )}
-      {items.map((item, idx) => (
-        <ListItemCard
-          key={idx}
-          title={item.evaluation_name || "(unnamed)"}
-          onRemove={() => removeAt(idx)}
-        >
+      <SwitchField
+        checked={enabled}
+        onCheckedChange={setEnabled}
+        label="Enable success evaluation"
+        hint="Runs the configured evaluator for sampled interactions."
+      />
+      {enabled && (
+        <div className="space-y-4">
           <FieldRow label="Evaluation name">
             <TextField
-              value={item.evaluation_name}
-              onChange={(v) => updateAt(idx, { evaluation_name: v ?? "" })}
+              value={current.evaluation_name}
+              onChange={(v) => update({ evaluation_name: v ?? "" })}
             />
           </FieldRow>
           <FieldRow label="Success definition prompt">
             <TextAreaField
-              value={item.success_definition_prompt}
+              value={current.success_definition_prompt}
               onChange={(v) =>
-                updateAt(idx, { success_definition_prompt: v ?? "" })
+                update({ success_definition_prompt: v ?? "" })
               }
               rows={4}
             />
           </FieldRow>
           <FieldRow
-            label={`Sampling rate (${(item.sampling_rate * 100).toFixed(0)}%)`}
+            label={`Sampling rate (${(current.sampling_rate * 100).toFixed(0)}%)`}
             hint="Fraction of interactions sampled for evaluation."
           >
             <input
@@ -734,16 +723,15 @@ export function AgentSuccessSection({
               min={0}
               max={1}
               step={0.05}
-              value={item.sampling_rate}
+              value={current.sampling_rate}
               onChange={(e) =>
-                updateAt(idx, { sampling_rate: Number(e.target.value) })
+                update({ sampling_rate: Number(e.target.value) })
               }
               className="w-full"
             />
           </FieldRow>
-        </ListItemCard>
-      ))}
-      <AddButton label="Add evaluation" onClick={add} />
+        </div>
+      )}
     </Section>
   );
 }

--- a/docs/components/configure/sections.tsx
+++ b/docs/components/configure/sections.tsx
@@ -481,83 +481,72 @@ export function ProfileExtractorsSection({
   value,
   setConfig,
 }: {
-  value: ProfileExtractorConfig[] | null;
+  value: ProfileExtractorConfig | null;
   setConfig: SetConfig;
 }) {
-  const items = value ?? [];
-  const updateAt = (idx: number, patch: Partial<ProfileExtractorConfig>) => {
+  const enabled = value !== null;
+  const current = value ?? defaultProfileExtractor();
+  const update = (patch: Partial<ProfileExtractorConfig>) => {
     setConfig((prev) => {
-      const next = [...(prev.profile_extractor_configs ?? [])];
-      next[idx] = { ...next[idx], ...patch };
-      return { ...prev, profile_extractor_configs: next };
+      const existing = prev.profile_extractor_config ?? defaultProfileExtractor();
+      return { ...prev, profile_extractor_config: { ...existing, ...patch } };
     });
   };
-  const removeAt = (idx: number) => {
-    setConfig((prev) => {
-      const next = [...(prev.profile_extractor_configs ?? [])];
-      next.splice(idx, 1);
-      return { ...prev, profile_extractor_configs: next };
-    });
-  };
-  const add = () => {
+  const setEnabled = (checked: boolean) => {
     setConfig((prev) => ({
       ...prev,
-      profile_extractor_configs: [
-        ...(prev.profile_extractor_configs ?? []),
-        defaultProfileExtractor(),
-      ],
+      profile_extractor_config: checked
+        ? (prev.profile_extractor_config ?? defaultProfileExtractor())
+        : null,
     }));
   };
 
   return (
     <Section
-      title="Profile extractors"
-      description="Extract user-level memory (role, preferences, stable facts). At least one is required; a default is seeded if you remove them all."
+      title="Profile extractor"
+      description="Extract user-level memory (role, preferences, stable facts)."
     >
-      {items.length === 0 && (
-        <p className="text-xs text-muted-foreground italic">
-          No profile extractors configured — a default will be seeded on save.
-        </p>
-      )}
-      {items.map((item, idx) => (
-        <ListItemCard
-          key={idx}
-          title={item.extractor_name || "(unnamed)"}
-          onRemove={() => removeAt(idx)}
-        >
+      <SwitchField
+        checked={enabled}
+        onCheckedChange={setEnabled}
+        label="Enable profile extraction"
+        hint="Runs one configured profile extractor for user-level memory."
+      />
+      {enabled && (
+        <div className="space-y-4">
           <FieldRow label="Name">
             <TextField
-              value={item.extractor_name}
-              onChange={(v) => updateAt(idx, { extractor_name: v ?? "" })}
+              value={current.extractor_name}
+              onChange={(v) => update({ extractor_name: v ?? "" })}
             />
           </FieldRow>
           <FieldRow label="Extraction definition prompt">
             <TextAreaField
-              value={item.extraction_definition_prompt}
+              value={current.extraction_definition_prompt}
               onChange={(v) =>
-                updateAt(idx, { extraction_definition_prompt: v ?? "" })
+                update({ extraction_definition_prompt: v ?? "" })
               }
               rows={4}
             />
           </FieldRow>
           <FieldRow label="Context prompt (optional)">
             <TextAreaField
-              value={item.context_prompt}
-              onChange={(v) => updateAt(idx, { context_prompt: v })}
+              value={current.context_prompt}
+              onChange={(v) => update({ context_prompt: v })}
               rows={2}
             />
           </FieldRow>
           <SwitchField
             label="Manual trigger only"
             hint="Skip automatic extraction — only run when triggered manually."
-            checked={item.manual_trigger}
-            onCheckedChange={(c) => updateAt(idx, { manual_trigger: c })}
+            checked={current.manual_trigger}
+            onCheckedChange={(c) => update({ manual_trigger: c })}
           />
           <div className="grid grid-cols-2 gap-3">
             <FieldRow label="Window size override">
               <NumberField
-                value={item.window_size_override}
-                onChange={(v) => updateAt(idx, { window_size_override: v })}
+                value={current.window_size_override}
+                onChange={(v) => update({ window_size_override: v })}
                 min={1}
                 allowNull
                 placeholder="(inherit)"
@@ -565,17 +554,16 @@ export function ProfileExtractorsSection({
             </FieldRow>
             <FieldRow label="Stride override">
               <NumberField
-                value={item.stride_size_override}
-                onChange={(v) => updateAt(idx, { stride_size_override: v })}
+                value={current.stride_size_override}
+                onChange={(v) => update({ stride_size_override: v })}
                 min={1}
                 allowNull
                 placeholder="(inherit)"
               />
             </FieldRow>
           </div>
-        </ListItemCard>
-      ))}
-      <AddButton label="Add profile extractor" onClick={add} />
+        </div>
+      )}
     </Section>
   );
 }
@@ -584,79 +572,68 @@ export function PlaybookExtractorsSection({
   value,
   setConfig,
 }: {
-  value: UserPlaybookExtractorConfig[] | null;
+  value: UserPlaybookExtractorConfig | null;
   setConfig: SetConfig;
 }) {
-  const items = value ?? [];
-  const updateAt = (
-    idx: number,
-    patch: Partial<UserPlaybookExtractorConfig>
-  ) => {
+  const enabled = value !== null;
+  const current = value ?? defaultPlaybookExtractor();
+  const update = (patch: Partial<UserPlaybookExtractorConfig>) => {
     setConfig((prev) => {
-      const next = [...(prev.user_playbook_extractor_configs ?? [])];
-      next[idx] = { ...next[idx], ...patch };
-      return { ...prev, user_playbook_extractor_configs: next };
+      const existing =
+        prev.user_playbook_extractor_config ?? defaultPlaybookExtractor();
+      return {
+        ...prev,
+        user_playbook_extractor_config: { ...existing, ...patch },
+      };
     });
   };
-  const removeAt = (idx: number) => {
-    setConfig((prev) => {
-      const next = [...(prev.user_playbook_extractor_configs ?? [])];
-      next.splice(idx, 1);
-      return { ...prev, user_playbook_extractor_configs: next };
-    });
-  };
-  const add = () => {
+  const setEnabled = (checked: boolean) => {
     setConfig((prev) => ({
       ...prev,
-      user_playbook_extractor_configs: [
-        ...(prev.user_playbook_extractor_configs ?? []),
-        defaultPlaybookExtractor(),
-      ],
+      user_playbook_extractor_config: checked
+        ? (prev.user_playbook_extractor_config ?? defaultPlaybookExtractor())
+        : null,
     }));
   };
 
   return (
     <Section
-      title="Playbook extractors"
-      description="Extract behavioral rules for the agent (what works, what doesn't). Defaults are seeded if empty."
+      title="Playbook extractor"
+      description="Extract behavioral rules for the agent (what works, what doesn't)."
       defaultOpen={false}
     >
-      {items.length === 0 && (
-        <p className="text-xs text-muted-foreground italic">
-          No playbook extractors configured — a default will be seeded on save.
-        </p>
-      )}
-      {items.map((item, idx) => (
-        <ListItemCard
-          key={idx}
-          title={item.extractor_name || "(unnamed)"}
-          onRemove={() => removeAt(idx)}
-        >
+      <SwitchField
+        checked={enabled}
+        onCheckedChange={setEnabled}
+        label="Enable playbook extraction"
+        hint="Runs one configured playbook extractor for agent guidance."
+      />
+      {enabled && (
+        <div className="space-y-4">
           <FieldRow label="Name">
             <TextField
-              value={item.extractor_name}
-              onChange={(v) => updateAt(idx, { extractor_name: v ?? "" })}
+              value={current.extractor_name}
+              onChange={(v) => update({ extractor_name: v ?? "" })}
             />
           </FieldRow>
           <FieldRow label="Extraction definition prompt">
             <TextAreaField
-              value={item.extraction_definition_prompt}
+              value={current.extraction_definition_prompt}
               onChange={(v) =>
-                updateAt(idx, { extraction_definition_prompt: v ?? "" })
+                update({ extraction_definition_prompt: v ?? "" })
               }
               rows={4}
             />
           </FieldRow>
           <FieldRow label="Context prompt (optional)">
             <TextAreaField
-              value={item.context_prompt}
-              onChange={(v) => updateAt(idx, { context_prompt: v })}
+              value={current.context_prompt}
+              onChange={(v) => update({ context_prompt: v })}
               rows={2}
             />
           </FieldRow>
-        </ListItemCard>
-      ))}
-      <AddButton label="Add playbook extractor" onClick={add} />
+        </div>
+      )}
     </Section>
   );
 }

--- a/docs/components/method/code-panel.tsx
+++ b/docs/components/method/code-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTheme } from "next-themes";
 import { Play, RotateCcw, ChevronDown, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -36,17 +36,13 @@ export function CodePanel({
 }: CodePanelProps) {
   const { resolvedTheme } = useTheme();
   const [showParams, setShowParams] = useState(true);
-  const [code, setCode] = useState(() =>
-    generatePythonCode(method, params)
+  const generatedCode = useMemo(
+    () => generatePythonCode(method, params),
+    [method, params]
   );
+  const [code, setCode] = useState(generatedCode);
   const [codeEdited, setCodeEdited] = useState(false);
-
-  // Regenerate code when params change (but not if user hand-edited)
-  useEffect(() => {
-    if (!codeEdited) {
-      setCode(generatePythonCode(method, params));
-    }
-  }, [method, params, codeEdited]);
+  const displayedCode = codeEdited ? code : generatedCode;
 
   const handleParamChange = useCallback(
     (name: string, value: unknown) => {
@@ -68,14 +64,14 @@ export function CodePanel({
 
   const handleRun = useCallback(() => {
     if (codeEdited) {
-      const parsed = parsePythonCode(code, method);
+      const parsed = parsePythonCode(displayedCode, method);
       if (parsed) {
         onRun(parsed.params);
         return;
       }
     }
     onRun(params);
-  }, [codeEdited, code, method, params, onRun]);
+  }, [codeEdited, displayedCode, method, params, onRun]);
 
   const handleReset = useCallback(() => {
     const emptyParams: Record<string, unknown> = {};
@@ -134,7 +130,7 @@ export function CodePanel({
         <MonacoEditor
           language="python"
           theme={resolvedTheme === "dark" ? "vs-dark" : "light"}
-          value={code}
+          value={displayedCode}
           onChange={handleCodeChange}
           options={{
             minimap: { enabled: false },

--- a/docs/hooks/use-settings.tsx
+++ b/docs/hooks/use-settings.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useRef,
   ReactNode,
 } from "react";
 
@@ -20,10 +21,11 @@ interface SettingsContextValue extends Settings {
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
 const STORAGE_KEY = "reflexio-docs-settings";
+const DEFAULT_SETTINGS: Settings = { apiEndpoint: "http://localhost:8081" };
 
 function loadSettings(): Settings {
   if (typeof window === "undefined") {
-    return { apiEndpoint: "http://localhost:8081" };
+    return DEFAULT_SETTINGS;
   }
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -31,17 +33,36 @@ function loadSettings(): Settings {
   } catch {
     // ignore
   }
-  return { apiEndpoint: "http://localhost:8081" };
+  return DEFAULT_SETTINGS;
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [settings, setSettings] = useState<Settings>(() => loadSettings());
+  const [settings, setSettings] = useState<Settings>(DEFAULT_SETTINGS);
+  const hasLoadedClientSettings = useRef(false);
+  const [clientSettingsLoaded, setClientSettingsLoaded] = useState(false);
 
   useEffect(() => {
-    if (typeof window !== "undefined") {
+    let isMounted = true;
+    queueMicrotask(() => {
+      if (!isMounted) return;
+      setSettings(loadSettings());
+      hasLoadedClientSettings.current = true;
+      setClientSettingsLoaded(true);
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (
+      typeof window !== "undefined" &&
+      hasLoadedClientSettings.current &&
+      clientSettingsLoaded
+    ) {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
     }
-  }, [settings]);
+  }, [settings, clientSettingsLoaded]);
 
   const setApiEndpoint = useCallback((endpoint: string) => {
     setSettings((prev) => ({ ...prev, apiEndpoint: endpoint }));

--- a/docs/hooks/use-settings.tsx
+++ b/docs/hooks/use-settings.tsx
@@ -35,21 +35,13 @@ function loadSettings(): Settings {
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [settings, setSettings] = useState<Settings>({
-    apiEndpoint: "http://localhost:8081",
-  });
-  const [mounted, setMounted] = useState(false);
+  const [settings, setSettings] = useState<Settings>(() => loadSettings());
 
   useEffect(() => {
-    setSettings(loadSettings());
-    setMounted(true);
-  }, []);
-
-  useEffect(() => {
-    if (mounted) {
+    if (typeof window !== "undefined") {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
     }
-  }, [settings, mounted]);
+  }, [settings]);
 
   const setApiEndpoint = useCallback((endpoint: string) => {
     setSettings((prev) => ({ ...prev, apiEndpoint: endpoint }));

--- a/docs/lib/config-schema.ts
+++ b/docs/lib/config-schema.ts
@@ -247,14 +247,35 @@ export function serializeConfig(config: ReflexioConfig): unknown {
     return Object.values(out).some((v) => v !== null) ? out : null;
   };
 
+  const cleanExtractor = <
+    T extends {
+      extraction_definition_prompt: string;
+      context_prompt: string | null;
+      metadata_definition_prompt: string | null;
+    },
+  >(
+    extractor: T | null,
+  ): T | null => {
+    if (!extractor || extractor.extraction_definition_prompt.trim() === "") {
+      return null;
+    }
+    return {
+      ...extractor,
+      context_prompt: clean(extractor.context_prompt),
+      metadata_definition_prompt: clean(extractor.metadata_definition_prompt),
+    };
+  };
+
   return {
     storage_config: config.storage_config
       ? { db_path: clean(config.storage_config.db_path) }
       : null,
     agent_context_prompt: clean(config.agent_context_prompt),
     tool_can_use: config.tool_can_use?.length ? config.tool_can_use : null,
-    profile_extractor_config: config.profile_extractor_config,
-    user_playbook_extractor_config: config.user_playbook_extractor_config,
+    profile_extractor_config: cleanExtractor(config.profile_extractor_config),
+    user_playbook_extractor_config: cleanExtractor(
+      config.user_playbook_extractor_config,
+    ),
     agent_success_config: config.agent_success_config,
     extraction_preset: config.extraction_preset,
     window_size: config.window_size,

--- a/docs/lib/config-schema.ts
+++ b/docs/lib/config-schema.ts
@@ -103,10 +103,9 @@ export interface ReflexioConfig {
   storage_config: StorageConfigSQLite | null;
   agent_context_prompt: string | null;
   tool_can_use: ToolUseConfig[] | null;
-  profile_extractor_configs: ProfileExtractorConfig[] | null;
-  user_playbook_extractor_configs: UserPlaybookExtractorConfig[] | null;
+  profile_extractor_config: ProfileExtractorConfig | null;
+  user_playbook_extractor_config: UserPlaybookExtractorConfig | null;
   agent_success_config: AgentSuccessConfig | null;
-  agent_success_configs?: AgentSuccessConfig[] | null;
   extraction_preset: ExtractionPreset | null;
   window_size: number;
   stride_size: number;
@@ -136,8 +135,8 @@ export function defaultConfig(): ReflexioConfig {
     storage_config: { db_path: null },
     agent_context_prompt: null,
     tool_can_use: null,
-    profile_extractor_configs: [],
-    user_playbook_extractor_configs: [],
+    profile_extractor_config: defaultProfileExtractor(),
+    user_playbook_extractor_config: defaultPlaybookExtractor(),
     agent_success_config: null,
     extraction_preset: null,
     window_size: 10,
@@ -254,13 +253,8 @@ export function serializeConfig(config: ReflexioConfig): unknown {
       : null,
     agent_context_prompt: clean(config.agent_context_prompt),
     tool_can_use: config.tool_can_use?.length ? config.tool_can_use : null,
-    profile_extractor_configs: config.profile_extractor_configs?.length
-      ? config.profile_extractor_configs
-      : null,
-    user_playbook_extractor_configs: config.user_playbook_extractor_configs
-      ?.length
-      ? config.user_playbook_extractor_configs
-      : null,
+    profile_extractor_config: config.profile_extractor_config,
+    user_playbook_extractor_config: config.user_playbook_extractor_config,
     agent_success_config: config.agent_success_config,
     extraction_preset: config.extraction_preset,
     window_size: config.window_size,

--- a/docs/lib/config-schema.ts
+++ b/docs/lib/config-schema.ts
@@ -105,7 +105,8 @@ export interface ReflexioConfig {
   tool_can_use: ToolUseConfig[] | null;
   profile_extractor_configs: ProfileExtractorConfig[] | null;
   user_playbook_extractor_configs: UserPlaybookExtractorConfig[] | null;
-  agent_success_configs: AgentSuccessConfig[] | null;
+  agent_success_config: AgentSuccessConfig | null;
+  agent_success_configs?: AgentSuccessConfig[] | null;
   extraction_preset: ExtractionPreset | null;
   window_size: number;
   stride_size: number;
@@ -137,7 +138,7 @@ export function defaultConfig(): ReflexioConfig {
     tool_can_use: null,
     profile_extractor_configs: [],
     user_playbook_extractor_configs: [],
-    agent_success_configs: null,
+    agent_success_config: null,
     extraction_preset: null,
     window_size: 10,
     stride_size: 5,
@@ -260,9 +261,7 @@ export function serializeConfig(config: ReflexioConfig): unknown {
       ?.length
       ? config.user_playbook_extractor_configs
       : null,
-    agent_success_configs: config.agent_success_configs?.length
-      ? config.agent_success_configs
-      : null,
+    agent_success_config: config.agent_success_config,
     extraction_preset: config.extraction_preset,
     window_size: config.window_size,
     stride_size: config.stride_size,

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -189,8 +189,7 @@ class RegenerateRequest(BaseModel):
     Args:
         evaluation_name (NonEmptyStr): Name of the evaluator to replay.
             Must match the ``agent_success_config.evaluation_name`` entry in
-            the caller's config. Legacy ``agent_success_configs`` list inputs
-            are normalized to the first entry.
+            the caller's config.
         from_ts (int): Inclusive lower bound of the window (Unix seconds).
         to_ts (int): Inclusive upper bound of the window (Unix seconds).
             Must be strictly greater than ``from_ts``.

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -188,8 +188,9 @@ class RegenerateRequest(BaseModel):
 
     Args:
         evaluation_name (NonEmptyStr): Name of the evaluator to replay.
-            Must match one of the ``agent_success_configs[*].evaluation_name``
-            entries in the caller's config.
+            Must match the ``agent_success_config.evaluation_name`` entry in
+            the caller's config. Legacy ``agent_success_configs`` list inputs
+            are normalized to the first entry.
         from_ts (int): Inclusive lower bound of the window (Unix seconds).
         to_ts (int): Inclusive upper bound of the window (Unix seconds).
             Must be strictly greater than ``from_ts``.

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -658,7 +658,7 @@ class Config(BaseModel):
         default_factory=_default_user_playbook_extractor_config
     )
     # agent level success
-    agent_success_configs: list[AgentSuccessConfig] | None = None
+    agent_success_config: AgentSuccessConfig | None = None
     # extraction preset — selects bundled window_size/stride_size values
     extraction_preset: ExtractionPreset | None = None
     # extraction parameters
@@ -738,6 +738,10 @@ class Config(BaseModel):
             ):
                 data["user_playbook_extractor_config"] = _first_or_none(
                     data["user_playbook_extractor_configs"]
+                )
+            if "agent_success_config" not in data and "agent_success_configs" in data:
+                data["agent_success_config"] = _first_or_none(
+                    data["agent_success_configs"]
                 )
             for key in (
                 "window_size",
@@ -835,3 +839,13 @@ class Config(BaseModel):
         self, value: list[UserPlaybookExtractorConfig] | None
     ) -> None:
         self.user_playbook_extractor_config = _first_or_none(value)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def agent_success_configs(self) -> list[AgentSuccessConfig]:
+        """Deprecated list view for callers that still expect evaluator lists."""
+        return [self.agent_success_config] if self.agent_success_config else []
+
+    @agent_success_configs.setter
+    def agent_success_configs(self, value: list[AgentSuccessConfig] | None) -> None:
+        self.agent_success_config = _first_or_none(value)

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -100,6 +100,44 @@ def _migrate_dict(data: Any, mapping: dict[str, str]) -> Any:
     return data
 
 
+# Retired list-valued config fields and the singular field that replaced them.
+# The first configured entry wins when an old list contains multiple items.
+_LEGACY_SINGLE_CONFIG_FIELDS: tuple[tuple[str, str], ...] = (
+    ("profile_extractor_configs", "profile_extractor_config"),
+    ("user_playbook_extractor_configs", "user_playbook_extractor_config"),
+    ("playbook_configs", "user_playbook_extractor_config"),
+    ("agent_feedback_configs", "user_playbook_extractor_config"),
+    ("agent_success_configs", "agent_success_config"),
+)
+
+
+def _first_config_entry(value: Any) -> Any:
+    if isinstance(value, list):
+        return value[0] if value else None
+    return value
+
+
+def normalize_legacy_config_shape(data: dict[str, Any]) -> dict[str, Any]:
+    """Map retired list-valued config fields onto current singular fields.
+
+    This is a stored-data upgrade path applied at storage load boundaries: any
+    config persisted before the single-extractor refactor still carries list
+    keys (e.g. ``agent_success_configs``) that ``Config`` would otherwise drop
+    as unknown fields, silently losing the user's customization. Legacy keys are
+    removed from the returned payload and the first configured entry wins.
+
+    Returns a shallow copy; the caller's dict is not mutated.
+    """
+    normalized = dict(data)
+    for legacy_field, current_field in _LEGACY_SINGLE_CONFIG_FIELDS:
+        if legacy_field not in normalized:
+            continue
+        if current_field not in normalized:
+            normalized[current_field] = _first_config_entry(normalized[legacy_field])
+        del normalized[legacy_field]
+    return normalized
+
+
 class _ExtractorWindowOverrideCompatMixin:
     @property
     def batch_size_override(self) -> int | None:

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .api_schema.validators import (
     NonEmptyStr,
@@ -58,8 +58,6 @@ _CONFIG_FIELD_MIGRATION: dict[str, str] = {
     "batch_interval": "stride_size",
     "extraction_window_size": "window_size",
     "extraction_window_stride": "stride_size",
-    "playbook_configs": "user_playbook_extractor_configs",
-    "agent_feedback_configs": "user_playbook_extractor_configs",
 }
 
 _AGGREGATOR_FIELD_MIGRATION: dict[str, str] = {
@@ -618,27 +616,11 @@ def _default_profile_extractor_config() -> ProfileExtractorConfig:
     )
 
 
-def _default_profile_extractor_configs() -> list[ProfileExtractorConfig]:
-    """Deprecated list-shaped default kept for compatibility."""
-    return [_default_profile_extractor_config()]
-
-
 def _default_user_playbook_extractor_config() -> UserPlaybookExtractorConfig:
     return UserPlaybookExtractorConfig(
         extractor_name="default_playbook_extractor",
         extraction_definition_prompt="Extract playbook rules about agent performance, including areas where the agent was helpful, areas for improvement, and any issues encountered during the interaction.",
     )
-
-
-def _default_user_playbook_extractor_configs() -> list[UserPlaybookExtractorConfig]:
-    """Deprecated list-shaped default kept for compatibility."""
-    return [_default_user_playbook_extractor_config()]
-
-
-def _first_or_none(value: Any) -> Any:
-    if isinstance(value, list):
-        return value[0] if value else None
-    return value
 
 
 class Config(BaseModel):
@@ -725,24 +707,6 @@ class Config(BaseModel):
         """
         data = _migrate_dict(data, _CONFIG_FIELD_MIGRATION)
         if isinstance(data, dict):
-            if (
-                "profile_extractor_config" not in data
-                and "profile_extractor_configs" in data
-            ):
-                data["profile_extractor_config"] = _first_or_none(
-                    data["profile_extractor_configs"]
-                )
-            if (
-                "user_playbook_extractor_config" not in data
-                and "user_playbook_extractor_configs" in data
-            ):
-                data["user_playbook_extractor_config"] = _first_or_none(
-                    data["user_playbook_extractor_configs"]
-                )
-            if "agent_success_config" not in data and "agent_success_configs" in data:
-                data["agent_success_config"] = _first_or_none(
-                    data["agent_success_configs"]
-                )
             for key in (
                 "window_size",
                 "stride_size",
@@ -788,8 +752,9 @@ class Config(BaseModel):
     @model_validator(mode="after")
     def check_pending_tool_calls_storage_backend(self) -> Self:
         """Pending tool calls require a database-backed storage backend."""
-        if self.pending_tool_call_config.enabled and isinstance(
-            self.storage_config, StorageConfigDisk
+        if self.pending_tool_call_config.enabled and not isinstance(
+            self.storage_config,
+            (StorageConfigSQLite, StorageConfigSupabase, StorageConfigPostgres),
         ):
             raise ValueError(
                 "pending_tool_call_config.enabled requires sqlite, supabase, or postgres storage"
@@ -813,39 +778,3 @@ class Config(BaseModel):
     @batch_interval.setter
     def batch_interval(self, value: int) -> None:
         self.stride_size = value
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def profile_extractor_configs(self) -> list[ProfileExtractorConfig]:
-        """Deprecated list view for callers that still expect extractor lists."""
-        return [self.profile_extractor_config] if self.profile_extractor_config else []
-
-    @profile_extractor_configs.setter
-    def profile_extractor_configs(
-        self, value: list[ProfileExtractorConfig] | None
-    ) -> None:
-        self.profile_extractor_config = _first_or_none(value)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def user_playbook_extractor_configs(self) -> list[UserPlaybookExtractorConfig]:
-        """Deprecated list view for callers that still expect extractor lists."""
-        if self.user_playbook_extractor_config is None:
-            return []
-        return [self.user_playbook_extractor_config]
-
-    @user_playbook_extractor_configs.setter
-    def user_playbook_extractor_configs(
-        self, value: list[UserPlaybookExtractorConfig] | None
-    ) -> None:
-        self.user_playbook_extractor_config = _first_or_none(value)
-
-    @computed_field  # type: ignore[prop-decorator]
-    @property
-    def agent_success_configs(self) -> list[AgentSuccessConfig]:
-        """Deprecated list view for callers that still expect evaluator lists."""
-        return [self.agent_success_config] if self.agent_success_config else []
-
-    @agent_success_configs.setter
-    def agent_success_configs(self, value: list[AgentSuccessConfig] | None) -> None:
-        self.agent_success_config = _first_or_none(value)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -172,6 +172,7 @@ _LEGACY_EXTRACTOR_PARTIAL_FIELDS: tuple[tuple[str, str], ...] = (
     ("user_playbook_extractor_configs", "user_playbook_extractor_config"),
     ("playbook_configs", "user_playbook_extractor_config"),
     ("agent_feedback_configs", "user_playbook_extractor_config"),
+    ("agent_success_configs", "agent_success_config"),
 )
 
 
@@ -1729,11 +1730,13 @@ def start_regenerate(
     """
     reflexio = get_reflexio(org_id=org_id)
     config = reflexio.request_context.configurator.get_config()
-    known = (
-        {c.evaluation_name for c in (config.agent_success_configs or [])}
-        if config is not None
-        else set()
-    )
+    success_config = getattr(config, "agent_success_config", None)
+    if success_config is None or not isinstance(
+        getattr(success_config, "evaluation_name", None), str
+    ):
+        legacy_configs = getattr(config, "agent_success_configs", None)
+        success_config = legacy_configs[0] if legacy_configs else None
+    known = {success_config.evaluation_name} if success_config else set()
     if payload.evaluation_name not in known:
         raise HTTPException(
             status_code=400,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -167,40 +167,6 @@ from reflexio.server.services.agent_success_evaluation.regen_jobs import (
 
 logger = logging.getLogger(__name__)
 
-_LEGACY_EXTRACTOR_PARTIAL_FIELDS: tuple[tuple[str, str], ...] = (
-    ("profile_extractor_configs", "profile_extractor_config"),
-    ("user_playbook_extractor_configs", "user_playbook_extractor_config"),
-    ("playbook_configs", "user_playbook_extractor_config"),
-    ("agent_feedback_configs", "user_playbook_extractor_config"),
-    ("agent_success_configs", "agent_success_config"),
-)
-
-
-def _normalize_legacy_extractor_partial(partial: dict[str, Any]) -> dict[str, Any]:
-    """Map legacy extractor list keys in PATCH payloads to canonical fields.
-
-    ``/api/update_config`` merges partial payloads over a serialized existing
-    config that already contains canonical extractor fields. Schema-level
-    migration cannot tell which keys came from the client, so legacy keys are
-    normalized before the merge.
-    """
-    normalized = dict(partial)
-    for legacy_name, canonical_name in _LEGACY_EXTRACTOR_PARTIAL_FIELDS:
-        if legacy_name not in partial:
-            continue
-        if canonical_name in partial or canonical_name in normalized:
-            normalized.pop(legacy_name, None)
-            continue
-
-        legacy_value = partial[legacy_name]
-        if isinstance(legacy_value, list):
-            normalized[canonical_name] = legacy_value[0] if legacy_value else None
-        else:
-            normalized[canonical_name] = legacy_value
-        normalized.pop(legacy_name, None)
-    return normalized
-
-
 # Re-exported for backwards compatibility — callers that did
 # ``from reflexio.server.api import default_get_org_id`` or ``DEFAULT_ORG_ID``
 # continue to work.
@@ -1253,8 +1219,7 @@ def update_config(
     existing = reflexio.request_context.configurator.get_config().model_dump(
         mode="python"
     )
-    normalized_partial = _normalize_legacy_extractor_partial(partial)
-    merged = {**existing, **normalized_partial}
+    merged = {**existing, **partial}
     # Pydantic validates the merged shape and rejects unknown / malformed
     # fields here, before storage validation in reflexio.set_config.
     # Convert ValidationError into 422 so callers passing a partial that
@@ -1731,11 +1696,6 @@ def start_regenerate(
     reflexio = get_reflexio(org_id=org_id)
     config = reflexio.request_context.configurator.get_config()
     success_config = getattr(config, "agent_success_config", None)
-    if success_config is None or not isinstance(
-        getattr(success_config, "evaluation_name", None), str
-    ):
-        legacy_configs = getattr(config, "agent_success_configs", None)
-        success_config = legacy_configs[0] if legacy_configs else None
     known = {success_config.evaluation_name} if success_config else set()
     if payload.evaluation_name not in known:
         raise HTTPException(

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
@@ -28,8 +28,8 @@ class AgentSuccessGenerationServiceConfig:
         request_interaction_data_models: The interactions to evaluate
         source: Source of the interactions
         evaluation_name_filter: Optional evaluator-name filter. When set,
-            _load_extractor_configs narrows to the single AgentSuccessConfig
-            whose evaluation_name matches; all others are skipped.
+            _load_extractor_config returns the configured AgentSuccessConfig only
+            when its evaluation_name matches.
     """
 
     session_id: str
@@ -48,8 +48,7 @@ class AgentSuccessEvaluationService(
     ]
 ):
     """
-    Service for evaluating agent success across multiple evaluation criteria.
-    Runs multiple AgentSuccessEvaluator instances sequentially.
+    Service for evaluating agent success with the configured evaluator.
     """
 
     def __init__(
@@ -88,23 +87,31 @@ class AgentSuccessEvaluationService(
             evaluation_name_filter=request.evaluation_name_filter,
         )
 
-    def _load_extractor_configs(self) -> list[AgentSuccessConfig]:
+    def _load_extractor_config(self) -> AgentSuccessConfig | None:
         """
-        Load agent success configs from configurator.
+        Load agent success config from configurator.
 
         When the active service_config carries an evaluation_name_filter
-        (set by run_group_evaluation in regenerate mode), skip every config
-        whose evaluation_name does not match — so the regenerate flow only
-        re-runs the targeted evaluator instead of every configured rubric.
+        (set by run_group_evaluation in regenerate mode), return None when
+        the configured evaluator's name does not match.
 
         Returns:
-            list[AgentSuccessConfig]: Agent success configurations to execute.
+            AgentSuccessConfig | None: Configured evaluator, or None when disabled
+            or filtered out.
         """
-        configs = self.configurator.get_config().agent_success_configs or []  # type: ignore[reportOptionalMemberAccess]
+        root_config = self.configurator.get_config()
+        config = getattr(root_config, "agent_success_config", None)
+        if config is None or not isinstance(
+            getattr(config, "evaluation_name", None), str
+        ):
+            legacy_configs = getattr(root_config, "agent_success_configs", None)
+            config = legacy_configs[0] if legacy_configs else None
         name_filter = getattr(self.service_config, "evaluation_name_filter", None)
         if name_filter is None:
-            return configs
-        return [c for c in configs if c.evaluation_name == name_filter]
+            return config
+        if config and config.evaluation_name == name_filter:
+            return config
+        return None
 
     def _create_extractor(
         self,

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
@@ -101,11 +101,6 @@ class AgentSuccessEvaluationService(
         """
         root_config = self.configurator.get_config()
         config = getattr(root_config, "agent_success_config", None)
-        if config is None or not isinstance(
-            getattr(config, "evaluation_name", None), str
-        ):
-            legacy_configs = getattr(root_config, "agent_success_configs", None)
-            config = legacy_configs[0] if legacy_configs else None
         name_filter = getattr(self.service_config, "evaluation_name_filter", None)
         if name_filter is None:
             return config

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -260,6 +260,7 @@ class BaseGenerationService(
             return len(result)
         return 1 if result else 0
 
+    @abstractmethod
     def _load_extractor_config(self) -> TExtractorConfig | None:
         """
         Load extractor configuration from the configurator.
@@ -267,13 +268,6 @@ class BaseGenerationService(
         Returns:
             Extractor configuration object from YAML, or None when disabled.
         """
-        legacy_loader = getattr(self, "_load_extractor_configs", None)
-        if callable(legacy_loader):
-            configs: Any = legacy_loader()
-            if isinstance(configs, list):
-                return configs[0] if configs else None
-            return None
-        raise NotImplementedError
 
     @abstractmethod
     def _load_generation_service_config(
@@ -371,33 +365,6 @@ class BaseGenerationService(
             Optional[str]: Scope ID (e.g., user_id) or None for org-level scope
         """
 
-    def _filter_extractor_configs_by_service_config(
-        self,
-        extractor_configs: list[TExtractorConfig],
-        service_config: TGenerationServiceConfig,
-    ) -> list[TExtractorConfig]:
-        """
-        Filter extractor configs based on request_sources_enabled and manual_trigger fields.
-
-        Args:
-            extractor_configs: List of extractor configuration objects from YAML
-            service_config: Runtime service configuration containing the source and allow_manual_trigger flag
-
-        Returns:
-            Filtered list of extractor configs that should run for the given source and trigger mode
-        """
-        # Extract filtering parameters from service_config
-        source = getattr(service_config, "source", None)
-        allow_manual_trigger = getattr(service_config, "allow_manual_trigger", False)
-        extractor_names = getattr(service_config, "extractor_names", None)
-
-        return filter_extractor_configs(
-            extractor_configs=extractor_configs,
-            source=source,
-            allow_manual_trigger=allow_manual_trigger,
-            extractor_names=extractor_names,
-        )
-
     def _filter_extractor_config_by_service_config(
         self,
         extractor_config: TExtractorConfig,
@@ -407,8 +374,11 @@ class BaseGenerationService(
         Filter the extractor config based on request_sources_enabled, manual_trigger,
         and explicit extractor name filters.
         """
-        filtered = self._filter_extractor_configs_by_service_config(
-            [extractor_config], service_config
+        filtered = filter_extractor_configs(
+            extractor_configs=[extractor_config],
+            source=getattr(service_config, "source", None),
+            allow_manual_trigger=getattr(service_config, "allow_manual_trigger", False),
+            extractor_names=getattr(service_config, "extractor_names", None),
         )
         return filtered[0] if filtered else None
 
@@ -497,25 +467,6 @@ class BaseGenerationService(
             stride_size,
         )
         return None
-
-    def _filter_configs_by_stride(
-        self, extractor_configs: list[TExtractorConfig]
-    ) -> list[TExtractorConfig]:
-        """Deprecated list-shaped wrapper for older callers/tests."""
-        state_service_name = self._get_extractor_state_service_name()
-        if (
-            state_service_name is None
-            or not getattr(self.service_config, "auto_run", True)
-            or getattr(self.service_config, "force_extraction", False)
-        ):
-            return extractor_configs
-
-        passing: list[TExtractorConfig] = []
-        for config in extractor_configs:
-            filtered = self._filter_config_by_stride(config)
-            if filtered is not None:
-                passing.append(filtered)
-        return passing
 
     # ===============================
     # In-progress state management via OperationStateManager
@@ -923,43 +874,6 @@ class BaseGenerationService(
             if executor is not None:
                 executor.shutdown(wait=False, cancel_futures=True)
 
-    def _execute_extractors(
-        self,
-        extractor_configs: list[TExtractorConfig],
-        identifier: str,
-    ) -> list:
-        """Deprecated list-shaped wrapper for older callers/tests."""
-        all_results: list = []
-        self._last_extraction_run_ids = []
-        run_stats = {"total": len(extractor_configs), "failed": 0, "timed_out": 0}
-        for config in extractor_configs:
-            try:
-                result = self._execute_extractor(config, identifier)
-            except ExtractorExecutionError:
-                run_stats["failed"] += self._last_extractor_run_stats.get("failed", 1)
-                run_stats["timed_out"] += self._last_extractor_run_stats.get(
-                    "timed_out", 0
-                )
-                continue
-            run_stats["failed"] += self._last_extractor_run_stats.get("failed", 0)
-            run_stats["timed_out"] += self._last_extractor_run_stats.get("timed_out", 0)
-            if result:
-                all_results.append(result)
-
-        self._last_extractor_run_stats = run_stats
-        if (
-            extractor_configs
-            and not all_results
-            and run_stats["failed"] == len(extractor_configs)
-        ):
-            error_msg = (
-                f"Configured extractor execution failed for {self._get_service_name()} "
-                f"identifier={identifier}"
-            )
-            logger.error(error_msg)
-            raise ExtractorExecutionError(error_msg)
-        return all_results
-
     def _finalize_extraction_runs(self) -> None:
         if self.storage is None:
             return
@@ -1007,9 +921,7 @@ class BaseGenerationService(
                 increment_finalization_attempts=True,
             )
 
-    def _should_run_before_extraction(
-        self, extractor_config: TExtractorConfig | list[TExtractorConfig]
-    ) -> bool:
+    def _should_run_before_extraction(self, extractor_config: TExtractorConfig) -> bool:
         """
         Pre-extraction check called before extractor execution.
 
@@ -1031,11 +943,6 @@ class BaseGenerationService(
         Returns:
             bool: True if extraction should proceed, False to skip
         """
-        if isinstance(extractor_config, list):
-            if not extractor_config:
-                return False
-            extractor_config = extractor_config[0]
-
         # Skip for non-auto runs (rerun/manual flows always run)
         if not getattr(self.service_config, "auto_run", True):
             return True
@@ -1155,7 +1062,7 @@ class BaseGenerationService(
         return None
 
     def _collect_scoped_interactions_for_precheck(
-        self, extractor_config: TExtractorConfig | list[TExtractorConfig]
+        self, extractor_config: TExtractorConfig
     ) -> tuple[list[RequestInteractionDataModel], TExtractorConfig]:
         """
         Collect interactions for consolidated pre-check using extractor-scoped filters.
@@ -1178,26 +1085,6 @@ class BaseGenerationService(
         )
 
         extra_kwargs = self._get_precheck_interaction_query_kwargs()
-
-        if isinstance(extractor_config, list):
-            deduped_sessions: dict[str, RequestInteractionDataModel] = {}
-            scoped_config = extractor_config[0] if extractor_config else None
-            for config in extractor_config:
-                session_data_models, scoped_config = (
-                    self._collect_scoped_interactions_for_precheck(config)
-                )
-                for data_model in session_data_models:
-                    request_id = getattr(data_model.request, "request_id", None)
-                    dedupe_key = (
-                        request_id
-                        or data_model.session_id
-                        or f"scoped_group_{len(deduped_sessions)}"
-                    )
-                    if dedupe_key not in deduped_sessions:
-                        deduped_sessions[dedupe_key] = data_model
-            if scoped_config is None:
-                raise ValueError("extractor_config list must not be empty")
-            return list(deduped_sessions.values()), scoped_config
 
         should_skip, effective_source = get_effective_source_filter(
             extractor_config, getattr(self.service_config, "source", None)

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -11,6 +11,7 @@ import uuid
 from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 from typing import Any, Generic, TypeVar
@@ -43,7 +44,7 @@ class StatusChangeOperation(StrEnum):
 
 
 class ExtractorExecutionError(RuntimeError):
-    """Raised when all extractors fail for a request/user context."""
+    """Raised when the configured extractor fails for a request/user context."""
 
 
 logger = logging.getLogger(__name__)
@@ -152,13 +153,20 @@ TGenerationServiceConfig = TypeVar("TGenerationServiceConfig")
 TRequest = TypeVar("TRequest")
 
 
+@dataclass(frozen=True)
+class PreparedGenerationRun(Generic[TExtractorConfig]):  # noqa: UP046
+    extractor_config: TExtractorConfig
+    extractor_name: str
+    identifier: str
+
+
 # Unified base class for all generation services (evaluation, playbook, profile)
 class BaseGenerationService(
     ABC,
     Generic[TExtractorConfig, TExtractor, TGenerationServiceConfig, TRequest],  # noqa: UP046
 ):
     """
-    Base class for generation services that run multiple extractors sequentially.
+    Base class for generation services that run one configured extractor.
 
     This unified class supports two types of services:
     1. Evaluation services (playbook, agent success) - process interactions and save UserPlaybook
@@ -171,9 +179,9 @@ class BaseGenerationService(
         TRequest: The request type (e.g., ProfileGenerationRequest, PlaybookGenerationRequest, AgentSuccessEvaluationRequest)
 
     Child classes must implement:
-    - _load_extractor_configs(): Load extractor configurations from configurator
+    - _load_extractor_config(): Load extractor configuration from configurator
     - _load_generation_service_config(): Extract parameters from request and return GenerationServiceConfig
-    - _create_extractor(): Create extractor instances with extractor config and service config
+    - _create_extractor(): Create extractor instance with extractor config and service config
     - _get_service_name(): Get service name for logging
     - _process_results(): Process and save results (can access self.service_config)
     """
@@ -247,23 +255,25 @@ class BaseGenerationService(
         )
 
     @staticmethod
-    def _count_generated_results(results: list) -> int:
-        count = 0
-        for result in results:
-            if isinstance(result, list):
-                count += len(result)
-            elif result:
-                count += 1
-        return count
+    def _count_generated_results(result: Any) -> int:
+        if isinstance(result, list):
+            return len(result)
+        return 1 if result else 0
 
-    @abstractmethod
-    def _load_extractor_configs(self) -> list[TExtractorConfig]:
+    def _load_extractor_config(self) -> TExtractorConfig | None:
         """
-        Load extractor configurations from the configurator.
+        Load extractor configuration from the configurator.
 
         Returns:
-            List of extractor configuration objects (from YAML)
+            Extractor configuration object from YAML, or None when disabled.
         """
+        legacy_loader = getattr(self, "_load_extractor_configs", None)
+        if callable(legacy_loader):
+            configs: Any = legacy_loader()
+            if isinstance(configs, list):
+                return configs[0] if configs else None
+            return None
+        raise NotImplementedError
 
     @abstractmethod
     def _load_generation_service_config(
@@ -388,6 +398,20 @@ class BaseGenerationService(
             extractor_names=extractor_names,
         )
 
+    def _filter_extractor_config_by_service_config(
+        self,
+        extractor_config: TExtractorConfig,
+        service_config: TGenerationServiceConfig,
+    ) -> TExtractorConfig | None:
+        """
+        Filter the extractor config based on request_sources_enabled, manual_trigger,
+        and explicit extractor name filters.
+        """
+        filtered = self._filter_extractor_configs_by_service_config(
+            [extractor_config], service_config
+        )
+        return filtered[0] if filtered else None
+
     def _get_extractor_state_service_name(self) -> str | None:
         """
         Get the service name used for extractor state (stride_size bookmark) lookups.
@@ -401,34 +425,31 @@ class BaseGenerationService(
         """
         return None
 
-    def _filter_configs_by_stride(
-        self, extractor_configs: list[TExtractorConfig]
-    ) -> list[TExtractorConfig]:
+    def _filter_config_by_stride(
+        self, extractor_config: TExtractorConfig
+    ) -> TExtractorConfig | None:
         """
-        Filter extractor configs by stride_size check before the should_run LLM call.
+        Filter extractor config by stride_size check before the should_run LLM call.
 
         Skips filtering when:
         - _get_extractor_state_service_name() returns None (service doesn't support stride_size)
         - auto_run is False (rerun/manual flows skip stride_size)
 
-        For each config, resolves window_size/stride_size params and checks if enough new
-        interactions exist since the last run. Only configs that pass stride_size are returned.
-
         Args:
-            extractor_configs: List of extractor configs after source/manual_trigger filtering
+            extractor_config: Extractor config after source/manual_trigger filtering
 
         Returns:
-            List of extractor configs that pass the stride_size check
+            Extractor config when it passes the stride_size check, otherwise None.
         """
         state_service_name = self._get_extractor_state_service_name()
         if state_service_name is None:
-            return extractor_configs
+            return extractor_config
 
         if not getattr(self.service_config, "auto_run", True):
-            return extractor_configs
+            return extractor_config
 
         if getattr(self.service_config, "force_extraction", False):
-            return extractor_configs
+            return extractor_config
 
         root_config = self.request_context.configurator.get_config()
         global_window_size = (
@@ -444,41 +465,57 @@ class BaseGenerationService(
             state_service_name,  # type: ignore[reportArgumentType]
         )
 
-        passing_configs: list[TExtractorConfig] = []
+        name = get_extractor_name(extractor_config)
+        _, stride_size = get_extractor_window_params(
+            extractor_config, global_window_size, global_stride_size
+        )
+
+        # Resolve effective source filter for this extractor
+        should_skip, effective_source = get_effective_source_filter(
+            extractor_config, getattr(self.service_config, "source", None)
+        )
+        if should_skip:
+            return None
+
+        (
+            _,
+            new_interactions,
+        ) = state_manager.get_extractor_state_with_new_interactions(
+            extractor_name=name,
+            user_id=getattr(self.service_config, "user_id", None),
+            sources=effective_source,
+        )
+        new_count = sum(len(ri.interactions) for ri in new_interactions)
+
+        if should_extractor_run_by_stride(new_count, stride_size):
+            return extractor_config
+
+        logger.info(
+            "Stride pre-filter: skipping extractor '%s' (new=%d, stride_size=%s)",
+            name,
+            new_count,
+            stride_size,
+        )
+        return None
+
+    def _filter_configs_by_stride(
+        self, extractor_configs: list[TExtractorConfig]
+    ) -> list[TExtractorConfig]:
+        """Deprecated list-shaped wrapper for older callers/tests."""
+        state_service_name = self._get_extractor_state_service_name()
+        if (
+            state_service_name is None
+            or not getattr(self.service_config, "auto_run", True)
+            or getattr(self.service_config, "force_extraction", False)
+        ):
+            return extractor_configs
+
+        passing: list[TExtractorConfig] = []
         for config in extractor_configs:
-            name = get_extractor_name(config)
-            _, stride_size = get_extractor_window_params(
-                config, global_window_size, global_stride_size
-            )
-
-            # Resolve effective source filter for this extractor
-            should_skip, effective_source = get_effective_source_filter(
-                config, getattr(self.service_config, "source", None)
-            )
-            if should_skip:
-                continue
-
-            (
-                _,
-                new_interactions,
-            ) = state_manager.get_extractor_state_with_new_interactions(
-                extractor_name=name,
-                user_id=getattr(self.service_config, "user_id", None),
-                sources=effective_source,
-            )
-            new_count = sum(len(ri.interactions) for ri in new_interactions)
-
-            if should_extractor_run_by_stride(new_count, stride_size):
-                passing_configs.append(config)
-            else:
-                logger.info(
-                    "Stride pre-filter: skipping extractor '%s' (new=%d, stride_size=%s)",
-                    name,
-                    new_count,
-                    stride_size,
-                )
-
-        return passing_configs
+            filtered = self._filter_config_by_stride(config)
+            if filtered is not None:
+                passing.append(filtered)
+        return passing
 
     # ===============================
     # In-progress state management via OperationStateManager
@@ -666,7 +703,7 @@ class BaseGenerationService(
         Run the actual generation logic.
 
         Orchestrates validation, config loading, extractor execution, and result
-        processing by delegating to _prepare_generation_run and _execute_extractors.
+        processing by delegating to _prepare_generation_run and _execute_extractor.
 
         Args:
             request: The request object containing parameters
@@ -677,22 +714,28 @@ class BaseGenerationService(
 
         generation_start = time.perf_counter()
         try:
-            extractor_configs, identifier = self._prepare_generation_run(request)
-            if extractor_configs is None:
+            prepared = self._prepare_generation_run(request)
+            if prepared is None:
                 return
 
             self._record_generation_event(
                 event_name="generation_started",
                 outcome="started",
-                count_value=len(extractor_configs),
-                metadata={"identifier": identifier},
+                count_value=1,
+                metadata={
+                    "identifier": prepared.identifier,
+                    "extractor_name": prepared.extractor_name,
+                },
             )
-            all_results = self._execute_extractors(extractor_configs, identifier)
-            generated_count = self._count_generated_results(all_results)
+            self._last_extraction_run_ids = []
+            result = self._execute_extractor(
+                prepared.extractor_config, prepared.identifier
+            )
+            generated_count = self._count_generated_results(result)
 
             try:
-                if all_results:
-                    self._process_results(all_results)
+                if result:
+                    self._process_results([result])
                 self._finalize_extraction_runs()
             except Exception as exc:
                 self._mark_extraction_runs_finalization_failed(exc)
@@ -704,9 +747,14 @@ class BaseGenerationService(
                 count_value=generated_count,
                 duration_ms=int((time.perf_counter() - generation_start) * 1000),
                 metadata={
-                    "identifier": identifier,
-                    "extractor_count": len(extractor_configs),
-                    "extractor_run_stats": self._last_extractor_run_stats,
+                    "identifier": prepared.identifier,
+                    "extractor_name": prepared.extractor_name,
+                    "extractor_failed": bool(
+                        self._last_extractor_run_stats.get("failed")
+                    ),
+                    "extractor_timed_out": bool(
+                        self._last_extractor_run_stats.get("timed_out")
+                    ),
                 },
             )
 
@@ -728,64 +776,62 @@ class BaseGenerationService(
 
     def _prepare_generation_run(
         self, request: TRequest
-    ) -> tuple[list[TExtractorConfig] | None, str]:
+    ) -> PreparedGenerationRun[TExtractorConfig] | None:
         """
-        Validate request, load config, filter extractor configs, and run pre-extraction checks.
+        Validate request, load config, filter extractor config, and run pre-extraction checks.
 
-        Loads the generation service config from the request, loads and filters extractor
-        configs by source, manual trigger, and stride_size, then runs the pre-extraction gate.
+        Loads the generation service config from the request, loads and filters the
+        extractor config by source, manual trigger, and stride_size, then runs the
+        pre-extraction gate.
 
         Args:
             request: The request object containing parameters
 
         Returns:
-            tuple: (extractor_configs, identifier) where extractor_configs is None if
-                generation should be skipped, or the filtered list of configs to execute.
-                identifier is a string for logging context.
+            PreparedGenerationRun when generation should proceed, otherwise None.
         """
         self.service_config = self._load_generation_service_config(request)
 
-        extractor_configs = self._load_extractor_configs()
-        if not extractor_configs:
-            logger.warning("No %s extractor configs found", self._get_service_name())
-            return None, ""
+        extractor_config = self._load_extractor_config()
+        if extractor_config is None:
+            logger.warning("No %s extractor config found", self._get_service_name())
+            return None
 
-        extractor_configs = self._filter_extractor_configs_by_service_config(
-            extractor_configs, self.service_config
+        extractor_config = self._filter_extractor_config_by_service_config(
+            extractor_config, self.service_config
         )
 
-        if not extractor_configs:
+        if extractor_config is None:
             source = getattr(self.service_config, "source", "N/A")
             source_display = source or "N/A"
             logger.info(
-                "No %s extractor configs enabled for source: %s",
+                "No %s extractor config enabled for source: %s",
                 self._get_service_name(),
                 source_display,
             )
-            return None, ""
+            return None
 
-        extractor_configs = self._filter_configs_by_stride(extractor_configs)
-        if not extractor_configs:
+        extractor_config = self._filter_config_by_stride(extractor_config)
+        if extractor_config is None:
             logger.info(
-                "No extractor configs passed stride_size check for %s",
+                "Extractor config did not pass stride_size check for %s",
                 self._get_service_name(),
             )
-            return None, ""
+            return None
 
         identifier = getattr(self.service_config, "user_id", None) or getattr(
             self.service_config, "request_id", "unknown"
         )
+        extractor_name = get_extractor_name(extractor_config)
 
-        should_run = self._should_run_before_extraction(extractor_configs)
+        should_run = self._should_run_before_extraction(extractor_config)
         self._record_generation_event(
             event_name="generation_gate_evaluated",
             outcome="should_run" if should_run else "should_skip",
-            count_value=len(extractor_configs),
+            count_value=1,
             metadata={
                 "identifier": identifier,
-                "extractor_names": [
-                    get_extractor_name(config) for config in extractor_configs
-                ],
+                "extractor_name": extractor_name,
             },
         )
 
@@ -795,101 +841,123 @@ class BaseGenerationService(
                 self._get_service_name(),
                 identifier,
             )
-            return None, identifier
+            return None
 
-        return extractor_configs, identifier
+        return PreparedGenerationRun(
+            extractor_config=extractor_config,
+            extractor_name=extractor_name,
+            identifier=identifier,
+        )
+
+    def _execute_extractor(
+        self,
+        extractor_config: TExtractorConfig,
+        identifier: str,
+    ) -> Any | None:
+        """
+        Run the configured extractor with timeout and error handling.
+
+        The extractor runs in a thread pool with a timeout guard so providers that
+        ignore their own timeout cannot block generation forever.
+
+        Args:
+            extractor_config: Filtered extractor config to execute
+            identifier: Logging context identifier (user_id or request_id)
+
+        Returns:
+            Extractor result, or None if the extractor succeeded with no output.
+
+        Raises:
+            ExtractorExecutionError: If the extractor fails with an exception or timeout.
+        """
+        if (
+            self.service_config is None
+        ):  # pragma: no cover — set by _prepare_generation_run
+            raise RuntimeError("service_config must be set before executing extractor")
+
+        self._last_extractor_run_stats = {"total": 1, "failed": 0, "timed_out": 0}
+        extractor = self._create_extractor(extractor_config, self.service_config)
+        executor: ThreadPoolExecutor | None = None
+        try:
+            executor = ThreadPoolExecutor(max_workers=1)
+            # Copy context so correlation ID propagates to worker thread
+            ctx = contextvars.copy_context()
+            future = executor.submit(ctx.run, extractor.run)  # type: ignore[reportAttributeAccessIssue]
+            result = future.result(timeout=EXTRACTOR_TIMEOUT_SECONDS)
+            if isinstance(result, ExtractionOutcome):
+                if result.run_id:
+                    self._last_extraction_run_ids.append(result.run_id)
+                if result.status == "completed" and result.items:
+                    return result.items
+                logger.info(
+                    "No results generated for %s identifier: %s",
+                    self._get_service_name(),
+                    identifier,
+                )
+                return None
+            if result:
+                return result
+            logger.info(
+                "No results generated for %s identifier: %s",
+                self._get_service_name(),
+                identifier,
+            )
+            return None
+        except FuturesTimeoutError as exc:
+            self._last_extractor_run_stats = {"total": 1, "failed": 1, "timed_out": 1}
+            error_msg = (
+                f"Extractor timed out after {EXTRACTOR_TIMEOUT_SECONDS} seconds "
+                f"for {self._get_service_name()} identifier={identifier}"
+            )
+            logger.error(error_msg)
+            raise ExtractorExecutionError(error_msg) from exc
+        except Exception as exc:
+            self._last_extractor_run_stats = {"total": 1, "failed": 1, "timed_out": 0}
+            error_msg = (
+                f"Extractor failed for {self._get_service_name()} "
+                f"identifier={identifier}: {exc} (type={type(exc).__name__})"
+            )
+            logger.error(error_msg)
+            raise ExtractorExecutionError(error_msg) from exc
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=False, cancel_futures=True)
 
     def _execute_extractors(
         self,
         extractor_configs: list[TExtractorConfig],
         identifier: str,
     ) -> list:
-        """
-        Run extractors sequentially with timeout and error handling.
-
-        Each extractor runs independently in a thread pool with a timeout guard.
-        Updates _last_extractor_run_stats and raises ExtractorExecutionError if
-        all extractors fail.
-
-        Args:
-            extractor_configs: Filtered list of extractor configs to execute
-            identifier: Logging context identifier (user_id or request_id)
-
-        Returns:
-            list: Results from successful extractors (may be empty if none produced output
-                but at least one succeeded without error)
-
-        Raises:
-            ExtractorExecutionError: If every extractor fails with an exception
-        """
-        if (
-            self.service_config is None
-        ):  # pragma: no cover — set by _prepare_generation_run
-            raise RuntimeError("service_config must be set before executing extractors")
-
+        """Deprecated list-shaped wrapper for older callers/tests."""
         all_results: list = []
         self._last_extraction_run_ids = []
         run_stats = {"total": len(extractor_configs), "failed": 0, "timed_out": 0}
-
         for config in extractor_configs:
-            extractor = self._create_extractor(config, self.service_config)
-            executor: ThreadPoolExecutor | None = None
             try:
-                executor = ThreadPoolExecutor(max_workers=1)
-                # Copy context so correlation ID propagates to worker thread
-                ctx = contextvars.copy_context()
-                future = executor.submit(ctx.run, extractor.run)  # type: ignore[reportAttributeAccessIssue]
-                result = future.result(timeout=EXTRACTOR_TIMEOUT_SECONDS)
-                if isinstance(result, ExtractionOutcome):
-                    if result.run_id:
-                        self._last_extraction_run_ids.append(result.run_id)
-                    if result.status == "completed" and result.items:
-                        all_results.append(result.items)
-                elif result:
-                    all_results.append(result)
-            except FuturesTimeoutError:
-                run_stats["failed"] += 1
-                run_stats["timed_out"] += 1
-                logger.error(
-                    "Extractor timed out after %d seconds for %s identifier=%s",
-                    EXTRACTOR_TIMEOUT_SECONDS,
-                    self._get_service_name(),
-                    identifier,
+                result = self._execute_extractor(config, identifier)
+            except ExtractorExecutionError:
+                run_stats["failed"] += self._last_extractor_run_stats.get("failed", 1)
+                run_stats["timed_out"] += self._last_extractor_run_stats.get(
+                    "timed_out", 0
                 )
                 continue
-            except Exception as e:
-                run_stats["failed"] += 1
-                logger.error(
-                    "Extractor failed for %s identifier=%s: %s (type=%s)",
-                    self._get_service_name(),
-                    identifier,
-                    str(e),
-                    type(e).__name__,
-                )
-                continue
-            finally:
-                if executor is not None:
-                    executor.shutdown(wait=False, cancel_futures=True)
+            run_stats["failed"] += self._last_extractor_run_stats.get("failed", 0)
+            run_stats["timed_out"] += self._last_extractor_run_stats.get("timed_out", 0)
+            if result:
+                all_results.append(result)
 
         self._last_extractor_run_stats = run_stats
-
-        if not all_results:
-            all_extractors_failed = (
-                run_stats["total"] > 0 and run_stats["failed"] == run_stats["total"]
+        if (
+            extractor_configs
+            and not all_results
+            and run_stats["failed"] == len(extractor_configs)
+        ):
+            error_msg = (
+                f"Configured extractor execution failed for {self._get_service_name()} "
+                f"identifier={identifier}"
             )
-            if all_extractors_failed:
-                error_msg = (
-                    f"All extractors failed for {self._get_service_name()} "
-                    f"identifier={identifier}"
-                )
-                logger.error(error_msg)
-                raise ExtractorExecutionError(error_msg)
-            logger.info(
-                "No results generated for %s identifier: %s",
-                self._get_service_name(),
-                identifier,
-            )
-
+            logger.error(error_msg)
+            raise ExtractorExecutionError(error_msg)
         return all_results
 
     def _finalize_extraction_runs(self) -> None:
@@ -940,10 +1008,10 @@ class BaseGenerationService(
             )
 
     def _should_run_before_extraction(
-        self, extractor_configs: list[TExtractorConfig]
+        self, extractor_config: TExtractorConfig | list[TExtractorConfig]
     ) -> bool:
         """
-        Pre-extraction check called before the sequential extraction loop.
+        Pre-extraction check called before extractor execution.
 
         Template method that:
         1. Skips for non-auto runs and mock mode
@@ -958,11 +1026,16 @@ class BaseGenerationService(
         no prompt hook is provided.
 
         Args:
-            extractor_configs: List of enabled extractor configs that will be run
+            extractor_config: Enabled extractor config that will be run
 
         Returns:
             bool: True if extraction should proceed, False to skip
         """
+        if isinstance(extractor_config, list):
+            if not extractor_config:
+                return False
+            extractor_config = extractor_config[0]
+
         # Skip for non-auto runs (rerun/manual flows always run)
         if not getattr(self.service_config, "auto_run", True):
             return True
@@ -988,8 +1061,8 @@ class BaseGenerationService(
             return True
 
         # Collect scoped interactions
-        session_data_models, scoped_configs = (
-            self._collect_scoped_interactions_for_precheck(extractor_configs)
+        session_data_models, scoped_config = (
+            self._collect_scoped_interactions_for_precheck(extractor_config)
         )
         if not session_data_models:
             logger.info(
@@ -1013,7 +1086,7 @@ class BaseGenerationService(
             return False
 
         # Build prompt via subclass hook
-        prompt = self._build_should_run_prompt(scoped_configs, session_data_models)
+        prompt = self._build_should_run_prompt(scoped_config, session_data_models)
         if not prompt:
             return True  # No prompt means no check needed, proceed
 
@@ -1023,11 +1096,11 @@ class BaseGenerationService(
         try:
             should_start = time.perf_counter()
             logger.info(
-                "event=consolidated_should_run_start service=%s identifier=%s model=%s extractors=%d",
+                "event=consolidated_should_run_start service=%s identifier=%s model=%s extractor=%s",
                 self._get_service_name(),
                 identifier,
                 should_run_model,
-                len(extractor_configs),
+                get_extractor_name(extractor_config),
             )
             log_llm_messages(
                 logger,
@@ -1063,7 +1136,7 @@ class BaseGenerationService(
 
     def _build_should_run_prompt(
         self,
-        scoped_configs: list[TExtractorConfig],  # noqa: ARG002
+        scoped_config: TExtractorConfig,  # noqa: ARG002
         session_data_models: list[RequestInteractionDataModel],  # noqa: ARG002
     ) -> str | None:
         """
@@ -1073,7 +1146,7 @@ class BaseGenerationService(
         and prompt rendering. Return None if no check is needed (always proceed).
 
         Args:
-            scoped_configs: Extractor configs that had scoped interactions
+            scoped_config: Extractor config that had scoped interactions
             session_data_models: Deduplicated request interaction data models
 
         Returns:
@@ -1082,8 +1155,8 @@ class BaseGenerationService(
         return None
 
     def _collect_scoped_interactions_for_precheck(
-        self, extractor_configs: list[TExtractorConfig]
-    ) -> tuple[list[RequestInteractionDataModel], list[TExtractorConfig]]:
+        self, extractor_config: TExtractorConfig | list[TExtractorConfig]
+    ) -> tuple[list[RequestInteractionDataModel], TExtractorConfig]:
         """
         Collect interactions for consolidated pre-check using extractor-scoped filters.
 
@@ -1091,10 +1164,10 @@ class BaseGenerationService(
         does not skip valid extraction because of an unrelated fixed interaction slice.
 
         Args:
-            extractor_configs: Enabled extractor configs after request-level filtering
+            extractor_config: Enabled extractor config after request-level filtering
 
         Returns:
-            tuple: (deduplicated session data models, extractor configs that had scoped interactions)
+            tuple: (session data models, extractor config)
         """
         root_config = self.request_context.configurator.get_config()
         global_window_size = (
@@ -1104,44 +1177,47 @@ class BaseGenerationService(
             getattr(root_config, "stride_size", None) if root_config else None
         )
 
-        deduped_sessions: dict[str, RequestInteractionDataModel] = {}
-        scoped_configs: list[TExtractorConfig] = []
         extra_kwargs = self._get_precheck_interaction_query_kwargs()
 
-        for config in extractor_configs:
-            should_skip, effective_source = get_effective_source_filter(
-                config, getattr(self.service_config, "source", None)
-            )
-            if should_skip:
-                continue
-
-            window_size, _ = get_extractor_window_params(
-                config, global_window_size, global_stride_size
-            )
-            fetch_k = window_size
-            session_data_models, _ = self.storage.get_last_k_interactions_grouped(  # type: ignore[reportOptionalMemberAccess]
-                user_id=getattr(self.service_config, "user_id", None),
-                k=fetch_k,
-                sources=effective_source,
-                start_time=getattr(self.service_config, "rerun_start_time", None),
-                end_time=getattr(self.service_config, "rerun_end_time", None),
-                **extra_kwargs,
-            )
-            if not session_data_models:
-                continue
-
-            scoped_configs.append(config)
-            for data_model in session_data_models:
-                request_id = getattr(data_model.request, "request_id", None)
-                dedupe_key = (
-                    request_id
-                    or data_model.session_id
-                    or f"scoped_group_{len(deduped_sessions)}"
+        if isinstance(extractor_config, list):
+            deduped_sessions: dict[str, RequestInteractionDataModel] = {}
+            scoped_config = extractor_config[0] if extractor_config else None
+            for config in extractor_config:
+                session_data_models, scoped_config = (
+                    self._collect_scoped_interactions_for_precheck(config)
                 )
-                if dedupe_key not in deduped_sessions:
-                    deduped_sessions[dedupe_key] = data_model
+                for data_model in session_data_models:
+                    request_id = getattr(data_model.request, "request_id", None)
+                    dedupe_key = (
+                        request_id
+                        or data_model.session_id
+                        or f"scoped_group_{len(deduped_sessions)}"
+                    )
+                    if dedupe_key not in deduped_sessions:
+                        deduped_sessions[dedupe_key] = data_model
+            if scoped_config is None:
+                raise ValueError("extractor_config list must not be empty")
+            return list(deduped_sessions.values()), scoped_config
 
-        return list(deduped_sessions.values()), scoped_configs
+        should_skip, effective_source = get_effective_source_filter(
+            extractor_config, getattr(self.service_config, "source", None)
+        )
+        if should_skip:
+            return [], extractor_config
+
+        window_size, _ = get_extractor_window_params(
+            extractor_config, global_window_size, global_stride_size
+        )
+        session_data_models, _ = self.storage.get_last_k_interactions_grouped(  # type: ignore[reportOptionalMemberAccess]
+            user_id=getattr(self.service_config, "user_id", None),
+            k=window_size,
+            sources=effective_source,
+            start_time=getattr(self.service_config, "rerun_start_time", None),
+            end_time=getattr(self.service_config, "rerun_end_time", None),
+            **extra_kwargs,
+        )
+
+        return session_data_models, extractor_config
 
     def _get_precheck_interaction_query_kwargs(self) -> dict:
         """

--- a/reflexio/server/services/configurator/base_configurator.py
+++ b/reflexio/server/services/configurator/base_configurator.py
@@ -19,11 +19,6 @@ _CONFIG_NAME_ALIASES = {
     "batch_interval": "stride_size",
     "extraction_window_size": "window_size",
     "extraction_window_stride": "stride_size",
-    "profile_extractor_configs": "profile_extractor_config",
-    "user_playbook_extractor_configs": "user_playbook_extractor_config",
-    "playbook_configs": "user_playbook_extractor_config",
-    "agent_feedback_configs": "user_playbook_extractor_config",
-    "agent_success_configs": "agent_success_config",
 }
 
 
@@ -101,22 +96,9 @@ class BaseConfigurator(ABC):
         config_name: str,
         config_value: str | int | float | bool | list | dict | BaseModel | None,
     ) -> None:
-        original_config_name = config_name
         config_name = _CONFIG_NAME_ALIASES.get(config_name, config_name)
         if config_name not in type(self.config).model_fields:
             raise ValueError(f"Invalid config name: {config_name}")
-
-        if (
-            original_config_name in _CONFIG_NAME_ALIASES
-            and config_name
-            in {
-                "profile_extractor_config",
-                "user_playbook_extractor_config",
-                "agent_success_config",
-            }
-            and isinstance(config_value, list)
-        ):
-            config_value = config_value[0] if config_value else None
 
         setattr(self.config, config_name, config_value)
         self.set_config(config=self.config)

--- a/reflexio/server/services/configurator/base_configurator.py
+++ b/reflexio/server/services/configurator/base_configurator.py
@@ -23,6 +23,7 @@ _CONFIG_NAME_ALIASES = {
     "user_playbook_extractor_configs": "user_playbook_extractor_config",
     "playbook_configs": "user_playbook_extractor_config",
     "agent_feedback_configs": "user_playbook_extractor_config",
+    "agent_success_configs": "agent_success_config",
 }
 
 
@@ -98,7 +99,7 @@ class BaseConfigurator(ABC):
     def set_config_by_name(
         self,
         config_name: str,
-        config_value: str | int | float | bool | list | dict | BaseModel,
+        config_value: str | int | float | bool | list | dict | BaseModel | None,
     ) -> None:
         original_config_name = config_name
         config_name = _CONFIG_NAME_ALIASES.get(config_name, config_name)
@@ -108,7 +109,11 @@ class BaseConfigurator(ABC):
         if (
             original_config_name in _CONFIG_NAME_ALIASES
             and config_name
-            in {"profile_extractor_config", "user_playbook_extractor_config"}
+            in {
+                "profile_extractor_config",
+                "user_playbook_extractor_config",
+                "agent_success_config",
+            }
             and isinstance(config_value, list)
         ):
             config_value = config_value[0] if config_value else None

--- a/reflexio/server/services/configurator/local_file_config_storage.py
+++ b/reflexio/server/services/configurator/local_file_config_storage.py
@@ -12,6 +12,7 @@ from reflexio.models.config_schema import (
     PlaybookConfig,
     ProfileExtractorConfig,
     StorageConfigSQLite,
+    normalize_legacy_config_shape,
 )
 from reflexio.server.services.configurator.config_storage import ConfigStorage
 
@@ -81,6 +82,12 @@ class LocalFileConfigStorage(ConfigStorage):
             with Path(self.config_file).open(encoding="utf-8") as f:
                 config_content = f.read()
                 data = json.loads(str(config_content))
+                # Upgrade retired list-valued extractor fields (e.g.
+                # agent_success_configs) to their singular replacements before
+                # validation. Without this, Config would drop the unknown legacy
+                # keys and silently lose the user's customization.
+                if isinstance(data, dict):
+                    data = normalize_legacy_config_shape(data)
                 # Detect legacy on-disk configs that used the removed "disk"
                 # storage backend and rewrite only the storage_config field
                 # to default SQLite. Other persisted fields (extractors,

--- a/reflexio/server/services/configurator/test_config_storage.py
+++ b/reflexio/server/services/configurator/test_config_storage.py
@@ -94,7 +94,7 @@ def test_load_config():
         storage_config=StorageConfigSQLite(
             db_path="/tmp/test.db",
         ),
-        profile_extractor_configs=[],
+        profile_extractor_config=None,
     )
 
     json_config = new_config.model_dump_json()

--- a/reflexio/server/services/configurator/test_config_storage.py
+++ b/reflexio/server/services/configurator/test_config_storage.py
@@ -4,7 +4,9 @@
 Simple test script to verify the new config storage classes work correctly.
 """
 
+import json
 import tempfile
+from pathlib import Path
 
 from reflexio.models.config_schema import (
     Config,
@@ -84,6 +86,54 @@ def test_configurator_integration():
         assert context == "Integration test prompt"
 
     print("  Configurator integration tests passed!")
+
+
+def test_load_config_upgrades_legacy_list_shape():
+    """Legacy list-shaped extractor fields on disk are migrated to singular fields.
+
+    Configs persisted before the single-extractor refactor store
+    ``*_extractor_configs`` lists and ``agent_success_configs``. Without
+    migration at the load boundary, ``Config`` would drop these unknown keys and
+    silently lose the user's customization.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        org_id = "legacy_org"
+        storage = LocalFileConfigStorage(org_id=org_id, base_dir=temp_dir)
+
+        legacy_payload = {
+            "storage_config": StorageConfigSQLite().model_dump(),
+            "profile_extractor_configs": [
+                {
+                    "extractor_name": "legacy_profile",
+                    "extraction_definition_prompt": "Extract legacy profile data.",
+                }
+            ],
+            "user_playbook_extractor_configs": [
+                {
+                    "extractor_name": "legacy_playbook",
+                    "extraction_definition_prompt": "Extract legacy playbook rules.",
+                }
+            ],
+            "agent_success_configs": [
+                {
+                    "evaluation_name": "legacy_success",
+                    "success_definition_prompt": "Evaluate legacy agent success.",
+                }
+            ],
+        }
+        Path(storage.config_file).parent.mkdir(parents=True, exist_ok=True)
+        Path(storage.config_file).write_text(
+            json.dumps(legacy_payload), encoding="utf-8"
+        )
+
+        loaded = storage.load_config()
+
+        assert loaded.profile_extractor_config is not None
+        assert loaded.profile_extractor_config.extractor_name == "legacy_profile"
+        assert loaded.user_playbook_extractor_config is not None
+        assert loaded.user_playbook_extractor_config.extractor_name == "legacy_playbook"
+        assert loaded.agent_success_config is not None
+        assert loaded.agent_success_config.evaluation_name == "legacy_success"
 
 
 def test_load_config():

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -155,23 +155,19 @@ def _select_current_extractor_config(
     root_config = request_context.configurator.get_config()
     if run.binding.extractor_kind == "profile":
         config = getattr(root_config, "profile_extractor_config", None)
-        legacy = getattr(root_config, "profile_extractor_configs", None)
     elif run.binding.extractor_kind == "playbook":
         config = getattr(root_config, "user_playbook_extractor_config", None)
-        legacy = getattr(root_config, "user_playbook_extractor_configs", None)
     else:
         raise ResumeWorkerError(
             f"Unsupported extractor kind {run.binding.extractor_kind!r}"
         )
 
-    candidates = [config, *(legacy or [])]
-    for candidate in candidates:
-        if (
-            candidate is not None
-            and getattr(candidate, "extractor_name", None) == run.binding.extractor_name
-            and isinstance(candidate, ProfileExtractorConfig | PlaybookConfig)
-        ):
-            return candidate
+    if (
+        config is not None
+        and getattr(config, "extractor_name", None) == run.binding.extractor_name
+        and isinstance(config, ProfileExtractorConfig | PlaybookConfig)
+    ):
+        return config
     raise ResumeWorkerError(
         f"Current extractor config not found for {run.binding.extractor_kind}:{run.binding.extractor_name}"
     )

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -1386,13 +1386,6 @@ class PlaybookAggregator:
     ) -> PlaybookAggregatorConfig | None:
         root_config = self.configurator.get_config()
         playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
-        if playbook_config is None or not isinstance(
-            getattr(playbook_config, "extractor_name", None), str
-        ):
-            legacy_configs = getattr(
-                root_config, "user_playbook_extractor_configs", None
-            )
-            playbook_config = legacy_configs[0] if legacy_configs else None
         if not playbook_config:
             return None
         if playbook_config.extractor_name == playbook_name:

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -133,13 +133,7 @@ class PlaybookGenerationService(
             extractor_names=[request.playbook_name] if request.playbook_name else None,
         )
 
-    def _load_extractor_configs(self) -> list[PlaybookConfig]:
-        """
-        Load the configured user playbook extractor from configurator.
-
-        Returns:
-            list[PlaybookConfig]: One user playbook extractor configuration object.
-        """
+    def _configured_playbook_config(self) -> PlaybookConfig | None:
         root_config = self.configurator.get_config()
         config = getattr(root_config, "user_playbook_extractor_config", None)
         if config is None or not isinstance(
@@ -149,7 +143,16 @@ class PlaybookGenerationService(
                 root_config, "user_playbook_extractor_configs", None
             )
             config = legacy_configs[0] if legacy_configs else None
-        return [config] if config else []
+        return config
+
+    def _load_extractor_config(self) -> PlaybookConfig | None:
+        """
+        Load the configured user playbook extractor from configurator.
+
+        Returns:
+            PlaybookConfig | None: The configured user playbook extractor, if enabled.
+        """
+        return self._configured_playbook_config()
 
     def _create_extractor(
         self,
@@ -176,7 +179,7 @@ class PlaybookGenerationService(
 
     def _build_should_run_prompt(
         self,
-        scoped_configs: list[PlaybookConfig],
+        scoped_config: PlaybookConfig,
         session_data_models: list[RequestInteractionDataModel],
     ) -> str | None:
         """
@@ -185,7 +188,7 @@ class PlaybookGenerationService(
         Renders the configured playbook definition for one LLM call.
 
         Args:
-            scoped_configs: Playbook extractor configs that had scoped interactions
+            scoped_config: Playbook extractor config that had scoped interactions
             session_data_models: Deduplicated request interaction data models
 
         Returns:
@@ -208,14 +211,11 @@ class PlaybookGenerationService(
 
         new_interactions = format_sessions_to_history_string(session_data_models)
 
-        # Keep the numbered-list shape for prompt compatibility.
-        definitions = []
-        for i, config in enumerate(scoped_configs, 1):
-            if config.extraction_definition_prompt:
-                definitions.append(
-                    f"{i}. {config.extraction_definition_prompt.strip()}"
-                )
-        combined_definition = "\n".join(definitions) if definitions else ""
+        combined_definition = (
+            scoped_config.extraction_definition_prompt.strip()
+            if scoped_config.extraction_definition_prompt
+            else ""
+        )
 
         if not combined_definition:
             return None
@@ -276,17 +276,7 @@ class PlaybookGenerationService(
                 PlaybookDeduplicator,
             )
 
-            root_config = self.configurator.get_config()
-            playbook_config = getattr(
-                root_config, "user_playbook_extractor_config", None
-            )
-            if playbook_config is None or not isinstance(
-                getattr(playbook_config, "extractor_name", None), str
-            ):
-                legacy_configs = getattr(
-                    root_config, "user_playbook_extractor_configs", None
-                )
-                playbook_config = legacy_configs[0] if legacy_configs else None
+            playbook_config = self._configured_playbook_config()
             dedup_config = (
                 playbook_config.deduplication_config if playbook_config else None
             )
@@ -453,15 +443,7 @@ class PlaybookGenerationService(
         Trigger playbook aggregation for playbook types that have aggregator config.
         This is called after raw user playbook entries are saved to check if aggregation should run.
         """
-        root_config = self.configurator.get_config()
-        playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
-        if playbook_config is None or not isinstance(
-            getattr(playbook_config, "extractor_name", None), str
-        ):
-            legacy_configs = getattr(
-                root_config, "user_playbook_extractor_configs", None
-            )
-            playbook_config = legacy_configs[0] if legacy_configs else None
+        playbook_config = self._configured_playbook_config()
         if not playbook_config or not playbook_config.aggregation_config:
             return
 

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -135,15 +135,7 @@ class PlaybookGenerationService(
 
     def _configured_playbook_config(self) -> PlaybookConfig | None:
         root_config = self.configurator.get_config()
-        config = getattr(root_config, "user_playbook_extractor_config", None)
-        if config is None or not isinstance(
-            getattr(config, "extractor_name", None), str
-        ):
-            legacy_configs = getattr(
-                root_config, "user_playbook_extractor_configs", None
-            )
-            config = legacy_configs[0] if legacy_configs else None
-        return config
+        return getattr(root_config, "user_playbook_extractor_config", None)
 
     def _load_extractor_config(self) -> PlaybookConfig | None:
         """

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -249,13 +249,7 @@ class ProfileGenerationService(
             ProfileExtractorConfig | None: The configured profile extractor, if enabled.
         """
         root_config = self.configurator.get_config()
-        config = getattr(root_config, "profile_extractor_config", None)
-        if config is None or not isinstance(
-            getattr(config, "extractor_name", None), str
-        ):
-            legacy_configs = getattr(root_config, "profile_extractor_configs", None)
-            config = legacy_configs[0] if legacy_configs else None
-        return config
+        return getattr(root_config, "profile_extractor_config", None)
 
     def _create_extractor(
         self,

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -53,7 +53,7 @@ class ProfileGenerationServiceConfig:
         existing_data: Existing profiles for the user
         allow_manual_trigger: Whether to allow extractors with manual_trigger=True
         output_pending_status: Whether to output profiles with PENDING status
-        extractor_names: Optional list of extractor names to filter which extractors run
+        extractor_names: Optional list of extractor names to filter which extractor runs
         rerun_start_time: Optional start time filter for rerun flows (Unix timestamp)
         rerun_end_time: Optional end time filter for rerun flows (Unix timestamp)
         auto_run: True for regular flow (checks stride_size), False for rerun/manual (skips stride_size)
@@ -241,12 +241,12 @@ class ProfileGenerationService(
         """check if the profiles are expired and update them if they are"""
         raise NotImplementedError
 
-    def _load_extractor_configs(self) -> list[ProfileExtractorConfig]:
+    def _load_extractor_config(self) -> ProfileExtractorConfig | None:
         """
         Load the configured profile extractor from configurator.
 
         Returns:
-            list[ProfileExtractorConfig]: One profile extractor configuration object.
+            ProfileExtractorConfig | None: The configured profile extractor, if enabled.
         """
         root_config = self.configurator.get_config()
         config = getattr(root_config, "profile_extractor_config", None)
@@ -255,7 +255,7 @@ class ProfileGenerationService(
         ):
             legacy_configs = getattr(root_config, "profile_extractor_configs", None)
             config = legacy_configs[0] if legacy_configs else None
-        return [config] if config else []
+        return config
 
     def _create_extractor(
         self,
@@ -282,17 +282,17 @@ class ProfileGenerationService(
 
     def _build_should_run_prompt(
         self,
-        scoped_configs: list[ProfileExtractorConfig],
+        scoped_config: ProfileExtractorConfig,
         session_data_models: list[RequestInteractionDataModel],
     ) -> str | None:
         """
         Build prompt for consolidated should_extract_profile check.
 
-        Combines all enabled extractors' profile definitions and override conditions
-        into a single criteria block for one LLM call.
+        Renders the configured extractor's profile definition and override
+        condition for one LLM call.
 
         Args:
-            scoped_configs: Profile extractor configs that had scoped interactions
+            scoped_config: Profile extractor config that had scoped interactions
             session_data_models: Deduplicated request interaction data models
 
         Returns:
@@ -302,29 +302,18 @@ class ProfileGenerationService(
         agent_context = self.configurator.get_agent_context()
         prompt_manager = self.request_context.prompt_manager
 
-        # Keep the criteria list shape for prompt compatibility.
-        # The single configured extractor can contribute:
-        # 1) extraction_definition_prompt (what to extract)
-        # 2) should_extract_profile_prompt_override (custom extraction condition)
-        combined_criteria_items = []
-        for i, config in enumerate(scoped_configs, 1):
-            criteria_parts = []
-            if config.extraction_definition_prompt:
-                criteria_parts.append(
-                    f"definition: {config.extraction_definition_prompt.strip()}"
-                )
-            if config.should_extract_profile_prompt_override:
-                criteria_parts.append(
-                    "condition: "
-                    f"{config.should_extract_profile_prompt_override.strip()}"
-                )
+        criteria_parts = []
+        if scoped_config.extraction_definition_prompt:
+            criteria_parts.append(
+                f"definition: {scoped_config.extraction_definition_prompt.strip()}"
+            )
+        if scoped_config.should_extract_profile_prompt_override:
+            criteria_parts.append(
+                "condition: "
+                f"{scoped_config.should_extract_profile_prompt_override.strip()}"
+            )
 
-            if criteria_parts:
-                combined_criteria_items.append(f"{i}. {'; '.join(criteria_parts)}")
-
-        combined_criteria = (
-            "\n".join(combined_criteria_items) if combined_criteria_items else ""
-        )
+        combined_criteria = "; ".join(criteria_parts)
         if not combined_criteria:
             return None
 

--- a/tests/cli/test_bootstrap_config.py
+++ b/tests/cli/test_bootstrap_config.py
@@ -163,12 +163,10 @@ class TestSaveAndLoadStorage:
         storage_obj = LocalFileConfigStorage("test-org", base_dir=str(tmp_path))
         config = Config(
             storage_config=StorageConfigSQLite(),
-            profile_extractor_configs=[
-                ProfileExtractorConfig(
-                    extractor_name="custom_extractor",
-                    extraction_definition_prompt="Custom prompt for testing",
-                ),
-            ],
+            profile_extractor_config=ProfileExtractorConfig(
+                extractor_name="custom_extractor",
+                extraction_definition_prompt="Custom prompt for testing",
+            ),
             agent_context_prompt="test context",
         )
         storage_obj.save_config(config)
@@ -187,11 +185,8 @@ class TestSaveAndLoadStorage:
         # Verify extractor and context are preserved
         reloaded = storage_obj.load_config()
         assert reloaded.agent_context_prompt == "test context"
-        assert reloaded.profile_extractor_configs is not None
-        assert len(reloaded.profile_extractor_configs) == 1
-        assert (
-            reloaded.profile_extractor_configs[0].extractor_name == "custom_extractor"
-        )
+        assert reloaded.profile_extractor_config is not None
+        assert reloaded.profile_extractor_config.extractor_name == "custom_extractor"
         assert (
             load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
             == "postgres"

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -68,7 +68,7 @@ def reflexio_with_config(temp_storage, ensure_mock_env):
         stride_size_override=1,
     )
     reflexio.request_context.configurator.set_config_by_name(
-        "profile_extractor_configs", [profile_extractor_config]
+        "profile_extractor_config", profile_extractor_config
     )
 
     return reflexio

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -858,6 +858,59 @@ class TestCrossFieldValidators:
             "playbook_first"
         ]
 
+    def test_config_accepts_singular_agent_success_config(self):
+        """Config: singular agent success config validates and serializes."""
+        success_config = AgentSuccessConfig(
+            evaluation_name="success_one",
+            success_definition_prompt="task completed",
+        )
+
+        config = Config(
+            storage_config=StorageConfigSQLite(),
+            agent_success_config=success_config,
+        )
+
+        dumped = config.model_dump()
+        assert config.agent_success_config == success_config
+        assert dumped["agent_success_config"]["evaluation_name"] == "success_one"
+        assert dumped["agent_success_configs"][0]["evaluation_name"] == "success_one"
+
+    def test_config_legacy_agent_success_list_keeps_first_entry(self):
+        """Config: legacy multi-entry success config lists are first-entry wins."""
+        config = Config.model_validate(
+            {
+                "storage_config": StorageConfigSQLite(),
+                "agent_success_configs": [
+                    AgentSuccessConfig(
+                        evaluation_name="success_first",
+                        success_definition_prompt="first",
+                    ),
+                    AgentSuccessConfig(
+                        evaluation_name="success_second",
+                        success_definition_prompt="second",
+                    ),
+                ],
+            }
+        )
+
+        assert config.agent_success_config is not None
+        assert config.agent_success_config.evaluation_name == "success_first"
+        assert [c.evaluation_name for c in config.agent_success_configs] == [
+            "success_first"
+        ]
+
+    def test_config_empty_legacy_agent_success_list_disables_evaluation(self):
+        """Config: empty legacy success config list normalizes to disabled."""
+        config = Config.model_validate(
+            {
+                "storage_config": StorageConfigSQLite(),
+                "agent_success_configs": [],
+            }
+        )
+
+        assert config.agent_success_config is None
+        assert config.agent_success_configs == []
+
     def test_config_accepts_legacy_playbook_aliases_first_entry_wins(self):
         """Config: legacy playbook alias fields normalize to the singular extractor."""
         config = Config.model_validate(

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -57,7 +57,6 @@ from reflexio.models.config_schema import (
     PlaybookConfig,
     PlaybookOptimizerConfig,
     ProfileExtractorConfig,
-    StorageConfigDisk,
     StorageConfigSQLite,
     ToolUseConfig,
 )
@@ -699,14 +698,6 @@ class TestCrossFieldValidators:
             config.user_playbook_extractor_config.extractor_name
             == "default_playbook_extractor"
         )
-        assert config.profile_extractor_configs is not None
-        assert config.user_playbook_extractor_configs is not None
-        assert config.profile_extractor_configs[0].extractor_name == (
-            "default_profile_extractor"
-        )
-        assert config.user_playbook_extractor_configs[0].extractor_name == (
-            "default_playbook_extractor"
-        )
         assert isinstance(config.pending_tool_call_config, PendingToolCallConfig)
         assert config.pending_tool_call_config.enabled is False
 
@@ -720,8 +711,6 @@ class TestCrossFieldValidators:
 
         assert config.profile_extractor_config is None
         assert config.user_playbook_extractor_config is None
-        assert config.profile_extractor_configs == []
-        assert config.user_playbook_extractor_configs == []
 
     def test_config_defaults_pending_tool_call_config_when_null(self):
         """Config: null pending_tool_call_config falls back to disabled defaults."""
@@ -766,29 +755,6 @@ class TestCrossFieldValidators:
         assert other_tool.pending_ttl_seconds == 60
         assert other_tool.similarity_threshold == 0.2
 
-    def test_pending_tool_calls_reject_disk_storage(self):
-        """Pending tool calls are supported only by database-backed storage."""
-        with pytest.raises(ValidationError, match="sqlite, supabase, or postgres"):
-            Config(
-                storage_config=StorageConfigDisk(dir_path="/tmp/reflexio"),
-                pending_tool_call_config=PendingToolCallConfig(enabled=True),
-            )
-
-    def test_config_disables_extractors_when_legacy_lists_are_empty(self):
-        """Config: empty legacy extractor lists explicitly disable extraction."""
-        config = Config.model_validate(
-            {
-                "storage_config": StorageConfigSQLite(),
-                "profile_extractor_configs": [],
-                "user_playbook_extractor_configs": [],
-            }
-        )
-
-        assert config.profile_extractor_config is None
-        assert config.user_playbook_extractor_config is None
-        assert config.profile_extractor_configs == []
-        assert config.user_playbook_extractor_configs == []
-
     def test_config_accepts_singular_extractor_fields(self):
         """Config: singular extractor fields validate and serialize."""
         profile_config = ProfileExtractorConfig(
@@ -813,50 +779,6 @@ class TestCrossFieldValidators:
         assert (
             dumped["user_playbook_extractor_config"]["extractor_name"] == "playbook_one"
         )
-        assert dumped["profile_extractor_configs"][0]["extractor_name"] == "profile_one"
-        assert (
-            dumped["user_playbook_extractor_configs"][0]["extractor_name"]
-            == "playbook_one"
-        )
-
-    def test_config_legacy_multi_extractor_lists_keep_first_entry(self):
-        """Config: legacy multi-entry extractor lists are accepted first-entry wins."""
-        config = Config.model_validate(
-            {
-                "storage_config": StorageConfigSQLite(),
-                "profile_extractor_configs": [
-                    ProfileExtractorConfig(
-                        extractor_name="profile_first",
-                        extraction_definition_prompt="first",
-                    ),
-                    ProfileExtractorConfig(
-                        extractor_name="profile_second",
-                        extraction_definition_prompt="second",
-                    ),
-                ],
-                "user_playbook_extractor_configs": [
-                    PlaybookConfig(
-                        extractor_name="playbook_first",
-                        extraction_definition_prompt="first",
-                    ),
-                    PlaybookConfig(
-                        extractor_name="playbook_second",
-                        extraction_definition_prompt="second",
-                    ),
-                ],
-            }
-        )
-
-        assert config.profile_extractor_config is not None
-        assert config.profile_extractor_config.extractor_name == "profile_first"
-        assert [c.extractor_name for c in config.profile_extractor_configs] == [
-            "profile_first"
-        ]
-        assert config.user_playbook_extractor_config is not None
-        assert config.user_playbook_extractor_config.extractor_name == "playbook_first"
-        assert [c.extractor_name for c in config.user_playbook_extractor_configs] == [
-            "playbook_first"
-        ]
 
     def test_config_accepts_singular_agent_success_config(self):
         """Config: singular agent success config validates and serializes."""
@@ -873,64 +795,6 @@ class TestCrossFieldValidators:
         dumped = config.model_dump()
         assert config.agent_success_config == success_config
         assert dumped["agent_success_config"]["evaluation_name"] == "success_one"
-        assert dumped["agent_success_configs"][0]["evaluation_name"] == "success_one"
-
-    def test_config_legacy_agent_success_list_keeps_first_entry(self):
-        """Config: legacy multi-entry success config lists are first-entry wins."""
-        config = Config.model_validate(
-            {
-                "storage_config": StorageConfigSQLite(),
-                "agent_success_configs": [
-                    AgentSuccessConfig(
-                        evaluation_name="success_first",
-                        success_definition_prompt="first",
-                    ),
-                    AgentSuccessConfig(
-                        evaluation_name="success_second",
-                        success_definition_prompt="second",
-                    ),
-                ],
-            }
-        )
-
-        assert config.agent_success_config is not None
-        assert config.agent_success_config.evaluation_name == "success_first"
-        assert [c.evaluation_name for c in config.agent_success_configs] == [
-            "success_first"
-        ]
-
-    def test_config_empty_legacy_agent_success_list_disables_evaluation(self):
-        """Config: empty legacy success config list normalizes to disabled."""
-        config = Config.model_validate(
-            {
-                "storage_config": StorageConfigSQLite(),
-                "agent_success_configs": [],
-            }
-        )
-
-        assert config.agent_success_config is None
-        assert config.agent_success_configs == []
-
-    def test_config_accepts_legacy_playbook_aliases_first_entry_wins(self):
-        """Config: legacy playbook alias fields normalize to the singular extractor."""
-        config = Config.model_validate(
-            {
-                "storage_config": StorageConfigSQLite(),
-                "playbook_configs": [
-                    {
-                        "playbook_name": "legacy_first",
-                        "playbook_definition_prompt": "first",
-                    },
-                    {
-                        "playbook_name": "legacy_second",
-                        "playbook_definition_prompt": "second",
-                    },
-                ],
-            }
-        )
-
-        assert config.user_playbook_extractor_config is not None
-        assert config.user_playbook_extractor_config.extractor_name == "legacy_first"
 
     def test_playbook_optimizer_accepts_webhook_backend(self):
         """PlaybookOptimizerConfig: webhook-only assistant backend is valid."""

--- a/tests/server/api_endpoints/conftest.py
+++ b/tests/server/api_endpoints/conftest.py
@@ -82,7 +82,7 @@ def client_with_org():
 def client_with_org_and_evaluator(client_with_org):
     """Same as ``client_with_org`` but with one configured AgentSuccessConfig.
 
-    Adds a single ``overall_success`` evaluator entry so the /regenerate
+    Adds the ``overall_success`` evaluator so the /regenerate
     POST passes the "known evaluation_name" gate.
 
     Returns:
@@ -91,14 +91,12 @@ def client_with_org_and_evaluator(client_with_org):
     client, org_id = client_with_org
     reflexio = get_reflexio(org_id=org_id)
     reflexio.request_context.configurator.set_config_by_name(
-        "agent_success_configs",
-        [
-            AgentSuccessConfig(
-                evaluation_name="overall_success",
-                success_definition_prompt=(
-                    "Evaluate whether the agent successfully completed the task."
-                ),
-            )
-        ],
+        "agent_success_config",
+        AgentSuccessConfig(
+            evaluation_name="overall_success",
+            success_definition_prompt=(
+                "Evaluate whether the agent successfully completed the task."
+            ),
+        ),
     )
     return client, org_id

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -290,17 +290,11 @@ class TestUpdateConfigRoute:
         mock_invalidate.assert_not_called()
 
     # -----------------------------------------------------------------
-    # R4: nested-list shallow-merge semantics
+    # R4: singular nested config patch semantics
     # -----------------------------------------------------------------
     @staticmethod
     def _existing_config_with_playbooks() -> Config:
-        """Existing config with a populated playbook_configs list.
-
-        Used to verify that PATCHing a *sibling* top-level field
-        preserves the playbook_configs list, AND that PATCHing
-        playbook_configs itself replaces the list wholesale (no deep
-        merge into list-of-dicts).
-        """
+        """Existing config with a populated playbook extractor config."""
         from reflexio.models.config_schema import (
             PlaybookAggregatorConfig,
             UserPlaybookExtractorConfig,
@@ -319,40 +313,29 @@ class TestUpdateConfigRoute:
             ),
         )
 
-    def test_nested_list_replaced_wholesale_when_patched(
+    def test_nested_config_requires_full_payload_when_patched(
         self, client, patched_reflexio, mock_reflexio
     ):
-        """PATCH'ing user_playbook_extractor_configs replaces the entire list.
-
-        This is the documented behavior: a partial that re-sends the
-        list with only one inner field set will FAIL Pydantic
-        validation because required fields like ``extractor_name`` and
-        ``extraction_definition_prompt`` are missing. Callers cannot
-        target a nested-list field with PATCH; they must round-trip
-        the full config via /api/get_config + /api/set_config.
-        """
+        """PATCH'ing a nested config requires the full nested object."""
         existing = self._existing_config_with_playbooks()
         self._wire_mock(mock_reflexio, existing)
 
-        # Try to flip just the inner aggregation_config field
         response = client.post(
             "/api/update_config",
             json={
-                "user_playbook_extractor_configs": [
-                    {"aggregation_config": {"min_cluster_size": 99}}
-                ]
+                "user_playbook_extractor_config": {
+                    "aggregation_config": {"min_cluster_size": 99}
+                }
             },
         )
 
-        # Pydantic rejects: extractor_name and extraction_definition_prompt
-        # are required on UserPlaybookExtractorConfig.
         assert response.status_code in {400, 422}, response.text
         mock_reflexio.set_config.assert_not_called()
 
-    def test_legacy_extractor_lists_override_existing_canonical_config(
+    def test_singular_extractor_configs_override_existing_config(
         self, client, patched_reflexio, mock_reflexio
     ):
-        """Legacy list fields in PATCH payloads update the singular config."""
+        """Singular extractor config fields update existing config."""
         existing = self._existing_config()
         self._wire_mock(mock_reflexio, existing)
 
@@ -360,18 +343,14 @@ class TestUpdateConfigRoute:
             response = client.post(
                 "/api/update_config",
                 json={
-                    "profile_extractor_configs": [
-                        {
-                            "extractor_name": "legacy_profile",
-                            "extraction_definition_prompt": "profile facts",
-                        }
-                    ],
-                    "user_playbook_extractor_configs": [
-                        {
-                            "extractor_name": "legacy_playbook",
-                            "extraction_definition_prompt": "playbook rules",
-                        }
-                    ],
+                    "profile_extractor_config": {
+                        "extractor_name": "profile",
+                        "extraction_definition_prompt": "profile facts",
+                    },
+                    "user_playbook_extractor_config": {
+                        "extractor_name": "playbook",
+                        "extraction_definition_prompt": "playbook rules",
+                    },
                 },
             )
 
@@ -379,14 +358,14 @@ class TestUpdateConfigRoute:
         merged = mock_reflexio.set_config.call_args.args[0]
         assert isinstance(merged, Config)
         assert merged.profile_extractor_config is not None
-        assert merged.profile_extractor_config.extractor_name == "legacy_profile"
+        assert merged.profile_extractor_config.extractor_name == "profile"
         assert merged.user_playbook_extractor_config is not None
-        assert merged.user_playbook_extractor_config.extractor_name == "legacy_playbook"
+        assert merged.user_playbook_extractor_config.extractor_name == "playbook"
 
-    def test_legacy_empty_extractor_lists_disable_existing_extractors(
+    def test_null_extractor_configs_disable_existing_extractors(
         self, client, patched_reflexio, mock_reflexio
     ):
-        """Legacy empty list fields in PATCH payloads disable extraction."""
+        """Null singular extractor config fields disable extraction."""
         existing = self._existing_config_with_playbooks()
         self._wire_mock(mock_reflexio, existing)
 
@@ -394,8 +373,8 @@ class TestUpdateConfigRoute:
             response = client.post(
                 "/api/update_config",
                 json={
-                    "profile_extractor_configs": [],
-                    "user_playbook_extractor_configs": [],
+                    "profile_extractor_config": None,
+                    "user_playbook_extractor_config": None,
                 },
             )
 
@@ -404,18 +383,11 @@ class TestUpdateConfigRoute:
         assert isinstance(merged, Config)
         assert merged.profile_extractor_config is None
         assert merged.user_playbook_extractor_config is None
-        assert merged.profile_extractor_configs == []
-        assert merged.user_playbook_extractor_configs == []
 
-    def test_nested_list_preserved_when_patching_unrelated_field(
+    def test_nested_config_preserved_when_patching_unrelated_field(
         self, client, patched_reflexio, mock_reflexio
     ):
-        """PATCH'ing a sibling field preserves the existing playbook_configs.
-
-        This is the safe pattern: top-level-shallow-merge means any
-        key not in the partial keeps its current value, including
-        nested-list fields like ``user_playbook_extractor_configs``.
-        """
+        """PATCH'ing a sibling field preserves the existing playbook config."""
         existing = self._existing_config_with_playbooks()
         self._wire_mock(mock_reflexio, existing)
 
@@ -430,10 +402,8 @@ class TestUpdateConfigRoute:
         assert isinstance(merged, Config)
         # The partial-touched field changed
         assert merged.extraction_backend == "agentic"
-        # Untouched nested list is preserved
-        assert merged.user_playbook_extractor_configs is not None
-        assert len(merged.user_playbook_extractor_configs) == 1
-        agg = merged.user_playbook_extractor_configs[0].aggregation_config
+        assert merged.user_playbook_extractor_config is not None
+        agg = merged.user_playbook_extractor_config.aggregation_config
         assert agg is not None
         assert agg.min_cluster_size == 2
         assert agg.clustering_similarity == 0.45

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
@@ -29,6 +29,7 @@ from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service import (
     AgentSuccessEvaluationService,
+    AgentSuccessGenerationServiceConfig,
 )
 from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_utils import (
     AgentSuccessEvaluationRequest,
@@ -70,6 +71,66 @@ def mock_chat_completion():
         return_value=mock_response,
     ):
         yield
+
+
+def _make_agent_success_service(temp_dir: str) -> AgentSuccessEvaluationService:
+    llm_config = LiteLLMConfig(model="gpt-4o-mini")
+    llm_client = LiteLLMClient(llm_config)
+    return AgentSuccessEvaluationService(
+        llm_client=llm_client,
+        request_context=RequestContext(org_id="0", storage_base_dir=temp_dir),
+    )
+
+
+def test_loads_singular_agent_success_config():
+    """The service loads the canonical single success evaluator config."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        service = _make_agent_success_service(temp_dir)
+        success_config = AgentSuccessConfig(
+            evaluation_name="overall_success",
+            success_definition_prompt="Evaluate task success",
+        )
+        service.configurator.set_config_by_name("agent_success_config", success_config)
+        service.service_config = AgentSuccessGenerationServiceConfig(
+            session_id="test_group",
+            agent_version="1.0",
+            request_interaction_data_models=[],
+        )
+
+        assert service._load_extractor_config() == success_config
+
+
+def test_loads_no_agent_success_config_when_disabled():
+    """A null single success evaluator config disables evaluation."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        service = _make_agent_success_service(temp_dir)
+        service.configurator.set_config_by_name("agent_success_config", None)
+        service.service_config = AgentSuccessGenerationServiceConfig(
+            session_id="test_group",
+            agent_version="1.0",
+            request_interaction_data_models=[],
+        )
+
+        assert service._load_extractor_config() is None
+
+
+def test_loads_no_agent_success_config_when_name_filter_mismatches():
+    """Regenerate filters out the configured evaluator when names do not match."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        service = _make_agent_success_service(temp_dir)
+        success_config = AgentSuccessConfig(
+            evaluation_name="overall_success",
+            success_definition_prompt="Evaluate task success",
+        )
+        service.configurator.set_config_by_name("agent_success_config", success_config)
+        service.service_config = AgentSuccessGenerationServiceConfig(
+            session_id="test_group",
+            agent_version="1.0",
+            request_interaction_data_models=[],
+            evaluation_name_filter="other_success",
+        )
+
+        assert service._load_extractor_config() is None
 
 
 def test_evaluate_agent_success(mock_chat_completion):

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
@@ -160,7 +160,7 @@ def test_evaluate_agent_success(mock_chat_completion):
             success_definition_prompt="Evaluate if the agent successfully completed the task",
         )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config]
+            "agent_success_config", success_config
         )
         agent_success_service.configurator.set_config_by_name(
             "tool_can_use",
@@ -212,7 +212,7 @@ def test_empty_interactions(mock_chat_completion):
             success_definition_prompt="Evaluate if the agent successfully completed the task",
         )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config]
+            "agent_success_config", success_config
         )
 
         # Create evaluation request with empty request_interaction_data_models
@@ -297,7 +297,7 @@ def test_error_handling(mock_chat_completion):
             success_definition_prompt="Evaluate if the agent successfully completed the task",
         )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config]
+            "agent_success_config", success_config
         )
 
         # Create request interaction data model
@@ -328,8 +328,8 @@ def test_error_handling(mock_chat_completion):
                 agent_success_service.run(evaluation_request)
 
 
-def test_multiple_configs(mock_chat_completion):
-    """Test that multiple configs can be processed."""
+def test_configured_success_evaluator_runs(mock_chat_completion):
+    """Test that the configured success evaluator can be processed."""
     user_id = "test_user_id"
     org_id = "0"
     interaction = Interaction(
@@ -349,17 +349,12 @@ def test_multiple_configs(mock_chat_completion):
             request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
         )
 
-        # Set up multiple agent success configs
-        success_config_1 = AgentSuccessConfig(
+        success_config = AgentSuccessConfig(
             evaluation_name="task_completion",
             success_definition_prompt="Evaluate if the agent completed the task",
         )
-        success_config_2 = AgentSuccessConfig(
-            evaluation_name="user_satisfaction",
-            success_definition_prompt="Evaluate if the user was satisfied",
-        )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config_1, success_config_2]
+            "agent_success_config", success_config
         )
 
         # Create request interaction data model
@@ -376,7 +371,7 @@ def test_multiple_configs(mock_chat_completion):
             request_interaction_data_models=[request_interaction],
         )
 
-        # The service should run without errors with multiple configs
+        # The service should run without errors with the configured evaluator.
         agent_success_service.run(evaluation_request)
 
         # Verify the service ran successfully
@@ -411,7 +406,7 @@ def test_with_tool_configs(mock_chat_completion):
             metadata_definition_prompt="Include tool usage statistics",
         )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config]
+            "agent_success_config", success_config
         )
         agent_success_service.configurator.set_config_by_name(
             "tool_can_use",
@@ -466,7 +461,7 @@ def test_none_request():
             success_definition_prompt="Evaluate if the agent successfully completed the task",
         )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config]
+            "agent_success_config", success_config
         )
 
         # Run with None request
@@ -517,7 +512,7 @@ def test_agent_success_message_construction_with_interactions():
             success_definition_prompt="Evaluate if the agent successfully completed the task",
         )
         agent_success_service.configurator.set_config_by_name(
-            "agent_success_configs", [success_config]
+            "agent_success_config", success_config
         )
         agent_success_service.configurator.set_config_by_name(
             "tool_can_use",

--- a/tests/server/services/playbook/test_cluster_change_detection.py
+++ b/tests/server/services/playbook/test_cluster_change_detection.py
@@ -410,9 +410,9 @@ class TestAggregatorRunWithChangeDetection:
         mock_playbook_config = MagicMock()
         mock_playbook_config.extractor_name = "test_playbook"
         mock_playbook_config.aggregation_config = config
-        mock_configurator.get_config.return_value.user_playbook_extractor_configs = [
+        mock_configurator.get_config.return_value.user_playbook_extractor_config = (
             mock_playbook_config
-        ]
+        )
 
         # Setup storage methods
         mock_storage.get_user_playbooks.return_value = user_playbooks

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -546,7 +546,7 @@ class TestGetPlaybookAggregatorConfig:
             extraction_definition_prompt="prompt",
             aggregation_config=fac,
         )
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = [afc]
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = afc
 
         result = agg._get_playbook_aggregator_config("my_fb")
 
@@ -558,13 +558,13 @@ class TestGetPlaybookAggregatorConfig:
             extractor_name="other",
             extraction_definition_prompt="prompt",
         )
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = [afc]
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = afc
 
         assert agg._get_playbook_aggregator_config("missing") is None
 
     def test_returns_none_when_no_playbook_configs(self):
         agg = _make_aggregator()
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = None
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = None
 
         assert agg._get_playbook_aggregator_config("any") is None
 
@@ -589,7 +589,7 @@ class TestRun:
             extraction_definition_prompt="prompt",
             aggregation_config=fac,
         )
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = [afc]
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = afc
         # storage returns
         agg.storage.count_user_playbooks.return_value = 5
         agg.storage.get_agent_playbooks.return_value = []
@@ -599,7 +599,7 @@ class TestRun:
 
     def test_no_config_returns_early(self):
         agg = _make_aggregator()
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = None
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = None
 
         req = PlaybookAggregatorRequest(agent_version="v1", playbook_name="fb")
         agg.run(req)
@@ -616,7 +616,7 @@ class TestRun:
             extraction_definition_prompt="prompt",
             aggregation_config=fac,
         )
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = [afc]
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = afc
 
         req = PlaybookAggregatorRequest(agent_version="v1", playbook_name="fb")
         agg.run(req)
@@ -633,7 +633,7 @@ class TestRun:
             extraction_definition_prompt="prompt",
             aggregation_config=fac,
         )
-        agg.configurator.get_config.return_value.user_playbook_extractor_configs = [afc]
+        agg.configurator.get_config.return_value.user_playbook_extractor_config = afc
         agg.storage.count_user_playbooks.return_value = 1
 
         req = PlaybookAggregatorRequest(agent_version="v1", playbook_name="fb")

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -105,7 +105,7 @@ def test_generate_playbook(mock_chat_completion):
             ),
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
         playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -157,7 +157,7 @@ def test_empty_interactions(mock_chat_completion):
             ),
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
 
         # Create playbook generation request with empty request interaction data models
@@ -244,7 +244,7 @@ def test_error_handling(mock_chat_completion):
             ),
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
 
         # Create request interaction data model
@@ -305,7 +305,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
             ),
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
         # window_size is not configured
 
@@ -362,7 +362,7 @@ def test_run_manual_regular_no_interactions(mock_chat_completion):
             ),
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
         playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -405,7 +405,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
             allow_manual_trigger=True,  # Required for manual generation
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
         playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -466,7 +466,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
             allow_manual_trigger=True,  # Required for manual generation
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
         playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -549,7 +549,7 @@ def test_run_manual_regular_output_pending_status_false(mock_chat_completion):
             allow_manual_trigger=True,  # Required for manual generation
         )
         playbook_generation_service.configurator.set_config_by_name(
-            "user_playbook_extractor_configs", [playbook_config]
+            "user_playbook_extractor_config", playbook_config
         )
         playbook_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -807,30 +807,21 @@ def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
             return_value=([session_id], [])
         )
 
-        extractor_configs = [
-            PlaybookConfig(
-                extractor_name="api_playbook",
-                extraction_definition_prompt="extract api-related playbook",
-                request_sources_enabled=["api"],
-                window_size_override=120,
-                aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
-            ),
-            PlaybookConfig(
-                extractor_name="web_playbook",
-                extraction_definition_prompt="extract web-related playbook",
-                request_sources_enabled=["web"],
-                window_size_override=80,
-                aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
-            ),
-        ]
+        extractor_config = PlaybookConfig(
+            extractor_name="api_playbook",
+            extraction_definition_prompt="extract api-related playbook",
+            request_sources_enabled=["api"],
+            window_size_override=120,
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        )
 
         (
             scoped_groups,
-            scoped_configs,
-        ) = service._collect_scoped_interactions_for_precheck(extractor_configs)
+            scoped_config,
+        ) = service._collect_scoped_interactions_for_precheck(extractor_config)
 
         assert len(scoped_groups) == 1
-        assert [c.extractor_name for c in scoped_configs] == ["api_playbook"]
+        assert scoped_config.extractor_name == "api_playbook"
         service.storage.get_last_k_interactions_grouped.assert_called_once()
         _, kwargs = service.storage.get_last_k_interactions_grouped.call_args
         assert kwargs["k"] == 120

--- a/tests/server/services/playbook/test_playbook_generation_service_integration.py
+++ b/tests/server/services/playbook/test_playbook_generation_service_integration.py
@@ -76,15 +76,13 @@ def mock_request_context():
     # Mock get_last_k_interactions_grouped to return empty by default
     context.storage.get_last_k_interactions_grouped.return_value = ([], [])
     context.configurator = MagicMock()
-    context.configurator.get_config.return_value.user_playbook_extractor_configs = [
+    context.configurator.get_config.return_value.user_playbook_extractor_config = (
         PlaybookConfig(
             extractor_name="test_playbook",
             extraction_definition_prompt="Test playbook definition",
-            aggregation_config=PlaybookAggregatorConfig(
-                min_cluster_size=2,
-            ),
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
         )
-    ]
+    )
     # Mock window_size for extractor
     context.configurator.get_config.return_value.window_size = 100
     context.prompt_manager = PromptManager()
@@ -254,7 +252,7 @@ def test_playbook_generation_with_no_playbook_config(
     _setup_mock_chat_completion(playbook_generation_service)
 
     # Set empty playbook config
-    mock_request_context.configurator.get_config.return_value.user_playbook_extractor_configs = []
+    mock_request_context.configurator.get_config.return_value.user_playbook_extractor_config = None
 
     # Create request interaction data model
     request_interaction_data_model = create_request_interaction_data_model(

--- a/tests/server/services/profile/test_profile_generation_service.py
+++ b/tests/server/services/profile/test_profile_generation_service.py
@@ -150,31 +150,14 @@ def sample_request_interaction_models(sample_interactions):
 class TestBuildShouldRunPrompt:
     """Tests for _build_should_run_prompt with profile-specific config."""
 
-    def test_returns_none_when_no_configs(
-        self, service, sample_request_interaction_models
-    ):
-        """Return None when scoped_configs list is empty."""
-        configs: list[ProfileExtractorConfig] = []
-
-        with patch.object(
-            service.configurator, "get_agent_context", return_value="Agent context"
-        ):
-            result = service._build_should_run_prompt(
-                configs, sample_request_interaction_models
-            )
-
-        assert result is None
-
     def test_returns_prompt_with_definition_only(
         self, service, request_context, sample_request_interaction_models
     ):
         """Prompt is rendered when config has extraction_definition_prompt."""
-        configs = [
-            ProfileExtractorConfig(
-                extractor_name="prefs",
-                extraction_definition_prompt="Extract user preferences",
-            ),
-        ]
+        config = ProfileExtractorConfig(
+            extractor_name="prefs",
+            extraction_definition_prompt="Extract user preferences",
+        )
 
         with (
             patch.object(
@@ -187,7 +170,7 @@ class TestBuildShouldRunPrompt:
             ) as mock_render,
         ):
             result = service._build_should_run_prompt(
-                configs, sample_request_interaction_models
+                config, sample_request_interaction_models
             )
 
             assert result == "rendered prompt"
@@ -201,13 +184,11 @@ class TestBuildShouldRunPrompt:
         self, service, request_context, sample_request_interaction_models
     ):
         """Prompt includes override condition when config has should_extract_profile_prompt_override."""
-        configs = [
-            ProfileExtractorConfig(
-                extractor_name="custom",
-                extraction_definition_prompt="Basic profile",
-                should_extract_profile_prompt_override="Check if user shared info",
-            ),
-        ]
+        config = ProfileExtractorConfig(
+            extractor_name="custom",
+            extraction_definition_prompt="Basic profile",
+            should_extract_profile_prompt_override="Check if user shared info",
+        )
 
         with (
             patch.object(
@@ -220,7 +201,7 @@ class TestBuildShouldRunPrompt:
             ) as mock_render,
         ):
             result = service._build_should_run_prompt(
-                configs, sample_request_interaction_models
+                config, sample_request_interaction_models
             )
 
             assert result == "rendered override"
@@ -230,21 +211,15 @@ class TestBuildShouldRunPrompt:
                 in variables["should_extract_profile_prompt"]
             )
 
-    def test_combines_multiple_configs(
+    def test_renders_single_config_criteria(
         self, service, request_context, sample_request_interaction_models
     ):
-        """Multiple configs are combined into numbered criteria list."""
-        configs = [
-            ProfileExtractorConfig(
-                extractor_name="prefs",
-                extraction_definition_prompt="Extract preferences",
-                should_extract_profile_prompt_override="User shared preference",
-            ),
-            ProfileExtractorConfig(
-                extractor_name="bio",
-                extraction_definition_prompt="Extract biography",
-            ),
-        ]
+        """Single config renders definition and override criteria."""
+        config = ProfileExtractorConfig(
+            extractor_name="prefs",
+            extraction_definition_prompt="Extract preferences",
+            should_extract_profile_prompt_override="User shared preference",
+        )
 
         with (
             patch.object(
@@ -257,31 +232,23 @@ class TestBuildShouldRunPrompt:
             ) as mock_render,
         ):
             result = service._build_should_run_prompt(
-                configs, sample_request_interaction_models
+                config, sample_request_interaction_models
             )
 
             assert result == "combined prompt"
             variables = mock_render.call_args[0][1]
             criteria = variables["should_extract_profile_prompt"]
-            assert "1." in criteria
-            assert "2." in criteria
             assert "Extract preferences" in criteria
-            assert "Extract biography" in criteria
+            assert "User shared preference" in criteria
 
-    def test_renders_with_multiple_definitions(
+    def test_renders_single_definition(
         self, service, request_context, sample_request_interaction_models
     ):
-        """Multiple configs with definitions are all included in criteria."""
-        configs = [
-            ProfileExtractorConfig(
-                extractor_name="hobbies",
-                extraction_definition_prompt="Extract hobbies",
-            ),
-            ProfileExtractorConfig(
-                extractor_name="food",
-                extraction_definition_prompt="Extract food preferences",
-            ),
-        ]
+        """Single config definition is included in criteria."""
+        config = ProfileExtractorConfig(
+            extractor_name="hobbies",
+            extraction_definition_prompt="Extract hobbies",
+        )
 
         with (
             patch.object(
@@ -294,14 +261,13 @@ class TestBuildShouldRunPrompt:
             ) as mock_render,
         ):
             result = service._build_should_run_prompt(
-                configs, sample_request_interaction_models
+                config, sample_request_interaction_models
             )
 
             assert result == "partial prompt"
             variables = mock_render.call_args[0][1]
             criteria = variables["should_extract_profile_prompt"]
             assert "Extract hobbies" in criteria
-            assert "Extract food preferences" in criteria
 
 
 # ===============================

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -646,8 +646,9 @@ class TestRun:
 
         service.run(request)
 
-        # _process_results called once with all results after all extractors complete
-        assert len(service._processed_results) == 2
+        # Legacy list configs are normalized to the first configured extractor.
+        assert len(service._processed_results) == 1
+        assert service._processed_results[0]["extractor_name"] == "extractor1"
 
     def test_run_with_none_request(self, base_service):
         """Test that run() handles None request gracefully."""
@@ -740,8 +741,10 @@ class TestRun:
         assert len(service._processed_results) == 1
         assert service._processed_results[0]["extractor_name"] == "extractor1"
 
-    def test_run_raises_when_all_extractors_fail(self, llm_client, request_context):
-        """Test that run() raises when all extractors fail."""
+    def test_run_raises_when_configured_extractor_fails(
+        self, llm_client, request_context
+    ):
+        """Test that run() raises when the configured extractor fails."""
         service = ConcreteGenerationService(
             llm_client,
             request_context,
@@ -765,10 +768,10 @@ class TestRun:
         with pytest.raises(ExtractorExecutionError):
             service.run(request)
 
-    def test_run_partial_success_when_some_extractors_fail(
+    def test_run_uses_first_legacy_config_when_later_configs_fail(
         self, llm_client, request_context
     ):
-        """Test that run() succeeds when at least one extractor returns a result."""
+        """Legacy config lists are first-entry-wins; later configs are ignored."""
         service = ConcreteGenerationService(
             llm_client,
             request_context,
@@ -780,7 +783,7 @@ class TestRun:
         service._create_extractor = MagicMock(
             side_effect=lambda extractor_config, service_config: MockExtractor(  # noqa: ARG005
                 result={"extractor_name": extractor_config.extractor_name},
-                should_raise=extractor_config.extractor_name == "extractor1",
+                should_raise=extractor_config.extractor_name == "extractor2",
             )
         )
 
@@ -792,7 +795,7 @@ class TestRun:
 
         service.run(request)
         assert len(service._processed_results) == 1
-        assert service._processed_results[0]["extractor_name"] == "extractor2"
+        assert service._processed_results[0]["extractor_name"] == "extractor1"
 
 
 # ===============================
@@ -1823,7 +1826,7 @@ class TestCancellationInBatch:
 
 
 class TestSequentialExecution:
-    """Tests for the sequential extractor execution in _run_generation."""
+    """Tests for the single configured extractor execution in _run_generation."""
 
     def test_sequential_single_extractor(self, llm_client, request_context):
         """Test sequential execution with a single extractor."""
@@ -1844,10 +1847,10 @@ class TestSequentialExecution:
         # Single extractor should produce one result
         assert len(service._processed_results) == 1
 
-    def test_sequential_multiple_extractors_all_succeed(
+    def test_legacy_multiple_configs_run_first_config_only(
         self, llm_client, request_context
     ):
-        """Test that all extractors run sequentially and each result is saved."""
+        """Test that legacy config lists normalize to the first config."""
         call_order = []
 
         class TrackingExtractor:
@@ -1890,14 +1893,12 @@ class TestSequentialExecution:
 
         service.run(request)
 
-        # Extractors ran sequentially
-        assert call_order == ["ext1", "ext2", "ext3"]
-        # _process_results called once with all 3 results
+        assert call_order == ["ext1"]
         assert len(service._process_calls) == 1
-        assert len(service._process_calls[0]) == 3
+        assert service._process_calls[0] == [{"name": "ext1"}]
 
-    def test_sequential_partial_failure(self, llm_client, request_context):
-        """Test that failure in one extractor doesn't stop others."""
+    def test_configured_extractor_failure_raises(self, llm_client, request_context):
+        """Test that failure in the configured extractor fails the run."""
 
         class PartialService(ConcreteGenerationService):
             def __init__(self, *args, **kwargs):
@@ -1918,18 +1919,16 @@ class TestSequentialExecution:
             llm_client,
             request_context,
             extractor_configs=[
-                MockExtractorConfig(extractor_name="ext1"),
                 MockExtractorConfig(extractor_name="failing"),
                 MockExtractorConfig(extractor_name="ext3"),
             ],
         )
 
         request = MockServiceConfig(user_id="test_user", request_id="test_request")
-        service.run(request)
 
-        # _process_results called once with the 2 successful results
-        assert len(service._process_calls) == 1
-        assert len(service._process_calls[0]) == 2
+        with pytest.raises(ExtractorExecutionError):
+            service.run(request)
+        assert service._process_calls == []
 
     def test_sequential_all_fail_raises(self, llm_client, request_context):
         """Test that all extractors failing raises ExtractorExecutionError."""
@@ -2015,7 +2014,7 @@ class TestSequentialExecution:
         request = MockServiceConfig(user_id="test_user", request_id="test_request")
         service.run(request)
 
-        assert observed_incremental == [False, False, False]
+        assert observed_incremental == [False]
 
     def test_sequential_does_not_pass_previously_extracted(
         self, llm_client, request_context
@@ -2046,7 +2045,7 @@ class TestSequentialExecution:
         request = MockServiceConfig(user_id="test_user", request_id="test_request")
         service.run(request)
 
-        assert observed_previously == [[], [], []]
+        assert observed_previously == [[]]
 
     def test_sequential_none_results_do_not_create_incremental_state(
         self, llm_client, request_context
@@ -2080,7 +2079,7 @@ class TestSequentialExecution:
         request = MockServiceConfig(user_id="test_user", request_id="test_request")
         service.run(request)
 
-        assert observed_previously == [[], [], []]
+        assert observed_previously == [[]]
 
     def test_sequential_completed_outcome_is_unwrapped(
         self, llm_client, request_context
@@ -2210,10 +2209,10 @@ class TestSequentialExecution:
         assert kwargs["last_error"] == "persist failed"
         assert kwargs["increment_finalization_attempts"] is True
 
-    def test_sequential_timeout_does_not_block_following_extractors(
+    def test_configured_extractor_timeout_fails_generation(
         self, llm_client, request_context, monkeypatch
     ):
-        """Test that timed-out extractors are skipped and later extractors still run."""
+        """Test that a timed-out configured extractor fails generation."""
         monkeypatch.setattr(
             "reflexio.server.services.base_generation_service.EXTRACTOR_TIMEOUT_SECONDS",
             0.01,
@@ -2247,10 +2246,11 @@ class TestSequentialExecution:
         )
 
         request = MockServiceConfig(user_id="test_user", request_id="test_request")
-        service.run(request)
 
-        assert len(service._process_calls) == 1
-        assert service._process_calls[0] == [{"name": "fast"}]
+        with pytest.raises(ExtractorExecutionError):
+            service.run(request)
+        assert service._process_calls == []
+        assert service._last_extractor_run_stats["total"] == 1
         assert service._last_extractor_run_stats["failed"] == 1
         assert service._last_extractor_run_stats["timed_out"] == 1
 

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -85,17 +85,24 @@ class MockExtractor:
 class ConcreteGenerationService(BaseGenerationService):
     """Concrete implementation of BaseGenerationService for testing."""
 
-    def __init__(self, llm_client, request_context, extractor_configs=None):
+    def __init__(
+        self, llm_client, request_context, extractor_config=None, extractor_configs=None
+    ):
         super().__init__(llm_client, request_context)
-        self._extractor_configs = extractor_configs or []
+        if extractor_config is not None:
+            self._extractor_config = extractor_config
+        elif extractor_configs:
+            self._extractor_config = extractor_configs[0]
+        else:
+            self._extractor_config = None
         self._processed_results = []
         # For upgrade/downgrade testing
         self._items_by_status = {}
         self._deleted_count = 0
         self._updated_count = 0
 
-    def _load_extractor_configs(self):
-        return self._extractor_configs
+    def _load_extractor_config(self):
+        return self._extractor_config
 
     def _load_generation_service_config(self, request):
         return request
@@ -210,175 +217,131 @@ def base_service(llm_client, request_context):
 
 
 # ===============================
-# Test: _filter_extractor_configs_by_service_config
+# Test: _filter_extractor_config_by_service_config
 # ===============================
 
 
-class TestFilterExtractorConfigsByServiceConfig:
-    """Tests for the _filter_extractor_configs_by_service_config method."""
+class TestFilterExtractorConfigByServiceConfig:
+    """Tests for the _filter_extractor_config_by_service_config method."""
 
     def test_no_filtering_without_source_attribute(self, base_service):
-        """Test that configs are not filtered if service_config has no source attribute."""
-        configs = [
-            MockExtractorConfig(extractor_name="extractor1"),
-            MockExtractorConfig(extractor_name="extractor2"),
-        ]
+        """Test that config is not filtered if service_config has no source attribute."""
+        config = MockExtractorConfig(extractor_name="extractor1")
 
-        # Create service config without source attribute
         class NoSourceConfig:
             pass
 
         service_config = NoSourceConfig()
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
         )
-        assert len(result) == 2
+        assert result is config
 
     def test_filter_by_source_enabled(self, base_service):
-        """Test filtering extractors by request_sources_enabled."""
-        configs = [
-            MockExtractorConfig(
-                extractor_name="extractor1", request_sources_enabled=["api", "web"]
-            ),
-            MockExtractorConfig(
-                extractor_name="extractor2", request_sources_enabled=["mobile"]
-            ),
-            MockExtractorConfig(extractor_name="extractor3"),  # No source restriction
-        ]
+        """Test filtering extractor by request_sources_enabled."""
+        config = MockExtractorConfig(
+            extractor_name="extractor1", request_sources_enabled=["api", "web"]
+        )
 
         service_config = MockServiceConfig(source="api")
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
         )
 
-        # extractor1 (api in enabled list) and extractor3 (no restriction) should pass
-        assert len(result) == 2
-        extractor_names = [c.extractor_name for c in result]
-        assert "extractor1" in extractor_names
-        assert "extractor3" in extractor_names
-        assert "extractor2" not in extractor_names
+        assert result is config
+
+    def test_filter_by_source_disabled(self, base_service):
+        """Test that source-mismatched extractor is filtered out."""
+        config = MockExtractorConfig(
+            extractor_name="extractor1", request_sources_enabled=["mobile"]
+        )
+
+        service_config = MockServiceConfig(source="api")
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
+        )
+
+        assert result is None
 
     def test_filter_by_manual_trigger(self, base_service):
-        """Test filtering extractors by manual_trigger flag."""
-        configs = [
-            MockExtractorConfig(extractor_name="extractor1", manual_trigger=True),
-            MockExtractorConfig(extractor_name="extractor2", manual_trigger=False),
-            MockExtractorConfig(extractor_name="extractor3"),  # Default False
-        ]
+        """Test filtering extractor by manual_trigger flag."""
+        config = MockExtractorConfig(extractor_name="extractor1", manual_trigger=True)
 
-        # allow_manual_trigger=False - manual_trigger=True extractors should be skipped
         service_config = MockServiceConfig(allow_manual_trigger=False)
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
         )
 
-        assert len(result) == 2
-        extractor_names = [c.extractor_name for c in result]
-        assert "extractor2" in extractor_names
-        assert "extractor3" in extractor_names
-        assert "extractor1" not in extractor_names
+        assert result is None
 
     def test_manual_trigger_allowed_when_allow_manual_trigger_true(self, base_service):
-        """Test that manual_trigger extractors are allowed when allow_manual_trigger=True."""
-        configs = [
-            MockExtractorConfig(extractor_name="extractor1", manual_trigger=True),
-            MockExtractorConfig(extractor_name="extractor2", manual_trigger=False),
-        ]
+        """Test that manual_trigger extractor is allowed when requested."""
+        config = MockExtractorConfig(extractor_name="extractor1", manual_trigger=True)
 
         service_config = MockServiceConfig(allow_manual_trigger=True)
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
         )
 
-        assert len(result) == 2
-        extractor_names = [c.extractor_name for c in result]
-        assert "extractor1" in extractor_names
-        assert "extractor2" in extractor_names
+        assert result is config
 
-    def test_filter_by_extractor_names(self, base_service):
-        """Test filtering extractors by extractor_names list in service_config."""
-        configs = [
-            MockExtractorConfig(extractor_name="extractor1"),
-            MockExtractorConfig(extractor_name="extractor2"),
-            MockExtractorConfig(extractor_name="extractor3"),
-        ]
+    def test_filter_by_matching_extractor_name(self, base_service):
+        """Test explicit extractor name filters."""
+        config = MockExtractorConfig(extractor_name="extractor1")
 
-        service_config = MockServiceConfig(extractor_names=["extractor1", "extractor3"])
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        service_config = MockServiceConfig(extractor_names=["extractor1"])
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
         )
 
-        assert len(result) == 2
-        extractor_names = [c.extractor_name for c in result]
-        assert "extractor1" in extractor_names
-        assert "extractor3" in extractor_names
-        assert "extractor2" not in extractor_names
+        assert result is config
+
+    def test_filter_by_non_matching_extractor_name(self, base_service):
+        """Test explicit extractor name mismatch filters out the config."""
+        config = MockExtractorConfig(extractor_name="extractor1")
+
+        service_config = MockServiceConfig(extractor_names=["extractor2"])
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
+        )
+
+        assert result is None
 
     def test_combined_filtering(self, base_service):
         """Test that all filter conditions are applied together."""
-        configs = [
-            MockExtractorConfig(
-                extractor_name="extractor1",
-                request_sources_enabled=["api"],
-                manual_trigger=False,
-            ),
-            MockExtractorConfig(
-                extractor_name="extractor2",
-                request_sources_enabled=["mobile"],
-                manual_trigger=False,
-            ),
-            MockExtractorConfig(
-                extractor_name="extractor3",
-                request_sources_enabled=["api"],
-                manual_trigger=True,
-            ),
-        ]
+        config = MockExtractorConfig(
+            extractor_name="extractor1",
+            request_sources_enabled=["api"],
+            manual_trigger=False,
+        )
 
-        # Source=api, allow_manual_trigger=False, filter by name
         service_config = MockServiceConfig(
             source="api",
             allow_manual_trigger=False,
-            extractor_names=["extractor1", "extractor3"],
+            extractor_names=["extractor1"],
         )
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
         )
 
-        # Only extractor1 passes all filters:
-        # - extractor2: wrong source
-        # - extractor3: manual_trigger=True but allow_manual_trigger=False
-        assert len(result) == 1
-        assert result[0].extractor_name == "extractor1"
-
-    def test_empty_configs_list(self, base_service):
-        """Test filtering with empty configs list."""
-        configs = []
-        service_config = MockServiceConfig(source="api")
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
-        )
-        assert len(result) == 0
+        assert result is config
 
     def test_none_source_in_service_config(self, base_service):
         """Test filtering when source is None in service_config."""
-        configs = [
-            MockExtractorConfig(
-                extractor_name="extractor1", request_sources_enabled=["api"]
-            ),
-            MockExtractorConfig(extractor_name="extractor2"),
-        ]
-
-        service_config = MockServiceConfig(source=None)
-        result = base_service._filter_extractor_configs_by_service_config(
-            configs, service_config
+        config = MockExtractorConfig(
+            extractor_name="extractor1", request_sources_enabled=["api"]
         )
 
-        # Both should pass since source is None (no filtering by source)
-        assert len(result) == 2
+        service_config = MockServiceConfig(source=None)
+        result = base_service._filter_extractor_config_by_service_config(
+            config, service_config
+        )
+
+        assert result is config
 
 
 # ===============================
-# Test: _filter_configs_by_stride
+# Test: _filter_config_by_stride
 # ===============================
 
 
@@ -389,8 +352,8 @@ class StrideEnabledService(ConcreteGenerationService):
         return "test_extractor"
 
 
-class TestFilterConfigsByStride:
-    """Tests for the _filter_configs_by_stride method."""
+class TestFilterConfigByStride:
+    """Tests for the _filter_config_by_stride method."""
 
     def _make_request_interaction_models(self, n_interactions: int):
         """Create mock RequestInteractionDataModel objects with n interactions."""
@@ -424,65 +387,46 @@ class TestFilterConfigsByStride:
             )
         ]
 
-    def test_returns_all_configs_when_no_service_name(
-        self, llm_client, request_context
-    ):
-        """Verify _filter_configs_by_stride returns all configs unchanged when
+    def test_returns_config_when_no_service_name(self, llm_client, request_context):
+        """Verify _filter_config_by_stride returns config unchanged when
         _get_extractor_state_service_name() returns None (e.g., AgentSuccessEvaluationService).
         """
         service = ConcreteGenerationService(
             llm_client,
             request_context,
-            extractor_configs=[
-                MockExtractorConfig(extractor_name="ext1"),
-                MockExtractorConfig(extractor_name="ext2"),
-            ],
+            extractor_config=MockExtractorConfig(extractor_name="ext1"),
         )
         service.service_config = MockServiceConfig()
 
-        configs = [
-            MockExtractorConfig(extractor_name="ext1"),
-            MockExtractorConfig(extractor_name="ext2"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        assert len(result) == 2
-        assert result is configs  # Same list object returned, no filtering
+        config = MockExtractorConfig(extractor_name="ext1")
+        result = service._filter_config_by_stride(config)
+        assert result is config
 
-    def test_returns_all_configs_when_auto_run_false(self, llm_client, request_context):
-        """Verify all configs pass when auto_run=False (rerun/manual mode)."""
+    def test_returns_config_when_auto_run_false(self, llm_client, request_context):
+        """Verify config passes when auto_run=False (rerun/manual mode)."""
         service = StrideEnabledService(
             llm_client,
             request_context,
-            extractor_configs=[],
         )
         service.service_config = MockServiceConfig(auto_run=False)
 
-        configs = [
-            MockExtractorConfig(extractor_name="ext1"),
-            MockExtractorConfig(extractor_name="ext2"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        assert len(result) == 2
-        assert result is configs  # Same list object returned, no filtering
+        config = MockExtractorConfig(extractor_name="ext1")
+        result = service._filter_config_by_stride(config)
+        assert result is config
 
-    def test_returns_all_configs_when_force_extraction_true(
+    def test_returns_config_when_force_extraction_true(
         self, llm_client, request_context
     ):
-        """Verify all configs pass when force_extraction=True (agent-curated publish)."""
+        """Verify config passes when force_extraction=True (agent-curated publish)."""
         service = StrideEnabledService(
             llm_client,
             request_context,
-            extractor_configs=[],
         )
         service.service_config = MockServiceConfig(force_extraction=True)
 
-        configs = [
-            MockExtractorConfig(extractor_name="ext1"),
-            MockExtractorConfig(extractor_name="ext2"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        assert len(result) == 2
-        assert result is configs  # Same list object returned, no filtering
+        config = MockExtractorConfig(extractor_name="ext1")
+        result = service._filter_config_by_stride(config)
+        assert result is config
 
     def _setup_stride_size_service(
         self, llm_client, request_context, n_new_interactions
@@ -506,66 +450,46 @@ class TestFilterConfigsByStride:
         service = StrideEnabledService(
             llm_client,
             request_context,
-            extractor_configs=[],
         )
         return service  # noqa: RET504
 
-    def test_filters_configs_when_stride_size_not_met(
-        self, llm_client, request_context
-    ):
-        """Verify configs are dropped when new interaction count < stride_size."""
+    def test_filters_config_when_stride_size_not_met(self, llm_client, request_context):
+        """Verify config is dropped when new interaction count < stride_size."""
         service = self._setup_stride_size_service(llm_client, request_context, 2)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
-        configs = [
-            MockExtractorConfig(extractor_name="ext1"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        assert len(result) == 0
+        config = MockExtractorConfig(extractor_name="ext1")
+        result = service._filter_config_by_stride(config)
+        assert result is None
 
-    def test_passes_configs_when_stride_size_met(self, llm_client, request_context):
-        """Verify configs pass through when new interaction count >= stride_size."""
+    def test_passes_config_when_stride_size_met(self, llm_client, request_context):
+        """Verify config passes through when new interaction count >= stride_size."""
         service = self._setup_stride_size_service(llm_client, request_context, 6)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
-        configs = [
-            MockExtractorConfig(extractor_name="ext1"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        assert len(result) == 1
-        assert result[0].extractor_name == "ext1"
+        config = MockExtractorConfig(extractor_name="ext1")
+        result = service._filter_config_by_stride(config)
+        assert result is config
 
     def test_handles_source_skip(self, llm_client, request_context):
-        """Verify configs that fail source filtering in stride_size check are skipped."""
+        """Verify config that fails source filtering in stride_size check is skipped."""
         service = self._setup_stride_size_service(llm_client, request_context, 10)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
-        # ext1 has sources_enabled=["mobile"] but triggering source is "api" -> should be skipped
-        # ext2 has no source restriction -> should pass stride_size check
-        configs = [
-            MockExtractorConfig(
-                extractor_name="ext1", request_sources_enabled=["mobile"]
-            ),
-            MockExtractorConfig(extractor_name="ext2"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        # ext1 skipped by source filter, ext2 passes stride_size
-        assert len(result) == 1
-        assert result[0].extractor_name == "ext2"
+        config = MockExtractorConfig(
+            extractor_name="ext1", request_sources_enabled=["mobile"]
+        )
+        result = service._filter_config_by_stride(config)
+        assert result is None
 
     def test_uses_per_extractor_stride_size_override(self, llm_client, request_context):
         """Verify per-extractor stride_size override is respected."""
         service = self._setup_stride_size_service(llm_client, request_context, 3)
         service.service_config = MockServiceConfig(auto_run=True, source="api")
 
-        # 3 new interactions: ext1 (stride_size=2 -> passes), ext2 (default stride_size=5 -> fails)
-        configs = [
-            MockExtractorConfig(extractor_name="ext1", stride_size_override=2),
-            MockExtractorConfig(extractor_name="ext2"),
-        ]
-        result = service._filter_configs_by_stride(configs)
-        assert len(result) == 1
-        assert result[0].extractor_name == "ext1"
+        config = MockExtractorConfig(extractor_name="ext1", stride_size_override=2)
+        result = service._filter_config_by_stride(config)
+        assert result is config
 
 
 # ===============================
@@ -586,8 +510,8 @@ class TestShouldRunBeforeExtraction:
         service = ConcreteGenerationService(llm_client, request_context)
         service.service_config = MockServiceConfig(auto_run=True)
 
-        configs = [MockExtractorConfig(extractor_name="test")]
-        result = service._should_run_before_extraction(configs)
+        config = MockExtractorConfig(extractor_name="test")
+        result = service._should_run_before_extraction(config)
 
         assert result is True
 
@@ -611,7 +535,7 @@ class TestShouldRunBeforeExtraction:
         llm_client.generate_chat_response = llm_call_spy
 
         result = service._should_run_before_extraction(
-            [MockExtractorConfig(extractor_name="test")]
+            MockExtractorConfig(extractor_name="test")
         )
 
         assert result is True
@@ -632,10 +556,7 @@ class TestRun:
         service = ConcreteGenerationService(
             llm_client,
             request_context,
-            extractor_configs=[
-                MockExtractorConfig(extractor_name="extractor1"),
-                MockExtractorConfig(extractor_name="extractor2"),
-            ],
+            extractor_config=MockExtractorConfig(extractor_name="extractor1"),
         )
 
         request = MockServiceConfig(
@@ -646,7 +567,6 @@ class TestRun:
 
         service.run(request)
 
-        # Legacy list configs are normalized to the first configured extractor.
         assert len(service._processed_results) == 1
         assert service._processed_results[0]["extractor_name"] == "extractor1"
 
@@ -666,7 +586,7 @@ class TestRun:
         service = ConcreteGenerationService(
             llm_client,
             request_context,
-            extractor_configs=[MockExtractorConfig(extractor_name="extractor1")],
+            extractor_config=MockExtractorConfig(extractor_name="extractor1"),
         )
 
         request = MockServiceConfig(
@@ -681,11 +601,9 @@ class TestRun:
         # The mock extractor returns a result, so we expect 1 result
         assert len(service._processed_results) == 1
 
-    def test_run_without_extractor_configs(self, llm_client, request_context):
-        """Test run() when no extractor configs are available."""
-        service = ConcreteGenerationService(
-            llm_client, request_context, extractor_configs=[]
-        )
+    def test_run_without_extractor_config(self, llm_client, request_context):
+        """Test run() when no extractor config is available."""
+        service = ConcreteGenerationService(llm_client, request_context)
 
         request = MockServiceConfig(
             request_interaction_data_models=[MagicMock()],
@@ -701,7 +619,7 @@ class TestRun:
         service = ConcreteGenerationService(
             llm_client,
             request_context,
-            extractor_configs=[MockExtractorConfig(extractor_name="extractor1")],
+            extractor_config=MockExtractorConfig(extractor_name="extractor1"),
         )
 
         request = MockServiceConfig(
@@ -715,19 +633,14 @@ class TestRun:
         assert service.service_config is not None
         assert service.service_config.user_id == "test_user"
 
-    def test_run_filters_extractor_configs(self, llm_client, request_context):
+    def test_run_filters_extractor_config(self, llm_client, request_context):
         """Test that run() applies config filtering before creating extractors."""
         service = ConcreteGenerationService(
             llm_client,
             request_context,
-            extractor_configs=[
-                MockExtractorConfig(
-                    extractor_name="extractor1", request_sources_enabled=["api"]
-                ),
-                MockExtractorConfig(
-                    extractor_name="extractor2", request_sources_enabled=["mobile"]
-                ),
-            ],
+            extractor_config=MockExtractorConfig(
+                extractor_name="extractor1", request_sources_enabled=["api"]
+            ),
         )
 
         request = MockServiceConfig(
@@ -737,9 +650,27 @@ class TestRun:
 
         service.run(request)
 
-        # Only extractor1 should run since source is "api"
         assert len(service._processed_results) == 1
         assert service._processed_results[0]["extractor_name"] == "extractor1"
+
+    def test_run_skips_filtered_extractor_config(self, llm_client, request_context):
+        """Test that run() skips source-mismatched config."""
+        service = ConcreteGenerationService(
+            llm_client,
+            request_context,
+            extractor_config=MockExtractorConfig(
+                extractor_name="extractor1", request_sources_enabled=["mobile"]
+            ),
+        )
+
+        request = MockServiceConfig(
+            source="api",
+            request_interaction_data_models=[MagicMock()],
+        )
+
+        service.run(request)
+
+        assert len(service._processed_results) == 0
 
     def test_run_raises_when_configured_extractor_fails(
         self, llm_client, request_context
@@ -748,10 +679,7 @@ class TestRun:
         service = ConcreteGenerationService(
             llm_client,
             request_context,
-            extractor_configs=[
-                MockExtractorConfig(extractor_name="extractor1"),
-                MockExtractorConfig(extractor_name="extractor2"),
-            ],
+            extractor_config=MockExtractorConfig(extractor_name="extractor1"),
         )
         service._create_extractor = MagicMock(
             side_effect=lambda extractor_config, service_config: MockExtractor(  # noqa: ARG005
@@ -767,35 +695,6 @@ class TestRun:
 
         with pytest.raises(ExtractorExecutionError):
             service.run(request)
-
-    def test_run_uses_first_legacy_config_when_later_configs_fail(
-        self, llm_client, request_context
-    ):
-        """Legacy config lists are first-entry-wins; later configs are ignored."""
-        service = ConcreteGenerationService(
-            llm_client,
-            request_context,
-            extractor_configs=[
-                MockExtractorConfig(extractor_name="extractor1"),
-                MockExtractorConfig(extractor_name="extractor2"),
-            ],
-        )
-        service._create_extractor = MagicMock(
-            side_effect=lambda extractor_config, service_config: MockExtractor(  # noqa: ARG005
-                result={"extractor_name": extractor_config.extractor_name},
-                should_raise=extractor_config.extractor_name == "extractor2",
-            )
-        )
-
-        request = MockServiceConfig(
-            user_id="test_user",
-            request_id="test_request",
-            request_interaction_data_models=[MagicMock()],
-        )
-
-        service.run(request)
-        assert len(service._processed_results) == 1
-        assert service._processed_results[0]["extractor_name"] == "extractor1"
 
 
 # ===============================

--- a/tests/server/services/test_configurator.py
+++ b/tests/server/services/test_configurator.py
@@ -36,16 +36,14 @@ def test_init_creates_config_file(temp_dir, test_org_id):
     with open(config_file, encoding="utf-8") as f:
         loaded_config = Config.model_validate(json.load(f))
         assert isinstance(loaded_config.storage_config, StorageConfigSQLite)
-        assert loaded_config.profile_extractor_configs is not None
-        assert len(loaded_config.profile_extractor_configs) == 1
+        assert loaded_config.profile_extractor_config is not None
         assert (
-            loaded_config.profile_extractor_configs[0].extractor_name
+            loaded_config.profile_extractor_config.extractor_name
             == "default_profile_extractor"
         )
-        assert loaded_config.user_playbook_extractor_configs is not None
-        assert len(loaded_config.user_playbook_extractor_configs) == 1
+        assert loaded_config.user_playbook_extractor_config is not None
         assert (
-            loaded_config.user_playbook_extractor_configs[0].extractor_name
+            loaded_config.user_playbook_extractor_config.extractor_name
             == "default_playbook_extractor"
         )
 
@@ -69,16 +67,14 @@ def test_set_and_get_config_by_name(configurator):
             ),
         ),
         (
-            "profile_extractor_configs",
-            [
-                ProfileExtractorConfig(
-                    extractor_name="test_extractor",
-                    should_extract_profile_prompt_override="test",
-                    context_prompt="test",
-                    extraction_definition_prompt="test",
-                    metadata_definition_prompt="test",
-                )
-            ],
+            "profile_extractor_config",
+            ProfileExtractorConfig(
+                extractor_name="test_extractor",
+                should_extract_profile_prompt_override="test",
+                context_prompt="test",
+                extraction_definition_prompt="test",
+                metadata_definition_prompt="test",
+            ),
         ),
     ]
 
@@ -95,7 +91,7 @@ def test_config_persistence(temp_dir, test_org_id):
         storage_config=StorageConfigSQLite(
             db_path="/tmp/test.db",  # noqa: S108
         ),
-        profile_extractor_configs=[],
+        profile_extractor_config=None,
     )
     config1.set_config(new_config)
 

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -109,7 +109,7 @@ def test_refresh_profiles_for_user(mock_chat_completion):
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -181,7 +181,7 @@ def test_test_refresh_profiles_for_user_with_image_encoding(mock_chat_completion
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -268,7 +268,7 @@ def test_profile_extraction_message_construction():
                 metadata_definition_prompt="cuisine type",
             )
             profile_generation_service.configurator.set_config_by_name(
-                "profile_extractor_configs", [profile_extractor_config]
+                "profile_extractor_config", profile_extractor_config
             )
             profile_generation_service.configurator.set_config_by_name(
                 "window_size", 100
@@ -433,7 +433,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -573,7 +573,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         # window_size is not configured
 
@@ -630,7 +630,7 @@ def test_run_manual_regular_no_interactions(mock_chat_completion):
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -671,7 +671,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -745,7 +745,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
             metadata_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [profile_extractor_config]
+            "profile_extractor_config", profile_extractor_config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 

--- a/tests/server/services/test_profile_source_filtering.py
+++ b/tests/server/services/test_profile_source_filtering.py
@@ -74,15 +74,8 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
             request_sources_enabled=["api"],
         )
 
-        # Config 2: only enabled for "webhook" source
-        config2 = ProfileExtractorConfig(
-            extractor_name="webhook_extractor",
-            extraction_definition_prompt="Webhook config",
-            request_sources_enabled=["webhook"],
-        )
-
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [config1, config2]
+            "profile_extractor_config", config1
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -149,7 +142,7 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
         )
 
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [config]
+            "profile_extractor_config", config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -215,7 +208,7 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
         )
 
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [config]
+            "profile_extractor_config", config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 
@@ -281,7 +274,7 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
         )
 
         profile_generation_service.configurator.set_config_by_name(
-            "profile_extractor_configs", [config]
+            "profile_extractor_config", config
         )
         profile_generation_service.configurator.set_config_by_name("window_size", 100)
 


### PR DESCRIPTION
## Summary
- simplify generation services around one configured extractor/evaluator per profile, playbook, and agent success flow
- add canonical `agent_success_config` with legacy `agent_success_configs` first-entry migration/serialization
- update docs configure UI and tests for single success evaluator behavior

## Testing
- `PYTEST_ADDOPTS='--no-cov' uv run pytest open_source/reflexio/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py open_source/reflexio/tests/models/test_validators.py open_source/reflexio/tests/server/services/test_base_generation_service.py open_source/reflexio/tests/server/api_endpoints/test_evaluations_regenerate_api.py -q` from enterprise repo: 203 passed
- `uv run ruff check ...` on touched Python files
- `uv run pyright ...` on touched backend files
- `cd open_source/reflexio/docs && npm run lint && npm run build` (lint has existing warnings only)
- local launch checklist phases 0-14 passed against backend 8081, cleanup restored config/test data

## Review follow-up
- add shared `normalize_legacy_config_shape()` to `config_schema.py` and apply it at the `local_file_config_storage` load boundary, so OSS on-disk configs persisted before the single-extractor refactor recover their singular extractor/evaluator fields instead of silently dropping the legacy list keys
- drop the dead `*_extractor_configs` fallback in `resume_worker._select_current_extractor_config` now that the deprecated computed list views are gone
- `PYTEST_ADDOPTS='--no-cov' uv run pytest -o 'addopts=' open_source/reflexio/reflexio/server/services/configurator/test_config_storage.py open_source/reflexio/tests/server/services/extraction/test_resume_worker.py` (incl. new `test_load_config_upgrades_legacy_list_shape`): passed
- `uv run ruff check` + `uv run pyright` clean on touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * UI sections now manage a single extractor/evaluator config with an enable/disable switch (simpler controls, no list workflows).
  * Configuration schema moved to singular extractor/evaluator fields; PATCHing now requires the full nested object and setting a field to null disables that extractor.
  * Regenerate/validation now prefers the configured single evaluator when present.

* **User Experience**
  * Code editor shows generated code until you edit it and runs the currently displayed code.

* **Stability**
  * Settings load/persistence improved for more reliable initialization and storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
