### PR TITLE
docs(server): add service-layer and api_endpoints code maps

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -54,6 +54,8 @@ Description: FastAPI backend server that processes user interactions to generate
 
 **Directory**: `api_endpoints/`
 
+**Detailed Documentation**: See [`api_endpoints/README.md`](api_endpoints/README.md) for the `RequestContext` contract and per-file handler map.
+
 | File | Purpose |
 |------|---------|
 | `request_context.py` | RequestContext (bundles org_id, storage, configurator, prompt_manager) |
@@ -171,6 +173,8 @@ python -m reflexio.server.scripts.manage_invitation_codes list --show-used
 ## Services
 
 **Directory**: `services/`
+
+**Detailed Documentation**: See [`services/README.md`](services/README.md) for the per-directory file index across generation, evaluation, async extraction, search, and persistence.
 
 **Service Boundary**: The service layer owns LLM orchestration, extraction, evaluation, optimization, search preparation, storage access, and long-running operation state. API endpoints should validate/authenticate requests, build `RequestContext`, and delegate into `Reflexio` or focused service helpers rather than embedding business logic.
 
@@ -611,6 +615,8 @@ All services follow BaseGenerationService:
 ## See Also
 
 - [Code Map (root README)](../README.md) -- high-level overview of all Reflexio components
+- [API Endpoints README](api_endpoints/README.md) -- RequestContext contract and handler/helper map
+- [Services README](services/README.md) -- per-directory index of the business-logic layer
 - [Prompt Bank README](prompt/prompt_bank/README.md) -- versioned prompt template system
 - [Playbook Service README](services/playbook/README.md) -- playbook extraction, aggregation, and deduplication pipeline
 - [Site Variables README](site_var/README.md) -- global configuration and feature flags

