### PR TITLE
feat: add search tracing hook

### DIFF
--- a/reflexio/lib/_agent_playbook.py
+++ b/reflexio/lib/_agent_playbook.py
@@ -24,6 +24,7 @@ from reflexio.models.api_schema.service_schemas import (
     PlaybookAggregationChangeLogResponse,
 )
 from reflexio.models.config_schema import SearchOptions
+from reflexio.server.tracing import profile_step
 
 
 class AgentPlaybookMixin(ReflexioBase):
@@ -238,9 +239,16 @@ class AgentPlaybookMixin(ReflexioBase):
                 if query_embedding
                 else None
             )
-            agent_playbooks = self._get_storage().search_agent_playbooks(
-                search_request, options
-            )
+            with profile_step(
+                "search.storage",
+                entity_type="agent_playbooks",
+                search_mode=search_request.search_mode,
+                top_k=search_request.top_k,
+            ) as span:
+                agent_playbooks = self._get_storage().search_agent_playbooks(
+                    search_request, options
+                )
+                span.set_data("result_count", len(agent_playbooks))
             return SearchAgentPlaybookResponse(
                 success=True,
                 agent_playbooks=agent_playbooks,

--- a/reflexio/lib/_base.py
+++ b/reflexio/lib/_base.py
@@ -21,6 +21,7 @@ from reflexio.server.llm.model_defaults import (
 from reflexio.server.services.configurator.base_configurator import BaseConfigurator
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.site_var.site_var_manager import SiteVarManager
+from reflexio.server.tracing import profile_step
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,15 @@ def _require_storage[T: BaseModel](
         return wrapper
 
     return decorator
+
+
+def _storage_backend_name(storage: BaseStorage) -> str:
+    class_name = storage.__class__.__name__.lower()
+    if "postgres" in class_name:
+        return "postgres"
+    if "supabase" in class_name:
+        return "supabase"
+    return class_name
 
 
 class ReflexioBase:
@@ -166,13 +176,23 @@ class ReflexioBase:
         storage = self._get_storage()
         if not storage.supports_embedding:
             return None
-        try:
-            return storage._get_embedding(query, purpose="query")  # type: ignore[reportAttributeAccessIssue]
-        except Exception as e:
-            logger.warning(
-                "Failed to generate query embedding due to %s — falling back to FTS", e
-            )
-            return None
+        with profile_step(
+            "search.embedding",
+            backend=_storage_backend_name(storage),
+            search_mode=search_mode,
+            purpose="query",
+        ) as span:
+            try:
+                embedding = storage._get_embedding(query, purpose="query")  # type: ignore[reportAttributeAccessIssue]
+                span.set_data("embedding_generated", embedding is not None)
+                return embedding
+            except Exception as e:
+                span.set_data("embedding_generated", False)
+                logger.warning(
+                    "Failed to generate query embedding due to %s — falling back to FTS",
+                    e,
+                )
+                return None
 
     def _reformulate_query(
         self, query: str | None, enabled: bool = False
@@ -192,11 +212,12 @@ class ReflexioBase:
         if not query or not enabled:
             return None
 
-        reformulator = self._get_query_reformulator()
-        result = reformulator.rewrite(query)
-        # Only return if different from original
-        if result.standalone_query != query:
-            return result.standalone_query
+        with profile_step("search.reformulate", enabled=enabled):
+            reformulator = self._get_query_reformulator()
+            result = reformulator.rewrite(query)
+            # Only return if different from original
+            if result.standalone_query != query:
+                return result.standalone_query
         return None
 
 

--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -39,6 +39,7 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.server.services.profile.profile_generation_service import (
     ProfileGenerationService,
 )
+from reflexio.server.tracing import profile_step
 
 
 class ProfilesMixin(ReflexioBase):
@@ -78,9 +79,16 @@ class ProfilesMixin(ReflexioBase):
             request.search_mode,
             query_embedding is not None,
         )
-        profiles = self._get_storage().search_user_profile(
-            request, status_filter=status_filter, query_embedding=query_embedding
-        )
+        with profile_step(
+            "search.storage",
+            entity_type="profiles",
+            search_mode=request.search_mode,
+            top_k=request.top_k,
+        ) as span:
+            profiles = self._get_storage().search_user_profile(
+                request, status_filter=status_filter, query_embedding=query_embedding
+            )
+            span.set_data("result_count", len(profiles))
         return SearchUserProfileResponse(
             success=True,
             user_profiles=profiles,

--- a/reflexio/lib/_user_playbook.py
+++ b/reflexio/lib/_user_playbook.py
@@ -27,6 +27,7 @@ from reflexio.models.config_schema import SearchOptions
 from reflexio.server.services.playbook.playbook_generation_service import (
     PlaybookGenerationService,
 )
+from reflexio.server.tracing import profile_step
 
 
 class UserPlaybookMixin(ReflexioBase):
@@ -131,9 +132,16 @@ class UserPlaybookMixin(ReflexioBase):
                 if query_embedding
                 else None
             )
-            user_playbooks = self._get_storage().search_user_playbooks(
-                search_request, options
-            )
+            with profile_step(
+                "search.storage",
+                entity_type="user_playbooks",
+                search_mode=search_request.search_mode,
+                top_k=search_request.top_k,
+            ) as span:
+                user_playbooks = self._get_storage().search_user_playbooks(
+                    search_request, options
+                )
+                span.set_data("result_count", len(user_playbooks))
             return SearchUserPlaybookResponse(
                 success=True,
                 user_playbooks=user_playbooks,

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -8,10 +8,12 @@ Executes in two phases:
 
 from __future__ import annotations
 
+import contextvars
 import logging
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
+from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from reflexio.models.api_schema.retriever_schema import (
     ConversationTurn,
@@ -32,6 +34,7 @@ from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.pre_retrieval import QueryReformulator
 from reflexio.server.services.storage.storage_base import BaseStorage
+from reflexio.server.tracing import profile_step, set_span_data
 
 if TYPE_CHECKING:
     from reflexio.server.api_endpoints.request_context import RequestContext
@@ -151,19 +154,31 @@ def _run_phase_a(
     )
 
     # Query reformulation (rewrite() handles all exceptions internally)
-    if enable_reformulation:
-        result = reformulator.rewrite(query, conversation_history)
-        standalone_query = result.standalone_query
-    else:
-        standalone_query = query
+    with profile_step(
+        "search.reformulate",
+        enabled=enable_reformulation,
+        has_conversation_history=bool(conversation_history),
+    ):
+        if enable_reformulation:
+            result = reformulator.rewrite(query, conversation_history)
+            standalone_query = result.standalone_query
+        else:
+            standalone_query = query
 
     # Embedding generation (uses reformulated query for semantic accuracy)
     embedding = None
     if supports_embedding:
-        try:
-            embedding = storage._get_embedding(standalone_query)  # type: ignore[reportAttributeAccessIssue]
-        except Exception as e:
-            logger.error("Embedding generation failed: %s", e)
+        with profile_step(
+            "search.embedding",
+            backend=_storage_backend_name(storage),
+            purpose="query",
+        ) as span:
+            try:
+                embedding = storage._get_embedding(standalone_query, purpose="query")  # type: ignore[reportAttributeAccessIssue]
+                span.set_data("embedding_generated", embedding is not None)
+            except Exception as e:
+                span.set_data("embedding_generated", False)
+                logger.error("Embedding generation failed: %s", e)
 
     return standalone_query, embedding
 
@@ -201,57 +216,81 @@ def _run_phase_b(
     allowed_agent_statuses = request.agent_playbook_status_filter
     executor = ThreadPoolExecutor(max_workers=3)
     try:
-        profiles_future = (
-            executor.submit(
-                _search_profiles_via_storage,
-                storage,
-                query,
-                top_k,
-                threshold,
-                request.user_id,
-                embedding,
+        with profile_step(
+            "search.phase_b",
+            backend=_storage_backend_name(storage),
+            entity_types=sorted(entity_types),
+            top_k=top_k,
+        ) as span:
+            profiles_future = (
+                _submit_with_current_context(
+                    executor,
+                    _search_profiles_via_storage,
+                    storage,
+                    query,
+                    top_k,
+                    threshold,
+                    request.user_id,
+                    embedding,
+                )
+                if "profiles" in entity_types
+                else None
             )
-            if "profiles" in entity_types
-            else None
-        )
-        agent_playbooks_future = (
-            executor.submit(
-                _search_agent_playbooks_via_storage,
-                storage,
-                query,
-                top_k,
-                threshold,
-                request.agent_version,
-                request.playbook_name,
-                allowed_agent_statuses,
-                options,
+            agent_playbooks_future = (
+                _submit_with_current_context(
+                    executor,
+                    _search_agent_playbooks_via_storage,
+                    storage,
+                    query,
+                    top_k,
+                    threshold,
+                    request.agent_version,
+                    request.playbook_name,
+                    allowed_agent_statuses,
+                    options,
+                )
+                if "agent_playbooks" in entity_types
+                else None
             )
-            if "agent_playbooks" in entity_types
-            else None
-        )
-        if "user_playbooks" in entity_types:
-            rf_request = SearchUserPlaybookRequest(
-                query=query,
-                user_id=request.user_id,
-                agent_version=request.agent_version,
-                playbook_name=request.playbook_name,
-                status_filter=None,
-                threshold=threshold,
-                top_k=top_k,
-            )
-            user_playbooks_future = executor.submit(
-                storage.search_user_playbooks, rf_request, options
-            )
-        else:
-            user_playbooks_future = None
+            if "user_playbooks" in entity_types:
+                rf_request = SearchUserPlaybookRequest(
+                    query=query,
+                    user_id=request.user_id,
+                    agent_version=request.agent_version,
+                    playbook_name=request.playbook_name,
+                    status_filter=None,
+                    threshold=threshold,
+                    top_k=top_k,
+                )
+                user_playbooks_future = _submit_with_current_context(
+                    executor,
+                    _search_user_playbooks_via_storage,
+                    storage,
+                    rf_request,
+                    options,
+                )
+            else:
+                user_playbooks_future = None
 
-        profiles = profiles_future.result(timeout=30) if profiles_future else []
-        agent_playbooks = (
-            agent_playbooks_future.result(timeout=30) if agent_playbooks_future else []
-        )
-        user_playbooks = (
-            user_playbooks_future.result(timeout=30) if user_playbooks_future else []
-        )
+            profiles = profiles_future.result(timeout=30) if profiles_future else []
+            agent_playbooks = (
+                agent_playbooks_future.result(timeout=30)
+                if agent_playbooks_future
+                else []
+            )
+            user_playbooks = (
+                user_playbooks_future.result(timeout=30)
+                if user_playbooks_future
+                else []
+            )
+            set_span_data(
+                span,
+                {
+                    "profiles_count": len(profiles),
+                    "agent_playbooks_count": len(agent_playbooks),
+                    "user_playbooks_count": len(user_playbooks),
+                },
+            )
     except FuturesTimeoutError:
         logger.error("Unified search timed out")
         return None, None, None
@@ -280,30 +319,36 @@ def _search_agent_playbooks_via_storage(
     ``_DEFAULT_AGENT_PLAYBOOK_STATUSES`` (APPROVED + PENDING). Callers that
     genuinely want REJECTED playbooks must opt in by passing the full list.
     """
-    statuses = (
-        list(allowed_statuses)
-        if allowed_statuses
-        else list(_DEFAULT_AGENT_PLAYBOOK_STATUSES)
-    )
-    request = SearchAgentPlaybookRequest(
-        query=query,
-        agent_version=agent_version,
-        playbook_name=playbook_name,
-        status_filter=[None],
-        playbook_status_filter=statuses,
-        threshold=threshold,
+    with profile_step(
+        "search.branch.agent_playbooks",
+        backend=_storage_backend_name(storage),
         top_k=top_k,
-    )
-    results: list[AgentPlaybook] = []
-    seen_ids: set[str] = set()
-    for playbook in storage.search_agent_playbooks(request, options):
-        playbook_id = str(getattr(playbook, "agent_playbook_id", ""))
-        if playbook_id and playbook_id not in seen_ids:
-            seen_ids.add(playbook_id)
-            results.append(playbook)
-            if len(results) >= top_k:
-                break
-    return results
+    ) as span:
+        statuses = (
+            list(allowed_statuses)
+            if allowed_statuses
+            else list(_DEFAULT_AGENT_PLAYBOOK_STATUSES)
+        )
+        request = SearchAgentPlaybookRequest(
+            query=query,
+            agent_version=agent_version,
+            playbook_name=playbook_name,
+            status_filter=[None],
+            playbook_status_filter=statuses,
+            threshold=threshold,
+            top_k=top_k,
+        )
+        results: list[AgentPlaybook] = []
+        seen_ids: set[str] = set()
+        for playbook in storage.search_agent_playbooks(request, options):
+            playbook_id = str(getattr(playbook, "agent_playbook_id", ""))
+            if playbook_id and playbook_id not in seen_ids:
+                seen_ids.add(playbook_id)
+                results.append(playbook)
+                if len(results) >= top_k:
+                    break
+        span.set_data("result_count", len(results))
+        return results
 
 
 def _search_profiles_via_storage(
@@ -327,22 +372,64 @@ def _search_profiles_via_storage(
     Returns:
         list[UserProfile]: Matching profiles, or [] on error/missing user_id
     """
-    if not user_id:
-        return []
-    try:
-        return storage.search_user_profile(
-            SearchUserProfileRequest(
-                user_id=user_id,
-                query=query,
-                top_k=top_k,
-                threshold=threshold,
-            ),
-            status_filter=[None],
-            query_embedding=embedding,
-        )
-    except Exception as e:
-        logger.error("Profile search failed: %s", e)
-        return []
+    with profile_step(
+        "search.branch.profiles",
+        backend=_storage_backend_name(storage),
+        top_k=top_k,
+    ) as span:
+        if not user_id:
+            span.set_data("result_count", 0)
+            return []
+        try:
+            profiles = storage.search_user_profile(
+                SearchUserProfileRequest(
+                    user_id=user_id,
+                    query=query,
+                    top_k=top_k,
+                    threshold=threshold,
+                ),
+                status_filter=[None],
+                query_embedding=embedding,
+            )
+            span.set_data("result_count", len(profiles))
+            return profiles
+        except Exception as e:
+            span.set_data("result_count", 0)
+            logger.error("Profile search failed: %s", e)
+            return []
+
+
+def _search_user_playbooks_via_storage(
+    storage: BaseStorage,
+    request: SearchUserPlaybookRequest,
+    options: SearchOptions,
+) -> list[UserPlaybook]:
+    with profile_step(
+        "search.branch.user_playbooks",
+        backend=_storage_backend_name(storage),
+        top_k=request.top_k,
+    ) as span:
+        user_playbooks = storage.search_user_playbooks(request, options)
+        span.set_data("result_count", len(user_playbooks))
+        return user_playbooks
+
+
+def _submit_with_current_context(
+    executor: ThreadPoolExecutor,
+    fn: Callable[..., object],
+    *args: object,
+) -> Future[Any]:
+    context = contextvars.copy_context()
+    return executor.submit(context.run, fn, *args)
+
+
+def _storage_backend_name(storage: BaseStorage) -> str:
+    class_name = storage.__class__.__name__.lower()
+    if "postgres" in class_name:
+        return "postgres"
+    if "supabase" in class_name:
+        return "supabase"
+    return class_name
 
 
 class UnifiedSearchService:

--- a/reflexio/server/tracing.py
+++ b/reflexio/server/tracing.py
@@ -1,0 +1,95 @@
+"""Optional tracing hook for request-path profiling.
+
+This module intentionally has no observability-vendor dependency. Deployments
+that want tracing can register a tracer; deployments that do not register one
+pay only a cheap context-manager/no-op cost.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Mapping
+from contextlib import AbstractContextManager, contextmanager
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class TraceSpan(Protocol):
+    """Minimal span handle exposed to shared Reflexio code."""
+
+    def set_data(self, key: str, value: Any) -> None:
+        """Attach low-cardinality metadata to the active span."""
+        ...
+
+
+class Tracer(Protocol):
+    """Process-global tracer interface configured by enterprise startup."""
+
+    def span(self, name: str, **data: Any) -> AbstractContextManager[TraceSpan]:
+        """Create a span context manager."""
+        ...
+
+
+class _NoopTraceSpan:
+    def set_data(self, key: str, value: Any) -> None:
+        del key, value
+
+
+_NOOP_SPAN = _NoopTraceSpan()
+_tracer: Tracer | None = None
+
+
+def configure_tracer(tracer: Tracer | None) -> None:
+    """Set the process-global tracer.
+
+    Args:
+        tracer: Tracer implementation, or None to disable tracing.
+    """
+    global _tracer
+    _tracer = tracer
+
+
+@contextmanager
+def profile_step(name: str, **data: Any) -> Iterator[TraceSpan]:
+    """Profile a named step if tracing is configured.
+
+    Tracing must never make product requests fail. Errors from creating,
+    entering, or exiting the tracing span are logged and swallowed. Exceptions
+    raised by the profiled product code are still propagated unchanged.
+    """
+    tracer = _tracer
+    if tracer is None:
+        yield _NOOP_SPAN
+        return
+
+    try:
+        span_cm = tracer.span(name, **data)
+        span = span_cm.__enter__()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Tracer failed to start span %s: %s", name, exc)
+        yield _NOOP_SPAN
+        return
+
+    try:
+        yield span
+    except BaseException as exc:
+        try:
+            span_cm.__exit__(type(exc), exc, exc.__traceback__)
+        except Exception as tracer_exc:  # noqa: BLE001
+            logger.warning("Tracer failed to finish span %s: %s", name, tracer_exc)
+        raise
+    else:
+        try:
+            span_cm.__exit__(None, None, None)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Tracer failed to finish span %s: %s", name, exc)
+
+
+def set_span_data(span: TraceSpan, values: Mapping[str, Any]) -> None:
+    """Best-effort helper for attaching multiple span fields."""
+    for key, value in values.items():
+        try:
+            span.set_data(key, value)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Tracer failed to set span data %s: %s", key, exc)


### PR DESCRIPTION
## Summary
- add a shared no-op tracing hook for request-path profiling
- instrument search reformulation, embedding, unified search phase/branch spans, and individual search storage calls
- propagate contextvars into unified search worker threads so trace context stays attached

## Tests
- `uv run ruff check open_source/reflexio/reflexio/server/tracing.py open_source/reflexio/reflexio/server/services/unified_search_service.py open_source/reflexio/reflexio/lib/_base.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_user_playbook.py open_source/reflexio/reflexio/lib/_agent_playbook.py reflexio_ext/server/api.py reflexio_ext/server/services/sentry_tracer.py reflexio_ext/server/services/storage/supabase_storage/_base.py reflexio_ext/server/services/storage/supabase_storage/_profiles.py reflexio_ext/server/services/storage/supabase_storage/_playbook.py reflexio_ext/server/services/storage/postgres_storage/_base.py reflexio_ext/cli/run_services.py reflexio_ext/tests/server/test_tracing_hook.py reflexio_ext/tests/server/test_api_sentry.py reflexio_ext/tests/cli/test_run_services.py reflexio_ext/tests/server/services/test_unified_search_service.py`
- `uv run pyright open_source/reflexio/reflexio/server/tracing.py open_source/reflexio/reflexio/server/services/unified_search_service.py open_source/reflexio/reflexio/lib/_base.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_user_playbook.py open_source/reflexio/reflexio/lib/_agent_playbook.py reflexio_ext/server/api.py reflexio_ext/server/services/sentry_tracer.py reflexio_ext/server/services/storage/supabase_storage/_base.py reflexio_ext/server/services/storage/supabase_storage/_profiles.py reflexio_ext/server/services/storage/supabase_storage/_playbook.py reflexio_ext/server/services/storage/postgres_storage/_base.py reflexio_ext/cli/run_services.py reflexio_ext/tests/server/test_tracing_hook.py reflexio_ext/tests/server/test_api_sentry.py reflexio_ext/tests/cli/test_run_services.py reflexio_ext/tests/server/services/test_unified_search_service.py`
- `uv run pytest -o 'addopts=' reflexio_ext/tests/server/test_tracing_hook.py reflexio_ext/tests/server/test_api_sentry.py reflexio_ext/tests/cli/test_run_services.py reflexio_ext/tests/server/services/test_unified_search_service.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced vendor-agnostic tracing framework enabling configurable system observability and performance monitoring.

* **Chores**
  * Instrumented search operations (agents, profiles, user playbooks) with metrics collection for result counts and backend performance tracking to improve system visibility and debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->