### PR TITLE
feat(search): operation limiters, embedding cache, and FTS search mode

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -178,6 +178,7 @@ class SearchOptions:
 
     query_embedding: list[float] | None = field(default=None)
     search_mode: SearchMode = field(default=SearchMode.HYBRID)
+    fresh: bool = field(default=False)
     rrf_k: int = field(default=60)
     vector_weight: float = field(default=1.0)
     fts_weight: float = field(default=1.0)
@@ -203,6 +204,8 @@ class StorageConfigSupabase(BaseModel):
     key: NonEmptyStr
     db_url: NonEmptyStr
     schema_name: str | None = Field(default=None, alias="schema")
+    read_url: NonEmptyStr | None = None
+    read_key: NonEmptyStr | None = None
 
 
 class StorageConfigPostgres(BaseModel):
@@ -215,6 +218,9 @@ class StorageConfigPostgres(BaseModel):
     # Seconds a query waits for a free pooled connection before failing. Bounds the
     # back-pressure applied when concurrent queries exceed pool_size.
     pool_acquire_timeout: float = Field(default=30.0, gt=0)
+    read_db_url: NonEmptyStr | None = None
+    read_pool_size: int | None = Field(default=None, ge=1)
+    read_pool_acquire_timeout: float | None = Field(default=None, gt=0)
 
 
 class StorageConfigManagedSupabase(BaseModel):

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -164,6 +164,11 @@ from reflexio.server.cache.reflexio_cache import (
     invalidate_reflexio_cache,
 )
 from reflexio.server.correlation import correlation_id_var, generate_correlation_id
+from reflexio.server.operation_limiter import (
+    OperationName,
+    limiter_http_exception,
+    run_with_operation_limit,
+)
 from reflexio.server.services.agent_success_evaluation.group_evaluation_runner import (
     run_group_evaluation,
 )
@@ -202,6 +207,22 @@ def get_rate_limit_key(request: Request) -> str:
 
 # Initialize rate limiter
 limiter = Limiter(key_func=get_rate_limit_key)
+
+
+def _run_limited_api[T](
+    org_id: str,
+    operation: OperationName,
+    fn: Callable[[], T],
+) -> T:
+    try:
+        return run_with_operation_limit(
+            org_id=org_id,
+            operation=operation,
+            fn=fn,
+        )
+    except TimeoutError as exc:
+        http_exc = limiter_http_exception(operation)
+        raise http_exc from exc
 
 
 def configure_rate_limiter(key_func: Callable[..., str]) -> None:
@@ -390,11 +411,29 @@ def publish_user_interaction(
 ) -> PublishUserInteractionResponse:
     if wait_for_response:
         # Process synchronously so the caller gets the real result
-        return publisher_api.add_user_interaction(org_id=org_id, request=payload)
+        return _run_limited_api(
+            org_id,
+            "publish",
+            lambda: publisher_api.add_user_interaction(org_id=org_id, request=payload),
+        )
+
+    def _limited_publish_task() -> None:
+        try:
+            run_with_operation_limit(
+                org_id=org_id,
+                operation="publish",
+                fn=lambda: publisher_api.add_user_interaction(
+                    org_id=org_id, request=payload
+                ),
+            )
+        except TimeoutError:
+            logger.warning(
+                "Dropped queued publish for org %s because publish limiter is saturated",
+                org_id,
+            )
+
     # Run in background — caller gets immediate acknowledgement
-    background_tasks.add_task(
-        publisher_api.add_user_interaction, org_id=org_id, request=payload
-    )
+    background_tasks.add_task(_limited_publish_task)
     return PublishUserInteractionResponse(
         success=True, message="Interaction queued for processing"
     )
