### PR TITLE
fix: embedding daemon resilience + resumable extraction no_tool_call retry

### DIFF
--- a/reflexio/server/llm/embedding_service.py
+++ b/reflexio/server/llm/embedding_service.py
@@ -12,6 +12,7 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from reflexio.server.llm.llm_utils import positive_int_env
 from reflexio.server.llm.providers.local_embedding_provider import LocalEmbedder
 from reflexio.server.llm.providers.nomic_embedding_provider import (
     NomicEmbedder,
@@ -31,6 +32,33 @@ _ACTIVE_MODEL: str | None = None
 _ACTIVE_MODEL_LOCK = threading.Lock()
 
 DEFAULT_OSS_EMBEDDING_MODEL = MINILM_MODEL
+
+# Bound how many embed/encode calls run at once. The endpoint is a sync ``def``
+# served from Starlette's threadpool, so without a guard a burst of requests
+# would run that many model.encode() calls in parallel, stacking their
+# activation memory and OOM-killing the daemon. The semaphore caps simultaneous
+# encodes; excess requests block on acquire() and are picked up when a slot
+# frees — they queue, they are never rejected. Pair with a small encode
+# batch_size so each in-flight encode stays cheap.
+_DEFAULT_MAX_CONCURRENCY = 4
+_ENV_MAX_CONCURRENCY = "REFLEXIO_EMBED_MAX_CONCURRENCY"
+_ENCODE_SEMAPHORE: threading.BoundedSemaphore | None = None
+_ENCODE_SEMAPHORE_LOCK = threading.Lock()
+
+
+def _max_concurrency() -> int:
+    """Resolve the max simultaneous encodes from env, defaulting to 4."""
+    return positive_int_env(_ENV_MAX_CONCURRENCY, _DEFAULT_MAX_CONCURRENCY, logger)
+
+
+def _encode_semaphore() -> threading.BoundedSemaphore:
+    """Return the process-wide encode semaphore, building it on first use."""
+    global _ENCODE_SEMAPHORE
+    if _ENCODE_SEMAPHORE is None:
+        with _ENCODE_SEMAPHORE_LOCK:
+            if _ENCODE_SEMAPHORE is None:
+                _ENCODE_SEMAPHORE = threading.BoundedSemaphore(_max_concurrency())
+    return _ENCODE_SEMAPHORE
 
 
 class EmbeddingRequest(BaseModel):
@@ -99,11 +127,24 @@ def create_embedding_app(default_model: str | None = None) -> FastAPI:
 
 def _embed_texts(model: str, texts: list[str]) -> list[list[float]]:
     _activate_model(model)
-    if is_nomic_model(model):
-        return NomicEmbedder.get().embed(texts)
-    if model == MINILM_MODEL:
-        return LocalEmbedder.get().embed(texts)
-    raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
+    semaphore = _encode_semaphore()
+    # Non-blocking probe purely for observability: if no slot is free, this
+    # request will have to wait. The real acquire below blocks until a slot
+    # opens, so the request queues and is picked up later — never rejected.
+    if not semaphore.acquire(blocking=False):
+        logger.info(
+            "Embedding request queued; all %d encode slots busy",
+            _max_concurrency(),
+        )
+        semaphore.acquire()
+    try:
+        if is_nomic_model(model):
+            return NomicEmbedder.get().embed(texts)
+        if model == MINILM_MODEL:
+            return LocalEmbedder.get().embed(texts)
+        raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
+    finally:
+        semaphore.release()
 
 
 def _activate_model(model: str) -> None:

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -1,8 +1,35 @@
 import inspect
+import logging
+import os
 from copy import deepcopy
 from typing import Any
 
 from pydantic import BaseModel
+
+
+def positive_int_env(name: str, default: int, logger: logging.Logger) -> int:
+    """Resolve a strictly-positive int from environment variable ``name``.
+
+    Falls back to ``default`` when the variable is unset/blank, not a valid
+    integer (logging a warning in that case), or not strictly positive.
+
+    Args:
+        name (str): Environment variable to read.
+        default (int): Value returned when the variable is missing or invalid.
+        logger (logging.Logger): Logger used to warn on a non-integer value.
+
+    Returns:
+        int: The parsed positive integer, or ``default``.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r; falling back to default %d", name, raw, default)
+        return default
+    return value if value > 0 else default
 
 _STRICT_SCHEMA_UNSUPPORTED_KEYWORDS = frozenset(
     {

--- a/reflexio/server/llm/providers/nomic_embedding_provider.py
+++ b/reflexio/server/llm/providers/nomic_embedding_provider.py
@@ -34,6 +34,8 @@ import os
 import threading
 from typing import Any
 
+from reflexio.server.llm.llm_utils import positive_int_env
+
 _LOGGER = logging.getLogger(__name__)
 
 _ENV_ENABLE = "CLAUDE_SMART_USE_LOCAL_EMBEDDING"
@@ -53,6 +55,18 @@ _TARGET_DIM = 512
 # The model has a 8192 token context window; we still cap chars
 # defensively to avoid pathological multi-MB inputs.
 _MAX_CHARS = 32_000
+
+# Encode in small mini-batches so a single large request can't spike memory:
+# peak activation memory scales with batch_size, not with the total number of
+# texts in the request. A small batch is what makes the daemon's bounded
+# concurrency (see ``embedding_service``) safe to raise above 1.
+_DEFAULT_ENCODE_BATCH_SIZE = 4
+_ENV_BATCH_SIZE = "REFLEXIO_EMBED_BATCH_SIZE"
+
+
+def _encode_batch_size() -> int:
+    """Resolve the encode mini-batch size from env, defaulting to 4."""
+    return positive_int_env(_ENV_BATCH_SIZE, _DEFAULT_ENCODE_BATCH_SIZE, _LOGGER)
 
 
 class NomicEmbedderError(RuntimeError):
@@ -146,7 +160,12 @@ class NomicEmbedder:
         # show_progress_bar=False so server logs stay clean during ingest
         # batches. convert_to_numpy=True returns a numpy ndarray; we slice
         # and renormalise per-row before converting to plain Python lists.
-        raw = model.encode(safe, show_progress_bar=False, convert_to_numpy=True)
+        raw = model.encode(
+            safe,
+            batch_size=_encode_batch_size(),
+            show_progress_bar=False,
+            convert_to_numpy=True,
+        )
         return [_truncate_and_renormalise(vec.tolist()) for vec in raw]
 
 

--- a/reflexio/server/services/extraction/resumable_agent.py
+++ b/reflexio/server/services/extraction/resumable_agent.py
@@ -43,6 +43,12 @@ logger = logging.getLogger(__name__)
 FINISH_EXTRACTION_TOOL_NAME = "finish_extraction"
 PROFILE_EXTRACTOR_KIND = "profile"
 
+# Max in-process retries when the model returns a plain-text turn with no tool
+# call (finished_reason="no_tool_call"). tool_choice="required" is not always
+# honored by every provider/model, so a single bad turn would otherwise drop the
+# extraction entirely. Retries re-issue the same prompt from scratch.
+_NO_TOOL_CALL_MAX_RETRIES = 2
+
 
 def _record_agent_usage_event(
     *,
@@ -351,18 +357,6 @@ class ResumableExtractionAgent:
         extra_tool_context: Any | None = None,
         log_label: str | None = None,
     ) -> AgentRunResult:
-        finish_ctx = _FinishExtractionContext()
-        ctx: Any = (
-            _ExtractionAgentToolContext(
-                finish_context=finish_ctx,
-                extra_tool_context=extra_tool_context,
-            )
-            if extra_tool_context is not None
-            else finish_ctx
-        )
-        registry = ToolRegistry(
-            [*(extra_tools or []), create_finish_extraction_tool(output_schema)]
-        )
         max_steps = self.max_steps
         if run.max_steps_remaining is not None:
             max_steps = min(max_steps, max(0, run.max_steps_remaining))
@@ -387,17 +381,64 @@ class ResumableExtractionAgent:
             else "required"
         )
 
-        result = run_tool_loop(
-            client=self.client,
-            messages=messages,
-            registry=registry,
-            model_role=self.model_role,
-            max_steps=max_steps,
-            ctx=ctx,
-            finish_tool_name=FINISH_EXTRACTION_TOOL_NAME,
-            tool_choice=tool_choice,
-            log_label=log_label,
-        )
+        # Retry only the no_tool_call termination: the model emitted plain text
+        # with zero tool calls, so nothing was committed and re-issuing the same
+        # prompt is safe. Each attempt uses a fresh finish_ctx/registry so no
+        # partial state leaks across attempts. We do NOT retry once the model has
+        # already registered async tool calls (e.g. attach_pending_info_request)
+        # — restarting from scratch would discard them.
+        for attempt in range(_NO_TOOL_CALL_MAX_RETRIES + 1):
+            finish_ctx = _FinishExtractionContext()
+            ctx: Any = (
+                _ExtractionAgentToolContext(
+                    finish_context=finish_ctx,
+                    extra_tool_context=extra_tool_context,
+                )
+                if extra_tool_context is not None
+                else finish_ctx
+            )
+            registry = ToolRegistry(
+                [*(extra_tools or []), create_finish_extraction_tool(output_schema)]
+            )
+
+            result = run_tool_loop(
+                client=self.client,
+                messages=messages,
+                registry=registry,
+                model_role=self.model_role,
+                max_steps=max_steps,
+                ctx=ctx,
+                finish_tool_name=FINISH_EXTRACTION_TOOL_NAME,
+                tool_choice=tool_choice,
+                log_label=log_label,
+            )
+
+            should_retry = (
+                result.finished_reason == "no_tool_call"
+                and not result.pending_tool_call_ids
+                and attempt < _NO_TOOL_CALL_MAX_RETRIES
+            )
+            if not should_retry:
+                break
+            logger.warning(
+                "event=extraction_agent_retry org_id=%s user_id=%s "
+                "extractor_kind=%s run_id=%s request_id=%s "
+                "finished_reason=%s attempt=%d max_retries=%d",
+                run.binding.org_id,
+                run.binding.user_id,
+                run.binding.extractor_kind,
+                run.id,
+                run.binding.request_id,
+                result.finished_reason,
+                attempt + 1,
+                _NO_TOOL_CALL_MAX_RETRIES,
+            )
+            _record_agent_usage_event(
+                run=run,
+                event_name="extraction_agent_retry",
+                error_kind=result.finished_reason,
+                metadata={"attempt": attempt + 1},
+            )
 
         committed_output = (
             finish_ctx.output.model_dump() if finish_ctx.output is not None else None

--- a/tests/server/llm/test_embedding_service_concurrency.py
+++ b/tests/server/llm/test_embedding_service_concurrency.py
@@ -1,0 +1,85 @@
+"""Tests for the embedding daemon's bounded, queueing concurrency control."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from reflexio.server.llm import embedding_service as es
+
+
+class _ConcurrencyRecorder:
+    """Stand-in embedder that records the peak number of simultaneous calls."""
+
+    def __init__(self, hold: float = 0.1) -> None:
+        self._hold = hold
+        self._lock = threading.Lock()
+        self.current = 0
+        self.peak = 0
+        self.calls = 0
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        with self._lock:
+            self.current += 1
+            self.calls += 1
+            self.peak = max(self.peak, self.current)
+        # Hold the slot so concurrent callers actually overlap.
+        time.sleep(self._hold)
+        with self._lock:
+            self.current -= 1
+        return [[0.0] * 512 for _ in texts]
+
+
+def _reset_service_state(
+    monkeypatch: pytest.MonkeyPatch, recorder: _ConcurrencyRecorder
+) -> None:
+    monkeypatch.setattr(es, "_ENCODE_SEMAPHORE", None)
+    monkeypatch.setattr(es, "_ACTIVE_MODEL", None)
+    monkeypatch.setattr(es.NomicEmbedder, "get", classmethod(lambda _cls: recorder))
+
+
+def test_max_concurrency_defaults_to_4(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("REFLEXIO_EMBED_MAX_CONCURRENCY", raising=False)
+    assert es._max_concurrency() == 4
+
+
+def test_max_concurrency_respects_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBED_MAX_CONCURRENCY", "2")
+    assert es._max_concurrency() == 2
+
+
+def test_max_concurrency_ignores_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBED_MAX_CONCURRENCY", "bogus")
+    assert es._max_concurrency() == 4
+
+
+def test_embed_texts_caps_and_queues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Excess concurrent requests queue (never reject) and the cap is honored."""
+    monkeypatch.setenv("REFLEXIO_EMBED_MAX_CONCURRENCY", "2")
+    recorder = _ConcurrencyRecorder(hold=0.1)
+    _reset_service_state(monkeypatch, recorder)
+
+    model = "local/nomic-embed-text-v1.5"
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            es._embed_texts(model, ["x"])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    # All six requests completed — they queued, none were rejected.
+    assert errors == []
+    assert recorder.calls == 6
+    # The semaphore never let more than the configured limit run at once.
+    assert recorder.peak <= 2
+    # ...and concurrency was actually exercised (not accidentally serialized).
+    assert recorder.peak >= 2

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -729,6 +729,14 @@ class TestEmbeddingDefaultResolution:
             "_resolve_default_embedding_model",
             lambda _: "local/minilm-l6-v2",
         )
+        # Stay hermetic: if a local embedding daemon happens to be running on
+        # this host, model-driven routing would call it instead of the
+        # in-process LocalEmbedder branch this test exercises. Force the service
+        # gate off.
+        monkeypatch.setattr(
+            "reflexio.server.llm.litellm_client.should_use_embedding_service",
+            lambda _model: False,
+        )
         monkeypatch.setattr(
             "reflexio.server.llm.litellm_client._is_chromadb_importable",
             lambda: True,

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -342,9 +342,15 @@ class TestLiteLLMClientShortCircuit:
 
         # Force "inprocess" provider mode so the embedding-service short-circuit
         # doesn't intercept the local/* model before the chromadb-import check.
+        # Clearing the env vars is not enough: model-driven routing probes the
+        # local daemon, so if one happens to be running on this host the call
+        # would route there. Force the service gate off to stay hermetic.
         monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
         monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
         monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+        monkeypatch.setattr(
+            litellm_client, "should_use_embedding_service", lambda _model: False
+        )
         monkeypatch.setattr(lep.importlib.util, "find_spec", lambda _name: None)
 
         client = LiteLLMClient(LiteLLMConfig(model="claude-code/default"))

--- a/tests/server/llm/test_nomic_embedding_provider.py
+++ b/tests/server/llm/test_nomic_embedding_provider.py
@@ -1,0 +1,52 @@
+"""Tests for the Nomic local embedding provider's batch-size cap."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
+
+
+def _embedder_with_fake_model() -> tuple[NomicEmbedder, MagicMock]:
+    """Build a NomicEmbedder whose model is a stub recording encode() calls."""
+    embedder = NomicEmbedder()
+    model = MagicMock()
+    # One native 768-dim row; embed() slices to 512 and renormalises.
+    model.encode.return_value = np.array([[0.1] * 768])
+    embedder._model = model
+    return embedder, model
+
+
+def test_embed_uses_default_batch_size(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the env override, encode() is called with batch_size=4."""
+    monkeypatch.delenv("REFLEXIO_EMBED_BATCH_SIZE", raising=False)
+    embedder, model = _embedder_with_fake_model()
+
+    out = embedder.embed(["hello"])
+
+    assert len(out) == 1
+    assert len(out[0]) == 512
+    assert model.encode.call_args.kwargs["batch_size"] == 4
+
+
+def test_embed_respects_batch_size_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """REFLEXIO_EMBED_BATCH_SIZE overrides the default mini-batch size."""
+    monkeypatch.setenv("REFLEXIO_EMBED_BATCH_SIZE", "16")
+    embedder, model = _embedder_with_fake_model()
+
+    embedder.embed(["hello"])
+
+    assert model.encode.call_args.kwargs["batch_size"] == 16
+
+
+def test_embed_ignores_invalid_batch_size_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer override falls back to the default rather than crashing."""
+    monkeypatch.setenv("REFLEXIO_EMBED_BATCH_SIZE", "not-a-number")
+    embedder, model = _embedder_with_fake_model()
+
+    embedder.embed(["hello"])
+
+    assert model.encode.call_args.kwargs["batch_size"] == 4

--- a/tests/server/services/extraction/test_resumable_agent.py
+++ b/tests/server/services/extraction/test_resumable_agent.py
@@ -224,31 +224,33 @@ def test_resumable_agent_marks_run_failed_on_loop_error(monkeypatch, storage):
     assert stored.last_error == "Extraction agent did not finish: error"
 
 
-def test_resumable_agent_no_tool_call_marks_failed(
+def test_resumable_agent_no_tool_call_marks_failed_after_retries(
     monkeypatch,
     storage,
     tool_call_completion,
 ):
-    """A no-tool-call turn is reported as 'no_tool_call' (not 'finish_tool').
+    """A persistent no-tool-call turn is retried up to the cap, then fails.
 
-    The model answered with plain text and zero tool calls, so the finish
-    handler never ran and no output was committed. The run must be marked
-    failed with the accurate, non-contradictory reason.
+    The model answers with plain text and zero tool calls on every attempt, so
+    the finish handler never runs and no output is committed. After exhausting
+    the retries (1 initial + 2 retries = 3 calls) the run is marked failed with
+    the accurate, non-contradictory reason.
     """
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
     _, make_stop = tool_call_completion
-    response = make_stop('{"profiles": null}')
+    responses = [make_stop('{"profiles": null}') for _ in range(3)]
     client = LiteLLMClient(LiteLLMConfig(model="claude-sonnet-4-6"))
     agent = ResumableExtractionAgent(client=client, storage=storage)
 
-    with patch("litellm.completion", side_effect=[response]):
+    with patch("litellm.completion", side_effect=responses) as completion:
         result = agent.start(
             run=_agent_run("run_no_tool"),
             messages=[{"role": "user", "content": "extract profiles"}],
             output_schema=StructuredProfilesOutput,
         )
 
+    assert completion.call_count == 3
     assert result.finished_reason == "no_tool_call"
     assert result.output is None
     stored = storage.get_agent_run("run_no_tool")
@@ -256,6 +258,48 @@ def test_resumable_agent_no_tool_call_marks_failed(
     assert stored.status == AgentRunStatus.FAILED
     assert stored.committed_output is None
     assert stored.last_error == "Extraction agent did not finish: no_tool_call"
+
+
+def test_resumable_agent_retries_no_tool_call_then_finishes(
+    monkeypatch,
+    storage,
+    tool_call_completion,
+):
+    """A transient no-tool-call turn is retried; a later finish_tool turn
+    recovers the output and the run completes."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
+    make_tc, make_stop = tool_call_completion
+    no_tool = make_stop('{"profiles": null}')
+    finish = make_tc(
+        FINISH_EXTRACTION_TOOL_NAME,
+        {
+            "profiles": [
+                {
+                    "content": "User prefers AWS ECS deployments.",
+                    "time_to_live": "infinity",
+                }
+            ]
+        },
+    )
+    client = LiteLLMClient(LiteLLMConfig(model="claude-sonnet-4-6"))
+    agent = ResumableExtractionAgent(client=client, storage=storage)
+
+    with patch("litellm.completion", side_effect=[no_tool, finish]) as completion:
+        result = agent.start(
+            run=_agent_run("run_retry"),
+            messages=[{"role": "user", "content": "extract profiles"}],
+            output_schema=StructuredProfilesOutput,
+        )
+
+    assert completion.call_count == 2
+    assert result.finished_reason == "finish_tool"
+    assert isinstance(result.output, StructuredProfilesOutput)
+    assert result.output.profiles is not None
+    assert result.output.profiles[0].content == "User prefers AWS ECS deployments."
+    stored = storage.get_agent_run("run_retry")
+    assert stored is not None
+    assert stored.status == AgentRunStatus.AGENT_COMPLETED
 
 
 def test_resumable_agent_requires_tool_call_when_extra_tools_present(


### PR DESCRIPTION
## Summary

Two reliability fixes for the local embedding daemon and the resumable
extraction agent.

### 1. Bound the embedding daemon's batch size and concurrency

The in-container daemon (`nomic-embed-text-v1.5` via sentence-transformers /
PyTorch) was getting OOM-killed under load: it serves `/v1/embeddings` as a
synchronous FastAPI endpoint in Starlette's threadpool, so concurrent requests
each called the shared `model.encode()` with no concurrency control and no
batch cap, stacking activation-memory spikes on top of the ~2 GB model baseline.

- **Cap encode batch size** — `NomicEmbedder.embed` passes `batch_size=4`
  (env `REFLEXIO_EMBED_BATCH_SIZE`) to `model.encode`, bounding per-request
  peak memory regardless of how many texts a request carries.
- **Bound daemon concurrency with a queue** — `_embed_texts` wraps the encode
  in a module-level `BoundedSemaphore` (default 4, env
  `REFLEXIO_EMBED_MAX_CONCURRENCY`). The acquire is **blocking with no
  timeout**, so when all slots are busy a request **waits and is picked up
  later — never rejected**; a log line is emitted when a request queues.

### 2. Retry `no_tool_call` termination in the resumable extraction agent

`tool_choice=required` is not always honored by every provider/model, so the
model can emit a plain-text turn with zero tool calls
(`finished_reason="no_tool_call"`), dropping the extraction entirely.

- Retry up to twice from a fresh `finish_ctx`/registry when the turn committed
  nothing and registered no async tool calls (so no partial state leaks and
  pending info requests are never discarded).
- Add a `positive_int_env` helper to `llm_utils` for env-driven positive ints.
- Emit a warning log + `extraction_agent_retry` usage event per retry.

## Changes

- `reflexio/server/llm/providers/nomic_embedding_provider.py` — batch-size cap
- `reflexio/server/llm/embedding_service.py` — concurrency semaphore (queueing)
- `reflexio/server/services/extraction/resumable_agent.py` — no_tool_call retry
- `reflexio/server/llm/llm_utils.py` — `positive_int_env` helper
- Test hardening: two embedding-routing tests now force the service gate off so
  they stay hermetic when a local daemon is running on the host.

## Test Plan

- `tests/server/llm/test_nomic_embedding_provider.py` — `batch_size` reaches
  `model.encode`, respects env override.
- `tests/server/llm/test_embedding_service_concurrency.py` — semaphore caps
  in-flight encodes; excess concurrent callers all complete (queue, never reject).
- `tests/server/services/extraction/test_resumable_agent.py` — 11 passed.
- Full `tests/server/llm/` suite: 368 passed, 60 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable process-wide concurrency limits for embedding generation via `REFLEXIO_EMBED_MAX_CONCURRENCY` environment variable (defaults to 4).
  * Added configurable batch size for Nomic embeddings via `REFLEXIO_EMBED_BATCH_SIZE` environment variable.
  * Added automatic retry mechanism for LLM extraction when initial requests generate no tool calls.

* **Tests**
  * Added comprehensive tests for embedding concurrency controls and batch size configuration.
  * Improved test isolation for embedding and extraction workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->