### PR TITLE
feat(embeddings): shared embedding-text builders + model-driven local routing

### DIFF
--- a/reflexio/server/llm/embedding_service.py
+++ b/reflexio/server/llm/embedding_service.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import math
 import threading
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
@@ -15,16 +18,19 @@ from reflexio.server.llm.providers.nomic_embedding_provider import (
     is_nomic_model,
 )
 
-_MINILM_MODEL = "local/minilm-l6-v2"
+logger = logging.getLogger(__name__)
+
+MINILM_MODEL = "local/minilm-l6-v2"
+NOMIC_TEXT_MODEL = "local/nomic-embed-text-v1.5"
 _SUPPORTED_MODELS = {
-    _MINILM_MODEL,
+    MINILM_MODEL,
     "local/nomic-embed-v1.5",
-    "local/nomic-embed-text-v1.5",
+    NOMIC_TEXT_MODEL,
 }
 _ACTIVE_MODEL: str | None = None
 _ACTIVE_MODEL_LOCK = threading.Lock()
 
-app = FastAPI(title="Reflexio Embedding Service")
+DEFAULT_OSS_EMBEDDING_MODEL = MINILM_MODEL
 
 
 class EmbeddingRequest(BaseModel):
@@ -45,36 +51,59 @@ class EmbeddingResponse(BaseModel):
     model: str
 
 
-@app.get("/health")
-def health() -> dict[str, Any]:
-    """Health check endpoint."""
-    return {"status": "ok", "active_model": _ACTIVE_MODEL}
+def create_embedding_app(default_model: str | None = None) -> FastAPI:
+    """Create the embedding daemon app and optionally warm a default model."""
 
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+        if not default_model:
+            yield
+            return
+        try:
+            _embed_texts(default_model, ["reflexio embedding daemon warmup"])
+        except Exception:
+            logger.exception("Failed to warm embedding model %s", default_model)
+            raise
+        yield
 
