### PR TITLE
feat(client): add pending tool call helpers

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -60,6 +60,10 @@ from reflexio.models.api_schema.domain.entities import (
     UpgradeUserPlaybooksRequest,
     UpgradeUserPlaybooksResponse,
 )
+from reflexio.models.api_schema.pending_tool_call_schema import (
+    PendingToolCallListResponse,
+    PendingToolCallResponse,
+)
 from reflexio.models.api_schema.service_schemas import (
     AddAgentPlaybookRequest,
     AddAgentPlaybookResponse,
@@ -2418,6 +2422,171 @@ class ReflexioClient:
         """
         response = self._make_request("POST", "/stall_state/notified")
         return MarkNotifiedResponse.model_validate(response)
+
+    # ===============================
+    # Pending tool calls (human questions)
+    # ===============================
+    # The resumable extraction agent can pause and emit an ``ask_human``
+    # pending tool call when it needs a human to answer a question before it
+    # can finish. These methods let a user list those questions, answer them
+    # to unblock the agent, edit a prior answer, mark a question N/A, or
+    # cancel it. See notebooks/08_resumable_agent_human_questions.ipynb.
+
+    def list_pending_tool_calls(
+        self, status: str | None = None, limit: int = 100
+    ) -> PendingToolCallListResponse:
+        """List pending tool calls (e.g. ``ask_human`` questions) for the org.
+
+        Args:
+            status (str | None): Optional status filter. One of ``"pending"``,
+                ``"resolved"``, ``"expired"``, ``"superseded"``, or
+                ``"cancelled"``. When None, all statuses are returned.
+            limit (int): Maximum number of results to return (1-500, default 100).
+
+        Returns:
+            PendingToolCallListResponse: The matching pending tool calls.
+        """
+        params: dict[str, Any] = {"limit": limit}
+        if status is not None:
+            params["status"] = status
+        response = self._make_request("GET", "/api/pending_tool_calls", params=params)
+        return PendingToolCallListResponse.model_validate(response)
+
+    def get_pending_tool_call(
+        self, pending_tool_call_id: str
+    ) -> PendingToolCallResponse:
+        """Fetch a single pending tool call by id.
+
+        Args:
+            pending_tool_call_id (str): The id of the pending tool call.
+
+        Returns:
+            PendingToolCallResponse: The pending tool call.
+        """
+        response = self._make_request(
+            "GET", f"/api/pending_tool_calls/{pending_tool_call_id}"
+        )
+        return PendingToolCallResponse.model_validate(response)
+
+    def resolve_pending_tool_call(
+        self,
+        pending_tool_call_id: str,
+        *,
+        result: dict[str, Any] | None = None,
+        answer: str | None = None,
+        valid_for_seconds: int | None = None,
+    ) -> PendingToolCallResponse:
+        """Resolve a pending tool call, unblocking dependent agent runs.
+
+        Provide exactly one of ``result`` or ``answer``. ``answer`` is a
+        convenience for the common ``ask_human`` case and is wrapped as
+        ``{"answer": answer}``; use ``result`` to send an arbitrary tool
+        result payload.
+
+        Args:
+            pending_tool_call_id (str): The id of the pending tool call.
+            result (dict[str, Any] | None): Raw tool result payload.
+            answer (str | None): Human answer text (wrapped as ``{"answer": ...}``).
+            valid_for_seconds (int | None): How long the resolved answer
+                stays valid for answer reuse. Server default when None.
+
+        Returns:
+            PendingToolCallResponse: The resolved pending tool call.
+
+        Raises:
+            ValueError: If both or neither of ``result`` and ``answer`` are set.
+        """
+        if (result is None) == (answer is None):
+            raise ValueError("Provide exactly one of 'result' or 'answer' to resolve.")
+        payload: dict[str, Any] = {
+            "result": result if result is not None else {"answer": answer}
+        }
+        if valid_for_seconds is not None:
+            payload["valid_for_seconds"] = valid_for_seconds
+        response = self._make_request(
+            "POST",
+            f"/api/pending_tool_calls/{pending_tool_call_id}/resolve",
+            json=payload,
+        )
+        return PendingToolCallResponse.model_validate(response)
+
+    def update_pending_tool_call_answer(
+        self,
+        pending_tool_call_id: str,
+        answer: str,
+        *,
+        valid_for_seconds: int | None = None,
+    ) -> PendingToolCallResponse:
+        """Edit the answer of an already-resolved ``ask_human`` question.
+
+        Editing schedules another resume of dependent agent runs with the new
+        answer.
+
+        Args:
+            pending_tool_call_id (str): The id of the pending tool call.
+            answer (str): The new (non-empty) answer text.
+            valid_for_seconds (int | None): How long the edited answer stays
+                valid for answer reuse. Server default when None.
+
+        Returns:
+            PendingToolCallResponse: The updated pending tool call.
+        """
+        payload: dict[str, Any] = {"answer": answer}
+        if valid_for_seconds is not None:
+            payload["valid_for_seconds"] = valid_for_seconds
+        response = self._make_request(
+            "PATCH",
+            f"/api/pending_tool_calls/{pending_tool_call_id}/answer",
+            json=payload,
+        )
+        return PendingToolCallResponse.model_validate(response)
+
+    def mark_pending_tool_call_not_applicable(
+        self,
+        pending_tool_call_id: str,
+        *,
+        valid_for_seconds: int | None = None,
+    ) -> PendingToolCallResponse:
+        """Mark an ``ask_human`` question as not applicable.
+
+        Resolves the question with the standard "user does not have
+        information" result so dependent agent runs can proceed.
+
+        Args:
+            pending_tool_call_id (str): The id of the pending tool call.
+            valid_for_seconds (int | None): How long the result stays valid
+                for answer reuse. Server default when None.
+
+        Returns:
+            PendingToolCallResponse: The resolved (N/A) pending tool call.
+        """
+        payload: dict[str, Any] = {}
+        if valid_for_seconds is not None:
+            payload["valid_for_seconds"] = valid_for_seconds
+        response = self._make_request(
+            "POST",
+            f"/api/pending_tool_calls/{pending_tool_call_id}/not_applicable",
+            json=payload,
+        )
+        return PendingToolCallResponse.model_validate(response)
+
+    def cancel_pending_tool_call(
+        self, pending_tool_call_id: str
+    ) -> PendingToolCallResponse:
+        """Cancel a pending tool call without answering it.
+
+        Only pending (unanswered) tool calls can be cancelled.
+
+        Args:
+            pending_tool_call_id (str): The id of the pending tool call.
+
+        Returns:
+            PendingToolCallResponse: The cancelled pending tool call.
+        """
+        response = self._make_request(
+            "POST", f"/api/pending_tool_calls/{pending_tool_call_id}/cancel"
+        )
+        return PendingToolCallResponse.model_validate(response)
 
     def clear_user_data(self, user_id: str) -> ClearUserDataResponse:
         """Delete all rows scoped to a single ``user_id``.

--- a/tests/client/test_pending_tool_call_client.py
+++ b/tests/client/test_pending_tool_call_client.py
@@ -1,0 +1,176 @@
+"""ReflexioClient methods for pending tool calls (human questions)."""
+# pyright: reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import tempfile
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from reflexio.client import ReflexioClient
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+from reflexio.server.api import create_app
+from reflexio.server.api_endpoints.request_context import (
+    RequestContext,
+    get_request_context,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.storage_base import (
+    PendingToolCallRecord,
+    PendingToolCallStatus,
+)
+
+ORG_ID = "test-pending-tool-call-org"
+
+
+@pytest.fixture()
+def storage():
+    """A real SQLiteStorage instance in a temporary directory."""
+    with (
+        tempfile.TemporaryDirectory() as tmp,
+        patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
+    ):
+        yield SQLiteStorage(org_id=ORG_ID, db_path=f"{tmp}/reflexio.db")
+
+
+@pytest.fixture()
+def client_with_server(storage):
+    """ReflexioClient pointed at a TestClient-backed FastAPI app.
+
+    The app's ``get_request_context`` dependency is overridden to use the
+    same ``SQLiteStorage`` instance as the ``storage`` fixture, so tests can
+    seed pending tool calls via ``storage.create_pending_tool_call(...)`` and
+    operate on them through the client.
+    """
+    app = create_app(get_org_id=lambda: ORG_ID)
+
+    fake_ctx = RequestContext.__new__(RequestContext)
+    fake_ctx.org_id = ORG_ID
+    fake_ctx.storage = storage
+    fake_ctx.configurator = MagicMock()
+    fake_ctx.configurator.get_config.return_value = Config(
+        storage_config=StorageConfigSQLite()
+    )
+
+    app.dependency_overrides[get_request_context] = lambda: fake_ctx
+
+    http_client = TestClient(app, raise_server_exceptions=True)
+
+    # Wrap the TestClient in a requests.Session-compatible shim so ReflexioClient
+    # can call it via its normal self.session.request(...) path.
+    class _TestClientSession:
+        """Thin adapter making TestClient look like a requests.Session."""
+
+        max_redirects = 0
+        headers: dict = {}
+
+        def update(self, d: dict) -> None:  # noqa: D401
+            self.headers.update(d)
+
+        def request(self, method: str, url: str, **kwargs) -> object:
+            path = url.replace("http://testserver", "")
+            kwargs.pop("timeout", None)
+            return http_client.request(method, path, **kwargs)
+
+    reflexio_client = ReflexioClient.__new__(ReflexioClient)
+    reflexio_client.base_url = "http://testserver"
+    reflexio_client.api_key = ""
+    reflexio_client.timeout = 30
+    reflexio_client.session = _TestClientSession()
+
+    return reflexio_client
+
+
+def _seed_ask_human(storage, call_id: str = "ptc-1") -> PendingToolCallRecord:
+    """Insert a pending ``ask_human`` tool call and return the stored record."""
+    now = datetime.now(UTC)
+    future = now + timedelta(hours=1)
+    record = PendingToolCallRecord(
+        id=call_id,
+        org_id=ORG_ID,
+        scope={"user_id": "alice"},
+        scope_hash=f"hash-{call_id}",
+        tool_name="ask_human",
+        dedup_key=f"dedup-{call_id}",
+        status=PendingToolCallStatus.PENDING,
+        question_text="What deployment target is canonical?",
+        user_id="alice",
+        created_at=now,
+        expires_at=future,
+        cache_until=future,
+    )
+    return storage.create_pending_tool_call(record)
+
+
+def test_list_and_get_pending_tool_call(client_with_server, storage):
+    _seed_ask_human(storage)
+
+    listed = client_with_server.list_pending_tool_calls(status="pending")
+    assert len(listed.pending_tool_calls) == 1
+    row = listed.pending_tool_calls[0]
+    assert row.id == "ptc-1"
+    assert row.tool_name == "ask_human"
+    assert row.status == PendingToolCallStatus.PENDING
+
+    fetched = client_with_server.get_pending_tool_call("ptc-1")
+    assert fetched.id == "ptc-1"
+    assert fetched.question_text == "What deployment target is canonical?"
+
+
+def test_resolve_with_answer(client_with_server, storage):
+    _seed_ask_human(storage)
+
+    resolved = client_with_server.resolve_pending_tool_call("ptc-1", answer="AWS ECS")
+    assert resolved.status == PendingToolCallStatus.RESOLVED
+    assert resolved.result == {"answer": "AWS ECS"}
+
+
+def test_resolve_with_raw_result(client_with_server, storage):
+    _seed_ask_human(storage)
+
+    resolved = client_with_server.resolve_pending_tool_call(
+        "ptc-1", result={"answer": "GCP", "extra": True}
+    )
+    assert resolved.status == PendingToolCallStatus.RESOLVED
+    assert resolved.result == {"answer": "GCP", "extra": True}
+
+
+def test_resolve_requires_exactly_one_of_result_or_answer(client_with_server, storage):
+    _seed_ask_human(storage)
+
+    with pytest.raises(ValueError):
+        client_with_server.resolve_pending_tool_call("ptc-1")
+    with pytest.raises(ValueError):
+        client_with_server.resolve_pending_tool_call(
+            "ptc-1", result={"answer": "x"}, answer="y"
+        )
+
+
+def test_update_answer_after_resolve(client_with_server, storage):
+    _seed_ask_human(storage)
+    client_with_server.resolve_pending_tool_call("ptc-1", answer="AWS ECS")
+
+    edited = client_with_server.update_pending_tool_call_answer(
+        "ptc-1", "Google Cloud Run"
+    )
+    assert edited.status == PendingToolCallStatus.RESOLVED
+    assert edited.result == {"answer": "Google Cloud Run"}
+
+
+def test_mark_not_applicable(client_with_server, storage):
+    _seed_ask_human(storage)
+
+    na = client_with_server.mark_pending_tool_call_not_applicable("ptc-1")
+    assert na.status == PendingToolCallStatus.RESOLVED
+    assert na.result is not None
+    assert na.result.get("not_applicable") is True
+
+
+def test_cancel_pending_tool_call(client_with_server, storage):
+    _seed_ask_human(storage)
+
+    cancelled = client_with_server.cancel_pending_tool_call("ptc-1")
+    assert cancelled.status == PendingToolCallStatus.CANCELLED


### PR DESCRIPTION
## Summary
- Add Python client helpers for pending tool call / human question workflows
- Support listing, fetching, resolving with answer or raw result, editing answers, marking N/A, and cancellation
- Add TestClient-backed coverage for the new client methods against the FastAPI routes

## Tests
- `uv run ruff check open_source/reflexio/reflexio/client/client.py open_source/reflexio/tests/client/test_pending_tool_call_client.py`
- `uv run pyright open_source/reflexio/reflexio/client/client.py open_source/reflexio/tests/client/test_pending_tool_call_client.py`
- `uv run pytest --no-cov open_source/reflexio/tests/client/test_pending_tool_call_client.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API operations for managing pending tool calls, including listing, retrieving, resolving with answers or results, updating answers, marking as not applicable, and cancelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->