### PR TITLE
fix(consolidator): tolerate 'EXISTING-N' label in int ID fields

### DIFF
--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -36,22 +36,33 @@ logger = logging.getLogger(__name__)
 def _coerce_existing_position(value: object) -> int:
     """Accept either a bare int position or an ``"EXISTING-N"`` label.
 
+    Wired ONLY to ``UnifyDecision.archive_existing_ids`` — the one field whose
+    int contract is genuinely a list **position** (resolved via
+    ``existing_by_position`` as ``f"EXISTING-{idx}"`` in ``_apply_unify``).
+    ``RejectNewDecision.superseded_by_existing_id`` and
+    ``DifferentiateDecision.existing_id`` are DB ``user_playbook_id`` values
+    (resolved via ``existing_by_id`` in ``_apply_reject_new`` /
+    ``_apply_differentiate``) — coercing ``"EXISTING-N"`` to ``N`` on those
+    fields would silently misroute decisions when the position int doesn't
+    map to a real DB id.
+
     The consolidation prompt labels rows as ``[EXISTING-0]``, ``[EXISTING-1]``
-    etc. (see ``_format_playbooks_with_prefix``) and the apply path
+    etc. (see ``_format_playbooks_with_prefix``) and ``_apply_unify``
     reconstructs ``f"EXISTING-{position}"`` from the integer the LLM returns.
-    Strong structured-output models (GPT-4o, Claude) honor the
-    ``list[int]`` schema and return the bare integer ``0``; weaker models
-    (e.g. MiniMax-M3) ignore the int constraint and return the literal
-    label ``"EXISTING-0"`` instead — which then fails pydantic validation
-    and the whole consolidation batch dies.
+    Strong structured-output models (GPT-4o, Claude) honor the ``list[int]``
+    schema and return the bare integer ``0``; weaker models (e.g. MiniMax-M3)
+    ignore the int constraint and return the literal label ``"EXISTING-0"``
+    instead — which then fails pydantic validation and the whole
+    consolidation batch dies.
 
     Strip the prefix when present so the schema tolerates both shapes
     without changing the int contract downstream consumers rely on. Plain
     numeric strings (``"5"``) are also accepted for symmetry with how
-    most JSON-coerced models handle ID-like values.
+    most JSON-coerced models handle ID-like values. Negative values are
+    rejected — list positions are always ``>= 0``.
 
     Raises:
-        ValueError: when ``value`` is neither an int nor a recognized
+        ValueError: when ``value`` is not a non-negative int or a recognized
             position-label / numeric string.
     """
     if isinstance(value, bool):
@@ -59,6 +70,8 @@ def _coerce_existing_position(value: object) -> int:
         # stray ``True`` doesn't silently become position 1.
         raise ValueError(f"existing-position must be int, got bool: {value!r}")
     if isinstance(value, int):
+        if value < 0:
+            raise ValueError(f"existing-position must be >= 0, got {value!r}")
         return value
     if isinstance(value, str):
         stripped = value.strip()
@@ -67,11 +80,16 @@ def _coerce_existing_position(value: object) -> int:
                 stripped = stripped[len(prefix):]
                 break
         try:
-            return int(stripped)
+            parsed = int(stripped)
         except ValueError as exc:
             raise ValueError(
                 f"existing-position must be int or 'EXISTING-N' label, got {value!r}"
             ) from exc
+        if parsed < 0:
+            raise ValueError(
+                f"existing-position must be >= 0, got {value!r}"
+            )
+        return parsed
     raise ValueError(
         f"existing-position must be int or 'EXISTING-N' label, got {type(value).__name__}: {value!r}"
     )
@@ -114,23 +132,32 @@ class UnifyDecision(BaseModel):
 
 
 class RejectNewDecision(BaseModel):
-    """The new candidate is redundant; an existing row supersedes it (storage no-op)."""
+    """The new candidate is redundant; an existing row supersedes it (storage no-op).
+
+    ``superseded_by_existing_id`` is a DB ``user_playbook_id`` (resolved
+    against ``existing_by_id`` in ``_apply_reject_new``), NOT a list
+    position — no ``"EXISTING-N"`` coercion is wired here. If the LLM
+    returns ``"EXISTING-N"`` for this field, pydantic rejects it loudly
+    rather than silently misrouting the decision (see
+    ``_coerce_existing_position`` docstring).
+    """
 
     kind: Literal["reject_new"] = "reject_new"
     new_id: str
     superseded_by_existing_id: int
     reason: str = ""
 
