### PR TITLE
chore: scrub private/personal references from the public repo

### DIFF
--- a/.claude/rules/pythonic-code.md
+++ b/.claude/rules/pythonic-code.md
@@ -98,7 +98,7 @@ paths:
 ### Derive Paths with Semantic Names
 ```python
 _THIS_DIR = Path(__file__).resolve().parent
-_PROJECT_ROOT = _THIS_DIR.parent.parent  # reflexio_ext/scripts/ -> repo root
+_PROJECT_ROOT = _THIS_DIR.parent.parent  # src/scripts/ -> repo root
 DATA_DIR = _PROJECT_ROOT / "data"
 CONFIG_PATH = _PROJECT_ROOT / "configs" / "default.yaml"
 ```

--- a/benchmark/gdpval/EXPERIMENT_PLAN.md
+++ b/benchmark/gdpval/EXPERIMENT_PLAN.md
@@ -41,7 +41,7 @@ Still to do:
 
 ## Phase B — Task selection (one-time, ~10 min)
 
-Load the GDPVal 50-task subset (`/Users/yilu/repos/OpenSpace/gdpval_bench/tasks_50.json`).
+Load the GDPVal 50-task subset (`$OPENSPACE_PATH/gdpval_bench/tasks_50.json`).
 Pick 10 tasks that satisfy ALL of:
 
 1. No hard format requirement in the prompt (no `\b(pdf|docx|xlsx|pptx|powerpoint|excel|word document)\b`, case-insensitive)
@@ -59,7 +59,7 @@ Save the selected task IDs + short names to
 Single invocation, fresh `--run-name`, all hosts and phases:
 
 ```bash
-cd /Users/yilu/repos/reflexio-gdpval-bench/open_source/reflexio
+cd /path/to/reflexio   # repo root
 BACKEND_PORT=8091 uv run python -m benchmark.gdpval.run_benchmark \
   --hosts openspace,hermes --phases p1,p2,p3 \
   --task-ids "<10 task IDs from Phase B>" \

--- a/benchmark/gdpval/RESULTS.md
+++ b/benchmark/gdpval/RESULTS.md
@@ -411,10 +411,10 @@ directory. The benchmark package lives at
 module.
 
 ```bash
-cd /Users/yilu/repos/reflexio-gdpval-bench/open_source/reflexio
+cd /path/to/reflexio   # repo root
 
 # 1. Start a Reflexio backend on port 8091
-nohup uv run python -m reflexio_ext.cli services start --only backend \
+nohup uv run python -m reflexio.cli services start --only backend \
   --backend-port 8091 > /tmp/reflexio-bench-logs/backend.log 2>&1 &
 
 # 2. Pin Reflexio's internal LLM pipeline to openai/gpt-5-mini.

--- a/benchmark/gdpval/memory/prompt_variants.py
+++ b/benchmark/gdpval/memory/prompt_variants.py
@@ -2,8 +2,7 @@
 
 This module holds alternate `GDPVAL_PLAYBOOK_EXTRACTOR_PROMPT` + injection
 header pairs that can be swapped into `reflexio_bridge.py` /
-`injection.py` during the iteration loop (see
-`/Users/yilu/.claude/plans/ethereal-wiggling-pike.md`).
+`injection.py` during the iteration loop.
 
 Each variant is a stand-alone string. When iterating, copy the chosen
 variant into the actual call sites — don't import from here in production

--- a/benchmark/gdpval/run_benchmark.py
+++ b/benchmark/gdpval/run_benchmark.py
@@ -28,15 +28,14 @@ from pathlib import Path
 from typing import Any
 
 _THIS_DIR = Path(__file__).resolve().parent  # open_source/reflexio/benchmark/gdpval/
-# The benchmark package lives inside the reflexio submodule at
-# open_source/reflexio/benchmark/gdpval/. Adding the submodule root
-# to sys.path makes `import benchmark.gdpval.x` work whether the user runs
-# `python -m benchmark.gdpval.run_benchmark` from the submodule root or from
-# the outer reflexio-gdpval-bench repo root.
-_SUBMODULE_ROOT = _THIS_DIR.parents[1]  # open_source/reflexio/
+# The benchmark package lives at benchmark/gdpval/ in the repo. Adding the
+# repo root to sys.path makes `import benchmark.gdpval.x` work whether the user
+# runs `python -m benchmark.gdpval.run_benchmark` from the repo root or
+# elsewhere.
+_REPO_ROOT = _THIS_DIR.parents[1]  # repo root (contains benchmark/)
 
-if str(_SUBMODULE_ROOT) not in sys.path:
-    sys.path.insert(0, str(_SUBMODULE_ROOT))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from dotenv import load_dotenv  # noqa: E402
 