-@app.post("/v1/embeddings")
-def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
-    """Create embeddings using the daemon's single active local model."""
-    _activate_model(request.model)
-    texts = [request.input] if isinstance(request.input, str) else list(request.input)
-    if is_nomic_model(request.model):
-        embeddings = NomicEmbedder.get().embed(texts)
-    elif request.model == _MINILM_MODEL:
-        embeddings = LocalEmbedder.get().embed(texts)
-    else:
-        raise HTTPException(
-            status_code=400, detail=f"Unsupported model: {request.model}"
+    embedding_app = FastAPI(title="Reflexio Embedding Service", lifespan=lifespan)
+
+    @embedding_app.get("/health")
+    def health() -> dict[str, Any]:
+        """Health check endpoint."""
+        return {"status": "ok", "active_model": _ACTIVE_MODEL}
+
+    @embedding_app.post("/v1/embeddings")
+    def create_embeddings(request: EmbeddingRequest) -> EmbeddingResponse:
+        """Create embeddings using the daemon's single active local model."""
+        texts = (
+            [request.input] if isinstance(request.input, str) else list(request.input)
+        )
+        embeddings = _embed_texts(request.model, texts)
+
+        if request.dimensions:
+            embeddings = [
+                _resize_embedding(vec, request.dimensions) for vec in embeddings
+            ]
+
+        return EmbeddingResponse(
+            data=[
+                EmbeddingData(embedding=embedding, index=index)
+                for index, embedding in enumerate(embeddings)
+            ],
+            model=request.model,
         )
 
-    if request.dimensions:
-        embeddings = [_resize_embedding(vec, request.dimensions) for vec in embeddings]
+    return embedding_app
 
-    return EmbeddingResponse(
-        data=[
-            EmbeddingData(embedding=embedding, index=index)
-            for index, embedding in enumerate(embeddings)
-        ],
-        model=request.model,
-    )
+
+def _embed_texts(model: str, texts: list[str]) -> list[list[float]]:
+    _activate_model(model)
+    if is_nomic_model(model):
+        return NomicEmbedder.get().embed(texts)
+    if model == MINILM_MODEL:
+        return LocalEmbedder.get().embed(texts)
+    raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
 
 
 def _activate_model(model: str) -> None:
@@ -108,3 +137,6 @@ def _resize_embedding(vec: list[float], dimensions: int) -> list[float]:
     if norm <= 0:
         return sliced
     return [value / norm for value in sliced]
+
+
+app = create_embedding_app(default_model=DEFAULT_OSS_EMBEDDING_MODEL)

--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -2,8 +2,8 @@
 
 Resolution order (highest priority first):
     1. LLMConfig override (org-level configuration)
-    2. llm_model_setting.json site var (non-empty string values)
-    3. Auto-detect from available API keys in environment / APIKeyConfig
+    2. For embeddings, Reflexio's local default model
+    3. For other roles, llm_model_setting.json site var and provider autodetection
 """
 
 from __future__ import annotations
@@ -372,16 +372,16 @@ def resolve_model_name(
     config_override: str | None = None,
     api_key_config: APIKeyConfig | None = None,
 ) -> str:
-    """Resolve a model name using the 3-tier chain.
+    """Resolve a model name using the role-specific default chain.
 
     Resolution order (highest priority first):
         1. config_override (from LLMConfig, org-level)
-        2. site_var_value (from llm_model_setting.json, non-empty strings only)
-        3. Auto-detect from available API keys
+        2. For EMBEDDING, the OSS local MiniLM model
+        3. For other roles, site_var_value then auto-detect from available API keys
 
     Args:
         role: The model role to resolve.
-        site_var_value: Value from llm_model_setting.json. Empty strings are treated as unset.
+        site_var_value: Value from llm_model_setting.json. Ignored for embeddings.
         config_override: Value from org-level LLMConfig.
         api_key_config: Optional org-level API key configuration for provider detection.
 
@@ -393,6 +393,11 @@ def resolve_model_name(
     """
     if config_override:
         return config_override
+    if role == ModelRole.EMBEDDING:
+        return (
+            _PROVIDER_DEFAULTS[_LOCAL_EMBEDDING_PROVIDER].embedding
+            or "local/minilm-l6-v2"
+        )
     if site_var_value:
         return site_var_value
     providers = detect_available_providers(api_key_config)
@@ -404,7 +409,7 @@ def validate_llm_availability(
 ) -> None:
     """Validate that at least one LLM provider and one embedding provider are available.
 
-    Should be called once during startup. Logs the auto-selected provider at INFO level.
+    Should be called once during startup. Logs available providers at INFO level.
 
     Args:
         api_key_config: Optional org-level API key configuration.
@@ -449,7 +454,11 @@ def validate_llm_availability(
         (p for p in providers if _PROVIDER_DEFAULTS[p].embedding), None
     )
     if embedding_provider:
-        logger.info("Embedding provider: %s", embedding_provider)
+        logger.info(
+            "Cloud embedding provider available: %s (used when the saved "
+            "embedding model selects this provider)",
+            embedding_provider,
+        )
         return
 
     from reflexio.server.llm.providers.local_embedding_provider import (
@@ -458,7 +467,8 @@ def validate_llm_availability(
 
     if is_chromadb_importable():
         logger.info(
-            "Embedding provider: %s (fallback — no cloud embedder configured)",
+            "Local MiniLM embedding fallback available: %s "
+            "(no cloud embedding provider configured)",
             _LOCAL_EMBEDDING_PROVIDER,
         )
         return

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -30,8 +30,11 @@ _ENV_CLAUDE_SMART_LOCAL = "CLAUDE_SMART_USE_LOCAL_EMBEDDING"
 _DEFAULT_LOCAL_PORT = 8072
 _DEFAULT_INTERNAL_SERVICE_TIMEOUT_MS = 2_000
 _DEFAULT_LOCAL_SERVICE_TIMEOUT_MS = 30_000
+_LOCAL_SERVICE_PROBE_TIMEOUT_SECONDS = 0.2
+_LOCAL_SERVICE_PROBE_CACHE_SECONDS = 5.0
 _SERVICE_MODES = {"local_service", "internal_service"}
 _VALID_MODES = {"cloud", *_SERVICE_MODES, "inprocess", "off"}
+_local_service_probe_cache: tuple[float, bool, str | None] | None = None
 
 
 class EmbeddingUnavailableError(RuntimeError):
@@ -79,6 +82,43 @@ def embedding_service_timeout_seconds(
     return max(timeout_ms, 1) / 1000
 
 
+def _is_local_model(model: str | None) -> bool:
+    return bool(model and model.startswith("local/"))
+
+
+def _local_service_status() -> tuple[bool, str | None]:
+    global _local_service_probe_cache
+    now = time.monotonic()
+    if (
+        _local_service_probe_cache is not None
+        and now - _local_service_probe_cache[0] < _LOCAL_SERVICE_PROBE_CACHE_SECONDS
+    ):
+        return _local_service_probe_cache[1], _local_service_probe_cache[2]
+
+    try:
+        response = httpx.get(
+            f"{_local_service_url()}/health",
+            timeout=_LOCAL_SERVICE_PROBE_TIMEOUT_SECONDS,
+        )
+        reachable = response.status_code < 500
+        active_model = response.json().get("active_model") if reachable else None
+        if not isinstance(active_model, str):
+            active_model = None
+    except httpx.HTTPError:
+        reachable = False
+        active_model = None
+    except ValueError:
+        reachable = False
+        active_model = None
+    _local_service_probe_cache = (now, reachable, active_model)
+    return reachable, active_model
+
+
+def _local_service_supports_model(model: str | None) -> bool:
+    reachable, active_model = _local_service_status()
+    return reachable and (active_model is None or active_model == model)
+
+
 def _ordered_embeddings_from_response(
     data: Any, expected_count: int
 ) -> list[list[float]]:
@@ -124,10 +164,10 @@ def _ordered_embeddings_from_response(
 def embedding_provider_mode(model: str | None = None) -> EmbeddingProviderMode:
     """Resolve the embedding provider mode for a model.
 
-    Backwards compatibility: a ``local/*`` model still uses the in-process
-    embedder unless the user explicitly chooses a mode or Claude Smart's legacy
-    ``CLAUDE_SMART_USE_LOCAL_EMBEDDING=1`` flag is present. That legacy flag
-    now means "use the shared local service" by default.
+    Explicit legacy env modes keep their historical behavior. With no explicit
+    env mode, routing is model-driven: ``local/*`` uses the local daemon when it
+    is reachable and otherwise falls back to the in-process embedder; cloud
+    models use their provider directly.
     """
     configured = os.environ.get(_ENV_PROVIDER)
     if configured:
@@ -145,8 +185,8 @@ def embedding_provider_mode(model: str | None = None) -> EmbeddingProviderMode:
     if os.environ.get(_ENV_SERVICE_URL):
         return "internal_service"
 
-    if model and model.startswith("local/"):
-        return "inprocess"
+    if _is_local_model(model):
+        return "local_service" if _local_service_supports_model(model) else "inprocess"
     return "cloud"
 
 

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -154,7 +154,7 @@ def register_if_chromadb_available() -> bool:
         _LOGGER.debug("Local embedder not registered: `chromadb` is not installed.")
         return False
     _REGISTERED = True
-    _LOGGER.info("Local embedding provider enabled (model=%s)", _MODEL_KEY)
+    _LOGGER.debug("Registered local MiniLM embedding handler (model=%s)", _MODEL_KEY)
     return True
 
 

--- a/reflexio/server/llm/providers/nomic_embedding_provider.py
+++ b/reflexio/server/llm/providers/nomic_embedding_provider.py
@@ -59,6 +59,10 @@ class NomicEmbedderError(RuntimeError):
     """Raised when the Nomic embedder is requested but its deps are missing."""
 
 
+def _huggingface_cache_path() -> str:
+    return os.environ.get("HF_HOME") or "~/.cache/huggingface"
+
+
 class NomicEmbedder:
     """Lazily-loaded singleton wrapping a sentence-transformers model.
 
@@ -102,8 +106,9 @@ class NomicEmbedder:
                 ) from exc
             _LOGGER.info(
                 "Loading Nomic embedding model %s — first call may download "
-                "~550 MB to ~/.cache/huggingface/",
+                "~550 MB to %s",
                 _HF_MODEL_NAME,
+                _huggingface_cache_path(),
             )
             # Force CPU device — MPS init has been observed to hang on some
             # Apple Silicon + macOS combos for several minutes during model
@@ -120,7 +125,7 @@ class NomicEmbedder:
                 "Nomic embedder ready (model=%s, target_dim=%d, native_dim=%d)",
                 _HF_MODEL_NAME,
                 _TARGET_DIM,
-                self._model.get_sentence_embedding_dimension(),
+                _embedding_dimension(self._model),
             )
             return self._model
 
@@ -165,6 +170,15 @@ def _truncate_and_renormalise(vec: list[float]) -> list[float]:
     if norm <= 0:
         return sliced
     return [x / norm for x in sliced]
+
+
+def _embedding_dimension(model: Any) -> int:
+    get_embedding_dimension = getattr(model, "get_embedding_dimension", None)
+    if callable(get_embedding_dimension):
+        dimension = get_embedding_dimension()
+    else:
+        dimension = model.get_sentence_embedding_dimension()
+    return int(dimension)  # type: ignore[arg-type]
 
 
 _REGISTERED = False

--- a/reflexio/server/llm/rerank/cross_encoder_reranker.py
+++ b/reflexio/server/llm/rerank/cross_encoder_reranker.py
@@ -108,12 +108,13 @@ def _get_model() -> Any:
             return _MODEL
         cross_encoder_cls = _import_cross_encoder()
         try:
+            _LOGGER.info("Loading reranker model %s", _MODEL_NAME)
             _MODEL = cross_encoder_cls(_MODEL_NAME)
         except Exception as e:  # noqa: BLE001 — surface as a typed failure
             raise CrossEncoderUnavailableError(
                 f"Failed to load cross-encoder model {_MODEL_NAME!r}: {e}"
             ) from e
-        _LOGGER.info("Loaded cross-encoder model %s", _MODEL_NAME)
+        _LOGGER.info("Reranker model ready (model=%s)", _MODEL_NAME)
         return _MODEL
 
 

--- a/reflexio/server/services/embedding_text.py
+++ b/reflexio/server/services/embedding_text.py
@@ -1,0 +1,41 @@
+"""Canonical text and prefixes used for vector embeddings."""
+
+from __future__ import annotations
+
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    AgentSuccessEvaluationResult,
+    Interaction,
+    UserPlaybook,
+    UserProfile,
+)
+
+SEARCH_DOCUMENT_PREFIX = "search_document: "
+SEARCH_QUERY_PREFIX = "search_query: "
+
+EmbeddingTextEntity = (
+    Interaction
+    | UserProfile
+    | UserPlaybook
+    | AgentPlaybook
+    | AgentSuccessEvaluationResult
+)
+
+
+def embedding_text(entity: EmbeddingTextEntity) -> str:
+    """Return the exact text used for an entity's stored embedding."""
+    if isinstance(entity, Interaction):
+        return f"{entity.content}\n{entity.user_action_description}"
+    if isinstance(entity, UserProfile):
+        return "\n".join([entity.content, str(entity.custom_features)])
+    if isinstance(entity, (UserPlaybook, AgentPlaybook)):
+        return entity.trigger or entity.content
+    if isinstance(entity, AgentSuccessEvaluationResult):
+        return f"{entity.failure_type} {entity.failure_reason}"
+    raise TypeError(f"Unsupported embedding text entity: {type(entity).__name__}")
+
+
+def embedding_input(text: str, *, purpose: str = "document") -> str:
+    """Apply the asymmetric search prefix used before embedding calls."""
+    prefix = SEARCH_DOCUMENT_PREFIX if purpose == "document" else SEARCH_QUERY_PREFIX
+    return prefix + text

--- a/reflexio/server/services/embedding_text.py
+++ b/reflexio/server/services/embedding_text.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     AgentSuccessEvaluationResult,
@@ -27,15 +29,34 @@ def embedding_text(entity: EmbeddingTextEntity) -> str:
     if isinstance(entity, Interaction):
         return f"{entity.content}\n{entity.user_action_description}"
     if isinstance(entity, UserProfile):
-        return "\n".join([entity.content, str(entity.custom_features)])
+        parts = [entity.content]
+        if entity.custom_features:
+            parts.append(str(entity.custom_features))
+        return "\n".join(parts)
     if isinstance(entity, (UserPlaybook, AgentPlaybook)):
         return entity.trigger or entity.content
     if isinstance(entity, AgentSuccessEvaluationResult):
-        return f"{entity.failure_type} {entity.failure_reason}"
+        return " ".join(
+            part
+            for part in (entity.failure_type, entity.failure_reason)
+            if part and part.strip()
+        )
     raise TypeError(f"Unsupported embedding text entity: {type(entity).__name__}")
 
 
-def embedding_input(text: str, *, purpose: str = "document") -> str:
-    """Apply the asymmetric search prefix used before embedding calls."""
-    prefix = SEARCH_DOCUMENT_PREFIX if purpose == "document" else SEARCH_QUERY_PREFIX
-    return prefix + text
+def embedding_input(
+    text: str, *, purpose: Literal["document", "query"] = "document"
+) -> str:
+    """Apply the asymmetric search prefix used before embedding calls.
+
+    ``purpose`` must be ``"document"`` or ``"query"``; any other value raises so a
+    misspelled call site fails fast instead of silently writing or searching the
+    wrong vector space.
+    """
+    if purpose == "document":
+        return SEARCH_DOCUMENT_PREFIX + text
+    if purpose == "query":
+        return SEARCH_QUERY_PREFIX + text
+    raise ValueError(
+        f"Unknown embedding purpose {purpose!r}; expected 'document' or 'query'"
+    )

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -7,13 +7,12 @@ import logging
 import os
 import uuid
 from datetime import UTC, datetime
-from typing import cast
+from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from reflexio.models.api_schema.retriever_schema import SearchUserProfileRequest
 from reflexio.models.api_schema.service_schemas import Status, UserProfile
-from reflexio.models.config_schema import EMBEDDING_DIMENSIONS
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.deduplication_utils import (
@@ -21,6 +20,7 @@ from reflexio.server.services.deduplication_utils import (
     format_dedup_timestamp,
     parse_item_id,
 )
+from reflexio.server.services.embedding_text import embedding_input
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileTimeToLive,
     calculate_expiration_timestamp,
@@ -321,12 +321,21 @@ class ProfileDeduplicator(BaseDeduplicator):
                     for query_text in query_texts
                 ]
             else:
+                storage_with_embeddings = cast(Any, storage)
+                embedding_model_name = storage_with_embeddings.embedding_model_name
+                embedding_dimensions = storage_with_embeddings.embedding_dimensions
                 logger.info(
-                    "Profile dedup query embeddings: source=llm_client model=default"
+                    "Profile dedup query embeddings: source=llm_client model=%s",
+                    embedding_model_name,
                 )
                 embeddings = list(
                     self.client.get_embeddings(
-                        query_texts, dimensions=EMBEDDING_DIMENSIONS
+                        [
+                            embedding_input(query_text, purpose="query")
+                            for query_text in query_texts
+                        ],
+                        model=embedding_model_name,
+                        dimensions=embedding_dimensions,
                     )
                 )
         except Exception as e:

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -7,6 +7,7 @@ import logging
 import os
 import uuid
 from datetime import UTC, datetime
+from typing import cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -302,11 +303,32 @@ class ProfileDeduplicator(BaseDeduplicator):
         if not query_texts:
             return []
 
-        # Batch-generate embeddings
+        # Generate embeddings with the request storage backend so dedup search
+        # uses the same model/prefix/routing as normal profile search.
+        embeddings: list[list[float] | None]
         try:
-            embeddings = self.client.get_embeddings(
-                query_texts, dimensions=EMBEDDING_DIMENSIONS
-            )
+            get_storage_embedding = getattr(storage, "_get_embedding", None)
+            if callable(get_storage_embedding):
+                logger.info(
+                    "Profile dedup query embeddings: source=storage model=%s",
+                    getattr(storage, "embedding_model_name", "unknown"),
+                )
+                embeddings = [
+                    cast(
+                        list[float],
+                        get_storage_embedding(query_text, purpose="query"),
+                    )
+                    for query_text in query_texts
+                ]
+            else:
+                logger.info(
+                    "Profile dedup query embeddings: source=llm_client model=default"
+                )
+                embeddings = list(
+                    self.client.get_embeddings(
+                        query_texts, dimensions=EMBEDDING_DIMENSIONS
+                    )
+                )
         except Exception as e:
             logger.warning("Failed to generate embeddings for dedup search: %s", e)
             embeddings = [None] * len(query_texts)

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.server.llm.providers import embedding_service_provider as esp
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
     embedding_provider_mode,
@@ -34,6 +35,46 @@ def test_local_model_without_opt_in_preserves_inprocess_mode(monkeypatch) -> Non
     monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+    monkeypatch.setattr(
+        esp.httpx,
+        "get",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            httpx.RequestError("connection refused")
+        ),
+    )
+
+    assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+
+
+def test_local_model_auto_uses_reachable_matching_daemon(monkeypatch) -> None:
+    class _HealthResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"active_model": "local/nomic-embed-text-v1.5"}
+
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+    monkeypatch.setattr(esp.httpx, "get", lambda *_args, **_kwargs: _HealthResponse())
+
+    assert embedding_provider_mode("local/nomic-embed-text-v1.5") == "local_service"
+
+
+def test_local_model_auto_avoids_reachable_mismatched_daemon(monkeypatch) -> None:
+    class _HealthResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"active_model": "local/nomic-embed-text-v1.5"}
+
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+    monkeypatch.setattr(esp.httpx, "get", lambda *_args, **_kwargs: _HealthResponse())
 
     assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
 

--- a/tests/server/llm/test_model_defaults.py
+++ b/tests/server/llm/test_model_defaults.py
@@ -182,7 +182,11 @@ class TestResolveModelName:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         for role in ModelRole:
             result = resolve_model_name(role)
-            expected = getattr(_PROVIDER_DEFAULTS["openai"], role.value)
+            expected = (
+                _PROVIDER_DEFAULTS["local"].embedding
+                if role == ModelRole.EMBEDDING
+                else getattr(_PROVIDER_DEFAULTS["openai"], role.value)
+            )
             assert result == expected, f"Mismatch for {role}"
 
     def test_auto_detect_anthropic(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -213,8 +217,8 @@ class TestResolveModelName:
         result = resolve_model_name(ModelRole.GENERATION)
         assert result == _PROVIDER_DEFAULTS["anthropic"].generation
 
-    def test_embedding_cross_provider_anthropic_primary(self) -> None:
-        """When only Anthropic key is in APIKeyConfig, embedding falls back to OpenAI via env."""
+    def test_embedding_config_default_ignores_cloud_api_keys(self) -> None:
+        """Embedding defaults to the OSS local model unless config overrides it."""
         from reflexio.models.config_schema import APIKeyConfig
 
         config = APIKeyConfig(
@@ -225,12 +229,12 @@ class TestResolveModelName:
             ModelRole.EMBEDDING,
             api_key_config=config,
         )
-        assert result == _PROVIDER_DEFAULTS["openai"].embedding
+        assert result == _PROVIDER_DEFAULTS["local"].embedding
 
     def test_gemini_embedding(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
         result = resolve_model_name(ModelRole.EMBEDDING)
-        assert result == _PROVIDER_DEFAULTS["gemini"].embedding
+        assert result == _PROVIDER_DEFAULTS["local"].embedding
 
     def test_embedding_fallback_to_local_when_no_cloud(
         self, monkeypatch: pytest.MonkeyPatch
@@ -246,14 +250,14 @@ class TestResolveModelName:
     def test_embedding_fallback_skipped_when_cloud_available(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Cloud embedder beats local fallback when both are available."""
+        """Local default still wins when cloud embedding keys are available."""
         from reflexio.server.llm.providers import local_embedding_provider as lep
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.setattr(lep.importlib.util, "find_spec", lambda _name: object())
         result = resolve_model_name(ModelRole.EMBEDDING)
-        assert result == _PROVIDER_DEFAULTS["openai"].embedding
+        assert result == _PROVIDER_DEFAULTS["local"].embedding
 
     def test_embedding_explicit_opt_in_beats_cloud(
         self, monkeypatch: pytest.MonkeyPatch
@@ -267,16 +271,15 @@ class TestResolveModelName:
         result = resolve_model_name(ModelRole.EMBEDDING)
         assert result == _PROVIDER_DEFAULTS["local"].embedding
 
-    def test_embedding_no_chromadb_raises(
+    def test_embedding_default_does_not_probe_chromadb(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Anthropic only + chromadb missing → RuntimeError with install hint."""
+        """Saved config owns overrides; default model selection does not inspect imports."""
         from reflexio.server.llm.providers import local_embedding_provider as lep
 
         monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-test")
         monkeypatch.setattr(lep.importlib.util, "find_spec", lambda _name: None)
-        with pytest.raises(RuntimeError, match="chromadb"):
-            resolve_model_name(ModelRole.EMBEDDING)
+        assert resolve_model_name(ModelRole.EMBEDDING) == _PROVIDER_DEFAULTS["local"].embedding
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/profile/test_profile_deduplicator.py
+++ b/tests/server/services/profile/test_profile_deduplicator.py
@@ -138,7 +138,7 @@ class TestPydanticModels:
             item_ids=["NEW-0"],
             merged_content="test",
             merged_time_to_live="one_day",
-            extra_field="not allowed",
+            extra_field="not allowed",  # pyright: ignore[reportCallIssue]
         )
         assert group.item_ids == ["NEW-0"]
         # JSON schema should forbid additional properties (used for LLM structured output)
@@ -1394,6 +1394,31 @@ class TestRetrieveExistingProfilesStatusFilter:
             llm_client=mock_llm_client,
         )
         assert deduplicator.output_pending_status is False
+
+    def test_fallback_embeddings_use_storage_model_and_query_prefix(
+        self, mock_request_context, mock_llm_client, mock_site_var_manager
+    ):
+        """Fallback batch embeddings stay compatible with stored profile vectors."""
+        mock_request_context.storage._get_embedding = None
+        mock_request_context.storage.embedding_model_name = "local/test-embedding-model"
+        mock_request_context.storage.embedding_dimensions = 768
+        mock_llm_client.get_embeddings.return_value = [[0.1] * 768]
+
+        deduplicator = ProfileDeduplicator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+
+        deduplicator._retrieve_existing_profiles(
+            [self._make_profile("User likes dark mode")],
+            "user",
+        )
+
+        mock_llm_client.get_embeddings.assert_called_once_with(
+            ["search_query: User likes dark mode"],
+            model="local/test-embedding-model",
+            dimensions=768,
+        )
 
     def test_rerun_mode_dedup_against_existing_pending(
         self, mock_request_context, mock_llm_client, mock_site_var_manager

--- a/tests/server/services/test_embedding_text.py
+++ b/tests/server/services/test_embedding_text.py
@@ -1,0 +1,72 @@
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    AgentSuccessEvaluationResult,
+    UserProfile,
+)
+from reflexio.server.services.embedding_text import embedding_input, embedding_text
+
+
+def test_user_profile_embedding_text_omits_empty_custom_features() -> None:
+    profile = UserProfile(
+        profile_id="p1",
+        user_id="u1",
+        content="likes dark mode",
+        last_modified_timestamp=1,
+        generated_from_request_id="r1",
+    )
+
+    assert embedding_text(profile) == "likes dark mode"
+
+    profile.custom_features = {}
+    assert embedding_text(profile) == "likes dark mode"
+
+
+def test_user_profile_embedding_text_includes_custom_features_when_present() -> None:
+    profile = UserProfile(
+        profile_id="p1",
+        user_id="u1",
+        content="likes dark mode",
+        last_modified_timestamp=1,
+        generated_from_request_id="r1",
+        custom_features={"theme": "dark"},
+    )
+
+    assert embedding_text(profile) == "likes dark mode\n{'theme': 'dark'}"
+
+
+def test_agent_success_embedding_text_omits_missing_failure_fields() -> None:
+    assert (
+        embedding_text(
+            AgentSuccessEvaluationResult(
+                agent_version="v1",
+                session_id="s1",
+                is_success=False,
+                failure_type=None,
+                failure_reason="agent stalled",
+            )
+        )
+        == "agent stalled"
+    )
+    assert (
+        embedding_text(
+            AgentSuccessEvaluationResult(
+                agent_version="v1",
+                session_id="s1",
+                is_success=True,
+                failure_type=None,
+                failure_reason=None,
+            )
+        )
+        == ""
+    )
+
+
+def test_embedding_input_applies_asymmetric_prefixes() -> None:
+    assert embedding_input("hello") == "search_document: hello"
+    assert embedding_input("hello", purpose="query") == "search_query: hello"
+
+
+def test_embedding_input_rejects_unknown_purpose() -> None:
+    with pytest.raises(ValueError, match="Unknown embedding purpose"):
+        embedding_input("hello", purpose="documnt")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Shared embedding-text composition and model-driven local embedding routing, extracted so both OSS and the enterprise tier reuse one code path (only the default model differs).

## What changed

- **New `reflexio/server/services/embedding_text.py`** — canonical `embedding_text(entity)` and `embedding_input(text, purpose)` builders plus the `search_document:` / `search_query:` prefix constants, so write paths and backfills share one source of truth instead of re-deriving strings per call site.
- **Model-driven routing** (`embedding_service_provider.py`) — a `local/*` model routes to the local daemon when it is reachable and owns the requested model, otherwise falls back to in-process; cloud models route to their provider. No global provider switch required.
- **Embedding-role default** (`model_defaults.py`) — the embedding role now resolves to the OSS local MiniLM model ahead of site-var/autodetect; logging clarified to distinguish cloud vs. local fallback availability.
- **Daemon building blocks** (`embedding_service.py`) — `NOMIC_TEXT_MODEL`, `_embed_texts`, and `create_embedding_app(default_model=...)` so a tier can launch a warmed local daemon on the same shared code. The Nomic provider now honors `HF_HOME` for its model cache.
- **Profile dedup** (`profile_deduplicator.py`) — query embeddings now go through `storage._get_embedding(..., purpose="query")` instead of a modelless `get_embeddings`, preventing a silent MiniLM fallback that would mismatch stored vectors.

## Testing

- `ruff check` / `pyright` clean on changed files
- `pytest tests/server/llm/test_embedding_service_provider.py tests/server/llm/test_model_defaults.py` — 61 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic embedding routing between local and service embedders based on availability.
  * Deterministic embedding text formatting and asymmetric search prefixes for document vs. query inputs.
  * Health reporting now includes the active embedding model.

* **Improvements**
  * Embedding selection now reliably defaults to the local embedding model even when cloud configs are present.
  * Improved detection and caching of local embedding service availability and model compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — review feedback addressed (46fcc52)

- **Avoid embedding literal `None`/empty for optional fields** — `embedding_text` now omits empty `custom_features` (profiles) and joins only non-empty `failure_type`/`failure_reason` (eval results), so stored vectors track real content.
- **Validate `purpose`** — `embedding_input(purpose=...)` is now `Literal["document","query"]` and raises on any other value instead of silently using the query prefix.
- **Dedup fallback vector space** — the `_retrieve_existing_profiles` fallback batch path now embeds with `storage.embedding_model_name` / `embedding_dimensions` and the `search_query:` prefix, matching the per-row path so backends without `_get_embedding` stay in the same space.

Added `tests/server/services/test_embedding_text.py` and a dedup fallback parity test. ruff + pyright clean; 51 tests pass.