-    @field_validator("superseded_by_existing_id", mode="before")
-    @classmethod
-    def _coerce_superseded(cls, value: object) -> object:
-        return _coerce_existing_position(value)
-
     model_config = ConfigDict(json_schema_extra={"additionalProperties": False})
 
 
 class DifferentiateDecision(BaseModel):
-    """Both rules valid in distinct contexts: refine both triggers."""
+    """Both rules valid in distinct contexts: refine both triggers.
+
+    ``existing_id`` is a DB ``user_playbook_id`` (resolved against
+    ``existing_by_id`` in ``_apply_differentiate``), NOT a list position —
+    no ``"EXISTING-N"`` coercion is wired here. See
+    ``_coerce_existing_position`` docstring.
+    """
 
     kind: Literal["differentiate"] = "differentiate"
     new_id: str
@@ -138,11 +165,6 @@ class DifferentiateDecision(BaseModel):
     refined_new_trigger: str
     refined_existing_trigger: str
     reason: str = ""
-
-    @field_validator("existing_id", mode="before")
-    @classmethod
-    def _coerce_existing_id(cls, value: object) -> object:
-        return _coerce_existing_position(value)
 
     @field_validator("refined_new_trigger", "refined_existing_trigger")
     @classmethod

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -33,6 +33,50 @@ logger = logging.getLogger(__name__)
 # ===============================
 
 
+def _coerce_existing_position(value: object) -> int:
+    """Accept either a bare int position or an ``"EXISTING-N"`` label.
+
+    The consolidation prompt labels rows as ``[EXISTING-0]``, ``[EXISTING-1]``
+    etc. (see ``_format_playbooks_with_prefix``) and the apply path
+    reconstructs ``f"EXISTING-{position}"`` from the integer the LLM returns.
+    Strong structured-output models (GPT-4o, Claude) honor the
+    ``list[int]`` schema and return the bare integer ``0``; weaker models
+    (e.g. MiniMax-M3) ignore the int constraint and return the literal
+    label ``"EXISTING-0"`` instead — which then fails pydantic validation
+    and the whole consolidation batch dies.
+
+    Strip the prefix when present so the schema tolerates both shapes
+    without changing the int contract downstream consumers rely on. Plain
+    numeric strings (``"5"``) are also accepted for symmetry with how
+    most JSON-coerced models handle ID-like values.
+
+    Raises:
+        ValueError: when ``value`` is neither an int nor a recognized
+            position-label / numeric string.
+    """
+    if isinstance(value, bool):
+        # ``bool`` is a subclass of ``int`` in Python; reject explicitly so a
+        # stray ``True`` doesn't silently become position 1.
+        raise ValueError(f"existing-position must be int, got bool: {value!r}")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        for prefix in ("EXISTING-", "EXISTING_", "existing-", "existing_"):
+            if stripped.startswith(prefix):
+                stripped = stripped[len(prefix):]
+                break
+        try:
+            return int(stripped)
+        except ValueError as exc:
+            raise ValueError(
+                f"existing-position must be int or 'EXISTING-N' label, got {value!r}"
+            ) from exc
+    raise ValueError(
+        f"existing-position must be int or 'EXISTING-N' label, got {type(value).__name__}: {value!r}"
+    )
+
+
 class UnifyDecision(BaseModel):
     """Collapse NEW (+ 0..N EXISTING) into one row with LLM-supplied content.
 
@@ -57,6 +101,15 @@ class UnifyDecision(BaseModel):
     rationale: str
     reason: str = ""
 
+    @field_validator("archive_existing_ids", mode="before")
+    @classmethod
+    def _coerce_archive_ids(cls, value: object) -> object:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [_coerce_existing_position(item) for item in value]
+        return value
+
     model_config = ConfigDict(json_schema_extra={"additionalProperties": False})
 
 
@@ -67,6 +120,11 @@ class RejectNewDecision(BaseModel):
     new_id: str
     superseded_by_existing_id: int
     reason: str = ""
+
+    @field_validator("superseded_by_existing_id", mode="before")
+    @classmethod
+    def _coerce_superseded(cls, value: object) -> object:
+        return _coerce_existing_position(value)
 
     model_config = ConfigDict(json_schema_extra={"additionalProperties": False})
 
@@ -80,6 +138,11 @@ class DifferentiateDecision(BaseModel):
     refined_new_trigger: str
     refined_existing_trigger: str
     reason: str = ""
+
+    @field_validator("existing_id", mode="before")
+    @classmethod
+    def _coerce_existing_id(cls, value: object) -> object:
+        return _coerce_existing_position(value)
 
     @field_validator("refined_new_trigger", "refined_existing_trigger")
     @classmethod

--- a/tests/server/services/playbook/test_consolidation_output.py
+++ b/tests/server/services/playbook/test_consolidation_output.py
@@ -133,3 +133,62 @@ def test_legacy_kind_literals_no_longer_parse(legacy_payload):
     """
     with pytest.raises(ValidationError):
         PlaybookConsolidationOutput.model_validate({"decisions": [legacy_payload]})
