### PR TITLE
feat(eval): prompt deviation guard CLI for between-epoch regression gating

### DIFF
--- a/tests/eval/consolidation/README.md
+++ b/tests/eval/consolidation/README.md
@@ -114,9 +114,9 @@ covers the provider's construction in default CI.
 
 ## Comparing two prompt versions (deviation guard)
 
-To gate a candidate `playbook_consolidation` version against a baseline (the
-between-epoch degradation check of the prompt-tuning loop), use the shared CLI
-which runs this harness under both pinned versions and fails on regression:
+To gate a candidate `playbook_consolidation` version against a baseline (catch
+regressions when iterating the prompt across versions), use the shared CLI which
+runs this harness under both pinned versions and fails on regression:
 
 ```bash
 uv run python -m tests.eval.prompt_deviation_guard \

--- a/tests/eval/consolidation/README.md
+++ b/tests/eval/consolidation/README.md
@@ -111,3 +111,17 @@ produced `ConsolidationDecision`. This path makes real LLM calls, so it lives
 behind the `@skip_low_priority` smoke `test_live_consolidation_provider_real`
 (run with `RUN_LOW_PRIORITY=1` + an API key). A non-skipped mocked-seam test
 covers the provider's construction in default CI.
+
+## Comparing two prompt versions (deviation guard)
+
+To gate a candidate `playbook_consolidation` version against a baseline (the
+between-epoch degradation check of the prompt-tuning loop), use the shared CLI
+which runs this harness under both pinned versions and fails on regression:
+
+```bash
+uv run python -m tests.eval.prompt_deviation_guard \
+    --component consolidation --candidate-version vX.Y.Z --judge-model claude-haiku-4-5
+```
+
+See `tests/eval/prompt_deviation_guard.py` (gate logic unit-tested in
+`tests/eval/test_prompt_deviation_guard.py`).

--- a/tests/eval/prompt_deviation_guard.py
+++ b/tests/eval/prompt_deviation_guard.py
@@ -1,0 +1,418 @@
+"""Prompt deviation guard — gate a candidate prompt version against a baseline.
+
+The between-epoch check of the agent-driven prompt-tuning loop (see
+``benchmarks/swe_bench_verified/PROMPT_TUNING_LOOP.md`` §4.5). After an epoch
+edits a memory prompt, this runs the component's deterministic eval harness
+under **two pinned prompt versions** — the prior (baseline) and the new
+(candidate) — and fails if any guard metric regresses beyond a tolerance, so a
+degrading edit can't advance to the next epoch.
+
+Two components are covered, each driven by its existing live provider + judge:
+
+- ``consolidation`` -> ``playbook_consolidation`` prompt, via
+  ``tests/eval/consolidation``
+- ``reflection`` -> ``memory_reflection`` prompt, via ``tests/eval/reflection``
+
+Version pinning needs no core change: ``RequestContext`` builds its own
+``PromptManager``, but the providers read ``ctx.prompt_manager``, so we swap in
+``PromptManager(version_override={prompt_id: version})`` after constructing the
+context. A non-active version file loads fine as long as it exists in the
+prompt bank.
+
+This makes real LLM calls (provider + optional judge), so it is a manual /
+gated tool — run with API keys. The pure gate logic (:func:`compare`) is unit
+tested without any LLM.
+
+Usage (from the ``open_source/reflexio`` submodule root)::
+
+    uv run python -m tests.eval.prompt_deviation_guard \\
+        --component consolidation \\
+        --candidate-version v2.4.0 \\
+        --judge-model claude-haiku-4-5
+
+Exits 0 when the candidate holds (PASS), 1 when it regresses (FAIL) — so an
+orchestrator can branch on the exit code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from typing import Literal
+
+Component = Literal["consolidation", "reflection"]
+COMPONENTS: tuple[Component, ...] = ("consolidation", "reflection")
+
+# Default per-metric tolerance: a higher-is-better metric may not drop by more
+# than this, and a lower-is-better metric may not rise by more than this.
+DEFAULT_TOLERANCE = 0.05
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """A guard metric on ``EvalResults`` and the direction that is "better".
+
+    Attributes:
+        name: The ``EvalResults`` property to read (e.g. ``kind_accuracy``).
+        higher_is_better: True when a larger value is an improvement (so a
+            *drop* is a regression); False when smaller is better (so a *rise*
+            is a regression).
+    """
+
+    name: str
+    higher_is_better: bool
+
+
+# Guard metrics per component. ``judge_accuracy`` / ``self_contradiction_rate``
+# can be None (no judge, or no judged ``unify``); such metrics are skipped, not
+# failed (see :func:`compare`).
+_METRIC_SPECS: dict[Component, tuple[MetricSpec, ...]] = {
+    "consolidation": (
+        MetricSpec("kind_accuracy", higher_is_better=True),
+        MetricSpec("judge_accuracy", higher_is_better=True),
+        MetricSpec("over_merge_rate", higher_is_better=False),
+        MetricSpec("under_merge_rate", higher_is_better=False),
+        MetricSpec("self_contradiction_rate", higher_is_better=False),
+    ),
+    "reflection": (
+        MetricSpec("label_accuracy", higher_is_better=True),
+        MetricSpec("judge_accuracy", higher_is_better=True),
+        MetricSpec("false_tighten_rate", higher_is_better=False),
+        MetricSpec("over_specialization_rate", higher_is_better=False),
+    ),
+}
+
+# The per-case produced field used for the baseline<->candidate agreement rate.
+_PRODUCED_ATTR: dict[Component, str] = {
+    "consolidation": "produced_kind",
+    "reflection": "produced_label",
+}
+
+
+@dataclass
+class MetricDelta:
+    """One metric's baseline/candidate comparison.
+
+    Attributes:
+        name: Metric name.
+        higher_is_better: Direction of improvement.
+        baseline: Baseline value, or None when not computed.
+        candidate: Candidate value, or None when not computed.
+        delta: ``candidate - baseline`` when both present, else None.
+        regressed: True when the candidate regressed beyond tolerance.
+    """
+
+    name: str
+    higher_is_better: bool
+    baseline: float | None
+    candidate: float | None
+    delta: float | None
+    regressed: bool
+
+    def to_json(self) -> dict[str, object]:
+        """Return a JSON-serialisable mapping of this metric delta."""
+        return {
+            "name": self.name,
+            "higher_is_better": self.higher_is_better,
+            "baseline": self.baseline,
+            "candidate": self.candidate,
+            "delta": self.delta,
+            "regressed": self.regressed,
+        }
+
+
+@dataclass
+class GuardReport:
+    """The full baseline-vs-candidate comparison and gate verdict.
+
+    Attributes:
+        component: Which component was guarded.
+        baseline_version: Pinned baseline prompt version (or None for active).
+        candidate_version: Pinned candidate prompt version.
+        tolerance: Per-metric tolerance applied.
+        metrics: Per-metric deltas.
+        agreement_rate: Fraction of cases whose produced kind/label is
+            unchanged between baseline and candidate (raw deviation signal,
+            independent of correctness). None when there are no cases.
+        passed: True when no guard metric regressed beyond tolerance.
+    """
+
+    component: Component
+    baseline_version: str | None
+    candidate_version: str
+    tolerance: float
+    metrics: list[MetricDelta] = field(default_factory=list)
+    agreement_rate: float | None = None
+    passed: bool = True
+
+    def to_json(self) -> dict[str, object]:
+        """Return a JSON-serialisable mapping of the whole report."""
+        return {
+            "component": self.component,
+            "baseline_version": self.baseline_version,
+            "candidate_version": self.candidate_version,
+            "tolerance": self.tolerance,
+            "agreement_rate": self.agreement_rate,
+            "passed": self.passed,
+            "metrics": [m.to_json() for m in self.metrics],
+        }
+
+    def render(self) -> str:
+        """Render a human-readable table + verdict."""
+
+        def fmt(v: float | None) -> str:
+            return "  --  " if v is None else f"{v:.3f}"
+
+        lines = [
+            f"Prompt deviation guard — {self.component}",
+            f"  baseline: {self.baseline_version or '(active)'}    "
+            f"candidate: {self.candidate_version}    tolerance: {self.tolerance:.3f}",
+            "",
+            f"  {'metric':<24} {'baseline':>9} {'candidate':>10} {'delta':>8}  dir   status",
+        ]
+        for m in self.metrics:
+            arrow = "↑" if m.higher_is_better else "↓"
+            status = (
+                "REGRESSED" if m.regressed else ("n/a" if m.delta is None else "ok")
+            )
+            delta = "   --  " if m.delta is None else f"{m.delta:+.3f}"
+            lines.append(
+                f"  {m.name:<24} {fmt(m.baseline):>9} {fmt(m.candidate):>10} "
+                f"{delta:>8}  {arrow}    {status}"
+            )
+        lines.append("")
+        lines.append(f"  agreement_rate: {fmt(self.agreement_rate)}")
+        lines.append(f"  VERDICT: {'PASS' if self.passed else 'FAIL'}")
+        return "\n".join(lines)
+
+
+def _agreement_rate(component: Component, baseline, candidate) -> float | None:
+    """Fraction of shared cases whose produced kind/label is unchanged.
+
+    Args:
+        component: Which component (selects the produced attribute).
+        baseline: Baseline ``EvalResults``.
+        candidate: Candidate ``EvalResults``.
+
+    Returns:
+        The agreement fraction over cases present in both runs, or None when
+        there are no shared cases.
+    """
+    attr = _PRODUCED_ATTR[component]
+    base = {o.case_id: getattr(o, attr) for o in baseline.outcomes}
+    cand = {o.case_id: getattr(o, attr) for o in candidate.outcomes}
+    shared = base.keys() & cand.keys()
+    if not shared:
+        return None
+    return sum(base[cid] == cand[cid] for cid in shared) / len(shared)
+
+
+def compare(
+    *,
+    component: Component,
+    baseline,
+    candidate,
+    tolerance: float = DEFAULT_TOLERANCE,
+    baseline_version: str | None = None,
+    candidate_version: str = "",
+) -> GuardReport:
+    """Compare two eval runs and decide whether the candidate holds.
+
+    Pure (no LLM): operates on two already-computed ``EvalResults``. A metric
+    with a None value on either side is skipped (not failed) — judge metrics
+    are None when no judge ran, and ``self_contradiction_rate`` is None when no
+    ``unify`` was produced.
+
+    Args:
+        component: Which component's metric specs to apply.
+        baseline: Baseline ``EvalResults``.
+        candidate: Candidate ``EvalResults``.
+        tolerance: Max allowed adverse change per metric.
+        baseline_version: Baseline version label (for the report only).
+        candidate_version: Candidate version label (for the report only).
+
+    Returns:
+        A :class:`GuardReport`; ``passed`` is False if any metric regressed.
+    """
+    report = GuardReport(
+        component=component,
+        baseline_version=baseline_version,
+        candidate_version=candidate_version,
+        tolerance=tolerance,
+        agreement_rate=_agreement_rate(component, baseline, candidate),
+    )
+    for spec in _METRIC_SPECS[component]:
+        b = getattr(baseline, spec.name)
+        c = getattr(candidate, spec.name)
+        delta = None if (b is None or c is None) else c - b
+        regressed = delta is not None and (
+            delta < -tolerance if spec.higher_is_better else delta > tolerance
+        )
+        report.metrics.append(
+            MetricDelta(
+                name=spec.name,
+                higher_is_better=spec.higher_is_better,
+                baseline=b,
+                candidate=c,
+                delta=delta,
+                regressed=regressed,
+            )
+        )
+    report.passed = not any(m.regressed for m in report.metrics)
+    return report
+
+
+def _run_component_eval(
+    *,
+    component: Component,
+    version: str | None,
+    model: str,
+    judge_model: str | None,
+):
+    """Run a component's eval harness under a pinned prompt version.
+
+    Builds a real ``LiteLLMClient`` for the provider (and an optional judge
+    client), a ``RequestContext`` with a version-pinned ``PromptManager``, then
+    runs the component's live provider over its illustrative fixtures. Makes
+    real LLM calls.
+
+    Args:
+        component: Which component to evaluate.
+        version: Prompt version to pin, or None to use the active version.
+        model: Model for the provider's LLM client.
+        judge_model: Model for the AI judge, or None to skip judging.
+
+    Returns:
+        The component's ``EvalResults``.
+    """
+    from reflexio.server.api_endpoints.request_context import RequestContext
+    from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+    from reflexio.server.prompt.prompt_manager import PromptManager
+
+    prompt_id = _prompt_id(component)
+    client = LiteLLMClient(LiteLLMConfig(model=model))
+    judge = LiteLLMClient(LiteLLMConfig(model=judge_model)) if judge_model else None
+
+    with tempfile.TemporaryDirectory() as tmp:
+        ctx = RequestContext(org_id="prompt-deviation-guard", storage_base_dir=tmp)
+        if version is not None:
+            ctx.prompt_manager = PromptManager(version_override={prompt_id: version})
+
+        # Each branch is kept fully self-contained (own provider, cases, runner)
+        # so the two components' incompatible decision/case types never unify.
+        if component == "consolidation":
+            from tests.eval.consolidation.fixtures import load_illustrative_cases
+            from tests.eval.consolidation.providers import (
+                make_consolidation_decision_provider,
+            )
+            from tests.eval.consolidation.runner import run_eval as run_consolidation
+
+            cons_provider = make_consolidation_decision_provider(
+                llm_client=client, request_context=ctx
+            )
+            return run_consolidation(
+                cases=load_illustrative_cases(),
+                decision_provider=cons_provider,
+                llm_client=judge,
+            )
+
+        from tests.eval.reflection.fixtures import load_illustrative_cases
+        from tests.eval.reflection.providers import make_reflection_decision_provider
+        from tests.eval.reflection.runner import run_eval as run_reflection
+
+        refl_provider = make_reflection_decision_provider(
+            llm_client=client, request_context=ctx
+        )
+        return run_reflection(
+            cases=load_illustrative_cases(),
+            decision_provider=refl_provider,
+            llm_client=judge,
+        )
+
+
+def _prompt_id(component: Component) -> str:
+    """Return the prompt-bank id for a component."""
+    if component == "consolidation":
+        from reflexio.server.services.playbook.playbook_consolidator import (
+            PlaybookConsolidator,
+        )
+
+        return PlaybookConsolidator.DEDUPLICATION_PROMPT_ID
+    from reflexio.server.services.reflection.reflection_extractor import (
+        REFLECTION_PROMPT_ID,
+    )
+
+    return REFLECTION_PROMPT_ID
+
+
+def _active_version(component: Component) -> str | None:
+    """Return the currently-active prompt version for a component."""
+    from reflexio.server.prompt.prompt_manager import PromptManager
+
+    return PromptManager().get_active_version(_prompt_id(component))
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns the process exit code (0 PASS, 1 FAIL)."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--component", required=True, choices=COMPONENTS)
+    parser.add_argument(
+        "--candidate-version",
+        required=True,
+        help="Prompt version to gate (e.g. v2.4.0); must exist in the bank.",
+    )
+    parser.add_argument(
+        "--baseline-version",
+        default=None,
+        help="Baseline version; defaults to the currently-active version.",
+    )
+    parser.add_argument("--model", default="claude-haiku-4-5")
+    parser.add_argument(
+        "--judge-model",
+        default=None,
+        help="AI-judge model; omit to skip judge metrics (faster/cheaper).",
+    )
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    parser.add_argument(
+        "--json",
+        dest="json_path",
+        default=None,
+        help="Optional path to dump the report JSON.",
+    )
+    args = parser.parse_args(argv)
+    component: Component = args.component
+
+    baseline_version = args.baseline_version or _active_version(component)
+    baseline = _run_component_eval(
+        component=component,
+        version=baseline_version,
+        model=args.model,
+        judge_model=args.judge_model,
+    )
+    candidate = _run_component_eval(
+        component=component,
+        version=args.candidate_version,
+        model=args.model,
+        judge_model=args.judge_model,
+    )
+    report = compare(
+        component=component,
+        baseline=baseline,
+        candidate=candidate,
+        tolerance=args.tolerance,
+        baseline_version=baseline_version,
+        candidate_version=args.candidate_version,
+    )
+    print(report.render())
+    if args.json_path:
+        from pathlib import Path
+
+        Path(args.json_path).write_text(json.dumps(report.to_json(), indent=2))
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/eval/prompt_deviation_guard.py
+++ b/tests/eval/prompt_deviation_guard.py
@@ -1,11 +1,9 @@
 """Prompt deviation guard — gate a candidate prompt version against a baseline.
 
-The between-epoch check of the agent-driven prompt-tuning loop (see
-``benchmarks/swe_bench_verified/PROMPT_TUNING_LOOP.md`` §4.5). After an epoch
-edits a memory prompt, this runs the component's deterministic eval harness
-under **two pinned prompt versions** — the prior (baseline) and the new
-(candidate) — and fails if any guard metric regresses beyond a tolerance, so a
-degrading edit can't advance to the next epoch.
+When you iterate on a memory prompt and add a new version, this runs that
+component's deterministic eval harness under **two pinned prompt versions** —
+the prior (baseline) and the new (candidate) — and fails if any guard metric
+regresses beyond a tolerance, so a degrading edit is caught before you adopt it.
 
 Two components are covered, each driven by its existing live provider + judge:
 
@@ -23,7 +21,7 @@ This makes real LLM calls (provider + optional judge), so it is a manual /
 gated tool — run with API keys. The pure gate logic (:func:`compare`) is unit
 tested without any LLM.
 
-Usage (from the ``open_source/reflexio`` submodule root)::
+Usage (from the repository root)::
 
     uv run python -m tests.eval.prompt_deviation_guard \\
         --component consolidation \\

--- a/tests/eval/prompt_deviation_guard.py
+++ b/tests/eval/prompt_deviation_guard.py
@@ -28,8 +28,9 @@ Usage (from the repository root)::
         --candidate-version v2.4.0 \\
         --judge-model claude-haiku-4-5
 
-Exits 0 when the candidate holds (PASS), 1 when it regresses (FAIL) — so an
-orchestrator can branch on the exit code.
+Exit codes: 0 when the candidate holds (PASS), 1 when it regresses (FAIL), and
+2 on an eval/infra error (provider or judge failed) — distinct from 1 so an
+orchestrator never misreads an outage as a prompt regression.
 """
 
 from __future__ import annotations
@@ -234,7 +235,13 @@ def compare(
 
     Returns:
         A :class:`GuardReport`; ``passed`` is False if any metric regressed.
+
+    Raises:
+        ValueError: If ``tolerance`` is negative (a negative tolerance would
+            invert the regression test and flag unchanged metrics).
     """
+    if tolerance < 0:
+        raise ValueError(f"tolerance must be >= 0, got {tolerance}")
     report = GuardReport(
         component=component,
         baseline_version=baseline_version,
@@ -354,7 +361,12 @@ def _active_version(component: Component) -> str | None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point. Returns the process exit code (0 PASS, 1 FAIL)."""
+    """CLI entry point. Returns the process exit code.
+
+    Exit codes: ``0`` PASS (candidate holds), ``1`` FAIL (a metric regressed),
+    ``2`` eval/infra error (provider or judge failed) — kept distinct from ``1``
+    so an orchestrator never misreads an outage as a prompt regression.
+    """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--component", required=True, choices=COMPONENTS)
     parser.add_argument(
@@ -381,21 +393,29 @@ def main(argv: list[str] | None = None) -> int:
         help="Optional path to dump the report JSON.",
     )
     args = parser.parse_args(argv)
+    if args.tolerance < 0:
+        parser.error("--tolerance must be >= 0")
     component: Component = args.component
 
     baseline_version = args.baseline_version or _active_version(component)
-    baseline = _run_component_eval(
-        component=component,
-        version=baseline_version,
-        model=args.model,
-        judge_model=args.judge_model,
-    )
-    candidate = _run_component_eval(
-        component=component,
-        version=args.candidate_version,
-        model=args.model,
-        judge_model=args.judge_model,
-    )
+    # Eval execution (LLM provider + judge) can fail for infra reasons —
+    # surface those as exit code 2, distinct from a regression FAIL (1).
+    try:
+        baseline = _run_component_eval(
+            component=component,
+            version=baseline_version,
+            model=args.model,
+            judge_model=args.judge_model,
+        )
+        candidate = _run_component_eval(
+            component=component,
+            version=args.candidate_version,
+            model=args.model,
+            judge_model=args.judge_model,
+        )
+    except Exception as exc:  # noqa: BLE001 — any eval failure is an infra error
+        print(f"[prompt-deviation-guard] eval execution failed: {exc}", file=sys.stderr)
+        return 2
     report = compare(
         component=component,
         baseline=baseline,

--- a/tests/eval/reflection/README.md
+++ b/tests/eval/reflection/README.md
@@ -83,3 +83,17 @@ calls, so it lives behind the `@skip_low_priority` smoke
 `test_live_reflection_provider_real` (run with `RUN_LOW_PRIORITY=1` + an API
 key); a non-skipped mocked-seam test covers the provider's construction in
 default CI.
+
+## Comparing two prompt versions (deviation guard)
+
+To gate a candidate `memory_reflection` version against a baseline (the
+between-epoch degradation check of the prompt-tuning loop), use the shared CLI
+which runs this harness under both pinned versions and fails on regression:
+
+```bash
+uv run python -m tests.eval.prompt_deviation_guard \
+    --component reflection --candidate-version vX.Y.Z --judge-model claude-haiku-4-5
+```
+
+See `tests/eval/prompt_deviation_guard.py` (gate logic unit-tested in
+`tests/eval/test_prompt_deviation_guard.py`).

--- a/tests/eval/reflection/README.md
+++ b/tests/eval/reflection/README.md
@@ -86,9 +86,9 @@ default CI.
 
 ## Comparing two prompt versions (deviation guard)
 
-To gate a candidate `memory_reflection` version against a baseline (the
-between-epoch degradation check of the prompt-tuning loop), use the shared CLI
-which runs this harness under both pinned versions and fails on regression:
+To gate a candidate `memory_reflection` version against a baseline (catch
+regressions when iterating the prompt across versions), use the shared CLI which
+runs this harness under both pinned versions and fails on regression:
 
 ```bash
 uv run python -m tests.eval.prompt_deviation_guard \

