### PR TITLE
Update notebooks for config schema

### DIFF
--- a/notebooks/04_configuration.ipynb
+++ b/notebooks/04_configuration.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Custom Configuration\n\n> **Time:** ~15 minutes | **Level:** Intermediate\n\nReflexio's behavior is controlled by **configuration**:\n- **Profile Extractors** — what to remember about users\n- **Playbook Configs** — how to identify agent improvements\n- **Tool Registration** — what tools your agent can use\n- **Success Evaluation** — how to measure agent performance\n\n### Prerequisites\n- Reflexio server running (`uv run reflexio services start --only backend`)\n- `OPENAI_API_KEY` set in your `.env` file"
+   "source": "# Custom Configuration\n\n> **Time:** ~15 minutes | **Level:** Intermediate\n\nReflexio's behavior is controlled by **configuration**:\n- **Profile Extractor** — what to remember about users\n- **Playbook Extractor** — how to identify agent improvements\n- **Tool Registration** — what tools your agent can use\n- **Success Evaluation** — how to measure agent performance\n\n### Prerequisites\n- Reflexio server running (`uv run reflexio services start --only backend`)\n- `OPENAI_API_KEY` set in your `.env` file"
   },
   {
    "cell_type": "code",
@@ -64,7 +64,7 @@
     "## Custom Profile Extractor\n",
     "\n",
     "> A **profile extractor** tells Reflexio what to remember about users.\n",
-    "> You can create multiple extractors for different concerns."
+    "> The current config schema uses one profile extractor; update its prompt when you want to change what it captures."
    ]
   },
   {
@@ -101,10 +101,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Multiple Extractors (Different Concerns)\n",
+    "## Refine the Extractor Scope\n",
     "\n",
-    "> Separate extractors focus on different aspects of the user.\n",
-    "> This keeps each extractor's prompt focused and improves extraction quality."
+    "> Keep the extractor prompt focused on the user attributes your agent should remember.\n",
+    "> Here we replace the earlier shopping-only extractor with a broader customer-profile extractor."
    ]
   },
   {
@@ -114,12 +114,14 @@
    "outputs": [],
    "source": [
     "config.profile_extractor_config = ProfileExtractorConfig(\n",
-    "    extractor_name=\"communication_style\",\n",
+    "    extractor_name=\"customer_profile\",\n",
     "    extraction_definition_prompt=(\n",
-    "        \"Extract the customer's communication style: \"\n",
-    "        \"formality level, preferred contact method (email/phone/chat), \"\n",
-    "        \"timezone indicators, and any accessibility needs.\"\n",
+    "        \"Extract the customer's shopping preferences and communication style, including: \"\n",
+    "        \"preferred product categories, budget range, brand preferences, \"\n",
+    "        \"must-have features, contact method preferences, timezone indicators, \"\n",
+    "        \"and any accessibility needs.\"\n",
     "    ),\n",
+    "    context_prompt=\"Acme Electronics customer support conversation.\",\n",
     ")\n",
     "show_success(f\"Profile extractor updated to {config.profile_extractor_config.extractor_name}\")\n"
    ]
@@ -127,7 +129,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Agent Playbook Configuration\n\n> **Playbook configs** control how Reflexio identifies agent mistakes and improvements.\n> The `playbook_definition_prompt` tells the LLM what patterns to look for."
+   "source": "## Agent Playbook Configuration\n\n> The **playbook extractor** controls how Reflexio identifies agent mistakes and improvements.\n> The `extraction_definition_prompt` tells the LLM what patterns to look for."
   },
   {
    "cell_type": "code",
@@ -212,17 +214,15 @@
    "outputs": [],
    "source": [
     "\n",
-    "config.agent_success_configs = [\n",
-    "    AgentSuccessConfig(\n",
-    "        evaluation_name=\"resolution_quality\",\n",
-    "        success_definition_prompt=(\n",
-    "            \"The agent successfully resolved the customer's issue if: \"\n",
-    "            \"the customer's question was fully answered, any requested actions were completed, \"\n",
-    "            \"and the customer expressed satisfaction or the issue was objectively resolved.\"\n",
-    "        ),\n",
-    "        sampling_rate=1.0,\n",
+    "config.agent_success_config = AgentSuccessConfig(\n",
+    "    evaluation_name=\"resolution_quality\",\n",
+    "    success_definition_prompt=(\n",
+    "        \"The agent successfully resolved the customer's issue if: \"\n",
+    "        \"the customer's question was fully answered, any requested actions were completed, \"\n",
+    "        \"and the customer expressed satisfaction or the issue was objectively resolved.\"\n",
     "    ),\n",
-    "]"
+    "    sampling_rate=1.0,\n",
+    ")"
    ]
   },
   {
@@ -263,10 +263,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Test: See Custom Extractors in Action\n",
+    "## Test: See the Custom Extractor in Action\n",
     "\n",
-    "> Publish an interaction and see how the custom extractors work.\n",
-    "> With two extractors configured, Reflexio will extract both shopping preferences and communication style."
+    "> Publish an interaction and see how the custom extractor works.\n",
+    "> The configured profile extractor captures both shopping preferences and communication style."
    ]
   },
   {
@@ -347,7 +347,7 @@
     "config.profile_extractor_config = None\n",
     "config.user_playbook_extractor_config = None\n",
     "config.tool_can_use = []\n",
-    "config.agent_success_configs = []\n",
+    "config.agent_success_config = None\n",
     "client.set_config(config)\n",
     "\n",
     "client.delete_all_interactions()\n",
@@ -359,7 +359,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Summary & Next Steps\n\nYou customized every aspect of Reflexio's behavior:\n\n| Config Area | What you set |\n|-------------|---------------|\n| **Profile Extractors** | `shopping_preferences` + `communication_style` |\n| **Playbook Config** | `quality_check` with aggregation threshold of 3 |\n| **Tools** | `order_lookup`, `knowledge_base`, `inventory_check` |\n| **Success Evaluation** | `resolution_quality` at 100% sampling |\n\n### Continue Learning\n\n| Notebook | What you'll learn |\n|----------|-------------------|\n| [07 — LangChain](07_langchain_integration.ipynb) | Integrate Reflexio with LangChain agents |\n| [05 — Concurrent Sessions](05_concurrent_sessions.ipynb) | Multi-user load and data isolation |\n| [06 — Simulation](06_real_world_simulation.ipynb) | Watch Reflexio learn from real conversations |"
+   "source": "## Summary & Next Steps\n\nYou customized every aspect of Reflexio's behavior:\n\n| Config Area | What you set |\n|-------------|---------------|\n| **Profile Extractor** | `customer_profile` |\n| **Playbook Extractor** | `quality_check` with aggregation threshold of 3 |\n| **Tools** | `order_lookup`, `knowledge_base`, `inventory_check` |\n| **Success Evaluation** | `resolution_quality` at 100% sampling |\n\n### Continue Learning\n\n| Notebook | What you'll learn |\n|----------|-------------------|\n| [07 — LangChain](07_langchain_integration.ipynb) | Integrate Reflexio with LangChain agents |\n| [05 — Concurrent Sessions](05_concurrent_sessions.ipynb) | Multi-user load and data isolation |\n| [06 — Simulation](06_real_world_simulation.ipynb) | Watch Reflexio learn from real conversations |"
   }
  ],
  "metadata": {

--- a/notebooks/_display_helpers.py
+++ b/notebooks/_display_helpers.py
@@ -184,14 +184,14 @@ def show_config(config: Config) -> None:
     profile_extractor_name = getattr(profile_extractor, "extractor_name", "Disabled")
     playbook_extractor_name = getattr(playbook_extractor, "extractor_name", "Disabled")
     tools = config.tool_can_use or []
-    success_configs = config.agent_success_configs or []
+    success_evaluator_count = 1 if config.agent_success_config else 0
 
     summary = f"""| Setting | Value |
 |---------|-------|
 | **Profile Extractor** | `{profile_extractor_name}` |
 | **Playbook Extractor** | `{playbook_extractor_name}` |
 | **Tools Registered** | {len(tools)} tools |
-| **Success Evaluators** | {len(success_configs)} configured |
+| **Success Evaluators** | {success_evaluator_count} configured |
 | **Extraction Window** | size={config.window_size}, stride={config.stride_size} |"""
 
     if tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,11 @@ dependencies = [
 [project.optional-dependencies]
 vec = ["sqlite-vec>=0.1.6"]
 notebooks = ["pandas>=3.0.2"]
-langchain = ["langchain-core>=1.2.28"]
+langchain = [
+    "langchain-core>=1.2.28",
+    "langchain-openai>=1.2.0",
+    "langgraph>=1.1.9",
+]
 benchmark = [
     "datasets>=4.8.4",
     "fire>=0.7.1",

--- a/uv.lock
+++ b/uv.lock
@@ -2486,6 +2486,76 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-openai"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/69/0ea9dabd903f750315ab31b8b85dad64f2927e56ddc26252dfe4e4ac2c40/langchain_openai-1.2.0.tar.gz", hash = "sha256:e88edf16002b9ed8e206161181c8a6fb2b3662da23195e0a844d040c3f93ab10", size = 1136352, upload-time = "2026-04-23T00:43:35.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/7b/e8c3beeab0ca042529533072ebee69c66327c1805b3133531b58c422baab/langchain_openai-1.2.0-py3-none-any.whl", hash = "sha256:b3ed14dc48e40890605136f26c6b07e8f293987d95e734ab67cbfa572c523456", size = 98592, upload-time = "2026-04-23T00:43:34.135Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/d5/9d9c65d5500a1ca7ea63d6d65aecfb248037018a74d7d4ef52e276bb4e4b/langgraph-1.1.9.tar.gz", hash = "sha256:bc5a49d5a5e71fda1f9c53c06c62f4caec9a95545b739d130a58b6ab3269e274", size = 560717, upload-time = "2026-04-21T13:43:06.809Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/58/0380420e66619d12c992c1f8cfda0c7a04e8f0fe8a84752245b9e7b1cba7/langgraph-1.1.9-py3-none-any.whl", hash = "sha256:7db13ceecde4ea643df6c097dcc9e534895dcd9fcc6500eeff2f2cde0fab16b2", size = 173744, upload-time = "2026-04-21T13:43:05.513Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/c8/01471b1b5601f2e9c9a69c39fc9a2fb8611613ede0002e5a2b81c0acd850/langgraph_prebuilt-1.0.10.tar.gz", hash = "sha256:5a6fc513f8907074563b6218ff991c4ed9db19ac63101314919686e8029ddb07", size = 169769, upload-time = "2026-04-17T17:59:45.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/49/d073375beabdc6955df6cbe570ba7786836bd4c817ae998955d35037f2fd/langgraph_prebuilt-1.0.10-py3-none-any.whl", hash = "sha256:e3baa1977d819982e690a357ba5bb77ccc1d4d8d4a029c48e502a3b6d171185f", size = 36086, upload-time = "2026-04-17T17:59:44.395Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.3.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/af/cdd4d6f3c05b3c1112ed3f12ef830faf15951b21d22cbc622a4becbbe25c/langgraph_sdk-0.3.15.tar.gz", hash = "sha256:29e805003d2c6e296823dd71992610976fd0428cefaa8b3304fd91f2247037de", size = 201924, upload-time = "2026-05-22T16:54:27.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/a5/0196d9c05749c25bc198e4909d68c998bc3120297e14944921baf2f4c384/langgraph_sdk-0.3.15-py3-none-any.whl", hash = "sha256:3838773acf7456d158165385d49f48f1e856f28b56ccd99ea139a8f27004815d", size = 98166, upload-time = "2026-05-22T16:54:26.013Z" },
+]
+
+[[package]]
 name = "langsmith"
 version = "0.7.33"
 source = { registry = "https://pypi.org/simple" }
@@ -3831,6 +3901,45 @@ wheels = [
 ]
 
 [[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
 name = "overrides"
 version = "7.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5136,6 +5245,8 @@ benchmark = [
 ]
 langchain = [
     { name = "langchain-core" },
+    { name = "langchain-openai" },
+    { name = "langgraph" },
 ]
 notebooks = [
     { name = "pandas" },
@@ -5195,6 +5306,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "json-repair", specifier = ">=0.30.0" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=1.2.28" },
+    { name = "langchain-openai", marker = "extra == 'langchain'", specifier = ">=1.2.0" },
+    { name = "langgraph", marker = "extra == 'langchain'", specifier = ">=1.1.9" },
     { name = "litellm", specifier = ">=1.80.11" },
     { name = "markdown", marker = "extra == 'benchmark'", specifier = ">=3.10.2" },
     { name = "nltk", specifier = ">=3.9.3" },


### PR DESCRIPTION
## Summary
- Update the configuration notebook for the current singular config schema (`profile_extractor_config`, `user_playbook_extractor_config`, `agent_success_config`)
- Fix notebook display helpers to read the singular agent success config
- Add the LangChain notebook's missing optional dependencies to the `langchain` extra

## Validation
- `uv run python -c "import reflexio"`
- Parsed and compiled all notebook code cells
- Scanned notebooks/helpers for retired config field names
- Verified direct `ReflexioClient` notebook method calls still exist
- `uv run --extra notebooks --extra langchain python ...` import smoke for all notebook imports
- `uv run ruff check notebooks/_display_helpers.py notebooks/04_configuration.ipynb pyproject.toml`

## Notes
- I did not execute the notebooks end-to-end because they require a running backend and live LLM-backed extraction side effects.
- Local uncommitted pending-tool-call/storage changes were intentionally left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration tutorial notebook to demonstrate revised profile extraction setup with expanded capture scope including communication style and accessibility preferences.

* **Chores**
  * Expanded langchain optional dependencies to include langchain-openai and langgraph.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->