### PR TITLE
feat(billing): OSS metering foundation (usage signals + DI seams)

### DIFF
--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -50,6 +50,11 @@ class SearchInteractionRequest(BaseModel):
 class SearchUserProfileRequest(BaseModel):
     user_id: NonEmptyStr
     generated_from_request_id: str | None = None
+    # Caller correlation IDs for billing attribution on the Application line.
+    # Optional; when populated they flow into the usage event request_id /
+    # session_id columns via _meter_applied_learnings in server/api.py.
+    request_id: str | None = None
+    session_id: str | None = None
     query: str | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
@@ -233,6 +238,10 @@ class GetAgentPlaybooksRequest(BaseModel):
     agent_version: str | None = None
     status_filter: list[Status | None] | None = None
     playbook_status_filter: PlaybookStatus | None = None
+    # Caller correlation IDs for billing attribution on the Application line.
+    # Optional; consumed by _meter_applied_learnings in server/api.py.
+    request_id: str | None = None
+    session_id: str | None = None
 
 
 class GetAgentPlaybooksResponse(BaseModel):
@@ -267,6 +276,10 @@ class SearchUserPlaybookRequest(BaseModel):
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
+    # Caller correlation IDs for billing attribution on the Application line.
+    # Optional; consumed by _meter_applied_learnings in server/api.py.
+    request_id: str | None = None
+    session_id: str | None = None
 
     @model_validator(mode="after")
     def check_time_range(self) -> Self:
@@ -320,6 +333,10 @@ class SearchAgentPlaybookRequest(BaseModel):
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
+    # Caller correlation IDs for billing attribution on the Application line.
+    # Optional; consumed by _meter_applied_learnings in server/api.py.
+    request_id: str | None = None
+    session_id: str | None = None
 
     @model_validator(mode="after")
     def check_time_range(self) -> Self:
@@ -621,6 +638,10 @@ class UnifiedSearchRequest(BaseModel):
     enable_reformulation: bool | None = False
     enable_agent_answer: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
+    # Caller correlation IDs for billing attribution on the Application line.
+    # Optional; consumed by _meter_applied_learnings in server/api.py.
+    request_id: str | None = None
+    session_id: str | None = None
 
 
 class UnifiedSearchResponse(BaseModel):

--- a/reflexio/server/_auth.py
+++ b/reflexio/server/_auth.py
@@ -9,6 +9,9 @@ import graph acyclic.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from functools import cache
+
 DEFAULT_ORG_ID = "self-host-org"
 
 
@@ -39,3 +42,36 @@ def default_get_caller_type() -> str:
             (kept as a plain string here so OSS stays free of reflexio_ext imports).
     """
     return "internal"  # == BillingCallerType.INTERNAL.value; literal keeps OSS clean
+
+
+@cache
+def default_billing_gate(line: str) -> Callable[..., None]:  # noqa: ARG001
+    """Return a stable no-op FastAPI dependency for the billing gate.
+
+    OSS / self-hosted deployments run without enforcement — this factory
+    always returns a dependency that does nothing.  Enterprise deployments
+    supply a real gate factory via the ``get_billing_gate`` parameter of
+    :func:`reflexio.server.api.create_app`, exactly mirroring how
+    ``get_caller_type`` overrides :func:`default_get_caller_type`.
+
+    ``lru_cache`` ensures the **same callable object** is returned for the
+    same ``line`` value.  FastAPI uses callable identity for
+    ``dependency_overrides``, so caching is essential: without it, each
+    ``Depends(default_billing_gate("application"))`` would create a fresh
+    closure and overrides would silently never fire.
+
+    OSS code must never import from ``reflexio_ext`` — the gate wiring is
+    purely additive and backwards-compatible.
+
+    Args:
+        line (str): Billing line (e.g. ``"application"``, ``"learnings_generated"``).
+            Accepted but unused in the default no-op implementation.
+
+    Returns:
+        Callable[..., None]: A FastAPI dependency that always passes through.
+    """
+
+    def _noop() -> None:
+        """No-op billing gate for OSS / self-hosted deployments."""
+
+    return _noop

--- a/reflexio/server/_auth.py
+++ b/reflexio/server/_auth.py
@@ -23,3 +23,19 @@ def default_get_org_id() -> str:
         str: The default org identifier used for self-hosted deployments.
     """
     return DEFAULT_ORG_ID
