### PR TITLE
test(profile): fix 3 stale pre-check + async-info-tool tests

### DIFF
--- a/tests/server/services/profile/test_profile_extractor.py
+++ b/tests/server/services/profile/test_profile_extractor.py
@@ -11,6 +11,7 @@ Tests the extractor's new responsibilities for:
 
 import os
 import tempfile
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -40,7 +41,14 @@ from reflexio.server.services.profile.profile_generation_service_utils import (
     StructuredProfilesOutput,
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
-from reflexio.server.services.storage.storage_base import AgentRunStatus
+from reflexio.server.services.storage.storage_base import (
+    AgentRunStatus,
+    PendingToolCallRecord,
+    PendingToolCallStatus,
+    build_pending_tool_call_dedup_key,
+    build_scope_hash,
+    human_feedback_scope,
+)
 
 # ===============================
 # Fixtures
@@ -667,7 +675,7 @@ class TestResumableAgentPath:
 
         assert raw_profiles[0]["content"] == "Loop extraction path."
 
-    def test_ask_human_is_org_scoped_and_run_still_finalizes(
+    def test_attach_pending_info_request_is_org_scoped_and_run_still_finalizes(
         self,
         monkeypatch,
         request_context,
@@ -677,6 +685,12 @@ class TestResumableAgentPath:
         sample_request_interaction_models,
         tool_call_completion,
     ):
+        """Post-#107 a profile extractor exposes attach_pending_info_request, not
+        ask_human. The attach tool does not CREATE a pending tool call; it attaches
+        the current run to an existing org-scoped Prior Knowledge (ask_human)
+        request. We seed that org-scoped pending call, have the agent attach to it,
+        and assert the org-scoping holds and the run still finalizes wired to it.
+        """
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
         request_context.storage = sqlite_storage
@@ -693,13 +707,38 @@ class TestResumableAgentPath:
             lambda prompt_id, variables: f"{prompt_id}: {variables}"
         )
 
+        # Seed an existing org-scoped ask_human pending tool call. The attach tool
+        # only succeeds against a record whose org/scope/tool_name match
+        # human_feedback_scope(org_id) + tool_name="ask_human".
+        org_scope = human_feedback_scope("test_org")
+        seeded_question = "Which deployment standard should be treated as canonical?"
+        seeded_call = PendingToolCallRecord(
+            id="ptc_seeded_prior_knowledge",
+            org_id="test_org",
+            user_id="test_user",
+            scope=org_scope,
+            scope_hash=build_scope_hash(org_scope),
+            tool_name="ask_human",
+            dedup_key=build_pending_tool_call_dedup_key(
+                tool_name="ask_human",
+                question_text=seeded_question,
+                answer_format="short text",
+            ),
+            status=PendingToolCallStatus.PENDING,
+            question_text=seeded_question,
+            answer_format="short text",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+            cache_until=datetime.now(UTC) + timedelta(hours=1),
+            valid_until=datetime.now(UTC) + timedelta(hours=1),
+        )
+        sqlite_storage.create_pending_tool_call(seeded_call)
+
         make_tc, _ = tool_call_completion
-        ask_response = make_tc(
-            "ask_human",
+        attach_response = make_tc(
+            "attach_pending_info_request",
             {
-                "question": "Which deployment standard should be treated as canonical?",
-                "answer_format": "short text",
-                "tags": ["deployment"],
+                "pending_tool_call_id": seeded_call.id,
+                "why_relevant": "Canonical deployment standard affects this profile.",
             },
         )
         finish_response = make_tc(
@@ -722,7 +761,7 @@ class TestResumableAgentPath:
         )
 
         with (
-            patch("litellm.completion", side_effect=[ask_response, finish_response]),
+            patch("litellm.completion", side_effect=[attach_response, finish_response]),
             patch(
                 "reflexio.server.services.extraction.resumable_agent.is_resumable_extraction_agent_feature_enabled",
                 return_value=True,
@@ -735,17 +774,28 @@ class TestResumableAgentPath:
             )
 
         assert raw_profiles[0]["content"] == "User prefers dark mode."
+
+        # The attach tool does not create new pending calls; the only one is the
+        # seeded org-scoped Prior Knowledge request.
         pending_calls = sqlite_storage.list_pending_tool_calls()
         assert len(pending_calls) == 1
         pending_call = pending_calls[0]
         assert pending_call.scope == {"org_id": "test_org", "scope_kind": "org"}
         assert pending_call.user_id == "test_user"
+
         row = sqlite_storage.conn.execute("SELECT id FROM _agent_runs").fetchone()
         assert row is not None
         run = sqlite_storage.get_agent_run(row["id"])
         assert run is not None
         assert run.status == AgentRunStatus.AGENT_COMPLETED
-        assert run.pending_tool_call_ids == [pending_call.id]
+
+        # attach_pending_info_request wires the run to the existing pending call via
+        # a run-tool dependency (it returns a synchronous Completed result, so it is
+        # NOT recorded in run.pending_tool_call_ids the way ask_human's AsyncAccepted
+        # would be). Assert the durable dependency edge instead.
+        assert run.pending_tool_call_ids == []
+        dependencies = sqlite_storage.list_run_tool_dependencies(run.id)
+        assert [dep.pending_tool_call_id for dep in dependencies] == [pending_call.id]
 
     def test_run_resumable_empty_output_still_surfaces_run_id(
         self,

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -1052,7 +1052,13 @@ def test_get_rerun_user_ids_returns_empty_when_no_matches():
 
 
 def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
-    """Pre-check should use extractor-specific window and source filters."""
+    """Pre-check should use the single extractor's window and source filters.
+
+    Post-#101 the pre-check is per-extractor: it takes ONE ProfileExtractorConfig
+    and returns (session_data_models, that_config). The source-scoping intent is
+    preserved by also asserting the should-skip path for a config whose enabled
+    sources do not include the triggering request source.
+    """
     org_id = "0"
     user_id = "test_user"
 
@@ -1096,36 +1102,54 @@ def test_collect_scoped_interactions_for_precheck_uses_extractor_scope():
             return_value=([session_data], [])
         )
 
-        extractor_configs = [
-            ProfileExtractorConfig(
-                extractor_name="api_profiles",
-                extraction_definition_prompt="communication preferences",
-                request_sources_enabled=["api"],
-                window_size_override=150,
-            ),
-            ProfileExtractorConfig(
-                extractor_name="web_profiles",
-                extraction_definition_prompt="shopping preferences",
-                request_sources_enabled=["web"],
-                window_size_override=90,
-            ),
-        ]
+        # Extractor whose enabled sources include the triggering "api" source:
+        # the pre-check should query storage with the extractor's window override
+        # (150) and the triggering source filter (["api"]), and return that config.
+        api_config = ProfileExtractorConfig(
+            extractor_name="api_profiles",
+            extraction_definition_prompt="communication preferences",
+            request_sources_enabled=["api"],
+            window_size_override=150,
+        )
 
-        (
-            scoped_groups,
-            scoped_configs,
-        ) = service._collect_scoped_interactions_for_precheck(extractor_configs)
+        scoped_groups, scoped_config = (
+            service._collect_scoped_interactions_for_precheck(api_config)
+        )
 
-        assert len(scoped_groups) == 1
-        assert [c.extractor_name for c in scoped_configs] == ["api_profiles"]
+        assert scoped_groups == [session_data]
+        assert scoped_config is api_config
         service.storage.get_last_k_interactions_grouped.assert_called_once()
         _, kwargs = service.storage.get_last_k_interactions_grouped.call_args
         assert kwargs["k"] == 150
         assert kwargs["sources"] == ["api"]
 
+        # Source-scoping intent: an extractor that does NOT enable the triggering
+        # "api" source must short-circuit (get_effective_source_filter should_skip)
+        # and return empty groups WITHOUT touching storage.
+        service.storage.get_last_k_interactions_grouped.reset_mock()
+        web_config = ProfileExtractorConfig(
+            extractor_name="web_profiles",
+            extraction_definition_prompt="shopping preferences",
+            request_sources_enabled=["web"],
+            window_size_override=90,
+        )
 
-def test_should_run_before_extraction_combines_all_extractor_criteria():
-    """Consolidated pre-check should include all enabled extractor definitions and override conditions."""
+        empty_groups, web_scoped_config = (
+            service._collect_scoped_interactions_for_precheck(web_config)
+        )
+
+        assert empty_groups == []
+        assert web_scoped_config is web_config
+        service.storage.get_last_k_interactions_grouped.assert_not_called()
+
+
+def test_should_run_before_extraction_includes_extractor_definition_and_override():
+    """Per-extractor pre-check prompt must include the extractor's definition AND override.
+
+    Post-#101 the pre-check runs per extractor with a single config; the prompt
+    built by ProfileGenerationService._build_should_run_prompt combines that one
+    extractor's extraction_definition_prompt and should_extract_profile_prompt_override.
+    """
     org_id = "0"
     user_id = "test_user"
 
@@ -1164,25 +1188,19 @@ def test_should_run_before_extraction_combines_all_extractor_criteria():
             interactions=[interaction],
         )
 
-        extractor_configs = [
-            ProfileExtractorConfig(
-                extractor_name="comm_profiles",
-                extraction_definition_prompt="communication preferences",
+        work_config = ProfileExtractorConfig(
+            extractor_name="work_profiles",
+            extraction_definition_prompt="career goals and projects",
+            should_extract_profile_prompt_override=(
+                "when user mentions work projects, deadlines, or role changes"
             ),
-            ProfileExtractorConfig(
-                extractor_name="work_profiles",
-                extraction_definition_prompt="career goals and projects",
-                should_extract_profile_prompt_override=(
-                    "when user mentions work projects, deadlines, or role changes"
-                ),
-            ),
-        ]
+        )
 
         with (
             patch.object(
                 service,
                 "_collect_scoped_interactions_for_precheck",
-                return_value=([session_data], extractor_configs),
+                return_value=([session_data], work_config),
             ),
             patch(
                 "reflexio.server.services.base_generation_service._cheap_should_run_reject",
@@ -1194,12 +1212,11 @@ def test_should_run_before_extraction_combines_all_extractor_criteria():
                 return_value="true",
             ) as mock_generate,
         ):
-            should_run = service._should_run_before_extraction(extractor_configs)
+            should_run = service._should_run_before_extraction(work_config)
 
         assert should_run is True
         mock_generate.assert_called_once()
         prompt = mock_generate.call_args.kwargs["messages"][0]["content"]
-        assert "communication preferences" in prompt
         assert "career goals and projects" in prompt
         assert "work projects, deadlines, or role changes" in prompt
 


### PR DESCRIPTION
## What

Fixes 3 stale tests in the profile-extraction suite that have been failing on `main`. **Test-only — no production code changes.** All three asserted contracts that two earlier refactors superseded; production is correct.

### Root cause
- **#101** (per-extractor pre-check): `_collect_scoped_interactions_for_precheck` / `_should_run_before_extraction` moved from a *consolidated-across-all-extractors (list)* design to **per-extractor (single config)**. Two tests still passed a `list`, yielding `AttributeError: 'list' object has no attribute 'extraction_definition_prompt'`.
- **#107** (scope async-info tools per extractor kind): profile extractors now expose `attach_pending_info_request`, not `ask_human`. The third test mocked an `ask_human` call for a profile extractor, so no tool ran → 0 pending calls.

### Changes
1. `test_collect_scoped_interactions_for_precheck_uses_extractor_scope` — single-config contract; still asserts extractor-specific window (`k=150`) + source (`["api"]`), and adds a non-matching-source → empty-groups (should_skip) assertion.
2. `test_should_run_before_extraction_combines_all_extractor_criteria` → renamed `..._includes_extractor_definition_and_override` — single-config; asserts the extractor's definition + override both reach the prompt. Dropped the obsolete cross-extractor assertion (criteria are no longer combined).
3. `test_ask_human_is_org_scoped_and_run_still_finalizes` → renamed `test_attach_pending_info_request_is_org_scoped_and_run_still_finalizes` — models the current profile attach-to-existing flow: seeds an org-scoped `ask_human` pending call, attaches via `attach_pending_info_request`, asserts org scope + run finalize + the run-tool-dependency edge (`pending_tool_call_ids` stays `[]` because attach returns a synchronous `Completed`, not `AsyncAccepted` — verified correct-per-production).

## Test
- The 3 targeted tests pass; both full files green (32 passed).
- ruff + pyright clean on the changed files.
- The `ask_human`/`AsyncAccepted` → `pending_tool_call_ids` population path remains covered elsewhere (`test_tools.py`, resumable-agent/resume-worker/e2e tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite for profile extraction to validate pending tool call attachment workflow.
  * Refactored pre-check behavior tests to operate on individual extractor configurations.
  * Adjusted test assertions to align with updated behavior expectations for extraction and dependency tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->