### PR TITLE
feat(llm): strict structured output, discriminated-union support, parse-failure retry

### DIFF
--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -130,7 +130,7 @@ def _prompt_llm_provider(env_path: Path) -> tuple[str, str, str]:
 _EMBEDDING_MODEL_NAMES: dict[str, str] = {
     "local": "local/minilm-l6-v2",
     "openai": "text-embedding-3-small",
-    "gemini": "text-embedding-004",
+    "gemini": "gemini/gemini-embedding-001",
 }
 
 
@@ -170,7 +170,7 @@ def _build_embedding_choices() -> list[tuple[str, str | None, str]]:
     choices.extend(
         [
             ("openai", "OPENAI_API_KEY", "OpenAI (text-embedding-3-small)"),
-            ("gemini", "GEMINI_API_KEY", "Gemini (text-embedding-004)"),
+            ("gemini", "GEMINI_API_KEY", "Gemini (gemini-embedding-001)"),
         ]
     )
     return choices

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -27,7 +27,10 @@ from reflexio.server.llm.image_utils import (
 from reflexio.server.llm.image_utils import (
     encode_image_to_base64 as _encode_image_to_base64,
 )
-from reflexio.server.llm.llm_utils import is_pydantic_model
+from reflexio.server.llm.llm_utils import (
+    is_pydantic_model,
+    strict_response_format_for_model,
+)
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.llm.providers.claude_code_provider import (
     register_if_enabled as _register_claude_code,
@@ -745,6 +748,7 @@ class LiteLLMClient:
             Tuple of (params dict, response_format, parse_structured_output, max_retries)
         """
         response_format = kwargs.pop("response_format", None)
+        strict_response_format = kwargs.pop("strict_response_format", True)
         parse_structured_output = kwargs.pop("parse_structured_output", True)
         max_retries_arg = kwargs.pop("max_retries", self.config.max_retries)
         try:
@@ -819,7 +823,11 @@ class LiteLLMClient:
         if self.config.top_p != 1.0:
             params["top_p"] = self.config.top_p
         if response_format:
-            params["response_format"] = response_format
+            params["response_format"] = self._provider_response_format(
+                response_format=response_format,
+                model=actual_model,
+                strict_response_format=strict_response_format,
+            )
         if tools is not None:
             params["tools"] = tools
         if tool_choice is not None:
@@ -853,6 +861,37 @@ class LiteLLMClient:
         )
 
         return params, response_format, parse_structured_output, max_retries
+
+    @staticmethod
+    @lru_cache(maxsize=256)
+    def _supports_response_schema(model: str) -> bool:
+        try:
+            return bool(litellm.supports_response_schema(model=model))
+        except Exception:
+            return False
+
+    def _provider_response_format(
+        self,
+        *,
+        response_format: Any,
+        model: str,
+        strict_response_format: bool,
+    ) -> Any:
+        """Return the provider-facing response_format while preserving parser schema.
+
+        Callers pass a Pydantic model so local parsing stays type-safe. When
+        LiteLLM says the target model supports JSON Schema response formats, we
+        send an explicit strict schema to constrain generation. Unsupported
+        providers keep the existing Pydantic response_format behavior.
+        """
+
+        if (
+            strict_response_format
+            and is_pydantic_model(response_format)
+            and self._supports_response_schema(model)
+        ):
+            return strict_response_format_for_model(response_format)
+        return response_format
 
     def _compute_cost_usd(self, response: Any, model: str | None) -> float | None:
         """Compute call cost in USD via the litellm price table.
@@ -993,7 +1032,13 @@ class LiteLLMClient:
         )
 
         last_error: Exception | None = None
-        for attempt in range(max_retries):
+        # A StructuredOutputParseError is typically a transient malformed or
+        # truncated response that succeeds on a fresh generation, so grant it
+        # one extra attempt beyond the configured budget (once per request).
+        effective_max_retries = max_retries
+        structured_parse_retry_granted = False
+        attempt = 0
+        while attempt < effective_max_retries:
             request_start = time.perf_counter()
             self.logger.info(
                 "event=llm_request_start model=%s timeout=%s has_response_format=%s attempt=%d/%d",
@@ -1001,7 +1046,7 @@ class LiteLLMClient:
                 params.get("timeout"),
                 response_format is not None,
                 attempt + 1,
-                max_retries,
+                effective_max_retries,
             )
             try:
                 response = litellm.completion(**params)
@@ -1017,7 +1062,7 @@ class LiteLLMClient:
                     params.get("timeout"),
                     response_format is not None,
                     attempt + 1,
-                    max_retries,
+                    effective_max_retries,
                     elapsed_seconds,
                     True,
                 )
