### PR TITLE
Manage human question answers

### DIFF
--- a/reflexio/models/api_schema/pending_tool_call_schema.py
+++ b/reflexio/models/api_schema/pending_tool_call_schema.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from reflexio.server.services.storage.storage_base import (
     PendingToolCallRecord,
@@ -64,5 +64,20 @@ class PendingToolCallListResponse(BaseModel):
 
 
 class ResolvePendingToolCallRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     result: dict[str, Any]
+    valid_for_seconds: int | None = Field(default=None, gt=0)
+
+
+class UpdatePendingToolCallAnswerRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    answer: str = Field(min_length=1)
+    valid_for_seconds: int | None = Field(default=None, gt=0)
+
+
+class MarkPendingToolCallNotApplicableRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     valid_for_seconds: int | None = Field(default=None, gt=0)

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -819,7 +819,12 @@ class Config(BaseModel):
         """Pending tool calls require a database-backed storage backend."""
         if self.pending_tool_call_config.enabled and not isinstance(
             self.storage_config,
-            (StorageConfigSQLite, StorageConfigSupabase, StorageConfigPostgres),
+            (
+                StorageConfigSQLite,
+                StorageConfigSupabase,
+                StorageConfigPostgres,
+                StorageConfigManagedSupabase,
+            ),
         ):
             raise ValueError(
                 "pending_tool_call_config.enabled requires sqlite, supabase, or postgres storage"

--- a/reflexio/server/api_endpoints/pending_tool_call_api.py
+++ b/reflexio/server/api_endpoints/pending_tool_call_api.py
@@ -8,6 +8,7 @@ import logging
 import time
 from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 
 from fastapi import (
     APIRouter,
@@ -20,9 +21,11 @@ from fastapi import (
 )
 
 from reflexio.models.api_schema.pending_tool_call_schema import (
+    MarkPendingToolCallNotApplicableRequest,
     PendingToolCallListResponse,
     PendingToolCallResponse,
     ResolvePendingToolCallRequest,
+    UpdatePendingToolCallAnswerRequest,
 )
 from reflexio.server.api_endpoints.request_context import (
     RequestContext,
@@ -37,6 +40,7 @@ from reflexio.server.services.storage.storage_base import (
     BaseStorage,
     PendingToolCallRecord,
     PendingToolCallStatus,
+    not_applicable_tool_result,
 )
 from reflexio.server.usage_metrics import record_usage_event
 
@@ -47,6 +51,7 @@ _UNSUPPORTED_DETAIL = (
     "Pending tool calls are not supported by the configured storage backend"
 )
 _HMAC_TIMESTAMP_TOLERANCE_SECONDS = 300
+_ASK_HUMAN_TOOL_NAME = "ask_human"
 
 
 def _require_storage(ctx: RequestContext) -> BaseStorage:
@@ -64,6 +69,37 @@ def _require_org_record(
     if record is None or record.org_id != org_id:
         raise HTTPException(status_code=404, detail="Pending tool call not found")
     return record
+
+
+def _require_ask_human_record(record: PendingToolCallRecord) -> None:
+    if record.tool_name != _ASK_HUMAN_TOOL_NAME:
+        raise HTTPException(
+            status_code=409,
+            detail="Only ask_human tool calls can be managed from this endpoint",
+        )
+
+
+def _reload_resolved_record_after_write_conflict(
+    *,
+    storage: BaseStorage,
+    pending_tool_call_id: str,
+    org_id: str,
+    desired_result: dict[str, Any],
+    different_result_detail: str,
+) -> PendingToolCallRecord:
+    latest = _run_with_pending_tool_call_migration_retry(
+        storage=storage,
+        operation=lambda: storage.get_pending_tool_call(pending_tool_call_id),
+    )
+    latest = _require_org_record(latest, org_id=org_id)
+    if latest.status == PendingToolCallStatus.RESOLVED:
+        if latest.result == desired_result:
+            return latest
+        raise HTTPException(status_code=409, detail=different_result_detail)
+    raise HTTPException(
+        status_code=409,
+        detail=f"Pending tool call is {latest.status.value}",
+    )
 
 
 def _drain_resumable_followups(ctx: RequestContext) -> None:
@@ -134,6 +170,19 @@ def _verify_hmac_signature(
         if hmac.compare_digest(provided, f"{expected_prefix}{digest}"):
             return
     raise HTTPException(status_code=401, detail="Invalid HMAC signature")
+
+
+def _valid_for_seconds(
+    *,
+    payload_value: int | None,
+    record: PendingToolCallRecord,
+    ctx: RequestContext,
+) -> int:
+    pending_config = ctx.configurator.get_config().pending_tool_call_config
+    return (
+        payload_value
+        or pending_config.for_tool(record.tool_name).prior_answer_valid_seconds
+    )
 
 
 @router.get("", response_model=PendingToolCallListResponse)
@@ -226,9 +275,10 @@ async def resolve_pending_tool_call(
             detail=f"Pending tool call is {record.status.value}",
         )
 
-    valid_for_seconds = (
-        payload.valid_for_seconds
-        or pending_config.for_tool(record.tool_name).prior_answer_valid_seconds
+    valid_for_seconds = _valid_for_seconds(
+        payload_value=payload.valid_for_seconds,
+        record=record,
+        ctx=ctx,
     )
     try:
         resolved = storage.resolve_pending_tool_call(
@@ -287,6 +337,194 @@ async def resolve_pending_tool_call(
     )
     background_tasks.add_task(_drain_resumable_followups, ctx)
     return PendingToolCallResponse.from_record(resolved)
+
+
+@router.patch("/{pending_tool_call_id}/answer", response_model=PendingToolCallResponse)
+async def update_pending_tool_call_answer(
+    pending_tool_call_id: str,
+    request: Request,
+    payload: UpdatePendingToolCallAnswerRequest,
+    background_tasks: BackgroundTasks,
+    x_reflexio_signature: str | None = Header(default=None),
+    x_reflexio_timestamp: str | None = Header(default=None),
+    ctx: RequestContext = Depends(get_request_context),
+) -> PendingToolCallResponse:
+    storage = _require_storage(ctx)
+    pending_config = ctx.configurator.get_config().pending_tool_call_config
+    _verify_hmac_signature(
+        body=await request.body(),
+        timestamp=x_reflexio_timestamp,
+        signature=x_reflexio_signature,
+        secrets=pending_config.hmac_secrets,
+    )
+    try:
+        existing = _run_with_pending_tool_call_migration_retry(
+            storage=storage,
+            operation=lambda: storage.get_pending_tool_call(pending_tool_call_id),
+        )
+    except NotImplementedError as exc:
+        raise HTTPException(status_code=503, detail=_UNSUPPORTED_DETAIL) from exc
+    except StorageError as exc:
+        raise HTTPException(status_code=503, detail=exc.message) from exc
+    record = _require_org_record(existing, org_id=ctx.org_id)
+    _require_ask_human_record(record)
+
+    if record.status != PendingToolCallStatus.RESOLVED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Pending tool call is {record.status.value}",
+        )
+    answer = payload.answer.strip()
+    if not answer:
+        raise HTTPException(status_code=422, detail="Answer cannot be empty")
+    desired_result = {"answer": answer}
+
+    try:
+        updated = storage.update_resolved_pending_tool_call_result(
+            pending_tool_call_id,
+            result=desired_result,
+            resolved_at=datetime.now(UTC),
+            valid_for_seconds=_valid_for_seconds(
+                payload_value=payload.valid_for_seconds,
+                record=record,
+                ctx=ctx,
+            ),
+        )
+    except StorageError as exc:
+        raise HTTPException(status_code=503, detail=exc.message) from exc
+    if updated is None:
+        updated = _reload_resolved_record_after_write_conflict(
+            storage=storage,
+            pending_tool_call_id=pending_tool_call_id,
+            org_id=ctx.org_id,
+            desired_result=desired_result,
+            different_result_detail=(
+                "Pending tool call already resolved with a different result"
+            ),
+        )
+    updated = _require_org_record(updated, org_id=ctx.org_id)
+    if updated.status != PendingToolCallStatus.RESOLVED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Pending tool call is {updated.status.value}",
+        )
+    if updated.result != desired_result:
+        raise HTTPException(
+            status_code=409,
+            detail="Pending tool call already resolved with a different result",
+        )
+    logger.info(
+        "event=pending_tool_call_answer_updated org_id=%s user_id=%s "
+        "pending_tool_call_id=%s tool_name=%s",
+        ctx.org_id,
+        record.user_id,
+        pending_tool_call_id,
+        record.tool_name,
+    )
+    record_usage_event(
+        org_id=ctx.org_id,
+        event_name="pending_tool_call_answer_updated",
+        event_category="extraction_agent",
+        user_id=record.user_id,
+        outcome="updated",
+        metadata={
+            "pending_tool_call_id": pending_tool_call_id,
+            "tool_name": record.tool_name,
+        },
+    )
+    background_tasks.add_task(_drain_resumable_followups, ctx)
+    return PendingToolCallResponse.from_record(updated)
+
+
+@router.post(
+    "/{pending_tool_call_id}/not_applicable",
+    response_model=PendingToolCallResponse,
+)
+async def mark_pending_tool_call_not_applicable(
+    pending_tool_call_id: str,
+    request: Request,
+    payload: MarkPendingToolCallNotApplicableRequest,
+    background_tasks: BackgroundTasks,
+    x_reflexio_signature: str | None = Header(default=None),
+    x_reflexio_timestamp: str | None = Header(default=None),
+    ctx: RequestContext = Depends(get_request_context),
+) -> PendingToolCallResponse:
+    storage = _require_storage(ctx)
+    pending_config = ctx.configurator.get_config().pending_tool_call_config
+    _verify_hmac_signature(
+        body=await request.body(),
+        timestamp=x_reflexio_timestamp,
+        signature=x_reflexio_signature,
+        secrets=pending_config.hmac_secrets,
+    )
+    try:
+        existing = _run_with_pending_tool_call_migration_retry(
+            storage=storage,
+            operation=lambda: storage.get_pending_tool_call(pending_tool_call_id),
+        )
+    except NotImplementedError as exc:
+        raise HTTPException(status_code=503, detail=_UNSUPPORTED_DETAIL) from exc
+    except StorageError as exc:
+        raise HTTPException(status_code=503, detail=exc.message) from exc
+    record = _require_org_record(existing, org_id=ctx.org_id)
+    _require_ask_human_record(record)
+
+    if record.status not in (
+        PendingToolCallStatus.PENDING,
+        PendingToolCallStatus.RESOLVED,
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Pending tool call is {record.status.value}",
+        )
+
+    try:
+        updated = storage.mark_pending_tool_call_not_applicable(
+            pending_tool_call_id,
+            resolved_at=datetime.now(UTC),
+            valid_for_seconds=_valid_for_seconds(
+                payload_value=payload.valid_for_seconds,
+                record=record,
+                ctx=ctx,
+            ),
+        )
+    except StorageError as exc:
+        raise HTTPException(status_code=503, detail=exc.message) from exc
+    desired_result = not_applicable_tool_result()
+    if updated is None:
+        updated = _reload_resolved_record_after_write_conflict(
+            storage=storage,
+            pending_tool_call_id=pending_tool_call_id,
+            org_id=ctx.org_id,
+            desired_result=desired_result,
+            different_result_detail=(
+                "Pending tool call could not be marked not applicable"
+            ),
+        )
+    updated = _require_org_record(updated, org_id=ctx.org_id)
+    if updated.status != PendingToolCallStatus.RESOLVED:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Pending tool call is {updated.status.value}",
+        )
+    if updated.result != desired_result:
+        raise HTTPException(
+            status_code=409,
+            detail="Pending tool call could not be marked not applicable",
+        )
+    record_usage_event(
+        org_id=ctx.org_id,
+        event_name="pending_tool_call_marked_not_applicable",
+        event_category="extraction_agent",
+        user_id=record.user_id,
+        outcome="not_applicable",
+        metadata={
+            "pending_tool_call_id": pending_tool_call_id,
+            "tool_name": record.tool_name,
+        },
+    )
+    background_tasks.add_task(_drain_resumable_followups, ctx)
+    return PendingToolCallResponse.from_record(updated)
 
 
 @router.post("/{pending_tool_call_id}/cancel", response_model=PendingToolCallResponse)

--- a/reflexio/server/services/storage/sqlite_storage/_agent_run.py
+++ b/reflexio/server/services/storage/sqlite_storage/_agent_run.py
@@ -17,6 +17,7 @@ from reflexio.server.services.storage.storage_base import (
     RunToolDependencyKind,
     RunToolDependencyRecord,
     embedding_similarity,
+    not_applicable_tool_result,
 )
 
 from ._base import SQLiteStorageBase, _json_dumps, _json_loads
@@ -172,6 +173,93 @@ class SQLiteAgentRunMixin:
                 now_s,
                 AgentRunStatus.FINALIZED_PENDING_TOOL.value,
                 PendingToolCallStatus.PENDING.value,
+            ),
+        )
+
+    def _mark_runs_ready_with_actionable_dependencies_unlocked(
+        self, now_s: str, *, pending_tool_call_id: str
+    ) -> None:
+        self.conn.execute(
+            """
+            UPDATE _agent_runs
+            SET status = ?,
+                updated_at = ?
+            WHERE status IN (?, ?)
+              AND EXISTS (
+                SELECT 1
+                FROM _run_tool_dependencies changed
+                WHERE changed.run_id = _agent_runs.id
+                  AND changed.pending_tool_call_id = ?
+              )
+              AND EXISTS (
+                SELECT 1
+                FROM _run_tool_dependencies d
+                JOIN _pending_tool_calls p
+                  ON p.id = d.pending_tool_call_id
+                WHERE d.run_id = _agent_runs.id
+                  AND d.resolved_at IS NOT NULL
+                  AND d.consumed_at IS NULL
+                  AND p.status = ?
+                  AND COALESCE(json_extract(p.result, '$.not_applicable'), 0) != 1
+              )
+            """,
+            (
+                AgentRunStatus.RESUME_READY.value,
+                now_s,
+                AgentRunStatus.FINALIZED.value,
+                AgentRunStatus.FINALIZED_PENDING_TOOL.value,
+                pending_tool_call_id,
+                PendingToolCallStatus.RESOLVED.value,
+            ),
+        )
+
+    def _finalize_runs_without_actionable_dependencies_unlocked(
+        self, now_s: str, *, pending_tool_call_id: str
+    ) -> None:
+        self.conn.execute(
+            """
+            UPDATE _agent_runs
+            SET status = ?,
+                finalized_at = COALESCE(finalized_at, ?),
+                updated_at = ?
+            WHERE status IN (?, ?)
+              AND EXISTS (
+                SELECT 1
+                FROM _run_tool_dependencies changed
+                WHERE changed.run_id = _agent_runs.id
+                  AND changed.pending_tool_call_id = ?
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM _run_tool_dependencies d
+                JOIN _pending_tool_calls p
+                  ON p.id = d.pending_tool_call_id
+                WHERE d.run_id = _agent_runs.id
+                  AND d.resolved_at IS NULL
+                  AND d.consumed_at IS NULL
+                  AND p.status = ?
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM _run_tool_dependencies d
+                JOIN _pending_tool_calls p
+                  ON p.id = d.pending_tool_call_id
+                WHERE d.run_id = _agent_runs.id
+                  AND d.resolved_at IS NOT NULL
+                  AND d.consumed_at IS NULL
+                  AND p.status = ?
+                  AND COALESCE(json_extract(p.result, '$.not_applicable'), 0) != 1
+              )
+            """,
+            (
+                AgentRunStatus.FINALIZED.value,
+                now_s,
+                now_s,
+                AgentRunStatus.FINALIZED_PENDING_TOOL.value,
+                AgentRunStatus.RESUME_READY.value,
+                pending_tool_call_id,
+                PendingToolCallStatus.PENDING.value,
+                PendingToolCallStatus.RESOLVED.value,
             ),
         )
 
@@ -822,6 +910,138 @@ class SQLiteAgentRunMixin:
         return self.get_pending_tool_call(call_id)
 
     @SQLiteStorageBase.handle_exceptions
+    def update_resolved_pending_tool_call_result(
+        self,
+        call_id: str,
+        *,
+        result: dict[str, Any],
+        resolved_at: datetime | None = None,
+        valid_for_seconds: int,
+    ) -> PendingToolCallRecord | None:
+        resolved = resolved_at or datetime.now(UTC)
+        valid_until = resolved + timedelta(seconds=valid_for_seconds)
+        now_s = _dt_str(resolved) or self._current_timestamp()
+        with self._lock:
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = self.conn.execute(
+                    """
+                    UPDATE _pending_tool_calls
+                    SET result = ?, resolved_at = ?, valid_until = ?
+                    WHERE id = ?
+                      AND status = ?
+                    """,
+                    (
+                        _json_dumps(result),
+                        _dt_str(resolved),
+                        _dt_str(valid_until),
+                        call_id,
+                        PendingToolCallStatus.RESOLVED.value,
+                    ),
+                )
+                if cur.rowcount == 0:
+                    self.conn.commit()
+                    return self.get_pending_tool_call(call_id)
+                self.conn.execute(
+                    """
+                    UPDATE _pending_tool_calls
+                    SET status = ?,
+                        superseded_by = ?
+                    WHERE id != ?
+                      AND status = ?
+                      AND (valid_until IS NULL OR valid_until > ?)
+                      AND (org_id, scope_hash, tool_name, dedup_key) = (
+                        SELECT org_id, scope_hash, tool_name, dedup_key
+                        FROM _pending_tool_calls
+                        WHERE id = ?
+                      )
+                    """,
+                    (
+                        PendingToolCallStatus.SUPERSEDED.value,
+                        call_id,
+                        call_id,
+                        PendingToolCallStatus.RESOLVED.value,
+                        _dt_str(resolved),
+                        call_id,
+                    ),
+                )
+                self.conn.execute(
+                    """
+                    UPDATE _run_tool_dependencies
+                    SET resolved_at = ?,
+                        consumed_at = NULL
+                    WHERE pending_tool_call_id = ?
+                    """,
+                    (_dt_str(resolved), call_id),
+                )
+                self._mark_runs_ready_with_actionable_dependencies_unlocked(
+                    now_s, pending_tool_call_id=call_id
+                )
+            except Exception:
+                self.conn.rollback()
+                raise
+            else:
+                self.conn.commit()
+        return self.get_pending_tool_call(call_id)
+
+    @SQLiteStorageBase.handle_exceptions
+    def mark_pending_tool_call_not_applicable(
+        self,
+        call_id: str,
+        *,
+        resolved_at: datetime | None = None,
+        valid_for_seconds: int,
+    ) -> PendingToolCallRecord | None:
+        resolved = resolved_at or datetime.now(UTC)
+        valid_until = resolved + timedelta(seconds=valid_for_seconds)
+        now_s = _dt_str(resolved) or self._current_timestamp()
+        with self._lock:
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                cur = self.conn.execute(
+                    """
+                    UPDATE _pending_tool_calls
+                    SET status = ?, result = ?, resolved_at = ?, valid_until = ?
+                    WHERE id = ?
+                      AND status IN (?, ?)
+                    """,
+                    (
+                        PendingToolCallStatus.RESOLVED.value,
+                        _json_dumps(not_applicable_tool_result()),
+                        _dt_str(resolved),
+                        _dt_str(valid_until),
+                        call_id,
+                        PendingToolCallStatus.PENDING.value,
+                        PendingToolCallStatus.RESOLVED.value,
+                    ),
+                )
+                if cur.rowcount == 0:
+                    self.conn.commit()
+                    return self.get_pending_tool_call(call_id)
+                self.conn.execute(
+                    """
+                    UPDATE _run_tool_dependencies
+                    SET resolved_at = COALESCE(resolved_at, ?),
+                        consumed_at = ?
+                    WHERE pending_tool_call_id = ?
+                      AND consumed_at IS NULL
+                    """,
+                    (_dt_str(resolved), _dt_str(resolved), call_id),
+                )
+                self._mark_runs_ready_with_actionable_dependencies_unlocked(
+                    now_s, pending_tool_call_id=call_id
+                )
+                self._finalize_runs_without_actionable_dependencies_unlocked(
+                    now_s, pending_tool_call_id=call_id
+                )
+            except Exception:
+                self.conn.rollback()
+                raise
+            else:
+                self.conn.commit()
+        return self.get_pending_tool_call(call_id)
+
+    @SQLiteStorageBase.handle_exceptions
     def claim_ready_agent_run(
         self,
         *,
@@ -852,6 +1072,7 @@ class SQLiteAgentRunMixin:
                       AND d.resolved_at IS NOT NULL
                       AND d.consumed_at IS NULL
                       AND p.status = ?
+                      AND COALESCE(json_extract(p.result, '$.not_applicable'), 0) != 1
                   )
                 ORDER BY
                     r.org_id ASC,
@@ -998,8 +1219,23 @@ class SQLiteAgentRunMixin:
         rows = self._fetchall(
             """
             SELECT DISTINCT org_id FROM (
+                SELECT r.org_id
+                FROM _agent_runs r
+                WHERE r.status IN (?, ?)
+                  AND EXISTS (
+                    SELECT 1
+                    FROM _run_tool_dependencies d
+                    JOIN _pending_tool_calls p
+                      ON p.id = d.pending_tool_call_id
+                    WHERE d.run_id = r.id
+                      AND d.resolved_at IS NOT NULL
+                      AND d.consumed_at IS NULL
+                      AND p.status = ?
+                      AND COALESCE(json_extract(p.result, '$.not_applicable'), 0) != 1
+                  )
+                UNION
                 SELECT org_id FROM _agent_runs
-                WHERE status IN (?, ?, ?, ?, ?)
+                WHERE status IN (?, ?, ?)
                 UNION
                 SELECT org_id FROM _pending_tool_calls
                 WHERE status = ?
@@ -1012,6 +1248,7 @@ class SQLiteAgentRunMixin:
             (
                 AgentRunStatus.RESUME_READY.value,
                 AgentRunStatus.RESUMING.value,
+                PendingToolCallStatus.RESOLVED.value,
                 AgentRunStatus.FINALIZATION_FAILED.value,
                 AgentRunStatus.FINALIZING.value,
                 AgentRunStatus.AGENT_COMPLETED.value,

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -1,6 +1,7 @@
 from reflexio.models.api_schema.domain.enums import Status
 
 from ._agent_run import (
+    NOT_APPLICABLE_ANSWER,
     AgentBinding,
     AgentRunMixin,
     AgentRunRecord,
@@ -16,7 +17,9 @@ from ._agent_run import (
     canonical_json,
     embedding_similarity,
     human_feedback_scope,
+    is_not_applicable_tool_result,
     normalize_dedup_text,
+    not_applicable_tool_result,
 )
 from ._base import BaseStorageCore, matches_status_filter
 from ._extras import ExtrasMixin
@@ -127,6 +130,7 @@ __all__ = [
     "AgentRunRecord",
     "AgentRunStatus",
     "BaseStorage",
+    "NOT_APPLICABLE_ANSWER",
     "PendingToolCallRecord",
     "PendingToolCallStatus",
     "PendingToolCallUpsertResult",
@@ -142,6 +146,8 @@ __all__ = [
     "canonical_json",
     "embedding_similarity",
     "human_feedback_scope",
+    "is_not_applicable_tool_result",
     "matches_status_filter",
+    "not_applicable_tool_result",
     "normalize_dedup_text",
 ]

--- a/reflexio/server/services/storage/storage_base/_agent_run.py
+++ b/reflexio/server/services/storage/storage_base/_agent_run.py
@@ -36,6 +36,9 @@ class PendingToolCallStatus(StrEnum):
     CANCELLED = "cancelled"
 
 
+NOT_APPLICABLE_ANSWER = "User does not have information about this question."
+
+
 class RunToolDependencyKind(StrEnum):
     FOLLOWUP = "followup"
 
@@ -174,6 +177,14 @@ def build_pending_tool_call_dedup_key(
     return hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
 
 
+def not_applicable_tool_result() -> dict[str, Any]:
+    return {"answer": NOT_APPLICABLE_ANSWER, "not_applicable": True}
+
+
+def is_not_applicable_tool_result(result: dict[str, Any] | None) -> bool:
+    return isinstance(result, dict) and result.get("not_applicable") is True
+
+
 def embedding_similarity(a: list[float] | None, b: list[float] | None) -> float | None:
     """Cosine similarity for optional embedding vectors."""
     if not a or not b or len(a) != len(b):
@@ -300,6 +311,25 @@ class AgentRunMixin:
         call_id: str,
         *,
         result: dict[str, Any],
+        resolved_at: datetime | None = None,
+        valid_for_seconds: int,
+    ) -> PendingToolCallRecord | None:
+        raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
+
+    def update_resolved_pending_tool_call_result(
+        self,
+        call_id: str,
+        *,
+        result: dict[str, Any],
+        resolved_at: datetime | None = None,
+        valid_for_seconds: int,
+    ) -> PendingToolCallRecord | None:
+        raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
+
+    def mark_pending_tool_call_not_applicable(
+        self,
+        call_id: str,
+        *,
         resolved_at: datetime | None = None,
         valid_for_seconds: int,
     ) -> PendingToolCallRecord | None:

--- a/reflexio/server/site_var/site_var_sources/feature_flags.json
+++ b/reflexio/server/site_var/site_var_sources/feature_flags.json
@@ -7,7 +7,7 @@
         "enabled_org_ids": []
     },
     "resumable_extraction_agent": {
-        "enabled": false,
+        "enabled": true,
         "enabled_org_ids": []
     }
 }

--- a/tests/e2e_tests/test_resumable_extraction_e2e.py
+++ b/tests/e2e_tests/test_resumable_extraction_e2e.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import os
 import tempfile
+import time
+import uuid
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
+from dotenv import dotenv_values
 
+from reflexio import InteractionData, ReflexioClient
 from reflexio.models.api_schema.service_schemas import Interaction, Request
 from reflexio.models.config_schema import (
     Config,
@@ -33,6 +42,10 @@ from reflexio.server.services.storage.storage_base import (
 )
 
 pytestmark = pytest.mark.e2e
+
+_LIVE_E2E_TIMEOUT_SECONDS = 240
+_LIVE_E2E_POLL_SECONDS = 5
+_LIVE_E2E_USER_AGENT = "reflexio-live-resumable-e2e"
 
 
 def _request_context(storage: SQLiteStorage) -> RequestContext:
@@ -149,6 +162,205 @@ def _seed_followup_ready_run(storage: SQLiteStorage) -> None:
     )
 
 
+def _load_live_e2e_settings() -> tuple[str, str]:
+    if os.environ.get("RUN_LIVE_RESUMABLE_E2E") != "true":
+        pytest.skip("Set RUN_LIVE_RESUMABLE_E2E=true to run live resumable E2E")
+    if os.environ.get("MOCK_LLM_RESPONSE", "").lower() == "true":
+        pytest.skip("Live resumable E2E requires MOCK_LLM_RESPONSE=false")
+
+    dotenv_values_from_file: dict[str, str | None] = {}
+    for start in (Path.cwd(), Path(__file__).resolve()):
+        for parent in (start, *start.parents):
+            env_path = parent / ".env"
+            if not env_path.exists():
+                continue
+            candidate = dotenv_values(env_path)
+            if candidate.get("REFLEXIO_API_KEY"):
+                dotenv_values_from_file = dict(candidate)
+                break
+        if dotenv_values_from_file:
+            break
+
+    api_key = os.environ.get("REFLEXIO_API_KEY") or dotenv_values_from_file.get(
+        "REFLEXIO_API_KEY"
+    )
+    base_url = (
+        os.environ.get("REFLEXIO_API_URL")
+        or dotenv_values_from_file.get("REFLEXIO_API_URL")
+        or "http://localhost:8081"
+    )
+
+    if not api_key:
+        pytest.skip("Live resumable E2E requires REFLEXIO_API_KEY")
+    return str(base_url).rstrip("/"), str(api_key)
+
+
+def _live_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": _LIVE_E2E_USER_AGENT,
+    }
+
+
+def _api_request(
+    method: str,
+    base_url: str,
+    path: str,
+    headers: dict[str, str],
+    **kwargs: Any,
+) -> Any:
+    response = requests.request(
+        method,
+        f"{base_url}{path}",
+        headers=headers,
+        timeout=60,
+        **kwargs,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def _poll_until(
+    label: str,
+    predicate: Callable[[], Any],
+    *,
+    timeout_seconds: int = _LIVE_E2E_TIMEOUT_SECONDS,
+) -> Any:
+    deadline = time.monotonic() + timeout_seconds
+    last_value: Any = None
+    while time.monotonic() < deadline:
+        last_value = predicate()
+        if last_value:
+            return last_value
+        time.sleep(_LIVE_E2E_POLL_SECONDS)
+    raise AssertionError(f"Timed out waiting for {label}; last value: {last_value!r}")
+
+
+def _config_restore_patch(config: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: config[key]
+        for key in (
+            "profile_extractor_config",
+            "user_playbook_extractor_config",
+            "pending_tool_call_config",
+            "skip_should_run_check",
+            "window_size",
+            "stride_size",
+            "extraction_backend",
+        )
+        if key in config
+    }
+
+
+def _apply_live_config_patch(
+    base_url: str,
+    headers: dict[str, str],
+    patch_payload: dict[str, Any],
+    *,
+    expected_extractor_name: str | None = None,
+) -> dict[str, Any]:
+    _api_request("POST", base_url, "/api/update_config", headers, json=patch_payload)
+    _api_request("POST", base_url, "/api/admin/cache/invalidate", headers, json={})
+    config = _api_request("GET", base_url, "/api/get_config", headers)
+    if expected_extractor_name is not None:
+        profile_config = config.get("profile_extractor_config") or {}
+        assert profile_config.get("extractor_name") == expected_extractor_name
+    return config
+
+
+def _live_resumable_config(marker: str) -> tuple[dict[str, Any], str, str]:
+    extractor_name = "resumable_human_question_live_e2e"
+    question_text = (
+        f"For live resumable test {marker}, what deployment target should be "
+        "treated as canonical?"
+    )
+    profile_prefix = f"Live resumable test {marker} canonical deployment target:"
+    return (
+        {
+            "profile_extractor_config": {
+                "extractor_name": extractor_name,
+                "extraction_definition_prompt": (
+                    f"This is an end-to-end test for marker {marker}. "
+                    "If the session mentions this marker but does not explicitly "
+                    "provide the canonical deployment target, call ask_human before "
+                    "extracting the deployment-target profile. Use this exact "
+                    f"question text: {question_text!r}. Use answer_format "
+                    f"'short text' and include the tag {marker!r}. After a human "
+                    "answer is available, you must call finish_extraction with "
+                    "exactly one profile. Never call finish_extraction with "
+                    "profiles null after a resolved answer is present. The profile "
+                    f"content must be exactly {profile_prefix!r} followed by one "
+                    "space and the human-provided answer. Use time_to_live "
+                    "'one_year'. Your first action for this marker must be the "
+                    "ask_human tool call. Do not infer or invent the target."
+                ),
+                "context_prompt": "Live E2E test for resumable extraction.",
+            },
+            "user_playbook_extractor_config": None,
+            "pending_tool_call_config": {
+                "enabled": True,
+                "human_input_enabled": True,
+                "prior_knowledge_injection_enabled": True,
+                "pending_ttl_seconds": 3600,
+                "dedup_cache_seconds": 60,
+                "prior_answer_valid_seconds": 3600,
+                "resume_poll_interval_seconds": 1.0,
+                "tool_overrides": {
+                    "ask_human": {
+                        "pending_ttl_seconds": 3600,
+                        "dedup_cache_seconds": 60,
+                        "prior_answer_valid_seconds": 3600,
+                    }
+                },
+            },
+            "skip_should_run_check": True,
+            "window_size": 4,
+            "stride_size": 4,
+            "extraction_backend": "classic",
+        },
+        question_text,
+        profile_prefix,
+    )
+
+
+def _find_pending_question(
+    base_url: str,
+    headers: dict[str, str],
+    *,
+    marker: str,
+    status: str,
+) -> dict[str, Any] | None:
+    payload = _api_request(
+        "GET",
+        base_url,
+        f"/api/pending_tool_calls?status={status}&limit=100",
+        headers,
+    )
+    for pending_call in payload["pending_tool_calls"]:
+        question = pending_call.get("question_text") or ""
+        tags = pending_call.get("tags") or []
+        result = pending_call.get("result") or {}
+        answer = result.get("answer") or ""
+        if marker in question or marker in tags or marker in answer:
+            return pending_call
+    return None
+
+
+def _profile_content_with(
+    client: ReflexioClient,
+    *,
+    user_id: str,
+    required_parts: tuple[str, ...],
+) -> str | None:
+    profiles = client.get_profiles(user_id=user_id, force_refresh=True).user_profiles
+    for profile in profiles:
+        content = profile.content
+        if all(part in content for part in required_parts):
+            return content
+    return None
+
+
 def test_resumable_extraction_resumes_after_human_answer(
     monkeypatch,
     tool_call_completion,
@@ -200,3 +412,133 @@ def test_resumable_extraction_resumes_after_human_answer(
         assert [profile.content for profile in storage.get_user_profile("user_1")] == [
             "User deployment target is AWS ECS."
         ]
+
+
+@pytest.mark.requires_credentials
+@pytest.mark.timeout(360)
+def test_live_resumable_question_resolve_and_edit_roundtrip():
+    """Exercise the resumable agent through the live API with real LLM calls.
+
+    This test intentionally avoids patching litellm. It requires a running
+    Reflexio backend, a valid API key, and live provider credentials in that
+    backend process.
+    """
+    base_url, api_key = _load_live_e2e_settings()
+    headers = _live_headers(api_key)
+    client = ReflexioClient(api_key=api_key, url_endpoint=base_url, timeout=300)
+    client.session.headers.update({"User-Agent": _LIVE_E2E_USER_AGENT})
+
+    marker = f"RESUMABLE_LIVE_E2E_{uuid.uuid4().hex[:8]}"
+    user_id = f"resumable_live_e2e_user_{uuid.uuid4().hex[:8]}"
+    session_id = f"resumable-live-e2e-{uuid.uuid4().hex[:8]}"
+    first_answer = "AWS ECS"
+    edited_answer = "Google Cloud Run"
+    config_patch, question_text, profile_prefix = _live_resumable_config(marker)
+
+    original_config = _api_request("GET", base_url, "/api/get_config", headers)
+    restore_patch = _config_restore_patch(original_config)
+
+    try:
+        _apply_live_config_patch(
+            base_url,
+            headers,
+            config_patch,
+            expected_extractor_name="resumable_human_question_live_e2e",
+        )
+
+        client.publish_interaction(
+            user_id=user_id,
+            session_id=session_id,
+            source="pytest-live-resumable-e2e",
+            wait_for_response=True,
+            force_extraction=True,
+            interactions=[
+                InteractionData(
+                    role="user",
+                    content=(
+                        f"Remember live resumable marker {marker}. "
+                        "The canonical deployment target is unknown and not "
+                        "available anywhere in this transcript. The only valid "
+                        "next step is to ask the configured human follow-up "
+                        "question before extracting any profile. Once a human "
+                        "answer exists, the durable profile should contain exactly "
+                        f"this prefix: {profile_prefix}"
+                    ),
+                ),
+                InteractionData(
+                    role="assistant",
+                    content=(
+                        "I cannot infer the deployment target. I need a human "
+                        "answer before storing any deployment-target profile."
+                    ),
+                ),
+            ],
+        )
+
+        pending_call = _poll_until(
+            "live ask_human pending question",
+            lambda: _find_pending_question(
+                base_url,
+                headers,
+                marker=marker,
+                status="pending",
+            ),
+        )
+        assert pending_call["tool_name"] == "ask_human"
+        assert pending_call["status"] == "pending"
+        assert pending_call["question_text"] == question_text
+        assert pending_call["user_id"] == user_id
+
+        pending_call_id = pending_call["id"]
+        resolved_call = _api_request(
+            "POST",
+            base_url,
+            f"/api/pending_tool_calls/{pending_call_id}/resolve",
+            headers,
+            json={"result": {"answer": first_answer}, "valid_for_seconds": 3600},
+        )
+        assert resolved_call["status"] == "resolved"
+        assert resolved_call["result"]["answer"] == first_answer
+
+        first_profile = _poll_until(
+            "live profile generated from resolved human answer",
+            lambda: _profile_content_with(
+                client,
+                user_id=user_id,
+                required_parts=(profile_prefix, first_answer),
+            ),
+        )
+        assert marker in first_profile
+
+        edited_call = _api_request(
+            "PATCH",
+            base_url,
+            f"/api/pending_tool_calls/{pending_call_id}/answer",
+            headers,
+            json={"answer": edited_answer, "valid_for_seconds": 3600},
+        )
+        assert edited_call["status"] == "resolved"
+        assert edited_call["result"]["answer"] == edited_answer
+        assert edited_call["result"].get("not_applicable") is not True
+
+        edited_profile = _poll_until(
+            "live profile regenerated from edited human answer",
+            lambda: _profile_content_with(
+                client,
+                user_id=user_id,
+                required_parts=(profile_prefix, edited_answer),
+            ),
+        )
+        assert marker in edited_profile
+
+        latest_resolved_call = _find_pending_question(
+            base_url,
+            headers,
+            marker=marker,
+            status="resolved",
+        )
+        assert latest_resolved_call is not None
+        assert latest_resolved_call["result"]["answer"] == edited_answer
+        assert latest_resolved_call["result"].get("not_applicable") is not True
+    finally:
+        _apply_live_config_patch(base_url, headers, restore_patch)

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -57,6 +57,7 @@ from reflexio.models.config_schema import (
     PlaybookConfig,
     PlaybookOptimizerConfig,
     ProfileExtractorConfig,
+    StorageConfigManagedSupabase,
     StorageConfigSQLite,
     ToolUseConfig,
 )
@@ -724,6 +725,15 @@ class TestCrossFieldValidators:
         assert config.pending_tool_call_config.enabled is False
         assert config.pending_tool_call_config.human_input_enabled is False
         assert config.pending_tool_call_config.max_pending_followups_per_scope == 10
+
+    def test_pending_tool_calls_allow_managed_supabase_storage(self):
+        """Managed Supabase is database-backed and supports pending tool calls."""
+        config = Config(
+            storage_config=StorageConfigManagedSupabase(managed_by="platform"),
+            pending_tool_call_config=PendingToolCallConfig(enabled=True),
+        )
+
+        assert config.pending_tool_call_config.enabled is True
 
     def test_pending_tool_call_config_validates_positive_limits(self):
         """PendingToolCallConfig rejects non-positive timeout and cap values."""

--- a/tests/server/api_endpoints/test_pending_tool_call_api.py
+++ b/tests/server/api_endpoints/test_pending_tool_call_api.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import tempfile
 import time
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -34,6 +35,7 @@ from reflexio.server.services.storage.storage_base import (
     build_pending_tool_call_dedup_key,
     build_scope_hash,
     human_feedback_scope,
+    not_applicable_tool_result,
 )
 
 
@@ -188,6 +190,262 @@ def test_resolve_pending_tool_call_is_idempotent_and_schedules_resume(
     run = storage.get_agent_run("run_1")
     assert run is not None
     assert run.status == AgentRunStatus.RESUME_READY
+
+
+def test_update_resolved_pending_tool_call_answer_schedules_resume(client, storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED))
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "Old answer", "not_applicable": True},
+            resolved_at=now - timedelta(minutes=10),
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(
+            run_id="run_1",
+            pending_tool_call_id="ptc_1",
+            resolved_at=now - timedelta(minutes=10),
+            consumed_at=now - timedelta(minutes=5),
+        )
+    )
+
+    response = client.patch(
+        "/api/pending_tool_calls/ptc_1/answer",
+        json={"answer": "AWS ECS", "valid_for_seconds": 3600},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {"answer": "AWS ECS"}
+    run = storage.get_agent_run("run_1")
+    deps = storage.list_run_tool_dependencies("run_1")
+    assert run is not None
+    assert run.status == AgentRunStatus.RESUME_READY
+    assert deps[0].resolved_at is not None
+    assert deps[0].consumed_at is None
+
+
+def test_update_resolved_pending_tool_call_answer_rejects_question_text(
+    client, storage
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "Old answer"},
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+
+    response = client.patch(
+        "/api/pending_tool_calls/ptc_1/answer",
+        json={"answer": "AWS ECS", "question_text": "Can this change?"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_update_resolved_pending_tool_call_answer_is_idempotent_after_conflict(
+    client,
+    storage,
+    monkeypatch,
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "AWS ECS"},
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    monkeypatch.setattr(
+        storage,
+        "update_resolved_pending_tool_call_result",
+        MagicMock(return_value=None),
+    )
+
+    response = client.patch(
+        "/api/pending_tool_calls/ptc_1/answer",
+        json={"answer": "AWS ECS"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {"answer": "AWS ECS"}
+
+
+def test_update_resolved_pending_tool_call_answer_conflict_rechecks_result(
+    client,
+    storage,
+    monkeypatch,
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "Old answer"},
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    monkeypatch.setattr(
+        storage,
+        "update_resolved_pending_tool_call_result",
+        MagicMock(return_value=None),
+    )
+
+    response = client.patch(
+        "/api/pending_tool_calls/ptc_1/answer",
+        json={"answer": "AWS ECS"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "Pending tool call already resolved with a different result"
+    )
+
+
+def test_mark_pending_tool_call_not_applicable_finalizes_only_na_run(
+    client, storage
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED_PENDING_TOOL))
+    storage.create_pending_tool_call(_pending_call("ptc_1", now=now))
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1")
+    )
+
+    response = client.post("/api/pending_tool_calls/ptc_1/not_applicable", json={})
+
+    assert response.status_code == 200
+    assert response.json()["result"] == {
+        "answer": "User does not have information about this question.",
+        "not_applicable": True,
+    }
+    run = storage.get_agent_run("run_1")
+    deps = storage.list_run_tool_dependencies("run_1")
+    assert run is not None
+    assert run.status == AgentRunStatus.FINALIZED
+    assert deps[0].resolved_at is not None
+    assert deps[0].consumed_at is not None
+
+
+def test_mark_pending_tool_call_not_applicable_keeps_mixed_pending_run_pending(
+    client, storage
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    second = _pending_call("ptc_2", now=now)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED_PENDING_TOOL))
+    storage.create_pending_tool_call(_pending_call("ptc_1", now=now))
+    storage.create_pending_tool_call(
+        replace(
+            second,
+            question_text="Which region?",
+            args={"question": "Which region?"},
+            dedup_key=build_pending_tool_call_dedup_key(
+                tool_name="ask_human",
+                question_text="Which region?",
+            ),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1")
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_2")
+    )
+
+    response = client.post("/api/pending_tool_calls/ptc_1/not_applicable", json={})
+
+    assert response.status_code == 200
+    run = storage.get_agent_run("run_1")
+    assert run is not None
+    assert run.status == AgentRunStatus.FINALIZED_PENDING_TOOL
+
+
+def test_mark_pending_tool_call_not_applicable_is_idempotent_after_conflict(
+    client,
+    storage,
+    monkeypatch,
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result=not_applicable_tool_result(),
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    monkeypatch.setattr(
+        storage,
+        "mark_pending_tool_call_not_applicable",
+        MagicMock(return_value=None),
+    )
+
+    response = client.post("/api/pending_tool_calls/ptc_1/not_applicable", json={})
+
+    assert response.status_code == 200
+    assert response.json()["result"] == not_applicable_tool_result()
+
+
+def test_mark_pending_tool_call_not_applicable_conflict_rechecks_result(
+    client,
+    storage,
+    monkeypatch,
+):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "Known answer"},
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    monkeypatch.setattr(
+        storage,
+        "mark_pending_tool_call_not_applicable",
+        MagicMock(return_value=None),
+    )
+
+    response = client.post("/api/pending_tool_calls/ptc_1/not_applicable", json={})
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == (
+        "Pending tool call could not be marked not applicable"
+    )
+
+
+def test_mark_pending_tool_call_not_applicable_drains_resume_worker(client, storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_pending_tool_call(_pending_call("ptc_1", now=now))
+
+    with (
+        patch(
+            "reflexio.server.api_endpoints.pending_tool_call_api."
+            "is_resumable_extraction_enabled",
+            return_value=True,
+        ),
+        patch(
+            "reflexio.server.api_endpoints.pending_tool_call_api."
+            "ExtractionResumeWorker"
+        ) as worker_cls,
+    ):
+        response = client.post("/api/pending_tool_calls/ptc_1/not_applicable", json={})
+
+    assert response.status_code == 200
+    worker_cls.assert_called_once()
+    worker_cls.return_value.drain.assert_called_once()
 
 
 def test_resolve_pending_tool_call_rejects_different_result(client, storage):

--- a/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
@@ -156,6 +156,146 @@ def test_sqlite_resolve_marks_linked_finalized_run_resume_ready(storage):
     assert pending.result == {"answer": "AWS ECS"}
 
 
+def test_sqlite_update_resolved_answer_resets_consumed_dependency(storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED))
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "not applicable", "not_applicable": True},
+            resolved_at=now - timedelta(minutes=10),
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(
+            run_id="run_1",
+            pending_tool_call_id="ptc_1",
+            resolved_at=now - timedelta(minutes=10),
+            consumed_at=now - timedelta(minutes=5),
+        )
+    )
+
+    updated = storage.update_resolved_pending_tool_call_result(
+        "ptc_1",
+        result={"answer": "AWS ECS"},
+        resolved_at=now,
+        valid_for_seconds=3600,
+    )
+
+    run = storage.get_agent_run("run_1")
+    deps = storage.list_run_tool_dependencies("run_1")
+    assert updated is not None
+    assert updated.result == {"answer": "AWS ECS"}
+    assert run is not None
+    assert run.status == AgentRunStatus.RESUME_READY
+    assert deps[0].resolved_at == now
+    assert deps[0].consumed_at is None
+
+
+def test_sqlite_mark_not_applicable_finalizes_run_with_only_na_dependencies(storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED_PENDING_TOOL))
+    storage.create_pending_tool_call(_pending_call("ptc_1", now=now))
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1")
+    )
+
+    updated = storage.mark_pending_tool_call_not_applicable(
+        "ptc_1",
+        resolved_at=now,
+        valid_for_seconds=3600,
+    )
+
+    run = storage.get_agent_run("run_1")
+    deps = storage.list_run_tool_dependencies("run_1")
+    assert updated is not None
+    assert updated.status == PendingToolCallStatus.RESOLVED
+    assert updated.result == {
+        "answer": "User does not have information about this question.",
+        "not_applicable": True,
+    }
+    assert run is not None
+    assert run.status == AgentRunStatus.FINALIZED
+    assert deps[0].resolved_at == now
+    assert deps[0].consumed_at == now
+
+
+def test_sqlite_mark_not_applicable_keeps_mixed_pending_run_waiting(storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED_PENDING_TOOL))
+    storage.create_pending_tool_call(_pending_call("ptc_1", now=now))
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_2", now=now),
+            question_text="Which region?",
+            args={"question": "Which region?"},
+            dedup_key=build_pending_tool_call_dedup_key(
+                tool_name="ask_human",
+                question_text="Which region?",
+            ),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1")
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_2")
+    )
+
+    storage.mark_pending_tool_call_not_applicable(
+        "ptc_1",
+        resolved_at=now,
+        valid_for_seconds=3600,
+    )
+
+    run = storage.get_agent_run("run_1")
+    assert run is not None
+    assert run.status == AgentRunStatus.FINALIZED_PENDING_TOOL
+
+
+def test_sqlite_mark_not_applicable_keeps_other_actionable_dependency_ready(storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FINALIZED_PENDING_TOOL))
+    storage.create_pending_tool_call(_pending_call("ptc_1", now=now))
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_2", now=now),
+            question_text="Which region?",
+            args={"question": "Which region?"},
+            dedup_key=build_pending_tool_call_dedup_key(
+                tool_name="ask_human",
+                question_text="Which region?",
+            ),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "us-west-2"},
+            resolved_at=now - timedelta(minutes=1),
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1")
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(
+            run_id="run_1",
+            pending_tool_call_id="ptc_2",
+            resolved_at=now - timedelta(minutes=1),
+        )
+    )
+
+    storage.mark_pending_tool_call_not_applicable(
+        "ptc_1",
+        resolved_at=now,
+        valid_for_seconds=3600,
+    )
+
+    run = storage.get_agent_run("run_1")
+    assert run is not None
+    assert run.status == AgentRunStatus.RESUME_READY
+
+
 def test_sqlite_resolve_supersedes_older_valid_answer_for_same_dedup_key(storage):
     now = datetime(2026, 5, 28, tzinfo=UTC)
     storage.create_pending_tool_call(
@@ -262,6 +402,35 @@ def test_sqlite_claim_requires_resolved_unconsumed_dependency(storage):
     )
 
 
+def test_sqlite_claim_ignores_not_applicable_dependencies(storage):
+    now = datetime(2026, 5, 28, tzinfo=UTC)
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.RESUME_READY))
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ptc_1", now=now),
+            status=PendingToolCallStatus.RESOLVED,
+            result={
+                "answer": "User does not have information about this question.",
+                "not_applicable": True,
+            },
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(
+            run_id="run_1",
+            pending_tool_call_id="ptc_1",
+            resolved_at=now,
+        )
+    )
+
+    assert (
+        storage.claim_ready_agent_run(org_id="org_1", worker_id="worker_1", now=now)
+        is None
+    )
+
+
 def test_sqlite_claim_finalization_failed_requires_committed_output(storage):
     now = datetime(2026, 5, 28, tzinfo=UTC)
     storage.create_agent_run(
@@ -327,6 +496,22 @@ def test_sqlite_list_resumable_work_org_ids_scans_all_orgs(storage):
     # org_a: a run ready to resume.
     storage.create_agent_run(
         _agent_run("ready_run", AgentRunStatus.RESUME_READY, org_id="org_a")
+    )
+    storage.create_pending_tool_call(
+        replace(
+            _pending_call("ready_call", now=now, org_id="org_a"),
+            status=PendingToolCallStatus.RESOLVED,
+            result={"answer": "AWS ECS"},
+            resolved_at=now,
+            valid_until=now + timedelta(hours=1),
+        )
+    )
+    storage.attach_run_tool_dependency(
+        RunToolDependencyRecord(
+            run_id="ready_run",
+            pending_tool_call_id="ready_call",
+            resolved_at=now,
+        )
     )
     # org_b: a run awaiting finalization retry.
     storage.create_agent_run(


### PR DESCRIPTION
## Summary
- Add answer-edit and mark-not-applicable API support for resolved ask_human pending tool calls
- Update SQLite run dependency lifecycle so edited non-N/A answers can resume, while N/A-only dependencies finalize without rerunning
- Add storage/API coverage plus a gated live resumable-agent E2E test that uses real backend/LLM calls

## Tests
- `uv run ruff check reflexio/models/api_schema/pending_tool_call_schema.py reflexio/models/config_schema.py reflexio/server/api_endpoints/pending_tool_call_api.py reflexio/server/services/storage/sqlite_storage/_agent_run.py reflexio/server/services/storage/storage_base/__init__.py reflexio/server/services/storage/storage_base/_agent_run.py tests/e2e_tests/test_resumable_extraction_e2e.py tests/models/test_validators.py tests/server/api_endpoints/test_pending_tool_call_api.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py`
- `uv run pyright reflexio/models/api_schema/pending_tool_call_schema.py reflexio/models/config_schema.py reflexio/server/api_endpoints/pending_tool_call_api.py reflexio/server/services/storage/sqlite_storage/_agent_run.py reflexio/server/services/storage/storage_base/__init__.py reflexio/server/services/storage/storage_base/_agent_run.py tests/e2e_tests/test_resumable_extraction_e2e.py tests/models/test_validators.py tests/server/api_endpoints/test_pending_tool_call_api.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py`
- `uv run pytest -q --no-cov tests/models/test_validators.py tests/server/api_endpoints/test_pending_tool_call_api.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py tests/e2e_tests/test_resumable_extraction_e2e.py`
- `uv run pytest -q --no-cov tests/e2e_tests/test_resumable_extraction_e2e.py`
- `RUN_LIVE_RESUMABLE_E2E=true MOCK_LLM_RESPONSE=false REFLEXIO_API_URL=http://localhost:8095 uv run pytest -q --no-cov tests/e2e_tests/test_resumable_extraction_e2e.py -k live_resumable_question_resolve_and_edit_roundtrip --timeout=360` against an isolated SQLite backend using MiniMax

## Notes
- The live E2E test stays gated and uses the default MiniMax generation path. The prompt is intentionally explicit so MiniMax reliably asks the question, resumes, emits a profile for `AWS ECS`, and re-emits it for `Google Cloud Run` after answer edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API endpoints to update resolved pending tool call answers and mark calls as not applicable
  * Enabled resumable extraction agent capability
  * Extended storage support to include Managed Supabase backend

* **Improvements**
  * Stricter API request validation—now rejects unrecognized fields during processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ReflexioAI/reflexio/pull/105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->