### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -4,8 +4,8 @@ Describe the code structure and component dependencies for source code of reflex
 ## Table of Contents
 
 - [Overview](#overview)
-- [reflexio_commons and reflexio_client](#reflexio_commons-and-reflexio_client)
-- [website](#website)
+- [models and client](#models-and-client)
+- [cli](#cli)
 - [reflexio_lib](#reflexio_lib)
 - [server](#server)
 - [data](#data)
@@ -14,77 +14,71 @@ Describe the code structure and component dependencies for source code of reflex
 ## Overview
 Reflexio is a user profiling and agent playbook system with three main access patterns:
 
-1. **Remote API Access** (`reflexio_client`) - Applications use Python SDK to call REST API
+1. **Remote API Access** (`client`) - Applications use Python SDK to call REST API
 2. **Local Library Access** (`reflexio_lib`) - Direct synchronous access without HTTP layer
-3. **Web UI** (`website`) - Next.js dashboard for viewing profiles, interactions, playbooks, evaluations, and settings
+3. **CLI Access** (`cli`) - Local command-line workflows for services, publishing, search, auth, config, and diagnostics
 
 **Core Flow**: User Interactions → Server Processing → Profile/Playbook/Evaluation → Storage
 
 **Shared Components**:
-- `reflexio_commons` - Data schemas and config models (client/server contract)
+- `models` - API and internal schemas shared by client, CLI, and server
 - `server` - FastAPI backend with LLM-based processing services
-- `data` - Local storage for configs and databases
+- `data` - Bundled configs and local fixtures
+- `docs` - Next.js API documentation site
 
-## reflexio_commons and reflexio_client
-These are local packages in the main repository:
-- `reflexio_commons` source: `reflexio/reflexio_commons/reflexio_commons/`
-- `reflexio_client` source: `reflexio/reflexio_client/reflexio/`
+## models and client
+Description: Shared data contracts and the Python SDK used by external applications, the CLI, and server endpoint helpers
 
-### reflexio_commons
-**Path**: `reflexio/reflexio_commons/`
-**Installed via**: Poetry path dependency with `develop = true` (editable mode)
-
-Description: Shared schemas and configuration models used across client and server
+### models
+**Path**: `models/`
 
 #### Main Entry Points
-- **API Schemas**: `reflexio_commons/api_schema/` - Pydantic models for requests/responses
-- **Config Schema**: `reflexio_commons/config_schema.py` - Configuration data models
+- **API Schemas**: `models/api_schema/` - Pydantic request/response models for public API surfaces
+- **Internal Schemas**: `models/api_schema/internal_schema.py` - Storage-facing profile, playbook, request, evaluation, and agent-run models
+- **Validators**: `models/api_schema/validators.py` - Cross-schema validation helpers
 
 #### Purpose
 Provides type-safe data contracts between client and server:
-1. **Service Schemas** - User interactions (with `ToolUsed`), profiles, playbooks (with `BlockingIssue`), evaluation results
+1. **Service Schemas** - Interactions, requests, profiles, user playbooks, agent playbooks, evaluations, and stall-state records
 2. **Retriever Schemas** - Search/get/set requests and responses
-3. **Login Schemas** - Authentication tokens and credentials
-4. **Config Schema** - YAML configuration structure (`tool_can_use` at root `Config` level, shared across services)
+3. **Login/Auth Schemas** - Credentials, API tokens, feature flags, and organization/account responses
+4. **Config Schema** - YAML/API configuration structure (`tool_can_use` at root `Config` level, shared across services)
 
-### reflexio_client
-**Path**: `reflexio/reflexio_client/`
+### client
+**Path**: `client/`
 
 Description: Python SDK for interacting with Reflexio API remotely
 
 #### Main Entry Point
-- **Client**: `reflexio/client.py` - `ReflexioClient` class
+- **Client**: `client.py` - `ReflexioClient` class
 
 #### Purpose
 Remote API client for applications to:
 1. **Publish interactions** - Send user interactions to server for processing
-2. **Search/retrieve data** - Query profiles, interactions, playbooks
-3. **Manage profiles** - Delete profiles, view change logs
+2. **Search/retrieve data** - Query profiles, interactions, playbooks, evaluations, and context
+3. **Manage profiles/playbooks** - Delete, regenerate, and update status where supported by API endpoints
 4. **Configure** - Set/get organization configuration
 
 #### Architecture Pattern
-All methods are **async** and return typed Pydantic responses. Automatically handles authentication via Bearer tokens.
+Async HTTP client wrapping typed models from `models/api_schema/`. Automatically handles authentication via Bearer tokens.
 
-## website
-Description: Next.js frontend for viewing profiles, interactions, playbooks, and evaluations
+## cli
+Description: Command-line entry point for operating Reflexio locally and against a running server
 
 ### Main Entry Points
-- **Profiles**: `app/profiles/page.tsx` - View and search user profiles
-- **Interactions**: `app/interactions/page.tsx` - View conversation history
-- **Playbooks**: `app/feedbacks/page.tsx` - View and manage agent playbooks
-- **Evaluations**: `app/evaluations/page.tsx` - View agent success evaluation results
-- **Settings**: `app/settings/page.tsx` - Configuration and settings management
+- **CLI app**: `cli/` - Typer command groups for services, publish/search/context, auth, config, status, and diagnostics
+- **Reference**: `cli/README.md` - Command map and common workflows
 
 ### Purpose
-Web-based interface to:
-1. **View profiles** - Browse user profiles with search functionality
-2. **View interactions** - Inspect user conversation history
-3. **Manage playbooks** - View and manage extracted playbooks
-4. **Monitor evaluations** - Track agent success metrics and failure analysis
-5. **Configure settings** - Manage application configuration
+Local operator interface to:
+1. **Run services** - Start/stop backend, docs, and optional embedding service
+2. **Publish interactions** - Send JSON, JSONL, stdin, or quick single-turn payloads
+3. **Search context** - Query profiles, user playbooks, and agent playbooks
+4. **Inspect/manage data** - List/delete/regenerate profiles and playbooks
+5. **Configure/authenticate** - Manage API keys, server URL, and configuration
 
 ### Architecture Pattern
-Built with Next.js App Router and ShadCN UI components. Communicates with FastAPI backend at `http://0.0.0.0:8081`.
+Thin Typer layer over the Python client and local service manager. Use `uv run reflexio --help` to inspect command groups.
 
 ## reflexio_lib
 Description: Local Python library interface for direct (non-API) access to Reflexio functionality
@@ -119,13 +113,13 @@ Receives user interactions from clients and processes them to:
 
 ### Component Relationships
 ```
-reflexio_client (Python SDK)
+client (Python SDK)
   -> api.py (FastAPI routes)
     -> api_endpoints/ (request handlers)
       -> reflexio_lib.Reflexio (main entry)
         -> services/generation_service.py (orchestrator)
           ├─> services/profile/ -> storage (BaseStorage)
-          ├─> services/feedback/ (playbook extraction) -> storage (BaseStorage)
+          ├─> services/playbook/ (playbook extraction) -> storage (BaseStorage)
           └─> services/agent_success_evaluation/ -> storage (BaseStorage)
 ```
 
@@ -138,10 +132,16 @@ reflexio_client (Python SDK)
   - `generation_service.py` - Orchestrator (runs profile/playbook/success services)
   - `base_generation_service.py` - Abstract base for parallel actor execution
   - `profile/` - Profile extraction & updates
-  - `feedback/` - Playbook extraction & aggregation
+  - `playbook/` - Playbook extraction, consolidation, and aggregation
   - `agent_success_evaluation/` - Success evaluation
+  - `reflection/` - Post-horizon reflection extraction
+  - `extraction/` - Resumable async extraction agent infrastructure
+  - `shadow_comparison/` - Per-turn regular vs shadow verdict judge
+  - `evaluation_overview/` - Evaluation-page aggregates and hero metrics
+  - `playbook_optimizer/` - Scenario-based playbook optimization experiments
+  - `braintrust/` - Braintrust eval export/sync support
   - `storage/` - Abstract layer (SQLite prod, LocalJSON test)
-  - `retriever/` - Semantic search
+  - `pre_retrieval/` - Query rewriting and document expansion helpers
   - `configurator/` - YAML config loader
 - **`site_var/`**: Global settings singleton
 

--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -181,4 +181,4 @@ Referenced by `SimpleConfigurator` for loading configs and by database operation
 - [Playbook Service README](server/services/playbook/README.md) -- playbook extraction, aggregation, and deduplication pipeline
 - [Site Variables README](server/site_var/README.md) -- global configuration and feature flags
 - [Retrieval Latency Benchmarks](benchmarks/retrieval_latency/README.md) -- search performance benchmarking
-- [OpenClaw Integration Eval](integrations/openclaw/eval/README.md) -- end-to-end integration evaluation suite
+- [OpenClaw Integration](integrations/openclaw/README.md) -- federated OpenClaw plugin setup and behavior

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -16,6 +16,9 @@ Description: FastAPI backend server that processes user interactions to generate
   - [Profile Generation](#profile-generation)
   - [Playbook Extraction](#playbook-extraction)
   - [Agent Success Evaluation](#agent-success-evaluation)
+  - [Reflection and Async Extraction](#reflection-and-async-extraction)
+  - [Shadow Comparison and Evaluation Overview](#shadow-comparison-and-evaluation-overview)
+  - [Playbook Optimizer and Braintrust](#playbook-optimizer-and-braintrust)
   - [Query Reformulator](#query-reformulator)
   - [Unified Search Service](#unified-search-service)
   - [Storage](#storage)
@@ -310,15 +313,15 @@ Users can regenerate and manage profile versions using a four-state system:
 
 ### Playbook Extraction
 
-**Directory**: `services/feedback/`
+**Directory**: `services/playbook/`
 
 **Detailed Documentation**: See [`services/playbook/README.md`](services/playbook/README.md) for detailed component documentation.
 
 Key files:
-- `feedback_generation_service.py`: Service orchestrator
-- `feedback_extractor.py`: Extractor that extracts user playbooks
-- `feedback_aggregator.py`: Aggregates similar user playbooks (with cluster-level change detection to skip unchanged clusters)
-- `feedback_deduplicator.py`: Deduplicates newly extracted playbooks against existing DB playbooks using LLM
+- `playbook_generation_service.py`: Service orchestrator
+- `playbook_extractor.py`: Extractor that extracts user playbooks
+- `playbook_aggregator.py`: Aggregates similar user playbooks (with cluster-level change detection to skip unchanged clusters)
+- `playbook_consolidator.py`: Reconciles newly extracted playbooks against existing DB playbooks using LLM
 
 **Flow**:
 - Interactions → PlaybookExtractor (extraction-only) → PlaybookConsolidator (consolidates new vs existing DB playbooks) → UserPlaybook (with optional `blocking_issue`) → Storage
@@ -328,7 +331,7 @@ Key files:
 
 **Rerun Behavior**: Groups interactions by `user_id` for per-user playbook extraction (fetches all users, then processes each user's interactions together)
 
-**Playbook Aggregation with Cluster Change Detection** (`feedback_aggregator.py`):
+**Playbook Aggregation with Cluster Change Detection** (`playbook_aggregator.py`):
 
 Aggregation clusters user playbooks by embedding similarity, then calls LLM per cluster to produce aggregated agent playbooks. Cluster-level change detection avoids redundant LLM calls on subsequent runs:
 
@@ -403,6 +406,45 @@ Key files:
 
 **Shadow Comparison**: Session-level shadow comparison was retracted in F1 because multi-turn shadow content suffers from trajectory contamination (turn 2+ user messages react to the regular response, not the shadow). The `regular_vs_shadow` field on `AgentSuccessEvaluationResult` is preserved as a nullable historical column but is always `None` on newly produced rows. Per-turn shadow comparison lives in a dedicated `services/shadow_comparison/` judge that writes its verdicts to a separate table — see the F1 spec.
 
+### Reflection and Async Extraction
+
+**Directories**: `services/reflection/`, `services/extraction/`
+
+Key files:
+- `reflection/reflection_service.py`: Post-horizon reflection orchestration for synthesizing longer-range memory artifacts
+- `reflection/reflection_extractor.py`: LLM extractor used by the reflection service
+- `extraction/resumable_agent.py`: Resumable extraction agent runtime
+- `extraction/resume_scheduler.py` and `extraction/resume_worker.py`: Background scheduling/worker loop for paused extraction runs
+- `extraction/tools.py` and `extraction/prior_answer_search.py`: Tool surface for async extraction agents
+- `extraction/agent_run_records.py`: Persistence helpers for extraction-agent run state
+
+**Pattern**: Synchronous profile/playbook/evaluation services still follow `BaseGenerationService`; async extraction uses resumable agent-run records and worker scheduling so long-running or tool-mediated extraction can continue outside the request path.
+
+### Shadow Comparison and Evaluation Overview
+
+**Directories**: `services/shadow_comparison/`, `services/evaluation_overview/`
+
+Key files:
+- `shadow_comparison/judge.py`: Per-turn regular-vs-shadow judge that writes shadow verdicts through storage
+- `shadow_comparison/outcome.py`: Verdict outcome model helpers
+- `evaluation_overview/service.py`: Aggregates evaluation-page metrics
+- `evaluation_overview/hero_state.py`, `distribution.py`, `group_aggregation.py`, `rule_attribution.py`, `shadow_aggregation.py`: Focused aggregation helpers
+
+**Pattern**: Session-level agent success evaluation remains in `agent_success_evaluation/`; dashboard-facing rollups and per-turn shadow verdict analysis live in these companion directories.
+
+### Playbook Optimizer and Braintrust
+
+**Directories**: `services/playbook_optimizer/`, `services/braintrust/`
+
+Key files:
+- `playbook_optimizer/optimizer.py`: Scenario-based playbook optimization loop
+- `playbook_optimizer/scheduler.py` and `rollout.py`: Scheduling and rollout helpers
+- `playbook_optimizer/judge.py`, `models.py`, `scenario_resolver.py`: Evaluation and scenario resolution models
+- `playbook_optimizer/assistant_webhook.py`: Assistant-facing webhook entry point for optimizer runs
+- `braintrust/service.py`, `braintrust/client.py`, `_cron.py`: Braintrust export/sync support
+
+**Pattern**: These are evaluation/optimization integrations around the core playbook pipeline. Keep production extraction changes in `services/playbook/`; use optimizer/Braintrust modules for experiments, rollouts, and external eval sync.
+
 ### Query Reformulator
 
 **File**: `services/pre_retrieval/_query_reformulator.py` - `QueryReformulator`
@@ -432,9 +474,10 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 
 | File | Purpose |
 |------|---------|
-| `storage_base.py` | BaseStorage abstract class |
-| `local_json_storage.py` | Local file-based for testing |
-| `sqlite_storage.py` | SQLite-based storage for local/self-hosted deployments |
+| `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
+| `sqlite_storage/` | SQLite-backed implementation split across the same domains |
+| `retention.py`, `retention_mixin.py` | Data retention and cleanup helpers |
+| `constants.py`, `error.py` | Storage constants and shared errors |
 
 **Pattern**: **NEVER import storage implementations directly** - Always use `request_context.storage`
 


### PR DESCRIPTION
## Summary
- Fixed the package-level README's OpenClaw reference to point at the existing OpenClaw integration README instead of a removed eval README.

## Repositories/submodules reviewed
- ReflexioAI/reflexio (default branch: main)

## README files updated
- `reflexio/README.md`

## Validation
- `git diff --check`
- Local README markdown link check across README* files

## Notes/Risks
- README-only change; no code or package behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized project README and server README with an updated Table of Contents and clearer component naming.
  * Expanded server architecture docs to include reflection/async extraction, shadow comparison/evaluation, playbook optimization, and Braintrust integrations.
  * Updated services documentation to a playbook-focused framing and refreshed component/service catalog.
  * Revised storage documentation to describe a split directory layout.
  * Updated OpenClaw reference to the main integration guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->