@@ -1044,12 +1089,24 @@ class LiteLLMClient:
             except Exception as e:
                 last_error = e
                 elapsed_seconds = time.perf_counter() - request_start
+                if (
+                    isinstance(e, StructuredOutputParseError)
+                    and not structured_parse_retry_granted
+                ):
+                    structured_parse_retry_granted = True
+                    effective_max_retries += 1
                 self._handle_retry_or_raise(
-                    e, params, attempt, max_retries, response_format, elapsed_seconds
+                    e,
+                    params,
+                    attempt,
+                    effective_max_retries,
+                    response_format,
+                    elapsed_seconds,
                 )
+            attempt += 1
 
         raise LiteLLMClientError(
-            f"API call failed after {max_retries} retries: {str(last_error)}"
+            f"API call failed after {effective_max_retries} retries: {str(last_error)}"
         )
 
     def _apply_prompt_caching(

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -814,6 +814,9 @@ class LiteLLMClient:
                 default_seed,
             )
             params["seed"] = default_seed
+        # Keep seed best-effort without mutating LiteLLM's process-wide
+        # drop_params setting. Providers that do not support seed can ignore it.
+        params["drop_params"] = True
         if seed_explicit and not self._is_temperature_restricted_model(actual_model):
             params["temperature"] = 0.0
 

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -60,6 +60,16 @@ def make_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
         for keyword in _STRICT_SCHEMA_UNSUPPORTED_KEYWORDS:
             node.pop(keyword, None)
 
+        # Strict structured output (OpenAI) permits ``anyOf`` but rejects
+        # ``oneOf`` and ``discriminator``. Pydantic emits ``oneOf`` for
+        # discriminated unions; fold it into ``anyOf`` so generation is
+        # constrained to the same variants. Pydantic still enforces the
+        # discriminator after parse, so semantics are preserved.
+        one_of = node.pop("oneOf", None)
+        node.pop("discriminator", None)
+        if isinstance(one_of, list):
+            node["anyOf"] = node.get("anyOf", []) + one_of
+
         properties = node.get("properties")
         if isinstance(properties, dict):
             node["additionalProperties"] = False
@@ -79,7 +89,7 @@ def make_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
         for key in ("items", "contains", "not"):
             visit(node.get(key))
 
-        for key in ("anyOf", "oneOf", "allOf", "prefixItems"):
+        for key in ("anyOf", "allOf", "prefixItems"):
             children = node.get(key)
             if isinstance(children, list):
                 for child in children:

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -1,7 +1,29 @@
 import inspect
+from copy import deepcopy
 from typing import Any
 
 from pydantic import BaseModel
+
+_STRICT_SCHEMA_UNSUPPORTED_KEYWORDS = frozenset(
+    {
+        "exclusiveMaximum",
+        "exclusiveMinimum",
+        "format",
+        "maxItems",
+        "maxLength",
+        "maxProperties",
+        "maximum",
+        "minItems",
+        "minLength",
+        "minProperties",
+        "minimum",
+        "multipleOf",
+        "pattern",
+        "patternProperties",
+        "propertyNames",
+        "uniqueItems",
+    }
+)
 
 
 def is_pydantic_model(response_format: Any) -> bool:
