### PR TITLE
chore(tests,format): clear pre-existing test+ruff drift caught by /check-and-test

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -233,7 +233,9 @@ class UserProfile(BaseModel):
     custom_features: dict | None = None
     source: str | None = None
     status: Status | None = None  # indicates the status of the profile
-    extractor_names: list[str] | None = None  # Retained provenance data column (merged on dedup); new profiles write None.
+    extractor_names: list[str] | None = (
+        None  # Retained provenance data column (merged on dedup); new profiles write None.
+    )
     expanded_terms: str | None = None
     embedding: EmbeddingVector = []
     source_span: str | None = None
@@ -891,7 +893,9 @@ class RerunProfileGenerationRequest(BaseModel):
     start_time: datetime | None = None
     end_time: datetime | None = None
     source: str | None = None
-    extractor_names: list[str] | None = None  # Deprecated compatibility field; ignored for selection.
+    extractor_names: list[str] | None = (
+        None  # Deprecated compatibility field; ignored for selection.
+    )
 
     @model_validator(mode="after")
     def check_time_range(self) -> Self:
@@ -936,7 +940,9 @@ class ManualPlaybookGenerationRequest(BaseModel):
 
     agent_version: str = DEFAULT_AGENT_VERSION
     source: str | None = None
-    playbook_name: str | None = None  # Deprecated compatibility field; ignored for selection.
+    playbook_name: str | None = (
+        None  # Deprecated compatibility field; ignored for selection.
+    )
 
     @field_validator("agent_version")
     @classmethod
@@ -956,7 +962,9 @@ class RerunPlaybookGenerationRequest(BaseModel):
     agent_version: str = DEFAULT_AGENT_VERSION
     start_time: datetime | None = None
     end_time: datetime | None = None
-    playbook_name: str | None = None  # Deprecated compatibility field; ignored for selection.
+    playbook_name: str | None = (
+        None  # Deprecated compatibility field; ignored for selection.
+    )
     source: str | None = None
 
     @field_validator("agent_version")

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -56,7 +56,9 @@ class SearchUserProfileRequest(BaseModel):
     top_k: int | None = Field(default=10, gt=0)
     source: str | None = None
     custom_feature: str | None = None
-    extractor_name: str | None = None  # Deprecated compatibility field; accepted but ignored.
+    extractor_name: str | None = (
+        None  # Deprecated compatibility field; accepted but ignored.
+    )
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID

--- a/reflexio/server/api_endpoints/publisher_api.py
+++ b/reflexio/server/api_endpoints/publisher_api.py
@@ -155,7 +155,9 @@ def delete_user_profile(
     try:
         return reflexio.delete_profile(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="delete_user_profile", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="delete_user_profile", org_id=org_id
+        ):
             logger.exception("Failed to delete user profile")
         return DeleteUserProfileResponse(success=False, message=str(e))
 
@@ -176,7 +178,9 @@ def delete_user_interaction(
     try:
         return reflexio.delete_interaction(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="delete_user_interaction", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="delete_user_interaction", org_id=org_id
+        ):
             logger.exception("Failed to delete user interaction")
         return DeleteUserInteractionResponse(success=False, message=str(e))
 
@@ -195,7 +199,9 @@ def delete_request(org_id: str, request: DeleteRequestRequest) -> DeleteRequestR
     try:
         return reflexio.delete_request(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="delete_request", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="delete_request", org_id=org_id
+        ):
             logger.exception("Failed to delete request")
         return DeleteRequestResponse(success=False, message=str(e))
 
@@ -214,7 +220,9 @@ def delete_session(org_id: str, request: DeleteSessionRequest) -> DeleteSessionR
     try:
         return reflexio.delete_session(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="delete_session", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="delete_session", org_id=org_id
+        ):
             logger.exception("Failed to delete session")
         return DeleteSessionResponse(success=False, message=str(e))
 
@@ -235,7 +243,9 @@ def delete_agent_playbook(
     try:
         return reflexio.delete_agent_playbook(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="delete_agent_playbook", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="delete_agent_playbook", org_id=org_id
+        ):
             logger.exception("Failed to delete agent playbook")
         return DeleteAgentPlaybookResponse(success=False, message=str(e))
 
@@ -256,7 +266,9 @@ def delete_user_playbook(
     try:
         return reflexio.delete_user_playbook(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="delete_user_playbook", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="delete_user_playbook", org_id=org_id
+        ):
             logger.exception("Failed to delete user playbook")
         return DeleteUserPlaybookResponse(success=False, message=str(e))
 
@@ -434,7 +446,9 @@ def run_playbook_aggregation(
             request.agent_version, request.playbook_name
         )
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="run_playbook_aggregation", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="run_playbook_aggregation", org_id=org_id
+        ):
             logger.exception("Failed to run playbook aggregation")
         return RunPlaybookAggregationResponse(success=False, message=str(e))
 
@@ -472,7 +486,9 @@ def update_agent_playbook_status(
     try:
         return reflexio.update_agent_playbook_status(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="update_playbook_status", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="update_playbook_status", org_id=org_id
+        ):
             logger.exception("Failed to update playbook status")
         return UpdatePlaybookStatusResponse(success=False, msg=str(e))
 
@@ -493,7 +509,9 @@ def update_agent_playbook(
     try:
         return reflexio.update_agent_playbook(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="update_agent_playbook", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="update_agent_playbook", org_id=org_id
+        ):
             logger.exception("Failed to update agent playbook")
         return UpdateAgentPlaybookResponse(success=False, msg=str(e))
 
@@ -514,7 +532,9 @@ def update_user_playbook(
     try:
         return reflexio.update_user_playbook(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="update_user_playbook", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="update_user_playbook", org_id=org_id
+        ):
             logger.exception("Failed to update user playbook")
         return UpdateUserPlaybookResponse(success=False, msg=str(e))
 
@@ -535,6 +555,8 @@ def update_user_profile(
     try:
         return reflexio.update_user_profile(request)
     except Exception as e:
-        with sentry_tags(subsystem="publisher_api", action="update_user_profile", org_id=org_id):
+        with sentry_tags(
+            subsystem="publisher_api", action="update_user_profile", org_id=org_id
+        ):
             logger.exception("Failed to update user profile")
         return UpdateUserProfileResponse(success=False, msg=str(e))

--- a/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
+++ b/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
@@ -172,11 +172,7 @@ def run_group_evaluation(
         prior_rows = storage.get_agent_success_evaluation_results(  # type: ignore[reportOptionalMemberAccess]
             limit=10000, agent_version=agent_version
         )
-        old_result_ids = [
-            r.result_id
-            for r in prior_rows
-            if r.session_id == session_id
-        ]
+        old_result_ids = [r.result_id for r in prior_rows if r.session_id == session_id]
 
     logger.info(
         "Running group evaluation for session=%s with %d requests and %d interactions"

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -161,7 +161,9 @@ def _select_current_extractor_config(
             f"Unsupported extractor kind {run.binding.extractor_kind!r}"
         )
 
-    if config is not None and isinstance(config, ProfileExtractorConfig | PlaybookConfig):
+    if config is not None and isinstance(
+        config, ProfileExtractorConfig | PlaybookConfig
+    ):
         return config
     raise ResumeWorkerError(
         f"Current extractor config not found for {run.binding.extractor_kind}"

--- a/reflexio/server/services/extractor_config_utils.py
+++ b/reflexio/server/services/extractor_config_utils.py
@@ -34,9 +34,12 @@ def get_extractor_name(config: object) -> str:
         return SINGLETON_USER_PLAYBOOK_NAME
     if isinstance(config, AgentSuccessConfig):
         return SINGLETON_AGENT_SUCCESS_EVALUATION_NAME
-    return getattr(config, "extractor_name", None) or getattr(
-        config, "playbook_name", None
-    ) or getattr(config, "evaluation_name", "unknown") or "unknown"
+    return (
+        getattr(config, "extractor_name", None)
+        or getattr(config, "playbook_name", None)
+        or getattr(config, "evaluation_name", "unknown")
+        or "unknown"
+    )
 
 
 def filter_extractor_configs[TExtractorConfig](

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -326,7 +326,8 @@ class GenerationService:
                             error_type=type(e).__name__,
                         ):
                             logger.exception(
-                                "Generation service failed for request %s", request_id,
+                                "Generation service failed for request %s",
+                                request_id,
                             )
                         result.warnings.append(msg)
             finally:
@@ -380,7 +381,8 @@ class GenerationService:
                 error_type=type(e).__name__,
             ):
                 logger.exception(
-                    "Failed to refresh user profile for user id: %s", user_id,
+                    "Failed to refresh user profile for user id: %s",
+                    user_id,
                 )
             raise
 
@@ -521,7 +523,8 @@ class GenerationService:
                             error_type=type(e).__name__,
                         ):
                             logger.exception(
-                                "Failed to cleanup retention target %s", target_name,
+                                "Failed to cleanup retention target %s",
+                                target_name,
                             )
             finally:
                 mgr.release_simple_lock()

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -77,7 +77,7 @@ def _coerce_existing_position(value: object) -> int:
         stripped = value.strip()
         for prefix in ("EXISTING-", "EXISTING_", "existing-", "existing_"):
             if stripped.startswith(prefix):
-                stripped = stripped[len(prefix):]
+                stripped = stripped[len(prefix) :]
                 break
         try:
             parsed = int(stripped)
@@ -86,9 +86,7 @@ def _coerce_existing_position(value: object) -> int:
                 f"existing-position must be int or 'EXISTING-N' label, got {value!r}"
             ) from exc
         if parsed < 0:
-            raise ValueError(
-                f"existing-position must be >= 0, got {value!r}"
-            )
+            raise ValueError(f"existing-position must be >= 0, got {value!r}")
         return parsed
     raise ValueError(
         f"existing-position must be int or 'EXISTING-N' label, got {type(value).__name__}: {value!r}"
@@ -656,7 +654,9 @@ class PlaybookConsolidator(BaseDeduplicator):
                 ):
                     logger.exception(
                         "event=consolidation_apply_failed kind=%s new_id=%s existing_id=%s",
-                        decision.kind, new_id_str, existing_id_str,
+                        decision.kind,
+                        new_id_str,
+                        existing_id_str,
                     )
                 continue
             new_rows.extend(rows)

--- a/reflexio/server/services/profile/profile_generation_service.py
+++ b/reflexio/server/services/profile/profile_generation_service.py
@@ -198,7 +198,8 @@ class ProfileGenerationService(
                     error_type=type(e).__name__,
                 ):
                     logger.exception(
-                        "Failed to save profiles for user id: %s", user_id,
+                        "Failed to save profiles for user id: %s",
+                        user_id,
                     )
                 return
 
@@ -224,7 +225,8 @@ class ProfileGenerationService(
                     ):
                         logger.exception(
                             "Failed to delete superseded profile %s for user %s",
-                            profile_id, user_id,
+                            profile_id,
+                            user_id,
                         )
 
         # Create profile changelog post-deduplication
@@ -250,7 +252,8 @@ class ProfileGenerationService(
                     error_type=type(e).__name__,
                 ):
                     logger.exception(
-                        "Failed to add profile change log for user %s", user_id,
+                        "Failed to add profile change log for user %s",
+                        user_id,
                     )
 
     def check_and_update_profiles(self, profiles: list[UserProfile]) -> None:

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -253,7 +253,8 @@ class ReflectionService:
                 ):
                     logger.exception(
                         "event=reflection_apply_failed kind=%s target_id=%s",
-                        decision.target_kind, decision.target_id,
+                        decision.target_kind,
+                        decision.target_id,
                     )
                 continue
             if applied:
@@ -498,7 +499,8 @@ class ReflectionService:
                 logger.exception(
                     "event=reflection_archive_after_insert_failed kind=profile "
                     "cited_id=%s new_id=%s",
-                    cited.profile_id, new_profile.profile_id,
+                    cited.profile_id,
+                    new_profile.profile_id,
                 )
             return True
         if not archived:
@@ -597,7 +599,8 @@ class ReflectionService:
                 logger.exception(
                     "event=reflection_archive_after_insert_failed kind=playbook "
                     "cited_id=%s new_id=%s",
-                    cited.user_playbook_id, new_playbook.user_playbook_id,
+                    cited.user_playbook_id,
+                    new_playbook.user_playbook_id,
                 )
             return True
         if not archived:

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -286,6 +286,10 @@ class TestSetupInitEmbeddingStep:
         so this is enough to keep the test from touching the real home dir.
         """
         fake_home.mkdir(parents=True, exist_ok=True)
+        # Clear REFLEXIO_LOG_DIR — the OSS conftest sets it session-wide to
+        # protect tests that don't patch home, but here we want `reflexio_home()`
+        # to fall through to the patched `Path.home()`.
+        monkeypatch.delenv("REFLEXIO_LOG_DIR", raising=False)
         monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
         # ``setup init`` queries chromadb importability via the module-level
         # helper. Force True so the local option appears as choice [1].

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Test configuration — delegates to shared reflexio.test_support module."""
 
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -12,6 +14,31 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from reflexio.test_support.llm_mock import cleanup_llm_mock, configure_llm_mock
+
+# Env vars that change OSS code paths and must not leak in from a developer's
+# `~/.reflexio/.env` or the enterprise worktree `.env`. CI sets none of these,
+# so the suite passes there even without the cleanup. Cleared once per session
+# before any test imports modules that read them at call time.
+_OSS_TEST_POLLUTING_ENV_VARS = (
+    "DEPLOYMENT_MODE",
+    "REFLEXIO_STORAGE",
+    "REFLEXIO_EMBEDDING_PROVIDER",
+    "REFLEXIO_EMBEDDING_SERVICE_URL",
+    "CLAUDE_SMART_USE_LOCAL_EMBEDDING",
+)
+for _var in _OSS_TEST_POLLUTING_ENV_VARS:
+    os.environ.pop(_var, None)
+
+# Redirect `~/.reflexio` for the entire test session so tests that call
+# `reflexio.cli.paths.reflexio_home()` (e.g. via `LocalFileConfigStorage`'s
+# default `base_dir`) don't pick up the developer's existing
+# `~/.reflexio/configs/config_<org>.json` files. Without this, any test that
+# constructs `create_app()` against the default `self-host-org` org_id loads
+# whatever leftover storage config the developer happens to have on disk —
+# producing `No storage factory registered for StorageConfigSupabase` when
+# the leftover was from a prior `--storage supabase` run.
+_REFLEXIO_TEST_HOME = Path(tempfile.mkdtemp(prefix="reflexio-test-home-"))
+os.environ["REFLEXIO_LOG_DIR"] = str(_REFLEXIO_TEST_HOME)
 
 
 def pytest_configure(config):

--- a/tests/server/api_endpoints/test_evaluations_regenerate_api.py
+++ b/tests/server/api_endpoints/test_evaluations_regenerate_api.py
@@ -48,11 +48,10 @@ def test_post_409_when_job_already_running(client_with_org_and_evaluator):
         "from_ts": 0,
         "to_ts": 9_999_999_999,
     }
-    # Patch threading.Thread so the worker never starts and the first job
-    # stays "running" — otherwise the empty-storage worker would finish
-    # immediately and the second POST would succeed.
-    with patch("reflexio.server.api.threading.Thread") as thread_cls:
-        thread_cls.return_value.start = lambda: None
+    # Patch the regen ThreadPoolExecutor's submit so the worker never starts
+    # and the first job stays "running" — otherwise the empty-storage worker
+    # would finish immediately and the second POST would succeed.
+    with patch("reflexio.server.api._regen_executor.submit", return_value=None):
         first = client.post("/api/evaluations/regenerate", json=body)
         assert first.status_code == 200, first.text
         second = client.post("/api/evaluations/regenerate", json=body)
@@ -92,8 +91,7 @@ def test_delete_cancels_running_job(client_with_org_and_evaluator):
         "from_ts": 0,
         "to_ts": 9_999_999_999,
     }
-    with patch("reflexio.server.api.threading.Thread") as thread_cls:
-        thread_cls.return_value.start = lambda: None
+    with patch("reflexio.server.api._regen_executor.submit", return_value=None):
         resp = client.post("/api/evaluations/regenerate", json=body)
         assert resp.status_code == 200, resp.text
         job_id = resp.json()["job_id"]

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -272,6 +272,12 @@ class TestLiteLLMClientShortCircuit:
         from reflexio.server.llm import litellm_client
         from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 
+        # Force "cloud" provider mode so the embedding-service short-circuit
+        # in get_embedding() doesn't intercept the call before litellm runs.
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+        monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+
         client = LiteLLMClient(LiteLLMConfig(model="claude-code/default"))
 
         fake_response = MagicMock()
@@ -334,6 +340,11 @@ class TestLiteLLMClientShortCircuit:
             LiteLLMConfig,
         )
 
+        # Force "inprocess" provider mode so the embedding-service short-circuit
+        # doesn't intercept the local/* model before the chromadb-import check.
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+        monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
         monkeypatch.setattr(lep.importlib.util, "find_spec", lambda _name: None)
 
         client = LiteLLMClient(LiteLLMConfig(model="claude-code/default"))

--- a/tests/server/llm/test_model_defaults.py
+++ b/tests/server/llm/test_model_defaults.py
@@ -407,9 +407,9 @@ class TestExtractionAgentRole:
         assert anthropic.extraction_agent is not None
         assert "sonnet" in anthropic.extraction_agent.lower()
 
-    def test_openai_defaults_map_to_gpt5_mini(self) -> None:
+    def test_openai_defaults_map_to_gpt5(self) -> None:
         openai = _PROVIDER_DEFAULTS["openai"]
-        assert openai.extraction_agent == "gpt-5-mini"
+        assert openai.extraction_agent == "gpt-5.5"
 
     def test_claude_code_defaults_cover_extraction_agent(self) -> None:
         cc = _PROVIDER_DEFAULTS["claude-code"]
@@ -452,7 +452,7 @@ class TestMinimaxExtractionAgentRole:
         )
 
         result = _auto_detect_model(ModelRole.EXTRACTION_AGENT, providers=["minimax"])
-        assert result == "minimax/MiniMax-M2.7"
+        assert result == "minimax/MiniMax-M3"
 
 
 # ---------------------------------------------------------------------------
@@ -467,7 +467,7 @@ class TestMinimaxOnlyEnvRegression:
     The contract this class locks in: when the only LLM env var in scope
     is MINIMAX_API_KEY, every generation-family role (the slots that
     profile_extractor / playbook_extractor / agent_success_evaluator
-    resolve at construction time) must resolve to ``minimax/MiniMax-M2.7``,
+    resolve at construction time) must resolve to ``minimax/MiniMax-M3``,
     not to any OpenAI default. This is the runtime expectation the
     setup-init wizard documents to MiniMax-only users.
 
@@ -483,8 +483,8 @@ class TestMinimaxOnlyEnvRegression:
         """``default_generation_model_name`` must be the MiniMax model."""
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-test")
         result = resolve_model_name(ModelRole.GENERATION)
-        assert result == "minimax/MiniMax-M2.7", (
-            f"Expected minimax/MiniMax-M2.7, got {result!r}. If this fails, "
+        assert result == "minimax/MiniMax-M3", (
+            f"Expected minimax/MiniMax-M3, got {result!r}. If this fails, "
             "MiniMax-only users will hit OpenAI auth errors at extraction time."
         )
 
@@ -494,7 +494,7 @@ class TestMinimaxOnlyEnvRegression:
         """``should_run_model_name`` must also resolve to the MiniMax model."""
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-test")
         result = resolve_model_name(ModelRole.SHOULD_RUN)
-        assert result == "minimax/MiniMax-M2.7"
+        assert result == "minimax/MiniMax-M3"
 
     def test_all_generation_roles_resolve_to_minimax(
         self, monkeypatch: pytest.MonkeyPatch
@@ -537,7 +537,7 @@ class TestMinimaxOnlyEnvRegression:
         assert "openai" not in providers, (
             f"Empty OPENAI_API_KEY must not promote OpenAI; got {providers}"
         )
-        assert resolve_model_name(ModelRole.GENERATION) == "minimax/MiniMax-M2.7"
+        assert resolve_model_name(ModelRole.GENERATION) == "minimax/MiniMax-M3"
 
     def test_minimax_with_chromadb_resolves_embedding_to_local(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/server/services/playbook/test_cluster_change_detection.py
+++ b/tests/server/services/playbook/test_cluster_change_detection.py
@@ -646,8 +646,9 @@ class TestAggregatorRunWithChangeDetection:
 
         # LLM should be called for ALL clusters
         assert mock_llm_client.generate_chat_response.call_count == len(clusters)
-        # archive_agent_playbooks_by_playbook_name should be called (full archive)
-        mock_storage.archive_agent_playbooks_by_playbook_name.assert_called_once()
+        # archive_agent_playbooks_by_playbook_name should be called for each
+        # full-archive playbook name (one call per name)
+        mock_storage.archive_agent_playbooks_by_playbook_name.assert_called()
 
     def test_error_during_save_restores_archived_playbooks(self):
         """If save_agent_playbooks fails, archived playbooks should be restored."""
@@ -732,7 +733,7 @@ class TestAggregatorRunWithChangeDetection:
 
         aggregator.run(request)
 
-        mock_storage.delete_archived_agent_playbooks_by_playbook_name.assert_called_once()
+        mock_storage.delete_archived_agent_playbooks_by_playbook_name.assert_called()
 
     def test_first_run_restores_archived_on_error(self):
         """Regression: first-run (non-rerun) must restore archived playbooks on save error."""
@@ -755,7 +756,7 @@ class TestAggregatorRunWithChangeDetection:
         with pytest.raises(Exception, match="Storage save error"):
             aggregator.run(request)
 
-        mock_storage.restore_archived_agent_playbooks_by_playbook_name.assert_called_once()
+        mock_storage.restore_archived_agent_playbooks_by_playbook_name.assert_called()
 
 
 class TestLLMResponseTypeSafety:

--- a/tests/server/services/profile/test_profile_deduplicator.py
+++ b/tests/server/services/profile/test_profile_deduplicator.py
@@ -294,7 +294,7 @@ class TestProfileDeduplicatorInit:
                 request_context=mock_request_context,
                 llm_client=mock_llm_client,
             )
-            assert deduplicator.model_name == "gpt-5-mini"
+            assert deduplicator.model_name == "gpt-5.5"
 
 
 # ===============================

--- a/tests/server/services/test_configurator.py
+++ b/tests/server/services/test_configurator.py
@@ -37,15 +37,9 @@ def test_init_creates_config_file(temp_dir, test_org_id):
         loaded_config = Config.model_validate(json.load(f))
         assert isinstance(loaded_config.storage_config, StorageConfigSQLite)
         assert loaded_config.profile_extractor_config is not None
-        assert (
-            loaded_config.profile_extractor_config.extractor_name
-            == "default_profile_extractor"
-        )
+        assert loaded_config.profile_extractor_config.extraction_definition_prompt
         assert loaded_config.user_playbook_extractor_config is not None
-        assert (
-            loaded_config.user_playbook_extractor_config.extractor_name
-            == "default_playbook_extractor"
-        )
+        assert loaded_config.user_playbook_extractor_config.extraction_definition_prompt
 
 
 def test_get_config_with_default(configurator):


### PR DESCRIPTION
## Summary

Clears the 21 pre-existing OSS test failures + 10 ruff-format drift files surfaced when running `/check-and-test` on the post-#124 main. None of the failures are regressions from #124 — they're stale assertions and developer-env leakage that CI didn't catch because CI runs in a clean env without `~/.reflexio/.env`. Single PR per repo.

## What's in here

### ruff format (10 files)
Pure whitespace tweaks (line-collapse to `lineWidth`, slice spacing). All under `reflexio/server/`. No behavior change.

### Test ↔ source resync — model defaults
| Test file | Was | Now |
|---|---|---|
| `tests/server/llm/test_model_defaults.py` | `MiniMax-M2.7` (5 sites) | `MiniMax-M3` (matches `model_defaults.py` since the "MiniMax-M3 as provider default" bump) |
| `tests/server/llm/test_model_defaults.py` | OpenAI `extraction_agent == "gpt-5-mini"` | `== "gpt-5.5"` |
| `tests/server/services/profile/test_profile_deduplicator.py` | auto-detect `model_name == "gpt-5-mini"` | `== "gpt-5.5"` (deduplicator uses `ModelRole.GENERATION`) |

### Behavioral-drift test repair
| Test file | Why it broke | Fix |
|---|---|---|
| `tests/server/services/playbook/test_cluster_change_detection.py` (3 tests) | `archive_/delete_/restore_archived_agent_playbooks_by_playbook_name` is now called **once per playbook name** in a loop, not once total | `assert_called_once()` → `assert_called()` — preserves the test's real intent ("verify archive was triggered") |
| `tests/server/api_endpoints/test_evaluations_regenerate_api.py` (2 tests) | `/api/evaluations/regenerate` now uses `_regen_executor.submit` (ThreadPoolExecutor), not `threading.Thread(...).start()` | Patch `reflexio.server.api._regen_executor.submit` instead of the no-longer-existing `reflexio.server.api.threading.Thread` |
| `tests/server/services/test_configurator.py::test_init_creates_config_file` | `ProfileExtractorConfig.extractor_name` is now `"Deprecated: kept for back-compat with stored configs. Extraction is singleton (one profile extractor per org), so the name is accepted but ignored."` — the default factory no longer sets it | Removed the two stale `extractor_name == "default_*"` assertions; kept the assertions that every default config still gets non-empty `extraction_definition_prompt` |

### Env-var leakage cleanup (conftest)
- `tests/conftest.py` now pops 5 env vars at session start (`DEPLOYMENT_MODE`, `REFLEXIO_STORAGE`, `REFLEXIO_EMBEDDING_PROVIDER`, `REFLEXIO_EMBEDDING_SERVICE_URL`, `CLAUDE_SMART_USE_LOCAL_EMBEDDING`) so a developer's `~/.reflexio/.env` doesn't flip OSS code paths. CI sets none of these, so CI was passing without the cleanup.
- `tests/conftest.py` also sets `REFLEXIO_LOG_DIR` to a per-session tmp dir so tests that construct `create_app()` against the default `self-host-org` org_id don't load whatever leftover `~/.reflexio/configs/config_self-host-org.json` the developer happens to have on disk. Without this, a prior `--storage supabase` run leaves a Supabase config that triggers `No storage factory registered for StorageConfigSupabase` on the first endpoint call.
- `tests/server/llm/test_local_embedding_provider.py::TestLiteLLMClientShortCircuit` (2 tests) now `monkeypatch.delenv` the 3 embedding-provider env vars so `should_use_embedding_service()` returns False and the test exercises the actual code path it claims to test, instead of routing through the HTTP service short-circuit.
- `tests/cli/test_setup_cmd.py::TestSetupInitEmbeddingStep._patch_home_and_chromadb` now `monkeypatch.delenv REFLEXIO_LOG_DIR` so the session-scoped redirect from conftest doesn't override the per-test `Path.home()` monkeypatch.

## Verification

- `uv run pytest tests/ --ignore=tests/e2e_tests/ -q -o 'addopts='` — **2933 passed, 71 skipped** (was 21 failed before this commit)
- `uv run ruff check reflexio/ tests/` — clean
- `uv run ruff format --check reflexio/` — clean

## Test plan

- [x] All 2933 unit + integration tests pass locally
- [x] Ruff lint + format clean
- [x] No behavior change in production code — only test assertions and conftest hygiene; ruff format is whitespace-only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment setup to prevent interference from local configurations, ensuring reliable test execution.

* **Documentation**
  * Added deprecation notices to API schema fields indicating `extractor_name` is accepted but ignored.

* **Tests**
  * Updated LLM model default expectations: OpenAI extraction now defaults to `gpt-5.5`, MiniMax to `M3`.
  * Adjusted test mocking strategy for regeneration endpoints.

* **Style**
  * Reformatted exception handling and logging calls across multiple service files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->