--- a/tests/eval/test_prompt_deviation_guard.py
+++ b/tests/eval/test_prompt_deviation_guard.py
@@ -8,6 +8,8 @@ the registry/wiring is sanity-checked cheaply instead.
 
 from __future__ import annotations
 
+import pytest
+
 from tests.eval import prompt_deviation_guard as guard
 from tests.eval.consolidation.runner import CaseOutcome as ConsOutcome
 from tests.eval.consolidation.runner import EvalResults as ConsResults
@@ -192,3 +194,45 @@ def test_report_json_round_trips() -> None:
     assert blob["candidate_version"] == "v9.9.9"
     assert blob["passed"] is True
     assert isinstance(blob["metrics"], list)
+
+
+# ---------------------------------------------------------------------------
+# Input validation + exit-code semantics
+# ---------------------------------------------------------------------------
+
+
+def test_negative_tolerance_raises() -> None:
+    rows = [("a", "unify", "unify")]
+    with pytest.raises(ValueError, match="tolerance must be >= 0"):
+        guard.compare(
+            component="consolidation",
+            baseline=_cons(rows),
+            candidate=_cons(rows),
+            tolerance=-0.1,
+        )
+
+
+def test_main_rejects_negative_tolerance() -> None:
+    # argparse parser.error() exits with SystemExit before any eval runs.
+    with pytest.raises(SystemExit):
+        guard.main(
+            [
+                "--component",
+                "consolidation",
+                "--candidate-version",
+                "v2.3.0",
+                "--tolerance",
+                "-0.1",
+            ]
+        )
+
+
+def test_main_returns_2_on_eval_infra_error(monkeypatch) -> None:
+    # An eval/provider failure must surface as exit code 2, not 1 (regression).
+    def _boom(**_kwargs):
+        raise RuntimeError("provider down")
+
+    monkeypatch.setattr(guard, "_active_version", lambda _c: "v2.3.0")
+    monkeypatch.setattr(guard, "_run_component_eval", _boom)
+    rc = guard.main(["--component", "consolidation", "--candidate-version", "v2.3.0"])
+    assert rc == 2