@@ -15,3 +37,66 @@ def is_pydantic_model(response_format: Any) -> bool:
         True if response_format is a Pydantic BaseModel class, False otherwise.
     """
     return inspect.isclass(response_format) and issubclass(response_format, BaseModel)
+
+
+def make_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a JSON schema shaped for strict structured-output decoding.
+
+    Strict structured-output providers generally require object schemas to
+    forbid extra keys and list all properties as required. Pydantic optional
+    fields are still preserved as nullable via their existing ``anyOf`` /
+    ``type: ["...", "null"]`` schema, so the model can emit ``null`` instead
+    of omitting the field. Provider-unsupported validation keywords are
+    removed from the request schema; Pydantic still enforces them after parse.
+    """
+
+    strict_schema = deepcopy(schema)
+
+    def visit(node: Any) -> None:
+        if not isinstance(node, dict):
+            return
+
+        node.pop("default", None)
+        for keyword in _STRICT_SCHEMA_UNSUPPORTED_KEYWORDS:
+            node.pop(keyword, None)
+
+        properties = node.get("properties")
+        if isinstance(properties, dict):
+            node["additionalProperties"] = False
+            node["required"] = list(properties.keys())
+            for child in properties.values():
+                visit(child)
+        else:
+            additional = node.get("additionalProperties")
+            if isinstance(additional, dict):
+                visit(additional)
+
+        defs = node.get("$defs")
+        if isinstance(defs, dict):
+            for child in defs.values():
+                visit(child)
+
+        for key in ("items", "contains", "not"):
+            visit(node.get(key))
+
+        for key in ("anyOf", "oneOf", "allOf", "prefixItems"):
+            children = node.get(key)
+            if isinstance(children, list):
+                for child in children:
+                    visit(child)
+
+    visit(strict_schema)
+    return strict_schema
+
+
+def strict_response_format_for_model(model: type[BaseModel]) -> dict[str, Any]:
+    """Build a LiteLLM/OpenAI-compatible strict ``json_schema`` response format."""
+
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": model.__name__,
+            "schema": make_strict_json_schema(model.model_json_schema()),
+            "strict": True,
+        },
+    }

--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -207,7 +207,7 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
         evaluation="gemini/gemini-3-flash-preview",
         should_run="gemini/gemini-3-flash-preview",
         pre_retrieval="gemini/gemini-3-flash-preview",
