### PR TITLE
fix(tuning): harden extraction runs and prompts

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -557,6 +557,13 @@ class InteractionData(BaseModel):
 # publish user interaction request
 class PublishUserInteractionRequest(BaseModel):
     request_id: NonEmptyStr | None = None
+    """Optional caller-supplied request id for idempotent/local tracing.
+
+    If omitted, the backend generates a UUID as before. Supplying this is useful
+    for async callers that need to observe the exact request in extraction
+    state without waiting for the full publish response.
+    """
+
     user_id: NonEmptyStr
     interaction_data_list: list[InteractionData] = Field(min_length=1)
     source: str = ""

--- a/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.2.1.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_extraction_context/v4.2.1.prompt.md
@@ -1,0 +1,282 @@
+---
+description: "Context setting prompt for resumable playbook extraction. Every claim must be grounded in the conversation and generalized to a reusable task context; both requirements apply jointly to Correction SOPs and Success Path Recipes."
+changelog: "v4.2.1: rejects prescriptive fix recipes whose correctness is only self-validated by agent-authored tests or assumptions, without an external/reference success signal. v4.2.0: adds emergent skill-convention guidance for structuring multi-aspect playbook content as a small set of grouped do/avoid rules (no schema change). v4.1.7: adds resumable extraction guidance, names legacy fallback and malformed-input branches in boundary-change recipes, and avoids a polarity output field. (in-place 2026-05-30: tool-oriented finish_extraction output framing; deprecated and removed blocking_issue.) (in-place 2026-05-30: clarify in the Output Format section that finish_extraction may be preceded by ask_human/attach_pending_info_request; restructure examples into one no-tool example plus a worked ask_human and attach_pending_info_request example; stress that ask_human is rare and reserved for critical missing org-level facts — finish_extraction alone is the norm.) (in-place 2026-05-30: condense the resumable guidance — state finish-required/optional once, replace the duplicated Output Format block with a one-line pointer, and trim example prose.) (in-place 2026-06-03: consolidate and shorten the ask_human condition: ask only for missing shared context needed to know what to do, while still finishing extraction.) (in-place 2026-06-03: frame finish_extraction as the final completion tool and pending-info tools as intermediate.) (in-place 2026-06-03: clarify that empty finish_extraction alone must not replace ask_human when the ask_human condition applies.) (in-place 2026-06-04: clarify ask_human and attach_pending_info_request are alternatives for the same gap, not a sequence.)"
+variables:
+  - agent_context_prompt
+  - extraction_definition_prompt
+  - tool_can_use
+---
+You are a self-improvement policy mining assistant for AI agents.
+Your job is to extract **reusable patterns** from agent trajectories that help similar future tasks run faster and more accurately. Extract task recipes, not transcripts: prefer entries that change a future agent's first actions, constraints, checks, or avoided detours.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Resumable Extraction Mode
+
+When tool calling is available, tools have two roles:
+
+* **Intermediate tools:** `ask_human` and `attach_pending_info_request` gather missing context before finalizing.
+* **Final completion tool:** `finish_extraction` commits the playbooks for this run. Call it once, after any needed intermediate tool calls.
+
+Use `ask_human` for missing shared/org context needed to know **what to do** in a durable playbook: the positive action, exact target, procedure, policy, or standard. This is okay even when other useful playbooks can still be extracted now.
+
+Choose exactly one intermediate path per missing fact: use `attach_pending_info_request` when Prior Knowledge already lists a matching pending request; otherwise use `ask_human`. Do not call `attach_pending_info_request` for a pending request that this same run just created with `ask_human`.
+
+Do not ask for user-scoped/private facts, context derivable from the trajectory, agent context, tool list, or Prior Knowledge, complete avoidance-only rules, or merely nice-to-have details.
+
+If an intermediate tool is needed, call exactly one of the two intermediate tools before `finish_extraction`. Then finalize the current run with any independently valid playbooks now, including avoidance rules; if none are valid without the answer, finalize with `{{"playbooks": []}}`.
+
+When the `ask_human` condition applies, an `ask_human` tool call is required before finalization. Do not replace the question with `finish_extraction` alone, even with an empty playbook list.
+
+Tool-call discipline: create actual tool calls; do not merely write "call ask_human" inside a playbook's `content`, `rationale`, or plain text, and do not invent missing "what to do" details.
+
+You extract TWO CATEGORIES of patterns, and a single trajectory can contain BOTH:
+
+1. **Correction SOPs** — patterns learned from user-correction signals (multi-turn dialogues where the user pushed back on the agent's default behavior).
+2. **Success Path Recipes** — compact solution paths extracted from successful task completions, so a future run of a similar task can go directly to the decisive source, action, and verification instead of re-discovering them.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Category 1 — Correction SOPs
+
+Extract a **Correction SOP** when ALL are true:
+1. The agent performed an action, assumption, or default behavior.
+2. The user signaled this behavior was incorrect, inefficient, or misaligned.
+3. The correction implies a **better default workflow** for similar future requests.
+
+### Valid Correction Signals
+Look for cross-turn causal patterns, not isolated messages.
+
+Valid signals include:
+* User correcting or rejecting the agent's approach
+* User redirecting the agent to a different mode or level of detail
+* User expressing dissatisfaction with how the agent behaved
+* User clarifying expectations that contradict the agent's behavior
+* Agent retrying a tool call with different inputs after getting poor or irrelevant results (self-correction)
+* Agent switching from one tool to another within the same task after inadequate results
+
+You MUST identify the triggering agent behavior
+(assumption made, default chosen, constraint ignored, or question not asked).
+
+### Trigger Quality
+
+A valid `trigger` describes the **problem or situation**, NOT the user's explicitly stated preference.
+* **BAD:** "User requests CLI tools." (Just restates the user's explicit ask.)
+* **GOOD:** "User reports timeout or performance failures on large data transfers (>10TB)."
+
+Both `trigger` and `content` must satisfy the joint grounded-and-generalized requirement defined in Content Grounding Rules below.
+
+### Tautology Check (Correction SOPs only)
+If the `trigger` can be reduced to "user asks for X" and the `content` is "do X", the SOP is tautological. Re-derive the real trigger as the *problem or situation* the agent encountered. This check does NOT apply to Success Path Recipes.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Category 2 — Success Path Recipes
+
+Extract a **Success Path Recipe** when ALL are true:
+1. The agent successfully completed the task (produced final deliverables, resolved the user's request, or reached the intended end state).
+2. The trajectory contains **reusable task structure** — at least one of:
+   - A failed tool call before a successful retry
+   - Parameters that had to be tuned after returning wrong or incomplete results
+   - A tool swapped mid-task after the first choice did not work
+   - A redundant or dead-end step that did not contribute to the final answer
+   - Discovery work (reading docs, probing formats, sampling data) that a future agent, armed with what was learned, could skip
+   - A decisive source, artifact, owner, signal, constraint, or intermediate result that determined the solution
+   - A narrow verification that proved the result before broader checks
+3. A future agent could act differently because of the recipe: start in a better place, choose a better action, verify earlier, or skip a detour.
+
+If the agent reached the answer on a clean first-try path with no reusable decision, verification, or shortcut, **do not emit a recipe** — there is nothing to optimize.
+
+A Success Path Recipe does NOT require a user-correction signal.
+
+### Success Path content format
+
+The `content` field is the **optimized, replayable path** — the straight-line sequence the original trajectory converged to, with detours removed. Use this compact shape: start at the decisive source/artifact/signal; take the ordered actions that solved it; carry forward any constraint or edge condition that was necessary for correctness; run the narrow verification; skip the named detour. Name the tool category, parameter shape, artifact role, or evidence cue when it helps retrieval.
+
+A strong recipe answers, when the trajectory supports it:
+- **Applies when:** the reusable situation class, not only this exact request.
+- **Do:** the shortest successful action pattern.
+- **Constraints:** preconditions, edge cases, options, or boundaries that changed the outcome.
+- **Avoid:** plausible detours, failed approaches, or incomplete fixes from the session.
+- **Validate:** the narrow check that proved the recipe before broader review.
+
+Use the final verified implementation state and independent correctness signals as the source of truth. Include exact code, parameters, commands, or config values only when they are anchored in the final diff, final inspected file state, final successful command, or an external/reference signal such as an existing test, upstream/reference patch, user-provided expected behavior, unchanged suite expectation, or final evaluation success. For code-fix trajectories, do not emit a prescriptive fix recipe when correctness is only self-validated by the same agent's new or edited test, local assertion, or inferred expected result; if independent support is absent or contradicted, extract only setup/verification detours that are independently supported, not the proposed root cause, skipped code path, expected result, or patch shape. If a detail was changed, failed, or is not visible in the final evidence, write the reusable action pattern instead of an exact snippet; omit the stale detail or capture it as negative/avoid evidence.
+
+If discovery found multiple analogous surfaces for the same invariant, carry that scope forward as a coverage checklist and verification target; do not collapse the recipe to the first edited or locally passing surface.
+
+When the final code changes a value's representation, type, precision, ownership, or lifecycle, keep the recipe but carry the semantic constraints and validation cases a future agent must preserve. Treat the exact implementation as mandatory only when the session proved that representation choice.
+
+When the fix refactors a boundary such as serialization, parsing, validation, adapters, or error handling, carry adjacent malformed-input and failure-path invariants into the recipe when the session inspected or tested them. Do not reduce the recipe to the new happy path if preserving the old error behavior was part of the explored surface.
+
+If a final passing boundary change keeps legacy fallback branches, unknown-type handling, null/empty inputs, or malformed data behavior, name those branches explicitly as constraints. Future agents should be able to distinguish the complete passing recipe from an incomplete happy-path implementation.
+
+For verification/setup detours, capture the reusable setup rule rather than a brittle command copy: the documented runner/source to consult, required working-directory or import-path relationship, missing declared dependency, and the failed assumption to avoid. Failed executable paths, wrong working directories, import-path errors, and missing declared dependencies all count as setup detours. Prioritize the pattern "failed command -> same goal succeeds with corrected path, environment, or dependency"; ignore benchmark sentinel/handoff mechanics unless they caused the task failure. If a failed setup command is followed by a successful retry and the lesson would change a future agent's first command, emit that setup recipe as its own playbook instead of folding it into the domain solution.
+
+Keep entries concise — a quick reference, not a recap. Omit restated user feedback, log excerpts, and summary preambles.
+
+End with one short line naming the detour from the original path that the reader should skip. Skip broad summaries, one-off facts, and domain details that would not change the next agent's actions. A generic "follow best practices" is worthless; a compact recipe plus the detour to skip is gold.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Content Grounding Rules (CRITICAL)
+
+Every entry — both Correction SOPs and Success Path Recipes — must satisfy two joint requirements:
+
+1. **Grounded** — every claim in `content` is supported by the conversation or the agent context. Do NOT invent policies, escalation paths, tools, teams, or procedures.
+2. **Generalized** — the entry applies in a different task context with no access to this conversation. Restate private or one-off artifacts in terms of their reusable role; original concretes may appear only when they are retrieval keys needed to recognize the same situation class.
+
+Grounding constrains the *source* of a claim (it must come from the conversation), not its *form*. A useful entry preserves concrete cues that help retrieval while explaining why they matter as part of a transferable role. The conversation is the evidence; the entry is the distilled, transferable rule.
+
+**GOOD content** — grounded in evidence:
+- Describes what the agent did wrong (traceable to a specific agent turn)
+- Describes what the user wanted instead (traceable to a specific user turn)
+- States what the agent should avoid doing (the observed mistake)
+- If the agent lacks a capability, says so honestly without inventing a workaround
+
+**BAD content** — hallucinated:
+- Invents escalation paths ("transfer to the shipping team") when no such team was mentioned
+- Invents specific procedures ("check the confirmation email for tracking links") when the user never mentioned these exist
+- Prescribes solutions the agent has no evidence it can actually do
+- Adds generic customer-service advice not grounded in this specific interaction
+
+**When the agent doesn't know what to do:** Describe what to AVOID (the observed mistake) and state the limitation honestly. It is much better to say "do not fabricate order status — admit you cannot look it up" than to invent a specific alternative the agent may not actually have. If the missing "what to do" detail satisfies the `ask_human` condition above, use the tool; otherwise emit only the grounded avoidance rule or no playbook.
+
+**Rule of thumb (both checks must pass):**
+1. *Grounded* — if you remove the conversation and only read the `content`, could someone verify every claim by re-reading the conversation? If not, you've hallucinated.
+2. *Generalized* — could a future agent in a similar task context, with no access to this conversation, apply the entry as written? If not, you've overfit — restate the pattern at the level of situation, artifact role, action sequence, verification, and detour.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Reasoning Procedure (REQUIRED)
+
+For **Correction SOPs**:
+1. Identify user turns containing correction, rejection, or redirection
+2. Trace backwards to the exact agent behavior that triggered it
+3. Identify the violated implicit expectation
+4. Draft the `trigger` (the problem or situation)
+5. Tautology Check (see above)
+6. Draft `content`: reason through what the agent did wrong and what the user's feedback tells us the agent should do differently. Ground every statement in evidence from the conversation. If the user told the agent what to do, capture that. If the user only told the agent what NOT to do, capture the avoidance. Do not guess what the right action is if the conversation doesn't tell you; use `ask_human` only when the condition above applies.
+
+For **Success Path Recipes**:
+1. Identify whether the agent completed the task successfully
+2. Scan the trajectory for **reusable task structure**: decisive source/artifact/signal, ordered actions, narrow verification, failed approach, parameter retry, tool swap, redundant step, or discovery work a future agent could skip. If none are present, **stop — do not emit a recipe.**
+3. Enumerate the final working approach as a sequence of tool categories, parameter shapes, artifact roles, evidence cues, ordered operations, correctness constraints, and verification signals
+4. Frame the trigger as a reusable task-type description (domain + action)
+5. Compose `content` as the **optimized straight-line path** — specific enough to replay without re-deriving anything, generalized enough to apply in a similar task context — and add one short line naming the detour from the original trajectory that the reader should skip. Preserve constraints and checks that made the final answer correct; those are often the difference between a useful recipe and a generic recap.
+
+Repeat for **every distinct** policy or recipe the conversation supports. If a task has both a domain solution and a reusable setup or verification detour, emit separate entries for those independent lessons.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Context of user interactions
+{agent_context_prompt}
+
+When reviewing the conversation, pay special attention to whether the agent explored all available tools to address the user's stated needs before accepting a negative outcome (e.g., cancellation, downgrade, churn, rejection).
+
+## Playbook Focus
+{extraction_definition_prompt}
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Tool Usage Analysis
+Tool calls in the conversation appear as `[used tool: tool_name({{"param": "value"}})]` prefixes on agent messages. A single message may have multiple `[used tool: ...]` prefixes when the agent called several tools in one turn. Analyze them for these patterns:
+
+[Available Tools]
+{tool_can_use}
+
+1. **Wrong tool selected** — feeds Correction SOPs.
+2. **Suboptimal tool inputs** — feeds Correction SOPs.
+3. **Tool retry patterns** — the final successful call reveals what should have been done first. For Correction SOPs, extract the lesson. For Success Path Recipes, include the *final working parameters* as part of the recipe.
+4. **Missed tool usage** — feeds Correction SOPs.
+5. **Working tool sequences** — for Success Path Recipes, capture the *order* in which tools were called and *what each contributed*.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Action vs avoidance framing
+
+Write each playbook in the form that best matches its evidence:
+
+- Use direct action language for successful, neutral, or ambiguous evidence. This is the default and covers most entries.
+- Use avoidance language only when the specific rule is grounded in a clear failure pattern: user pushback, self-correction away from an approach, external refutation, or explicit dislike.
+
+When writing an avoidance rule, start `content` with `Avoid`, `Do not`, `Don't`, or `Never`, and make the `rationale` name the observed failure pattern. Do not add a separate polarity field; downstream systems infer orientation from the wording and evidence.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Structuring multi-aspect content
+
+When the guidance for a playbook covers multiple steps or sub-aspects of a task, write `content` as a short set of rules grouped by sub-goal, rather than one dense sentence. Phrase each rule as a clear action (do) rule, or as an avoidance rule (`Avoid`/`Do not`/`Don't`/`Never`) when it names a failure to steer around. Keep it minimal — only the rules the evidence supports; a single-point playbook stays a single rule. Do not force structure where the guidance is atomic.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Output Format (Strict JSON)
+
+Complete the run by calling the final completion tool, `finish_extraction`, with a single JSON argument: an object with one key `"playbooks"` whose value is a list of zero or more playbook entries. Put the JSON in the tool call — do not write it as a plain-text reply. Correction SOPs and Success Path Recipes use the SAME schema — the `trigger` wording distinguishes them. Do not add markdown headings, prose, comments, chain-of-thought, or extra top-level keys; put all natural-language guidance inside the allowed entry fields.
+
+When an intermediate tool is needed, call it before the final `finish_extraction` call. Examples 2 and 3 below show those shapes.
+
+{{
+    "playbooks": [
+        {{
+            "rationale": "1-2 sentence summary: for a Correction SOP, what implicit expectation was violated. For a Success Path Recipe, why this recipe captures transferable value.",
+            "trigger": "The problem or situation where the agent's default was wrong, OR the task type for a recipe.",
+            "content": "The main actionable content — grounded in the conversation. For a Correction SOP: what the agent should do or avoid based on evidence from user feedback. For a Success Path Recipe: the compact replay recipe with applies-when context, start point, ordered actions, necessary constraints, verification, and detour to skip."
+        }}
+    ]
+}}
+
+**How many entries to return:**
+* Emit one entry per distinct Correction SOP.
+* Emit one entry per distinct Success Path Recipe **only when the trajectory contained reusable task structure** (see Category 2, condition 2). Clean first-try successes with no reusable decision, verification, or shortcut yield zero recipes — padding the playbook with obvious recaps degrades its value.
+* Correction SOPs are independent of recipe emission: extract a SOP whenever a correction signal is present, regardless of whether any recipe qualifies.
+
+When truly nothing applies, call `finish_extraction` with an empty list:
+
+{{"playbooks": []}}
+
+**Never split a single policy across multiple entries; never merge two independent policies into one.**
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Examples
+
+**Example 1 — `finish_extraction` only (the normal case):**
+One trajectory can yield both categories as separate entries in one call. Here the user corrected a default (turn 2: "Don't give me the code yet, explain the strategy first") *and* the run revealed a reusable path (started from the authoritative spec, validated against the acceptance tests, after a broad-search detour). Everything is grounded, so no resumable tool is needed.
+* **Call `finish_extraction` with:**
+{{
+  "playbooks": [
+    {{
+      "rationale": "Correction SOP — the agent jumped straight to code, but the user wanted to understand the approach first. The trigger names the problem situation, not the user's literal ask.",
+      "trigger": "User asks for help with complex implementations or architectural decisions.",
+      "content": "Present the high-level strategy first, ask whether to proceed, then generate implementation only after the approach is aligned."
+    }},
+    {{
+      "rationale": "Success Path Recipe — captures the selection-and-validation structure the run converged to after a broad-search detour. The trigger is a reusable task type, not a correction.",
+      "trigger": "Producing a structured deliverable from source material when the correct output depends on an authoritative spec and acceptance checks.",
+      "content": "(1) Start from the authoritative spec/source artifact that defines the criteria. (2) Extract the required output structure. (3) Apply the transformation in the order the criteria require. (4) Validate against the narrow acceptance checks before broad review. Detour to skip: do not begin with broad exploration once the authoritative source is known."
+    }}
+  ]
+}}
+The `trigger` wording distinguishes them: a problem-situation trigger marks a Correction SOP, a task-type trigger marks a Success Path Recipe.
+
+**Example 2 — `ask_human` then empty `finish_extraction`:**
+The agent deployed a backend service; the user said "use our canonical deployment target — you know the internal standard" but never named it, and no pending request covers it. The durable playbook must name the exact target because the deployment path is target-specific, so a generic "confirm the target" recipe would be invalid. Ask for the target, then still finish with no playbooks for this run.
+* **First, call `ask_human` as a tool call:**
+{{"question": "What is this org's canonical deployment target for backend services? The trajectory references an 'internal standard' but never names it.", "answer_format": "deployment target / platform name", "tags": ["deployment", "org-standard"]}}
+* **Then call `finish_extraction` as a separate tool call:**
+{{
+  "playbooks": []
+}}
+
+**Example 3 — `attach_pending_info_request` then `finish_extraction`:**
+Same gap as Example 2, but Prior Knowledge already lists a pending request for that exact question — so attach to it instead of asking again, then finish.
+* **Prior Knowledge contains:**
+```
+Pending requests:
+- pending_tool_call_id: ptc_7f3a91
+  question: What is this org's canonical deployment target for backend services?
+```
+* **Call `attach_pending_info_request`:**
+{{"pending_tool_call_id": "ptc_7f3a91", "why_relevant": "Same undecided org deployment standard; resume when answered."}}
+* **Then call `finish_extraction`** with the same empty result as Example 2. Only ever pass a `pending_tool_call_id` that appears verbatim in the Prior Knowledge "Pending requests" section.
+
+━━━━━━━━━━━━━━━━━━━━━━
+## Rules for Output Fields
+
+* The top-level response MUST be a JSON object with a single `"playbooks"` key whose value is a list (possibly empty)
+* Each entry in `"playbooks"` MUST satisfy ALL of the following:
+  * "rationale" is REQUIRED — 1-2 sentence summary of why this entry captures reusable value
+  * "trigger" is REQUIRED — situation/condition for Correction SOPs OR task-type descriptor for Success Path Recipes (used as search key)
+  * "content" is REQUIRED — the main actionable content. MUST satisfy both joint requirements (grounded in conversation evidence AND generalized to apply in other repos). See Content Grounding Rules.
+* Each playbook MUST correspond to a triggering agent behavior OR a successful task completion in the trajectory
+* Vague, stylistic, or unanchored advice is invalid for BOTH categories
+* Each entry must describe a **distinct, independent** policy or recipe

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -857,6 +857,10 @@ class BaseGenerationService(
                 f"for {self._get_service_name()} identifier={identifier}"
             )
             logger.error(error_msg)
+            self._fail_active_extraction_runs(
+                extractor_kind=get_extractor_name(extractor_config),
+                last_error=error_msg,
+            )
             raise ExtractorExecutionError(error_msg) from exc
         except Exception as exc:
             self._last_extractor_run_stats = {"total": 1, "failed": 1, "timed_out": 0}
@@ -869,6 +873,44 @@ class BaseGenerationService(
         finally:
             if executor is not None:
                 executor.shutdown(wait=False, cancel_futures=True)
+
+    def _fail_active_extraction_runs(
+        self,
+        *,
+        extractor_kind: str,
+        last_error: str,
+    ) -> None:
+        """Mark active agent-run rows failed when the service timeout fires."""
+        if self.storage is None or self.service_config is None:
+            return
+        request_id = getattr(self.service_config, "request_id", None)
+        if not request_id:
+            return
+        user_id = getattr(self.service_config, "user_id", None)
+        try:
+            failed_count = self.storage.fail_running_agent_runs_for_request(
+                org_id=self.request_context.org_id,
+                extractor_kind=extractor_kind,
+                user_id=user_id,
+                request_id=request_id,
+                last_error=last_error,
+            )
+        except NotImplementedError:
+            return
+        except Exception as exc:  # noqa: BLE001 - keep timeout error primary
+            logger.warning(
+                "Failed to mark timed-out %s agent runs failed: %s",
+                extractor_kind,
+                exc,
+            )
+            return
+        if failed_count:
+            logger.warning(
+                "Marked %d timed-out %s agent run(s) failed for request_id=%s",
+                failed_count,
+                extractor_kind,
+                request_id,
+            )
 
     def _finalize_extraction_runs(self) -> None:
         if self.storage is None:

--- a/reflexio/server/services/extraction/resumable_agent.py
+++ b/reflexio/server/services/extraction/resumable_agent.py
@@ -443,14 +443,39 @@ class ResumableExtractionAgent:
         committed_output = (
             finish_ctx.output.model_dump() if finish_ctx.output is not None else None
         )
+        active_statuses = (AgentRunStatus.RUNNING, AgentRunStatus.RESUMING)
         if result.finished_reason == "finish_tool" and committed_output is not None:
-            self.storage.update_agent_run_status(
+            stored_run = self.storage.update_agent_run_status(
                 run.id,
                 AgentRunStatus.AGENT_COMPLETED,
                 committed_output=committed_output,
                 pending_tool_call_ids=result.pending_tool_call_ids,
                 max_steps_remaining=result.max_steps_remaining,
+                expected_statuses=active_statuses,
             )
+            if (
+                stored_run is None
+                or stored_run.status != AgentRunStatus.AGENT_COMPLETED
+            ):
+                logger.warning(
+                    "event=extraction_agent_late_output_discarded org_id=%s "
+                    "user_id=%s extractor_kind=%s run_id=%s request_id=%s "
+                    "stored_status=%s",
+                    run.binding.org_id,
+                    run.binding.user_id,
+                    run.binding.extractor_kind,
+                    run.id,
+                    run.binding.request_id,
+                    stored_run.status if stored_run is not None else None,
+                )
+                return AgentRunResult(
+                    run_id=run.id,
+                    output=None,
+                    pending_tool_call_ids=[],
+                    messages=result.messages,
+                    trace=result.trace,
+                    finished_reason="late_output_discarded",
+                )
             logger.info(
                 "event=extraction_agent_finished org_id=%s user_id=%s "
                 "extractor_kind=%s run_id=%s request_id=%s "
@@ -478,6 +503,7 @@ class ResumableExtractionAgent:
                 AgentRunStatus.FAILED,
                 max_steps_remaining=result.max_steps_remaining,
                 last_error=last_error,
+                expected_statuses=active_statuses,
             )
             logger.warning(
                 "event=extraction_agent_failed org_id=%s user_id=%s "

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -8,7 +8,7 @@ import os
 from datetime import UTC, datetime
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from reflexio.models.api_schema.retriever_schema import SearchUserPlaybookRequest
 from reflexio.models.api_schema.service_schemas import UserPlaybook
@@ -199,6 +199,31 @@ class PlaybookConsolidationOutput(BaseModel):
     """
 
     decisions: list[ConsolidationDecision] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _repair_single_missing_new_id(cls, value: object) -> object:
+        """Recover the common one-candidate LLM omission of ``new_id``.
+
+        The consolidation prompt is usually called with a single extracted
+        playbook. Some weaker structured-output models emit a valid-looking
+        ``unify`` decision but omit ``new_id`` even though only ``NEW-0`` can
+        be meant. Repair only that unambiguous one-decision shape; multi-NEW
+        omissions remain validation errors.
+        """
+        if not isinstance(value, dict):
+            return value
+        decisions = value.get("decisions")
+        if not isinstance(decisions, list) or len(decisions) != 1:
+            return value
+        decision = decisions[0]
+        if not isinstance(decision, dict) or decision.get("new_id"):
+            return value
+        repaired = dict(value)
+        repaired_decision = dict(decision)
+        repaired_decision["new_id"] = "NEW-0"
+        repaired["decisions"] = [repaired_decision]
+        return repaired
 
     model_config = ConfigDict(json_schema_extra={"additionalProperties": False})
 

--- a/reflexio/server/services/storage/sqlite_storage/_agent_run.py
+++ b/reflexio/server/services/storage/sqlite_storage/_agent_run.py
@@ -333,6 +333,7 @@ class SQLiteAgentRunMixin:
         next_resume_at: datetime | None = None,
         last_error: str | None = None,
         increment_finalization_attempts: bool = False,
+        expected_statuses: tuple[AgentRunStatus, ...] | None = None,
     ) -> AgentRunRecord | None:
         current_timestamp = self._current_timestamp()
         assignments = ["status = ?", "updated_at = ?"]
@@ -361,13 +362,57 @@ class SQLiteAgentRunMixin:
             assignments.append("finalized_at = ?")
             params.append(current_timestamp)
         params.append(run_id)
+        status_filter = ""
+        if expected_statuses:
+            placeholders = ",".join("?" for _ in expected_statuses)
+            status_filter = f" AND status IN ({placeholders})"
+            params.extend(expected.value for expected in expected_statuses)
         with self._lock:
             self.conn.execute(
-                f"UPDATE _agent_runs SET {', '.join(assignments)} WHERE id = ?",
+                f"UPDATE _agent_runs SET {', '.join(assignments)} WHERE id = ?{status_filter}",
                 params,
             )
             self.conn.commit()
         return self.get_agent_run(run_id)
+
+    @SQLiteStorageBase.handle_exceptions
+    def fail_running_agent_runs_for_request(
+        self,
+        *,
+        org_id: str,
+        extractor_kind: str,
+        user_id: str | None,
+        request_id: str,
+        last_error: str,
+    ) -> int:
+        current_timestamp = self._current_timestamp()
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                UPDATE _agent_runs
+                SET status = ?,
+                    updated_at = ?,
+                    last_error = ?
+                WHERE org_id = ?
+                  AND extractor_kind = ?
+                  AND user_id IS ?
+                  AND request_id = ?
+                  AND status IN (?, ?)
+                """,
+                (
+                    AgentRunStatus.FAILED.value,
+                    current_timestamp,
+                    last_error,
+                    org_id,
+                    extractor_kind,
+                    user_id,
+                    request_id,
+                    AgentRunStatus.RUNNING.value,
+                    AgentRunStatus.RESUMING.value,
+                ),
+            )
+            self.conn.commit()
+            return cursor.rowcount
 
     @SQLiteStorageBase.handle_exceptions
     def create_pending_tool_call(

--- a/reflexio/server/services/storage/storage_base/_agent_run.py
+++ b/reflexio/server/services/storage/storage_base/_agent_run.py
@@ -220,7 +220,19 @@ class AgentRunMixin:
         next_resume_at: datetime | None = None,
         last_error: str | None = None,
         increment_finalization_attempts: bool = False,
+        expected_statuses: tuple[AgentRunStatus, ...] | None = None,
     ) -> AgentRunRecord | None:
+        raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
+
+    def fail_running_agent_runs_for_request(
+        self,
+        *,
+        org_id: str,
+        extractor_kind: str,
+        user_id: str | None,
+        request_id: str,
+        last_error: str,
+    ) -> int:
         raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
 
     def create_pending_tool_call(

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -742,11 +742,15 @@ class TestEmbeddingDefaultResolution:
             "reflexio.server.llm.litellm_client._is_chromadb_importable",
             lambda: True,
         )
+        monkeypatch.setattr(
+            "reflexio.server.llm.litellm_client.should_use_embedding_service",
+            lambda _model: False,
+        )
         fake_embedder = MagicMock()
         fake_embedder.embed.return_value = [[0.9, 0.8, 0.7]]
         monkeypatch.setattr(
-            "reflexio.server.llm.litellm_client.LocalEmbedder.get",
-            classmethod(lambda _cls: fake_embedder),
+            "reflexio.server.llm.litellm_client.LocalEmbedder",
+            MagicMock(get=MagicMock(return_value=fake_embedder)),
         )
 
         client = _build_client()

--- a/tests/server/services/extraction/test_resumable_agent.py
+++ b/tests/server/services/extraction/test_resumable_agent.py
@@ -159,6 +159,52 @@ def test_resumable_agent_finishes_profile_output(
     }
 
 
+def test_resumable_agent_discards_late_output_after_timeout_failure(
+    monkeypatch,
+    storage,
+    tool_call_completion,
+):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
+    make_tc, _make_stop = tool_call_completion
+    response = make_tc(
+        FINISH_EXTRACTION_TOOL_NAME,
+        {
+            "profiles": [
+                {
+                    "content": "User prefers AWS ECS deployments.",
+                    "time_to_live": "infinity",
+                }
+            ]
+        },
+    )
+    client = LiteLLMClient(LiteLLMConfig(model="claude-sonnet-4-6"))
+    agent = ResumableExtractionAgent(client=client, storage=storage)
+
+    def fail_then_return(*args, **kwargs):
+        storage.update_agent_run_status(
+            "run_late",
+            AgentRunStatus.FAILED,
+            last_error="Extractor timed out after 300 seconds",
+        )
+        return response
+
+    with patch("litellm.completion", side_effect=fail_then_return):
+        result = agent.start(
+            run=_agent_run("run_late"),
+            messages=[{"role": "user", "content": "extract profiles"}],
+            output_schema=StructuredProfilesOutput,
+        )
+
+    assert result.finished_reason == "late_output_discarded"
+    assert result.output is None
+    stored = storage.get_agent_run("run_late")
+    assert stored is not None
+    assert stored.status == AgentRunStatus.FAILED
+    assert stored.committed_output is None
+    assert stored.last_error == "Extractor timed out after 300 seconds"
+
+
 def test_resumable_agent_finishes_playbook_output(
     monkeypatch,
     storage,

--- a/tests/server/services/playbook/test_consolidation_output.py
+++ b/tests/server/services/playbook/test_consolidation_output.py
@@ -71,6 +71,52 @@ def test_unify_accepts_empty_archive_existing_ids():
     assert unify.archive_existing_ids == []
 
 
+def test_single_unify_decision_without_new_id_repairs_to_new_zero():
+    """A one-candidate consolidation response can safely infer ``NEW-0``.
+
+    MiniMax-M3 sometimes returned a ``unify`` decision with content, trigger,
+    rationale, and archive ids, but omitted ``new_id``. In the one-decision
+    shape there is only one possible candidate label, so the output schema
+    repairs it before the discriminated union validates.
+    """
+    out = PlaybookConsolidationOutput.model_validate(
+        {
+            "decisions": [
+                {
+                    "kind": "unify",
+                    "archive_existing_ids": ["EXISTING-0"],
+                    "content": "Unified guidance.",
+                    "trigger": "when fixing a known regression",
+                    "rationale": "The new rule extends the existing one.",
+                }
+            ]
+        }
+    )
+    decision = out.decisions[0]
+    assert isinstance(decision, UnifyDecision)
+    assert decision.new_id == "NEW-0"
+    assert decision.archive_existing_ids == [0]
+
+
+def test_multiple_decisions_without_new_id_still_fail_validation():
+    """Do not infer ``new_id`` when multiple NEW candidates are possible."""
+    with pytest.raises(ValidationError):
+        PlaybookConsolidationOutput.model_validate(
+            {
+                "decisions": [
+                    {
+                        "kind": "unify",
+                        "archive_existing_ids": [],
+                        "content": "A",
+                        "trigger": "t",
+                        "rationale": "r",
+                    },
+                    {"kind": "independent"},
+                ]
+            }
+        )
+
+
 def test_reject_new_requires_superseded_existing_id():
     """``RejectNewDecision`` must name the superseding existing id."""
     with pytest.raises(ValidationError):

--- a/tests/server/services/prompt/test_prompt_manager.py
+++ b/tests/server/services/prompt/test_prompt_manager.py
@@ -198,6 +198,25 @@ class TestPromptManager:
         assert result1 == result2
         assert result1 == "This is a test prompt with test_value and another_value"
 
+    def test_active_playbook_consolidation_prompt_renders_json_guidance(self):
+        """Guard literal JSON-shape guidance against str.format() parsing."""
+        current_dir = Path(prompt.__file__).parent
+        prompt_bank_path = (current_dir / "prompt_bank").resolve()
+        pm = PromptManager(str(prompt_bank_path))
+
+        rendered = pm.render_prompt(
+            "playbook_consolidation",
+            {
+                "new_playbook_count": "1",
+                "new_playbooks": "NEW-0: candidate",
+                "existing_playbooks": "EXISTING-0: prior",
+            },
+        )
+
+        assert "Output Format Guidance" in rendered
+        assert '"decisions"' in rendered
+        assert "Do not emit markdown" in rendered
+
     def test_all_prompt_md_files_valid(self):
         """Test that all .prompt.md files in prompt_bank have valid frontmatter."""
         current_dir = Path(prompt.__file__).parent

--- a/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
@@ -110,6 +110,22 @@ def test_sqlite_update_agent_run_status_records_lifecycle_timestamps(storage):
     assert finalized.finalized_at is not None
 
 
+def test_sqlite_update_agent_run_status_honors_expected_statuses(storage):
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FAILED))
+
+    updated = storage.update_agent_run_status(
+        "run_1",
+        AgentRunStatus.AGENT_COMPLETED,
+        committed_output={"profiles": []},
+        expected_statuses=(AgentRunStatus.RUNNING, AgentRunStatus.RESUMING),
+    )
+
+    assert updated is not None
+    assert updated.status == AgentRunStatus.FAILED
+    assert updated.committed_output is None
+    assert updated.agent_completed_at is None
+
+
 def test_sqlite_pending_tool_call_active_dedup_lookup(storage):
     now = datetime(2026, 5, 28, tzinfo=UTC)
     pending = storage.create_pending_tool_call(_pending_call("ptc_1", now=now))


### PR DESCRIPTION
## Summary
- harden prompt-tuning extraction runs by preserving caller request IDs through generation and storage
- add hard LiteLLM timeout handling so timed-out extractor calls cannot continue writing late results
- add extractor and consolidator prompt revisions for SWE-bench failures found during the tuning loop
- add tests for timeout behavior, request-id persistence, prompt version mapping, and consolidation output shape

## Verification
- `uv run ruff check` on staged Python files
- `uv run pyright` on staged Python files
- `uv run pytest --no-cov -q tests/server/llm/test_litellm_client_unit.py tests/server/services/extraction/test_resumable_agent.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py tests/server/services/playbook/test_consolidation_output.py tests/server/services/prompt/test_prompt_manager.py tests/server/services/test_prompt_model_mapping.py tests/eval/extraction/test_extraction_eval.py`

## Notes
This replaces the closed, unmerged PR #130 with a fresh PR containing the latest branch head `ee57851`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional request ID field to API requests for idempotent tracing and request correlation.

* **Bug Fixes**
  * Improved extraction timeout error handling by recording failure details before raising errors.
  * Enhanced agent run status validation to prevent processing late output after failures.
  * Added automatic repair for specific playbook consolidation output validation errors.

* **Documentation**
  * Updated playbook extraction prompt with improved tool-calling discipline and correctness constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->