--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -1,7 +1,6 @@
 """CLI bootstrap config: resolve and persist storage settings without a running server.
 
 Provides the priority chain: CLI flag > env var (.env) > config file > default.
-See docs_for_coding_agent/cli-config-state-management.md for the full design.
 """
 
 from __future__ import annotations

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -885,9 +885,8 @@ def openai_codex_setup(
     reads from this file directly — no dependency on OpenClaw or any other
     CLI. The proxy auto-refreshes the access token when it nears expiry.
 
-    Run this once, then start the codex proxy with::
-
-        ./reflexio_ext/scripts/start_with_codex_proxy.sh
+    Run this once; the codex proxy (``codex_proxy.py``) then picks up the
+    stored tokens automatically on start.
 
     Re-run this command if your subscription tier changes or the
     refresh_token gets revoked (rare).

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -107,8 +107,8 @@ def load_reflexio_env(
 
     Args:
         package_data_module: Module containing bundled .env.example
-            (for importlib.resources). OS package uses "reflexio.data",
-            enterprise uses "reflexio_ext.data".
+            (for importlib.resources). The OS package passes "reflexio.data";
+            a downstream build may pass its own data module.
         auto_generate_keys: Env var names to auto-generate as hex tokens
             (e.g., ["JWT_SECRET_KEY"]).
 
@@ -150,8 +150,8 @@ def ensure_user_env_for_setup(
 
     Args:
         package_data_module: Module containing the bundled ``.env.example``
-            template (for ``importlib.resources``). OS uses ``reflexio.data``,
-            enterprise uses ``reflexio_ext.data``.
+            template (for ``importlib.resources``). The OS package passes
+            ``reflexio.data``; a downstream build may pass its own data module.
         auto_generate_keys: Env var names to auto-fill with random hex
             tokens when creating from the template.
 

--- a/reflexio/lib/_storage_labels.py
+++ b/reflexio/lib/_storage_labels.py
@@ -24,8 +24,8 @@ def describe_storage(
     to print anywhere.
 
     Enterprise-only storage types (Supabase, Postgres, local directory)
-    are matched by class name so we don't take a hard import dependency
-    on ``reflexio_ext`` from the open-source package.
+    are matched by class name so the open-source package takes no hard
+    import dependency on its enterprise extension.
 
     Args:
         storage_config: The storage configuration to describe.

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -77,7 +77,7 @@ Description: FastAPI backend server that processes user interactions to generate
 - **Operations/admin**: `GET /api/get_operation_status`, `POST /api/cancel_operation`, `POST /api/admin/cache/invalidate`, `DELETE /api/delete_interaction`, `DELETE /api/delete_request`, `DELETE /api/delete_session`, `DELETE /api/delete_requests_by_ids`, `DELETE /api/delete_all_interactions`, `POST /api/clear_user_data`
 - **Human clarification/stall state**: `GET /api/pending_tool_calls`, `GET /api/pending_tool_calls/{pending_tool_call_id}`, `POST /api/pending_tool_calls/{pending_tool_call_id}/resolve`, `PATCH /api/pending_tool_calls/{pending_tool_call_id}/answer`, `POST /api/pending_tool_calls/{pending_tool_call_id}/not_applicable`, `POST /api/pending_tool_calls/{pending_tool_call_id}/cancel`, `GET /api/stall_state`, `POST /api/stall_state/notified`
 
-**Authentication Pattern**: The open-source app uses `default_get_org_id` and `DEFAULT_ORG_ID` for local/no-auth starts. Enterprise wraps `create_app()` in `reflexio_ext/server/api.py` with authenticated org resolution, login/OAuth/account/share/waitlist routers, admin checks, Sentry tracing, and usage metrics.
+**Authentication Pattern**: The open-source app uses `default_get_org_id` and `DEFAULT_ORG_ID` for local/no-auth starts. The enterprise extension wraps `create_app()` with authenticated org resolution, login/OAuth/account/share/waitlist routers, admin checks, Sentry tracing, and usage metrics.
 
 **Pattern**: Core route handlers call `Reflexio` through `get_reflexio(org_id)`; endpoint helper files should not instantiate `Reflexio` directly.
 

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -492,7 +492,7 @@ class BaseGenerationService(
         reproduce the original publish (user_id, request_id, agent_version,
         source, force_extraction, etc.). Without this, the rerun runs with the
         wrong holder's request and the queued user's interactions are silently
-        skipped (R2 / reflexio-enterprise#59).
+        skipped (R2).
 
         Returns ``None`` to opt out — the queue then stores only the
         request_id and the rerun falls back to the original holder's request,
@@ -580,7 +580,7 @@ class BaseGenerationService(
 
         # Try to acquire lock — pass the serialized payload so blocked
         # publishes land in the queue with their own data attached. This is
-        # the fix for R2 / reflexio-enterprise#59: without the payload, the
+        # the fix for R2: without the payload, the
         # rerun re-uses the holder's request and the queued users' batches
         # never get extracted.
         my_payload = self._serialize_request_for_queue(request)

--- a/reflexio/server/services/operation_state_utils.py
+++ b/reflexio/server/services/operation_state_utils.py
@@ -403,7 +403,7 @@ class OperationStateManager:
                 request when the lock is held by someone else. Required for the
                 rerun loop to operate on the SAME interactions the original
                 publish enqueued, not whatever the bookmark currently points at
-                (R2 / reflexio-enterprise#59).
+                (R2).
 
         Returns:
             bool: True if lock acquired (proceed with generation), False if skipped
@@ -545,7 +545,7 @@ class OperationStateManager:
         FIFO drain — preserves order so blocked publishes are processed in the
         order they arrived. Replaces the older single-slot ``pending_request_id``
         last-wins behaviour that silently dropped earlier blocked publishes
-        (R2 / reflexio-enterprise#59).
+        (R2).
 
         On a legacy state row (written by a pre-fix server before redeploy)
         the queue is missing but ``pending_request_id`` may be set; we surface

--- a/reflexio/server/services/storage/storage_base/_operations.py
+++ b/reflexio/server/services/storage/storage_base/_operations.py
@@ -160,7 +160,7 @@ class OperationMixin:
             payload (dict | None): Optional serialized request payload preserved
                 for the rerun loop. Required so the rerun runs against the SAME
                 interactions the blocked publish enqueued, not whatever the
-                bookmark currently points at (R2 / reflexio-enterprise#59).
+                bookmark currently points at (R2).
 
         Returns:
             dict: Result with keys:

--- a/tests/e2e_tests/test_concurrent_playbook_extraction.py
+++ b/tests/e2e_tests/test_concurrent_playbook_extraction.py
@@ -1,4 +1,4 @@
-"""Concurrent playbook extraction (reflexio-enterprise#59 / R2 — fixed).
+"""Concurrent playbook extraction (R2 — fixed).
 
 Three publishes for distinct user_ids land within ~2s of each other on the
 shared per-org ``playbook_generation`` lock. Pre-fix:

--- a/tests/server/services/storage/test_storage_contract_operations.py
+++ b/tests/server/services/storage/test_storage_contract_operations.py
@@ -75,7 +75,7 @@ class TestOperationStateCRUD:
 
 
 # ---------------------------------------------------------------------------
-# TestPendingRequestQueue — R2 / reflexio-enterprise#59
+# TestPendingRequestQueue — R2
 # ---------------------------------------------------------------------------
 
 

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -1398,7 +1398,7 @@ class TestInProgressLockMechanism:
 
 class TestPayloadAwareDrain:
     """Drain loop must rerun against the QUEUED request's payload, not the
-    original holder's. This is the R2 fix (reflexio-enterprise#59).
+    original holder's. This is the R2 fix.
     """
 
     def test_drain_uses_queued_payload_not_original(self, llm_client, request_context):

--- a/tests/server/services/test_operation_state_utils.py
+++ b/tests/server/services/test_operation_state_utils.py
@@ -561,7 +561,7 @@ class TestClearLock:
 
 
 # ===============================
-# Use Case 2b: Pending-Request Queue (R2 / reflexio-enterprise#59)
+# Use Case 2b: Pending-Request Queue (R2)
 # ===============================
 #
 # Replaces the single-slot pending_request_id mechanism. When N>1 publishes


### PR DESCRIPTION
## What

This is the public/open-source repo, so it must not point readers at content only visible in the **private** `reflexio-enterprise` repo, nor leak personal/local paths. All changes are comment/docstring/doc-only — **no behavior change**.

### Private reflexio-enterprise references
- **7× `reflexio-enterprise#59`** private-issue citations dropped across the pending-request-queue ("R2") code + tests (kept the `R2` label).
- **`bootstrap_config.py`** — removed the dead `See docs_for_coding_agent/…` pointer (private-only doc).
- **`setup_cmd.py`** (`openai-codex --help`) — stopped pointing at the private `reflexio_ext/scripts/start_with_codex_proxy.sh`.
- **`.claude/rules/pythonic-code.md`** — genericized a `reflexio_ext/scripts/` path example.

### Open-core extension-seam mentions (genericized)
- `env_loader.py`, `lib/_storage_labels.py`, `server/README.md` — reworded `reflexio_ext` mentions to describe the extension contract without naming the private package/file path.

### gdpval benchmark — scrubbed in place (kept public)
`benchmark/gdpval/` stays public (needed for marketing data/claims). Made it public-appropriate: replaced personal `/Users/<user>/…` paths with generic/`$ENV` paths, dropped the private `reflexio-gdpval-bench` repo name, used public `reflexio.cli` instead of `reflexio_ext.cli`, removed a personal `~/.claude/plans/` reference. Framework names (OpenSpace/Hermes) kept — part of the published `RESULTS.md` narrative; code resolves their paths via env vars.

## Verification
- `import reflexio` OK; ruff clean; `py_compile` OK on changed gdpval modules.
- `git grep` for `reflexio-enterprise#59`, `/Users/`, `reflexio-gdpval-bench`, gdpval `reflexio_ext` → clean.