--- a/tests/eval/test_prompt_deviation_guard.py
+++ b/tests/eval/test_prompt_deviation_guard.py
@@ -1,0 +1,194 @@
+"""Unit tests for the prompt deviation guard's gate logic.
+
+These exercise :func:`compare` against real ``EvalResults`` built from crafted
+``CaseOutcome``s — no LLM, no real provider/judge. The real end-to-end path
+(``_run_component_eval`` / ``main``) makes paid LLM calls and is not run here;
+the registry/wiring is sanity-checked cheaply instead.
+"""
+
+from __future__ import annotations
+
+from tests.eval import prompt_deviation_guard as guard
+from tests.eval.consolidation.runner import CaseOutcome as ConsOutcome
+from tests.eval.consolidation.runner import EvalResults as ConsResults
+from tests.eval.reflection.runner import CaseOutcome as ReflOutcome
+from tests.eval.reflection.runner import EvalResults as ReflResults
+
+
+def _cons(rows, *, judged: bool = False) -> ConsResults:
+    """Build consolidation ``EvalResults`` from ``(case_id, gold, produced)``."""
+    res = ConsResults()
+    for cid, gold, produced in rows:
+        res.outcomes.append(
+            ConsOutcome(
+                case_id=cid,
+                gold_kind=gold,
+                produced_kind=produced,
+                kind_match=(gold == produced),
+                judge_correct=(gold == produced) if judged else None,
+                self_contradiction=False if (judged and produced == "unify") else None,
+            )
+        )
+    return res
+
+
+def _refl(rows, *, judged: bool = False) -> ReflResults:
+    """Build reflection ``EvalResults`` from ``(case_id, gold, produced)``."""
+    res = ReflResults()
+    for cid, gold, produced in rows:
+        res.outcomes.append(
+            ReflOutcome(
+                case_id=cid,
+                gold_label=gold,
+                produced_label=produced,
+                label_match=(gold == produced),
+                judge_correct=(gold == produced) if judged else None,
+            )
+        )
+    return res
+
+
+def _metric(report: guard.GuardReport, name: str) -> guard.MetricDelta:
+    return next(m for m in report.metrics if m.name == name)
+
+
+# ---------------------------------------------------------------------------
+# PASS / no-regression
+# ---------------------------------------------------------------------------
+
+
+def test_identical_runs_pass_with_full_agreement() -> None:
+    rows = [("a", "unify", "unify"), ("b", "differentiate", "differentiate")]
+    report = guard.compare(
+        component="consolidation", baseline=_cons(rows), candidate=_cons(rows)
+    )
+    assert report.passed
+    assert report.agreement_rate == 1.0
+    assert all(not m.regressed for m in report.metrics)
+
+
+def test_small_change_within_tolerance_passes() -> None:
+    # 4 cases: baseline all correct (1.0); candidate 3/4 correct (0.75).
+    # Drop of 0.25 > default 0.05 would fail, so use a bigger tolerance.
+    base = _cons([(str(i), "unify", "unify") for i in range(4)])
+    cand = _cons(
+        [("0", "unify", "reject_new"), *[(str(i), "unify", "unify") for i in (1, 2, 3)]]
+    )
+    report = guard.compare(
+        component="consolidation", baseline=base, candidate=cand, tolerance=0.5
+    )
+    assert report.passed
+
+
+# ---------------------------------------------------------------------------
+# FAIL — higher-is-better metric drops
+# ---------------------------------------------------------------------------
+
+
+def test_kind_accuracy_drop_fails() -> None:
+    base = _cons([(str(i), "unify", "unify") for i in range(4)])  # 1.0
+    cand = _cons([(str(i), "unify", "reject_new") for i in range(4)])  # 0.0
+    report = guard.compare(component="consolidation", baseline=base, candidate=cand)
+    assert not report.passed
+    assert _metric(report, "kind_accuracy").regressed
+    assert _metric(report, "kind_accuracy").delta == -1.0
+
+
+def test_label_accuracy_drop_fails_reflection() -> None:
+    base = _refl([(str(i), "widen", "widen") for i in range(4)])  # 1.0
+    cand = _refl([(str(i), "widen", "no_change") for i in range(4)])  # 0.0
+    report = guard.compare(component="reflection", baseline=base, candidate=cand)
+    assert not report.passed
+    assert _metric(report, "label_accuracy").regressed
+
+
+# ---------------------------------------------------------------------------
+# FAIL — lower-is-better metric rises
+# ---------------------------------------------------------------------------
+
+
+def test_over_merge_rate_rise_fails() -> None:
+    # kind_accuracy held constant (both mismatch) to isolate over_merge_rate.
+    base = _cons([("a", "differentiate", "independent")])  # separate, no over-merge
+    cand = _cons([("a", "differentiate", "unify")])  # separate gold, merged -> over
+    report = guard.compare(component="consolidation", baseline=base, candidate=cand)
+    om = _metric(report, "over_merge_rate")
+    assert om.baseline == 0.0
+    assert om.candidate == 1.0
+    assert om.regressed
+    assert not report.passed
+    # kind_accuracy unchanged (0.0 -> 0.0), so it must NOT be flagged.
+    assert not _metric(report, "kind_accuracy").regressed
+
+
+def test_false_tighten_rate_rise_fails_reflection() -> None:
+    base = _refl([("a", "widen", "no_change")])  # not a false tighten
+    cand = _refl([("a", "widen", "tighten")])  # gold != tighten, produced tighten
+    report = guard.compare(component="reflection", baseline=base, candidate=cand)
+    ft = _metric(report, "false_tighten_rate")
+    assert ft.baseline == 0.0
+    assert ft.candidate == 1.0
+    assert ft.regressed
+    assert not report.passed
+
+
+# ---------------------------------------------------------------------------
+# None-valued judge metrics are skipped, not failed
+# ---------------------------------------------------------------------------
+
+
+def test_unjudged_metrics_are_skipped_not_failed() -> None:
+    rows = [("a", "unify", "unify")]
+    report = guard.compare(
+        component="consolidation", baseline=_cons(rows), candidate=_cons(rows)
+    )
+    judge = _metric(report, "judge_accuracy")
+    assert judge.baseline is None
+    assert judge.candidate is None
+    assert judge.delta is None
+    assert not judge.regressed
+    assert report.passed
+
+
+def test_agreement_rate_counts_unchanged_cases() -> None:
+    base = _cons([("a", "unify", "unify"), ("b", "unify", "unify")])
+    cand = _cons([("a", "unify", "unify"), ("b", "unify", "reject_new")])
+    report = guard.compare(component="consolidation", baseline=base, candidate=cand)
+    assert report.agreement_rate == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Registry / wiring sanity (cheap; catches typos without an LLM)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_ids_resolve_for_both_components() -> None:
+    assert guard._prompt_id("consolidation") == "playbook_consolidation"
+    assert guard._prompt_id("reflection") == "memory_reflection"
+
+
+def test_metric_specs_cover_every_component() -> None:
+    for component in guard.COMPONENTS:
+        specs = guard._METRIC_SPECS[component]
+        assert specs
+        # Every spec name must be a real EvalResults property.
+        results_cls = ConsResults if component == "consolidation" else ReflResults
+        for spec in specs:
+            assert isinstance(
+                getattr(results_cls(), spec.name, "MISSING"), (float, type(None))
+            )
+
+
+def test_report_json_round_trips() -> None:
+    rows = [("a", "unify", "unify")]
+    report = guard.compare(
+        component="consolidation",
+        baseline=_cons(rows),
+        candidate=_cons(rows),
+        candidate_version="v9.9.9",
+    )
+    blob = report.to_json()
+    assert blob["component"] == "consolidation"
+    assert blob["candidate_version"] == "v9.9.9"
+    assert blob["passed"] is True
+    assert isinstance(blob["metrics"], list)


