### PR TITLE
refactor(llm): adopt native litellm num_retries + fallbacks, drop custom retry loop

### DIFF
--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -11,7 +11,7 @@ import logging
 import os
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import Any
 
@@ -207,24 +207,40 @@ class LiteLLMConfig:
     Configuration for LiteLLM client.
 
     Args:
-        model: Model name to use (e.g., 'gpt-4o', 'claude-3-5-sonnet-20241022', 'azure/gpt-4')
-        temperature: Temperature for response generation (0.0 to 2.0)
-        max_tokens: Maximum tokens to generate
-        timeout: Request timeout in seconds
-        max_retries: Maximum number of retry attempts
-        retry_delay: Initial delay between retries in seconds (exponential backoff)
-        top_p: Top-p sampling parameter
-        api_key_config: Optional API key configuration from Config (overrides env vars)
+        model: Model name to use (e.g., 'gpt-4o', 'claude-3-5-sonnet-20241022').
+        temperature: Temperature for response generation (0.0 to 2.0).
+        max_tokens: Maximum tokens to generate.
+        timeout: Request timeout in seconds.
+        max_retries: Maximum retry attempts on the primary model. Passed
+            directly to litellm's num_retries. Default 3.
+        retry_delay: Currently unused — LiteLLM owns retry backoff. Kept for
+            backward compatibility; remove in a follow-up sweep.
+        top_p: Top-p sampling parameter.
+        api_key_config: Optional API key configuration from Config (overrides env vars).
+        fallback_models: Models LiteLLM tries in order after the primary
+            exhausts num_retries. Passed directly to litellm's fallbacks param.
+            Default is an empty list (no fallback) so local reflexio and the
+            claude-smart integration are never silently routed to an unintended
+            provider. Production opts in via the env var
+            REFLEXIO_LLM_FALLBACK_MODELS (comma-separated, e.g. "gpt-5-mini").
+            Self-references are deduped at request time.
     """
 
     model: str
     temperature: float = 0.7
     max_tokens: int | None = None
     timeout: int = 120
-    max_retries: int = 1
+    max_retries: int = 3
     retry_delay: float = 1.0
     top_p: float = 1.0
     api_key_config: APIKeyConfig | None = None
+    fallback_models: list[str] = field(
+        default_factory=lambda: [
+            m.strip()
+            for m in os.environ.get("REFLEXIO_LLM_FALLBACK_MODELS", "").split(",")
+            if m.strip()
+        ]
+    )
 
 
 @dataclass

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -657,7 +657,11 @@ class LiteLLMClient:
             if api_version:
                 params["api_version"] = api_version
 
-            response = litellm.embedding(**params, timeout=self.config.timeout)
+            response = litellm.embedding(
+                **params,
+                timeout=self.config.timeout,
+                num_retries=self.config.max_retries,
+            )
             return response.data[0]["embedding"]
         except Exception as e:
             raise LiteLLMClientError(f"Embedding generation failed: {str(e)}") from e
@@ -741,7 +745,11 @@ class LiteLLMClient:
             if api_version:
                 params["api_version"] = api_version
 
-            response = litellm.embedding(**params, timeout=self.config.timeout)
+            response = litellm.embedding(
+                **params,
+                timeout=self.config.timeout,
+                num_retries=self.config.max_retries,
+            )
             # Response data may not be in order, sort by index to ensure correct ordering
             sorted_data = sorted(response.data, key=lambda x: x["index"])
             return [item["embedding"] for item in sorted_data]

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -490,6 +490,8 @@ class LiteLLMClient:
         tools: list[Any] | None = None,
         tool_choice: str | dict[str, Any] | None = None,
         model_role: ModelRole | None = None,
+        max_retries: int | None = None,
+        fallback_models: list[str] | None = None,
         **kwargs: Any,
     ) -> str | BaseModel | ToolCallingChatResponse:
         """
@@ -505,6 +507,12 @@ class LiteLLMClient:
             model_role: Optional ``ModelRole`` to override the model selected for
                 this request. The role is resolved via ``resolve_model_name`` using
                 the client's ``api_key_config``.
+            max_retries (int | None): Optional per-call override for the number of
+                retry attempts. When ``None`` (the default), the value falls back to
+                ``LiteLLMConfig.max_retries``.
+            fallback_models (list[str] | None): Optional per-call override for the
+                fallback model chain. When ``None`` (the default), the value falls
+                back to ``LiteLLMConfig.fallback_models``.
             **kwargs: Additional parameters including:
                 - response_format: Pydantic BaseModel class for structured output
                 - parse_structured_output: Whether to parse structured output (default True)
@@ -547,6 +555,10 @@ class LiteLLMClient:
             kwargs["tool_choice"] = tool_choice
         if model_role is not None:
             kwargs["model_role"] = model_role
+        if max_retries is not None:
+            kwargs["max_retries"] = max_retries
+        if fallback_models is not None:
+            kwargs["fallback_models"] = fallback_models
 
         return self._make_request(final_messages, **kwargs)
 

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -301,19 +301,6 @@ class LiteLLMClient:
         "xai/": "xai",
     }
 
-    # Non-retryable error patterns
-    NON_RETRYABLE_ERRORS = [
-        "invalid_api_key",
-        "unauthorized",
-        "permission_denied",
-        "quota_exceeded",
-        "billing",
-        "invalid_request",
-        "authentication",
-        "forbidden",
-        "rate_limit",  # Rate limits are handled by LiteLLM internally
-    ]
-
     # Models that only support temperature=1.0 (custom values cause errors or degraded performance)
     TEMPERATURE_RESTRICTED_MODELS = {
         "gpt-5",
@@ -765,7 +752,7 @@ class LiteLLMClient:
 
     def _build_completion_params(
         self, messages: list[dict[str, Any]], **kwargs: Any
-    ) -> tuple[dict[str, Any], Any, bool, int]:
+    ) -> tuple[dict[str, Any], Any, bool, int, list[str]]:
         """Build completion request parameters from messages and kwargs.
 
         Args:
@@ -773,7 +760,9 @@ class LiteLLMClient:
             **kwargs: Additional parameters (response_format, max_retries, model, etc.)
 
         Returns:
-            Tuple of (params dict, response_format, parse_structured_output, max_retries)
+            Tuple of (params dict, response_format, parse_structured_output,
+            max_retries, fallback_models). ``fallback_models`` already has any
+            entry equal to the primary model removed.
         """
         response_format = kwargs.pop("response_format", None)
         strict_response_format = kwargs.pop("strict_response_format", True)
@@ -783,6 +772,14 @@ class LiteLLMClient:
             max_retries = max(1, int(max_retries_arg))
         except (TypeError, ValueError):
             max_retries = max(1, int(self.config.max_retries))
+
+        # Per-call fallback_models wins over config when explicitly provided.
+        # Use sentinel-style check so an explicit empty list disables fallback
+        # for the call even when the config has fallbacks set.
+        if "fallback_models" in kwargs:
+            fallback_models_raw = kwargs.pop("fallback_models") or []
+        else:
+            fallback_models_raw = list(self.config.fallback_models)
 
         # Pop tool-calling kwargs before the final params.update(kwargs) so they
         # don't leak into the params dict twice.
@@ -814,8 +811,11 @@ class LiteLLMClient:
             "model": actual_model,
             "messages": messages,
             "timeout": kwargs.pop("timeout", self.config.timeout),
-            "num_retries": 0,
         }
+
+        # Drop any fallback entry that points back at the primary — sending the
+        # same broken endpoint twice never helps.
+        fallback_models = [m for m in fallback_models_raw if m != actual_model]
 
         temperature = kwargs.pop("temperature", self.config.temperature)
         if self._is_temperature_restricted_model(actual_model):
@@ -891,7 +891,13 @@ class LiteLLMClient:
             params["messages"], params["model"]
         )
 
-        return params, response_format, parse_structured_output, max_retries
+        return (
+            params,
+            response_format,
+            parse_structured_output,
+            max_retries,
+            fallback_models,
+        )
 
     @staticmethod
     @lru_cache(maxsize=256)
@@ -982,163 +988,156 @@ class LiteLLMClient:
             cost_suffix,
         )
 