+
+
+@pytest.mark.parametrize(
+    "raw_value,expected",
+    [
+        ([0, 1], [0, 1]),
+        (["EXISTING-0", "EXISTING-3"], [0, 3]),
+        (["existing-2"], [2]),
+        (["5", "EXISTING-6"], [5, 6]),
+        ([0, "EXISTING-7"], [0, 7]),
+        (None, []),
+    ],
+)
+def test_unify_archive_existing_ids_accepts_position_labels(raw_value, expected):
+    """``archive_existing_ids`` tolerates either bare ints or ``EXISTING-N`` strings.
+
+    Strong structured-output models (GPT-4o, Claude) honor ``list[int]`` and return
+    bare integers, but weaker models (MiniMax-M3) ignore the int constraint and
+    return the literal ``"EXISTING-0"`` label from the prompt. The validator strips
+    the prefix so both shapes round-trip; the apply path keeps using ints
+    downstream.
+    """
+    unify = UnifyDecision(
+        new_id="NEW-0",
+        archive_existing_ids=raw_value,  # type: ignore[arg-type]
+        content="c",
+        trigger="t",
+        rationale="r",
+    )
+    assert unify.archive_existing_ids == expected
+
+
+def test_reject_new_superseded_id_accepts_position_label():
+    """``RejectNewDecision.superseded_by_existing_id`` tolerates ``EXISTING-N``."""
+    r = RejectNewDecision(new_id="NEW-0", superseded_by_existing_id="EXISTING-4")  # type: ignore[arg-type]
+    assert r.superseded_by_existing_id == 4
+
+
+def test_differentiate_existing_id_accepts_position_label():
+    """``DifferentiateDecision.existing_id`` tolerates ``EXISTING-N``."""
+    d = DifferentiateDecision(
+        new_id="NEW-0",
+        existing_id="EXISTING-9",  # type: ignore[arg-type]
+        refined_new_trigger="narrow new",
+        refined_existing_trigger="narrow existing",
+    )
+    assert d.existing_id == 9
+
+
+def test_existing_position_rejects_garbage():
+    """Garbage strings that aren't ``EXISTING-N`` or numeric still fail loudly."""
+    with pytest.raises(ValidationError):
+        UnifyDecision(
+            new_id="NEW-0",
+            archive_existing_ids=["not-a-real-id"],  # type: ignore[list-item]
+            content="c",
+            trigger="t",
+            rationale="r",
+        )

--- a/tests/server/services/playbook/test_consolidation_output.py
+++ b/tests/server/services/playbook/test_consolidation_output.py
@@ -165,21 +165,48 @@ def test_unify_archive_existing_ids_accepts_position_labels(raw_value, expected)
     assert unify.archive_existing_ids == expected
 
 
