### PR TITLE
fix: enable MiniMax-M3 as provider default (tool-calling override)

### DIFF
--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -224,17 +224,17 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
         embedding=None,
     ),
     "minimax": ProviderDefaults(
-        generation="minimax/MiniMax-M2.7",
-        evaluation="minimax/MiniMax-M2.7",
-        should_run="minimax/MiniMax-M2.7",
-        pre_retrieval="minimax/MiniMax-M2.7",
+        generation="minimax/MiniMax-M3",
+        evaluation="minimax/MiniMax-M3",
+        should_run="minimax/MiniMax-M3",
+        pre_retrieval="minimax/MiniMax-M3",
         embedding=None,
         # Same M2.7 model handles resumable extraction. Surfaced by an
         # e2e run on a MiniMax-only VPS where publish printed
         # "No provider in ['minimax'] supports role=extraction_agent"
         # warnings and silently skipped profile creation. Without this,
         # MiniMax-only users can publish but get zero profiles.
-        extraction_agent="minimax/MiniMax-M2.7",
+        extraction_agent="minimax/MiniMax-M3",
     ),
     "dashscope": ProviderDefaults(
         generation="dashscope/qwen-plus",
@@ -258,10 +258,10 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
         embedding=None,
     ),
     "zai": ProviderDefaults(
-        generation="zai/glm-4-flash",
-        evaluation="zai/glm-4-flash",
-        should_run="zai/glm-4-flash",
-        pre_retrieval="zai/glm-4-flash",
+        generation="zai/glm-5.1",
+        evaluation="zai/glm-5.1",
+        should_run="zai/glm-5.1",
+        pre_retrieval="zai/glm-5.1",
         embedding=None,
     ),
 }

--- a/reflexio/server/llm/tools.py
+++ b/reflexio/server/llm/tools.py
@@ -191,6 +191,12 @@ _TOOL_CALLING_OVERRIDES: tuple[str, ...] = (
     # tools=[...])` round-trip that returned a proper tool_call message.
     # litellm 1.80.x has 'minimax/MiniMax-M2' in model_cost but not 'MiniMax-M2.7'.
     "minimax/MiniMax-M2",
+    # MiniMax-M3 supports OpenAI-compatible tools the same way the M2 family
+    # does, but litellm 1.80.x has no 'minimax/MiniMax-M3' model_cost entry so
+    # supports_function_calling returns False. Verified by a live
+    # `litellm.completion(model='minimax/MiniMax-M3', tools=[...])` round-trip
+    # that returned a proper tool_call message (finish_reason='tool_calls').
+    "minimax/MiniMax-M3",
     # claude-code/* models route through our local CLI provider
     # (see providers/claude_code_provider.py). litellm has no registry
     # entry for them, so it returns False. The provider handles tool

--- a/tests/server/llm/test_tools.py
+++ b/tests/server/llm/test_tools.py
@@ -640,6 +640,8 @@ class TestSupportsToolCallingOverrides:
         # Family override applies to all M2.x variants
         assert tools_mod.supports_tool_calling("minimax/MiniMax-M2") is True
         assert tools_mod.supports_tool_calling("minimax/MiniMax-M2-special") is True
+        # M3 has its own override entry (same registry gap as the M2 family)
+        assert tools_mod.supports_tool_calling("minimax/MiniMax-M3") is True
 
     def test_override_does_not_apply_to_other_minimax_models(self, monkeypatch):
         """The override is prefix-scoped: 'minimax/MiniMax-M2' applies to M2 family


### PR DESCRIPTION
## Summary

Enable `minimax/MiniMax-M3` end-to-end as a provider default. Previously, switching MiniMax defaults to M3 caused the resumable extraction tool loop to raise `Model minimax/MiniMax-M3 lacks tool-calling and no fallback_schema provided`, silently skipping profile and playbook generation.

The root cause is a litellm registry gap: litellm 1.80.x has no `model_cost` entry for `minimax/MiniMax-M3`, so `litellm.supports_function_calling()` returns `False`. The extraction agent relies on native tool-calling and passes no fallback schema, so it errors out. (The M2 family is already rescued via `_TOOL_CALLING_OVERRIDES`; M3 was not covered because the override is prefix-scoped to `minimax/MiniMax-M2`.)

## Changes

- **`server/llm/tools.py`** — add `minimax/MiniMax-M3` to `_TOOL_CALLING_OVERRIDES` so `supports_tool_calling()` reports `True` despite the litellm registry gap.
- **`server/llm/model_defaults.py`** — switch MiniMax provider defaults from `MiniMax-M2.7` to `MiniMax-M3` (generation, evaluation, should_run, pre_retrieval, extraction_agent); bump `zai` defaults to `glm-5.1`.
- **`tests/server/llm/test_tools.py`** — assert `supports_tool_calling("minimax/MiniMax-M3") is True` even when litellm reports `False`.

## Test Plan

- Verified a live round-trip: `litellm.completion(model="minimax/MiniMax-M3", tools=[...])` returns a proper `tool_calls` message (`finish_reason="tool_calls"`).
- `pytest tests/server/llm/test_tools.py` — 21 passed.
- `ruff check` / `ruff format` clean on changed files.
- `import reflexio` succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated default AI models to newer versions for MiniMax and ZAI providers
  * Improved tool calling support for MiniMax-M3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->