@@ -483,7 +522,11 @@ def search_user_profiles(
     payload: SearchUserProfileRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> SearchProfilesViewResponse:
-    response = get_reflexio(org_id=org_id).search_user_profiles(payload)
+    response = _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).search_user_profiles(payload),
+    )
     return SearchProfilesViewResponse(
         success=response.success,
         user_profiles=[to_profile_view(p) for p in response.user_profiles],
@@ -512,7 +555,11 @@ def rerank_user_profiles(
     Returns:
         SearchProfilesViewResponse: Reranked profiles, top_k entries.
     """
-    response = get_reflexio(org_id=org_id).rerank_user_profiles(payload)
+    response = _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).rerank_user_profiles(payload),
+    )
     return SearchProfilesViewResponse(
         success=response.success,
         user_profiles=[to_profile_view(p) for p in response.user_profiles],
@@ -542,8 +589,12 @@ def storage_stats(
     Returns:
         StorageStatsResponse: Counts and timestamp range for the user.
     """
-    return get_reflexio(org_id=org_id).storage_stats(
-        StorageStatsRequest(user_id=user_id)
+    return _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).storage_stats(
+            StorageStatsRequest(user_id=user_id)
+        ),
     )
 
 
@@ -558,7 +609,11 @@ def search_interactions(
     payload: SearchInteractionRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> SearchInteractionsViewResponse:
-    response = get_reflexio(org_id=org_id).search_interactions(payload)
+    response = _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).search_interactions(payload),
+    )
     return SearchInteractionsViewResponse(
         success=response.success,
         interactions=[to_interaction_view(i) for i in response.interactions],
@@ -590,7 +645,11 @@ def search_user_playbooks_endpoint(
     Returns:
         SearchUserPlaybooksViewResponse: Response containing matching user playbooks
     """
-    response = get_reflexio(org_id=org_id).search_user_playbooks(payload)
+    response = _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).search_user_playbooks(payload),
+    )
     return SearchUserPlaybooksViewResponse(
         success=response.success,
         user_playbooks=[to_user_playbook_view(rf) for rf in response.user_playbooks],
@@ -622,7 +681,11 @@ def search_agent_playbooks_endpoint(
     Returns:
         SearchAgentPlaybooksViewResponse: Response containing matching agent playbooks
     """
-    response = get_reflexio(org_id=org_id).search_agent_playbooks(payload)
+    response = _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).search_agent_playbooks(payload),
+    )
     return SearchAgentPlaybooksViewResponse(
         success=response.success,
         agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
@@ -655,7 +718,11 @@ def unified_search_endpoint(
     Returns:
         UnifiedSearchViewResponse: Combined search results
     """
-    response = get_reflexio(org_id=org_id).unified_search(payload, org_id=org_id)
+    response = _run_limited_api(
+        org_id,
+        "search",
+        lambda: get_reflexio(org_id=org_id).unified_search(payload, org_id=org_id),
+    )
     return UnifiedSearchViewResponse(
         success=response.success,
         profiles=[to_profile_view(p) for p in response.profiles],
@@ -1152,7 +1219,11 @@ def run_playbook_aggregation(
     payload: RunPlaybookAggregationRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> RunPlaybookAggregationResponse:
-    return publisher_api.run_playbook_aggregation(org_id=org_id, request=payload)
+    return _run_limited_api(
+        org_id,
+        "aggregation",
+        lambda: publisher_api.run_playbook_aggregation(org_id=org_id, request=payload),
+    )
 
 
 @core_router.post("/api/set_config")

--- a/reflexio/server/operation_limiter.py
+++ b/reflexio/server/operation_limiter.py
@@ -1,0 +1,179 @@
+"""Process-local concurrency limiters for latency-sensitive operations."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from collections.abc import Callable
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from fastapi import HTTPException, status
+
+from reflexio.server.usage_metrics import record_usage_event
+
+OperationName = Literal["search", "publish", "aggregation"]
+
+_DEFAULT_LIMITS: dict[OperationName, int] = {
+    "search": 8,
+    "publish": 4,
+    "aggregation": 1,
+}
+_DEFAULT_TIMEOUT_SECONDS: dict[OperationName, float] = {
+    "search": 2.0,
+    "publish": 5.0,
+    "aggregation": 1.0,
+}
+
+
+@dataclass
+class _LimiterState:
+    semaphore: threading.BoundedSemaphore
+    limit: int
+    waiting: int = 0
+
+
+_limiters: dict[tuple[str, OperationName], _LimiterState] = {}
+_limiters_lock = threading.Lock()
+
+
+def _env_key(operation: OperationName, suffix: str) -> str:
+    return f"REFLEXIO_{operation.upper()}_CONCURRENCY_{suffix}"
+
+
+def _limit_for(operation: OperationName) -> int:
+    raw = os.getenv(_env_key(operation, "LIMIT"), "").strip()
+    if raw.isdigit():
+        return max(1, int(raw))
+    return _DEFAULT_LIMITS[operation]
+
+
+def _timeout_for(operation: OperationName) -> float:
+    raw = os.getenv(_env_key(operation, "TIMEOUT_SECONDS"), "").strip()
+    if raw:
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_TIMEOUT_SECONDS[operation]
+
+
+def _state_for(org_id: str, operation: OperationName) -> _LimiterState:
+    key = (str(org_id), operation)
+    desired_limit = _limit_for(operation)
+    with _limiters_lock:
+        state = _limiters.get(key)
+        if state is None or state.limit != desired_limit:
+            state = _LimiterState(
+                semaphore=threading.BoundedSemaphore(desired_limit),
+                limit=desired_limit,
+            )
+            _limiters[key] = state
+        return state
+
+
+def _record_limiter_event(
+    *,
+    org_id: str,
+    operation: OperationName,
+    event_name: str,
+    outcome: str,
+    wait_ms: int,
+    waiting: int,
+    limit: int,
+) -> None:
+    record_usage_event(
+        org_id=org_id,
+        event_name=event_name,
+        event_category="limiter",
+        pipeline=operation,
+        outcome=outcome,
+        duration_ms=wait_ms,
+        metadata={
+            "operation": operation,
+            "waiting": waiting,
+            "limit": limit,
+        },
+    )
+
+
+@contextmanager
+def operation_limit(
+    org_id: str,
+    operation: OperationName,
+    *,
+    timeout_seconds: float | None = None,
+) -> Any:
+    """Acquire the per-org limiter for an operation, recording wait metrics."""
+    state = _state_for(org_id, operation)
+    timeout = _timeout_for(operation) if timeout_seconds is None else timeout_seconds
+    start = time.perf_counter()
+    with _limiters_lock:
+        state.waiting += 1
+        waiting = state.waiting
+    acquired = False
+    try:
+        acquired = state.semaphore.acquire(timeout=timeout)
+        wait_ms = int((time.perf_counter() - start) * 1000)
+        with _limiters_lock:
+            state.waiting -= 1
+            waiting_after = state.waiting
+        if not acquired:
+            _record_limiter_event(
+                org_id=org_id,
+                operation=operation,
+                event_name="limiter_acquire_timeout",
+                outcome="timeout",
+                wait_ms=wait_ms,
+                waiting=waiting_after,
+                limit=state.limit,
+            )
+            raise TimeoutError(
+                f"{operation} concurrency limit reached for org {org_id}"
+            )
+        _record_limiter_event(
+            org_id=org_id,
+            operation=operation,
+            event_name="limiter_acquired",
+            outcome="acquired",
+            wait_ms=wait_ms,
+            waiting=waiting,
+            limit=state.limit,
+        )
+        yield
+    finally:
+        if acquired:
+            state.semaphore.release()
+
+
+def run_with_operation_limit[T](
+    *,
+    org_id: str,
+    operation: OperationName,
+    fn: Callable[[], T],
+    timeout_seconds: float | None = None,
+) -> T:
+    with operation_limit(org_id, operation, timeout_seconds=timeout_seconds):
+        return fn()
+
+
+def limiter_http_exception(operation: OperationName) -> HTTPException:
+    """Return the API error used when an operation limiter is saturated."""
+    retry_after = str(max(1, int(_timeout_for(operation))))
+    status_code = (
+        status.HTTP_429_TOO_MANY_REQUESTS
+        if operation == "search"
+        else status.HTTP_503_SERVICE_UNAVAILABLE
+    )
+    return HTTPException(
+        status_code=status_code,
+        detail=f"{operation} concurrency limit reached",
+        headers={"Retry-After": retry_after},
+    )
+
+
+def reset_operation_limiters_for_tests() -> None:
+    with _limiters_lock:
+        _limiters.clear()

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import os
+import threading
 import time
 import uuid
 from collections.abc import Callable
@@ -57,6 +59,23 @@ CLEANUP_STALE_LOCK_SECONDS = 600
 # Timeout for the outer generation service parallel execution
 GENERATION_SERVICE_TIMEOUT_SECONDS = 600
 _STALL_WARNING_PREFIX = "Reflexio learning is paused"
+
+
+def _retention_cleanup_interval_seconds() -> float:
+    raw = os.getenv("REFLEXIO_RETENTION_CLEANUP_INTERVAL_SECONDS", "300") or "300"
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        logger.warning(
+            "Invalid REFLEXIO_RETENTION_CLEANUP_INTERVAL_SECONDS=%r; using 300",
+            raw,
+        )
+        return 300.0
+
+
+_RETENTION_CLEANUP_INTERVAL_SECONDS = _retention_cleanup_interval_seconds()
+_retention_cleanup_last_run: dict[tuple[str, str], float] = {}
+_retention_cleanup_lock = threading.Lock()
 
 
 @dataclass
@@ -449,10 +468,11 @@ class GenerationService:
 
     def _cleanup_storage_tables_if_needed(self) -> None:
         """Best-effort publish-boundary cleanup for capped storage tables."""
+        now = time.monotonic()
         limits = {
             target_name: limit
             for target_name, limit in get_row_retention_limits().items()
-            if limit > 0
+            if limit > 0 and self._should_check_retention_target(target_name, now)
         }
         if not limits:
             return
@@ -484,6 +504,20 @@ class GenerationService:
         except Exception as e:
             logger.error("Failed to cleanup storage tables: %s", e)
             # Don't raise - cleanup failure shouldn't block normal operation
+
+    def _should_check_retention_target(self, target_name: str, now: float) -> bool:
+        if _RETENTION_CLEANUP_INTERVAL_SECONDS <= 0:
+            return True
+        key = (self.org_id, target_name)
+        with _retention_cleanup_lock:
+            last_run = _retention_cleanup_last_run.get(key)
+            if (
+                last_run is not None
+                and now - last_run < _RETENTION_CLEANUP_INTERVAL_SECONDS
+            ):
+                return False
+            _retention_cleanup_last_run[key] = now
+            return True
 
     def _active_learning_stall_warning(self) -> str | None:
         """Return a warning when extraction should not auto-retry.

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -21,6 +21,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
 )
 from reflexio.models.config_schema import PlaybookConfig
+from reflexio.server.operation_limiter import run_with_operation_limit
 from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     StatusChangeOperation,
@@ -458,7 +459,18 @@ class PlaybookGenerationService(
             request_context=self.request_context,
             agent_version=self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
         )
-        aggregator.run(aggregator_request)
+        try:
+            run_with_operation_limit(
+                org_id=self.request_context.org_id,
+                operation="aggregation",
+                fn=lambda: aggregator.run(aggregator_request),
+            )
+        except TimeoutError:
+            logger.info(
+                "Skipping inline aggregation for playbook_name=%s agent_version=%s: aggregation limiter is saturated",
+                playbook_name,
+                self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
+            )
 
     # ===============================
     # Rerun hook implementations (override base class methods)

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import os
+import threading
+import time
+from collections import OrderedDict
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -29,7 +33,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
     UserProfile,
 )
-from reflexio.models.config_schema import SearchOptions
+from reflexio.models.config_schema import SearchMode, SearchOptions
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.pre_retrieval import QueryReformulator
@@ -49,6 +53,23 @@ _DEFAULT_ENTITY_TYPES = frozenset({"profiles", "agent_playbooks", "user_playbook
 _DEFAULT_AGENT_PLAYBOOK_STATUSES: tuple[PlaybookStatus, ...] = (
     PlaybookStatus.APPROVED,
     PlaybookStatus.PENDING,
+)
+_SEARCH_FANOUT_MAX_WORKERS = max(
+    1, int(os.getenv("REFLEXIO_SEARCH_FANOUT_WORKERS", "16") or "16")
+)
+_SEARCH_FANOUT_EXECUTOR = ThreadPoolExecutor(
+    max_workers=_SEARCH_FANOUT_MAX_WORKERS,
+    thread_name_prefix="reflexio-search",
+)
+_EMBEDDING_CACHE_TTL_SECONDS = max(
+    0, int(os.getenv("REFLEXIO_QUERY_EMBEDDING_CACHE_TTL_SECONDS", "300") or "300")
+)
+_EMBEDDING_CACHE_MAX_SIZE = max(
+    1, int(os.getenv("REFLEXIO_QUERY_EMBEDDING_CACHE_MAX_SIZE", "1024") or "1024")
+)
+_embedding_cache_lock = threading.Lock()
+_embedding_cache: OrderedDict[tuple[str, int, str, str], tuple[float, list[float]]] = (
+    OrderedDict()
 )
 
 
@@ -94,6 +115,7 @@ def run_unified_search(
         conversation_history=request.conversation_history,
         enable_reformulation=bool(request.enable_reformulation),
         pre_retrieval_model_name=pre_retrieval_model_name,
+        search_mode=request.search_mode,
     )
 
     # --- Phase B: parallel searches across all entity types ---
@@ -130,6 +152,7 @@ def _run_phase_a(
     conversation_history: list[ConversationTurn] | None = None,
     enable_reformulation: bool = False,
     pre_retrieval_model_name: str | None = None,
+    search_mode: SearchMode = SearchMode.HYBRID,
 ) -> tuple[str, list[float] | None]:
     """Run query reformulation and embedding generation sequentially.
 
@@ -143,6 +166,7 @@ def _run_phase_a(
         conversation_history (list, optional): Prior conversation turns for context-aware query reformulation
         enable_reformulation (bool): Whether query reformulation is enabled for this request
         pre_retrieval_model_name (str, optional): Model name override for query reformulation
+        search_mode (SearchMode): Search mode; FTS-only mode skips embedding generation entirely
 
     Returns:
         tuple[str, Optional[list[float]]]: (standalone_query, embedding_vector) — embedding is None when unsupported or on failure
@@ -165,16 +189,17 @@ def _run_phase_a(
         else:
             standalone_query = query
 
-    # Embedding generation (uses reformulated query for semantic accuracy)
+    # Embedding generation (uses reformulated query for semantic accuracy).
+    # FTS-only search has no use for an embedding, so skip the call entirely.
     embedding = None
-    if supports_embedding:
+    if supports_embedding and search_mode != SearchMode.FTS:
         with profile_step(
             "search.embedding",
             backend=_storage_backend_name(storage),
             purpose="query",
         ) as span:
             try:
-                embedding = storage._get_embedding(standalone_query, purpose="query")  # type: ignore[reportAttributeAccessIssue]
+                embedding = _get_cached_query_embedding(storage, standalone_query)
                 span.set_data("embedding_generated", embedding is not None)
             except Exception as e:
                 span.set_data("embedding_generated", False)
@@ -210,11 +235,10 @@ def _run_phase_b(
     Returns:
         tuple: (profiles, agent_playbooks, user_playbooks) — all None on timeout/failure
     """
-    options = SearchOptions(query_embedding=embedding)
+    options = SearchOptions(query_embedding=embedding, search_mode=request.search_mode)
 
     entity_types = set(request.entity_types or _DEFAULT_ENTITY_TYPES)
     allowed_agent_statuses = request.agent_playbook_status_filter
-    executor = ThreadPoolExecutor(max_workers=3)
     try:
         with profile_step(
             "search.phase_b",
@@ -224,7 +248,7 @@ def _run_phase_b(
         ) as span:
             profiles_future = (
                 _submit_with_current_context(
-                    executor,
+                    _SEARCH_FANOUT_EXECUTOR,
                     _search_profiles_via_storage,
                     storage,
                     query,
@@ -232,13 +256,14 @@ def _run_phase_b(
                     threshold,
                     request.user_id,
                     embedding,
+                    request.search_mode,
                 )
                 if "profiles" in entity_types
                 else None
             )
             agent_playbooks_future = (
                 _submit_with_current_context(
-                    executor,
+                    _SEARCH_FANOUT_EXECUTOR,
                     _search_agent_playbooks_via_storage,
                     storage,
                     query,
@@ -261,9 +286,10 @@ def _run_phase_b(
                     status_filter=None,
                     threshold=threshold,
                     top_k=top_k,
+                    search_mode=request.search_mode,
                 )
                 user_playbooks_future = _submit_with_current_context(
-                    executor,
+                    _SEARCH_FANOUT_EXECUTOR,
                     _search_user_playbooks_via_storage,
                     storage,
                     rf_request,
@@ -297,10 +323,38 @@ def _run_phase_b(
     except Exception as e:
         logger.error("Unified search failed: %s", e)
         return None, None, None
-    finally:
-        executor.shutdown(wait=False, cancel_futures=True)
 
     return profiles, agent_playbooks, user_playbooks
+
+
+def _get_cached_query_embedding(
+    storage: BaseStorage,
+    query: str,
+) -> list[float]:
+    """Return a cached query embedding when available."""
+    model_name = str(getattr(storage, "embedding_model_name", "unknown"))
+    dimensions = int(getattr(storage, "embedding_dimensions", 0) or 0)
+    normalized_query = " ".join(query.casefold().split())
+    key = (model_name, dimensions, normalized_query, "query")
+    now = time.monotonic()
+    if _EMBEDDING_CACHE_TTL_SECONDS > 0:
+        with _embedding_cache_lock:
+            cached = _embedding_cache.get(key)
+            if cached is not None:
+                created_at, value = cached
+                if now - created_at <= _EMBEDDING_CACHE_TTL_SECONDS:
+                    _embedding_cache.move_to_end(key)
+                    return list(value)
+                del _embedding_cache[key]
+
+    embedding = storage._get_embedding(query, purpose="query")  # type: ignore[reportAttributeAccessIssue]
+    if _EMBEDDING_CACHE_TTL_SECONDS > 0 and embedding:
+        with _embedding_cache_lock:
+            _embedding_cache[key] = (now, list(embedding))
+            _embedding_cache.move_to_end(key)
+            while len(_embedding_cache) > _EMBEDDING_CACHE_MAX_SIZE:
+                _embedding_cache.popitem(last=False)
+    return embedding
 
 
 def _search_agent_playbooks_via_storage(
@@ -337,6 +391,7 @@ def _search_agent_playbooks_via_storage(
             playbook_status_filter=statuses,
             threshold=threshold,
             top_k=top_k,
+            search_mode=options.search_mode,
         )
         results: list[AgentPlaybook] = []
         seen_ids: set[str] = set()
@@ -358,6 +413,7 @@ def _search_profiles_via_storage(
     threshold: float,
     user_id: str | None,
     embedding: list[float] | None,
+    search_mode: SearchMode,
 ) -> list[UserProfile]:
     """Search profiles via storage.search_user_profile, returning [] on error or missing user_id.
 
@@ -368,6 +424,7 @@ def _search_profiles_via_storage(
         threshold (float): Minimum match threshold
         user_id (Optional[str]): User ID filter (required for profile search)
         embedding (Optional[list[float]]): Pre-computed query embedding, or None for text-only search
+        search_mode (SearchMode): Search mode (hybrid/vector/fts)
 
     Returns:
         list[UserProfile]: Matching profiles, or [] on error/missing user_id
@@ -387,6 +444,7 @@ def _search_profiles_via_storage(
                     query=query,
                     top_k=top_k,
                     threshold=threshold,
+                    search_mode=search_mode,
                 ),
                 status_filter=[None],
                 query_embedding=embedding,

--- a/tests/server/test_operation_limiter.py
+++ b/tests/server/test_operation_limiter.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import threading
+
+import pytest
+from fastapi import status
+
+from reflexio.server.operation_limiter import (
+    limiter_http_exception,
+    operation_limit,
+    reset_operation_limiters_for_tests,
+)
+from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiters_and_metrics():
+    reset_operation_limiters_for_tests()
+    configure_usage_event_recorder(None)
+    yield
+    reset_operation_limiters_for_tests()
+    configure_usage_event_recorder(None)
+
+
+def test_operation_limiter_records_success_and_timeout(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_SEARCH_CONCURRENCY_LIMIT", "1")
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    ready = threading.Event()
+    release = threading.Event()
+
+    def _hold_limit() -> None:
+        with operation_limit("org_1", "search", timeout_seconds=0.1):
+            ready.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=_hold_limit)
+    holder.start()
+    try:
+        assert ready.wait(timeout=5)
+        with (
+            pytest.raises(TimeoutError),
+            operation_limit("org_1", "search", timeout_seconds=0.01),
+        ):
+            pass
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    event_names = [event.event_name for event in events]
+    assert "limiter_acquired" in event_names
+    assert "limiter_acquire_timeout" in event_names
+    timeout_event = next(e for e in events if e.event_name == "limiter_acquire_timeout")
+    assert timeout_event.event_category == "limiter"
+    assert timeout_event.pipeline == "search"
+    assert timeout_event.metadata["operation"] == "search"
+
+
+def test_limiter_http_exception_maps_search_to_429():
+    exc = limiter_http_exception("search")
+
+    assert exc.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert exc.headers == {"Retry-After": "2"}


### PR DESCRIPTION
## Summary

Reduces search latency and protects storage backends under concurrent load. This is the open-source core half of the change; the enterprise storage wiring (read replicas, playbook-filter RPCs) lives in a companion enterprise PR.

## Changes

**Operation concurrency limiters** (`server/operation_limiter.py`)
- Process-local, per-org `BoundedSemaphore` limiters for `search`, `publish`, and `aggregation`, each with a bounded acquire timeout.
- Emits `limiter_acquired` / `limiter_acquire_timeout` usage-metric events (wait time, queue depth, limit).
- Limits and timeouts are env-tunable (`REFLEXIO_{SEARCH,PUBLISH,AGGREGATION}_CONCURRENCY_LIMIT` / `_TIMEOUT_SECONDS`).
- `limiter_http_exception` maps saturation to HTTP 429 (search) or 503 (publish/aggregation) with a `Retry-After` header.

**Search path** (`server/services/unified_search_service.py`)
- Cache query embeddings with a TTL + LRU; skip embedding generation entirely in FTS-only mode.
- Share a single bounded thread pool for search fan-out instead of constructing a new `ThreadPoolExecutor` per request (preserves tracing context via `contextvars`).
- Plumb `search_mode` through phase A/B and into the per-entity storage requests.

**API + services** (`server/api.py`, `generation_service.py`, `playbook_generation_service.py`)
- Wrap search / publish / aggregation endpoints with the operation limiter; background publishes and inline aggregation degrade gracefully when saturated.
- Throttle publish-boundary retention cleanup to a configurable interval (`REFLEXIO_RETENTION_CLEANUP_INTERVAL_SECONDS`).

**Config** (`models/config_schema.py`)
- Add `read_url`/`read_key` to Supabase and `read_db_url` + read-pool settings to Postgres storage configs (consumed by the enterprise storage layer).
- Add `SearchOptions.fresh`.

## Test Plan

- `tests/server/test_operation_limiter.py` covers acquire/timeout/release, metric emission, and limit reconfiguration.
- `uv run pyright` and `uv run ruff check` pass on the changed files.
- Imports verified (`python -c "import reflexio.server.api"`).
