### PR TITLE
fix(tests): isolate embedding tests from shell env routing

### DIFF
--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -617,8 +617,34 @@ class TestIsNonRetryableError:
 # ===================================================================
 
 
+# Env vars that route embedding calls away from litellm.embedding.
+# When any of these is set in the shell, embedding_provider_mode() may resolve
+# to "local_service" or "internal_service", causing get_embedding /
+# get_embeddings to detour through get_service_embeddings (HTTP to
+# 127.0.0.1:8072 by default) before reaching the mocked litellm.embedding.
+# Tests below mock litellm.embedding and assert against that code path, so the
+# routing env vars must be cleared per-test. Production routing logic is
+# covered in tests/server/llm/test_embedding_service_provider.py.
+_EMBEDDING_ROUTING_ENV_VARS = (
+    "REFLEXIO_EMBEDDING_PROVIDER",
+    "REFLEXIO_EMBEDDING_SERVICE_URL",
+    "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
+)
+
+
+def _force_litellm_embedding_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear shell-leaked embedding-routing env vars so tests exercise the
+    litellm.embedding code path, not the local/internal service branches."""
+    for name in _EMBEDDING_ROUTING_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
 class TestGetEmbedding:
     """Tests for the single-text embedding endpoint."""
+
+    @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
 
     @pytest.fixture(autouse=True)
     def _pin_default_model(self, monkeypatch):
@@ -693,6 +719,10 @@ class TestGetEmbeddings:
     """Tests for the batch embedding endpoint."""
 
     @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
+
+    @pytest.fixture(autouse=True)
     def _pin_default_model(self, monkeypatch):
         # See TestGetEmbedding._pin_default_model — these tests assert against
         # the litellm-backed default and must not be intercepted by the
@@ -755,6 +785,10 @@ class TestGetEmbeddings:
 
 class TestEmbeddingDefaultResolution:
     """Tests for the caching and routing behavior of the embedding default."""
+
+    @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
 
     def test_resolve_default_embedding_model_is_cached(self, monkeypatch):
         """``_resolve_default_embedding_model`` must hit resolve_model_name once.
@@ -821,6 +855,10 @@ class TestEmbeddingDefaultResolution:
 
 class TestEmbeddingTruncation:
     """Tests for the embedding-input truncation helpers."""
+
+    @pytest.fixture(autouse=True)
+    def _force_litellm_route(self, monkeypatch):
+        _force_litellm_embedding_route(monkeypatch)
 
     @pytest.fixture(autouse=True)
     def _reset_caches(self):


### PR DESCRIPTION
## Problem

The shell environment commonly has `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` set (and similar `REFLEXIO_EMBEDDING_PROVIDER` / `REFLEXIO_EMBEDDING_SERVICE_URL` leaks). When that env reaches `tests/server/llm/test_litellm_client_unit.py`, `embedding_provider_mode()` resolves to `"local_service"` and `LiteLLMClient.get_embedding(...)` detours through `get_service_embeddings(...)` — an HTTP call to `127.0.0.1:8072` — **before** the mocked `litellm.embedding` is ever reached. The local HTTP service (when running) returns 400; when not running, the request times out. Either way the test errors out.

Three independent contributors working on the LLM-refactor series all reported the same observation: "12 pre-existing failures in `TestGetEmbedding*` / `TestGetEmbeddings*` / `TestEmbeddingDefaultResolution*` / `TestEmbeddingTruncation*`, identical before and after my change." Each new contributor pays this cognitive overhead.

The Task 6 implementer (embedding `num_retries` parity) discovered the underlying mechanism and applied the fix locally — a `_force_litellm_route(monkeypatch)` helper that clears the routing env vars per-test in their new `TestEmbeddingRetries` class. This PR generalizes that pattern to the four pre-existing classes.

## Change

Add a module-level helper `_force_litellm_embedding_route(monkeypatch)` that deletes the three routing env vars (`REFLEXIO_EMBEDDING_PROVIDER`, `REFLEXIO_EMBEDDING_SERVICE_URL`, `CLAUDE_SMART_USE_LOCAL_EMBEDDING`), and add a class-scoped autouse fixture in each of the four affected classes that calls it.

Class-scoped (not module-scoped) keeps the blast radius small — neighboring `TestResolveApiKey`, `TestGenerateResponse`, etc. classes are unaffected. Production routing logic remains covered by `tests/server/llm/test_embedding_service_provider.py`.

## Before / After

```
# Repro with CLAUDE_SMART_USE_LOCAL_EMBEDDING=1
CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 uv run pytest tests/server/llm/test_litellm_client_unit.py \
  -k "TestGetEmbedding or TestGetEmbeddings or TestEmbeddingDefaultResolution or TestEmbeddingTruncation" \
  -o 'addopts='

# Before this PR
12 failed, 15 passed, 146 deselected

# After this PR
27 passed, 146 deselected
```

Full-file run (`uv run pytest tests/server/llm/test_litellm_client_unit.py -o 'addopts='`) is **173 passed** in both clean and env-leaked shells.

## Scope

- Only touches `tests/server/llm/test_litellm_client_unit.py`.
- No production code changes (`embedding_service_provider.py`, `litellm_client.py` untouched).
- No assertion changes — only env-var setup.

## Related

C3 from the `/test-e2e-cli` retrospective.

## Out of scope (surfaced for the team lead)

`tests/server/llm/test_local_embedding_provider.py::TestLiteLLMClientShortCircuit` (2 tests) fails for the **same** env-leak reason on `origin/main`. Worth a follow-up PR with the same fixture. Five other failures in `tests/server/llm/test_model_defaults.py` are unrelated (default-model name drift: `gpt-5-mini` -> `gpt-5.5`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced embedding test isolation to ensure unit tests properly exercise mocked code paths.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal test infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->