-        embedding="gemini/text-embedding-004",
+        embedding="gemini/gemini-embedding-001",
     ),
     "deepseek": ProviderDefaults(
         generation="deepseek/deepseek-chat",

--- a/reflexio/server/llm/tools.py
+++ b/reflexio/server/llm/tools.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from reflexio.server.llm.llm_utils import make_strict_json_schema
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 
 if TYPE_CHECKING:
@@ -67,14 +68,19 @@ class Tool(BaseModel):
     name: str
     args_model: type[BaseModel]
     handler: Callable[[BaseModel, Any], ToolHandlerResult]
+    strict: bool = True
 
     def openai_spec(self) -> dict:
+        parameters = self.args_model.model_json_schema()
+        if self.strict:
+            parameters = make_strict_json_schema(parameters)
         return {
             "type": "function",
             "function": {
                 "name": self.name,
                 "description": (self.args_model.__doc__ or "").strip(),
-                "parameters": self.args_model.model_json_schema(),
+                "parameters": parameters,
+                "strict": self.strict,
             },
         }
 

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from reflexio.models.config_schema import (
     AnthropicConfig,
@@ -44,6 +44,7 @@ from reflexio.server.llm.litellm_client import (
     _truncate_for_embedding,
     create_litellm_client,
 )
+from reflexio.server.llm.llm_utils import make_strict_json_schema
 
 # ---------------------------------------------------------------------------
 # Pydantic models used for structured-output tests
@@ -1063,6 +1064,96 @@ class TestMaybeParseStructuredOutput:
             )
 
 
+class TestStrictStructuredOutputRequest:
+    """Provider-facing structured output request format."""
+
+    def test_strict_json_schema_strips_provider_unsupported_constraints(self):
+        class NestedLabel(BaseModel):
+            label: str = Field(min_length=1, max_length=20)
+
+        class BoundedScore(BaseModel):
+            score: float = Field(ge=0.0, le=1.0)
+            tags: list[str] = Field(min_length=1, max_length=3)
+            code: str = Field(min_length=2, max_length=8, pattern="^[a-z]+$")
+            nested: NestedLabel
+
+        schema = make_strict_json_schema(BoundedScore.model_json_schema())
+
+        score_schema = schema["properties"]["score"]
+        tags_schema = schema["properties"]["tags"]
+        code_schema = schema["properties"]["code"]
+        assert "minimum" not in score_schema
+        assert "maximum" not in score_schema
+        assert "minItems" not in tags_schema
+        assert "maxItems" not in tags_schema
+        assert "minLength" not in code_schema
+        assert "maxLength" not in code_schema
+        assert "pattern" not in code_schema
+        nested_label_schema = schema["$defs"]["NestedLabel"]["properties"]["label"]
+        assert "minLength" not in nested_label_schema
+        assert "maxLength" not in nested_label_schema
+        assert schema["additionalProperties"] is False
+        assert set(schema["required"]) == {"score", "tags", "code", "nested"}
+
+    def test_supported_model_uses_strict_json_schema_response_format(self):
+        client = _build_client(LiteLLMConfig(model="gpt-4o-mini"))
+
+        with patch.object(
+            LiteLLMClient,
+            "_supports_response_schema",
+            return_value=True,
+        ):
+            params, parser_schema, parse_structured, _ = (
+                client._build_completion_params(
+                    [{"role": "user", "content": "test"}],
+                    response_format=SampleResponse,
+                )
+            )
+
+        provider_format = params["response_format"]
+        assert provider_format["type"] == "json_schema"
+        assert provider_format["json_schema"]["strict"] is True
+        assert provider_format["json_schema"]["schema"]["additionalProperties"] is False
+        assert set(provider_format["json_schema"]["schema"]["required"]) == {
+            "answer",
+            "score",
+        }
+        assert parser_schema is SampleResponse
+        assert parse_structured is True
+
+    def test_unsupported_model_keeps_pydantic_response_format(self):
+        client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M2.7"))
+
+        with patch.object(
+            LiteLLMClient,
+            "_supports_response_schema",
+            return_value=False,
+        ):
+            params, parser_schema, _, _ = client._build_completion_params(
+                [{"role": "user", "content": "test"}],
+                response_format=SampleResponse,
+            )
+
+        assert params["response_format"] is SampleResponse
+        assert parser_schema is SampleResponse
+
+    def test_strict_response_format_can_be_disabled_per_call(self):
+        client = _build_client(LiteLLMConfig(model="gpt-4o-mini"))
+
+        with patch.object(
+            LiteLLMClient,
+            "_supports_response_schema",
+            return_value=True,
+        ):
+            params, _, _, _ = client._build_completion_params(
+                [{"role": "user", "content": "test"}],
+                response_format=SampleResponse,
+                strict_response_format=False,
+            )
+
+        assert params["response_format"] is SampleResponse
+
+
 # ===================================================================
 # Retry-on-parse-failure tests
 # ===================================================================
@@ -1112,7 +1203,11 @@ class TestStructuredOutputRetry:
         assert result.score == 42
 
     def test_structured_output_parse_failure_all_retries_exhausted_raises(self):
-        """Every attempt returns malformed content — raises LiteLLMClientError wrapping StructuredOutputParseError after exhaustion."""
+        """Every attempt returns malformed content — raises LiteLLMClientError wrapping StructuredOutputParseError after exhaustion.
+
+        Parse failures get one extra attempt beyond the configured budget, so
+        max_retries=2 yields 3 total attempts.
+        """
         call_count = 0
 
         def fake_completion(**kwargs):
@@ -1133,7 +1228,56 @@ class TestStructuredOutputRetry:
                 response_format=SampleResponse,
             )
 
+        assert call_count == 3
+
+    def test_structured_output_parse_failure_extra_retry_at_default_budget(self):
+        """With max_retries=1, a parse failure still gets one extra attempt and can recover."""
+        call_count = 0
+        valid_json = '{"answer": "ok", "score": 42}'
+
+        def fake_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            content = "not valid json {{{{" if call_count == 1 else valid_json
+            return self._make_mock_response(content)
+
+        client = _build_client(
+            LiteLLMConfig(model="gpt-4o-mini", max_retries=1, retry_delay=0)
+        )
+
+        with patch("litellm.completion", side_effect=fake_completion):
+            result = client.generate_chat_response(
+                messages=[{"role": "user", "content": "test"}],
+                response_format=SampleResponse,
+            )
+
         assert call_count == 2