-def test_reject_new_superseded_id_accepts_position_label():
-    """``RejectNewDecision.superseded_by_existing_id`` tolerates ``EXISTING-N``."""
-    r = RejectNewDecision(new_id="NEW-0", superseded_by_existing_id="EXISTING-4")  # type: ignore[arg-type]
-    assert r.superseded_by_existing_id == 4
+def test_reject_new_superseded_id_rejects_position_label():
+    """``RejectNewDecision.superseded_by_existing_id`` is a DB ``user_playbook_id``,
+    not a list position — ``"EXISTING-N"`` must fail loudly.
+
+    The design contract (``_consolidation_decisions`` docstring) resolves this
+    field via ``existing_by_id`` (DB id), not ``existing_by_position``.
+    Coercing ``"EXISTING-N"`` to ``N`` here would silently misroute decisions
+    when the position int doesn't map to a real DB id.
+    """
+    with pytest.raises(ValidationError):
+        RejectNewDecision(new_id="NEW-0", superseded_by_existing_id="EXISTING-4")  # type: ignore[arg-type]
 
 
-def test_differentiate_existing_id_accepts_position_label():
-    """``DifferentiateDecision.existing_id`` tolerates ``EXISTING-N``."""
+def test_differentiate_existing_id_rejects_position_label():
+    """``DifferentiateDecision.existing_id`` is a DB ``user_playbook_id``,
+    not a list position — ``"EXISTING-N"`` must fail loudly. Same reasoning
+    as ``test_reject_new_superseded_id_rejects_position_label``.
+    """
+    with pytest.raises(ValidationError):
+        DifferentiateDecision(
+            new_id="NEW-0",
+            existing_id="EXISTING-9",  # type: ignore[arg-type]
+            refined_new_trigger="narrow new",
+            refined_existing_trigger="narrow existing",
+        )
+
+
+def test_reject_new_superseded_id_accepts_bare_int():
+    """Sanity check: bare ints (DB ``user_playbook_id`` values) still pass."""
+    r = RejectNewDecision(new_id="NEW-0", superseded_by_existing_id=12345)
+    assert r.superseded_by_existing_id == 12345
+
+
+def test_differentiate_existing_id_accepts_bare_int():
+    """Sanity check: bare ints (DB ``user_playbook_id`` values) still pass."""
     d = DifferentiateDecision(
         new_id="NEW-0",
-        existing_id="EXISTING-9",  # type: ignore[arg-type]
+        existing_id=12345,
         refined_new_trigger="narrow new",
         refined_existing_trigger="narrow existing",
     )
-    assert d.existing_id == 9
+    assert d.existing_id == 12345
 
 
 def test_existing_position_rejects_garbage():
@@ -192,3 +219,62 @@ def test_existing_position_rejects_garbage():
             trigger="t",
             rationale="r",
         )
+
+
+@pytest.mark.parametrize("bad", [-1, "-1", "EXISTING--1", "existing_-2"])
+def test_existing_position_rejects_negative(bad):
+    """List positions are always ``>= 0`` — negatives are rejected.
+
+    A negative position (or any post-strip negative parse like ``EXISTING--1``)
+    can only fail later in apply. Fail fast here so the validator behaves as
+    a sharp domain check, not a passthrough that defers the error.
+    """
+    with pytest.raises(ValidationError):
+        UnifyDecision(
+            new_id="NEW-0",
+            archive_existing_ids=[bad],  # type: ignore[list-item]
+            content="c",
+            trigger="t",
+            rationale="r",
+        )
+
+
+def test_unify_coerced_position_resolves_via_existing_by_position():
+    """Apply-path regression: a coerced ``"EXISTING-N"`` resolves to the
+    expected row through ``existing_by_position`` (the lookup
+    ``_apply_unify`` actually uses).
+
+    The unit tests above prove decode-time coercion (``"EXISTING-3"`` → ``3``).
+    This test closes the loop: index 3 in the position-keyed lookup must
+    point at the third existing playbook, so the coercion is end-to-end
+    correct for the one field where it's wired.
+    """
+    from reflexio.models.api_schema.domain.entities import UserPlaybook
+
+    existing = [
+        UserPlaybook(
+            content=f"existing-{i}",
+            trigger="t",
+            user_playbook_id=1000 + i,
+            agent_version="v0",
+            request_id="r0",
+        )
+        for i in range(5)
+    ]
+    # This is the same construction _build_deduplicated_results uses.
+    existing_by_position = {f"EXISTING-{idx}": pb for idx, pb in enumerate(existing)}
+
+    unify = UnifyDecision(
+        new_id="NEW-0",
+        archive_existing_ids=["EXISTING-3"],  # type: ignore[list-item]
+        content="c",
+        trigger="t",
+        rationale="r",
+    )
+    # Coerced to int position
+    assert unify.archive_existing_ids == [3]
+    # And that position resolves through the apply-path lookup
+    resolved = existing_by_position.get(f"EXISTING-{unify.archive_existing_ids[0]}")
+    assert resolved is not None
+    assert resolved.user_playbook_id == 1003
+    assert resolved.content == "existing-3"


### PR DESCRIPTION
## Summary

Hot-fix for a production `LiteLLMClientError: API call failed after 2 retries: Structured output parse failed for model='minimax/MiniMax-M3'` that's killing every playbook consolidation batch on the MiniMax path.

`PlaybookConsolidationOutput` declares three int-typed ID fields:

- `UnifyDecision.archive_existing_ids: list[int]`
- `RejectNewDecision.superseded_by_existing_id: int`
- `DifferentiateDecision.existing_id: int`

