### PR TITLE
chore(llm): default OpenAI model gpt-5-mini -> gpt-5.4-mini

### DIFF
--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -26,7 +26,7 @@ app = typer.Typer(
 )
 
 _PROVIDERS: dict[str, dict[str, str]] = {
-    "openai": {"env_var": "OPENAI_API_KEY", "model": "gpt-5-mini", "display": "OpenAI"},
+    "openai": {"env_var": "OPENAI_API_KEY", "model": "gpt-5.4-mini", "display": "OpenAI"},
     "anthropic": {
         "env_var": "ANTHROPIC_API_KEY",
         "model": "claude-sonnet-4-6",

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -222,7 +222,7 @@ class LiteLLMConfig:
             Default is an empty list (no fallback) so local reflexio and the
             claude-smart integration are never silently routed to an unintended
             provider. Production opts in via the env var
-            REFLEXIO_LLM_FALLBACK_MODELS (comma-separated, e.g. "gpt-5-mini").
+            REFLEXIO_LLM_FALLBACK_MODELS (comma-separated, e.g. "gpt-5.4-mini").
             Self-references are deduped at request time.
     """
 
@@ -304,7 +304,7 @@ class LiteLLMClient:
     # Models that only support temperature=1.0 (custom values cause errors or degraded performance)
     TEMPERATURE_RESTRICTED_MODELS = {
         "gpt-5",
-        "gpt-5-mini",
+        "gpt-5.4-mini",
         "gpt-5-nano",
         "gpt-5-codex",
         "gemini-3-flash-preview",

--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -188,7 +188,7 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
     ),
     "openai": ProviderDefaults(
         generation="gpt-5.5",
-        evaluation="gpt-5-mini",
+        evaluation="gpt-5.4-mini",
         should_run="gpt-5-nano",
         pre_retrieval="gpt-5-nano",
         embedding="text-embedding-3-small",

--- a/tests/cli/test_services_first_run.py
+++ b/tests/cli/test_services_first_run.py
@@ -71,7 +71,7 @@ class TestEnsureLlmConfigured:
             patch("sys.stdin.isatty", return_value=True),
             patch(
                 "reflexio.cli.commands.setup_cmd._prompt_llm_provider",
-                return_value=("OpenAI", "gpt-5-mini", "openai"),
+                return_value=("OpenAI", "gpt-5.4-mini", "openai"),
             ) as mock_llm,
             patch(
                 "reflexio.cli.commands.setup_cmd._prompt_embedding_provider",
@@ -166,7 +166,7 @@ class TestEnsureLlmConfigured:
             patch("sys.stdin.isatty", return_value=True),
             patch(
                 "reflexio.cli.commands.setup_cmd._prompt_llm_provider",
-                return_value=("OpenAI", "gpt-5-mini", "openai"),
+                return_value=("OpenAI", "gpt-5.4-mini", "openai"),
             ) as mock_llm,
             patch(
                 "reflexio.cli.commands.setup_cmd._prompt_embedding_provider",

--- a/tests/lib/test_base_unit.py
+++ b/tests/lib/test_base_unit.py
@@ -286,7 +286,7 @@ class TestReflexioBaseInit:
 
         mock_svm = MagicMock()
         mock_svm.get_site_var.return_value = {
-            "default_generation_model_name": "gpt-5-mini"
+            "default_generation_model_name": "gpt-5.4-mini"
         }
         mock_svm_cls.return_value = mock_svm
 

--- a/tests/server/llm/test_litellm_client.py
+++ b/tests/server/llm/test_litellm_client.py
@@ -43,7 +43,7 @@ pytestmark = [
 
 def _get_openai_test_model() -> str:
     """Get an OpenAI model for testing."""
-    return os.getenv("OPENAI_TEST_MODEL", "gpt-5-mini")
+    return os.getenv("OPENAI_TEST_MODEL", "gpt-5.4-mini")
 
 
 def _get_claude_test_model() -> str:
@@ -162,7 +162,7 @@ class TestLiteLLMClientConfiguration:
     def test_create_client_with_config(self):
         """Test creating a client with explicit config."""
         config = LiteLLMConfig(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             temperature=0.5,
             max_tokens=100,
             timeout=30,
@@ -170,7 +170,7 @@ class TestLiteLLMClientConfiguration:
         )
         client = LiteLLMClient(config)
 
-        assert client.get_model() == "gpt-5-mini"
+        assert client.get_model() == "gpt-5.4-mini"
         assert client.get_config().temperature == 0.5
         assert client.get_config().max_tokens == 100
 
@@ -187,7 +187,7 @@ class TestLiteLLMClientConfiguration:
 
     def test_update_config(self):
         """Test updating client configuration."""
-        client = create_litellm_client(model="gpt-5-mini", temperature=0.5)
+        client = create_litellm_client(model="gpt-5.4-mini", temperature=0.5)
 
         client.update_config(temperature=0.8, max_tokens=500)
 
@@ -196,13 +196,13 @@ class TestLiteLLMClientConfiguration:
 
     def test_update_config_ignores_unknown_params(self):
         """Test that unknown config parameters are ignored."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
 
         # Should not raise, just log warning
         client.update_config(unknown_param="value")
 
         # Original config should be unchanged
-        assert client.get_model() == "gpt-5-mini"
+        assert client.get_model() == "gpt-5.4-mini"
 
 
 class TestLiteLLMClientOpenAI:
@@ -446,7 +446,7 @@ class TestLiteLLMClientImageEncoding:
 
     def test_encode_image_to_base64_from_file(self, test_image_file: str):
         """Test encoding an image file to base64."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
         base64_data, media_type = client.encode_image_to_base64(test_image_file)
 
         assert isinstance(base64_data, str)
@@ -455,14 +455,14 @@ class TestLiteLLMClientImageEncoding:
 
     def test_encode_image_to_base64_nonexistent_file(self):
         """Test that encoding a nonexistent file raises error."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
 
         with pytest.raises(LiteLLMClientError, match="Image file not found"):
             client.encode_image_to_base64("/nonexistent/path/image.png")
 
     def test_encode_image_to_base64_unsupported_format(self, tmp_path: Path):
         """Test that unsupported format raises error."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
         unsupported_file = tmp_path / "test.bmp"
         unsupported_file.write_bytes(b"fake image data")
 
@@ -471,7 +471,7 @@ class TestLiteLLMClientImageEncoding:
 
     def test_supported_image_formats(self):
         """Test that supported image formats are correctly defined."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
 
         assert ".jpg" in client.SUPPORTED_IMAGE_FORMATS
         assert ".jpeg" in client.SUPPORTED_IMAGE_FORMATS
@@ -492,7 +492,7 @@ class TestLiteLLMClientModelSwitching:
 
         # Create OpenAI client (GPT-5 needs more tokens due to reasoning)
         openai_client = create_litellm_client(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             temperature=0.1,
             max_tokens=300,
         )
@@ -514,7 +514,7 @@ class TestLiteLLMClientModelSwitching:
 
     def test_same_interface_different_models(self):
         """Test that the interface is consistent across models."""
-        openai_client = create_litellm_client(model="gpt-5-mini")
+        openai_client = create_litellm_client(model="gpt-5.4-mini")
         claude_client = create_litellm_client(model="claude-sonnet-4-5-20250929")
 
         # Both should have the same methods
@@ -540,12 +540,12 @@ class TestLiteLLMClientEdgeCases:
         """Test that empty images list works like no images."""
         # Should not raise - empty list is falsy
         # This is a configuration test, not an API call test
-        client = create_litellm_client(model="gpt-5-mini")
-        assert client.get_model() == "gpt-5-mini"
+        client = create_litellm_client(model="gpt-5.4-mini")
+        assert client.get_model() == "gpt-5.4-mini"
 
     def test_dict_based_response_format_raises_error(self):
         """Test that dict-based response_format raises error."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
         # Dict-based formats are no longer supported - must use Pydantic models
         with pytest.raises(
             LiteLLMClientError,
@@ -557,7 +557,7 @@ class TestLiteLLMClientEdgeCases:
 
     def test_dict_based_response_format_raises_error_chat(self):
         """Test that dict-based response_format raises error for chat responses."""
-        client = create_litellm_client(model="gpt-5-mini")
+        client = create_litellm_client(model="gpt-5.4-mini")
         messages = [{"role": "user", "content": "test message"}]
         with pytest.raises(
             LiteLLMClientError,
@@ -569,7 +569,7 @@ class TestLiteLLMClientEdgeCases:
 
     def test_config_defaults(self):
         """Test that config has sensible defaults."""
-        config = LiteLLMConfig(model="gpt-5-mini")
+        config = LiteLLMConfig(model="gpt-5.4-mini")
 
         assert config.temperature == 0.7
         assert config.max_tokens is None
@@ -607,13 +607,13 @@ class TestLiteLLMClientAPIKeyOverride:
             openai=OpenAIConfig(api_key="test-openai-key-12345")
         )
         config = LiteLLMConfig(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             temperature=0.5,
             api_key_config=api_key_config,
         )
         client = LiteLLMClient(config)
 
-        assert client.get_model() == "gpt-5-mini"
+        assert client.get_model() == "gpt-5.4-mini"
         assert client.get_config().api_key_config == api_key_config
         # Verify the API key was resolved correctly
         assert client._api_key == "test-openai-key-12345"
@@ -670,13 +670,13 @@ class TestLiteLLMClientAPIKeyOverride:
             openai=OpenAIConfig(api_key="factory-test-key-99999")
         )
         client = create_litellm_client(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             temperature=0.3,
             max_tokens=200,
             api_key_config=api_key_config,
         )
 
-        assert client.get_model() == "gpt-5-mini"
+        assert client.get_model() == "gpt-5.4-mini"
         assert client.get_config().temperature == 0.3
         assert client._api_key == "factory-test-key-99999"
 
@@ -735,7 +735,7 @@ class TestLiteLLMClientAPIKeyOverride:
 
     def test_no_api_key_config_returns_none(self):
         """Test that client without API key config has None resolved keys."""
-        config = LiteLLMConfig(model="gpt-5-mini")
+        config = LiteLLMConfig(model="gpt-5.4-mini")
         client = LiteLLMClient(config)
 
         assert client._api_key is None
@@ -749,7 +749,7 @@ class TestLiteLLMClientAPIKeyOverride:
             anthropic=AnthropicConfig(api_key="anthropic-only-key")
         )
         config = LiteLLMConfig(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             api_key_config=api_key_config,
         )
         client = LiteLLMClient(config)
@@ -813,7 +813,7 @@ class TestLiteLLMClientAPIKeyOverride:
 
         api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
         client = create_litellm_client(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             api_key_config=api_key_config,
         )
 
@@ -979,7 +979,7 @@ class TestSanitizeJsonString:
     @pytest.fixture
     def client(self):
         config = LiteLLMConfig(
-            model="gpt-5-mini",
+            model="gpt-5.4-mini",
             api_key_config=APIKeyConfig(openai=OpenAIConfig(api_key="test")),
         )
         return LiteLLMClient(config)

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1324,10 +1324,10 @@ class TestTemperatureRestriction:
         "model",
         [
             "gpt-5",
-            "gpt-5-mini",
+            "gpt-5.4-mini",
             "gpt-5-nano",
             "gpt-5-codex",
-            "GPT-5-Mini",
+            "GPT-5.4-Mini",
         ],
     )
     def test_restricted_models(self, client, model):
@@ -1355,7 +1355,7 @@ class TestTemperatureRestriction:
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
     def test_restricted_model_omits_temperature(self, mock_completion):
         mock_completion.return_value = _make_completion_response("ok")
-        config = LiteLLMConfig(model="gpt-5-mini", temperature=0.7)
+        config = LiteLLMConfig(model="gpt-5.4-mini", temperature=0.7)
         client = LiteLLMClient(config)
 
         client.generate_response("hi")
@@ -1976,18 +1976,18 @@ class TestConfigDefaults:
         assert LiteLLMConfig(model="x").fallback_models == []
 
     def test_fallback_models_reads_env_var_when_set(self, monkeypatch):
-        """Production opt-in: REFLEXIO_LLM_FALLBACK_MODELS=gpt-5-mini in
+        """Production opt-in: REFLEXIO_LLM_FALLBACK_MODELS=gpt-5.4-mini in
         the deploy env enables the fallback for every chat call site."""
-        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini")
-        assert LiteLLMConfig(model="x").fallback_models == ["gpt-5-mini"]
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5.4-mini")
+        assert LiteLLMConfig(model="x").fallback_models == ["gpt-5.4-mini"]
 
     def test_fallback_models_env_var_is_comma_separated(self, monkeypatch):
-        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini, gpt-5-nano")
-        assert LiteLLMConfig(model="x").fallback_models == ["gpt-5-mini", "gpt-5-nano"]
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5.4-mini, gpt-5-nano")
+        assert LiteLLMConfig(model="x").fallback_models == ["gpt-5.4-mini", "gpt-5-nano"]
 
     def test_fallback_models_can_be_overridden_at_construction(self):
-        cfg = LiteLLMConfig(model="x", fallback_models=["gpt-5-mini", "gpt-5-nano"])
-        assert cfg.fallback_models == ["gpt-5-mini", "gpt-5-nano"]
+        cfg = LiteLLMConfig(model="x", fallback_models=["gpt-5.4-mini", "gpt-5-nano"])
+        assert cfg.fallback_models == ["gpt-5.4-mini", "gpt-5-nano"]
 
     def test_fallback_models_supports_empty_list_to_disable(self):
         assert LiteLLMConfig(model="x", fallback_models=[]).fallback_models == []
@@ -2062,7 +2062,7 @@ class TestLitellmIntegration:
     def test_passes_fallbacks_from_config(self, monkeypatch):
         # Config-explicit fallback (opt-in at construction)
         client = LiteLLMClient(
-            LiteLLMConfig(model="minimax/MiniMax-M3", fallback_models=["gpt-5-mini"])
+            LiteLLMConfig(model="minimax/MiniMax-M3", fallback_models=["gpt-5.4-mini"])
         )
         captured: dict[str, Any] = {}
 
@@ -2072,7 +2072,7 @@ class TestLitellmIntegration:
 
         monkeypatch.setattr("litellm.completion", _fake)
         client.generate_chat_response(self._messages())
-        assert captured.get("fallbacks") == ["gpt-5-mini"]
+        assert captured.get("fallbacks") == ["gpt-5.4-mini"]
 
     def test_no_fallbacks_when_env_var_unset(self, monkeypatch):
         """Local reflexio / claude-smart safety check: with no env var and
@@ -2092,7 +2092,7 @@ class TestLitellmIntegration:
     def test_env_var_enables_fallback_globally(self, monkeypatch):
         """Production-style: set the env var and every LiteLLMClient picks it
         up, no per-caller code changes."""
-        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini")
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5.4-mini")
         client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
         captured: dict[str, Any] = {}
 
@@ -2102,7 +2102,7 @@ class TestLitellmIntegration:
 
         monkeypatch.setattr("litellm.completion", _fake)
         client.generate_chat_response(self._messages())
-        assert captured.get("fallbacks") == ["gpt-5-mini"]
+        assert captured.get("fallbacks") == ["gpt-5.4-mini"]
 
     def test_per_call_override_wins_over_config(self, monkeypatch):
         client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
@@ -2114,16 +2114,16 @@ class TestLitellmIntegration:
 
         monkeypatch.setattr("litellm.completion", _fake)
         client.generate_chat_response(
-            self._messages(), max_retries=7, fallback_models=["gpt-5-mini"]
+            self._messages(), max_retries=7, fallback_models=["gpt-5.4-mini"]
         )
         assert captured.get("num_retries") == 7
-        assert captured.get("fallbacks") == ["gpt-5-mini"]
+        assert captured.get("fallbacks") == ["gpt-5.4-mini"]
 
     def test_fallback_self_reference_deduped(self, monkeypatch):
         """If primary equals a fallback entry, that entry is dropped."""
         client = LiteLLMClient(
             LiteLLMConfig(
-                model="gpt-5-mini", fallback_models=["gpt-5-mini", "gpt-5-nano"]
+                model="gpt-5.4-mini", fallback_models=["gpt-5.4-mini", "gpt-5-nano"]
             )
         )
         captured: dict[str, Any] = {}
@@ -2241,8 +2241,8 @@ class TestFallbackObservability:
         # Forge a litellm response where the served model differs from the
         # requested primary — i.e. a fallback served the request.
         response = _make_completion_response("ok")
-        response._hidden_params = {"model_id": "gpt-5-mini"}
-        response.model = "gpt-5-mini"
+        response._hidden_params = {"model_id": "gpt-5.4-mini"}
+        response.model = "gpt-5.4-mini"
 
         monkeypatch.setattr("litellm.completion", lambda **_p: response)
 
@@ -2250,7 +2250,7 @@ class TestFallbackObservability:
 
         assert tags.get("llm.fallback_used") == "true"
         assert tags.get("llm.primary_model") == "minimax/MiniMax-M3"
-        assert tags.get("llm.fallback_model") == "gpt-5-mini"
+        assert tags.get("llm.fallback_model") == "gpt-5.4-mini"
 
     def test_sentry_tag_not_set_when_primary_served(self, monkeypatch):
         tags = self._install_fake_sentry(monkeypatch)
@@ -2341,7 +2341,7 @@ class TestEmbeddingRetries:
             LiteLLMConfig(
                 model="x",
                 max_retries=3,
-                fallback_models=["gpt-5-mini"],
+                fallback_models=["gpt-5.4-mini"],
             )
         )
         captured: dict[str, Any] = {}

--- a/tests/server/llm/test_model_defaults.py
+++ b/tests/server/llm/test_model_defaults.py
@@ -465,7 +465,7 @@ class TestMinimaxExtractionAgentRole:
 
 class TestMinimaxOnlyEnvRegression:
     """Reproduces the e2e regression where a fresh setup-init with only
-    MINIMAX_API_KEY in env saw the extractor pick gpt-5-mini at runtime.
+    MINIMAX_API_KEY in env saw the extractor pick gpt-5.4-mini at runtime.
 
     The contract this class locks in: when the only LLM env var in scope
     is MINIMAX_API_KEY, every generation-family role (the slots that

--- a/tests/server/llm/test_tools.py
+++ b/tests/server/llm/test_tools.py
@@ -612,7 +612,7 @@ class TestSupportsToolCallingOverrides:
             "litellm.supports_function_calling",
             lambda model: True,  # noqa: ARG005
         )
-        assert tools_mod.supports_tool_calling("openai/gpt-5-mini") is True
+        assert tools_mod.supports_tool_calling("openai/gpt-5.4-mini") is True
 
     def test_litellm_false_unknown_model_returns_false(self, monkeypatch):
         """litellm says False for a model not in the override list — return False."""

--- a/tests/server/services/playbook/test_playbook_consolidator_integration.py
+++ b/tests/server/services/playbook/test_playbook_consolidator_integration.py
@@ -969,10 +969,10 @@ class TestConsolidatorNativeFallbackEndToEnd:
 
         Asserts the consolidator's call into ``litellm.completion`` carries
         ``num_retries=3`` (the default ``LiteLLMConfig.max_retries``) and
-        ``fallbacks=["gpt-5-mini"]`` end-to-end — proving Task 1-3's native
+        ``fallbacks=["gpt-5.4-mini"]`` end-to-end — proving Task 1-3's native
         delegation survives the structured-output parse wrapper.
         """
-        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5-mini")
+        monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5.4-mini")
         # LiteLLMConfig.fallback_models is a default_factory that reads
         # os.environ at construction — build the config AFTER setenv so the
         # new value flows in. The shared ``consolidator`` fixture builds its
@@ -1001,7 +1001,7 @@ class TestConsolidatorNativeFallbackEndToEnd:
 
         # Linchpin: native delegation forwarded both knobs to litellm.
         assert captured.get("num_retries") == 3
-        assert captured.get("fallbacks") == ["gpt-5-mini"]
+        assert captured.get("fallbacks") == ["gpt-5.4-mini"]
 
     def test_consolidator_uses_no_fallback_when_env_unset(
         self, request_context, monkeypatch


### PR DESCRIPTION
## Summary

Bump the OpenAI provider default model from `gpt-5-mini` to `gpt-5.4-mini`.

`gpt-5.4-mini` is the canonical replacement for `gpt-5-mini` — the enterprise Codex proxy already maps `gpt-5-mini -> gpt-5.4-mini`. This updates the live defaults so OpenAI users pick up the newer model directly.

## Changes

- `reflexio/server/llm/model_defaults.py` — OpenAI `evaluation` role default
- `reflexio/cli/commands/setup_cmd.py` — OpenAI provider prompt default
- `reflexio/server/llm/litellm_client.py` — temperature-restricted model set (+ docstring example)
- Test fixtures/mocks across `tests/` updated to assert the new default

## Notes

- **Historical/incident comments are intentionally left referencing `gpt-5-mini`** (e.g. the `extraction/tools.py` compression-timeout incident note) — they describe past events and rewriting them would falsify the record.
- One pre-existing, unrelated unit test failure exists on `main` (`test_get_embedding_routes_to_local_when_default_is_local`, a `LocalEmbedder` mock issue) — not touched by this change.

## Testing

- `ruff check` clean on all changed files
- Targeted unit suites pass: `test_model_defaults`, `test_litellm_client_unit`, `test_tools`, `test_services_first_run`, `test_base_unit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default OpenAI language model from `gpt-5-mini` to `gpt-5.4-mini` across the setup wizard and system defaults
  * Updated evaluation model defaults and temperature restriction handling to use the new model version
  * Synchronized test suites to match the updated model configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->