+        assert isinstance(result, SampleResponse)
+        assert result.answer == "ok"
+
+    def test_non_parse_error_gets_no_extra_retry_at_default_budget(self):
+        """A non-parse error with max_retries=1 still runs exactly once — the extra retry is parse-only."""
+        call_count = 0
+
+        def fake_completion(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("boom")
+
+        client = _build_client(
+            LiteLLMConfig(model="gpt-4o-mini", max_retries=1, retry_delay=0)
+        )
+
+        with (
+            patch("litellm.completion", side_effect=fake_completion),
+            pytest.raises(LiteLLMClientError),
+        ):
+            client.generate_chat_response(
+                messages=[{"role": "user", "content": "test"}],
+                response_format=SampleResponse,
+            )
+
+        assert call_count == 1
 
 
 # ===================================================================

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -14,6 +14,7 @@ import zlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import litellm
 import pytest
 from pydantic import BaseModel, Field
 
@@ -1435,7 +1436,20 @@ class TestTemperatureRestriction:
 
         call_kwargs = mock_completion.call_args.kwargs
         assert call_kwargs["seed"] == 42
+        assert call_kwargs["drop_params"] is True
         assert call_kwargs["temperature"] == 0.3
+
+    def test_drop_params_is_scoped_to_completion_params(self, monkeypatch):
+        """Best-effort seed should not change LiteLLM's process-global setting."""
+        monkeypatch.setattr(litellm, "drop_params", False)
+        client = LiteLLMClient(LiteLLMConfig(model="gpt-4o"))
+
+        params, _, _, _ = client._build_completion_params(
+            [{"role": "user", "content": "hi"}]
+        )
+
+        assert params["drop_params"] is True
+        assert litellm.drop_params is False
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
     def test_explicit_seed_env_forces_temperature_zero(

--- a/tests/server/llm/test_tools.py
+++ b/tests/server/llm/test_tools.py
@@ -44,6 +44,12 @@ def test_tool_openai_spec_uses_docstring_and_schema():
     assert spec["type"] == "function"
     assert spec["function"]["name"] == "emit_profile"
     assert "Emit a candidate user profile item." in spec["function"]["description"]
+    assert spec["function"]["strict"] is True
+    assert spec["function"]["parameters"]["additionalProperties"] is False
+    assert set(spec["function"]["parameters"]["required"]) == {
+        "content",
+        "time_to_live",
+    }
     assert spec["function"]["parameters"]["properties"]["content"]["type"] == "string"
 
 


### PR DESCRIPTION
## Summary

Make structured LLM output **strict** end-to-end and more robust to transient parse failures, plus a couple of related LLM-config fixes.

When a provider reports (via LiteLLM) that it supports response schemas, we now send an explicit strict `json_schema` `response_format` so generation is constrained to the model's shape. We still parse the raw response against the original Pydantic model, so validation keywords that strict mode doesn't support (`min`/`max`, `pattern`, etc.) are still enforced locally. Tool parameter schemas are emitted in strict form too.

## Changes

- **Strict structured output** (`llm_utils.py`, `litellm_client.py`, `tools.py`): emit a strict JSON schema as `response_format` for schema-capable providers; build strict tool parameter schemas; keep local Pydantic validation as the source of truth for unsupported keywords.
- **Discriminated unions in strict schema** (`llm_utils.py`): Pydantic emits `oneOf` + `discriminator` for discriminated unions, which OpenAI strict mode rejects. Fold them into `anyOf` (which strict permits) so generation is constrained to the same variants; Pydantic still enforces the discriminator after parse, preserving semantics.
- **Parse-failure retry** (`litellm_client.py`): grant a `StructuredOutputParseError` one extra attempt beyond the configured retry budget — malformed/truncated responses usually succeed on a fresh generation.
- **`drop_params` scoping** (`litellm_client.py`): pass `drop_params=True` per-call instead of mutating LiteLLM's process-wide setting, so best-effort `seed` no longer has a global side effect.
- **Gemini embedding default** (`model_defaults.py`, `setup_cmd.py`): switch to `gemini-embedding-001` (`text-embedding-004` retired).

## Test Plan

- `tests/server/llm/test_litellm_client_unit.py` — strict-schema construction (including discriminated-union `oneOf`→`anyOf` folding), `drop_params` is per-call and does not touch `litellm.drop_params`, parse-failure extra-retry behavior.
- `tests/server/llm/test_tools.py` — strict tool parameter schemas.
- `uv run pytest tests/server/llm/ -m "not requires_credentials"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for strict JSON schema structured outputs, enabling enhanced validation and improved compatibility across different language model providers.
  * Implemented enhanced automatic error recovery for structured output parsing failures with additional built-in retry mechanisms to improve reliability.

* **Updates**
  * Updated Gemini embedding model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->