### PR DESCRIPTION
## What

Adds `python -m tests.eval.prompt_deviation_guard` — a CLI that gates a **candidate prompt version against a baseline** by running a component's deterministic eval harness under both pinned versions and failing when any guard metric regresses beyond a tolerance.

This is the **between-epoch degradation check** of the agent-driven prompt-tuning loop (documented in `benchmarks/swe_bench_verified/PROMPT_TUNING_LOOP.md` §4.5 in the enterprise repo).

## Why

The tuning loop edits memory prompts (`playbook_consolidation`, `memory_reflection`) each epoch. SWE-bench gives a realistic but non-deterministic end-to-end signal; this guard adds the **repeatable** check — run the component's own judged eval on old-vs-new and reject a degrading edit before it advances.

## How

- **Version pinning, no core change:** `RequestContext` builds its own `PromptManager`, but the live providers read `ctx.prompt_manager`, so the guard assigns `ctx.prompt_manager = PromptManager(version_override={prompt_id: version})` after constructing the context.
- Reuses the existing live providers + component judges (`tests/eval/{consolidation,reflection}`).
- **Guard metrics:** consolidation — `kind_accuracy`↑, `judge_accuracy`↑, `over_merge_rate`↓, `under_merge_rate`↓, `self_contradiction_rate`↓; reflection — `label_accuracy`↑, `judge_accuracy`↑, `false_tighten_rate`↓, `over_specialization_rate`↓. None-valued judge metrics are skipped, not failed.
- Reports an `agreement_rate` (fraction of cases whose decision is unchanged between versions) as a raw deviation signal. Exit 0 = PASS, 1 = FAIL.

