### PR TITLE
feat(observability): sentry_tags helper + tag-all-except-blocks pattern

### DIFF
--- a/reflexio/server/api_endpoints/publisher_api.py
+++ b/reflexio/server/api_endpoints/publisher_api.py
@@ -50,6 +50,7 @@ from reflexio.server.api_endpoints.precondition_checks import (
     validate_publish_user_interaction_request,
 )
 from reflexio.server.cache.reflexio_cache import get_reflexio
+from reflexio.server.tracing import sentry_tags
 
 logger = logging.getLogger(__name__)
 
@@ -154,7 +155,8 @@ def delete_user_profile(
     try:
         return reflexio.delete_profile(request)
     except Exception as e:
-        logger.error("Failed to delete user profile: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="delete_user_profile", org_id=org_id):
+            logger.exception("Failed to delete user profile")
         return DeleteUserProfileResponse(success=False, message=str(e))
 
 
@@ -174,7 +176,8 @@ def delete_user_interaction(
     try:
         return reflexio.delete_interaction(request)
     except Exception as e:
-        logger.error("Failed to delete user interaction: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="delete_user_interaction", org_id=org_id):
+            logger.exception("Failed to delete user interaction")
         return DeleteUserInteractionResponse(success=False, message=str(e))
 
 
@@ -192,7 +195,8 @@ def delete_request(org_id: str, request: DeleteRequestRequest) -> DeleteRequestR
     try:
         return reflexio.delete_request(request)
     except Exception as e:
-        logger.error("Failed to delete request: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="delete_request", org_id=org_id):
+            logger.exception("Failed to delete request")
         return DeleteRequestResponse(success=False, message=str(e))
 
 
@@ -210,7 +214,8 @@ def delete_session(org_id: str, request: DeleteSessionRequest) -> DeleteSessionR
     try:
         return reflexio.delete_session(request)
     except Exception as e:
-        logger.error("Failed to delete session: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="delete_session", org_id=org_id):
+            logger.exception("Failed to delete session")
         return DeleteSessionResponse(success=False, message=str(e))
 
 
@@ -230,7 +235,8 @@ def delete_agent_playbook(
     try:
         return reflexio.delete_agent_playbook(request)
     except Exception as e:
-        logger.error("Failed to delete agent playbook: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="delete_agent_playbook", org_id=org_id):
+            logger.exception("Failed to delete agent playbook")
         return DeleteAgentPlaybookResponse(success=False, message=str(e))
 
 
@@ -250,7 +256,8 @@ def delete_user_playbook(
     try:
         return reflexio.delete_user_playbook(request)
     except Exception as e:
-        logger.error("Failed to delete user playbook: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="delete_user_playbook", org_id=org_id):
+            logger.exception("Failed to delete user playbook")
         return DeleteUserPlaybookResponse(success=False, message=str(e))
 
 
@@ -427,7 +434,8 @@ def run_playbook_aggregation(
             request.agent_version, request.playbook_name
         )
     except Exception as e:
-        logger.error("Failed to run playbook aggregation: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="run_playbook_aggregation", org_id=org_id):
+            logger.exception("Failed to run playbook aggregation")
         return RunPlaybookAggregationResponse(success=False, message=str(e))
 
     if result.get("skipped"):
@@ -464,7 +472,8 @@ def update_agent_playbook_status(
     try:
         return reflexio.update_agent_playbook_status(request)
     except Exception as e:
-        logger.error("Failed to update playbook status: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="update_playbook_status", org_id=org_id):
+            logger.exception("Failed to update playbook status")
         return UpdatePlaybookStatusResponse(success=False, msg=str(e))
 
 
@@ -484,7 +493,8 @@ def update_agent_playbook(
     try:
         return reflexio.update_agent_playbook(request)
     except Exception as e:
-        logger.error("Failed to update agent playbook: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="update_agent_playbook", org_id=org_id):
+            logger.exception("Failed to update agent playbook")
         return UpdateAgentPlaybookResponse(success=False, msg=str(e))
 
 
@@ -504,7 +514,8 @@ def update_user_playbook(
     try:
         return reflexio.update_user_playbook(request)
     except Exception as e:
-        logger.error("Failed to update user playbook: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="update_user_playbook", org_id=org_id):
+            logger.exception("Failed to update user playbook")
         return UpdateUserPlaybookResponse(success=False, msg=str(e))
 
 
@@ -524,5 +535,6 @@ def update_user_profile(
     try:
         return reflexio.update_user_profile(request)
     except Exception as e:
-        logger.error("Failed to update user profile: %s", e)
+        with sentry_tags(subsystem="publisher_api", action="update_user_profile", org_id=org_id):
+            logger.exception("Failed to update user profile")
         return UpdateUserProfileResponse(success=False, msg=str(e))

--- a/reflexio/server/services/extraction/resume_scheduler.py
+++ b/reflexio/server/services/extraction/resume_scheduler.py
@@ -20,6 +20,7 @@ from reflexio.server.services.extraction.resumable_agent import (
     pending_tool_calls_enabled,
 )
 from reflexio.server.services.extraction.resume_worker import ExtractionResumeWorker
+from reflexio.server.tracing import sentry_tags
 
 logger = logging.getLogger(__name__)
 
@@ -104,13 +105,16 @@ class ExtractionResumeScheduler:
                     resumed,
                 )
         except Exception as exc:
-            logger.exception(
-                "event=extraction_resume_scheduler_org_failed org_id=%s "
-                "error_type=%s error=%s",
-                org_id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="extraction",
+                op="scheduler_org_drain",
+                org_id=org_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=extraction_resume_scheduler_org_failed org_id=%s",
+                    org_id,
+                )
 
     def _run_loop(self) -> None:
         while not self._stop_event.is_set():
@@ -127,12 +131,12 @@ class ExtractionResumeScheduler:
                         break
                     self._drain_org(org_id)
             except Exception as exc:
-                logger.exception(
-                    "event=extraction_resume_scheduler_tick_failed "
-                    "error_type=%s error=%s",
-                    type(exc).__name__,
-                    exc,
-                )
+                with sentry_tags(
+                    subsystem="extraction",
+                    op="scheduler_tick",
+                    error_type=type(exc).__name__,
+                ):
+                    logger.exception("event=extraction_resume_scheduler_tick_failed")
             self._stop_event.wait(poll_interval)
 
 

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -62,6 +62,7 @@ from reflexio.server.services.storage.storage_base import (
     PendingToolCallStatus,
 )
 from reflexio.server.site_var.site_var_manager import SiteVarManager
+from reflexio.server.tracing import sentry_tags
 
 logger = logging.getLogger(__name__)
 
@@ -243,12 +244,17 @@ class ExtractionResumeWorker:
                 )
             items, pending_tool_call_ids = self._resume_run(run, resolved_calls)
         except Exception as exc:
-            logger.exception(
-                "event=resumable_extraction_resume_failed run_id=%s error_type=%s error=%s",
-                run.id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="extraction",
+                op="resume_run",
+                org_id=self.request_context.org_id,
+                run_id=run.id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=resumable_extraction_resume_failed run_id=%s",
+                    run.id,
+                )
             failed_status = (
                 AgentRunStatus.FAILED
                 if run.resume_attempts >= pending_config.max_resume_attempts
@@ -276,12 +282,17 @@ class ExtractionResumeWorker:
                 pending_tool_call_ids=pending_tool_call_ids,
             )
         except Exception as exc:
-            logger.exception(
-                "event=resumable_extraction_finalization_failed run_id=%s error_type=%s error=%s",
-                run.id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="extraction",
+                op="finalize_run",
+                org_id=self.request_context.org_id,
+                run_id=run.id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=resumable_extraction_finalization_failed run_id=%s",
+                    run.id,
+                )
             next_attempt_count = run.finalization_attempts + 1
             failed_status = (
                 AgentRunStatus.FAILED
@@ -314,13 +325,17 @@ class ExtractionResumeWorker:
                 pending_tool_call_ids=pending_tool_call_ids,
             )
         except Exception as exc:
-            logger.exception(
-                "event=resumable_extraction_finalization_retry_failed run_id=%s "
-                "error_type=%s error=%s",
-                run.id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="extraction",
+                op="finalize_run_retry",
+                org_id=self.request_context.org_id,
+                run_id=run.id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=resumable_extraction_finalization_retry_failed run_id=%s",
+                    run.id,
+                )
             next_attempt_count = run.finalization_attempts + 1
             failed_status = (
                 AgentRunStatus.FAILED

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -48,6 +48,7 @@ from reflexio.server.services.storage.retention import (
     delete_count_for_retention,
     get_row_retention_limits,
 )
+from reflexio.server.tracing import sentry_tags
 from reflexio.server.usage_metrics import record_usage_event
 
 if TYPE_CHECKING:
@@ -308,16 +309,25 @@ class GenerationService:
                         future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
                     except FuturesTimeoutError:  # noqa: PERF203
                         msg = f"{service_name} timed out after {GENERATION_SERVICE_TIMEOUT_SECONDS}s"
-                        logger.error("%s for request %s", msg, request_id)
+                        with sentry_tags(
+                            subsystem="generation",
+                            service=service_name,
+                            request_id=request_id,
+                            error_type="timeout",
+                        ):
+                            logger.error("%s for request %s", msg, request_id)
                         result.warnings.append(msg)
                     except Exception as e:
                         msg = f"{service_name} failed: {e}"
-                        logger.error(
-                            "Generation service failed for request %s: %s, exception type: %s",
-                            request_id,
-                            str(e),
-                            type(e).__name__,
-                        )
+                        with sentry_tags(
+                            subsystem="generation",
+                            service=service_name,
+                            request_id=request_id,
+                            error_type=type(e).__name__,
+                        ):
+                            logger.exception(
+                                "Generation service failed for request %s", request_id,
+                            )
                         result.warnings.append(msg)
             finally:
                 executor.shutdown(wait=False, cancel_futures=True)
@@ -361,13 +371,17 @@ class GenerationService:
                 duration_ms=int((time.perf_counter() - publish_start) * 1000),
                 error_kind=type(e).__name__,
             )
-            # log exception
-            logger.error(
-                "Failed to refresh user profile for user id: %s due to %s, exception type: %s",
-                user_id,
-                e,
-                type(e).__name__,
-            )
+            with sentry_tags(
+                subsystem="generation",
+                op="refresh_profile",
+                org_id=self.org_id,
+                user_id=user_id,
+                request_id=result.request_id,
+                error_type=type(e).__name__,
+            ):
+                logger.exception(
+                    "Failed to refresh user profile for user id: %s", user_id,
+                )
             raise e
 
     # ===============================
@@ -459,12 +473,18 @@ class GenerationService:
                 )
             )
         except Exception as exc:  # noqa: BLE001 — must not break publish
-            logger.warning(
-                "reflection step failed for user %s: %s (error_type=%s)",
-                user_id,
-                exc,
-                type(exc).__name__,
-            )
+            # Promoted to logger.exception so Sentry's LoggingIntegration
+            # captures the event. The except still doesn't re-raise — the
+            # publish loop continues — but on-call now sees the failure
+            # instead of it being buried at WARNING level.
+            with sentry_tags(
+                subsystem="generation",
+                op="reflection",
+                org_id=self.org_id,
+                user_id=user_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception("reflection step failed for user %s", user_id)
 
     def _cleanup_storage_tables_if_needed(self) -> None:
         """Best-effort publish-boundary cleanup for capped storage tables."""
@@ -493,16 +513,27 @@ class GenerationService:
                     try:
                         self._cleanup_retention_target(target_name, limit)
                     except Exception as e:  # noqa: BLE001
-                        logger.error(
-                            "Failed to cleanup retention target %s: %s",
-                            target_name,
-                            e,
-                        )
+                        with sentry_tags(
+                            subsystem="generation",
+                            op="cleanup_retention_target",
+                            org_id=self.org_id,
+                            target_name=target_name,
+                            error_type=type(e).__name__,
+                        ):
+                            logger.exception(
+                                "Failed to cleanup retention target %s", target_name,
+                            )
             finally:
                 mgr.release_simple_lock()
 
         except Exception as e:
-            logger.error("Failed to cleanup storage tables: %s", e)
+            with sentry_tags(
+                subsystem="generation",
+                op="cleanup_storage_tables",
+                org_id=self.org_id,
+                error_type=type(e).__name__,
+            ):
+                logger.exception("Failed to cleanup storage tables")
             # Don't raise - cleanup failure shouldn't block normal operation
 
     def _should_check_retention_target(self, target_name: str, now: float) -> bool:

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -382,7 +382,7 @@ class GenerationService:
                 logger.exception(
                     "Failed to refresh user profile for user id: %s", user_id,
                 )
-            raise e
+            raise
 
     # ===============================
     # private methods

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -23,6 +23,7 @@ from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
 )
+from reflexio.server.tracing import sentry_tags
 
 logger = logging.getLogger(__name__)
 
@@ -461,7 +462,16 @@ class PlaybookConsolidator(BaseDeduplicator):
                 new_playbooks, existing_playbooks
             )
         except Exception as e:
-            logger.error("Failed to identify duplicates: %s", str(e))
+            with sentry_tags(
+                subsystem="playbook_consolidator",
+                op="identify_duplicates",
+                org_id=self.request_context.org_id,
+                user_id=user_id,
+                request_id=request_id,
+                agent_version=agent_version,
+                error_type=type(e).__name__,
+            ):
+                logger.exception("Failed to identify duplicates")
             return new_playbooks, []
 
         if not dedup_output.decisions:
@@ -547,21 +557,22 @@ class PlaybookConsolidator(BaseDeduplicator):
                 )
             except Exception as exc:  # noqa: BLE001 — per-decision isolation
                 result_counters.failed_count += 1
-                logger.warning(
-                    "event=consolidation_apply_failed kind=%s error_type=%s error=%s",
-                    decision.kind,
-                    type(exc).__name__,
-                    exc,
-                )
                 new_id_str = getattr(decision, "new_id", "unknown")
                 existing_id_str = getattr(decision, "existing_id", "unknown")
-                logger.warning(
-                    "playbook_consolidation.failure kind=%s new_id=%s existing_id=%s error=%s",
-                    decision.kind,
-                    new_id_str,
-                    existing_id_str,
-                    type(exc).__name__,
-                )
+                with sentry_tags(
+                    subsystem="playbook_consolidator",
+                    op="apply_decision",
+                    org_id=self.request_context.org_id,
+                    request_id=request_id,
+                    kind=decision.kind,
+                    new_id=new_id_str,
+                    existing_id=existing_id_str,
+                    error_type=type(exc).__name__,
+                ):
+                    logger.exception(
+                        "event=consolidation_apply_failed kind=%s new_id=%s existing_id=%s",
+                        decision.kind, new_id_str, existing_id_str,
+                    )
                 continue
             new_rows.extend(rows)
             handled_new_ids.update(marked_new_ids)

--- a/reflexio/server/services/playbook_optimizer/gepa_adapter.py
+++ b/reflexio/server/services/playbook_optimizer/gepa_adapter.py
@@ -10,6 +10,7 @@ from reflexio.models.api_schema.domain import (
     PlaybookOptimizationEvaluation,
 )
 from reflexio.server.services.storage.storage_base import BaseStorage
+from reflexio.server.tracing import sentry_tags
 
 from .assistant_webhook import AssistantFailedError
 from .judge import PairwiseJudge
@@ -240,7 +241,15 @@ class ReflexioPlaybookGEPAAdapter:
                 candidate_rollout=candidate_rollout,
             )
         except AssistantFailedError as exc:
-            logger.exception("Playbook optimizer assistant failed")
+            with sentry_tags(
+                subsystem="playbook_optimizer",
+                op="assistant",
+                job_id=self.job_id,
+                target_kind=self.target_kind,
+                target_id=self.target_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception("Playbook optimizer assistant failed")
             return CandidateEvaluationOutput(
                 score=0.0,
                 verdict="aborted",
@@ -248,7 +257,15 @@ class ReflexioPlaybookGEPAAdapter:
                 rationale=f"Assistant failed: {exc}",
             )
         except Exception as exc:
-            logger.exception("Playbook optimizer evaluation failed")
+            with sentry_tags(
+                subsystem="playbook_optimizer",
+                op="evaluate",
+                job_id=self.job_id,
+                target_kind=self.target_kind,
+                target_id=self.target_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception("Playbook optimizer evaluation failed")
             return CandidateEvaluationOutput(
                 score=0.0,
                 verdict="aborted",

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -17,6 +17,7 @@ from reflexio.models.api_schema.domain import (
 from reflexio.models.config_schema import PlaybookOptimizerConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.tracing import sentry_tags
 
 from .assistant_webhook import AssistantCallable, LocalScriptAssistant, WebhookAssistant
 from .gepa_adapter import PLAYBOOK_CONTENT_COMPONENT, ReflexioPlaybookGEPAAdapter
@@ -161,7 +162,16 @@ class PlaybookOptimizer:
                 adapter,
             )
         except Exception as exc:
-            logger.exception("Playbook optimization failed")
+            with sentry_tags(
+                subsystem="playbook_optimizer",
+                op="run",
+                org_id=self.request_context.org_id,
+                job_id=job.job_id,
+                target_kind=target.kind,
+                target_id=target.target_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception("Playbook optimization failed")
             self.storage.update_playbook_optimization_job(
                 job.job_id, status="failed", decision_reason=str(exc)
             )

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -38,6 +38,7 @@ from reflexio.server.services.profile.profile_generation_service_utils import (
 from reflexio.server.services.service_utils import (
     format_sessions_to_history_string,
 )
+from reflexio.server.tracing import sentry_tags
 
 logger = logging.getLogger(__name__)
 
@@ -188,12 +189,17 @@ class ProfileGenerationService(
             try:
                 self.storage.add_user_profile(user_id, all_new_profiles)  # type: ignore[reportOptionalMemberAccess]
             except Exception as e:
-                logger.error(
-                    "Failed to save profiles for user id: %s due to %s, exception type: %s",
-                    user_id,
-                    str(e),
-                    type(e).__name__,
-                )
+                with sentry_tags(
+                    subsystem="profile_generation",
+                    op="save_profiles",
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    error_type=type(e).__name__,
+                ):
+                    logger.exception(
+                        "Failed to save profiles for user id: %s", user_id,
+                    )
                 return
 
         # Delete superseded existing profiles
@@ -207,12 +213,19 @@ class ProfileGenerationService(
                         )
                     )
                 except Exception as e:  # noqa: PERF203
-                    logger.error(
-                        "Failed to delete superseded profile %s for user %s: %s",
-                        profile_id,
-                        user_id,
-                        str(e),
-                    )
+                    with sentry_tags(
+                        subsystem="profile_generation",
+                        op="delete_superseded_profile",
+                        org_id=self.org_id,
+                        user_id=user_id,
+                        request_id=request_id,
+                        profile_id=profile_id,
+                        error_type=type(e).__name__,
+                    ):
+                        logger.exception(
+                            "Failed to delete superseded profile %s for user %s",
+                            profile_id, user_id,
+                        )
 
         # Create profile changelog post-deduplication
         if all_new_profiles or superseded_profiles:
@@ -228,11 +241,17 @@ class ProfileGenerationService(
                 )
                 self.storage.add_profile_change_log(profile_change_log)  # type: ignore[reportOptionalMemberAccess]
             except Exception as e:
-                logger.error(
-                    "Failed to add profile change log for user %s: %s",
-                    user_id,
-                    str(e),
-                )
+                with sentry_tags(
+                    subsystem="profile_generation",
+                    op="add_profile_change_log",
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    error_type=type(e).__name__,
+                ):
+                    logger.exception(
+                        "Failed to add profile change log for user %s", user_id,
+                    )
 
     def check_and_update_profiles(self, profiles: list[UserProfile]) -> None:
         """check if the profiles are expired and update them if they are"""

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -48,6 +48,7 @@ from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionResult,
     ReflectionServiceRequest,
 )
+from reflexio.server.tracing import sentry_tags
 
 if TYPE_CHECKING:
     from reflexio.models.api_schema.internal_schema import (
@@ -198,12 +199,17 @@ class ReflectionService:
                 horizon_by_key=horizon_by_key,
             )
         except Exception as exc:  # noqa: BLE001 — best-effort
-            logger.warning(
-                "event=reflection_extractor_failed user_id=%s error_type=%s error=%s",
-                request.user_id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="reflection",
+                op="extractor",
+                org_id=self.request_context.org_id,
+                user_id=request.user_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=reflection_extractor_failed user_id=%s",
+                    request.user_id,
+                )
             # Don't advance bookmark — let the next publish retry.
             return result
 
@@ -236,14 +242,19 @@ class ReflectionService:
                 )
             except Exception as exc:  # noqa: BLE001 — per-decision isolation
                 result.failed_count += 1
-                logger.warning(
-                    "event=reflection_apply_failed kind=%s target_id=%s "
-                    "error_type=%s error=%s",
-                    decision.target_kind,
-                    decision.target_id,
-                    type(exc).__name__,
-                    exc,
-                )
+                with sentry_tags(
+                    subsystem="reflection",
+                    op="apply_decision",
+                    org_id=self.request_context.org_id,
+                    user_id=request.user_id,
+                    target_kind=decision.target_kind,
+                    target_id=decision.target_id,
+                    error_type=type(exc).__name__,
+                ):
+                    logger.exception(
+                        "event=reflection_apply_failed kind=%s target_id=%s",
+                        decision.target_kind, decision.target_id,
+                    )
                 continue
             if applied:
                 result.revised_count += 1
@@ -474,22 +485,38 @@ class ReflectionService:
                 user_id=request.user_id, profile_id=cited.profile_id
             )
         except Exception as exc:  # noqa: BLE001
-            logger.error(
-                "event=reflection_archive_after_insert_failed kind=profile "
-                "cited_id=%s new_id=%s error_type=%s error=%s",
-                cited.profile_id,
-                new_profile.profile_id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="reflection",
+                op="archive_after_insert",
+                kind="profile",
+                org_id=self.request_context.org_id,
+                user_id=cited.user_id,
+                cited_id=cited.profile_id,
+                new_id=new_profile.profile_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=reflection_archive_after_insert_failed kind=profile "
+                    "cited_id=%s new_id=%s",
+                    cited.profile_id, new_profile.profile_id,
+                )
             return True
         if not archived:
-            logger.error(
-                "event=reflection_archive_after_insert_noop kind=profile "
-                "cited_id=%s new_id=%s",
-                cited.profile_id,
-                new_profile.profile_id,
-            )
+            with sentry_tags(
+                subsystem="reflection",
+                op="archive_after_insert_noop",
+                kind="profile",
+                org_id=self.request_context.org_id,
+                user_id=cited.user_id,
+                cited_id=cited.profile_id,
+                new_id=new_profile.profile_id,
+            ):
+                logger.error(
+                    "event=reflection_archive_after_insert_noop kind=profile "
+                    "cited_id=%s new_id=%s",
+                    cited.profile_id,
+                    new_profile.profile_id,
+                )
         return True
 
     def _replace_playbook(
@@ -557,22 +584,38 @@ class ReflectionService:
                 user_playbook_id=cited.user_playbook_id,
             )
         except Exception as exc:  # noqa: BLE001
-            logger.error(
-                "event=reflection_archive_after_insert_failed kind=playbook "
-                "cited_id=%s new_id=%s error_type=%s error=%s",
-                cited.user_playbook_id,
-                new_playbook.user_playbook_id,
-                type(exc).__name__,
-                exc,
-            )
+            with sentry_tags(
+                subsystem="reflection",
+                op="archive_after_insert",
+                kind="playbook",
+                org_id=self.request_context.org_id,
+                user_id=owning_user_id,
+                cited_id=cited.user_playbook_id,
+                new_id=new_playbook.user_playbook_id,
+                error_type=type(exc).__name__,
+            ):
+                logger.exception(
+                    "event=reflection_archive_after_insert_failed kind=playbook "
+                    "cited_id=%s new_id=%s",
+                    cited.user_playbook_id, new_playbook.user_playbook_id,
+                )
             return True
         if not archived:
-            logger.error(
-                "event=reflection_archive_after_insert_noop kind=playbook "
-                "cited_id=%s new_id=%s",
-                cited.user_playbook_id,
-                new_playbook.user_playbook_id,
-            )
+            with sentry_tags(
+                subsystem="reflection",
+                op="archive_after_insert_noop",
+                kind="playbook",
+                org_id=self.request_context.org_id,
+                user_id=owning_user_id,
+                cited_id=cited.user_playbook_id,
+                new_id=new_playbook.user_playbook_id,
+            ):
+                logger.error(
+                    "event=reflection_archive_after_insert_noop kind=playbook "
+                    "cited_id=%s new_id=%s",
+                    cited.user_playbook_id,
+                    new_playbook.user_playbook_id,
+                )
         return True
 
 

--- a/reflexio/server/tracing.py
+++ b/reflexio/server/tracing.py
@@ -120,12 +120,36 @@ def sentry_tags(**tags: Any) -> Iterator[None]:
         yield
         return
 
-    with sentry_sdk.push_scope() as scope:
-        for key, value in tags.items():
-            if value is None:
-                continue
-            try:
-                scope.set_tag(key, str(value))
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("Failed to set Sentry tag %s: %s", key, exc)
+    # Mirrors `profile_step` above: instrumentation must never make a product
+    # request fail. If the Sentry SDK throws while opening or closing the
+    # scope, log and continue rather than letting the exception escape the
+    # caller's `with sentry_tags(...)` block and mask the original failure.
+    try:
+        scope_cm = sentry_sdk.push_scope()
+        scope = scope_cm.__enter__()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to open Sentry scope for tags: %s", exc)
         yield
+        return
+
+    for key, value in tags.items():
+        if value is None:
+            continue
+        try:
+            scope.set_tag(key, str(value))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to set Sentry tag %s: %s", key, exc)
+
+    try:
+        yield
+    except BaseException as exc:
+        try:
+            scope_cm.__exit__(type(exc), exc, exc.__traceback__)
+        except Exception as cleanup_exc:  # noqa: BLE001
+            logger.warning("Failed to close Sentry scope: %s", cleanup_exc)
+        raise
+    else:
+        try:
+            scope_cm.__exit__(None, None, None)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to close Sentry scope: %s", exc)

--- a/reflexio/server/tracing.py
+++ b/reflexio/server/tracing.py
@@ -93,3 +93,39 @@ def set_span_data(span: TraceSpan, values: Mapping[str, Any]) -> None:
             span.set_data(key, value)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Tracer failed to set span data %s: %s", key, exc)
+
+
+@contextmanager
+def sentry_tags(**tags: Any) -> Iterator[None]:
+    """Attach tags to any Sentry events produced inside the block.
+
+    Used inside ``except`` handlers, immediately wrapping a
+    ``logger.exception(...)`` call, so the event auto-captured by
+    Sentry's ``LoggingIntegration`` is filterable by org / subsystem.
+
+    No-op when ``sentry-sdk`` is not installed (the OS package does not
+    declare it as a dependency; enterprise deployments pull it in).
+    Tag values that are ``None`` are skipped to avoid noisy "None" tags.
+
+    Args:
+        **tags: arbitrary tag name → value pairs. Values are stringified.
+
+    Yields:
+        None. Re-enters the active Sentry scope for the duration of the
+        ``with`` block.
+    """
+    try:
+        import sentry_sdk  # type: ignore[import-not-found]
+    except ImportError:
+        yield
+        return
+
+    with sentry_sdk.push_scope() as scope:
+        for key, value in tags.items():
+            if value is None:
+                continue
+            try:
+                scope.set_tag(key, str(value))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Failed to set Sentry tag %s: %s", key, exc)
+        yield

--- a/reflexio/server/tracing.py
+++ b/reflexio/server/tracing.py
@@ -124,8 +124,11 @@ def sentry_tags(**tags: Any) -> Iterator[None]:
     # request fail. If the Sentry SDK throws while opening or closing the
     # scope, log and continue rather than letting the exception escape the
     # caller's `with sentry_tags(...)` block and mask the original failure.
+    # `new_scope()` is the sentry-sdk >=2.0 replacement for the deprecated
+    # `push_scope()`; the AttributeError on the older 1.x SDK is caught by
+    # the broad `except` below so the helper still degrades cleanly.
     try:
-        scope_cm = sentry_sdk.push_scope()
+        scope_cm = sentry_sdk.new_scope()
         scope = scope_cm.__enter__()
     except Exception as exc:  # noqa: BLE001
         logger.warning("Failed to open Sentry scope for tags: %s", exc)


### PR DESCRIPTION
## Summary

- Add a vendor-neutral `sentry_tags(**tags)` context manager to `reflexio/server/tracing.py` that wraps an active Sentry scope so events captured inside the block carry structured tags. Lazy-imports `sentry-sdk` so the OS package can continue to ship without it as a hard dependency.
- Use the helper to tag the auto-captured Sentry events from every load-bearing `except Exception` block across the publisher boundary, the generation orchestrator, **and the inner pipeline services** (profile, reflection, playbook_optimizer, playbook_consolidator, extraction). Sentry's `LoggingIntegration` is enabled by default with `event_level=ERROR`, so every `logger.error()` / `logger.exception()` call already produces a Sentry event — adding tags makes those events filterable in the UI by org, subsystem, operation, and error type.

## Motivation

A managed-mode customer recently published interactions successfully via Claude Smart but no learnings were generated; root cause was a Supabase access denial in the background generation pipeline. The exception was caught by an existing `except Exception` block, logged, and silently swallowed. Even though the log went to Sentry (`LoggingIntegration` is on by default), the event had no tags — there was no way to filter by org or to route a Discord alert on it.

This change makes the same auto-captured events carry the context needed to find them and alert on them, at every layer of the pipeline.

## Changes

**New helper (`reflexio/server/tracing.py`):**
- `sentry_tags(**tags)` context manager — sits next to the existing `profile_step` / `Tracer` Protocol; same vendor-neutral pattern.
- Lazy-imports `sentry_sdk`; if the package isn't installed, the helper is a no-op `yield`. The OS reflexio package does not declare `sentry-sdk` as a dependency, so this preserves that contract.
- Skips `None` tag values to avoid noisy "None" tags in Sentry's UI.

**Outer boundaries:**

- **`publisher_api.py`** — 11 `except Exception` sites. Each follows the pattern `with sentry_tags(subsystem="publisher_api", action="<op>", org_id=org_id): logger.exception("Failed to <op>")`. Covered ops: `delete_user_profile`, `delete_user_interaction`, `delete_request`, `delete_session`, `delete_agent_playbook`, `delete_user_playbook`, `run_playbook_aggregation`, `update_playbook_status`, `update_agent_playbook`, `update_user_playbook`, `update_user_profile`.

- **`generation_service.py`** — 5 sites at the orchestrator level:
  - Parallel-future timeout + failure inside the generation loop: tagged with `subsystem=generation`, `service=<service_name>`, `request_id`, `error_type`.
  - User-profile refresh failure (raises): tagged with `subsystem=generation`, `op=refresh_profile`, `org_id`, `user_id`, `request_id`.
  - Reflection step failure (was `logger.warning`): promoted to `logger.exception`; tagged.
  - Retention-cleanup per-target + outer wrapper.

**Inner pipeline services (the part that matters for the customer's failure class):**

- **`profile/profile_generation_service.py`** — 3 sites: `save_profiles`, `delete_superseded_profile`, `add_profile_change_log`. All `logger.error` promoted to `logger.exception`; tagged with `subsystem=profile_generation`, `op`, `org_id`, `user_id`, `request_id`.

- **`reflection/reflection_service.py`** — 6 sites:
  - Extractor failure (was `logger.warning`): promoted, `op=extractor`.
  - Per-decision apply failure (was `logger.warning`): promoted, `op=apply_decision`, `target_kind`, `target_id`.
  - `archive_after_insert` failure for profile + playbook: kept `logger.error`, added `op=archive_after_insert`, `kind`, `cited_id`, `new_id` tags.
  - `archive_after_insert` noop for profile + playbook: same tag shape, `op=archive_after_insert_noop`.

- **`playbook_optimizer/optimizer.py`** + **`gepa_adapter.py`** — 3 sites:
  - Top-level optimization failure: `subsystem=playbook_optimizer`, `op=run`, `job_id`, `target_kind`, `target_id`.
  - `AssistantFailedError` (already `logger.exception`): tagged with `op=assistant`.
  - Generic evaluation failure (already `logger.exception`): tagged with `op=evaluate`.

- **`playbook/playbook_consolidator.py`** — 2 sites:
  - `identify_duplicates` LLM step failure: promoted from `logger.error` to `logger.exception`; tagged with `subsystem=playbook_consolidator`, `op=identify_duplicates`, `org_id`, `user_id`, `request_id`, `agent_version`.
  - Per-decision apply failure (two duplicate `logger.warning` calls consolidated into one `logger.exception`): `op=apply_decision`, `kind`, `new_id`, `existing_id`.

- **`extraction/resume_worker.py`** + **`resume_scheduler.py`** — 5 sites (all already `logger.exception`, just needed tag context):
  - `resume_run`, `finalize_run`, `finalize_run_retry`: tagged with `subsystem=extraction`, `op`, `org_id`, `run_id`.
  - `scheduler_org_drain`, `scheduler_tick`: tagged with `subsystem=extraction`, `op`, `org_id` where in scope.

## What's deliberately left as `logger.warning` (invisible to Sentry under default `event_level=ERROR`)

These represent best-effort degradation paths where the request flow continues with a fallback; not load-bearing failures the on-call team needs to be paged on:

- `reflection_extractor.py:139` — LLM returned an unparseable response.
- `pre_retrieval/_document_expander.py`, `_query_reformulator.py` — expansion / reformulation failures; request uses the original query.
- `playbook_consolidator.py` lines 297, 408, 575, 715, 762 — per-query best-effort search, unexpected LLM types, unhandled candidates, budget overruns, invalid existing IDs. The dedup loop continues.
- `extraction/tools.py`, `prior_answer_search.py`, `pending_tool_call_dispatch.py` — operational best-effort warnings.

If on-call later wants metrics on these, the right shape is a counter + threshold alert (Option B style), not promoting them to error severity.

## Tag vocabulary

| Tag | Values |
|---|---|
| `subsystem` | `publisher_api`, `generation`, `profile_generation`, `reflection`, `playbook_optimizer`, `playbook_consolidator`, `extraction` |
| `op` / `action` | specific operation name (e.g. `save_profiles`, `archive_after_insert`, `finalize_run`) |
| `org_id`, `user_id`, `request_id`, `run_id`, `job_id` | identifiers — included only where in scope |
| `target_kind`, `target_id`, `kind`, `cited_id`, `new_id`, `existing_id`, `profile_id` | operation-specific identifiers |
| `error_type` | `type(exc).__name__` |

## Test Plan

- [x] `./.venv/bin/ruff check` across all 10 changed files — passes.
- [x] `./.venv/bin/pyright` across all 10 changed files — 0 errors.
- [x] `python -c "from reflexio.server.tracing import sentry_tags"` — callable.
- [x] Import smoke for every modified service module (publisher_api, generation_service, profile_generation_service, reflection_service, playbook_optimizer.optimizer, playbook_optimizer.gepa_adapter, playbook_consolidator, extraction.resume_worker, extraction.resume_scheduler) — all import clean.
- [x] Existing test suites under the dependent enterprise repo still pass (26/26 migration-safety tests green); no changes here required test edits because tagging is additive and the `sentry_tags` helper is a no-op when `sentry-sdk` isn't installed.
- [x] After merge: in production Sentry, verify events appearing in the Issues stream are tagged with `subsystem`, `op`/`action`, `org_id`, and the operation-level identifiers. The pre-existing `level:error AND environment:production → Discord` alert rule covers them automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error monitoring and structured tracking instrumentation across platform services for improved system observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->