### PR TITLE
feat(cli): resolve data DB URL from DATA_DB_URL; start docs from OSS services

### DIFF
--- a/docs/next.config.ts
+++ b/docs/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
+import path from "node:path";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: path.resolve(__dirname),
+  },
 };
 
 export default nextConfig;

--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -26,6 +26,13 @@ _DEFAULT_STORAGE = "sqlite"
 _TYPE_TO_BACKEND: dict[type, str] = {}  # populated on first use
 
 
+def _data_db_url_from_env() -> str:
+    """Resolve the canonical data DB URL, accepting the legacy alias."""
+    return os.environ.get("DATA_DB_URL", "") or os.environ.get(
+        "DATA_SUPABASE_DB_URL", ""
+    )
+
+
 def _ensure_type_map() -> dict[type, str]:
     """Lazy-build the StorageConfig type → backend string map."""
     if not _TYPE_TO_BACKEND:
@@ -140,7 +147,7 @@ def save_storage_to_config(
         case "supabase":
             url = os.environ.get("DATA_SUPABASE_URL", "")
             key = os.environ.get("DATA_SUPABASE_KEY", "")
-            db_url = os.environ.get("DATA_SUPABASE_DB_URL", "")
+            db_url = _data_db_url_from_env()
             if url and key and db_url:
                 config.storage_config = StorageConfigSupabase(
                     url=url, key=key, db_url=db_url
@@ -148,11 +155,11 @@ def save_storage_to_config(
             else:
                 logger.warning(
                     "Supabase storage requested but credentials are missing "
-                    "(DATA_SUPABASE_URL, DATA_SUPABASE_KEY, DATA_SUPABASE_DB_URL). "
+                    "(DATA_SUPABASE_URL, DATA_SUPABASE_KEY, DATA_DB_URL). "
                     "Keeping existing storage config."
                 )
         case "postgres":
-            db_url = os.environ.get("REFLEXIO_POSTGRES_DB_URL", "")
+            db_url = os.environ.get("DATA_DB_URL", "").strip()
             schema = os.environ.get("REFLEXIO_POSTGRES_SCHEMA", "").strip()
             pool_size_raw = os.environ.get("REFLEXIO_POSTGRES_POOL_SIZE", "").strip()
             pool_size = int(pool_size_raw) if pool_size_raw.isdigit() else 10
@@ -191,7 +198,7 @@ def save_storage_to_config(
                 config.storage_config = StorageConfigPostgres(**postgres_kwargs)
             else:
                 logger.warning(
-                    "Postgres storage requested but REFLEXIO_POSTGRES_DB_URL "
+                    "Postgres storage requested but DATA_DB_URL "
                     "is missing. Keeping existing storage config."
                 )
         case _:

--- a/reflexio/cli/run_services.py
+++ b/reflexio/cli/run_services.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import logging
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -294,6 +295,19 @@ def should_start_local_embedding_service() -> bool:
     return os.environ.get("CLAUDE_SMART_USE_LOCAL_EMBEDDING") == "1"
 
 
+def _ensure_nextjs_dependencies(project_dir: Path) -> bool:
+    """Install Next.js project dependencies when node_modules is missing."""
+    if (project_dir / "node_modules").exists():
+        return True
+
+    print(f"Installing {project_dir.name} dependencies...")
+    result = subprocess.run(["npm", "install"], cwd=str(project_dir), check=False)
+    if result.returncode != 0:
+        print(f"Error: npm install failed in {project_dir}.")
+        return False
+    return True
+
+
 def execute(args: argparse.Namespace) -> None:
     """Execute the run-services command."""
     load_reflexio_env()
@@ -354,6 +368,8 @@ def execute(args: argparse.Namespace) -> None:
 
     if "docs" in only:
         if DOCS_DIR.is_dir():
+            if not _ensure_nextjs_dependencies(DOCS_DIR):
+                sys.exit(1)
             services.append(build_nextjs_service("docs", ports, cwd=str(DOCS_DIR)))
         elif docs_explicit:
             print(

--- a/tests/cli/test_bootstrap_config.py
+++ b/tests/cli/test_bootstrap_config.py
@@ -127,6 +127,17 @@ class TestSaveAndLoadStorage:
     ) -> None:
         monkeypatch.setenv("DATA_SUPABASE_URL", "https://example.supabase.co")
         monkeypatch.setenv("DATA_SUPABASE_KEY", "test-key-123")
+        monkeypatch.setenv("DATA_DB_URL", "postgresql://localhost/test")
+        save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
+        result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+        assert result == "supabase"
+
+    def test_round_trip_supabase_with_legacy_db_url_alias(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DATA_SUPABASE_URL", "https://example.supabase.co")
+        monkeypatch.setenv("DATA_SUPABASE_KEY", "test-key-123")
+        monkeypatch.delenv("DATA_DB_URL", raising=False)
         monkeypatch.setenv("DATA_SUPABASE_DB_URL", "postgresql://localhost/test")
         save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
         result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
@@ -143,12 +154,15 @@ class TestSaveAndLoadStorage:
 
         monkeypatch.delenv("DATA_SUPABASE_URL", raising=False)
         monkeypatch.delenv("DATA_SUPABASE_KEY", raising=False)
+        monkeypatch.delenv("DATA_DB_URL", raising=False)
         monkeypatch.delenv("DATA_SUPABASE_DB_URL", raising=False)
         save_storage_to_config("supabase", org_id="test-org", base_dir=str(tmp_path))
         result = load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
         assert result == "sqlite"
 
-    def test_preserves_existing_config_fields(self, tmp_path: Path) -> None:
+    def test_preserves_existing_config_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Updating storage_config must not clobber extractors or other fields."""
         from reflexio.models.config_schema import (
             Config,
@@ -171,16 +185,9 @@ class TestSaveAndLoadStorage:
         )
         storage_obj.save_config(config)
 
-        # Now update storage to postgres (via env var)
-        import os
-
-        os.environ["REFLEXIO_POSTGRES_DB_URL"] = "postgresql://localhost/test"
-        try:
-            save_storage_to_config(
-                "postgres", org_id="test-org", base_dir=str(tmp_path)
-            )
-        finally:
-            os.environ.pop("REFLEXIO_POSTGRES_DB_URL", None)
+        # Now update storage to postgres (via canonical data DB URL)
+        monkeypatch.setenv("DATA_DB_URL", "postgresql://localhost/test")
+        save_storage_to_config("postgres", org_id="test-org", base_dir=str(tmp_path))
 
         # Verify extractor and context are preserved
         reloaded = storage_obj.load_config()
@@ -191,6 +198,23 @@ class TestSaveAndLoadStorage:
             load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
             == "postgres"
         )
+
+    def test_postgres_without_data_db_url_preserves_existing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        save_storage_to_config("sqlite", org_id="test-org", base_dir=str(tmp_path))
+        monkeypatch.delenv("DATA_DB_URL", raising=False)
+
+        save_storage_to_config("postgres", org_id="test-org", base_dir=str(tmp_path))
+
+        assert (
+            load_storage_from_config(org_id="test-org", base_dir=str(tmp_path))
+            == "sqlite"
+        )
+        assert "DATA_DB_URL" in caplog.text
 
     def test_load_returns_none_when_no_file(self, tmp_path: Path) -> None:
         result = load_storage_from_config(org_id="nonexistent", base_dir=str(tmp_path))

--- a/tests/cli/test_service_builders.py
+++ b/tests/cli/test_service_builders.py
@@ -12,6 +12,7 @@ import typer
 
 from reflexio.cli.commands.services import validate_storage_backend
 from reflexio.cli.run_services import (
+    _ensure_nextjs_dependencies,
     build_backend_service,
     build_embedding_service,
     build_nextjs_service,
@@ -239,6 +240,51 @@ class TestBuildNextjsService:
     def test_port_from_dict(self) -> None:
         svc = build_nextjs_service("docs", {"docs": 4567}, cwd="docs")
         assert svc.command[-1] == "4567"
+
+    def test_ensure_nextjs_dependencies_skips_existing_node_modules(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        project_dir = tmp_path / "docs"
+        (project_dir / "node_modules").mkdir(parents=True)
+        run_calls = []
+        monkeypatch.setattr(
+            "reflexio.cli.run_services.subprocess.run",
+            lambda *args, **kwargs: run_calls.append((args, kwargs)),
+        )
+
+        assert _ensure_nextjs_dependencies(project_dir) is True
+        assert run_calls == []
+
+    def test_ensure_nextjs_dependencies_runs_npm_install(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        project_dir = tmp_path / "docs"
+        project_dir.mkdir()
+        run_calls = []
+
+        def fake_run(*args, **kwargs):
+            run_calls.append((args, kwargs))
+            return argparse.Namespace(returncode=0)
+
+        monkeypatch.setattr("reflexio.cli.run_services.subprocess.run", fake_run)
+
+        assert _ensure_nextjs_dependencies(project_dir) is True
+        assert run_calls == [
+            ((["npm", "install"],), {"cwd": str(project_dir), "check": False})
+        ]
+
+    def test_ensure_nextjs_dependencies_reports_install_failure(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        project_dir = tmp_path / "docs"
+        project_dir.mkdir()
+
+        def fake_run(*_args, **_kwargs):
+            return argparse.Namespace(returncode=1)
+
+        monkeypatch.setattr("reflexio.cli.run_services.subprocess.run", fake_run)
+
+        assert _ensure_nextjs_dependencies(project_dir) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Supporting OSS changes for the enterprise server-start / deployment-mode
simplification work.

## Changes

- **`bootstrap_config.py`**: resolve the data DB URL from the canonical
  `DATA_DB_URL` env var when persisting storage config, accepting the legacy
  `DATA_SUPABASE_DB_URL` alias for Supabase and replacing the
  `REFLEXIO_POSTGRES_DB_URL` lookup for Postgres. Warning messages updated to
  reference `DATA_DB_URL`.
- **`run_services`**: start the docs server from the OSS services path.

## Test Plan

- `uv run ruff check` / `ruff format` clean on changed files
- `uv run pyright` clean on changed files
- Updated `tests/cli/test_bootstrap_config.py` covers the new DB URL resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now automatically checks for and installs Next.js dependencies when running docs, improving setup experience.

* **Chores**
  * Improved database configuration environment variable handling with better fallback support.
  * Updated configuration warnings to reflect current environment variable naming.
  * Added tests for dependency installation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->