### PR TITLE
feat: harden API security and resumable extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,10 +49,13 @@ dependencies = [
     # so the CrossEncoder/SentenceTransformer surface is guaranteed.
     "sentence-transformers>=3.0",
     "einops>=0.8.0",
+    # Native KNN search via the sqlite-vec loadable extension. A pure-Python
+    # fallback exists (see sqlite_storage/_base.py) for the rare platform whose
+    # SQLite build can't load extensions, but ship the fast path by default.
+    "sqlite-vec>=0.1.6",
 ]
 
 [project.optional-dependencies]
-vec = ["sqlite-vec>=0.1.6"]
 notebooks = ["pandas>=3.0.2"]
 benchmark = [
     "datasets>=4.8.4",

--- a/reflexio/models/api_schema/validators.py
+++ b/reflexio/models/api_schema/validators.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import ipaddress
 import os
 import re
+import socket
 from typing import Annotated, Any
 from urllib.parse import urlparse
 
@@ -125,6 +126,28 @@ def _is_strict_mode() -> bool:
     )
 
 
+def _is_forbidden_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return whether an IP address is unsafe for server-side HTTP callbacks."""
+    return (
+        str(ip) in METADATA_IPS
+        or ip.is_private
+        or ip.is_reserved
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _resolved_host_ips(host: str, port: int | None) -> set[str]:
+    """Resolve a hostname into IP address strings for SSRF validation."""
+    try:
+        addr_info = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise ValueError(f"URL hostname could not be resolved: {host}") from exc
+    return {str(entry[4][0]) for entry in addr_info}
+
+
 def _check_safe_url(v: Any) -> Any:
     """Validate URL is not targeting dangerous resources.
 
@@ -154,9 +177,7 @@ def _check_safe_url(v: Any) -> Any:
             raise ValueError(f"URL must not target cloud metadata endpoint: {host}")
 
         # In strict mode, also block private/localhost
-        if _is_strict_mode() and (
-            ip.is_private or ip.is_reserved or ip.is_loopback or ip.is_link_local
-        ):
+        if _is_strict_mode() and _is_forbidden_ip(ip):
             raise ValueError(
                 f"URL targets private/reserved IP '{host}'. "
                 f"If running locally, unset REFLEXIO_BLOCK_PRIVATE_URLS."
@@ -170,6 +191,18 @@ def _check_safe_url(v: Any) -> Any:
                 f"URL targets '{host}'. "
                 f"If running locally, unset REFLEXIO_BLOCK_PRIVATE_URLS."
             ) from None
+        if _is_strict_mode():
+            for resolved_ip in _resolved_host_ips(host, parsed.port):
+                try:
+                    ip = ipaddress.ip_address(resolved_ip)
+                except ValueError:
+                    continue
+                if _is_forbidden_ip(ip):
+                    raise ValueError(
+                        f"URL hostname '{host}' resolves to private/reserved IP "
+                        f"'{resolved_ip}'. If running locally, unset "
+                        f"REFLEXIO_BLOCK_PRIVATE_URLS."
+                    ) from None
 
     return v
 

--- a/reflexio/models/api_schema/validators.py
+++ b/reflexio/models/api_schema/validators.py
@@ -126,10 +126,15 @@ def _is_strict_mode() -> bool:
     )
 
 
+def _is_metadata_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return whether an IP address is a known cloud metadata endpoint."""
+    return str(ip) in METADATA_IPS
+
+
 def _is_forbidden_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return whether an IP address is unsafe for server-side HTTP callbacks."""
     return (
-        str(ip) in METADATA_IPS
+        _is_metadata_ip(ip)
         or ip.is_private
         or ip.is_reserved
         or ip.is_loopback
@@ -173,7 +178,7 @@ def _check_safe_url(v: Any) -> Any:
 
     try:
         ip = ipaddress.ip_address(host)
-        if str(ip) in METADATA_IPS:
+        if _is_metadata_ip(ip):
             raise ValueError(f"URL must not target cloud metadata endpoint: {host}")
 
         # In strict mode, also block private/localhost
@@ -185,24 +190,39 @@ def _check_safe_url(v: Any) -> Any:
     except ValueError as e:
         if "must not target" in str(e) or "targets private" in str(e):
             raise
-        # Not an IP (hostname) — check localhost in strict mode
-        if _is_strict_mode() and host in ("localhost", "0.0.0.0"):  # noqa: S104
+        # Not an IP literal (hostname). Resolve and inspect each IP: cloud
+        # metadata endpoints are ALWAYS blocked (no legitimate use case),
+        # while private/reserved ranges are blocked only in strict mode.
+        strict = _is_strict_mode()
+        if strict and host in ("localhost", "0.0.0.0"):  # noqa: S104
             raise ValueError(
                 f"URL targets '{host}'. "
                 f"If running locally, unset REFLEXIO_BLOCK_PRIVATE_URLS."
             ) from None
-        if _is_strict_mode():
-            for resolved_ip in _resolved_host_ips(host, parsed.port):
-                try:
-                    ip = ipaddress.ip_address(resolved_ip)
-                except ValueError:
-                    continue
-                if _is_forbidden_ip(ip):
-                    raise ValueError(
-                        f"URL hostname '{host}' resolves to private/reserved IP "
-                        f"'{resolved_ip}'. If running locally, unset "
-                        f"REFLEXIO_BLOCK_PRIVATE_URLS."
-                    ) from None
+        try:
+            resolved_ips = _resolved_host_ips(host, parsed.port)
+        except ValueError:
+            # A resolution failure is only fatal in strict mode; otherwise we
+            # cannot confirm a metadata target and must not break local dev.
+            if strict:
+                raise
+            resolved_ips = set()
+        for resolved_ip in resolved_ips:
+            try:
+                ip = ipaddress.ip_address(resolved_ip)
+            except ValueError:
+                continue
+            if _is_metadata_ip(ip):
+                raise ValueError(
+                    f"URL hostname '{host}' resolves to cloud metadata "
+                    f"endpoint '{resolved_ip}'."
+                ) from None
+            if strict and _is_forbidden_ip(ip):
+                raise ValueError(
+                    f"URL hostname '{host}' resolves to private/reserved IP "
+                    f"'{resolved_ip}'. If running locally, unset "
+                    f"REFLEXIO_BLOCK_PRIVATE_URLS."
+                ) from None
 
     return v
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -2766,14 +2766,26 @@ def create_app(
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[reportArgumentType]
 
     # CORS
-    origins = _resolve_cors_origins()
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-    )
+    # The locked-down, credentialed allowlist is an enterprise concern: only
+    # hosts that wire in auth (``require_auth=True``) restrict browser origins.
+    # OSS/local runs have no auth and bundle their own docs playground on a
+    # separate port, so they allow any origin (no credentials needed).
+    if require_auth:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=_resolve_cors_origins(),
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+    else:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     # Reject oversized requests before they reach endpoint handlers.
     app.add_middleware(BodySizeLimitMiddleware)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1,8 +1,9 @@
 import asyncio
 import inspect
 import logging
-import threading
+import os
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Any
 
@@ -194,6 +195,51 @@ SYNC_REQUEST_TIMEOUT_SECONDS = (
 )
 SUSPICIOUS_USER_AGENTS = ["bot", "crawler", "spider", "scraper", "curl", "wget"]
 ALLOWED_EMPTY_UA_PATHS = ["/health", "/"]  # Paths that allow empty user agents
+DEFAULT_MAX_BODY_BYTES = 10 * 1024 * 1024
+REGENERATE_MAX_WORKERS = 2
+_regen_executor = ThreadPoolExecutor(
+    max_workers=REGENERATE_MAX_WORKERS,
+    thread_name_prefix="reflexio-regen",
+)
+
+
+def _resolve_cors_origins() -> list[str]:
+    """Resolve browser origins allowed to make credentialed CORS requests."""
+    configured_origins = os.getenv("REFLEXIO_ALLOWED_ORIGINS", "").strip()
+    if configured_origins:
+        origins = [
+            origin.strip().rstrip("/")
+            for origin in configured_origins.split(",")
+            if origin.strip()
+        ]
+        return origins or ["http://localhost:8080"]
+
+    frontend_url = os.getenv("FRONTEND_URL", "").strip()
+    if frontend_url:
+        return [frontend_url.rstrip("/")]
+
+    return ["http://localhost:8080"]
+
+
+def _max_body_bytes_from_env() -> int:
+    raw_value = os.getenv("REFLEXIO_MAX_BODY_BYTES", str(DEFAULT_MAX_BODY_BYTES))
+    try:
+        max_bytes = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid REFLEXIO_MAX_BODY_BYTES=%r; using %s",
+            raw_value,
+            DEFAULT_MAX_BODY_BYTES,
+        )
+        return DEFAULT_MAX_BODY_BYTES
+    if max_bytes <= 0:
+        logger.warning(
+            "Ignoring non-positive REFLEXIO_MAX_BODY_BYTES=%r; using %s",
+            raw_value,
+            DEFAULT_MAX_BODY_BYTES,
+        )
+        return DEFAULT_MAX_BODY_BYTES
+    return max_bytes
 
 
 def get_rate_limit_key(request: Request) -> str:
@@ -310,6 +356,52 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
                 status_code=status.HTTP_504_GATEWAY_TIMEOUT,
                 content={"detail": "Request timeout"},
             )
+
+
+class BodySizeLimitMiddleware(BaseHTTPMiddleware):
+    """Reject requests whose declared body size exceeds the configured limit."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        from starlette.responses import JSONResponse
+
+        content_length = request.headers.get("content-length")
+        if content_length is not None:
+            try:
+                body_bytes = int(content_length)
+            except ValueError:
+                body_bytes = 0
+            if body_bytes > _max_body_bytes_from_env():
+                return JSONResponse(
+                    status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                    content={"detail": "Request body too large"},
+                )
+
+        return await call_next(request)
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach conservative browser security headers to every response."""
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault(
+            "Referrer-Policy", "strict-origin-when-cross-origin"
+        )
+        if (
+            request.url.scheme == "https"
+            or request.headers.get("x-forwarded-proto", "").lower() == "https"
+        ):
+            response.headers.setdefault(
+                "Strict-Transport-Security",
+                "max-age=31536000; includeSubDomains",
+            )
+        return response
 
 
 class CorrelationIdMiddleware(BaseHTTPMiddleware):
@@ -931,7 +1023,9 @@ def delete_user_playbooks_by_ids(
     response_model=BulkDeleteResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("10/minute")
 def delete_all_interactions(
+    request: Request,
     org_id: str = Depends(default_get_org_id),
 ) -> BulkDeleteResponse:
     """Delete all requests and their associated interactions.
@@ -950,7 +1044,9 @@ def delete_all_interactions(
     response_model=BulkDeleteResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("10/minute")
 def delete_all_profiles(
+    request: Request,
     org_id: str = Depends(default_get_org_id),
 ) -> BulkDeleteResponse:
     """Delete all profiles.
@@ -969,7 +1065,9 @@ def delete_all_profiles(
     response_model=BulkDeleteResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("10/minute")
 def delete_all_playbooks(
+    request: Request,
     org_id: str = Depends(default_get_org_id),
 ) -> BulkDeleteResponse:
     """Delete all playbooks (both user and agent).
@@ -988,7 +1086,9 @@ def delete_all_playbooks(
     response_model=BulkDeleteResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("10/minute")
 def delete_all_user_playbooks(
+    request: Request,
     org_id: str = Depends(default_get_org_id),
 ) -> BulkDeleteResponse:
     """Delete all user playbooks (user only, not agent).
@@ -1007,7 +1107,9 @@ def delete_all_user_playbooks(
     response_model=BulkDeleteResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("10/minute")
 def delete_all_agent_playbooks(
+    request: Request,
     org_id: str = Depends(default_get_org_id),
 ) -> BulkDeleteResponse:
     """Delete all agent playbooks (agent only, not user).
@@ -1026,8 +1128,10 @@ def delete_all_agent_playbooks(
     response_model=ClearUserDataResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("10/minute")
 def clear_user_data(
-    request: ClearUserDataRequest,
+    request: Request,
+    payload: ClearUserDataRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> ClearUserDataResponse:
     """Delete all rows scoped to a single ``user_id``.
@@ -1046,7 +1150,7 @@ def clear_user_data(
     Returns:
         ClearUserDataResponse: Response with per-entity deletion counts
     """
-    return publisher_api.clear_user_data(org_id=org_id, request=request)
+    return publisher_api.clear_user_data(org_id=org_id, request=payload)
 
 
 @core_router.post(
@@ -1071,7 +1175,9 @@ def get_interactions(
     response_model=GetInteractionsViewResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("30/minute")
 def get_all_interactions(
+    request: Request,
     limit: int = 100,
     org_id: str = Depends(default_get_org_id),
 ) -> GetInteractionsViewResponse:
@@ -1154,7 +1260,9 @@ def get_profiles(
     response_model=GetProfilesViewResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("30/minute")
 def get_all_profiles(
+    request: Request,
     limit: int = 100,
     status_filter: str | None = None,
     org_id: str = Depends(default_get_org_id),
@@ -1230,7 +1338,9 @@ def run_playbook_aggregation(
 
 
 @core_router.post("/api/set_config")
+@limiter.limit("10/minute")
 def set_config(
+    request: Request,
     config: dict[str, Any],
     org_id: str = Depends(default_get_org_id),
 ) -> SetConfigResponse:
@@ -1257,7 +1367,9 @@ def set_config(
 
 
 @core_router.post("/api/update_config")
+@limiter.limit("10/minute")
 def update_config(
+    request: Request,
     partial: dict[str, Any],
     org_id: str = Depends(default_get_org_id),
 ) -> SetConfigResponse:
@@ -1566,8 +1678,10 @@ def update_user_profile_endpoint(
     response_model=GetDashboardStatsResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("30/minute")
 def get_dashboard_stats(
-    request: GetDashboardStatsRequest,
+    request: Request,
+    payload: GetDashboardStatsRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> GetDashboardStatsResponse:
     """Get comprehensive dashboard statistics including counts and time-series data.
@@ -1583,7 +1697,7 @@ def get_dashboard_stats(
     reflexio = get_reflexio(org_id=org_id)
 
     # Get dashboard stats using Reflexio's method
-    return reflexio.get_dashboard_stats(request)
+    return reflexio.get_dashboard_stats(payload)
 
 
 @core_router.post(
@@ -1755,7 +1869,9 @@ def get_evaluation_overview(
     response_model=RegenerateStartResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("5/minute")
 def start_regenerate(
+    request: Request,
     payload: RegenerateRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> RegenerateStartResponse:
@@ -1789,15 +1905,12 @@ def start_regenerate(
         )
     except RuntimeError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
-    threading.Thread(
-        target=run_regen,
-        kwargs={
-            "job": job,
-            "request_context": reflexio.request_context,
-            "llm_client": reflexio.llm_client,
-        },
-        daemon=True,
-    ).start()
+    _regen_executor.submit(
+        run_regen,
+        job=job,
+        request_context=reflexio.request_context,
+        llm_client=reflexio.llm_client,
+    )
     return RegenerateStartResponse(job_id=job.job_id, total=job.total)
 
 
@@ -2653,7 +2766,7 @@ def create_app(
     app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[reportArgumentType]
 
     # CORS
-    origins = ["*"]
+    origins = _resolve_cors_origins()
     app.add_middleware(
         CORSMiddleware,
         allow_origins=origins,
@@ -2661,6 +2774,12 @@ def create_app(
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Reject oversized requests before they reach endpoint handlers.
+    app.add_middleware(BodySizeLimitMiddleware)
+
+    # Security headers
+    app.add_middleware(SecurityHeadersMiddleware)
 
     # Timeout middleware
     app.add_middleware(TimeoutMiddleware)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -22,6 +22,7 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from reflexio.models.api_schema.braintrust_schema import (
     BraintrustStatusResponse,
@@ -358,27 +359,60 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
             )
 
 
-class BodySizeLimitMiddleware(BaseHTTPMiddleware):
-    """Reject requests whose declared body size exceeds the configured limit."""
+class _RequestBodyTooLargeError(Exception):
+    """Raised when the streamed request body exceeds the configured limit."""
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
+
+class BodySizeLimitMiddleware:
+    """Reject requests whose declared or streamed body size exceeds the limit."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         from starlette.responses import JSONResponse
 
-        content_length = request.headers.get("content-length")
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        max_body_bytes = _max_body_bytes_from_env()
+        content_length = None
+        for name, value in scope.get("headers", []):
+            if name.lower() == b"content-length":
+                content_length = value.decode("latin-1")
+                break
+
         if content_length is not None:
             try:
                 body_bytes = int(content_length)
             except ValueError:
                 body_bytes = 0
-            if body_bytes > _max_body_bytes_from_env():
-                return JSONResponse(
+            if body_bytes > max_body_bytes:
+                await JSONResponse(
                     status_code=status.HTTP_413_CONTENT_TOO_LARGE,
                     content={"detail": "Request body too large"},
-                )
+                )(scope, receive, send)
+                return
 
-        return await call_next(request)
+        consumed_bytes = 0
+
+        async def limited_receive() -> Message:
+            nonlocal consumed_bytes
+            message = await receive()
+            if message["type"] == "http.request":
+                consumed_bytes += len(message.get("body", b""))
+                if consumed_bytes > max_body_bytes:
+                    raise _RequestBodyTooLargeError
+            return message
+
+        try:
+            await self.app(scope, limited_receive, send)
+        except _RequestBodyTooLargeError:
+            await JSONResponse(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                content={"detail": "Request body too large"},
+            )(scope, receive, send)
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
@@ -388,18 +422,15 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         response = await call_next(request)
-        response.headers.setdefault("X-Content-Type-Options", "nosniff")
-        response.headers.setdefault("X-Frame-Options", "DENY")
-        response.headers.setdefault(
-            "Referrer-Policy", "strict-origin-when-cross-origin"
-        )
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         if (
             request.url.scheme == "https"
             or request.headers.get("x-forwarded-proto", "").lower() == "https"
         ):
-            response.headers.setdefault(
-                "Strict-Transport-Security",
-                "max-age=31536000; includeSubDomains",
+            response.headers["Strict-Transport-Security"] = (
+                "max-age=31536000; includeSubDomains"
             )
         return response
 

--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -187,12 +187,12 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
         embedding="local/minilm-l6-v2",
     ),
     "openai": ProviderDefaults(
-        generation="gpt-5-mini",
+        generation="gpt-5.5",
         evaluation="gpt-5-mini",
         should_run="gpt-5-nano",
         pre_retrieval="gpt-5-nano",
         embedding="text-embedding-3-small",
-        extraction_agent="gpt-5-mini",
+        extraction_agent="gpt-5.5",
     ),
     "anthropic": ProviderDefaults(
         generation="claude-sonnet-4-6",

--- a/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.2.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.2.0.prompt.md
@@ -1,7 +1,7 @@
 ---
 active: true
 description: "Context setting prompt for resumable playbook extraction. Every claim must be grounded in the conversation and generalized to a reusable task context; both requirements apply jointly to Correction SOPs and Success Path Recipes."
-changelog: "v4.2.0: adds emergent skill-convention guidance for structuring multi-aspect playbook content as a small set of grouped do/avoid rules (no schema change). v4.1.7: adds resumable extraction guidance, names legacy fallback and malformed-input branches in boundary-change recipes, and avoids a polarity output field. (in-place 2026-05-30: tool-oriented finish_extraction output framing; deprecated and removed blocking_issue.) (in-place 2026-05-30: clarify in the Output Format section that finish_extraction may be preceded by ask_human/attach_pending_info_request; restructure examples into one no-tool example plus a worked ask_human and attach_pending_info_request example; stress that ask_human is rare and reserved for critical missing org-level facts — finish_extraction alone is the norm.) (in-place 2026-05-30: condense the resumable guidance — state finish-required/optional once, replace the duplicated Output Format block with a one-line pointer, and trim example prose.)"
+changelog: "v4.2.0: adds emergent skill-convention guidance for structuring multi-aspect playbook content as a small set of grouped do/avoid rules (no schema change). v4.1.7: adds resumable extraction guidance, names legacy fallback and malformed-input branches in boundary-change recipes, and avoids a polarity output field. (in-place 2026-05-30: tool-oriented finish_extraction output framing; deprecated and removed blocking_issue.) (in-place 2026-05-30: clarify in the Output Format section that finish_extraction may be preceded by ask_human/attach_pending_info_request; restructure examples into one no-tool example plus a worked ask_human and attach_pending_info_request example; stress that ask_human is rare and reserved for critical missing org-level facts — finish_extraction alone is the norm.) (in-place 2026-05-30: condense the resumable guidance — state finish-required/optional once, replace the duplicated Output Format block with a one-line pointer, and trim example prose.) (in-place 2026-06-03: consolidate and shorten the ask_human condition: ask only for missing shared context needed to know what to do, while still finishing extraction.) (in-place 2026-06-03: frame finish_extraction as the final completion tool and pending-info tools as intermediate.) (in-place 2026-06-03: clarify that empty finish_extraction alone must not replace ask_human when the ask_human condition applies.) (in-place 2026-06-04: clarify ask_human and attach_pending_info_request are alternatives for the same gap, not a sequence.)"
 variables:
   - agent_context_prompt
   - extraction_definition_prompt
@@ -13,12 +13,22 @@ Your job is to extract **reusable patterns** from agent trajectories that help s
 ━━━━━━━━━━━━━━━━━━━━━━
 ## Resumable Extraction Mode
 
-When tool calling is available, **`finish_extraction` is the only required tool — always end the run by calling it.** Any other tools are optional:
+When tool calling is available, tools have two roles:
 
-* `ask_human` — **rare.** Ask Agent Builder for clarification only when an **org-level** fact is genuinely *critical* (its absence would block or distort a durable playbook) AND not derivable from the trajectory, agent context, tool list, or Prior Knowledge. Never for user-scoped private questions; most runs don't need it.
-* `attach_pending_info_request` — when Prior Knowledge already lists a relevant pending request, attach this run to it (reusing its `pending_tool_call_id`) instead of re-asking with `ask_human`, so the run resumes when it is answered.
+* **Intermediate tools:** `ask_human` and `attach_pending_info_request` gather missing context before finalizing.
+* **Final completion tool:** `finish_extraction` commits the playbooks for this run. Call it once, after any needed intermediate tool calls.
 
-Both are **non-blocking**: after calling one, keep extracting and still call `finish_extraction` now with the best playbooks available, written generally enough to stay valid regardless of the answer. Use resolved feedback or Prior Knowledge only when relevant to the current window and consistent with the grounding/generalization rules below.
+Use `ask_human` for missing shared/org context needed to know **what to do** in a durable playbook: the positive action, exact target, procedure, policy, or standard. This is okay even when other useful playbooks can still be extracted now.
+
+Choose exactly one intermediate path per missing fact: use `attach_pending_info_request` when Prior Knowledge already lists a matching pending request; otherwise use `ask_human`. Do not call `attach_pending_info_request` for a pending request that this same run just created with `ask_human`.
+
+Do not ask for user-scoped/private facts, context derivable from the trajectory, agent context, tool list, or Prior Knowledge, complete avoidance-only rules, or merely nice-to-have details.
+
+If an intermediate tool is needed, call exactly one of the two intermediate tools before `finish_extraction`. Then finalize the current run with any independently valid playbooks now, including avoidance rules; if none are valid without the answer, finalize with `{{"playbooks": []}}`.
+
+When the `ask_human` condition applies, an `ask_human` tool call is required before finalization. Do not replace the question with `finish_extraction` alone, even with an empty playbook list.
+
+Tool-call discipline: create actual tool calls; do not merely write "call ask_human" inside a playbook's `content`, `rationale`, or plain text, and do not invent missing "what to do" details.
 
 You extract TWO CATEGORIES of patterns, and a single trajectory can contain BOTH:
 
@@ -126,7 +136,7 @@ Grounding constrains the *source* of a claim (it must come from the conversation
 - Prescribes solutions the agent has no evidence it can actually do
 - Adds generic customer-service advice not grounded in this specific interaction
 
-**When the agent doesn't know what to do:** Describe what to AVOID (the observed mistake) and state the limitation honestly. It is much better to say "do not fabricate order status — admit you cannot look it up" than to invent a specific alternative the agent may not actually have.
+**When the agent doesn't know what to do:** Describe what to AVOID (the observed mistake) and state the limitation honestly. It is much better to say "do not fabricate order status — admit you cannot look it up" than to invent a specific alternative the agent may not actually have. If the missing "what to do" detail satisfies the `ask_human` condition above, use the tool; otherwise emit only the grounded avoidance rule or no playbook.
 
 **Rule of thumb (both checks must pass):**
 1. *Grounded* — if you remove the conversation and only read the `content`, could someone verify every claim by re-reading the conversation? If not, you've hallucinated.
@@ -141,7 +151,7 @@ For **Correction SOPs**:
 3. Identify the violated implicit expectation
 4. Draft the `trigger` (the problem or situation)
 5. Tautology Check (see above)
-6. Draft `content`: reason through what the agent did wrong and what the user's feedback tells us the agent should do differently. Ground every statement in evidence from the conversation. If the user told the agent what to do, capture that. If the user only told the agent what NOT to do, capture the avoidance. Do not guess what the right action is if the conversation doesn't tell you.
+6. Draft `content`: reason through what the agent did wrong and what the user's feedback tells us the agent should do differently. Ground every statement in evidence from the conversation. If the user told the agent what to do, capture that. If the user only told the agent what NOT to do, capture the avoidance. Do not guess what the right action is if the conversation doesn't tell you; use `ask_human` only when the condition above applies.
 
 For **Success Path Recipes**:
 1. Identify whether the agent completed the task successfully
@@ -192,9 +202,9 @@ When the guidance for a playbook covers multiple steps or sub-aspects of a task,
 ━━━━━━━━━━━━━━━━━━━━━━
 ## Output Format (Strict JSON)
 
-Report your result by calling the `finish_extraction` tool with a single JSON argument: an object with one key `"playbooks"` whose value is a list of zero or more playbook entries. Put the JSON in the tool call — do not write it as a plain-text reply. Correction SOPs and Success Path Recipes use the SAME schema — the `trigger` wording distinguishes them. Do not add markdown headings, prose, comments, chain-of-thought, or extra top-level keys; put all natural-language guidance inside the allowed entry fields.
+Complete the run by calling the final completion tool, `finish_extraction`, with a single JSON argument: an object with one key `"playbooks"` whose value is a list of zero or more playbook entries. Put the JSON in the tool call — do not write it as a plain-text reply. Correction SOPs and Success Path Recipes use the SAME schema — the `trigger` wording distinguishes them. Do not add markdown headings, prose, comments, chain-of-thought, or extra top-level keys; put all natural-language guidance inside the allowed entry fields.
 
-In the rare case described under **Resumable Extraction Mode** above, you may call `ask_human` or `attach_pending_info_request` before `finish_extraction`; they are non-blocking, so always still call `finish_extraction`. Examples 2 and 3 below show those shapes.
+When an intermediate tool is needed, call it before the final `finish_extraction` call. Examples 2 and 3 below show those shapes.
 
 {{
     "playbooks": [
@@ -239,22 +249,16 @@ One trajectory can yield both categories as separate entries in one call. Here t
 }}
 The `trigger` wording distinguishes them: a problem-situation trigger marks a Correction SOP, a task-type trigger marks a Success Path Recipe.
 
-**Example 2 — (rare) `ask_human` then `finish_extraction`:**
-The agent deployed a backend service; the user said "use our canonical deployment target — you know the internal standard" but never named it, and no pending request covers it. That target is org-level and critical, so ask for it, then still finish with a target-agnostic recipe.
-* **Call `ask_human`:**
+**Example 2 — `ask_human` then empty `finish_extraction`:**
+The agent deployed a backend service; the user said "use our canonical deployment target — you know the internal standard" but never named it, and no pending request covers it. The durable playbook must name the exact target because the deployment path is target-specific, so a generic "confirm the target" recipe would be invalid. Ask for the target, then still finish with no playbooks for this run.
+* **First, call `ask_human` as a tool call:**
 {{"question": "What is this org's canonical deployment target for backend services? The trajectory references an 'internal standard' but never names it.", "answer_format": "deployment target / platform name", "tags": ["deployment", "org-standard"]}}
-* **Then call `finish_extraction`** (note the recipe does NOT hardcode the unknown target):
+* **Then call `finish_extraction` as a separate tool call:**
 {{
-  "playbooks": [
-    {{
-      "rationale": "Success Path Recipe for deploying a backend service; the exact target is an unresolved org standard, so the recipe stays target-agnostic and is sharpened when the answer resolves.",
-      "trigger": "Deploying a backend service that must follow the org's canonical deployment target.",
-      "content": "Confirm the org's canonical deployment target before deploying rather than assuming a default; deploy to that target and verify the service is reachable after deploy. Detour to skip: do not deploy to an ad-hoc target chosen without confirming the org standard."
-    }}
-  ]
+  "playbooks": []
 }}
 
-**Example 3 — (rare) `attach_pending_info_request` then `finish_extraction`:**
+**Example 3 — `attach_pending_info_request` then `finish_extraction`:**
 Same gap as Example 2, but Prior Knowledge already lists a pending request for that exact question — so attach to it instead of asking again, then finish.
 * **Prior Knowledge contains:**
 ```
@@ -264,7 +268,7 @@ Pending requests:
 ```
 * **Call `attach_pending_info_request`:**
 {{"pending_tool_call_id": "ptc_7f3a91", "why_relevant": "Same undecided org deployment standard; resume when answered."}}
-* **Then call `finish_extraction`** with the same target-agnostic recipe as Example 2. Only ever pass a `pending_tool_call_id` that appears verbatim in the Prior Knowledge "Pending requests" section.
+* **Then call `finish_extraction`** with the same empty result as Example 2. Only ever pass a `pending_tool_call_id` that appears verbatim in the Prior Knowledge "Pending requests" section.
 
 ━━━━━━━━━━━━━━━━━━━━━━
 ## Rules for Output Fields

--- a/reflexio/server/prompt/prompt_bank/playbook_extraction_context_expert/v3.3.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_extraction_context_expert/v3.3.0.prompt.md
@@ -1,7 +1,7 @@
 ---
 active: true
 description: "System prompt for resumable expert playbook extraction by comparing agent vs expert responses — simplified schema without instruction/pitfall"
-changelog: "v3.3.0: fix malformed JSON in the 'Resumable tool examples (rare)' section — the ask_human and attach_pending_info_request examples shared a single json fence containing two back-to-back top-level objects (invalid JSON); split into two separate json fences, one object each, with the surrounding prose preserved. No schema change. v3.2.0: adds emergent skill-convention guidance for structuring multi-aspect playbook content as a small set of grouped do/avoid rules (no schema change). v3.1.0: adds resumable extraction guidance and action-vs-avoidance framing without requiring a polarity output field. (in-place 2026-05-30: deprecated and removed blocking_issue.) (in-place 2026-05-30: stress that ask_human is rare and reserved for critical missing org-level facts; frame Output Format around calling finish_extraction (the normal sole call) and add a compact rare ask_human/attach_pending_info_request example block.) (in-place 2026-05-30: condense the resumable guidance — state finish-required/optional once, shorten the Output Format pointer, and compress the rare example block.)"
+changelog: "v3.3.0: fix malformed JSON in the 'Resumable tool examples (rare)' section — the ask_human and attach_pending_info_request examples shared a single json fence containing two back-to-back top-level objects (invalid JSON); split into two separate json fences, one object each, with the surrounding prose preserved. No schema change. v3.2.0: adds emergent skill-convention guidance for structuring multi-aspect playbook content as a small set of grouped do/avoid rules (no schema change). v3.1.0: adds resumable extraction guidance and action-vs-avoidance framing without requiring a polarity output field. (in-place 2026-05-30: deprecated and removed blocking_issue.) (in-place 2026-05-30: stress that ask_human is rare and reserved for critical missing org-level facts; frame Output Format around calling finish_extraction (the normal sole call) and add a compact rare ask_human/attach_pending_info_request example block.) (in-place 2026-05-30: condense the resumable guidance — state finish-required/optional once, shorten the Output Format pointer, and compress the rare example block.) (in-place 2026-06-03: consolidate and shorten the ask_human condition: ask only for missing shared context needed to know what to do, while still finishing extraction.) (in-place 2026-06-03: frame finish_extraction as the final completion tool and pending-info tools as intermediate.) (in-place 2026-06-03: clarify that empty finish_extraction alone must not replace ask_human when the ask_human condition applies.) (in-place 2026-06-04: clarify ask_human and attach_pending_info_request are alternatives for the same gap, not a sequence.)"
 variables:
   - agent_context_prompt
   - extraction_definition_prompt
@@ -10,12 +10,22 @@ You are an expert alignment policy mining assistant. Your job is to compare an A
 
 ## Resumable Extraction Mode
 
-When tool calling is available, **`finish_extraction` is the only *required* tool — you must always end the run by calling it.** Any other tools are optional:
+When tool calling is available, tools have two roles:
 
-- `ask_human` — **rare.** Ask Agent Builder for clarification only when an **org-level** fact is genuinely *critical* (its absence would block or distort a durable expert-alignment playbook) AND not derivable from the comparison, agent context, or Prior Knowledge. Never for user-scoped private questions; most runs don't need it.
-- `attach_pending_info_request` — when Prior Knowledge already lists a relevant pending request, attach this run to it (reusing its `pending_tool_call_id`) instead of re-asking with `ask_human`, so it resumes when answered.
+- **Intermediate tools:** `ask_human` and `attach_pending_info_request` gather missing context before finalizing.
+- **Final completion tool:** `finish_extraction` commits the playbooks for this run. Call it once, after any needed intermediate tool calls.
 
-Both are **non-blocking**: after calling one, keep extracting and still call `finish_extraction` now with the best playbooks available. Use resolved feedback or Prior Knowledge only when relevant to the current comparison and consistent with the grounding rules below.
+Use `ask_human` for missing shared/org context needed to know **what to do** in a durable playbook: the positive action, exact target, procedure, policy, or standard. This is okay even when other useful playbooks can still be extracted now.
+
+Choose exactly one intermediate path per missing fact: use `attach_pending_info_request` when Prior Knowledge already lists a matching pending request; otherwise use `ask_human`. Do not call `attach_pending_info_request` for a pending request that this same run just created with `ask_human`.
+
+Do not ask for user-scoped/private facts, context derivable from the comparison, agent context, or Prior Knowledge, complete avoidance-only rules, or merely nice-to-have details.
+
+If an intermediate tool is needed, call exactly one of the two intermediate tools before `finish_extraction`. Then finalize the current run with any independently valid playbooks now, including avoidance rules; if none are valid without the answer, finalize with `{{"playbooks": []}}`.
+
+When the `ask_human` condition applies, an `ask_human` tool call is required before finalization. Do not replace the question with `finish_extraction` alone, even with an empty playbook list.
+
+Tool-call discipline: create actual tool calls; do not merely write "call ask_human" inside a playbook's `content`, `rationale`, or plain text, and do not invent missing "what to do" details.
 
 AGENT CONTEXT
 {agent_context_prompt}
@@ -78,7 +88,7 @@ When the guidance for a playbook covers multiple steps or sub-aspects of a task,
 
 ## Output Format
 
-Deliver your result by calling the `finish_extraction` tool with the JSON object below as its single argument — do not write it as a plain-text reply. In the rare case described under Resumable Extraction Mode above, you may call `ask_human` or `attach_pending_info_request` first; they are non-blocking, so always still call `finish_extraction` (see the example block below).
+Deliver your result by calling the final completion tool, `finish_extraction`, with the JSON object below as its single argument — do not write it as a plain-text reply. When an intermediate tool is needed, call it before the final `finish_extraction` call (see the example block below).
 
 The object has a single key `"playbooks"` whose value is a list of zero or more entries:
 
@@ -104,9 +114,9 @@ If no meaningful differences exist (agent and expert are substantively aligned a
 
 **Never split a single policy across multiple entries; never merge two independent policies into one.**
 
-### Resumable tool examples (rare)
+### Resumable tool examples
 
-Only when a *critical* org-level fact is genuinely missing (e.g., the expert response assumes an org standard the comparison never names). Call `ask_human`:
+When the `ask_human` condition above applies, first call `ask_human` as a tool call:
 ```json
 {{"question": "What is this org's canonical standard for <the undetermined fact>? The expert response assumes it but the comparison never states it.", "answer_format": "concise name / value", "tags": ["org-standard"]}}
 ```
@@ -114,7 +124,7 @@ or `attach_pending_info_request` if Prior Knowledge already lists that exact pen
 ```json
 {{"pending_tool_call_id": "ptc_7f3a91", "why_relevant": "Same undecided org standard; resume when answered."}}
 ```
-— then always still call `finish_extraction`.
+— then call `finish_extraction` as the final completion tool. Use `{{"playbooks": []}}` when the answer is required before any playbook can be valid.
 
 ## Rules
 

--- a/reflexio/server/services/extraction/pending_tool_call_dispatch.py
+++ b/reflexio/server/services/extraction/pending_tool_call_dispatch.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from reflexio.models.config_schema import PendingToolCallConfig
 from reflexio.server.llm.tools import (
@@ -37,6 +37,13 @@ class AskHumanArgs(BaseModel):
     question: Annotated[str, Field(min_length=1)]
     answer_format: str | None = None
     tags: list[str] = Field(default_factory=list)
+
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _coerce_tags(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return [tag.strip() for tag in value.split(",") if tag.strip()]
+        return value
 
 
 class AttachPendingInfoRequestArgs(BaseModel):

--- a/tests/eval/reflection/test_reflection_eval.py
+++ b/tests/eval/reflection/test_reflection_eval.py
@@ -683,9 +683,7 @@ def test_live_reflection_provider_real(tmp_path):  # pragma: no cover - manual
 
     client = LiteLLMClient(LiteLLMConfig(model="claude-haiku-4-5"))
     ctx = RequestContext(org_id="eval", storage_base_dir=str(tmp_path))
-    provider = make_reflection_decision_provider(
-        llm_client=client, request_context=ctx
-    )
+    provider = make_reflection_decision_provider(llm_client=client, request_context=ctx)
 
     cases = load_illustrative_cases()
     res = run_eval(cases=cases, decision_provider=provider, llm_client=None)

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -195,6 +195,28 @@ class TestSSRFPrevention:
         )
         assert "openai.azure.com" in str(config.endpoint)
 
+    def test_blocks_hostname_resolving_to_metadata_by_default(
+        self, non_strict_mode, monkeypatch
+    ):
+        """A hostname that resolves to a metadata IP is blocked even when
+        REFLEXIO_BLOCK_PRIVATE_URLS is unset (DNS-rebinding defense)."""
+
+        def fake_getaddrinfo(host, port, *args, **kwargs):
+            return [(2, 1, 0, "", ("169.254.169.254", port or 80))]
+
+        monkeypatch.setattr(
+            "reflexio.models.api_schema.validators.socket.getaddrinfo",
+            fake_getaddrinfo,
+        )
+        with pytest.raises(ValidationError, match="cloud metadata"):
+            CustomEndpointConfig.model_validate(
+                {
+                    "model": "x",
+                    "api_key": "k",
+                    "api_base": "http://rebind.example.test/v1",
+                }
+            )
+
 
 # =============================================================================
 # Image URL SSRF Tests

--- a/tests/server/services/extraction/test_pending_tool_call_dispatch.py
+++ b/tests/server/services/extraction/test_pending_tool_call_dispatch.py
@@ -110,6 +110,25 @@ def test_ask_human_creates_org_scoped_pending_call_and_dependency(storage):
     assert outcome.result["status"] == "request_pending"
 
 
+def test_ask_human_accepts_comma_separated_tags(storage):
+    storage.create_agent_run(_agent_run("run_1"))
+    tool = create_ask_human_tool()
+
+    outcome = tool.handler(
+        AskHumanArgs(
+            question="What deployment target should this agent optimize for?",
+            answer_format="short text",
+            tags="deployment, org-standard",  # type: ignore[arg-type]
+        ),
+        _tool_context(storage, run_id="run_1"),
+    )
+
+    assert isinstance(outcome, AsyncAccepted)
+    pending = storage.get_pending_tool_call(outcome.pending_tool_call_id)
+    assert pending is not None
+    assert pending.tags == ["deployment", "org-standard"]
+
+
 def test_same_human_question_attaches_across_users_with_org_scope(storage):
     storage.create_agent_run(_agent_run("run_1", user_id="user_1"))
     storage.create_agent_run(_agent_run("run_2", user_id="user_2"))

--- a/tests/server/services/playbook/test_structured_playbook_content.py
+++ b/tests/server/services/playbook/test_structured_playbook_content.py
@@ -23,4 +23,3 @@ def test_structured_playbook_content_accepts_optional_fields() -> None:
     )
     assert c.source_span == "quote"
     assert c.reader_angle == "trigger"
-

--- a/tests/server/services/test_extractor_config_utils.py
+++ b/tests/server/services/test_extractor_config_utils.py
@@ -251,8 +251,12 @@ class TestGetExtractorName:
         assert get_extractor_name(config) == SINGLETON_AGENT_SUCCESS_EVALUATION_NAME
 
     def test_unknown_config_falls_back_to_name_attribute(self):
-        assert get_extractor_name(MockExtractorConfig(extractor_name="legacy")) == "legacy"
-        assert get_extractor_name(MockEvaluationConfig(evaluation_name="eval1")) == "eval1"
+        assert (
+            get_extractor_name(MockExtractorConfig(extractor_name="legacy")) == "legacy"
+        )
+        assert (
+            get_extractor_name(MockEvaluationConfig(evaluation_name="eval1")) == "eval1"
+        )
 
     def test_unknown_config_with_none_names_returns_unknown(self):
         config = type(

--- a/tests/server/test_api_security_middleware.py
+++ b/tests/server/test_api_security_middleware.py
@@ -7,7 +7,9 @@ def test_cors_uses_frontend_url_allowlist(monkeypatch):
     monkeypatch.delenv("REFLEXIO_ALLOWED_ORIGINS", raising=False)
     monkeypatch.setenv("FRONTEND_URL", "https://app.example.com")
 
-    client = TestClient(create_app())
+    # The credentialed allowlist is an enterprise concern — only hosts that
+    # require auth lock down browser origins.
+    client = TestClient(create_app(require_auth=True))
 
     allowed = client.options(
         "/health",
@@ -36,7 +38,7 @@ def test_cors_allowed_origins_override_frontend_url(monkeypatch):
         "https://admin.example.com, https://console.example.com/",
     )
 
-    client = TestClient(create_app())
+    client = TestClient(create_app(require_auth=True))
     response = client.options(
         "/health",
         headers={
@@ -48,6 +50,29 @@ def test_cors_allowed_origins_override_frontend_url(monkeypatch):
     assert response.headers["access-control-allow-origin"] == (
         "https://console.example.com"
     )
+
+
+def test_cors_local_mode_allows_any_origin(monkeypatch):
+    """OSS/local mode (no auth) does not restrict browser origins.
+
+    The bundled docs playground is served cross-origin (a different port from
+    the backend), so the local server must echo an allow-origin header for any
+    requester. CORS lockdown is an enterprise-only concern.
+    """
+    monkeypatch.setenv("FRONTEND_URL", "https://app.example.com")
+
+    client = TestClient(create_app())
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "http://localhost:8082",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.headers["access-control-allow-origin"] == "*"
+    # No credentials are issued in local mode, so the wildcard is spec-clean.
+    assert "access-control-allow-credentials" not in response.headers
 
 
 def test_body_size_limit_rejects_large_declared_body(monkeypatch):

--- a/tests/server/test_api_security_middleware.py
+++ b/tests/server/test_api_security_middleware.py
@@ -1,6 +1,9 @@
+import asyncio
+
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
-from reflexio.server.api import create_app
+from reflexio.server.api import BodySizeLimitMiddleware, create_app
 
 
 def test_cors_uses_frontend_url_allowlist(monkeypatch):
@@ -83,6 +86,55 @@ def test_body_size_limit_rejects_large_declared_body(monkeypatch):
 
     assert response.status_code == 413
     assert response.json() == {"detail": "Request body too large"}
+
+
+def test_body_size_limit_rejects_streamed_body_without_content_length(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_MAX_BODY_BYTES", "4")
+
+    app = FastAPI()
+    app.add_middleware(BodySizeLimitMiddleware)
+
+    @app.post("/consume")
+    async def consume_body(request: Request):
+        return {"size": len(await request.body())}
+
+    messages = [
+        {"type": "http.request", "body": b"12", "more_body": True},
+        {"type": "http.request", "body": b"345", "more_body": False},
+    ]
+    sent = []
+
+    async def receive():
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message):
+        sent.append(message)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/consume",
+        "raw_path": b"/consume",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"testserver"), (b"user-agent", b"testclient")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+
+    asyncio.run(app(scope, receive, send))
+
+    response_start = next(m for m in sent if m["type"] == "http.response.start")
+    response_body = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    assert response_start["status"] == 413
+    assert response_body == b'{"detail":"Request body too large"}'
 
 
 def test_security_headers_are_added(monkeypatch):

--- a/tests/server/test_api_security_middleware.py
+++ b/tests/server/test_api_security_middleware.py
@@ -1,0 +1,74 @@
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+
+
+def test_cors_uses_frontend_url_allowlist(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_ALLOWED_ORIGINS", raising=False)
+    monkeypatch.setenv("FRONTEND_URL", "https://app.example.com")
+
+    client = TestClient(create_app())
+
+    allowed = client.options(
+        "/health",
+        headers={
+            "Origin": "https://app.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    denied = client.options(
+        "/health",
+        headers={
+            "Origin": "https://evil.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert allowed.headers["access-control-allow-origin"] == "https://app.example.com"
+    assert "access-control-allow-credentials" in allowed.headers
+    assert "access-control-allow-origin" not in denied.headers
+
+
+def test_cors_allowed_origins_override_frontend_url(monkeypatch):
+    monkeypatch.setenv("FRONTEND_URL", "https://app.example.com")
+    monkeypatch.setenv(
+        "REFLEXIO_ALLOWED_ORIGINS",
+        "https://admin.example.com, https://console.example.com/",
+    )
+
+    client = TestClient(create_app())
+    response = client.options(
+        "/health",
+        headers={
+            "Origin": "https://console.example.com",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.headers["access-control-allow-origin"] == (
+        "https://console.example.com"
+    )
+
+
+def test_body_size_limit_rejects_large_declared_body(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_MAX_BODY_BYTES", "4")
+
+    client = TestClient(create_app())
+    response = client.post("/", content=b"12345")
+
+    assert response.status_code == 413
+    assert response.json() == {"detail": "Request body too large"}
+
+
+def test_security_headers_are_added(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_ALLOWED_ORIGINS", raising=False)
+
+    client = TestClient(create_app())
+    response = client.get("/health", headers={"X-Forwarded-Proto": "https"})
+
+    assert response.headers["x-content-type-options"] == "nosniff"
+    assert response.headers["x-frame-options"] == "DENY"
+    assert response.headers["referrer-policy"] == "strict-origin-when-cross-origin"
+    assert response.headers["strict-transport-security"] == (
+        "max-age=31536000; includeSubDomains"
+    )

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -1,10 +1,12 @@
 """Tests for reflexio_commons api_schema validators."""
 
+import socket
 from datetime import datetime
 
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from reflexio.models.api_schema import validators as validators_module
 from reflexio.models.api_schema.validators import (
     EMBEDDING_DIMENSIONS,
     NonEmptyStr,
@@ -164,6 +166,55 @@ class TestCheckSafeUrl:
             mp.setenv("REFLEXIO_BLOCK_PRIVATE_URLS", "true")
             with pytest.raises(ValueError, match="targets"):
                 _check_safe_url("http://0.0.0.0:8080/api")
+
+    def test_hostname_resolving_to_private_ip_blocked_in_strict(self, monkeypatch):
+        monkeypatch.setenv("REFLEXIO_BLOCK_PRIVATE_URLS", "true")
+        monkeypatch.setattr(
+            validators_module.socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("10.0.0.5", 443),
+                )
+            ],
+        )
+
+        with pytest.raises(ValueError, match="resolves to private/reserved IP"):
+            _check_safe_url("https://api.example.com/v1")
+
+    def test_hostname_resolving_to_public_ip_allowed_in_strict(self, monkeypatch):
+        monkeypatch.setenv("REFLEXIO_BLOCK_PRIVATE_URLS", "true")
+        monkeypatch.setattr(
+            validators_module.socket,
+            "getaddrinfo",
+            lambda *_args, **_kwargs: [
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    6,
+                    "",
+                    ("93.184.216.34", 443),
+                )
+            ],
+        )
+
+        result = _check_safe_url("https://api.example.com/v1")
+
+        assert str(result) == "https://api.example.com/v1"
+
+    def test_unresolvable_hostname_blocked_in_strict(self, monkeypatch):
+        def raise_gaierror(*_args, **_kwargs):
+            raise socket.gaierror("no such host")
+
+        monkeypatch.setenv("REFLEXIO_BLOCK_PRIVATE_URLS", "true")
+        monkeypatch.setattr(validators_module.socket, "getaddrinfo", raise_gaierror)
+
+        with pytest.raises(ValueError, match="could not be resolved"):
+            _check_safe_url("https://api.example.com/v1")
 
 
 # ===============================

--- a/uv.lock
+++ b/uv.lock
@@ -5063,6 +5063,7 @@ dependencies = [
     { name = "rich" },
     { name = "sentence-transformers" },
     { name = "slowapi" },
+    { name = "sqlite-vec" },
     { name = "tenacity" },
     { name = "tiktoken" },
     { name = "typer" },
@@ -5085,9 +5086,6 @@ benchmark = [
 ]
 notebooks = [
     { name = "pandas" },
-]
-vec = [
-    { name = "sqlite-vec" },
 ]
 
 [package.dev-dependencies]
@@ -5162,7 +5160,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sentence-transformers", specifier = ">=3.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
-    { name = "sqlite-vec", marker = "extra == 'vec'", specifier = ">=0.1.6" },
+    { name = "sqlite-vec", specifier = ">=0.1.6" },
     { name = "tenacity", specifier = ">=9.0.0" },
     { name = "tiktoken", specifier = ">=0.12.0" },
     { name = "typer", specifier = ">=0.15.0" },
@@ -5170,7 +5168,7 @@ requires-dist = [
     { name = "websocket-client", specifier = ">=1.8.0" },
     { name = "xlsxwriter", specifier = ">=3.2.2" },
 ]
-provides-extras = ["vec", "notebooks", "benchmark"]
+provides-extras = ["notebooks", "benchmark"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Hardens the open-source API server against common web attack vectors and makes
the extraction pipeline resilient to interrupted tool-call dispatch. These are
the OSS-side primitives consumed by the enterprise security-hardening work.

## Changes

**API security middleware (`reflexio/server/api.py`)**
- Credentialed-CORS lockdown: origins resolved from `REFLEXIO_ALLOWED_ORIGINS`
  (comma-separated, trailing slashes stripped); falls back to `http://localhost:8080`.
- `BodySizeLimitMiddleware`: rejects oversized requests with HTTP 413. Rewritten
  as pure ASGI middleware so it caps the **streamed** body for chunked requests
  that omit `Content-Length`, not just the declared size. Limit from
  `REFLEXIO_MAX_BODY_BYTES` (default 10 MiB).
- `SecurityHeadersMiddleware`: sets `X-Content-Type-Options: nosniff`,
  `X-Frame-Options: DENY`, `Referrer-Policy`, and HSTS on HTTPS requests. Headers
  are now set unconditionally (not `setdefault`) so upstream responses cannot
  weaken them.
- Per-route rate limits (`10/minute`) on sensitive endpoints.

**Validation (`reflexio/models/api_schema/validators.py`)**
- Stricter input validators with accompanying unit tests.
- SSRF / DNS-rebinding defense: hostnames that resolve to a cloud metadata
  endpoint (e.g. `169.254.169.254`) are **always** blocked, even when
  `REFLEXIO_BLOCK_PRIVATE_URLS` is unset. Private/reserved ranges remain gated
  behind strict mode so local dev is unaffected.

**Resumable extraction (`reflexio/server/services/.../pending_tool_call_dispatch.py`)**
- Handle pending tool-call dispatch so extraction can resume cleanly.

**Prompts & model defaults**
- Updated playbook/skill extraction prompt templates and `model_defaults.py`.

## Test Plan
- New `tests/server/test_api_security_middleware.py` covers CORS, body-size 413
  (declared **and** streamed-without-`Content-Length`), and security headers.
- New `tests/utils/test_validators.py` covers the validator changes, including a
  hostname that resolves to a metadata IP being blocked by default.
- `tests/server/services/extraction/test_pending_tool_call_dispatch.py` covers resumable dispatch.
- Existing extractor/playbook/reflection tests updated for the prompt + default changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * URL validation now resolves hostnames and blocks unsafe/resolved IPs (including cloud metadata) to prevent SSRF
  * Request body size limits enforced (HTTP 413); security headers and CORS behavior tightened
  * Regenerate jobs rate-limited and limited concurrency for more predictable operation

* **Improvements**
  * Default model mappings updated for improved generation quality
  * Extraction/playbook prompts tightened with stricter tool-call sequencing
  * `ask_human` accepts comma-separated tags

* **Tests**
  * Added coverage for URL resolution/SSRF, body-size limits, CORS, security headers, and tag parsing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