+
+
+def default_get_caller_type() -> str:
+    """Return the default caller type for local / self-hosted deployments.
+
+    Every call is treated as ``"internal"`` (no billing discrimination) in the
+    OSS build.  Enterprise deployments override this via
+    ``app.dependency_overrides[default_get_caller_type] = <classifier>``
+    inside :func:`reflexio.server.api.create_app`, exactly like
+    :func:`default_get_org_id`.
+
+    Returns:
+        str: The literal ``"internal"`` — equals ``BillingCallerType.INTERNAL.value``
+            (kept as a plain string here so OSS stays free of reflexio_ext imports).
+    """
+    return "internal"  # == BillingCallerType.INTERNAL.value; literal keeps OSS clean

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -2987,9 +2987,9 @@ def create_app(
     # the same sentinel object is returned for the same line — which is why
     # the overrides reliably fire at request time.
     if get_billing_gate is not None:
-        for _line in ("application", "learnings_generated"):
-            app.dependency_overrides[default_billing_gate(_line)] = get_billing_gate(
-                _line
+        for line in ("application", "learnings_generated"):
+            app.dependency_overrides[default_billing_gate(line)] = get_billing_gate(
+                line
             )
 
     # When a custom get_org_id is provided together with require_auth,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -156,7 +156,11 @@ from reflexio.models.config_schema import (
     SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
     Config,
 )
-from reflexio.server._auth import DEFAULT_ORG_ID, default_get_org_id
+from reflexio.server._auth import (
+    DEFAULT_ORG_ID,
+    default_get_caller_type,
+    default_get_org_id,
+)
 from reflexio.server.api_endpoints import (
     account_api,
     health_api,
@@ -187,7 +191,12 @@ logger = logging.getLogger(__name__)
 # Re-exported for backwards compatibility — callers that did
 # ``from reflexio.server.api import default_get_org_id`` or ``DEFAULT_ORG_ID``
 # continue to work.
-__all__ = ["DEFAULT_ORG_ID", "create_app", "default_get_org_id"]
+__all__ = [
+    "DEFAULT_ORG_ID",
+    "create_app",
+    "default_get_caller_type",
+    "default_get_org_id",
+]
 
 # Bot protection configuration
 REQUEST_TIMEOUT_SECONDS = 60
@@ -2714,6 +2723,7 @@ def create_app(
     additional_routers: list[APIRouter] | None = None,
     middleware_config: dict | None = None,
     require_auth: bool = False,
+    get_caller_type: Callable[..., str] | None = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -2724,6 +2734,9 @@ def create_app(
         middleware_config: Optional middleware overrides (not used yet, reserved for future).
         require_auth: When True, declares a Bearer security scheme in the OpenAPI spec
             so Swagger UI shows lock icons and the Authorize button works.
+        get_caller_type: Custom dependency for classifying the caller (e.g., production
+            agent vs dashboard).  When provided, overrides the default_get_caller_type
+            dependency globally, exactly mirroring the get_org_id override.
 
     Returns:
         Configured FastAPI application.
@@ -2731,7 +2744,7 @@ def create_app(
     from collections.abc import AsyncIterator
     from contextlib import asynccontextmanager
 
-    from reflexio.server._auth import default_get_org_id
+    from reflexio.server._auth import default_get_caller_type, default_get_org_id
     from reflexio.server.api_endpoints.request_context import RequestContext
     from reflexio.server.llm.model_defaults import validate_llm_availability
     from reflexio.server.services.extraction.resume_scheduler import (
@@ -2836,6 +2849,10 @@ def create_app(
     # Override get_org_id dependency if custom one provided
     if get_org_id is not None:
         app.dependency_overrides[default_get_org_id] = get_org_id
+
+    # Override get_caller_type dependency if custom one provided
+    if get_caller_type is not None:
+        app.dependency_overrides[default_get_caller_type] = get_caller_type
 
     # When a custom get_org_id is provided together with require_auth,
     # auth is enforced on every route — mark this app instance so the

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1666,8 +1666,10 @@ def get_user_playbooks(
     response_model=GetAgentPlaybooksViewResponse,
     response_model_exclude_none=True,
 )
+@limiter.limit("120/minute")  # Rate limit for read operations
 def get_agent_playbooks(
-    request: GetAgentPlaybooksRequest,
+    request: Request,
+    payload: GetAgentPlaybooksRequest,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
     _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
@@ -1675,7 +1677,8 @@ def get_agent_playbooks(
     """Get agent playbooks with internal fields filtered out.
 
     Args:
-        request (GetAgentPlaybooksRequest): The get request
+        request (Request): The HTTP request object (for rate limiting)
+        payload (GetAgentPlaybooksRequest): The get request
         org_id (str): Organization ID
         caller_type (str): Billing caller classification (injected via dependency).
 
@@ -1683,7 +1686,7 @@ def get_agent_playbooks(
         GetAgentPlaybooksViewResponse: Response containing agent playbooks without internal fields
     """
     reflexio = get_reflexio(org_id=org_id)
-    response = reflexio.get_agent_playbooks(request)
+    response = reflexio.get_agent_playbooks(payload)
     resp = GetAgentPlaybooksViewResponse(
         success=response.success,
         agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
@@ -1693,8 +1696,8 @@ def get_agent_playbooks(
         org_id=org_id,
         caller_type=caller_type,
         surfaced_count=len(resp.agent_playbooks),
-        request_id=getattr(request, "request_id", None),
-        session_id=getattr(request, "session_id", None),
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
     )
     return resp
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -465,6 +465,44 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
 core_router = APIRouter()
 
 
+def _meter_applied_learnings(
+    *,
+    org_id: str,
+    caller_type: str,
+    surfaced_count: int,
+    request_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Emit the ③ Application event via the OSS emission helper.
+
+    No-op unless a production-agent caller surfaced >= 1 result.  The cheap
+    caller-type and count guard runs first so the get_reflexio / config lookup
+    is skipped on the free paths (dashboard / empty result).
+
+    Args:
+        org_id: Organization ID for the requesting caller.
+        caller_type: Resolved caller classification (e.g. ``"production_agent"``).
+        surfaced_count: Total number of learnings returned to the caller.
+        request_id: Optional request correlation ID from the payload.
+        session_id: Optional session ID from the payload.
+    """
+    if caller_type != "production_agent" or surfaced_count <= 0:
+        return
+    from reflexio.server.billing_meter import record_applied_learnings
+    from reflexio.server.billing_signals import platform_llm_from_config
+
+    config = get_reflexio(org_id=org_id).request_context.configurator.get_config()
+    record_applied_learnings(
+        org_id=org_id,
+        surfaced_count=surfaced_count,
+        caller_type=caller_type,
+        platform_llm=platform_llm_from_config(config),
+        platform_storage=None,  # resolved enterprise-side at rollup (Phase 1)
+        request_id=request_id,
+        session_id=session_id,
+    )
+
+
 @core_router.get("/")
 def root() -> dict[str, str]:
     return {
@@ -656,17 +694,26 @@ def search_user_profiles(
     request: Request,
     payload: SearchUserProfileRequest,
     org_id: str = Depends(default_get_org_id),
+    caller_type: str = Depends(default_get_caller_type),
 ) -> SearchProfilesViewResponse:
     response = _run_limited_api(
         org_id,
         "search",
         lambda: get_reflexio(org_id=org_id).search_user_profiles(payload),
     )
-    return SearchProfilesViewResponse(
+    resp = SearchProfilesViewResponse(
         success=response.success,
         user_profiles=[to_profile_view(p) for p in response.user_profiles],
         msg=response.msg,
     )
+    _meter_applied_learnings(
+        org_id=org_id,
+        caller_type=caller_type,
+        surfaced_count=len(resp.user_profiles),
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
+    )
+    return resp
 
 
 @core_router.post(
@@ -766,6 +813,7 @@ def search_user_playbooks_endpoint(
     request: Request,
     payload: SearchUserPlaybookRequest,
     org_id: str = Depends(default_get_org_id),
+    caller_type: str = Depends(default_get_caller_type),
 ) -> SearchUserPlaybooksViewResponse:
     """Search user playbooks with semantic search and advanced filtering.
 
@@ -776,6 +824,7 @@ def search_user_playbooks_endpoint(
         request (Request): The HTTP request object (for rate limiting)
         payload (SearchUserPlaybookRequest): The search request
         org_id (str): Organization ID
+        caller_type (str): Billing caller classification (injected via dependency).
 
     Returns:
         SearchUserPlaybooksViewResponse: Response containing matching user playbooks
@@ -785,11 +834,19 @@ def search_user_playbooks_endpoint(
         "search",
         lambda: get_reflexio(org_id=org_id).search_user_playbooks(payload),
     )
-    return SearchUserPlaybooksViewResponse(
+    resp = SearchUserPlaybooksViewResponse(
         success=response.success,
         user_playbooks=[to_user_playbook_view(rf) for rf in response.user_playbooks],
         msg=response.msg,
     )
+    _meter_applied_learnings(
+        org_id=org_id,
+        caller_type=caller_type,
+        surfaced_count=len(resp.user_playbooks),
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
+    )
+    return resp
 
 
 @core_router.post(
@@ -802,6 +859,7 @@ def search_agent_playbooks_endpoint(
     request: Request,
     payload: SearchAgentPlaybookRequest,
     org_id: str = Depends(default_get_org_id),
+    caller_type: str = Depends(default_get_caller_type),
 ) -> SearchAgentPlaybooksViewResponse:
     """Search agent playbooks with semantic search and advanced filtering.
 
@@ -812,6 +870,7 @@ def search_agent_playbooks_endpoint(
         request (Request): The HTTP request object (for rate limiting)
         payload (SearchAgentPlaybookRequest): The search request
         org_id (str): Organization ID
+        caller_type (str): Billing caller classification (injected via dependency).
 
     Returns:
         SearchAgentPlaybooksViewResponse: Response containing matching agent playbooks
@@ -821,11 +880,19 @@ def search_agent_playbooks_endpoint(
         "search",
         lambda: get_reflexio(org_id=org_id).search_agent_playbooks(payload),
     )
-    return SearchAgentPlaybooksViewResponse(
+    resp = SearchAgentPlaybooksViewResponse(
         success=response.success,
         agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
         msg=response.msg,
     )
+    _meter_applied_learnings(
+        org_id=org_id,
+        caller_type=caller_type,
+        surfaced_count=len(resp.agent_playbooks),
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
+    )
+    return resp
 
 
 @core_router.post(
@@ -838,6 +905,7 @@ def unified_search_endpoint(
     request: Request,
     payload: UnifiedSearchRequest,
     org_id: str = Depends(default_get_org_id),
+    caller_type: str = Depends(default_get_caller_type),
 ) -> UnifiedSearchViewResponse:
     """Search across all entity types (profiles, agent playbooks, user playbooks).
 
@@ -849,6 +917,7 @@ def unified_search_endpoint(
         request (Request): The HTTP request object (for rate limiting)
         payload (UnifiedSearchRequest): The unified search request
         org_id (str): Organization ID
+        caller_type (str): Billing caller classification (injected via dependency).
 
     Returns:
         UnifiedSearchViewResponse: Combined search results
@@ -858,7 +927,7 @@ def unified_search_endpoint(
         "search",
         lambda: get_reflexio(org_id=org_id).unified_search(payload, org_id=org_id),
     )
-    return UnifiedSearchViewResponse(
+    resp = UnifiedSearchViewResponse(
         success=response.success,
         profiles=[to_profile_view(p) for p in response.profiles],
         agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
@@ -868,6 +937,16 @@ def unified_search_endpoint(
         agent_trace=response.agent_trace,
         rehydrated_text=response.rehydrated_text,
     )
+    _meter_applied_learnings(
+        org_id=org_id,
+        caller_type=caller_type,
+        surfaced_count=len(resp.profiles)
+        + len(resp.agent_playbooks)
+        + len(resp.user_playbooks),
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
+    )
+    return resp
 
 
 @core_router.get("/api/profile_change_log", response_model=ProfileChangeLogViewResponse)
@@ -1580,23 +1659,33 @@ def get_user_playbooks(
 def get_agent_playbooks(
     request: GetAgentPlaybooksRequest,
     org_id: str = Depends(default_get_org_id),
+    caller_type: str = Depends(default_get_caller_type),
 ) -> GetAgentPlaybooksViewResponse:
     """Get agent playbooks with internal fields filtered out.
 
     Args:
         request (GetAgentPlaybooksRequest): The get request
         org_id (str): Organization ID
+        caller_type (str): Billing caller classification (injected via dependency).
 
     Returns:
         GetAgentPlaybooksViewResponse: Response containing agent playbooks without internal fields
     """
     reflexio = get_reflexio(org_id=org_id)
     response = reflexio.get_agent_playbooks(request)
-    return GetAgentPlaybooksViewResponse(
+    resp = GetAgentPlaybooksViewResponse(
         success=response.success,
         agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
         msg=response.msg,
     )
+    _meter_applied_learnings(
+        org_id=org_id,
+        caller_type=caller_type,
+        surfaced_count=len(resp.agent_playbooks),
+        request_id=getattr(request, "request_id", None),
+        session_id=getattr(request, "session_id", None),
+    )
+    return resp
 
 
 @core_router.post(

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -505,7 +505,9 @@ def _meter_applied_learnings(
             session_id=session_id,
         )
     except Exception:
-        logger.warning("applied-learnings metering failed for org %s", org_id, exc_info=True)
+        logger.warning(
+            "applied-learnings metering failed for org %s", org_id, exc_info=True
+        )
 
 
 @core_router.get("/")
@@ -2828,6 +2830,7 @@ def create_app(
     require_auth: bool = False,
     get_caller_type: Callable[..., str] | None = None,
     get_billing_gate: Callable[[str], Callable[..., None]] | None = None,
+    mount_data_plane: bool = True,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -2847,6 +2850,14 @@ def create_app(
             ``"learnings_generated"``) the returned dependency overrides the
             ``default_billing_gate(line)`` sentinel in ``dependency_overrides``,
             exactly mirroring the ``get_caller_type`` override pattern.
+        mount_data_plane: When True (default), include the data-plane routers
+            (core, stall-state, pending-tool-call) and run the data-plane
+            lifespan work (LLM availability check, cross-encoder prewarm,
+            resume scheduler). When False, skip both so a control-plane host
+            can build an app without requiring LLM/storage or starting the
+            scheduler, while keeping all other scaffolding (middleware, CORS,
+            auth overrides, OpenAPI security, health, ``/meta/version``,
+            ``additional_routers``).
 
     Returns:
         Configured FastAPI application.
@@ -2882,18 +2893,20 @@ def create_app(
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
-        validate_llm_availability()
-        from reflexio.server.llm.rerank import prewarm as _prewarm_cross_encoder
+        scheduler = None
+        if mount_data_plane:
+            validate_llm_availability()
+            from reflexio.server.llm.rerank import prewarm as _prewarm_cross_encoder
 
-        _prewarm_cross_encoder()
-        # The scheduler discovers every org with resumable work each tick and
-        # drives a per-org worker with org-scoped claims, so it is not limited
-        # to the bootstrap org. The bootstrap org is only used to read config
-        # and to seed cross-org discovery.
-        scheduler = maybe_start_resume_scheduler(
-            lambda org_id: RequestContext(org_id=org_id),
-            bootstrap_org_id=_lifespan_org_id(),
-        )
+            _prewarm_cross_encoder()
+            # The scheduler discovers every org with resumable work each tick and
+            # drives a per-org worker with org-scoped claims, so it is not limited
+            # to the bootstrap org. The bootstrap org is only used to read config
+            # and to seed cross-org discovery.
+            scheduler = maybe_start_resume_scheduler(
+                lambda org_id: RequestContext(org_id=org_id),
+                bootstrap_org_id=_lifespan_org_id(),
+            )
         try:
             yield
         finally:
@@ -2975,7 +2988,9 @@ def create_app(
     # the overrides reliably fire at request time.
     if get_billing_gate is not None:
         for _line in ("application", "learnings_generated"):
-            app.dependency_overrides[default_billing_gate(_line)] = get_billing_gate(_line)
+            app.dependency_overrides[default_billing_gate(_line)] = get_billing_gate(
+                _line
+            )
 
     # When a custom get_org_id is provided together with require_auth,
     # auth is enforced on every route — mark this app instance so the
@@ -2985,14 +3000,18 @@ def create_app(
     # multi-tenant embeddings) can coexist without leaking state.
     app.state.my_config_enabled = bool(get_org_id is not None and require_auth)
 
-    # Include core routes
-    app.include_router(core_router)
+    # Include data-plane routes (core, stall-state, pending-tool-call). A
+    # control-plane host sets mount_data_plane=False to skip these while
+    # keeping every other piece of scaffolding below.
+    if mount_data_plane:
+        # Include core routes
+        app.include_router(core_router)
 
-    # Include stall_state routes
-    app.include_router(stall_state_api.router)
+        # Include stall_state routes
+        app.include_router(stall_state_api.router)
 
-    # Include pending tool call routes
-    app.include_router(pending_tool_call_api.router)
+        # Include pending tool call routes
+        app.include_router(pending_tool_call_api.router)
 
     # Include additional routers
     for router in additional_routers or []:

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -488,19 +488,22 @@ def _meter_applied_learnings(
     """
     if caller_type != "production_agent" or surfaced_count <= 0:
         return
-    from reflexio.server.billing_meter import record_applied_learnings
-    from reflexio.server.billing_signals import platform_llm_from_config
+    try:
+        from reflexio.server.billing_meter import record_applied_learnings
+        from reflexio.server.billing_signals import platform_llm_from_config
 
-    config = get_reflexio(org_id=org_id).request_context.configurator.get_config()
-    record_applied_learnings(
-        org_id=org_id,
-        surfaced_count=surfaced_count,
-        caller_type=caller_type,
-        platform_llm=platform_llm_from_config(config),
-        platform_storage=None,  # resolved enterprise-side at rollup (Phase 1)
-        request_id=request_id,
-        session_id=session_id,
-    )
+        config = get_reflexio(org_id=org_id).request_context.configurator.get_config()
+        record_applied_learnings(
+            org_id=org_id,
+            surfaced_count=surfaced_count,
+            caller_type=caller_type,
+            platform_llm=platform_llm_from_config(config),
+            platform_storage=None,  # resolved enterprise-side at rollup (Phase 1)
+            request_id=request_id,
+            session_id=session_id,
+        )
+    except Exception:
+        logger.warning("applied-learnings metering failed for org %s", org_id, exc_info=True)
 
 
 @core_router.get("/")

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -158,6 +158,7 @@ from reflexio.models.config_schema import (
 )
 from reflexio.server._auth import (
     DEFAULT_ORG_ID,
+    default_billing_gate,
     default_get_caller_type,
     default_get_org_id,
 )
@@ -194,6 +195,7 @@ logger = logging.getLogger(__name__)
 __all__ = [
     "DEFAULT_ORG_ID",
     "create_app",
+    "default_billing_gate",
     "default_get_caller_type",
     "default_get_org_id",
 ]
@@ -584,6 +586,7 @@ def publish_user_interaction(
     background_tasks: BackgroundTasks,
     org_id: str = Depends(default_get_org_id),
     wait_for_response: bool = False,
+    _gate: None = Depends(default_billing_gate("learnings_generated")),  # noqa: B008
 ) -> PublishUserInteractionResponse:
     if wait_for_response:
         # Process synchronously so the caller gets the real result
@@ -698,6 +701,7 @@ def search_user_profiles(
     payload: SearchUserProfileRequest,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
+    _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
 ) -> SearchProfilesViewResponse:
     response = _run_limited_api(
         org_id,
@@ -817,6 +821,7 @@ def search_user_playbooks_endpoint(
     payload: SearchUserPlaybookRequest,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
+    _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
 ) -> SearchUserPlaybooksViewResponse:
     """Search user playbooks with semantic search and advanced filtering.
 
@@ -863,6 +868,7 @@ def search_agent_playbooks_endpoint(
     payload: SearchAgentPlaybookRequest,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
+    _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
 ) -> SearchAgentPlaybooksViewResponse:
     """Search agent playbooks with semantic search and advanced filtering.
 
@@ -909,6 +915,7 @@ def unified_search_endpoint(
     payload: UnifiedSearchRequest,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
+    _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
 ) -> UnifiedSearchViewResponse:
     """Search across all entity types (profiles, agent playbooks, user playbooks).
 
@@ -1663,6 +1670,7 @@ def get_agent_playbooks(
     request: GetAgentPlaybooksRequest,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
+    _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
 ) -> GetAgentPlaybooksViewResponse:
     """Get agent playbooks with internal fields filtered out.
 
@@ -2816,6 +2824,7 @@ def create_app(
     middleware_config: dict | None = None,
     require_auth: bool = False,
     get_caller_type: Callable[..., str] | None = None,
+    get_billing_gate: Callable[[str], Callable[..., None]] | None = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -2829,6 +2838,12 @@ def create_app(
         get_caller_type: Custom dependency for classifying the caller (e.g., production
             agent vs dashboard).  When provided, overrides the default_get_caller_type
             dependency globally, exactly mirroring the get_org_id override.
+        get_billing_gate: Optional factory ``(line: str) -> FastAPI dependency`` that
+            replaces the default no-op gate for each billable billing line.  When
+            provided, for every line used in the app (``"application"`` and
+            ``"learnings_generated"``) the returned dependency overrides the
+            ``default_billing_gate(line)`` sentinel in ``dependency_overrides``,
+            exactly mirroring the ``get_caller_type`` override pattern.
 
     Returns:
         Configured FastAPI application.
@@ -2836,7 +2851,11 @@ def create_app(
     from collections.abc import AsyncIterator
     from contextlib import asynccontextmanager
 
-    from reflexio.server._auth import default_get_caller_type, default_get_org_id
+    from reflexio.server._auth import (
+        default_billing_gate,
+        default_get_caller_type,
+        default_get_org_id,
+    )
     from reflexio.server.api_endpoints.request_context import RequestContext
     from reflexio.server.llm.model_defaults import validate_llm_availability
     from reflexio.server.services.extraction.resume_scheduler import (
@@ -2945,6 +2964,15 @@ def create_app(
     # Override get_caller_type dependency if custom one provided
     if get_caller_type is not None:
         app.dependency_overrides[default_get_caller_type] = get_caller_type
+
+    # Override billing gate dependencies if a custom gate factory is provided.
+    # Each billing line needs its own override because dependency_overrides is
+    # keyed by callable identity.  ``default_billing_gate`` uses lru_cache so
+    # the same sentinel object is returned for the same line — which is why
+    # the overrides reliably fire at request time.
+    if get_billing_gate is not None:
+        for _line in ("application", "learnings_generated"):
+            app.dependency_overrides[default_billing_gate(_line)] = get_billing_gate(_line)
 
     # When a custom get_org_id is provided together with require_auth,
     # auth is enforced on every route — mark this app instance so the

--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -1,0 +1,139 @@
+"""OSS emission helpers: translate billing signals into usage_events.
+
+The single source of truth for each billing event's name/category/fields. Plain
+primitive signatures (no reflexio_ext types) so OSS call sites — the generation
+service and search endpoints — can use them directly. Each is a thin, non-blocking
+wrapper over the ``record_usage_event`` hook (which only enqueues). No DB I/O.
+"""
+
+from __future__ import annotations
+
+from reflexio.server.usage_metrics import record_usage_event
+
+_INTERNAL = "internal"   # == BillingCallerType.INTERNAL.value (kept literal; OSS stays clean)
+
+
+def record_extraction_tokens(
+    *,
+    org_id: str,
+    billing_input_tokens: int,
+    prompt_tokens: int,
+    completion_tokens: int,
+    platform_llm: bool | None,
+    platform_storage: bool | None,
+    pipeline: str | None = None,
+    request_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Emit the Learning cost facet — call only when extraction fired.
+
+    No-op when ``billing_input_tokens <= 0``.
+
+    Args:
+        org_id: Organisation identifier.
+        billing_input_tokens: Input-anchored token count (the metered basis).
+        prompt_tokens: Real provider prompt tokens (COGS; not billed to customer).
+        completion_tokens: Real provider completion tokens (COGS; not billed).
+        platform_llm: True iff the platform supplies the LLM for this org.
+        platform_storage: True iff the platform supplies storage; None defers to rollup.
+        pipeline: Optional pipeline tag (e.g. ``"profile"``).
+        request_id: Optional request correlation ID.
+        session_id: Optional session ID.
+    """
+    if billing_input_tokens <= 0:
+        return
+    record_usage_event(
+        org_id=org_id,
+        event_name="extraction_tokens",
+        event_category="learning",
+        pipeline=pipeline,
+        request_id=request_id,
+        session_id=session_id,
+        count_value=billing_input_tokens,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        billing_input_tokens=billing_input_tokens,
+        platform_llm=platform_llm,
+        platform_storage=platform_storage,
+        caller_type=_INTERNAL,
+    )
+
+
+def record_learnings_generated(
+    *,
+    org_id: str,
+    count: int,
+    platform_llm: bool | None,
+    platform_storage: bool | None,
+    pipeline: str | None = None,
+    request_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Emit the Learning value facet — number of profiles/playbooks generated.
+
+    No-op when ``count <= 0``.
+
+    Args:
+        org_id: Organisation identifier.
+        count: Number of learnings generated in this run.
+        platform_llm: True iff the platform supplies the LLM for this org.
+        platform_storage: True iff the platform supplies storage; None defers to rollup.
+        pipeline: Optional pipeline tag (e.g. ``"playbook"``).
+        request_id: Optional request correlation ID.
+        session_id: Optional session ID.
+    """
+    if count <= 0:
+        return
+    record_usage_event(
+        org_id=org_id,
+        event_name="learnings_generated",
+        event_category="learning",
+        pipeline=pipeline,
+        request_id=request_id,
+        session_id=session_id,
+        count_value=count,
+        platform_llm=platform_llm,
+        platform_storage=platform_storage,
+        caller_type=_INTERNAL,
+    )
+
+
+def record_applied_learnings(
+    *,
+    org_id: str,
+    surfaced_count: int,
+    caller_type: str,
+    platform_llm: bool | None,
+    platform_storage: bool | None,
+    pipeline: str | None = None,
+    request_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Emit the Application line — surfaced top-K learnings.
+
+    No-op unless ``caller_type == "production_agent"`` AND ``surfaced_count > 0``.
+
+    Args:
+        org_id: Organisation identifier.
+        surfaced_count: Number of learnings surfaced in the search response.
+        caller_type: Caller classification string (e.g. ``"production_agent"``).
+        platform_llm: True iff the platform supplies the LLM for this org.
+        platform_storage: True iff the platform supplies storage; None defers to rollup.
+        pipeline: Optional pipeline tag.
+        request_id: Optional request correlation ID.
+        session_id: Optional session ID.
+    """
+    if caller_type != "production_agent" or surfaced_count <= 0:
+        return
+    record_usage_event(
+        org_id=org_id,
+        event_name="learning_applied",
+        event_category="application",
+        pipeline=pipeline,
+        request_id=request_id,
+        session_id=session_id,
+        count_value=surfaced_count,
+        platform_llm=platform_llm,
+        platform_storage=platform_storage,
+        caller_type=caller_type,
+    )

--- a/reflexio/server/billing_signals.py
+++ b/reflexio/server/billing_signals.py
@@ -2,11 +2,36 @@
 
 Single source of truth for whether the platform supplies the LLM, so the OSS
 generation service and the enterprise attribution resolver never diverge.
+Also provides the one canonical input-anchored tokenizer for the whole platform.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+import tiktoken
+
+# One fixed canonical encoding for the whole platform. Changing this is a
+# price-book-affecting decision; do not make it model-dependent.
+_CANONICAL_ENCODING_NAME = "cl100k_base"
+_encoding = tiktoken.get_encoding(_CANONICAL_ENCODING_NAME)
+
+
+def count_input_tokens(text: str) -> int:
+    """Count billable input tokens for ``text`` under the canonical cl100k_base encoding.
+
+    This is the single canonical tokenizer for the whole platform. Enterprise
+    code delegates here so OSS and enterprise always use the same encoding.
+
+    Args:
+        text (str): The input text to tokenize.
+
+    Returns:
+        int: Number of tokens under cl100k_base, or 0 for empty input.
+    """
+    if not text:
+        return 0
+    return len(_encoding.encode(text, disallowed_special=()))
 
 
 def platform_llm_from_config(config: Any) -> bool:
@@ -25,5 +50,9 @@ def platform_llm_from_config(config: Any) -> bool:
     api_key_config = getattr(config, "api_key_config", None)
     if api_key_config is None:
         return True
-    data = api_key_config.model_dump(exclude_none=True) if hasattr(api_key_config, "model_dump") else {}
+    data = (
+        api_key_config.model_dump(exclude_none=True)
+        if hasattr(api_key_config, "model_dump")
+        else {}
+    )
     return not any(bool(v) for v in data.values())

--- a/reflexio/server/billing_signals.py
+++ b/reflexio/server/billing_signals.py
@@ -1,0 +1,29 @@
+"""OSS-pure billing signal helpers (no reflexio_ext imports).
+
+Single source of truth for whether the platform supplies the LLM, so the OSS
+generation service and the enterprise attribution resolver never diverge.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def platform_llm_from_config(config: Any) -> bool:
+    """Return True iff Reflexio (not the customer) supplies the LLM for ``config``.
+
+    A populated ``api_key_config`` provider sub-config means BYO-LLM → False.
+    A missing/empty ``api_key_config`` means platform-supplied → True.
+
+    Args:
+        config: The org's resolved ``Config`` object, or None.
+
+    Returns:
+        bool: True when the platform supplies the LLM; False when the customer
+            has configured a BYO provider key.
+    """
+    api_key_config = getattr(config, "api_key_config", None)
+    if api_key_config is None:
+        return True
+    data = api_key_config.model_dump(exclude_none=True) if hasattr(api_key_config, "model_dump") else {}
+    return not any(bool(v) for v in data.values())

--- a/reflexio/server/billing_signals.py
+++ b/reflexio/server/billing_signals.py
@@ -7,6 +7,7 @@ Also provides the one canonical input-anchored tokenizer for the whole platform.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import tiktoken
@@ -55,4 +56,9 @@ def platform_llm_from_config(config: Any) -> bool:
         if hasattr(api_key_config, "model_dump")
         else {}
     )
+    # Guard against a model_dump that returns a non-mapping: without this,
+    # `.values()` would raise. Default to platform-supplied (True) on a shape
+    # we don't understand rather than misclassifying the org as BYO-LLM.
+    if not isinstance(data, Mapping):
+        return True
     return not any(bool(v) for v in data.values())

--- a/reflexio/server/llm/token_accounting.py
+++ b/reflexio/server/llm/token_accounting.py
@@ -1,0 +1,48 @@
+"""Plain, dependency-free per-run token accounting (OSS-safe).
+
+Folds the per-turn token counts already present on a ToolLoopTrace into a single
+run total. The enterprise billing layer converts this into a TokenUsage; OSS never
+imports reflexio_ext.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class RunTokenTotals:
+    """Accumulated token counts for a single extraction agent run."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    def add(self, *, prompt_tokens: int | None, completion_tokens: int | None) -> None:
+        """Accumulate token counts, treating None as 0.
+
+        Args:
+            prompt_tokens: Prompt token count for one turn, or None if unavailable.
+            completion_tokens: Completion token count for one turn, or None if unavailable.
+        """
+        self.prompt_tokens += int(prompt_tokens or 0)
+        self.completion_tokens += int(completion_tokens or 0)
+
+
+def sum_trace_tokens(trace: Any) -> RunTokenTotals:
+    """Fold a ToolLoopTrace's per-turn token counts into one RunTokenTotals.
+
+    Args:
+        trace: A ToolLoopTrace (or duck-typed equivalent) with a ``turns`` attribute.
+            Each turn may have ``prompt_tokens`` and ``completion_tokens`` attributes.
+
+    Returns:
+        RunTokenTotals with the summed prompt and completion tokens across all turns.
+    """
+    totals = RunTokenTotals()
+    for turn in getattr(trace, "turns", []) or []:
+        totals.add(
+            prompt_tokens=getattr(turn, "prompt_tokens", None),
+            completion_tokens=getattr(turn, "completion_tokens", None),
+        )
+    return totals

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -166,6 +166,10 @@ class BaseGenerationService(
     ABC,
     Generic[TExtractorConfig, TExtractor, TGenerationServiceConfig, TRequest],  # noqa: UP046
 ):
+    # Only profile/playbook GENERATION services bill the ② Learning line;
+    # reflection/consolidation/aggregation/evaluation are bundled, not metered.
+    # Default is False so any future subclass is safe by default (opt-IN).
+    EMITS_LEARNING_BILLING: bool = False
     """
     Base class for generation services that run one configured extractor.
 
@@ -315,48 +319,61 @@ class BaseGenerationService(
         (cost facet) via the OSS emission helpers. ``platform_storage`` is left
         ``None`` here and resolved enterprise-side at rollup (Phase 1).
 
+        Gated by ``EMITS_LEARNING_BILLING`` — only profile/playbook generation
+        services opt in. Evaluation, reflection, consolidation and aggregation
+        are bundled and must NOT separately meter the ② Learning line.
+
         Args:
             prepared: The prepared generation run (used for input-text computation).
             generated_count: Number of learnings produced by this extraction run.
         """
-        from reflexio.server.billing_meter import (
-            record_extraction_tokens,
-            record_learnings_generated,
-        )
-        from reflexio.server.billing_signals import (
-            count_input_tokens,
-            platform_llm_from_config,
-        )
+        if not self.EMITS_LEARNING_BILLING:
+            return
 
-        config = self.request_context.configurator.get_config()
-        platform_llm = platform_llm_from_config(config)
-        ctx = self._usage_context()
+        try:
+            from reflexio.server.billing_meter import (
+                record_extraction_tokens,
+                record_learnings_generated,
+            )
+            from reflexio.server.billing_signals import (
+                count_input_tokens,
+                platform_llm_from_config,
+            )
 
-        # ② Learning — value: learnings generated (helper no-ops on count <= 0).
-        record_learnings_generated(
-            org_id=ctx["org_id"],
-            count=generated_count,
-            platform_llm=platform_llm,
-            platform_storage=None,
-            pipeline=ctx.get("pipeline"),
-            request_id=ctx.get("request_id"),
-            session_id=ctx.get("session_id"),
-        )
+            config = self.request_context.configurator.get_config()
+            platform_llm = platform_llm_from_config(config)
+            ctx = self._usage_context()
 
-        # ② Learning — cost: input-anchored extraction tokens + real provider tokens.
-        totals = self._last_token_totals or RunTokenTotals()
-        billing_input_tokens = count_input_tokens(self._extraction_input_text(prepared))
-        record_extraction_tokens(
-            org_id=ctx["org_id"],
-            billing_input_tokens=billing_input_tokens,
-            prompt_tokens=totals.prompt_tokens,
-            completion_tokens=totals.completion_tokens,
-            platform_llm=platform_llm,
-            platform_storage=None,
-            pipeline=ctx.get("pipeline"),
-            request_id=ctx.get("request_id"),
-            session_id=ctx.get("session_id"),
-        )
+            # ② Learning — value: learnings generated (helper no-ops on count <= 0).
+            record_learnings_generated(
+                org_id=ctx["org_id"],
+                count=generated_count,
+                platform_llm=platform_llm,
+                platform_storage=None,
+                pipeline=ctx.get("pipeline"),
+                request_id=ctx.get("request_id"),
+                session_id=ctx.get("session_id"),
+            )
+
+            # ② Learning — cost: input-anchored extraction tokens + real provider tokens.
+            totals = self._last_token_totals or RunTokenTotals()
+            billing_input_tokens = count_input_tokens(self._extraction_input_text(prepared))
+            record_extraction_tokens(
+                org_id=ctx["org_id"],
+                billing_input_tokens=billing_input_tokens,
+                prompt_tokens=totals.prompt_tokens,
+                completion_tokens=totals.completion_tokens,
+                platform_llm=platform_llm,
+                platform_storage=None,
+                pipeline=ctx.get("pipeline"),
+                request_id=ctx.get("request_id"),
+                session_id=ctx.get("session_id"),
+            )
+        except Exception:
+            logger.warning(
+                "_record_billing_learning_events failed; billing learning events not emitted",
+                exc_info=True,
+            )
 
     @staticmethod
     def _count_generated_results(result: Any) -> int:

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -677,6 +677,7 @@ class BaseGenerationService(
                 },
             )
             self._last_extraction_run_ids = []
+            self._last_token_totals = None
             result = self._execute_extractor(
                 prepared.extractor_config, prepared.identifier
             )

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -278,6 +278,9 @@ class BaseGenerationService(
 
         if self.storage is None or self.service_config is None:
             return ""
+        # Deliberate extra storage read: re-fetches the extractor's input window so
+        # billing token counting sees exactly the text the LLM saw. Kept separate
+        # from the extraction path on purpose; not refactored into a shared fetch.
         try:
             root_config = self.request_context.configurator.get_config()
             global_window_size = (
@@ -348,8 +351,8 @@ class BaseGenerationService(
             # session_id source. _usage_context() never includes it, and neither
             # the Profile/Playbook service configs nor their requests carry a
             # session_id (unlike the Application-line path in server/api.py, which
-            # reads it from the publish payload). Learning events therefore meter
-            # without session attribution by design.
+            # reads request_id/session_id off the search request payload). Learning
+            # events therefore meter without session attribution by design.
 
             # ② Learning — value: learnings generated (helper no-ops on count <= 0).
             record_learnings_generated(

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -254,6 +254,104 @@ class BaseGenerationService(
             metadata=metadata,
         )
 
+    def _extraction_input_text(self, prepared: "PreparedGenerationRun[Any]") -> str:
+        """Return the interaction content fed to the extractor as a single string.
+
+        Replays the same storage query the extractor uses (same user_id, source,
+        window params) so ``count_input_tokens`` sees the same text the LLM saw.
+        Returns an empty string when storage is unavailable or no interactions exist.
+
+        Args:
+            prepared: The prepared generation run, used to access extractor_config
+                for window/source parameters.
+
+        Returns:
+            str: Formatted interaction history string, or "" if nothing is found.
+        """
+        from reflexio.server.services.service_utils import (
+            format_sessions_to_history_string,
+        )
+
+        if self.storage is None or self.service_config is None:
+            return ""
+        try:
+            root_config = self.request_context.configurator.get_config()
+            global_window_size = (
+                getattr(root_config, "window_size", None) if root_config else None
+            )
+            global_stride_size = (
+                getattr(root_config, "stride_size", None) if root_config else None
+            )
+            window_size, _ = get_extractor_window_params(
+                prepared.extractor_config, global_window_size, global_stride_size
+            )
+            _, effective_source = get_effective_source_filter(
+                prepared.extractor_config, getattr(self.service_config, "source", None)
+            )
+            session_data_models, _ = self.storage.get_last_k_interactions_grouped(
+                user_id=getattr(self.service_config, "user_id", None),
+                k=window_size,
+                sources=effective_source,
+                start_time=getattr(self.service_config, "rerun_start_time", None),
+                end_time=getattr(self.service_config, "rerun_end_time", None),
+                **self._get_precheck_interaction_query_kwargs(),
+            )
+            return format_sessions_to_history_string(session_data_models)
+        except Exception:
+            return ""
+
+    def _record_billing_learning_events(
+        self, *, prepared: "PreparedGenerationRun[Any]", generated_count: int
+    ) -> None:
+        """Emit the ② Learning billing events. Called ONLY when extraction fired.
+
+        Emits ``learnings_generated`` (value facet) and ``extraction_tokens``
+        (cost facet) via the OSS emission helpers. ``platform_storage`` is left
+        ``None`` here and resolved enterprise-side at rollup (Phase 1).
+
+        Args:
+            prepared: The prepared generation run (used for input-text computation).
+            generated_count: Number of learnings produced by this extraction run.
+        """
+        from reflexio.server.billing_meter import (
+            record_extraction_tokens,
+            record_learnings_generated,
+        )
+        from reflexio.server.billing_signals import (
+            count_input_tokens,
+            platform_llm_from_config,
+        )
+
+        config = self.request_context.configurator.get_config()
+        platform_llm = platform_llm_from_config(config)
+        ctx = self._usage_context()
+
+        # ② Learning — value: learnings generated (helper no-ops on count <= 0).
+        record_learnings_generated(
+            org_id=ctx["org_id"],
+            count=generated_count,
+            platform_llm=platform_llm,
+            platform_storage=None,
+            pipeline=ctx.get("pipeline"),
+            request_id=ctx.get("request_id"),
+            session_id=ctx.get("session_id"),
+        )
+
+        # ② Learning — cost: input-anchored extraction tokens + real provider tokens.
+        totals = self._last_token_totals or RunTokenTotals()
+        billing_input_tokens = count_input_tokens(self._extraction_input_text(prepared))
+        record_extraction_tokens(
+            org_id=ctx["org_id"],
+            billing_input_tokens=billing_input_tokens,
+            prompt_tokens=totals.prompt_tokens,
+            completion_tokens=totals.completion_tokens,
+            platform_llm=platform_llm,
+            platform_storage=None,
+            pipeline=ctx.get("pipeline"),
+            request_id=ctx.get("request_id"),
+            session_id=ctx.get("session_id"),
+        )
+
     @staticmethod
     def _count_generated_results(result: Any) -> int:
         if isinstance(result, list):
@@ -706,6 +804,9 @@ class BaseGenerationService(
                         self._last_extractor_run_stats.get("timed_out")
                     ),
                 },
+            )
+            self._record_billing_learning_events(
+                prepared=prepared, generated_count=generated_count
             )
 
         except Exception as e:

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -20,6 +20,7 @@ from reflexio.models.api_schema.internal_schema import RequestInteractionDataMod
 from reflexio.models.api_schema.service_schemas import Status
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.token_accounting import RunTokenTotals
 from reflexio.server.services.extraction.outcome import ExtractionOutcome
 from reflexio.server.services.extractor_config_utils import (
     filter_extractor_configs,
@@ -209,6 +210,7 @@ class BaseGenerationService(
             "timed_out": 0,
         }
         self._last_extraction_run_ids: list[str] = []
+        self._last_token_totals: RunTokenTotals | None = None
 
     def _usage_pipeline(self) -> str | None:
         service_name = self._get_service_name()
@@ -834,6 +836,7 @@ class BaseGenerationService(
             if isinstance(result, ExtractionOutcome):
                 if result.run_id:
                     self._last_extraction_run_ids.append(result.run_id)
+                self._last_token_totals = result.token_totals
                 if result.status == "completed" and result.items:
                     return result.items
                 logger.info(

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -215,6 +215,10 @@ class BaseGenerationService(
         }
         self._last_extraction_run_ids: list[str] = []
         self._last_token_totals: RunTokenTotals | None = None
+        # Window fetched by the should-run gate (_collect_scoped_interactions_for_precheck),
+        # stashed so the billing path (_extraction_input_text) can reuse it instead of
+        # re-querying storage. None when the gate did not run (bypass paths).
+        self._last_precheck_sessions: list[Any] | None = None
 
     def _usage_pipeline(self) -> str | None:
         service_name = self._get_service_name()
@@ -278,9 +282,15 @@ class BaseGenerationService(
 
         if self.storage is None or self.service_config is None:
             return ""
-        # Deliberate extra storage read: re-fetches the extractor's input window so
-        # billing token counting sees exactly the text the LLM saw. Kept separate
-        # from the extraction path on purpose; not refactored into a shared fetch.
+        # Reuse the window the should-run gate already fetched
+        # (_collect_scoped_interactions_for_precheck stashed it). Same query params,
+        # so the token count is byte-identical — and we avoid a second storage read.
+        if self._last_precheck_sessions is not None:
+            return format_sessions_to_history_string(self._last_precheck_sessions)
+        # Fallback storage read: used ONLY when the gate did not pre-fetch
+        # (bypass paths: auto_run=False, force_extraction, skip_should_run_check,
+        # mock mode). Re-fetches the extractor's input window so billing token
+        # counting sees exactly the text the LLM saw.
         try:
             root_config = self.request_context.configurator.get_config()
             global_window_size = (
@@ -874,6 +884,13 @@ class BaseGenerationService(
         Returns:
             PreparedGenerationRun when generation should proceed, otherwise None.
         """
+        # Reset BEFORE the should-run gate runs. The gate
+        # (_collect_scoped_interactions_for_precheck) stashes its fetched window
+        # here for the billing path to reuse. On bypass paths (auto_run=False,
+        # force_extraction, skip_should_run_check, mock mode) the gate never runs,
+        # so this stays None and billing falls back to its own fetch.
+        self._last_precheck_sessions = None
+
         self.service_config = self._load_generation_service_config(request)
 
         extractor_config = self._load_extractor_config()
@@ -1266,6 +1283,8 @@ class BaseGenerationService(
             extractor_config, getattr(self.service_config, "source", None)
         )
         if should_skip:
+            # Stash for the billing path to reuse (same window the gate saw).
+            self._last_precheck_sessions = []
             return [], extractor_config
 
         window_size, _ = get_extractor_window_params(
@@ -1280,6 +1299,9 @@ class BaseGenerationService(
             **extra_kwargs,
         )
 
+        # Stash for the billing path (_extraction_input_text) to reuse instead of
+        # re-querying storage for billing_input_tokens.
+        self._last_precheck_sessions = session_data_models
         return session_data_models, extractor_config
 
     def _get_precheck_interaction_query_kwargs(self) -> dict:

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -285,9 +285,11 @@ class BaseGenerationService(
             window_size, _ = get_extractor_window_params(
                 prepared.extractor_config, global_window_size, global_stride_size
             )
-            _, effective_source = get_effective_source_filter(
+            should_skip, effective_source = get_effective_source_filter(
                 prepared.extractor_config, getattr(self.service_config, "source", None)
             )
+            if should_skip:
+                return ""
             session_data_models, _ = self.storage.get_last_k_interactions_grouped(
                 user_id=getattr(self.service_config, "user_id", None),
                 k=window_size,
@@ -298,6 +300,10 @@ class BaseGenerationService(
             )
             return format_sessions_to_history_string(session_data_models)
         except Exception:
+            logger.warning(
+                "_extraction_input_text failed; billing_input_tokens will be 0",
+                exc_info=True,
+            )
             return ""
 
     def _record_billing_learning_events(

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -344,6 +344,13 @@ class BaseGenerationService(
             platform_llm = platform_llm_from_config(config)
             ctx = self._usage_context()
 
+            # session_id is intentionally not passed: the generation path has no
+            # session_id source. _usage_context() never includes it, and neither
+            # the Profile/Playbook service configs nor their requests carry a
+            # session_id (unlike the Application-line path in server/api.py, which
+            # reads it from the publish payload). Learning events therefore meter
+            # without session attribution by design.
+
             # ② Learning — value: learnings generated (helper no-ops on count <= 0).
             record_learnings_generated(
                 org_id=ctx["org_id"],
@@ -352,12 +359,13 @@ class BaseGenerationService(
                 platform_storage=None,
                 pipeline=ctx.get("pipeline"),
                 request_id=ctx.get("request_id"),
-                session_id=ctx.get("session_id"),
             )
 
             # ② Learning — cost: input-anchored extraction tokens + real provider tokens.
             totals = self._last_token_totals or RunTokenTotals()
-            billing_input_tokens = count_input_tokens(self._extraction_input_text(prepared))
+            billing_input_tokens = count_input_tokens(
+                self._extraction_input_text(prepared)
+            )
             record_extraction_tokens(
                 org_id=ctx["org_id"],
                 billing_input_tokens=billing_input_tokens,
@@ -367,7 +375,6 @@ class BaseGenerationService(
                 platform_storage=None,
                 pipeline=ctx.get("pipeline"),
                 request_id=ctx.get("request_id"),
-                session_id=ctx.get("session_id"),
             )
         except Exception:
             logger.warning(

--- a/reflexio/server/services/extraction/outcome.py
+++ b/reflexio/server/services/extraction/outcome.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from reflexio.server.llm.token_accounting import RunTokenTotals
 
 
 @dataclass(frozen=True)
@@ -13,12 +16,17 @@ class ExtractionOutcome[T]:
     status: Literal["completed", "empty"]
     items: list[T] = field(default_factory=list)
     run_id: str | None = None
+    token_totals: RunTokenTotals | None = None
 
     @classmethod
     def completed(
-        cls, items: list[T], *, run_id: str | None = None
+        cls,
+        items: list[T],
+        *,
+        run_id: str | None = None,
+        token_totals: RunTokenTotals | None = None,
     ) -> ExtractionOutcome[T]:
-        return cls(status="completed", items=items, run_id=run_id)
+        return cls(status="completed", items=items, run_id=run_id, token_totals=token_totals)
 
     @classmethod
     def empty(cls, *, run_id: str | None = None) -> ExtractionOutcome[T]:

--- a/reflexio/server/services/playbook/playbook_extractor.py
+++ b/reflexio/server/services/playbook/playbook_extractor.py
@@ -10,8 +10,8 @@ from reflexio.models.config_schema import PlaybookConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
-from reflexio.server.services.extraction.outcome import ExtractionOutcome
 from reflexio.server.llm.token_accounting import RunTokenTotals, sum_trace_tokens
+from reflexio.server.services.extraction.outcome import ExtractionOutcome
 from reflexio.server.services.extraction.resumable_agent import (
     run_resumable_extraction_agent,
 )
@@ -80,7 +80,7 @@ class PlaybookExtractor:
         self.service_config: PlaybookGenerationServiceConfig = service_config
         self.agent_context: str = agent_context
         self._last_resumable_run_id: str | None = None
-        self._last_resumable_trace: RunTokenTotals | None = None
+        self._last_resumable_token_totals: RunTokenTotals | None = None
 
         # Get LLM config overrides from configuration
         config = self.request_context.configurator.get_config()
@@ -225,7 +225,7 @@ class PlaybookExtractor:
             return ExtractionOutcome.completed(
                 user_playbooks,
                 run_id=self._last_resumable_run_id,
-                token_totals=self._last_resumable_trace,
+                token_totals=self._last_resumable_token_totals,
             )
         return user_playbooks
 
@@ -321,7 +321,7 @@ class PlaybookExtractor:
             log_label="Playbook extraction",
         )
         self._last_resumable_run_id = result.run_id
-        self._last_resumable_trace = sum_trace_tokens(result.trace)
+        self._last_resumable_token_totals = sum_trace_tokens(result.trace)
         if not isinstance(result.output, StructuredPlaybookList):
             logger.warning(
                 "Playbook extraction did not finish: %s",

--- a/reflexio/server/services/playbook/playbook_extractor.py
+++ b/reflexio/server/services/playbook/playbook_extractor.py
@@ -11,6 +11,7 @@ from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.services.extraction.outcome import ExtractionOutcome
+from reflexio.server.llm.token_accounting import RunTokenTotals, sum_trace_tokens
 from reflexio.server.services.extraction.resumable_agent import (
     run_resumable_extraction_agent,
 )
@@ -79,6 +80,7 @@ class PlaybookExtractor:
         self.service_config: PlaybookGenerationServiceConfig = service_config
         self.agent_context: str = agent_context
         self._last_resumable_run_id: str | None = None
+        self._last_resumable_trace: RunTokenTotals | None = None
 
         # Get LLM config overrides from configuration
         config = self.request_context.configurator.get_config()
@@ -223,6 +225,7 @@ class PlaybookExtractor:
             return ExtractionOutcome.completed(
                 user_playbooks,
                 run_id=self._last_resumable_run_id,
+                token_totals=self._last_resumable_trace,
             )
         return user_playbooks
 
@@ -318,6 +321,7 @@ class PlaybookExtractor:
             log_label="Playbook extraction",
         )
         self._last_resumable_run_id = result.run_id
+        self._last_resumable_trace = sum_trace_tokens(result.trace)
         if not isinstance(result.output, StructuredPlaybookList):
             logger.warning(
                 "Playbook extraction did not finish: %s",

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -84,6 +84,9 @@ class PlaybookGenerationService(
     Runs the configured PlaybookExtractor for each generation request.
     """
 
+    # Playbook generation produces learnings — opt in to ② Learning billing.
+    EMITS_LEARNING_BILLING: bool = True
+
     def __init__(
         self,
         llm_client: LiteLLMClient,

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -13,6 +13,7 @@ from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.extraction.outcome import ExtractionOutcome
+from reflexio.server.llm.token_accounting import RunTokenTotals, sum_trace_tokens
 from reflexio.server.services.extraction.resumable_agent import (
     run_resumable_extraction_agent,
 )
@@ -83,6 +84,7 @@ class ProfileExtractor:
         self.service_config: ProfileGenerationServiceConfig = service_config
         self.agent_context = agent_context
         self._last_resumable_run_id: str | None = None
+        self._last_resumable_trace: RunTokenTotals | None = None
 
         # Get LLM config overrides from configuration
         config = self.request_context.configurator.get_config()
@@ -238,7 +240,9 @@ class ProfileExtractor:
             )
             self._update_operation_state(request_interaction_data_models)
             return ExtractionOutcome.completed(
-                user_profiles, run_id=raw_profiles.run_id
+                user_profiles,
+                run_id=raw_profiles.run_id,
+                token_totals=raw_profiles.token_totals or self._last_resumable_trace,
             )
         user_profiles = self._convert_raw_to_user_profiles(
             raw_profiles=raw_profiles or [],
@@ -258,6 +262,7 @@ class ProfileExtractor:
             return ExtractionOutcome.completed(
                 user_profiles,
                 run_id=self._last_resumable_run_id,
+                token_totals=self._last_resumable_trace,
             )
         return user_profiles or None
 
@@ -392,6 +397,7 @@ class ProfileExtractor:
             log_label="Profile extraction",
         )
         self._last_resumable_run_id = result.run_id
+        self._last_resumable_trace = sum_trace_tokens(result.trace)
         if not isinstance(result.output, StructuredProfilesOutput):
             logger.warning(
                 "Profile extraction did not finish: %s", result.finished_reason

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -84,7 +84,7 @@ class ProfileExtractor:
         self.service_config: ProfileGenerationServiceConfig = service_config
         self.agent_context = agent_context
         self._last_resumable_run_id: str | None = None
-        self._last_resumable_trace: RunTokenTotals | None = None
+        self._last_resumable_token_totals: RunTokenTotals | None = None
 
         # Get LLM config overrides from configuration
         config = self.request_context.configurator.get_config()
@@ -245,7 +245,8 @@ class ProfileExtractor:
                 # `or` is safe: a dataclass instance (even RunTokenTotals(0,0)) is
                 # always truthy, so a real-but-zero total is never overwritten by
                 # the fallback trace.
-                token_totals=raw_profiles.token_totals or self._last_resumable_trace,
+                token_totals=raw_profiles.token_totals
+                or self._last_resumable_token_totals,
             )
         user_profiles = self._convert_raw_to_user_profiles(
             raw_profiles=raw_profiles or [],
@@ -265,7 +266,7 @@ class ProfileExtractor:
             return ExtractionOutcome.completed(
                 user_profiles,
                 run_id=self._last_resumable_run_id,
-                token_totals=self._last_resumable_trace,
+                token_totals=self._last_resumable_token_totals,
             )
         return user_profiles or None
 
@@ -400,7 +401,7 @@ class ProfileExtractor:
             log_label="Profile extraction",
         )
         self._last_resumable_run_id = result.run_id
-        self._last_resumable_trace = sum_trace_tokens(result.trace)
+        self._last_resumable_token_totals = sum_trace_tokens(result.trace)
         if not isinstance(result.output, StructuredProfilesOutput):
             logger.warning(
                 "Profile extraction did not finish: %s", result.finished_reason

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -12,8 +12,8 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
-from reflexio.server.services.extraction.outcome import ExtractionOutcome
 from reflexio.server.llm.token_accounting import RunTokenTotals, sum_trace_tokens
+from reflexio.server.services.extraction.outcome import ExtractionOutcome
 from reflexio.server.services.extraction.resumable_agent import (
     run_resumable_extraction_agent,
 )
@@ -242,6 +242,9 @@ class ProfileExtractor:
             return ExtractionOutcome.completed(
                 user_profiles,
                 run_id=raw_profiles.run_id,
+                # `or` is safe: a dataclass instance (even RunTokenTotals(0,0)) is
+                # always truthy, so a real-but-zero total is never overwritten by
+                # the fallback trace.
                 token_totals=raw_profiles.token_totals or self._last_resumable_trace,
             )
         user_profiles = self._convert_raw_to_user_profiles(

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -232,22 +232,6 @@ class ProfileExtractor:
             ) from e
 
         logger.info("Generated raw profiles: %s", raw_profiles)
-        if isinstance(raw_profiles, ExtractionOutcome):
-            user_profiles = self._convert_raw_to_user_profiles(
-                raw_profiles=raw_profiles.items,
-                user_id=self.service_config.user_id,
-                request_id=self.service_config.request_id,
-            )
-            self._update_operation_state(request_interaction_data_models)
-            return ExtractionOutcome.completed(
-                user_profiles,
-                run_id=raw_profiles.run_id,
-                # `or` is safe: a dataclass instance (even RunTokenTotals(0,0)) is
-                # always truthy, so a real-but-zero total is never overwritten by
-                # the fallback trace.
-                token_totals=raw_profiles.token_totals
-                or self._last_resumable_token_totals,
-            )
         user_profiles = self._convert_raw_to_user_profiles(
             raw_profiles=raw_profiles or [],
             user_id=self.service_config.user_id,

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -81,6 +81,9 @@ class ProfileGenerationService(
 ):
     """Service to generate user profiles from interactions"""
 
+    # Profile generation produces learnings — opt in to ② Learning billing.
+    EMITS_LEARNING_BILLING: bool = True
+
     def __init__(
         self,
         llm_client: LiteLLMClient,

--- a/reflexio/server/usage_metrics.py
+++ b/reflexio/server/usage_metrics.py
@@ -34,6 +34,12 @@ class UsageEvent:
     backend: str | None = None
     outcome: str | None = None
     count_value: int = 1
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    billing_input_tokens: int | None = None
+    platform_llm: bool | None = None
+    platform_storage: bool | None = None
+    caller_type: str | None = None
     duration_ms: int | None = None
     error_kind: str | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
@@ -73,6 +79,12 @@ def record_usage_event(
     backend: str | None = None,
     outcome: str | None = None,
     count_value: int = 1,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    billing_input_tokens: int | None = None,
+    platform_llm: bool | None = None,
+    platform_storage: bool | None = None,
+    caller_type: str | None = None,
     duration_ms: int | None = None,
     error_kind: str | None = None,
     metadata: Mapping[str, Any] | None = None,
@@ -104,6 +116,12 @@ def record_usage_event(
                 backend=backend,
                 outcome=outcome,
                 count_value=count_value,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                billing_input_tokens=billing_input_tokens,
+                platform_llm=platform_llm,
+                platform_storage=platform_storage,
+                caller_type=caller_type,
                 duration_ms=duration_ms,
                 error_kind=error_kind,
                 metadata=metadata or {},

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -8,9 +8,14 @@ dashboard callers or empty result sets.
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 
-from reflexio.models.api_schema.ui.entities import AgentPlaybookView, ProfileView
+from reflexio.models.api_schema.ui.entities import (
+    AgentPlaybookView,
+    ProfileView,
+    UserPlaybookView,
+)
 from reflexio.server.api import create_app
 from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
 
@@ -27,6 +32,10 @@ def _make_profile_view(user_id: str = "u1") -> ProfileView:
 
 def _make_agent_playbook_view() -> AgentPlaybookView:
     return AgentPlaybookView(agent_version="v1", content="content")
+
+
+def _make_user_playbook_view() -> UserPlaybookView:
+    return UserPlaybookView(agent_version="v1", request_id="r1", content="content")
 
 
 def _client(caller_type: str) -> TestClient:
@@ -90,7 +99,9 @@ def test_production_agent_search_meters_surfaced_count() -> None:
 
     applied = [e for e in events if e.event_name == "learning_applied"]
     assert len(applied) == 1
-    assert applied[0].count_value == 3  # 2 profiles + 1 agent_playbook + 0 user_playbooks
+    assert (
+        applied[0].count_value == 3
+    )  # 2 profiles + 1 agent_playbook + 0 user_playbooks
     assert applied[0].caller_type == "production_agent"
 
 
@@ -99,7 +110,9 @@ def test_dashboard_search_meters_nothing() -> None:
     events = _capture()
     try:
         with _patch_unified_search([_make_profile_view()], [], []):
-            _client("dashboard").post("/api/search", json={"query": "x", "user_id": "u1"})
+            _client("dashboard").post(
+                "/api/search", json={"query": "x", "user_id": "u1"}
+            )
     finally:
         configure_usage_event_recorder(None)
 
@@ -140,11 +153,13 @@ def test_metering_failure_does_not_break_search_response() -> None:
         mock_response.user_playbooks = []
         mock_reflexio_search.unified_search.return_value = mock_response
         # Make get_config raise so metering blows up after the search completes.
-        mock_reflexio_search.request_context.configurator.get_config.side_effect = RuntimeError(
-            "boom"
+        mock_reflexio_search.request_context.configurator.get_config.side_effect = (
+            RuntimeError("boom")
         )
 
-        with patch("reflexio.server.api.get_reflexio", return_value=mock_reflexio_search):
+        with patch(
+            "reflexio.server.api.get_reflexio", return_value=mock_reflexio_search
+        ):
             resp = _client("production_agent").post(
                 "/api/search", json={"query": "x", "user_id": "u1"}
             )
@@ -153,4 +168,143 @@ def test_metering_failure_does_not_break_search_response() -> None:
         configure_usage_event_recorder(None)
 
     # Metering failed silently — no learning_applied event should have been emitted.
+    assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+# --- Per-endpoint metering (the four non-unified routes) -----------------------
+#
+# Each of these endpoints calls a distinct service method on get_reflexio and
+# derives surfaced_count from a distinct response list attribute. The cases below
+# exercise the real endpoint handler + view conversion + _meter_applied_learnings
+# wiring for each, asserting the emitted surfaced_count matches that route's shape.
+
+
+@contextmanager
+def _patch_service_method(method_name: str, response_attr: str, items: list):
+    """Patch get_reflexio so ``method_name`` returns a canned service response.
+
+    The response carries ``items`` on ``response_attr`` (e.g. ``user_profiles``)
+    so the endpoint's view conversion and surfaced_count computation run for real.
+    get_config() returns None so platform_llm_from_config(None) is True without
+    iterating a MagicMock.
+    """
+    mock_reflexio = MagicMock()
+    mock_response = MagicMock()
+    mock_response.success = True
+    mock_response.msg = "OK"
+    setattr(mock_response, response_attr, items)
+    getattr(mock_reflexio, method_name).return_value = mock_response
+    mock_reflexio.request_context.configurator.get_config.return_value = None
+
+    with patch("reflexio.server.api.get_reflexio", return_value=mock_reflexio):
+        yield
+
+
+# (path, payload, service method, response attribute, surfaced item factory)
+_ENDPOINT_CASES = [
+    pytest.param(
+        "/api/search_profiles",
+        {"user_id": "u1", "query": "x"},
+        "search_user_profiles",
+        "user_profiles",
+        _make_profile_view,
+        id="search_profiles",
+    ),
+    pytest.param(
+        "/api/search_user_playbooks",
+        {"query": "x"},
+        "search_user_playbooks",
+        "user_playbooks",
+        _make_user_playbook_view,
+        id="search_user_playbooks",
+    ),
+    pytest.param(
+        "/api/search_agent_playbooks",
+        {"query": "x"},
+        "search_agent_playbooks",
+        "agent_playbooks",
+        _make_agent_playbook_view,
+        id="search_agent_playbooks",
+    ),
+    pytest.param(
+        "/api/get_agent_playbooks",
+        {},
+        "get_agent_playbooks",
+        "agent_playbooks",
+        _make_agent_playbook_view,
+        id="get_agent_playbooks",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "method_name", "response_attr", "make_item"),
+    _ENDPOINT_CASES,
+)
+def test_production_agent_per_endpoint_meters_surfaced_count(
+    path: str,
+    payload: dict,
+    method_name: str,
+    response_attr: str,
+    make_item,
+) -> None:
+    """Each non-unified route emits one learning_applied event with its own count."""
+    events = _capture()
+    items = [make_item(), make_item()]
+    try:
+        with _patch_service_method(method_name, response_attr, items):
+            resp = _client("production_agent").post(path, json=payload)
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    applied = [e for e in events if e.event_name == "learning_applied"]
+    assert len(applied) == 1
+    assert applied[0].count_value == 2  # len(items) for this endpoint's response shape
+    assert applied[0].caller_type == "production_agent"
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "method_name", "response_attr", "make_item"),
+    _ENDPOINT_CASES,
+)
+def test_dashboard_per_endpoint_meters_nothing(
+    path: str,
+    payload: dict,
+    method_name: str,
+    response_attr: str,
+    make_item,
+) -> None:
+    """A dashboard caller never meters, regardless of the route or result size."""
+    events = _capture()
+    try:
+        with _patch_service_method(method_name, response_attr, [make_item()]):
+            resp = _client("dashboard").post(path, json=payload)
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "method_name", "response_attr", "make_item"),
+    _ENDPOINT_CASES,
+)
+def test_empty_result_per_endpoint_meters_nothing(
+    path: str,
+    payload: dict,
+    method_name: str,
+    response_attr: str,
+    make_item,
+) -> None:
+    """A production-agent call surfacing zero results meters nothing on any route."""
+    events = _capture()
+    try:
+        with _patch_service_method(method_name, response_attr, []):
+            resp = _client("production_agent").post(path, json=payload)
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
     assert [e for e in events if e.event_name == "learning_applied"] == []

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -38,8 +38,12 @@ def _make_user_playbook_view() -> UserPlaybookView:
     return UserPlaybookView(agent_version="v1", request_id="r1", content="content")
 
 
-def _client(caller_type: str) -> TestClient:
-    app = create_app(get_org_id=lambda: "test-org", get_caller_type=lambda: caller_type)
+def _client(caller_type: str, get_billing_gate=None) -> TestClient:
+    app = create_app(
+        get_org_id=lambda: "test-org",
+        get_caller_type=lambda: caller_type,
+        get_billing_gate=get_billing_gate,
+    )
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -131,6 +135,44 @@ def test_empty_result_meters_nothing() -> None:
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+def test_get_billing_gate_override_seam() -> None:
+    """create_app wires the get_billing_gate override for every billing line.
+
+    The enterprise enforcement gate is injected through this seam: create_app must
+    register an override for each line ("application" + "learnings_generated"),
+    keyed by the lru_cached ``default_billing_gate`` sentinel the routes depend on,
+    and the override must actually fire when an application route is served. This
+    pins the core DI contract so it can't silently regress.
+    """
+    from reflexio.server.api import default_billing_gate
+
+    fired: list[str] = []
+
+    def gate_factory(line: str):
+        def _gate() -> None:
+            fired.append(line)
+
+        return _gate
+
+    app = create_app(
+        get_org_id=lambda: "test-org",
+        get_caller_type=lambda: "production_agent",
+        get_billing_gate=gate_factory,
+    )
+
+    # Both billing lines are overridden, keyed by the exact sentinel the routes use.
+    overrides = app.dependency_overrides
+    assert default_billing_gate("application") in overrides
+    assert default_billing_gate("learnings_generated") in overrides
+
+    # The "application" override fires for real on an application route.
+    client = TestClient(app, raise_server_exceptions=False)
+    with _patch_unified_search([_make_profile_view()], [], []):
+        resp = client.post("/api/search", json={"query": "x", "user_id": "u1"})
+    assert resp.status_code == 200
+    assert "application" in fired
 
 
 def test_metering_failure_does_not_break_search_response() -> None:

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -1,0 +1,120 @@
+"""Tests for applied-learnings metering at search endpoints.
+
+Verifies that ``_meter_applied_learnings`` emits exactly one ``learning_applied``
+usage event when a production-agent caller surfaces >= 1 result, and nothing for
+dashboard callers or empty result sets.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from reflexio.models.api_schema.ui.entities import AgentPlaybookView, ProfileView
+from reflexio.server.api import create_app
+from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
+
+
+def _make_profile_view(user_id: str = "u1") -> ProfileView:
+    return ProfileView(
+        profile_id="p1",
+        user_id=user_id,
+        content="content",
+        last_modified_timestamp=0,
+        generated_from_request_id="r1",
+    )
+
+
+def _make_agent_playbook_view() -> AgentPlaybookView:
+    return AgentPlaybookView(agent_version="v1", content="content")
+
+
+def _client(caller_type: str) -> TestClient:
+    app = create_app(get_org_id=lambda: "test-org", get_caller_type=lambda: caller_type)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@contextmanager
+def _patch_unified_search(
+    profiles: list,
+    agent_playbooks: list,
+    user_playbooks: list,
+):
+    """Patch get_reflexio so the unified_search method returns a canned service response.
+
+    The mock response carries properly-sized lists so the view converters succeed.
+    get_config() returns None so platform_llm_from_config(None) returns True without
+    iterating MagicMock values.
+    """
+    mock_reflexio = MagicMock()
+    # Set up the service-level response (not the view response).
+    # The endpoint calls unified_search then wraps each item with to_*_view().
+    # We need the response's list attributes to hold properly-typed objects.
+    mock_response = MagicMock()
+    mock_response.success = True
+    mock_response.msg = "OK"
+    mock_response.reformulated_query = None
+    mock_response.agent_trace = None
+    mock_response.rehydrated_text = None
+    mock_response.profiles = profiles
+    mock_response.agent_playbooks = agent_playbooks
+    mock_response.user_playbooks = user_playbooks
+    mock_reflexio.unified_search.return_value = mock_response
+    # Prevent platform_llm_from_config from iterating MagicMock.values()
+    mock_reflexio.request_context.configurator.get_config.return_value = None
+
+    with patch("reflexio.server.api.get_reflexio", return_value=mock_reflexio):
+        yield
+
+
+def _capture() -> list[UsageEvent]:
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    return events
+
+
+def test_production_agent_search_meters_surfaced_count() -> None:
+    """A production-agent call with results emits one learning_applied event."""
+    events = _capture()
+    profiles = [_make_profile_view("u1"), _make_profile_view("u2")]
+    agent_playbooks = [_make_agent_playbook_view()]
+    user_playbooks: list = []
+    try:
+        with _patch_unified_search(profiles, agent_playbooks, user_playbooks):
+            resp = _client("production_agent").post(
+                "/api/search", json={"query": "x", "user_id": "u1"}
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    applied = [e for e in events if e.event_name == "learning_applied"]
+    assert len(applied) == 1
+    assert applied[0].count_value == 3  # 2 profiles + 1 agent_playbook + 0 user_playbooks
+    assert applied[0].caller_type == "production_agent"
+
+
+def test_dashboard_search_meters_nothing() -> None:
+    """A dashboard (JWT) caller never emits learning_applied regardless of results."""
+    events = _capture()
+    try:
+        with _patch_unified_search([_make_profile_view()], [], []):
+            _client("dashboard").post("/api/search", json={"query": "x", "user_id": "u1"})
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+def test_empty_result_meters_nothing() -> None:
+    """A production-agent call that surfaces zero results emits nothing."""
+    events = _capture()
+    try:
+        with _patch_unified_search([], [], []):
+            _client("production_agent").post(
+                "/api/search", json={"query": "x", "user_id": "u1"}
+            )
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert [e for e in events if e.event_name == "learning_applied"] == []

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -118,3 +118,39 @@ def test_empty_result_meters_nothing() -> None:
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+def test_metering_failure_does_not_break_search_response() -> None:
+    """A get_reflexio error inside the metering helper must not turn a 200 into a 500."""
+    events = _capture()
+    profiles = [_make_profile_view("u1")]
+    try:
+        # The unified_search mock is wired via _patch_unified_search (first get_reflexio call).
+        # Inside the helper, get_reflexio is called a second time; we make *that* call's
+        # get_config raise so the metering path fails while the search response succeeds.
+        mock_reflexio_search = MagicMock()
+        mock_response = MagicMock()
+        mock_response.success = True
+        mock_response.msg = "OK"
+        mock_response.reformulated_query = None
+        mock_response.agent_trace = None
+        mock_response.rehydrated_text = None
+        mock_response.profiles = profiles
+        mock_response.agent_playbooks = []
+        mock_response.user_playbooks = []
+        mock_reflexio_search.unified_search.return_value = mock_response
+        # Make get_config raise so metering blows up after the search completes.
+        mock_reflexio_search.request_context.configurator.get_config.side_effect = RuntimeError(
+            "boom"
+        )
+
+        with patch("reflexio.server.api.get_reflexio", return_value=mock_reflexio_search):
+            resp = _client("production_agent").post(
+                "/api/search", json={"query": "x", "user_id": "u1"}
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    # Metering failed silently — no learning_applied event should have been emitted.
+    assert [e for e in events if e.event_name == "learning_applied"] == []

--- a/tests/server/llm/test_token_accounting.py
+++ b/tests/server/llm/test_token_accounting.py
@@ -1,0 +1,107 @@
+"""Unit tests for the OSS per-run token accounting helpers.
+
+Covers ``RunTokenTotals.add`` (including the ``int(x or 0)`` None->0 coercion)
+and ``sum_trace_tokens`` (the missing/empty ``turns`` guard and summation across
+turns).
+"""
+
+from types import SimpleNamespace
+
+from reflexio.server.llm.token_accounting import RunTokenTotals, sum_trace_tokens
+
+
+def test_run_token_totals_default_zero() -> None:
+    """A fresh RunTokenTotals starts at zero on both counters."""
+    totals = RunTokenTotals()
+    assert totals.prompt_tokens == 0
+    assert totals.completion_tokens == 0
+
+
+def test_add_accumulates_across_calls() -> None:
+    """Repeated .add calls accumulate prompt and completion tokens independently."""
+    totals = RunTokenTotals()
+    totals.add(prompt_tokens=10, completion_tokens=3)
+    totals.add(prompt_tokens=5, completion_tokens=7)
+    assert totals.prompt_tokens == 15
+    assert totals.completion_tokens == 10
+
+
+def test_add_coerces_none_to_zero() -> None:
+    """None token values are coerced to 0 via int(x or 0), not raising."""
+    totals = RunTokenTotals(prompt_tokens=4, completion_tokens=2)
+    totals.add(prompt_tokens=None, completion_tokens=None)
+    assert totals.prompt_tokens == 4
+    assert totals.completion_tokens == 2
+
+
+def test_add_mixed_none_and_value() -> None:
+    """A None on one axis coerces to 0 while the other axis still accumulates."""
+    totals = RunTokenTotals()
+    totals.add(prompt_tokens=None, completion_tokens=9)
+    totals.add(prompt_tokens=6, completion_tokens=None)
+    assert totals.prompt_tokens == 6
+    assert totals.completion_tokens == 9
+
+
+def test_sum_trace_tokens_empty_turns() -> None:
+    """A trace whose turns list is empty folds to zeros."""
+    trace = SimpleNamespace(turns=[])
+    totals = sum_trace_tokens(trace)
+    assert totals.prompt_tokens == 0
+    assert totals.completion_tokens == 0
+
+
+def test_sum_trace_tokens_missing_turns_attribute() -> None:
+    """A trace with no ``turns`` attribute at all folds to zeros (getattr default)."""
+    trace = SimpleNamespace()
+    totals = sum_trace_tokens(trace)
+    assert totals.prompt_tokens == 0
+    assert totals.completion_tokens == 0
+
+
+def test_sum_trace_tokens_none_turns() -> None:
+    """A trace whose ``turns`` is None folds to zeros via the ``or []`` guard."""
+    trace = SimpleNamespace(turns=None)
+    totals = sum_trace_tokens(trace)
+    assert totals.prompt_tokens == 0
+    assert totals.completion_tokens == 0
+
+
+def test_sum_trace_tokens_sums_multiple_turns() -> None:
+    """Token counts are summed across multiple turns."""
+    trace = SimpleNamespace(
+        turns=[
+            SimpleNamespace(prompt_tokens=10, completion_tokens=2),
+            SimpleNamespace(prompt_tokens=20, completion_tokens=5),
+            SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        ]
+    )
+    totals = sum_trace_tokens(trace)
+    assert totals.prompt_tokens == 31
+    assert totals.completion_tokens == 8
+
+
+def test_sum_trace_tokens_turn_missing_token_attrs() -> None:
+    """Turns missing token attributes contribute 0 (getattr default -> None -> 0)."""
+    trace = SimpleNamespace(
+        turns=[
+            SimpleNamespace(prompt_tokens=4, completion_tokens=3),
+            SimpleNamespace(),  # no prompt_tokens / completion_tokens
+        ]
+    )
+    totals = sum_trace_tokens(trace)
+    assert totals.prompt_tokens == 4
+    assert totals.completion_tokens == 3
+
+
+def test_sum_trace_tokens_turn_none_token_values() -> None:
+    """Turns with explicit None token values contribute 0 via .add coercion."""
+    trace = SimpleNamespace(
+        turns=[
+            SimpleNamespace(prompt_tokens=None, completion_tokens=None),
+            SimpleNamespace(prompt_tokens=8, completion_tokens=6),
+        ]
+    )
+    totals = sum_trace_tokens(trace)
+    assert totals.prompt_tokens == 8
+    assert totals.completion_tokens == 6

--- a/tests/server/services/test_generation_billing_emission.py
+++ b/tests/server/services/test_generation_billing_emission.py
@@ -22,6 +22,7 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.billing_signals import count_input_tokens
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
@@ -29,10 +30,12 @@ from reflexio.server.services.base_generation_service import (
 )
 from reflexio.server.services.profile.profile_generation_service import (
     ProfileGenerationService,
+    ProfileGenerationServiceConfig,
 )
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileGenerationRequest,
 )
+from reflexio.server.services.service_utils import format_sessions_to_history_string
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
 
@@ -349,3 +352,128 @@ def test_non_learning_service_emits_no_learning_billing_events():
     assert learning_events == [], (
         f"EMITS_LEARNING_BILLING=False service must not emit learning events; got: {learning_events}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Dedup: billing reuses the should-run gate's already-fetched window instead of
+# re-querying storage purely to recompute billing_input_tokens.
+# ---------------------------------------------------------------------------
+
+
+def _build_profile_service(storage: SQLiteStorage) -> ProfileGenerationService:
+    """Build a ProfileGenerationService over ``storage`` with service_config primed."""
+    ctx = _request_context(storage)
+    llm_client = LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini"))
+    service = ProfileGenerationService(llm_client=llm_client, request_context=ctx)
+    service.service_config = ProfileGenerationServiceConfig(
+        user_id=_USER_ID,
+        request_id=_REQUEST_ID,
+        source="api",
+        auto_run=True,
+    )
+    return service
+
+
+def _known_sessions(storage: SQLiteStorage) -> list[Any]:
+    """Return realistic RequestInteractionDataModel objects from real storage.
+
+    Seeds substantive interactions and reads them back through the same storage
+    method (`get_last_k_interactions_grouped`) the billing path uses, so the
+    session models have the exact shape `format_sessions_to_history_string`
+    consumes in production.
+    """
+    _seed_interactions(storage)
+    sessions, _ = storage.get_last_k_interactions_grouped(
+        user_id=_USER_ID, k=10, sources=["api"]
+    )
+    assert sessions, "expected seeded interactions to be returned"
+    return sessions
+
+
+def _prepared() -> PreparedGenerationRun[Any]:
+    """A minimal prepared run with a real profile extractor config."""
+    return PreparedGenerationRun(
+        extractor_config=ProfileExtractorConfig(
+            extractor_name="billing_test_extractor",
+            extraction_definition_prompt="Extract durable preferences.",
+        ),
+        extractor_name="billing_test_extractor",
+        identifier=_USER_ID,
+    )
+
+
+def test_billing_reuses_precheck_window_without_refetch(tmp_path):
+    """When the gate stashed its window, billing reuses it and skips storage.
+
+    Proves the dedup: `_extraction_input_text` returns the formatted text of the
+    stashed sessions and never calls `get_last_k_interactions_grouped`.
+    """
+    storage = _build_sqlite_storage(tmp_path)
+    known_sessions = _known_sessions(storage)
+    expected_text = format_sessions_to_history_string(known_sessions)
+
+    service = _build_profile_service(storage)
+    service._last_precheck_sessions = known_sessions
+    # Replace storage with a mock so any storage read would be observable.
+    service.storage = MagicMock()
+
+    text = service._extraction_input_text(_prepared())
+
+    assert text == expected_text
+    service.storage.get_last_k_interactions_grouped.assert_not_called()
+
+
+def test_billing_refetches_when_no_precheck_window(tmp_path):
+    """When the gate did NOT pre-fetch, billing falls back to its own storage read.
+
+    Proves the fallback still works on bypass paths: with the stash None,
+    `_extraction_input_text` calls `get_last_k_interactions_grouped` exactly once
+    and returns the same formatted text.
+    """
+    storage = _build_sqlite_storage(tmp_path)
+    known_sessions = _known_sessions(storage)
+    expected_text = format_sessions_to_history_string(known_sessions)
+
+    service = _build_profile_service(storage)
+    service._last_precheck_sessions = None
+    mock_storage = MagicMock()
+    mock_storage.get_last_k_interactions_grouped.return_value = (known_sessions, None)
+    service.storage = mock_storage
+
+    text = service._extraction_input_text(_prepared())
+
+    assert text == expected_text
+    mock_storage.get_last_k_interactions_grouped.assert_called_once()
+
+
+def test_billing_token_count_unchanged_reuse_vs_refetch(tmp_path):
+    """Equivalence guard: the reuse path and the refetch path bill identically.
+
+    For the same window, the reuse-path text must equal the refetch-path text and
+    `count_input_tokens` must agree — the metered quantity is byte-identical, so
+    the refactor cannot change a customer's bill.
+    """
+    storage = _build_sqlite_storage(tmp_path)
+    known_sessions = _known_sessions(storage)
+
+    # Reuse path: stash set, storage mocked to prove no read happens.
+    reuse_service = _build_profile_service(storage)
+    reuse_service._last_precheck_sessions = known_sessions
+    reuse_service.storage = MagicMock()
+    reuse_text = reuse_service._extraction_input_text(_prepared())
+    reuse_service.storage.get_last_k_interactions_grouped.assert_not_called()
+
+    # Refetch path: stash None, storage returns the same window.
+    refetch_service = _build_profile_service(storage)
+    refetch_service._last_precheck_sessions = None
+    refetch_storage = MagicMock()
+    refetch_storage.get_last_k_interactions_grouped.return_value = (
+        known_sessions,
+        None,
+    )
+    refetch_service.storage = refetch_storage
+    refetch_text = refetch_service._extraction_input_text(_prepared())
+    refetch_storage.get_last_k_interactions_grouped.assert_called_once()
+
+    assert reuse_text == refetch_text
+    assert count_input_tokens(reuse_text) == count_input_tokens(refetch_text)

--- a/tests/server/services/test_generation_billing_emission.py
+++ b/tests/server/services/test_generation_billing_emission.py
@@ -4,6 +4,8 @@ Verifies that:
 - A real extraction emits ``extraction_tokens`` and ``learnings_generated`` events.
 - A should_run-skipped request emits NO billing learning events (but the ops gate
   event still fires with ``outcome=should_skip``).
+- AgentSuccessEvaluationService (EMITS_LEARNING_BILLING=False) never emits ②
+  Learning events — the gate blocks it regardless of outcome.
 
 Uses the verified SQLite + litellm mock harness so no real LLM calls are made.
 """
@@ -21,6 +23,10 @@ from reflexio.models.config_schema import (
 )
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.server.services.base_generation_service import (
+    BaseGenerationService,
+    PreparedGenerationRun,
+)
 from reflexio.server.services.profile.profile_generation_service import (
     ProfileGenerationService,
 )
@@ -249,4 +255,97 @@ def test_should_run_skip_emits_no_learning_billing(tmp_path, monkeypatch):
     gate_events = [e for e in events if e.event_name == "generation_gate_evaluated"]
     assert any(e.outcome == "should_skip" for e in gate_events), (
         f"expected should_skip gate event, got: {gate_events}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate test: non-learning services must NEVER emit ② Learning billing events
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_request_context() -> RequestContext:
+    """Return a RequestContext with a minimal Config (no profile/playbook config)."""
+    ctx = RequestContext.__new__(RequestContext)
+    ctx.org_id = _ORG_ID
+    ctx.storage = MagicMock()
+    ctx.storage_base_dir = None
+    ctx.configurator = MagicMock()
+    ctx.configurator.get_config.return_value = Config(
+        storage_config=StorageConfigSQLite(),
+    )
+    ctx.configurator.get_agent_context.return_value = "gate test context"
+    ctx.prompt_manager = MagicMock()
+    return ctx
+
+
+class _StubService(BaseGenerationService):  # type: ignore[type-arg]
+    """Minimal concrete subclass with EMITS_LEARNING_BILLING=False (the default).
+
+    Used to assert that the gate blocks ② Learning emission when a service has
+    not opted in.  Mirrors what AgentSuccessEvaluationService and any other
+    bundled service would look like.
+    """
+
+    EMITS_LEARNING_BILLING: bool = False  # explicit; also inherited default
+
+    def _load_extractor_config(self):  # pragma: no cover
+        return None
+
+    def _load_generation_service_config(self, request):  # pragma: no cover
+        return request
+
+    def _create_extractor(self, extractor_config, service_config):  # pragma: no cover
+        return MagicMock()
+
+    def _get_service_name(self) -> str:
+        return "stub_evaluation"
+
+    def _get_base_service_name(self) -> str:
+        return "stub_evaluation"
+
+    def _process_results(self, results):  # pragma: no cover
+        pass
+
+    def _should_track_in_progress(self) -> bool:
+        return False
+
+    def _get_lock_scope_id(self, request):  # pragma: no cover
+        return None
+
+
+def test_non_learning_service_emits_no_learning_billing_events():
+    """Services with EMITS_LEARNING_BILLING=False must emit zero ② Learning events.
+
+    The test directly calls ``_record_billing_learning_events`` (with a recorder
+    installed) and asserts that neither ``learnings_generated`` nor
+    ``extraction_tokens`` are emitted.  This proves the opt-in gate works
+    regardless of ``generated_count``, mirroring how AgentSuccessEvaluationService
+    behaves.
+    """
+    ctx = _make_minimal_request_context()
+    llm_client = LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini"))
+    service = _StubService(llm_client=llm_client, request_context=ctx)
+    # Prime service_config so _usage_context() doesn't choke
+    service.service_config = MagicMock()
+
+    prepared = PreparedGenerationRun(
+        extractor_config=MagicMock(),
+        extractor_name="stub_extractor",
+        identifier="stub_user",
+    )
+
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        service._record_billing_learning_events(prepared=prepared, generated_count=5)
+    finally:
+        configure_usage_event_recorder(None)
+
+    learning_events = [
+        e
+        for e in events
+        if e.event_name in {"learnings_generated", "extraction_tokens"}
+    ]
+    assert learning_events == [], (
+        f"EMITS_LEARNING_BILLING=False service must not emit learning events; got: {learning_events}"
     )

--- a/tests/server/services/test_generation_billing_emission.py
+++ b/tests/server/services/test_generation_billing_emission.py
@@ -1,0 +1,252 @@
+"""Tests for ② Learning billing event emission at the generation service layer.
+
+Verifies that:
+- A real extraction emits ``extraction_tokens`` and ``learnings_generated`` events.
+- A should_run-skipped request emits NO billing learning events (but the ops gate
+  event still fires with ``outcome=should_skip``).
+
+Uses the verified SQLite + litellm mock harness so no real LLM calls are made.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from reflexio.models.api_schema.service_schemas import Interaction, Request
+from reflexio.models.config_schema import (
+    Config,
+    ProfileExtractorConfig,
+    StorageConfigSQLite,
+)
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.server.services.profile.profile_generation_service import (
+    ProfileGenerationService,
+)
+from reflexio.server.services.profile.profile_generation_service_utils import (
+    ProfileGenerationRequest,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
+
+# ---------------------------------------------------------------------------
+# Helpers: build a RequestContext backed by a real SQLiteStorage, mirroring
+# the pattern from tests/e2e_tests/test_resumable_extraction_e2e.py.
+# ---------------------------------------------------------------------------
+
+_ORG_ID = "billing_emission_test_org"
+_USER_ID = "billing_emission_user"
+_REQUEST_ID = "billing_emission_req_1"
+
+
+def _request_context(storage: SQLiteStorage) -> RequestContext:
+    """Build a RequestContext wired to ``storage``, with a fixed Config."""
+    ctx = RequestContext.__new__(RequestContext)
+    ctx.org_id = _ORG_ID
+    ctx.storage = storage
+    ctx.storage_base_dir = None
+    ctx.configurator = MagicMock()
+    ctx.configurator.get_config.return_value = Config(
+        storage_config=StorageConfigSQLite(),
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="billing_test_extractor",
+            extraction_definition_prompt="Extract durable preferences.",
+        ),
+    )
+    ctx.configurator.get_agent_context.return_value = "Billing test agent context"
+    ctx.prompt_manager = MagicMock()
+    ctx.prompt_manager.render_prompt.side_effect = lambda prompt_id, variables: (
+        f"{prompt_id}: {variables}"
+    )
+    return ctx
+
+
+def _build_sqlite_storage(tmp_path: Any) -> SQLiteStorage:
+    """Create a SQLiteStorage with _get_embedding patched to a zero vector."""
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        return SQLiteStorage(org_id=_ORG_ID, db_path=str(tmp_path / "reflexio.db"))
+
+
+def _seed_interactions(storage: SQLiteStorage) -> None:
+    """Seed substantive interactions that should trigger extraction."""
+    storage.add_request(
+        Request(
+            request_id=_REQUEST_ID,
+            user_id=_USER_ID,
+            created_at=1_000,
+            source="api",
+            agent_version="v1",
+            session_id=_REQUEST_ID,
+        )
+    )
+    storage._insert_interaction(
+        Interaction(
+            interaction_id=1,
+            user_id=_USER_ID,
+            request_id=_REQUEST_ID,
+            created_at=1_000,
+            role="user",
+            content=(
+                "Please remember that I always prefer dark-mode UIs and prefer "
+                "concise answers without emojis. This is important for my workflow."
+            ),
+        )
+    )
+    storage._insert_interaction(
+        Interaction(
+            interaction_id=2,
+            user_id=_USER_ID,
+            request_id=_REQUEST_ID,
+            created_at=1_001,
+            role="assistant",
+            content="Understood, I will remember those preferences.",
+        )
+    )
+
+
+def _run_profile_generation(storage: SQLiteStorage, *, auto_run: bool = True) -> None:
+    """Run one ProfileGenerationService extraction over the given storage."""
+    ctx = _request_context(storage)
+    llm_config = LiteLLMConfig(model="gpt-4o-mini")
+    llm_client = LiteLLMClient(llm_config)
+    service = ProfileGenerationService(llm_client=llm_client, request_context=ctx)
+    request = ProfileGenerationRequest(
+        user_id=_USER_ID,
+        request_id=_REQUEST_ID,
+        source="api",
+        auto_run=auto_run,
+    )
+    service.run(request)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_real_extraction_emits_tokens_and_learnings(tmp_path):
+    """A successful extraction emits extraction_tokens + learnings_generated.
+
+    MOCK_LLM_RESPONSE=true is active (autouse conftest), so the profile extractor
+    takes the deterministic mock path and we verify the billing events it triggers.
+    auto_run=False bypasses the should_run gate so extraction always fires.
+    """
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            storage = SQLiteStorage(
+                org_id=_ORG_ID, db_path=str(tmp_path / "reflexio.db")
+            )
+            _seed_interactions(storage)
+            _run_profile_generation(storage, auto_run=False)
+    finally:
+        configure_usage_event_recorder(None)
+
+    learning = [e for e in events if e.event_category == "learning"]
+    names = {e.event_name for e in learning}
+    assert "extraction_tokens" in names, f"expected extraction_tokens in {names}"
+    assert "learnings_generated" in names, f"expected learnings_generated in {names}"
+
+    # extraction_tokens.count_value is the input-anchored basis (> 0 because the
+    # interactions are non-empty), independent of whatever the mock reports.
+    tok = next(e for e in learning if e.event_name == "extraction_tokens")
+    assert tok.count_value > 0
+    assert tok.billing_input_tokens == tok.count_value
+    assert tok.platform_llm is True  # no api_key_config in the seeded Config
+
+    # learnings_generated.count_value must equal the existing generation_succeeded count.
+    gen = next(e for e in learning if e.event_name == "learnings_generated")
+    succ = next(e for e in events if e.event_name == "generation_succeeded")
+    assert gen.count_value == succ.count_value
+
+
+def test_should_run_skip_emits_no_learning_billing(tmp_path, monkeypatch):
+    """A should_run-gated skip emits NO extraction_tokens / learnings_generated.
+
+    The ops gate event still fires with outcome=should_skip. We:
+    - Clear MOCK_LLM_RESPONSE so the pre-extraction gate is not bypassed.
+    - Set stride_size=1 and seed a short interaction so the stride check passes
+      but the cheap pre-filter rejects the batch (all_user_turns_too_short).
+    """
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            storage = SQLiteStorage(
+                org_id=_ORG_ID, db_path=str(tmp_path / "reflexio.db")
+            )
+            # Seed a very short interaction (< 30 chars) that the cheap pre-filter
+            # rejects as "all_user_turns_too_short".
+            storage.add_request(
+                Request(
+                    request_id=_REQUEST_ID,
+                    user_id=_USER_ID,
+                    created_at=1_000,
+                    source="api",
+                    session_id=_REQUEST_ID,
+                )
+            )
+            storage._insert_interaction(
+                Interaction(
+                    interaction_id=1,
+                    user_id=_USER_ID,
+                    request_id=_REQUEST_ID,
+                    created_at=1_000,
+                    role="User",
+                    content="hi",  # << 30 chars → all_user_turns_too_short
+                )
+            )
+
+            # Build a custom request context with stride_size=1 so the stride
+            # pre-filter passes (new=1, stride_size=1).
+            ctx = RequestContext.__new__(RequestContext)
+            ctx.org_id = _ORG_ID
+            ctx.storage = storage
+            ctx.storage_base_dir = None
+            ctx.configurator = MagicMock()
+            ctx.configurator.get_config.return_value = Config(
+                storage_config=StorageConfigSQLite(),
+                profile_extractor_config=ProfileExtractorConfig(
+                    extractor_name="billing_test_extractor",
+                    extraction_definition_prompt="Extract durable preferences.",
+                ),
+                stride_size=1,
+            )
+            ctx.configurator.get_agent_context.return_value = "Billing skip test"
+            ctx.prompt_manager = MagicMock()
+            ctx.prompt_manager.render_prompt.side_effect = lambda prompt_id, variables: (
+                f"{prompt_id}: {variables}"
+            )
+
+            llm_config = LiteLLMConfig(model="gpt-4o-mini")
+            llm_client = LiteLLMClient(llm_config)
+            service = ProfileGenerationService(
+                llm_client=llm_client, request_context=ctx
+            )
+            request = ProfileGenerationRequest(
+                user_id=_USER_ID,
+                request_id=_REQUEST_ID,
+                source="api",
+                auto_run=True,
+            )
+            service.run(request)
+    finally:
+        configure_usage_event_recorder(None)
+
+    billing_learning = [
+        e
+        for e in events
+        if e.event_category == "learning"
+        and e.event_name in {"extraction_tokens", "learnings_generated"}
+    ]
+    assert billing_learning == [], f"unexpected billing events: {billing_learning}"
+
+    # The existing ops event still fires with the skip outcome.
+    gate_events = [e for e in events if e.event_name == "generation_gate_evaluated"]
+    assert any(e.outcome == "should_skip" for e in gate_events), (
+        f"expected should_skip gate event, got: {gate_events}"
+    )

--- a/tests/server/test_billing_meter.py
+++ b/tests/server/test_billing_meter.py
@@ -1,0 +1,81 @@
+from unittest.mock import patch
+
+from reflexio.server.billing_meter import (
+    record_applied_learnings,
+    record_extraction_tokens,
+    record_learnings_generated,
+)
+
+HOOK = "reflexio.server.billing_meter.record_usage_event"
+
+
+def test_record_extraction_tokens_emits_event_when_platform_llm():
+    with patch(HOOK) as hook:
+        record_extraction_tokens(
+            org_id="org1", billing_input_tokens=1100, prompt_tokens=1200,
+            completion_tokens=300, platform_llm=True, platform_storage=None, pipeline="profile",
+        )
+    hook.assert_called_once()
+    kwargs = hook.call_args.kwargs
+    assert kwargs["event_name"] == "extraction_tokens"
+    assert kwargs["event_category"] == "learning"
+    assert kwargs["count_value"] == 1100   # billing_input_tokens is the metered count
+    assert kwargs["prompt_tokens"] == 1200
+    assert kwargs["platform_llm"] is True
+    assert kwargs["caller_type"] == "internal"
+
+
+def test_record_extraction_tokens_still_captures_on_byo_llm():
+    # Even on BYO-LLM we capture (platform_llm=False); the rating layer drops the charge.
+    with patch(HOOK) as hook:
+        record_extraction_tokens(
+            org_id="org1", billing_input_tokens=850, prompt_tokens=900,
+            completion_tokens=100, platform_llm=False, platform_storage=None,
+        )
+    assert hook.call_args.kwargs["platform_llm"] is False
+
+
+def test_record_extraction_tokens_noop_when_zero_input():
+    with patch(HOOK) as hook:
+        record_extraction_tokens(org_id="org1", billing_input_tokens=0, prompt_tokens=0,
+                                 completion_tokens=0, platform_llm=True, platform_storage=None)
+    hook.assert_not_called()
+
+
+def test_record_learnings_generated_uses_count_value():
+    with patch(HOOK) as hook:
+        record_learnings_generated(org_id="org1", count=3, platform_llm=True,
+                                   platform_storage=None, pipeline="playbook")
+    kwargs = hook.call_args.kwargs
+    assert kwargs["event_name"] == "learnings_generated"
+    assert kwargs["event_category"] == "learning"
+    assert kwargs["count_value"] == 3
+
+
+def test_record_learnings_generated_noop_for_zero():
+    with patch(HOOK) as hook:
+        record_learnings_generated(org_id="org1", count=0, platform_llm=True, platform_storage=None)
+    hook.assert_not_called()
+
+
+def test_record_applied_learnings_billable_only_for_production_agent():
+    with patch(HOOK) as hook:
+        record_applied_learnings(org_id="org1", surfaced_count=4,
+                                 caller_type="production_agent", platform_llm=True, platform_storage=None)
+    assert hook.call_count == 1
+    assert hook.call_args.kwargs["count_value"] == 4
+    assert hook.call_args.kwargs["caller_type"] == "production_agent"
+
+
+def test_record_applied_learnings_noop_for_dashboard():
+    with patch(HOOK) as hook:
+        record_applied_learnings(org_id="org1", surfaced_count=4,
+                                 caller_type="dashboard", platform_llm=True, platform_storage=None)
+    hook.assert_not_called()
+
+
+def test_record_applied_learnings_noop_for_empty_result():
+    with patch(HOOK) as hook:
+        record_applied_learnings(org_id="org1", surfaced_count=0,
+                                 caller_type="production_agent", platform_llm=True, platform_storage=None)
+    hook.assert_not_called()

--- a/tests/server/test_billing_meter.py
+++ b/tests/server/test_billing_meter.py
@@ -32,7 +32,18 @@ def test_record_extraction_tokens_still_captures_on_byo_llm():
             org_id="org1", billing_input_tokens=850, prompt_tokens=900,
             completion_tokens=100, platform_llm=False, platform_storage=None,
         )
+    hook.assert_called_once()
     assert hook.call_args.kwargs["platform_llm"] is False
+
+
+def test_record_extraction_tokens_noop_on_negative():
+    # Negative billing_input_tokens (e.g. from a corrupt trace) must not emit an event.
+    with patch(HOOK) as hook:
+        record_extraction_tokens(
+            org_id="org1", billing_input_tokens=-1, prompt_tokens=0,
+            completion_tokens=0, platform_llm=True, platform_storage=None,
+        )
+    hook.assert_not_called()
 
 
 def test_record_extraction_tokens_noop_when_zero_input():

--- a/tests/server/test_billing_signals.py
+++ b/tests/server/test_billing_signals.py
@@ -1,7 +1,29 @@
 """Unit tests for the OSS billing-signals helper."""
 
 from reflexio.models.config_schema import APIKeyConfig, Config, OpenAIConfig
-from reflexio.server.billing_signals import platform_llm_from_config
+from reflexio.server.billing_signals import count_input_tokens, platform_llm_from_config
+
+
+def test_count_input_tokens_empty_string_is_zero():
+    """Empty input short-circuits to 0 without invoking the encoder."""
+    assert count_input_tokens("") == 0
+
+
+def test_count_input_tokens_known_string_is_stable():
+    """A fixed string yields a stable cl100k_base count (regression guard vs. encoding drift)."""
+    # "hello world" tokenizes to exactly 2 tokens under cl100k_base. Asserting the
+    # literal here makes any silent change to the canonical encoding fail loudly.
+    assert count_input_tokens("hello world") == 2
+
+
+def test_count_input_tokens_handles_special_token_text_without_raising():
+    """Text containing special-token markup is tokenized literally, not rejected.
+
+    ``disallowed_special=()`` means a string like ``<|endoftext|>`` is encoded as
+    ordinary text rather than raising ``ValueError``.
+    """
+    count = count_input_tokens("hello <|endoftext|> world")
+    assert count == 8
 
 
 def test_platform_llm_true_when_no_api_key_config():

--- a/tests/server/test_billing_signals.py
+++ b/tests/server/test_billing_signals.py
@@ -1,0 +1,29 @@
+"""Unit tests for the OSS billing-signals helper."""
+
+from reflexio.models.config_schema import APIKeyConfig, Config, OpenAIConfig
+from reflexio.server.billing_signals import platform_llm_from_config
+
+
+def test_platform_llm_true_when_no_api_key_config():
+    """Config with no api_key_config → platform supplies the LLM."""
+    assert platform_llm_from_config(Config(storage_config=None)) is True
+
+
+def test_platform_llm_false_when_byo_openai_key():
+    """Config with a populated OpenAI sub-config → customer BYO-LLM."""
+    cfg = Config(
+        storage_config=None,
+        api_key_config=APIKeyConfig(openai=OpenAIConfig(api_key="sk-x")),
+    )
+    assert platform_llm_from_config(cfg) is False
+
+
+def test_platform_llm_true_for_none_config():
+    """None config (missing entirely) defaults to platform-supplied LLM."""
+    assert platform_llm_from_config(None) is True
+
+
+def test_platform_llm_true_for_empty_api_key_config():
+    """APIKeyConfig with all providers None → no BYO key → platform LLM."""
+    cfg = Config(storage_config=None, api_key_config=APIKeyConfig())
+    assert platform_llm_from_config(cfg) is True

--- a/tests/server/test_create_app.py
+++ b/tests/server/test_create_app.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+
+
+def _paths(app) -> set[str]:
+    return {r.path for r in app.routes}
+
+
+def test_mount_data_plane_true_includes_core_routes():
+    app = create_app(mount_data_plane=True)
+    paths = _paths(app)
+    assert "/api/search_profiles" in paths  # a core_router data-plane route
+    assert "/meta/version" in paths
+
+
+def test_mount_data_plane_false_excludes_core_routes_keeps_scaffolding():
+    app = create_app(mount_data_plane=False)
+    paths = _paths(app)
+    assert "/api/search_profiles" not in paths  # data-plane routes gone
+    assert "/meta/version" in paths  # scaffolding stays
+
+
+def test_mount_data_plane_false_still_mounts_additional_routers():
+    from fastapi import APIRouter
+
+    r = APIRouter()
+
+    @r.get("/cp/ping")
+    def _ping() -> dict:
+        return {"ok": True}
+
+    app = create_app(mount_data_plane=False, additional_routers=[r])
+    with TestClient(app) as c:
+        assert c.get("/cp/ping").json() == {"ok": True}


### PR DESCRIPTION
## Summary

Adds the **OSS metering foundation** that the (closed-source) billing layer builds on. This is the open-source half: it emits structured usage signals and exposes clean dependency-injection seams so a downstream deployment can attach billing/enforcement **without the OSS core depending on any of it**. With no overrides registered, behavior is unchanged — every hook is a no-op and metering is fully isolated from the request success path.

Three value signals are emitted as `UsageEvent`s:

1. **Learning** — extraction input tokens (input-anchored, model-agnostic `cl100k_base` count) + learnings generated. Metered **only** for profile/playbook generation; eval/reflection pipelines do not bill.
2. **Application** — applied learnings (surfaced top-K) for production agents only; dashboard/non-agent callers and empty results emit nothing.
3. **Access** — caller-type classification seam (`default_get_caller_type`, no-op `"internal"` in OSS).

## Changes

- **`billing_signals.py`** — single source of the platform-LLM rule + the canonical billing tokenizer (`count_input_tokens`).
- **`billing_meter.py`** — emission helpers; the one source of usage-event shape.
- **`usage_metrics.py`** — `UsageEvent` gains token/attribution/caller fields; `record_usage_event` swallows recorder failures so metering can never 500 a request.
- **`llm/token_accounting.py`** — `RunTokenTotals` + `sum_trace_tokens` fold tool-loop trace tokens into run totals reachable by the generation service.
- **`services/base_generation_service.py`** — `EMITS_LEARNING_BILLING` flag (true only on profile/playbook generation); emission isolated in try/except.
- **`server/_auth.py` / `server/api.py`** — `default_get_caller_type` + no-op `default_billing_gate` DI seams; `create_app(get_caller_type=, get_billing_gate=)`; applied-learnings metering wired into the 5 search/read endpoints; `get_agent_playbooks` gains a `120/minute` rate limit.

## Isolation guarantees

- No new dependency on any closed-source / enterprise code.
- Every metering call site is wrapped so a failure logs and continues — the product response is never affected (covered by `test_metering_failure_does_not_break_search_response`).
- All hooks default to no-ops; a deployment opts in via `app.dependency_overrides`.

## Test plan

- `tests/server/test_billing_signals.py`, `tests/server/test_billing_meter.py` — emission helpers + tokenizer (empty-string, encoding-drift guard, special-token handling).
- `tests/server/llm/test_token_accounting.py` — None-coercion, empty/missing-trace guards, multi-turn summation.
- `tests/server/api_endpoints/test_applied_learnings_metering.py` — per-endpoint surfaced-count metering across all 5 endpoints × {production-agent, dashboard, empty}.
- `tests/server/services/test_generation_billing_emission.py` — learning emission gated to profile/playbook generation; eval pipeline does not bill.
- 36 metering/billing tests pass; `ruff` + `pyright` clean; `import reflexio` verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metering for learnings (generated and applied) with per-run token accounting, optional generation billing, and configurable per-line billing gates with overridable caller-type classification.
  * Usage events now include prompt/completion/input token counts, platform/caller context, and accept request/session correlation IDs for billing attribution; app factory can toggle mounting of data-plane routes.

* **Tests**
  * Added comprehensive tests for applied‑learnings metering, token accounting, billing signal detection, generation billing emission, and app router mounting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->