--- a/reflexio/server/api_endpoints/README.md
+++ b/reflexio/server/api_endpoints/README.md
@@ -1,0 +1,34 @@
+# server/api_endpoints
+Description: Bridge between FastAPI routes and business logic — builds `RequestContext`, validates requests, and delegates into `Reflexio`. Most endpoints are registered on the `core_router` in `../api.py`; the files here are the handlers/helpers it calls.
+
+> For the complete endpoint list (publish, retrieval, search, profile/playbook lifecycle, evaluation, Braintrust, operations), see the parent [server README](../README.md#api-endpoints).
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `request_context.py` | `RequestContext` — bundles `org_id`, `storage`, `configurator`, `prompt_manager`. Built per request via `get_request_context()` (FastAPI `Depends`). The one object every handler reads storage/config/prompts through. |
+| `publisher_api.py` | Publishing + direct CRUD helpers: `add_user_interaction/profile/playbook`, `update_*`, and the full family of single / by-ids / bulk delete helpers for interactions, profiles, playbooks, requests, and sessions; plus `run_playbook_aggregation()` and `clear_user_data()`. |
+| `account_api.py` | Identity/config helpers behind `/api/whoami`, `/api/my_config`. |
+| `health_api.py` | `GET /`, `/health`, `/healthz`, `/healthz/eval`; `install()` adds response-time + liveness tracking. |
+| `pending_tool_call_api.py` | Router for resumable-extraction human clarification: list/get, `resolve`, `answer`, `not_applicable`, `cancel`; HMAC signature verify + migration-retry helpers. |
+| `stall_state_api.py` | `GET /api/stall_state`, `POST /api/stall_state/notified` — extraction-agent waiting state. |
+| `precondition_checks.py` | `precondition_checks()` — shared request validation. |
+
+## Architecture Pattern
+
+```
+api.py (core_router + sub-routers)
+  -> Depends(get_request_context) -> RequestContext(org_id, storage, configurator, prompt_manager)
+    -> get_reflexio(org_id) -> Reflexio (reflexio_lib) -> services/
+```
+
+- **`RequestContext` is the context-passing contract** — handlers receive it via `Depends` and never reach for storage/config/prompts globally.
+- **Route handlers call `Reflexio` through `get_reflexio(org_id)`** — these helper files do **not** instantiate `Reflexio()` directly.
+- **Auth is injected, not implemented here** — the OS app uses `default_get_org_id` / `DEFAULT_ORG_ID`; the enterprise extension swaps in authenticated org resolution (see `reflexio_ext/server/api_endpoints/`).
+
+## Requirements / Problems to Avoid
+
+- **NEVER instantiate `Reflexio()` in a handler** — use `get_reflexio(org_id)` from `server/cache/`.
+- **Keep business logic in `services/`** — endpoints validate, build context, and delegate; they don't embed extraction/evaluation logic.
+- **Pending-tool-call writes can race** — use the migration-retry + HMAC-verify helpers already in `pending_tool_call_api.py` rather than writing raw.

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -1,0 +1,58 @@
+# server/services
+Description: Core business-logic layer — LLM orchestration, extraction, evaluation, optimization, search preparation, storage access, and long-running operation state.
+
+> This is a directory-local index. For the full request flow, workflow tables (versioning, generation modes, cluster change detection), and the `OperationStateManager` use cases, see the parent [server README](../README.md#services).
+
+**Service Boundary**: services own the LLM/extraction/evaluation/storage logic; API endpoints only authenticate, build `RequestContext`, and delegate into `Reflexio` or a focused service helper.
+
+## Orchestration & Base Infrastructure
+
+| File | Purpose |
+|------|---------|
+| `generation_service.py` | `GenerationService` — saves interactions, runs profile + playbook generation in parallel (ThreadPoolExecutor), schedules deferred evaluation when `session_id` is present. |
+| `base_generation_service.py` | `BaseGenerationService` — abstract base; the **Service Pattern** (load configs → create actors → run in parallel → save results). Per-extractor timeout `EXTRACTOR_TIMEOUT_SECONDS = 300`. |
+| `operation_state_utils.py` | `OperationStateManager` — all `_operation_state` access (progress, concurrency locks, extractor/aggregator bookmarks, cluster fingerprints, cancellation). |
+| `extractor_config_utils.py`, `extractor_interaction_utils.py` | Filter extractors by source / `allow_manual_trigger` / names; per-extractor stride + window + bookmark handling. |
+| `deduplication_utils.py`, `service_utils.py`, `embedding_text.py` | LLM dedup helpers (used by `ProfileDeduplicator` + `PlaybookConsolidator`), message construction / JSON extraction / response logging, embedding text builders. |
+
+## Generation Services
+
+| Directory | Entry class | Key files |
+|-----------|-------------|-----------|
+| `profile/` | `ProfileGenerationService` | `profile_extractor.py`, `profile_deduplicator.py`, `profile_updater.py` |
+| `playbook/` | `PlaybookGenerationService` | `playbook_extractor.py`, `playbook_consolidator.py`, `playbook_aggregator.py` (cluster-fingerprint change detection) — has its own [README](playbook/README.md) |
+| `agent_success_evaluation/` | `AgentSuccessEvaluationService` | `agent_success_evaluator.py` (session-level), `delayed_group_evaluator.py` (`GroupEvaluationScheduler`, 10-min defer), `group_evaluation_runner.py`, `regen_jobs.py` |
+| `reflection/` | `ReflectionService` | `reflection_extractor.py` — post-horizon reflection; runs **before** extraction so extractors read post-reflection state |
+
+## Async Extraction
+
+| Directory | Purpose |
+|-----------|---------|
+| `extraction/` | Resumable extraction agent: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `tools.py`, `plan.py`, `agent_run_records.py`, `invariants.py`. Long-horizon / tool-mediated extraction continues outside the request path. |
+
+## Evaluation, Search & Integrations
+
+| Path | Purpose |
+|------|---------|
+| `shadow_comparison/` | `ShadowComparisonJudge` — per-turn regular-vs-shadow verdicts written to a separate table (session-level shadow was retracted due to trajectory contamination). |
+| `evaluation_overview/` | Dashboard rollups: `service.py`, `hero_state.py`, `distribution.py`, `group_aggregation.py`, `rule_attribution.py`, `shadow_aggregation.py`, `eval_sampler.py`. |
+| `playbook_optimizer/` | Scenario-based playbook optimization: `optimizer.py`, `scheduler.py`, `rollout.py`, `judge.py`, `scenario_resolver.py`, `gepa_adapter.py`, `assistant_webhook.py`. |
+| `braintrust/` | Braintrust export/sync: `service.py`, `client.py`, `_cron.py`, `_encryption.py`. |
+| `pre_retrieval/` | `QueryReformulator` (`_query_reformulator.py`) + `_document_expander.py` — query rewrite & doc expansion for recall. |
+| `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks. |
+| `retrieval/` | `relevance_floor.py` — result relevance thresholding. |
+
+## Persistence & Config
+
+| Path | Purpose |
+|------|---------|
+| `storage/` | `storage_base/` (`BaseStorage` split by domain) + `sqlite_storage/` + `retention*.py`. Access via `request_context.storage` only. |
+| `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
+
+## Key Rules
+
+- **NEVER instantiate services bypassing the Service Pattern** — extend `BaseGenerationService`; load YAML configs, create actors, run in parallel, save to storage.
+- **NEVER import storage implementations directly** — use `request_context.storage` (`BaseStorage`).
+- **ALWAYS use `LiteLLMClient`** for completions/embeddings and `request_context.prompt_manager.render_prompt(...)` for prompts — no hardcoded prompts, no direct OpenAI/Claude clients.
+- **All `_operation_state` writes go through `OperationStateManager`** — don't touch the table directly (it backs locks, bookmarks, progress, and cancellation).
+- **`tool_can_use` lives at root `Config`** — shared by playbook extraction and success evaluation, not per-service.


### PR DESCRIPTION
## What

Add directory-local **code-map READMEs** for the server's two largest undocumented layers, and cross-link them from the existing `server/README.md`:

- `reflexio/server/services/README.md` — per-directory index of the business-logic layer (generation, evaluation, async extraction, search, persistence) with entry classes and key rules.
- `reflexio/server/api_endpoints/README.md` — the `RequestContext` contract plus a per-file handler/helper map.
- `reflexio/server/README.md` — adds "Detailed Documentation" links to the two new maps (API Endpoints, Services, and See Also sections).

## Why

These two directories had no README, so an agent landing in `services/` or `api_endpoints/` had no local navigation. The new maps follow the repo's `how_to_write_readme.md` code-map conventions (concise, navigation-focused, NEVER/ALWAYS rules preserved) and complement — rather than duplicate — the workflow detail already in `server/README.md`.

## Scope

Documentation only — no code or behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation structure with navigation improvements and detailed guides for the API endpoints and services architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->