## Usage

```bash
uv run python -m tests.eval.prompt_deviation_guard \
    --component consolidation --candidate-version vX.Y.Z --judge-model claude-haiku-4-5
```

## Tests

The pure gate logic (`compare`) is fully unit-tested with crafted `EvalResults` (pass within tolerance; fail on higher-is-better drop and lower-is-better rise; None judge metrics skipped; agreement_rate; JSON round-trip) plus registry/prompt-id wiring checks.

- `uv run pytest tests/eval/test_prompt_deviation_guard.py -o 'addopts=' -q` → 11 passed
- `uv run pytest tests/eval/consolidation tests/eval/reflection -o 'addopts=' -q` → green
- ruff + pyright clean

**Not run:** the real-LLM paths (`main`/`_run_component_eval`) — they cost money / need API keys, so they're manual/gated. The CLI's `--help` and argparse are verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool to compare candidate prompt versions against baselines, evaluate metric deltas, and emit a pass/fail verdict.

* **Documentation**
  * Added guidance for the prompt deviation guard workflow and example CLI usage for comparing prompt versions.

* **Tests**
  * Added unit tests covering gate logic, tolerance handling, agreement-rate computation, and skipping of unjudged metrics.

* **Chores**
  * CLI can render results and optionally write a JSON report; exit code reflects pass/fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->