-    def _handle_retry_or_raise(
-        self,
-        error: Exception,
-        params: dict[str, Any],
-        attempt: int,
-        max_retries: int,
-        response_format: Any,
-        elapsed_seconds: float,
+    def _emit_fallback_observability(
+        self, response: Any, params: dict[str, Any]
     ) -> None:
-        """Handle retry logic or raise on non-retryable/final errors.
+        """Surface fallback-routing info to logs and Sentry when applicable.
+
+        LiteLLM rewrites ``response.model`` to the model that actually served
+        the call, so we detect a fallback by comparing it against the model
+        we asked for. The check is best-effort: any exception inside this
+        helper is swallowed so observability never breaks the request.
 
         Args:
-            error: The exception that occurred
-            params: Request parameters (for logging)
-            attempt: Current attempt index (0-based)
-            max_retries: Maximum number of retries
-            response_format: Response format (for logging)
-            elapsed_seconds: Time elapsed for this attempt
-
-        Raises:
-            LiteLLMClientError: If the error is non-retryable or this was the last attempt
+            response: The litellm completion response object.
+            params: The params dict that was passed to ``litellm.completion`` —
+                used to read the originally requested primary model name.
         """
-        error_str = str(error).lower()
-
-        self.logger.error(
-            "event=llm_request_end model=%s timeout=%s has_response_format=%s attempt=%d/%d elapsed_seconds=%.3f success=%s error_type=%s error=%s",
-            params.get("model"),
-            params.get("timeout"),
-            response_format is not None,
-            attempt + 1,
-            max_retries,
-            elapsed_seconds,
-            False,
-            type(error).__name__,
-            str(error),
-        )
-
-        if self._is_non_retryable_error(error_str):
-            self.logger.error("Non-retryable error: %s", error)
-            raise LiteLLMClientError(f"API call failed: {str(error)}") from error
-
-        if attempt < max_retries - 1:
-            delay = self.config.retry_delay * (2**attempt)
-            self.logger.warning(
-                "Request failed (attempt %s/%s): %s. Retrying in %ss...",
-                attempt + 1,
-                max_retries,
-                error,
-                delay,
+        try:
+            primary_model = params.get("model")
+            hidden = getattr(response, "_hidden_params", {}) or {}
+            served_model = (
+                hidden.get("model_id")
+                or hidden.get("model")
+                or getattr(response, "model", None)
             )
-            time.sleep(delay)
-        else:
-            self.logger.error(
-                "LLM request failed (model=%s, has_response_format=%s): %s",
-                params.get("model"),
-                response_format is not None,
-                error,
+
+            if not served_model or served_model == primary_model:
+                return
+
+            self.logger.info(
+                "event=llm_fallback_used primary_model=%s served_model=%s",
+                primary_model,
+                served_model,
             )
+
+            # Local import keeps sentry out of module-init paths the tests
+            # exercise without a Sentry SDK installed. sentry_sdk is an
+            # enterprise-only dependency; OSS callers run without it and the
+            # ImportError is intentionally absorbed by the outer except.
+            import sentry_sdk  # type: ignore[import-not-found]
+
+            sentry_sdk.set_tag("llm.fallback_used", "true")
+            sentry_sdk.set_tag("llm.primary_model", str(primary_model))
+            sentry_sdk.set_tag("llm.fallback_model", str(served_model))
+        except Exception:  # noqa: BLE001 — observability must not break the call
+            return
 
     def _make_request(
         self, messages: list[dict[str, Any]], **kwargs: Any
     ) -> str | BaseModel | ToolCallingChatResponse:
         """
-        Make a request to the LLM with retry logic.
+        Make a request to the LLM, delegating retries and fallback to litellm.
+
+        Retry and fallback semantics are handed to ``litellm.completion`` via
+        the native ``num_retries`` and ``fallbacks`` kwargs. Per the documented
+        flow at https://docs.litellm.ai/docs/router_architecture, the primary
+        model is tried ``num_retries+1`` times, then each fallback gets a single
+        attempt. The one piece we still own at the client level is a single
+        retry for ``StructuredOutputParseError``: LiteLLM cannot detect a
+        post-hoc Pydantic re-validation failure because it sees a successful
+        HTTP response.
 
         Args:
             messages: List of messages to send.
-            **kwargs: Additional parameters.
+            **kwargs: Additional parameters (response_format, max_retries,
+                fallback_models, tools, etc.).
 
         Returns:
             Response content as string, BaseModel instance, or
             ToolCallingChatResponse when the request was in tool-calling mode.
 
         Raises:
-            LiteLLMClientError: If the request fails after all retries.
+            LiteLLMClientError: If the request fails after all retries and
+                fallbacks have been exhausted by litellm.
         """
-        params, response_format, parse_structured_output, max_retries = (
+        params, response_format, parse_structured_output, max_retries, fallbacks = (
             self._build_completion_params(messages, **kwargs)
         )
 
-        last_error: Exception | None = None
-        # A StructuredOutputParseError is typically a transient malformed or
-        # truncated response that succeeds on a fresh generation, so grant it
-        # one extra attempt beyond the configured budget (once per request).
-        effective_max_retries = max_retries
-        structured_parse_retry_granted = False
-        attempt = 0
-        while attempt < effective_max_retries:
-            request_start = time.perf_counter()
+        # Hand retries + fallbacks to litellm. ``num_retries`` is the documented
+        # alias for max_retries on litellm.completion.
+        params["num_retries"] = max_retries
+        if fallbacks:
+            params["fallbacks"] = fallbacks
+
+        request_start = time.perf_counter()
+        self.logger.info(
+            "event=llm_request_start model=%s timeout=%s has_response_format=%s num_retries=%d fallbacks=%s",
+            params.get("model"),
+            params.get("timeout"),
+            response_format is not None,
+            max_retries,
+            fallbacks,
+        )
+
+        def _call_and_parse() -> str | BaseModel | ToolCallingChatResponse:
+            response = litellm.completion(**params)
+            self._emit_fallback_observability(response, params)
+            message = response.choices[0].message  # type: ignore[reportAttributeAccessIssue]
+            content = message.content
+            self._log_token_usage(params, response)
             self.logger.info(
-                "event=llm_request_start model=%s timeout=%s has_response_format=%s attempt=%d/%d",
+                "event=llm_request_end model=%s timeout=%s has_response_format=%s elapsed_seconds=%.3f success=%s",
                 params.get("model"),
                 params.get("timeout"),
                 response_format is not None,
-                attempt + 1,
-                effective_max_retries,
+                time.perf_counter() - request_start,
+                True,
             )
+
+            # Tool-calling path: return a structured response instead of
+            # going through _maybe_parse_structured_output.
+            if "tools" in params:
+                raw_usage = getattr(response, "usage", None)
+                call_cost = self._compute_cost_usd(response, params.get("model"))
+                return ToolCallingChatResponse(
+                    content=content,
+                    tool_calls=getattr(message, "tool_calls", None),
+                    finish_reason=response.choices[0].finish_reason,  # type: ignore[reportAttributeAccessIssue]
+                    usage=raw_usage,
+                    cost_usd=call_cost,
+                )
+
+            return self._maybe_parse_structured_output(
+                content,  # type: ignore[reportArgumentType]
+                response_format,
+                parse_structured_output,
+            )
+
+        try:
             try:
-                response = litellm.completion(**params)
-                message = response.choices[0].message  # type: ignore[reportAttributeAccessIssue]
-                content = message.content
-                elapsed_seconds = time.perf_counter() - request_start
-
-                self._log_token_usage(params, response)
-
-                self.logger.info(
-                    "event=llm_request_end model=%s timeout=%s has_response_format=%s attempt=%d/%d elapsed_seconds=%.3f success=%s",
+                return _call_and_parse()
+            except StructuredOutputParseError:
+                # LiteLLM's num_retries covers API errors, but a Pydantic
+                # re-validation failure happens AFTER litellm sees a
+                # successful 200 — so we owe one explicit second attempt at
+                # the model. PR #121 documented this as a MiniMax-M3
+                # mitigation.
+                self.logger.warning(
+                    "event=llm_parse_retry model=%s — primary returned malformed structured output, retrying once",
                     params.get("model"),
-                    params.get("timeout"),
-                    response_format is not None,
-                    attempt + 1,
-                    effective_max_retries,
-                    elapsed_seconds,
-                    True,
                 )
-
-                # Tool-calling path: return a structured response instead of
-                # going through _maybe_parse_structured_output.
-                if "tools" in params:
-                    raw_usage = getattr(response, "usage", None)
-                    call_cost = self._compute_cost_usd(response, params.get("model"))
-                    return ToolCallingChatResponse(
-                        content=content,
-                        tool_calls=getattr(message, "tool_calls", None),
-                        finish_reason=response.choices[0].finish_reason,  # type: ignore[reportAttributeAccessIssue]
-                        usage=raw_usage,
-                        cost_usd=call_cost,
-                    )
-
-                return self._maybe_parse_structured_output(
-                    content,  # type: ignore[reportArgumentType]
-                    response_format,
-                    parse_structured_output,  # type: ignore[reportArgumentType]
-                )
-
-            except Exception as e:
-                last_error = e
-                elapsed_seconds = time.perf_counter() - request_start
-                if (
-                    isinstance(e, StructuredOutputParseError)
-                    and not structured_parse_retry_granted
-                ):
-                    structured_parse_retry_granted = True
-                    effective_max_retries += 1
-                self._handle_retry_or_raise(
-                    e,
-                    params,
-                    attempt,
-                    effective_max_retries,
-                    response_format,
-                    elapsed_seconds,
-                )
-            attempt += 1
-
-        raise LiteLLMClientError(
-            f"API call failed after {effective_max_retries} retries: {str(last_error)}"
-        )
+                return _call_and_parse()
+        except Exception as e:
+            self.logger.error(
+                "event=llm_request_end model=%s elapsed_seconds=%.3f success=False error_type=%s error=%s",
+                params.get("model"),
+                time.perf_counter() - request_start,
+                type(e).__name__,
+                e,
+            )
+            raise LiteLLMClientError(f"API call failed: {e}") from e
 
     def _apply_prompt_caching(
         self, messages: list[dict[str, Any]], model: str
@@ -1536,18 +1535,6 @@ class LiteLLMClient:
 
         # Remove trailing commas before } or ]
         return re.sub(r",\s*([}\]])", r"\1", s)
-
-    def _is_non_retryable_error(self, error_str: str) -> bool:
-        """
-        Check if an error is non-retryable.
-
-        Args:
-            error_str: Error message string.
-
-        Returns:
-            True if error should not be retried.
-        """
-        return any(pattern in error_str for pattern in self.NON_RETRYABLE_ERRORS)
 
     def update_config(self, **kwargs) -> None:
         """

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -8,6 +8,7 @@ also supporting a horizontally-scaled internal service in cloud deployments.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import time
@@ -199,7 +200,15 @@ def get_service_embeddings(
             response.raise_for_status()
             body = response.json()
             return _ordered_embeddings_from_response(body.get("data"), len(texts))
-        except Exception as exc:  # noqa: BLE001 - normalized to typed degradation signal
+        except (httpx.HTTPError, json.JSONDecodeError, ValueError) as exc:
+            # Real transient + remote-data-shape classes only: httpx.HTTPError
+            # covers RequestError (network) + HTTPStatusError (4xx/5xx, raised
+            # by raise_for_status); JSONDecodeError covers response.json()
+            # parse failures; ValueError is the typed signal raised by
+            # _ordered_embeddings_from_response for malformed service payloads.
+            # Anything outside this set (AttributeError, TypeError, etc.) is a
+            # programming bug and propagates raw — retrying won't help and
+            # wrapping it as EmbeddingUnavailableError hides the real defect.
             last_error = exc
             if attempt == 0:
                 time.sleep(0.1)

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
@@ -159,3 +160,88 @@ def test_service_response_rejects_index_mismatch(monkeypatch) -> None:
 
     with pytest.raises(EmbeddingUnavailableError, match="duplicate index 1"):
         get_service_embeddings(["a", "b"], model="local/nomic-embed-v1.5")
+
+
+class TestEmbeddingServiceExceptionScope:
+    """Narrow exception scope: real transient errors retry, programming bugs propagate raw.
+
+    The retry loop in ``get_service_embeddings`` previously caught bare
+    ``Exception``, meaning a programming bug (``AttributeError``,
+    ``TypeError``) would be retried once and then wrapped as
+    ``EmbeddingUnavailableError`` — hiding the real defect. These tests pin
+    the narrowed scope: only ``httpx.HTTPError``, ``json.JSONDecodeError``,
+    and ``ValueError`` (the shape-error signal from
+    ``_ordered_embeddings_from_response``) are caught.
+    """
+
+    @staticmethod
+    def _route_to_local_service(monkeypatch) -> None:
+        """Configure env so ``get_service_embeddings`` reaches the retry loop.
+
+        ``REFLEXIO_EMBEDDING_PROVIDER=local_service`` is one of the
+        ``_SERVICE_MODES`` that passes the routing guards.
+        """
+        monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+
+    def test_programming_bug_propagates_raw_without_retry(self, monkeypatch) -> None:
+        """An ``AttributeError`` inside the call body must propagate raw on
+        the first attempt — not be caught, retried, and re-wrapped as
+        ``EmbeddingUnavailableError``.
+        """
+        self._route_to_local_service(monkeypatch)
+        call_count = {"n": 0}
+
+        class _BrokenClient:
+            def __init__(self, timeout: float) -> None:
+                self.timeout = timeout
+
+            def __enter__(self) -> _BrokenClient:
+                return self
+
+            def __exit__(self, *_args) -> None:
+                return None
+
+            def post(self, *_a, **_k):
+                call_count["n"] += 1
+                raise AttributeError("simulated programming bug")
+
+        monkeypatch.setattr(
+            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
+            _BrokenClient,
+        )
+
+        with pytest.raises(AttributeError, match="simulated programming bug"):
+            get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
+        assert call_count["n"] == 1, "programming bug must NOT be retried"
+
+    def test_httpx_request_error_still_retries(self, monkeypatch) -> None:
+        """Network errors continue to retry once then surface as
+        ``EmbeddingUnavailableError`` — existing transient-error behavior
+        is preserved by the narrowed clause.
+        """
+        self._route_to_local_service(monkeypatch)
+        call_count = {"n": 0}
+
+        class _FlakyClient:
+            def __init__(self, timeout: float) -> None:
+                self.timeout = timeout
+
+            def __enter__(self) -> _FlakyClient:
+                return self
+
+            def __exit__(self, *_args) -> None:
+                return None
+
+            def post(self, *_a, **_k):
+                call_count["n"] += 1
+                raise httpx.RequestError("connection refused")
+
+        monkeypatch.setattr(
+            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
+            _FlakyClient,
+        )
+
+        with pytest.raises(EmbeddingUnavailableError):
+            get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
+        assert call_count["n"] == 2, "transient HTTP error must retry once"

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -514,106 +514,6 @@ class TestGenerateChatResponse:
 
 
 # ===================================================================
-# _make_request / retry logic tests
-# ===================================================================
-
-
-class TestMakeRequestRetry:
-    """Tests for the retry wrapper around litellm.completion."""
-
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_success_on_first_try(self, mock_completion):
-        mock_completion.return_value = _make_completion_response("ok")
-        client = _build_client()
-
-        result = client._make_request([{"role": "user", "content": "hi"}])
-
-        assert result == "ok"
-        assert mock_completion.call_count == 1
-
-    @patch("reflexio.server.llm.litellm_client.time.sleep")
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_success_on_retry(self, mock_completion, mock_sleep):
-        mock_completion.side_effect = [
-            RuntimeError("temporary failure"),
-            _make_completion_response("ok"),
-        ]
-        config = LiteLLMConfig(model="gpt-4o", max_retries=2, retry_delay=0.01)
-        client = LiteLLMClient(config)
-
-        result = client._make_request([{"role": "user", "content": "hi"}])
-
-        assert result == "ok"
-        assert mock_completion.call_count == 2
-        mock_sleep.assert_called_once()
-
-    @patch("reflexio.server.llm.litellm_client.time.sleep")
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_all_retries_fail(self, mock_completion, mock_sleep):
-        mock_completion.side_effect = RuntimeError("boom")
-        config = LiteLLMConfig(model="gpt-4o", max_retries=2, retry_delay=0.01)
-        client = LiteLLMClient(config)
-
-        with pytest.raises(LiteLLMClientError, match="failed after 2 retries"):
-            client._make_request([{"role": "user", "content": "hi"}])
-
-        assert mock_completion.call_count == 2
-
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_non_retryable_error_stops_immediately(self, mock_completion):
-        mock_completion.side_effect = RuntimeError("invalid_api_key: bad key")
-        config = LiteLLMConfig(model="gpt-4o", max_retries=3)
-        client = LiteLLMClient(config)
-
-        with pytest.raises(LiteLLMClientError, match="invalid_api_key"):
-            client._make_request([{"role": "user", "content": "hi"}])
-
-        assert mock_completion.call_count == 1
-
-
-# ===================================================================
-# _is_non_retryable_error tests
-# ===================================================================
-
-
-class TestIsNonRetryableError:
-    """Verify classification of errors as retryable vs non-retryable."""
-
-    @pytest.fixture()
-    def client(self):
-        return _build_client()
-
-    @pytest.mark.parametrize(
-        "error_str",
-        [
-            "invalid_api_key provided",
-            "unauthorized access",
-            "permission_denied for resource",
-            "quota_exceeded for project",
-            "billing account inactive",
-            "invalid_request: bad payload",
-            "authentication failed",
-            "forbidden resource",
-            "rate_limit exceeded",
-        ],
-    )
-    def test_non_retryable_patterns(self, client, error_str):
-        assert client._is_non_retryable_error(error_str) is True
-
-    @pytest.mark.parametrize(
-        "error_str",
-        [
-            "connection timed out",
-            "internal server error",
-            "service unavailable",
-            "network error",
-        ],
-    )
-    def test_retryable_patterns(self, client, error_str):
-        assert client._is_non_retryable_error(error_str) is False
-
-
-# ===================================================================
 # get_embedding tests
 # ===================================================================
 
@@ -1105,7 +1005,7 @@ class TestStrictStructuredOutputRequest:
             "_supports_response_schema",
             return_value=True,
         ):
-            params, parser_schema, parse_structured, _ = (
+            params, parser_schema, parse_structured, _, _ = (
                 client._build_completion_params(
                     [{"role": "user", "content": "test"}],
                     response_format=SampleResponse,
@@ -1131,7 +1031,7 @@ class TestStrictStructuredOutputRequest:
             "_supports_response_schema",
             return_value=False,
         ):
-            params, parser_schema, _, _ = client._build_completion_params(
+            params, parser_schema, _, _, _ = client._build_completion_params(
                 [{"role": "user", "content": "test"}],
                 response_format=SampleResponse,
             )
@@ -1147,7 +1047,7 @@ class TestStrictStructuredOutputRequest:
             "_supports_response_schema",
             return_value=True,
         ):
-            params, _, _, _ = client._build_completion_params(
+            params, _, _, _, _ = client._build_completion_params(
                 [{"role": "user", "content": "test"}],
                 response_format=SampleResponse,
                 strict_response_format=False,
@@ -1205,10 +1105,14 @@ class TestStructuredOutputRetry:
         assert result.score == 42
 
     def test_structured_output_parse_failure_all_retries_exhausted_raises(self):
-        """Every attempt returns malformed content — raises LiteLLMClientError wrapping StructuredOutputParseError after exhaustion.
+        """Every attempt returns malformed content — raises LiteLLMClientError.
 
-        Parse failures get one extra attempt beyond the configured budget, so
-        max_retries=2 yields 3 total attempts.
+        Post-refactor, client-side parse-retry is decoupled from
+        ``max_retries`` (which now feeds litellm's ``num_retries`` for
+        transport-level errors). A malformed structured response is treated
+        as a 200 by litellm, so it falls through to our explicit one-shot
+        parse-retry. After that single retry also fails, we surface the
+        error. With max_retries=2 we still expect exactly 2 total calls.
         """
         call_count = 0
 
@@ -1230,7 +1134,7 @@ class TestStructuredOutputRetry:
                 response_format=SampleResponse,
             )
 
-        assert call_count == 3
+        assert call_count == 2
 
     def test_structured_output_parse_failure_extra_retry_at_default_budget(self):
         """With max_retries=1, a parse failure still gets one extra attempt and can recover."""
@@ -1445,7 +1349,7 @@ class TestTemperatureRestriction:
         monkeypatch.setattr(litellm, "drop_params", False)
         client = LiteLLMClient(LiteLLMConfig(model="gpt-4o"))
 
-        params, _, _, _ = client._build_completion_params(
+        params, _, _, _, _ = client._build_completion_params(
             [{"role": "user", "content": "hi"}]
         )
 
@@ -1586,7 +1490,7 @@ class TestBuildCompletionParams:
         config = LiteLLMConfig(model="gpt-4o", max_retries=2)
         client = LiteLLMClient(config)
 
-        params, _, _, max_retries = client._build_completion_params(
+        params, _, _, max_retries, _ = client._build_completion_params(
             [{"role": "user", "content": "hi"}],
             max_retries="invalid",
         )
@@ -1860,55 +1764,6 @@ class TestLogTokenUsage:
 
 
 # ===================================================================
-# _handle_retry_or_raise tests
-# ===================================================================
-
-
-class TestHandleRetryOrRaise:
-    """Tests for _handle_retry_or_raise."""
-
-    def test_non_retryable_error_raises_immediately(self):
-        client = _build_client()
-        with pytest.raises(LiteLLMClientError, match="API call failed"):
-            client._handle_retry_or_raise(
-                RuntimeError("invalid_api_key: bad key"),
-                {"model": "gpt-4o"},
-                attempt=0,
-                max_retries=3,
-                response_format=None,
-                elapsed_seconds=0.5,
-            )
-
-    @patch("reflexio.server.llm.litellm_client.time.sleep")
-    def test_retryable_error_sleeps(self, mock_sleep):
-        config = LiteLLMConfig(model="gpt-4o", retry_delay=1.0)
-        client = LiteLLMClient(config)
-        # Should not raise, just sleep
-        client._handle_retry_or_raise(
-            RuntimeError("connection timeout"),
-            {"model": "gpt-4o"},
-            attempt=0,
-            max_retries=3,
-            response_format=None,
-            elapsed_seconds=0.5,
-        )
-        mock_sleep.assert_called_once_with(1.0)  # 1.0 * 2^0
-
-    def test_last_attempt_does_not_raise(self):
-        """On last attempt, _handle_retry_or_raise just logs; _make_request raises later."""
-        client = _build_client()
-        # Should not raise for retryable error on last attempt
-        client._handle_retry_or_raise(
-            RuntimeError("connection timeout"),
-            {"model": "gpt-4o"},
-            attempt=2,
-            max_retries=3,
-            response_format=None,
-            elapsed_seconds=0.5,
-        )
-
-
-# ===================================================================
 # create_litellm_client convenience function tests
 # ===================================================================
 
@@ -1942,66 +1797,39 @@ class TestCreateLiteLLMClient:
 
 
 # ===================================================================
-# Additional retry/error handling edge cases
+# max_retries clamping edge cases (guard clause in _build_completion_params)
 # ===================================================================
 
 
-class TestRetryErrorEdgeCases:
-    """Additional edge cases for retry logic and error handling."""
+class TestMaxRetriesClamping:
+    """max_retries clamping in _build_completion_params.
 
-    @patch("reflexio.server.llm.litellm_client.time.sleep")
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_exponential_backoff_delay(self, mock_completion, mock_sleep):
-        """Verify exponential backoff: delay = retry_delay * 2^attempt."""
-        mock_completion.side_effect = [
-            RuntimeError("temp failure 1"),
-            RuntimeError("temp failure 2"),
-            _make_completion_response("ok"),
-        ]
-        config = LiteLLMConfig(model="gpt-4o", max_retries=3, retry_delay=1.0)
-        client = LiteLLMClient(config)
-
-        result = client._make_request([{"role": "user", "content": "hi"}])
-
-        assert result == "ok"
-        assert mock_sleep.call_count == 2
-        # First retry: 1.0 * 2^0 = 1.0
-        assert mock_sleep.call_args_list[0][0][0] == 1.0
-        # Second retry: 1.0 * 2^1 = 2.0
-        assert mock_sleep.call_args_list[1][0][0] == 2.0
-
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_non_retryable_stops_on_first_attempt(self, mock_completion):
-        """Non-retryable errors should not trigger retries."""
-        mock_completion.side_effect = RuntimeError("quota_exceeded for project")
-        config = LiteLLMConfig(model="gpt-4o", max_retries=5)
-        client = LiteLLMClient(config)
-
-        with pytest.raises(LiteLLMClientError, match="quota_exceeded"):
-            client._make_request([{"role": "user", "content": "hi"}])
-
-        # Should only try once
-        assert mock_completion.call_count == 1
+    Retry orchestration itself is delegated to litellm; we only sanity-check
+    that the value forwarded into ``num_retries`` is at least 1 even when the
+    config holds a degenerate value.
+    """
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
     def test_max_retries_zero_treated_as_one(self, mock_completion):
-        """max_retries=0 should be treated as at least 1 attempt."""
+        """max_retries=0 should be clamped to at least 1."""
         mock_completion.return_value = _make_completion_response("ok")
         config = LiteLLMConfig(model="gpt-4o", max_retries=0)
         client = LiteLLMClient(config)
 
         result = client._make_request([{"role": "user", "content": "hi"}])
         assert result == "ok"
+        assert mock_completion.call_args.kwargs["num_retries"] == 1
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
     def test_negative_max_retries_treated_as_one(self, mock_completion):
-        """Negative max_retries should be treated as at least 1."""
+        """Negative max_retries should be clamped to at least 1."""
         mock_completion.return_value = _make_completion_response("ok")
         config = LiteLLMConfig(model="gpt-4o", max_retries=-1)
         client = LiteLLMClient(config)
 
         result = client._make_request([{"role": "user", "content": "hi"}])
         assert result == "ok"
+        assert mock_completion.call_args.kwargs["num_retries"] == 1
 
 
 class TestTokenUsageLoggingEdgeCases:
@@ -2076,7 +1904,7 @@ class TestBuildCompletionParamsEdgeCases:
         config = LiteLLMConfig(model="gpt-4o", max_retries=2)
         client = LiteLLMClient(config)
 
-        _, _, _, max_retries = client._build_completion_params(
+        _, _, _, max_retries, _ = client._build_completion_params(
             [{"role": "user", "content": "hi"}],
             max_retries=5,
         )
@@ -2091,7 +1919,7 @@ class TestBuildCompletionParamsEdgeCases:
         config = LiteLLMConfig(model="gpt-4o", api_key_config=api_key_config)
         client = LiteLLMClient(config)
 
-        params, _, _, _ = client._build_completion_params(
+        params, _, _, _, _ = client._build_completion_params(
             [{"role": "user", "content": "hi"}],
             model="claude-3-5-sonnet",
         )
@@ -2167,3 +1995,171 @@ class TestPerCallOverrides:
         client.generate_chat_response([{"role": "user", "content": "hi"}])
         assert "max_retries" not in seen_kwargs
         assert "fallback_models" not in seen_kwargs
+
+
+# ===================================================================
+# litellm.completion integration: retries + fallback delegation
+# ===================================================================
+
+
+class TestLitellmIntegration:
+    """Assert _make_request hands the right knobs to litellm.completion."""
+
+    @staticmethod
+    def _messages() -> list[dict[str, Any]]:
+        return [{"role": "user", "content": "hi"}]
+
+    def test_passes_num_retries_from_config(self, monkeypatch):
+        client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(self._messages())
+        assert captured.get("num_retries") == 3
+
+    def test_passes_fallbacks_from_config(self, monkeypatch):
+        # Config-explicit fallback (opt-in at construction)
+        client = LiteLLMClient(
+            LiteLLMConfig(model="minimax/MiniMax-M3", fallback_models=["gpt-5-mini"])
+        )
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(self._messages())
+        assert captured.get("fallbacks") == ["gpt-5-mini"]
+
+    def test_no_fallbacks_when_env_var_unset(self, monkeypatch):
+        """Local reflexio / claude-smart safety check: with no env var and
+        no explicit construction arg, no fallback is passed."""
+        monkeypatch.delenv("REFLEXIO_LLM_FALLBACK_MODELS", raising=False)
+        client = LiteLLMClient(LiteLLMConfig(model="claude-code/claude-sonnet-4-6"))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(self._messages())
+        assert "fallbacks" not in captured
+
+    def test_env_var_enables_fallback_globally(self, monkeypatch):
+        """Production-style: set the env var and every LiteLLMClient picks it
+        up, no per-caller code changes."""
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini")
+        client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(self._messages())
+        assert captured.get("fallbacks") == ["gpt-5-mini"]
+
+    def test_per_call_override_wins_over_config(self, monkeypatch):
+        client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(
+            self._messages(), max_retries=7, fallback_models=["gpt-5-mini"]
+        )
+        assert captured.get("num_retries") == 7
+        assert captured.get("fallbacks") == ["gpt-5-mini"]
+
+    def test_fallback_self_reference_deduped(self, monkeypatch):
+        """If primary equals a fallback entry, that entry is dropped."""
+        client = LiteLLMClient(
+            LiteLLMConfig(
+                model="gpt-5-mini", fallback_models=["gpt-5-mini", "gpt-5-nano"]
+            )
+        )
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(self._messages())
+        assert captured.get("fallbacks") == ["gpt-5-nano"]
+
+    def test_empty_fallbacks_omits_kwarg(self, monkeypatch):
+        client = LiteLLMClient(LiteLLMConfig(model="x", fallback_models=[]))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        client.generate_chat_response(self._messages())
+        # Per LiteLLM docs, omitting `fallbacks` is the documented "no
+        # fallback" signal; passing [] is undefined behavior.
+        assert "fallbacks" not in captured
+
+    def test_parse_failure_triggers_one_explicit_retry(self, monkeypatch):
+        """Pre-refactor parse-retry preserved: when client-side Pydantic
+        re-validation raises StructuredOutputParseError, the call retries
+        ONCE. LiteLLM's num_retries can't catch this because litellm sees a
+        successful 200 — the parse failure is post-hoc."""
+
+        class Strict(BaseModel):
+            required_field: str
+
+        client = LiteLLMClient(LiteLLMConfig(model="x"))
+        attempts: list[str] = []
+        responses_in_order = [
+            _make_completion_response("{}"),  # malformed: missing required_field
+            _make_completion_response('{"required_field": "ok"}'),
+        ]
+
+        def _fake(**params):
+            attempts.append(params["model"])
+            return responses_in_order.pop(0)
+
+        monkeypatch.setattr("litellm.completion", _fake)
+
+        result = client.generate_chat_response(
+            self._messages(), response_format=Strict, parse_structured_output=True
+        )
+        assert isinstance(result, Strict)
+        assert len(attempts) == 2  # initial + one parse-retry
+
+    def test_parse_failure_only_retries_once(self, monkeypatch):
+        """If the parse-retry ALSO returns malformed output, the error
+        surfaces — no infinite parse-retry loop."""
+
+        class Strict(BaseModel):
+            required_field: str
+
+        client = LiteLLMClient(LiteLLMConfig(model="x"))
+        attempts: list[str] = []
+
+        def _always_malformed(**params):
+            attempts.append(params["model"])
+            return _make_completion_response("{}")
+
+        monkeypatch.setattr("litellm.completion", _always_malformed)
+
+        with pytest.raises(LiteLLMClientError):
+            client.generate_chat_response(
+                self._messages(),
+                response_format=Strict,
+                parse_structured_output=True,
+            )
+        assert len(attempts) == 2  # initial + one parse-retry, then give up

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -518,8 +518,34 @@ class TestGenerateChatResponse:
 # ===================================================================
 
 
+# Env vars that route embedding calls away from litellm.embedding.
+# When any of these is set in the shell, embedding_provider_mode() may resolve
+# to "local_service" or "internal_service", causing get_embedding /
+# get_embeddings to detour through get_service_embeddings (HTTP to
+# 127.0.0.1:8072 by default) before reaching the mocked litellm.embedding.
+# Tests below mock litellm.embedding and assert against that code path, so the
+# routing env vars must be cleared per-test. Production routing logic is
+# covered in tests/server/llm/test_embedding_service_provider.py.
+_EMBEDDING_ROUTING_ENV_VARS = (
+    "REFLEXIO_EMBEDDING_PROVIDER",
+    "REFLEXIO_EMBEDDING_SERVICE_URL",
+    "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
+)
+
+
+def _force_litellm_embedding_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear shell-leaked embedding-routing env vars so tests exercise the
+    litellm.embedding code path, not the local/internal service branches."""
+    for name in _EMBEDDING_ROUTING_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
 class TestGetEmbedding:
     """Tests for the single-text embedding endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
 
     @pytest.fixture(autouse=True)
     def _pin_default_model(self, monkeypatch):
@@ -594,6 +620,10 @@ class TestGetEmbeddings:
     """Tests for the batch embedding endpoint."""
 
     @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
+
+    @pytest.fixture(autouse=True)
     def _pin_default_model(self, monkeypatch):
         # See TestGetEmbedding._pin_default_model — these tests assert against
         # the litellm-backed default and must not be intercepted by the
@@ -656,6 +686,10 @@ class TestGetEmbeddings:
 
 class TestEmbeddingDefaultResolution:
     """Tests for the caching and routing behavior of the embedding default."""
+
+    @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
 
     def test_resolve_default_embedding_model_is_cached(self, monkeypatch):
         """``_resolve_default_embedding_model`` must hit resolve_model_name once.
@@ -722,6 +756,10 @@ class TestEmbeddingDefaultResolution:
 
 class TestEmbeddingTruncation:
     """Tests for the embedding-input truncation helpers."""
+
+    @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
 
     @pytest.fixture(autouse=True)
     def _reset_caches(self):

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -12,6 +12,7 @@ import struct
 import tempfile
 import zlib
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import litellm
@@ -2124,3 +2125,45 @@ class TestConfigDefaults:
 
     def test_fallback_models_supports_empty_list_to_disable(self):
         assert LiteLLMConfig(model="x", fallback_models=[]).fallback_models == []
+
+
+class TestPerCallOverrides:
+    def test_per_call_max_retries_forwards_to_make_request(self, monkeypatch):
+        client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
+        seen_kwargs: dict[str, Any] = {}
+        monkeypatch.setattr(
+            client,
+            "_make_request",
+            lambda _messages, **kw: seen_kwargs.update(kw) or "ok",
+        )
+        client.generate_chat_response(
+            [{"role": "user", "content": "hi"}], max_retries=7
+        )
+        assert seen_kwargs.get("max_retries") == 7
+
+    def test_per_call_fallback_models_forwards_to_make_request(self, monkeypatch):
+        client = LiteLLMClient(LiteLLMConfig(model="x"))
+        seen_kwargs: dict[str, Any] = {}
+        monkeypatch.setattr(
+            client,
+            "_make_request",
+            lambda _messages, **kw: seen_kwargs.update(kw) or "ok",
+        )
+        client.generate_chat_response(
+            [{"role": "user", "content": "hi"}], fallback_models=["claude-x"]
+        )
+        assert seen_kwargs.get("fallback_models") == ["claude-x"]
+
+    def test_per_call_overrides_optional_default_to_config(self, monkeypatch):
+        # When caller doesn't pass, neither flows through -- _make_request reads
+        # the config defaults.
+        client = LiteLLMClient(LiteLLMConfig(model="x"))
+        seen_kwargs: dict[str, Any] = {}
+        monkeypatch.setattr(
+            client,
+            "_make_request",
+            lambda _messages, **kw: seen_kwargs.update(kw) or "ok",
+        )
+        client.generate_chat_response([{"role": "user", "content": "hi"}])
+        assert "max_retries" not in seen_kwargs
+        assert "fallback_models" not in seen_kwargs

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2096,3 +2096,31 @@ class TestBuildCompletionParamsEdgeCases:
         )
         assert params["model"] == "claude-3-5-sonnet"
         assert params["api_key"] == "ant-key"
+
+
+class TestConfigDefaults:
+    def test_max_retries_default_is_three(self):
+        assert LiteLLMConfig(model="x").max_retries == 3
+
+    def test_fallback_models_default_is_empty_without_env_var(self, monkeypatch):
+        """Default is OFF so local reflexio + claude-smart never silently
+        route to an unintended provider."""
+        monkeypatch.delenv("REFLEXIO_LLM_FALLBACK_MODELS", raising=False)
+        assert LiteLLMConfig(model="x").fallback_models == []
+
+    def test_fallback_models_reads_env_var_when_set(self, monkeypatch):
+        """Production opt-in: REFLEXIO_LLM_FALLBACK_MODELS=gpt-5-mini in
+        the deploy env enables the fallback for every chat call site."""
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini")
+        assert LiteLLMConfig(model="x").fallback_models == ["gpt-5-mini"]
+
+    def test_fallback_models_env_var_is_comma_separated(self, monkeypatch):
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini, gpt-5-nano")
+        assert LiteLLMConfig(model="x").fallback_models == ["gpt-5-mini", "gpt-5-nano"]
+
+    def test_fallback_models_can_be_overridden_at_construction(self):
+        cfg = LiteLLMConfig(model="x", fallback_models=["gpt-5-mini", "gpt-5-nano"])
+        assert cfg.fallback_models == ["gpt-5-mini", "gpt-5-nano"]
+
+    def test_fallback_models_supports_empty_list_to_disable(self):
+        assert LiteLLMConfig(model="x", fallback_models=[]).fallback_models == []

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2163,3 +2163,69 @@ class TestLitellmIntegration:
                 parse_structured_output=True,
             )
         assert len(attempts) == 2  # initial + one parse-retry, then give up
+
+
+# ===================================================================
+# Fallback observability: Sentry tags + structured log line
+# ===================================================================
+
+
+class TestFallbackObservability:
+    """Verify Sentry tags fire when litellm served the request via a
+    fallback model, and stay silent when the primary served. The detection
+    mechanism reads ``response.model`` / ``response._hidden_params`` and
+    compares against the requested primary.
+
+    ``sentry_sdk`` is an enterprise-only dependency and is not installed
+    in the OSS test env. ``_emit_fallback_observability`` performs a local
+    ``import sentry_sdk`` inside its ``try`` block, so we inject a fake
+    module into ``sys.modules`` to capture the ``set_tag`` calls without
+    pulling in the real SDK.
+    """
+
+    @staticmethod
+    def _install_fake_sentry(monkeypatch) -> dict[str, str]:
+        """Register a fake ``sentry_sdk`` module that records ``set_tag``
+        calls into the returned dict."""
+        import sys  # noqa: PLC0415
+        import types  # noqa: PLC0415
+
+        tags: dict[str, str] = {}
+        fake = types.ModuleType("sentry_sdk")
+        fake.set_tag = lambda k, v: tags.__setitem__(k, str(v))  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "sentry_sdk", fake)
+        return tags
+
+    def test_sentry_tag_set_when_response_indicates_fallback(self, monkeypatch):
+        tags = self._install_fake_sentry(monkeypatch)
+        client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
+
+        # Forge a litellm response where the served model differs from the
+        # requested primary — i.e. a fallback served the request.
+        response = _make_completion_response("ok")
+        response._hidden_params = {"model_id": "gpt-5-mini"}
+        response.model = "gpt-5-mini"
+
+        monkeypatch.setattr("litellm.completion", lambda **_p: response)
+
+        client.generate_chat_response([{"role": "user", "content": "hi"}])
+
+        assert tags.get("llm.fallback_used") == "true"
+        assert tags.get("llm.primary_model") == "minimax/MiniMax-M3"
+        assert tags.get("llm.fallback_model") == "gpt-5-mini"
+
+    def test_sentry_tag_not_set_when_primary_served(self, monkeypatch):
+        tags = self._install_fake_sentry(monkeypatch)
+        client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
+
+        # Forge a response where the served model matches the primary —
+        # no fallback occurred.
+        response = _make_completion_response("ok")
+        response._hidden_params = {"model_id": "minimax/MiniMax-M3"}
+        response.model = "minimax/MiniMax-M3"
+
+        monkeypatch.setattr("litellm.completion", lambda **_p: response)
+
+        client.generate_chat_response([{"role": "user", "content": "hi"}])
+
+        assert "llm.fallback_used" not in tags

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2229,3 +2229,94 @@ class TestFallbackObservability:
         client.generate_chat_response([{"role": "user", "content": "hi"}])
 
         assert "llm.fallback_used" not in tags
+
+
+class TestEmbeddingRetries:
+    """Embedding calls get num_retries parity with chat. Cross-model
+    fallback is intentionally NOT added — embedding vector spaces are
+    model-specific; switching mid-call would silently corrupt the index."""
+
+    @staticmethod
+    def _force_litellm_route(monkeypatch):
+        """Neutralize the embedding-service router so the call reaches
+        litellm.embedding. The CI/local env may have
+        CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 or REFLEXIO_EMBEDDING_SERVICE_URL
+        set, both of which divert to the HTTP service path.
+        """
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+        monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+
+    def test_get_embedding_passes_num_retries(self, monkeypatch):
+        from types import SimpleNamespace
+
+        self._force_litellm_route(monkeypatch)
+        client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return SimpleNamespace(data=[{"embedding": [0.1] * 1536, "index": 0}])
+
+        monkeypatch.setattr("litellm.embedding", _fake)
+        monkeypatch.setattr(
+            client,
+            "_resolve_default_embedding_model",
+            lambda: "text-embedding-3-small",
+        )
+        client.get_embedding("hello")
+        assert captured.get("num_retries") == 3
+
+    def test_get_embeddings_batch_passes_num_retries(self, monkeypatch):
+        from types import SimpleNamespace
+
+        self._force_litellm_route(monkeypatch)
+        client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return SimpleNamespace(
+                data=[
+                    {"embedding": [0.1] * 1536, "index": 0},
+                    {"embedding": [0.2] * 1536, "index": 1},
+                ]
+            )
+
+        monkeypatch.setattr("litellm.embedding", _fake)
+        monkeypatch.setattr(
+            client,
+            "_resolve_default_embedding_model",
+            lambda: "text-embedding-3-small",
+        )
+        client.get_embeddings(["a", "b"])
+        assert captured.get("num_retries") == 3
+
+    def test_embedding_never_receives_fallbacks_kwarg(self, monkeypatch):
+        """Even with fallback_models set on the config, embedding calls
+        MUST NOT receive a fallbacks kwarg — vector spaces are model-
+        specific and silent cross-model fallback would corrupt the index."""
+        from types import SimpleNamespace
+
+        self._force_litellm_route(monkeypatch)
+        client = LiteLLMClient(
+            LiteLLMConfig(
+                model="x",
+                max_retries=3,
+                fallback_models=["gpt-5-mini"],
+            )
+        )
+        captured: dict[str, Any] = {}
+
+        def _fake(**params):
+            captured.update(params)
+            return SimpleNamespace(data=[{"embedding": [0.1] * 1536, "index": 0}])
+
+        monkeypatch.setattr("litellm.embedding", _fake)
+        monkeypatch.setattr(
+            client,
+            "_resolve_default_embedding_model",
+            lambda: "text-embedding-3-small",
+        )
+        client.get_embedding("hi")
+        assert "fallbacks" not in captured

--- a/tests/server/services/playbook/test_playbook_consolidator_integration.py
+++ b/tests/server/services/playbook/test_playbook_consolidator_integration.py
@@ -23,13 +23,14 @@ from __future__ import annotations
 
 import os
 import tempfile
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from reflexio.models.api_schema.service_schemas import UserPlaybook
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.playbook.playbook_consolidator import (
     DifferentiateDecision,
     IndependentDecision,
@@ -873,3 +874,167 @@ class TestContradictionResolutionContract:
         # The assertion above pins the contract: if the apply layer ever grows
         # a runtime guard, this test will fail and should be updated to assert
         # that the violation is rejected at apply time instead.
+
+
+# ===============================
+# End-to-end: native litellm retry + fallback flows through the consolidator
+# ===============================
+
+
+def _make_completion_response(content: str) -> MagicMock:
+    """Build a minimal mock ``litellm.completion`` response.
+
+    Mirrors the shape consumed by :class:`LiteLLMClient._make_request`: a
+    single choice with ``message.content`` plus a token-usage object whose
+    cache-detail fields are present but empty so the logging path does not
+    raise. Matches the helper in ``tests/server/llm/test_litellm_client_unit.py``
+    so the behaviour observed here is identical to that suite.
+
+    Args:
+        content (str): Raw text body the consolidator will parse as JSON into
+            ``PlaybookConsolidationOutput``.
+
+    Returns:
+        MagicMock: Object compatible with ``response.choices[0].message.content``.
+    """
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = "stop"
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    resp.usage.prompt_tokens_details = None
+    resp.usage.cache_creation_input_tokens = None
+    resp.usage.cache_read_input_tokens = None
+    # ``_emit_fallback_observability`` reads ``_hidden_params`` and falls back
+    # to ``response.model``; leave both unset so it short-circuits without
+    # tripping the Sentry path.
+    resp._hidden_params = {}
+    resp.model = None
+    return resp
+
+
+def _build_real_client_consolidator(
+    request_context: RequestContext,
+    *,
+    config: LiteLLMConfig,
+) -> PlaybookConsolidator:
+    """Build a ``PlaybookConsolidator`` wired to a real ``LiteLLMClient``.
+
+    The shared ``consolidator`` fixture in this file wires the consolidator to
+    a ``MagicMock(spec=LiteLLMClient)`` — useful for testing the apply path
+    but it never reaches ``litellm.completion``, so the native fallback
+    delegation cannot be observed through it. These end-to-end tests need a
+    real ``LiteLLMClient`` instance so the request actually flows into
+    ``_make_request`` -> ``litellm.completion``.
+
+    Args:
+        request_context (RequestContext): Real ``RequestContext`` (storage +
+            mocked prompt manager + real configurator).
+        config (LiteLLMConfig): Fully-formed config — built fresh per-test so
+            the ``fallback_models`` default factory reads the test's env state
+            at construction time.
+
+    Returns:
+        PlaybookConsolidator: Consolidator whose ``client`` is a real
+            ``LiteLLMClient``; ``model_name`` is fixed to ``"gpt-test"`` via
+            the same ``SiteVarManager`` patch used by the file's shared
+            fixture so the apply path is comparable.
+    """
+    client = LiteLLMClient(config)
+    with patch(
+        "reflexio.server.services.deduplication_utils.SiteVarManager"
+    ) as mock_svm:
+        mock_svm.return_value.get_site_var.return_value = {
+            "default_generation_model_name": "gpt-test"
+        }
+        return PlaybookConsolidator(request_context=request_context, llm_client=client)
+
+
+class TestConsolidatorNativeFallbackEndToEnd:
+    """End-to-end: ``_consolidation_decisions`` forwards retry + fallback into ``litellm.completion``.
+
+    The consolidator was the original production incident site (structured
+    output parse path on top of native retry + fallback), so this is the
+    highest-fidelity exercise of the Task 1-4 plumbing. Pinning both the
+    "env var on => fallback configured" and "env var unset => no fallback"
+    branches at this level prevents regressions where the plumbing works in
+    isolation but breaks once a structured-output wrapper sits on top.
+    """
+
+    def test_consolidator_calls_litellm_with_fallback_configured(
+        self, request_context, monkeypatch
+    ):
+        """Production-style: ``REFLEXIO_LLM_FALLBACK_MODELS`` set globally.
+
+        Asserts the consolidator's call into ``litellm.completion`` carries
+        ``num_retries=3`` (the default ``LiteLLMConfig.max_retries``) and
+        ``fallbacks=["gpt-5-mini"]`` end-to-end — proving Task 1-3's native
+        delegation survives the structured-output parse wrapper.
+        """
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini")
+        # LiteLLMConfig.fallback_models is a default_factory that reads
+        # os.environ at construction — build the config AFTER setenv so the
+        # new value flows in. The shared ``consolidator`` fixture builds its
+        # mock client lazily but caches it for the test's lifetime; this
+        # parallel builder sidesteps that cache entirely.
+        consolidator = _build_real_client_consolidator(
+            request_context,
+            config=LiteLLMConfig(model="minimax/MiniMax-M3"),
+        )
+
+        captured: dict[str, Any] = {}
+
+        def _fake(**params: Any) -> MagicMock:
+            captured.update(params)
+            return _make_completion_response('{"decisions": []}')
+
+        monkeypatch.setattr("litellm.completion", _fake)
+
+        result = consolidator._consolidation_decisions(
+            new_playbooks=[], existing_playbooks=[]
+        )
+
+        # End-to-end shape: parsed cleanly into the structured-output model.
+        assert isinstance(result, PlaybookConsolidationOutput)
+        assert result.decisions == []
+
+        # Linchpin: native delegation forwarded both knobs to litellm.
+        assert captured.get("num_retries") == 3
+        assert captured.get("fallbacks") == ["gpt-5-mini"]
+
+    def test_consolidator_uses_no_fallback_when_env_unset(
+        self, request_context, monkeypatch
+    ):
+        """Local / OSS safety contract: no env var => no fallback configured.
+
+        With ``REFLEXIO_LLM_FALLBACK_MODELS`` unset and no explicit
+        construction-arg, ``litellm.completion`` MUST NOT receive a
+        ``fallbacks`` kwarg. This preserves the "never silently route to an
+        unintended provider" guarantee for local reflexio and the
+        claude-smart integration documented in ``LiteLLMConfig``.
+        """
+        monkeypatch.delenv("REFLEXIO_LLM_FALLBACK_MODELS", raising=False)
+        consolidator = _build_real_client_consolidator(
+            request_context,
+            config=LiteLLMConfig(model="claude-code/claude-sonnet-4-6"),
+        )
+
+        captured: dict[str, Any] = {}
+
+        def _fake(**params: Any) -> MagicMock:
+            captured.update(params)
+            return _make_completion_response('{"decisions": []}')
+
+        monkeypatch.setattr("litellm.completion", _fake)
+
+        result = consolidator._consolidation_decisions(
+            new_playbooks=[], existing_playbooks=[]
+        )
+
+        assert isinstance(result, PlaybookConsolidationOutput)
+        assert result.decisions == []
+        # ``num_retries`` still flows (default 3); only ``fallbacks`` must be
+        # absent so litellm has no fallback chain to traverse.
+        assert captured.get("num_retries") == 3
+        assert "fallbacks" not in captured


### PR DESCRIPTION
## Summary

Production reliability fix for MiniMax-M3 connection timeouts killing playbook consolidation batches. Applies to all 11 chat-completion call sites in the OSS submodule, not just the consolidator.

**Architecture: simplification, not addition.** Delegates retry + fallback semantics to LiteLLM's documented \`num_retries=\` + \`fallbacks=\` (per https://docs.litellm.ai/docs/router_architecture). This is the industry-standard pattern: LangChain \`with_fallbacks\`, Vercel AI Gateway, Portkey, Helicone, Cloudflare AI Gateway, and Maxim's Bifrost all implement it.

## Changes

1. \`LiteLLMConfig.max_retries\` default 1 → 3.
2. New \`LiteLLMConfig.fallback_models: list[str]\` — **default empty**; production opts in via \`REFLEXIO_LLM_FALLBACK_MODELS=gpt-5-mini\` env var. Empty default protects local reflexio, OSS users without OpenAI keys, and the claude-smart integration from silent cross-provider fallback (privacy, cost, and architectural correctness).
3. \`_make_request\` simplified: deletes the outer retry while-loop, deletes \`_handle_retry_or_raise\`, deletes \`_is_non_retryable_error\`, deletes \`NON_RETRYABLE_ERRORS\`. Single call to \`litellm.completion(num_retries=N, fallbacks=[...])\`.
4. Per-call overrides on \`generate_chat_response\`: \`max_retries=\`, \`fallback_models=\` (mirrors the existing \`timeout=\` pattern; preserves the two existing call sites that already tune — reflection_extractor and playbook_optimizer judge).
5. Self-reference dedup: if primary == fallback entry, drop it (no useless self-retry).
6. Structured-output parse-retry preserved as an explicit single retry (LiteLLM's \`num_retries\` covers API errors but not client-side Pydantic re-validation).
7. Observability: \`_emit_fallback_observability\` detects fallback by comparing \`response.model\` to the requested primary; emits Sentry tags (\`llm.fallback_used\`, \`llm.primary_model\`, \`llm.fallback_model\`) and structured log on rescue.
8. **Embedding parity**: both \`litellm.embedding(...)\` calls now pass \`num_retries=self.config.max_retries\`. No \`fallbacks=\` — cross-model embedding fallback would silently corrupt the vector space, which is a deliberate architectural choice.
9. **Embedding-service retry scope narrowed**: \`embedding_service_provider.py:202\` changes \`except Exception\` to \`except (httpx.HTTPError, json.JSONDecodeError, ValueError)\`. Preserves retry on all real transient errors; prevents retry-on-programming-bug.

## Tracked upstream LiteLLM issues

We adopt LiteLLM as-is and track these upstream rather than working around them in product code:
- [#7303](https://github.com/BerriAI/litellm/issues/7303) — \`request_timeout\` enforcement gap (closed \"not planned\"). Mitigation: monitor Sentry \`llm.fallback_used\` rate; if hung-connection failures don't trigger fallback, file an enterprise-side ticket.
- [#19985](https://github.com/BerriAI/litellm/issues/19985), [#18968](https://github.com/BerriAI/litellm/issues/18968) — track upstream.

## What this does NOT fix

- \"MiniMax drops required JSON fields\" parse-error class (PR #121 disclaimed it; mitigated partially via the preserved parse-retry).
- Behavioral drift: rare batches will be decided by gpt-5-mini instead of MiniMax once production opts in. Sentry tagging makes every such batch auditable.

## Tests

- \`TestConfigDefaults\` — defaults wired correctly, env-var reading, comma-separation, explicit overrides.
- \`TestPerCallOverrides\` — per-call kwargs forward to \`_make_request\`.
- \`TestLitellmIntegration\` — \`num_retries\` and \`fallbacks\` flow into \`litellm.completion\`; self-references deduped; empty list omits the kwarg; structured-output parse-retry preserved as one explicit retry.
- \`TestFallbackObservability\` — Sentry tags fire when a fallback served the response, stay quiet when primary served.
- \`TestEmbeddingRetries\` — embedding calls get \`num_retries\` parity; never receive \`fallbacks\` (vector-space safety).
- \`TestEmbeddingServiceExceptionScope\` — programming bugs propagate raw; transient errors still retry.
- \`TestConsolidatorNativeFallbackEndToEnd\` — end-to-end through the consolidator path with structured-output parsing on top.

Deletes \`TestMakeRequestRetry\`, \`TestIsNonRetryableError\`, \`TestHandleRetryOrRaise\` (subjects no longer exist).

## Deployment action required (enterprise side)

After merging this PR and bumping the enterprise submodule pointer, add \`REFLEXIO_LLM_FALLBACK_MODELS=gpt-5-mini\` to the ECS task definition / AWS Secrets Manager env vars. Without this, the deployed code falls back to the empty default — no fallback fires, and the MiniMax timeout incident reproduces. Default-empty is the safe choice for OSS / local / claude-smart, but production needs the explicit opt-in.

Note: the enterprise test file \`reflexio_ext/tests/server/llm/test_litellm_client_unit.py\` references symbols deleted here (\`_handle_retry_or_raise\`, \`_is_non_retryable_error\`, the 4-tuple \`_build_completion_params\`). The enterprise PR that bumps the submodule pointer must update those tests to use the new public surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback model support for LLM requests with environment-based configuration
  * Enhanced retry mechanism for embedding service calls with explicit retry count forwarding

* **Bug Fixes**
  * Improved exception handling in embedding service to distinguish transient errors from programming failures

* **Tests**
  * Added comprehensive test coverage for retry clamping, configuration defaults, fallback behavior, and observability tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->