### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -6,16 +6,15 @@ Describe the code structure and component dependencies for source code of reflex
 - [Overview](#overview)
 - [models and client](#models-and-client)
 - [cli](#cli)
-- [reflexio_lib](#reflexio_lib)
+- [lib](#lib)
 - [server](#server)
-- [data](#data)
 - [See Also](#see-also)
 
 ## Overview
 Reflexio is a user profiling and agent playbook system with three main access patterns:
 
 1. **Remote API Access** (`client`) - Applications use Python SDK to call REST API
-2. **Local Library Access** (`reflexio_lib`) - Direct synchronous access without HTTP layer
+2. **Local Library Access** (`lib/reflexio_lib.py`) - Direct synchronous access without HTTP layer
 3. **CLI Access** (`cli`) - Local command-line workflows for services, publishing, search, auth, config, and diagnostics
 
 **Core Flow**: User Interactions → Server Processing → Profile/Playbook/Evaluation → Storage
@@ -23,7 +22,6 @@ Reflexio is a user profiling and agent playbook system with three main access pa
 **Shared Components**:
 - `models` - API and internal schemas shared by client, CLI, and server
 - `server` - FastAPI backend with LLM-based processing services
-- `data` - Bundled configs and local fixtures
 - `docs` - Next.js API documentation site
 
 ## models and client
@@ -80,11 +78,12 @@ Local operator interface to:
 ### Architecture Pattern
 Thin Typer layer over the Python client and local service manager. Use `uv run reflexio --help` to inspect command groups.
 
-## reflexio_lib
+## lib
 Description: Local Python library interface for direct (non-API) access to Reflexio functionality
 
 ### Main Entry Point
-- **Library**: `reflexio_lib.py` - `Reflexio` class
+- **Library**: `lib/reflexio_lib.py` - `Reflexio` class
+- **Domain helpers**: `lib/_profiles.py`, `lib/_user_playbook.py`, `lib/_agent_playbook.py`, `lib/_search.py`, `lib/_generation.py`, `lib/_reflection.py`, `lib/_dashboard.py`, `lib/_operations.py` - focused method groups mixed into `Reflexio`
 
 ### Purpose
 Direct programmatic access without HTTP/API layer:
@@ -116,7 +115,7 @@ Receives user interactions from clients and processes them to:
 client (Python SDK)
   -> api.py (FastAPI routes)
     -> api_endpoints/ (request handlers)
-      -> reflexio_lib.Reflexio (main entry)
+      -> lib/reflexio_lib.py Reflexio (main entry)
         -> services/generation_service.py (orchestrator)
           ├─> services/profile/ -> storage (BaseStorage)
           ├─> services/playbook/ (playbook extraction) -> storage (BaseStorage)
@@ -125,8 +124,7 @@ client (Python SDK)
 
 ### Key Components
 - **`api_endpoints/`**: Request handling, `RequestContext` (bundles storage/config/prompts), auth
-- **`db/`**: Auth & config storage only (SQLite) - NOT for profiles/interactions
-- **`llm/`**: Unified LLM client (auto-detects OpenAI/Claude from model name)
+- **`llm/`**: LiteLLM-based generation, embedding providers, tool schemas, and rerankers
 - **`prompt/`**: Versioned prompt templates in `prompt_bank/`
 - **`services/`**: Core business logic
   - `generation_service.py` - Orchestrator (runs profile/playbook/success services)
@@ -141,6 +139,8 @@ client (Python SDK)
   - `playbook_optimizer/` - Scenario-based playbook optimization experiments
   - `braintrust/` - Braintrust eval export/sync support
   - `storage/` - Abstract layer (SQLite prod, LocalJSON test)
+  - `retrieval/` - Relevance-floor helpers for search result filtering
+  - `search/` - Search-specific support modules
   - `pre_retrieval/` - Query rewriting and document expansion helpers
   - `configurator/` - YAML config loader
 - **`site_var/`**: Global settings singleton
@@ -155,24 +155,6 @@ client (Python SDK)
 **Storage Abstraction**: All access via `BaseStorage` interface, implementation selected by configurator, supports vector similarity search
 
 **Data Flow**: `User Interaction -> Storage (save) -> Services (parallel: LLM + Prompts) -> Results -> Storage (save)`
-
-
-## data
-Description: Local storage directory for configuration files and SQLite databases
-
-### Main Entry Points
-- **Configs**: `configs/` - YAML configuration files for extractors and evaluators
-- **Database**: `sql_app.db` - SQLite database for auth and config storage
-- **JSON Storage**: `user_profiles_*.json` - Local JSON files for testing
-
-### Purpose
-Local data storage for:
-1. **Configuration files** - YAML configs defining extraction/evaluation behavior
-2. **Authentication database** - User credentials and API tokens (SQLite/Postgres)
-3. **Test data** - LocalJsonStorage files for development/testing
-
-### Architecture Pattern
-Referenced by `SimpleConfigurator` for loading configs and by database operations for auth/config persistence. Not directly accessed by application code.
 
 ## See Also
 

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -21,6 +21,7 @@ Description: FastAPI backend server that processes user interactions to generate
   - [Playbook Optimizer and Braintrust](#playbook-optimizer-and-braintrust)
   - [Query Reformulator](#query-reformulator)
   - [Unified Search Service](#unified-search-service)
+  - [Retrieval Relevance Floor](#retrieval-relevance-floor)
   - [Storage](#storage)
   - [Configurator](#configurator)
 - [Architecture Patterns](#architecture-patterns)
@@ -88,9 +89,11 @@ Description: FastAPI backend server that processes user interactions to generate
 
 Key files:
 - `litellm_client.py`: Unified LiteLLMClient using LiteLLM for multi-provider support
-- `openai_client.py`: OpenAI implementation (legacy, do not use directly)
-- `claude_client.py`: Claude implementation (legacy, do not use directly)
 - `llm_utils.py`: Helper functions for Pydantic model conversion
+- `model_defaults.py`: Default model identifiers and provider aliases
+- `embedding_service.py`: Local/remote embedding service integration
+- `providers/`: Provider adapters for local/Nomic embeddings and Claude Code parsing
+- `rerank/`: LLM and cross-encoder rerankers for search result ordering
 
 **Features**:
 - Uses LiteLLM for multi-provider support (OpenAI, Claude, Azure, OpenRouter, Gemini, custom endpoints, etc.)
@@ -181,6 +184,7 @@ python -m reflexio.server.scripts.manage_invitation_codes list --show-used
 - **Evaluation**: `agent_success_evaluation/`, `shadow_comparison/`, and `evaluation_overview/` handle session grading, per-turn shadow verdicts, regeneration jobs, and dashboard-facing rollups.
 - **Async clarification**: `extraction/` and `reflection/` manage resumable agent runs, pending tool calls, prior-answer search, and long-horizon reflection updates.
 - **Search preparation**: `pre_retrieval/` and `unified_search_service.py` handle query reformulation, document expansion, embeddings, and cross-entity search orchestration.
+- **Retrieval filtering**: `retrieval/relevance_floor.py` applies configurable score floors before returning search results.
 - **Optimization/integrations**: `playbook_optimizer/` and `braintrust/` run candidate playbook optimization, rollout support, and Braintrust export/sync.
 - **Persistence/config**: `storage/`, `configurator/`, and `operation_state_utils.py` provide storage abstractions, config loading, locks, bookmarks, progress, and cancellation.
 
@@ -453,6 +457,15 @@ Searches across all entity types (profiles, agent_playbooks, user_playbooks) in 
 - **Phase B**: Entity searches across all types (parallel via ThreadPoolExecutor, 3 workers)
 
 Pre-computed embeddings passed to storage methods via `query_embedding` parameter to avoid redundant embedding calls.
+
+### Retrieval Relevance Floor
+
+**Directory**: `services/retrieval/`
+
+Key files:
+- `relevance_floor.py`: Computes and applies result score floors for profile, user playbook, and agent playbook searches.
+
+**Pattern**: Search endpoints and `run_unified_search()` should use retrieval-floor helpers rather than duplicating threshold logic. Configuration lives in `Config.retrieval_floor` so callers can keep score filtering consistent across entity types.
 
 ### Storage
 


### PR DESCRIPTION
## Summary
- Syncs model-facing code-map READMEs with the latest Reflexio package layout.
- Corrects stale navigation around `lib/reflexio_lib.py`, removes non-existent package `data`/`db` references, and documents current LLM/retrieval components.

## Repositories/submodules reviewed
- `ReflexioAI/reflexio` (`open_source/reflexio` submodule of `yyiilluu/reflexio-enterprise`)

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`

## Validation
- `git diff --check`
- Local markdown link/path check for the updated README files

## Notes/Risks
- Updates follow `how_to_write_readme.md`: concise code-map/navigation changes only.
- `open_source/reflexio/README.md` was intentionally not restructured because it is the public user-facing README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined project documentation structure with improved organization of `lib` and `server` components
  * Enhanced component diagrams and expanded key files listings for better clarity on architecture and entry points
  * Streamlined documentation to better guide users through the system's core services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->