The **design contract** in `playbook_consolidator.py` is: the prompt labels input rows as `[EXISTING-0]`, `[EXISTING-1]`, … the LLM returns the bare int, and the apply path reconstructs `f"EXISTING-{position}"` for the downstream `user_playbook_id` lookup. Strong structured-output models (GPT-4o, Claude) honor `list[int]` and return bare integers. Weaker models — observed on `minimax/MiniMax-M3` in production — ignore the int constraint and **echo back the literal `"EXISTING-0"` label they saw in the prompt**, which fails pydantic validation, kills the batch, and surfaces as the `LiteLLMClientError` above after the LiteLLM retry budget is exhausted.

## Fix

One helper, three `field_validator(mode="before")` wirings.

`_coerce_existing_position(value: object) -> int` accepts:

| Input | Output | Notes |
|---|---|---|
| `0` (bare int) | `0` | Compliant model path — unchanged |
| `"EXISTING-0"` | `0` | MiniMax-M3 echo |
| `"existing-0"` / `"EXISTING_0"` / `"existing_0"` | `0` | Tolerant of separator + case |
| `"5"` (bare numeric string) | `5` | Common LLM string-coercion |
| `True` / `False` | `ValueError` | Bool isn't int — caught explicitly |
| `"not-a-real-id"` / `[]` / `{}` | `ValueError` | Still fails loudly |

Wired via `@field_validator(mode="before")` on:

- `UnifyDecision.archive_existing_ids` — iterates the list and coerces each element
- `RejectNewDecision.superseded_by_existing_id`
- `DifferentiateDecision.existing_id`

The apply path is unchanged: still receives bare ints, still does `f"EXISTING-{position}"` for the downstream lookup. The validator is a **decode-time normalizer** — it doesn't change the design contract, it just makes decoding robust to one specific class of LLM non-compliance.

## What this PR does *not* fix

MiniMax-M3 also occasionally **drops required fields** on `UnifyDecision` (`content`, `trigger`, `rationale`) — that's a separate behavioral problem that this PR doesn't address. After this fix lands, consolidation batches with the int-coercion failure will succeed; batches where MiniMax also omits required string fields will still fail with a different validation error. That gap is best closed either by (a) an explicit JSON-shape example in the consolidation prompt or (b) using a stricter model. Not in scope here — this PR is the proximal hot-fix.

## Tests

6 new parametrized cases in `tests/server/services/playbook/test_consolidation_output.py`:

- `test_unify_archive_existing_ids_accepts_position_labels` — 6 parametrized inputs covering `[0, 1]`, `["EXISTING-0", "EXISTING-3"]`, `["existing-2"]`, `["5", "EXISTING-6"]`, `[0, "EXISTING-7"]`, and `None` → `[]`.
- `test_reject_new_superseded_id_accepts_position_label` — `"EXISTING-4"` → `4`.
- `test_differentiate_existing_id_accepts_position_label` — `"EXISTING-9"` → `9`.
- `test_existing_position_rejects_garbage` — `"not-a-real-id"` still raises `ValidationError`.

Plus all 12 pre-existing tests in the file continue to pass — the validator is non-breaking on the compliant-model path.

```
$ uv run pytest tests/server/services/playbook/test_consolidation_output.py
======================== 18 passed in 0.42s ========================
```

The broader consolidator suite (61 tests) also passes. There's one unrelated failure in `test_cluster_change_detection.py::test_rerun_bypasses_change_detection` that pre-dates this branch — verified via `git stash` swap.

## Test Plan

- [x] `pytest tests/server/services/playbook/test_consolidation_output.py` — 18 pass
- [x] `pytest tests/server/services/playbook/` — 61 pass (1 pre-existing unrelated failure)
- [x] Bare int still round-trips unchanged (compliant model path verified)
- [x] `"EXISTING-N"` string coerces to `N` for all three int-ID fields
- [x] Garbage strings still raise `ValidationError`
- [ ] Next production deploy will exercise this on the live MiniMax-M3 path (this is the hot-fix being chased)

## Related

This is the OSS half of [ReflexioAI/reflexio-enterprise#152](https://github.com/ReflexioAI/reflexio-enterprise/pull/152), which bumps the submodule pointer to pull in this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and normalization of position references: accepts integers, numeric strings and position labels (case-insensitive) and coerces None to an empty list; negative or malformed values are rejected.  
  * Clarified that DB ID fields reject position-style labels and only accept bare numeric IDs.

* **Tests**
  * Added comprehensive schema tests covering normalization, rejection cases, and mapping of coerced position labels to underlying records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->