### PR TITLE
feat(extraction): slice long interaction content by token budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ XAI_API_KEY=
 LOCAL_STORAGE_PATH=
 
 # ====================
+# Extraction
+# ====================
+# Per-interaction content token budget when formatting interactions into an
+# extraction/evaluation prompt. When an interaction's content exceeds this many
+# tokens, the first half and last half are kept (head + tail) and the middle is
+# elided. Set to <=0 to disable slicing (pass full content). Default 512.
+REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS=512
+
+# ====================
 # Testing & Logging
 # ====================
 # Set to true to enable test environment mode

--- a/reflexio/server/services/service_utils.py
+++ b/reflexio/server/services/service_utils.py
@@ -5,10 +5,13 @@ Utils for service layer
 import ast
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
+
+import tiktoken
 
 from reflexio.cli.log_format import LLM_IO_LOG_FILE, next_llm_entry_id
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
@@ -24,6 +27,88 @@ logger = logging.getLogger(__name__)
 # Custom log level for model responses (between INFO=20 and WARNING=30)
 # Already registered in server/__init__.py; import the numeric constant only.
 MODEL_RESPONSE_LEVEL = 25
+
+# Per-interaction content token budget when formatting interactions into an
+# extraction/evaluation prompt. Read from REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS;
+# a value <= 0 disables slicing. See _resolve_max_interaction_content_tokens.
+DEFAULT_MAX_INTERACTION_CONTENT_TOKENS = 512
+_MAX_INTERACTION_CONTENT_TOKENS_ENV = "REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS"
+# Inserted between the head and tail of a sliced interaction so the LLM can see
+# that the middle of the content was elided.
+_CONTENT_TRUNCATION_MARKER = " …[truncated] "
+# Encoder used purely as a length heuristic for slicing. tiktoken does not know
+# the real tokenizer for non-OpenAI providers, but cl100k_base is a consistent,
+# good-enough proxy for budgeting prompt content (mirrors the embedding path).
+_CONTENT_ENCODING_NAME = "cl100k_base"
+_content_token_encoding: tiktoken.Encoding | None = None
+# Guards against logging the same malformed env value on every call.
+_INVALID_MAX_TOKENS_WARNED = False
+
+
+def _get_content_token_encoding() -> tiktoken.Encoding:
+    """Return a process-cached tiktoken encoder for content slicing."""
+    global _content_token_encoding
+    if _content_token_encoding is None:
+        _content_token_encoding = tiktoken.get_encoding(_CONTENT_ENCODING_NAME)
+    return _content_token_encoding
+
+
+def _resolve_max_interaction_content_tokens() -> int | None:
+    """Resolve the per-interaction content token budget from the environment.
+
+    Returns:
+        int | None: The positive token budget, or None when slicing is
+            disabled (env value <= 0). Unset or malformed values fall back to
+            ``DEFAULT_MAX_INTERACTION_CONTENT_TOKENS``.
+    """
+    global _INVALID_MAX_TOKENS_WARNED
+    raw = os.getenv(_MAX_INTERACTION_CONTENT_TOKENS_ENV, "").strip()
+    if not raw:
+        return DEFAULT_MAX_INTERACTION_CONTENT_TOKENS
+    try:
+        value = int(raw)
+    except ValueError:
+        if not _INVALID_MAX_TOKENS_WARNED:
+            logger.warning(
+                "Invalid %s=%r; falling back to default %d",
+                _MAX_INTERACTION_CONTENT_TOKENS_ENV,
+                raw,
+                DEFAULT_MAX_INTERACTION_CONTENT_TOKENS,
+            )
+            _INVALID_MAX_TOKENS_WARNED = True
+        return DEFAULT_MAX_INTERACTION_CONTENT_TOKENS
+    return value if value > 0 else None
+
+
+def slice_content_by_tokens(content: str, max_tokens: int | None) -> str:
+    """Slice interaction content to a token budget, keeping head and tail.
+
+    When the content exceeds ``max_tokens`` tokens, keep the first ``max_tokens
+    // 2`` tokens and the last ``max_tokens - max_tokens // 2`` tokens, joined by
+    a truncation marker so the elision is visible to the LLM. Content within
+    budget (or when ``max_tokens`` is None / content is empty) is returned
+    unchanged.
+
+    Args:
+        content (str): The interaction content to slice.
+        max_tokens (int | None): Token budget, or None to disable slicing.
+
+    Returns:
+        str: The original or head+marker+tail-sliced content.
+    """
+    if max_tokens is None or not content:
+        return content
+    encoding = _get_content_token_encoding()
+    tokens = encoding.encode(content)
+    if len(tokens) <= max_tokens:
+        return content
+    head = max_tokens // 2
+    tail = max_tokens - head
+    return (
+        f"{encoding.decode(tokens[:head])}"
+        f"{_CONTENT_TRUNCATION_MARKER}"
+        f"{encoding.decode(tokens[-tail:])}"
+    )
 
 
 def _format_response_for_logging(response: Any) -> Any:
@@ -188,22 +273,22 @@ def format_interactions_to_history_string(interactions: list[Interaction]) -> st
         user: I love sushi
         user: click menu item
     """
+    max_content_tokens = _resolve_max_interaction_content_tokens()
     formatted_interactions = []
     for interaction in interactions:
         # Add text content with tools_used prefix if present
         if interaction.content:
+            content = slice_content_by_tokens(interaction.content, max_content_tokens)
             if interaction.tools_used:
                 tool_prefix = " ".join(
                     f"[used tool: {t.tool_name}({json.dumps(t.tool_data)})]"
                     for t in interaction.tools_used
                 )
                 formatted_interactions.append(
-                    f"{interaction.role}: ```{tool_prefix} {interaction.content}```"
+                    f"{interaction.role}: ```{tool_prefix} {content}```"
                 )
             else:
-                formatted_interactions.append(
-                    f"{interaction.role}: ```{interaction.content}```"
-                )
+                formatted_interactions.append(f"{interaction.role}: ```{content}```")
 
         # Add user action
         if interaction.user_action != UserActionType.NONE:

--- a/tests/server/services/test_service_utils.py
+++ b/tests/server/services/test_service_utils.py
@@ -12,9 +12,16 @@ from reflexio.models.api_schema.service_schemas import (
     UserActionType,
 )
 from reflexio.server.services.service_utils import (
+    _CONTENT_TRUNCATION_MARKER,
+    DEFAULT_MAX_INTERACTION_CONTENT_TOKENS,
+    _get_content_token_encoding,
+    _resolve_max_interaction_content_tokens,
     format_interactions_to_history_string,
     format_sessions_to_history_string,
+    slice_content_by_tokens,
 )
+
+_ENV_MAX_TOKENS = "REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS"
 
 
 def test_format_interactions_to_history_string_with_content():
@@ -207,8 +214,6 @@ def _create_request(request_id: str, created_at: int) -> Request:
         request_id=request_id,
         user_id="test_user",
         created_at=created_at,
-        app_id="test_app",
-        agent_id="test_agent",
     )
 
 
@@ -433,6 +438,102 @@ def test_format_sessions_to_history_string_preserves_order_within_group():
         "user: ```Late message```"
     )
     assert result == expected
+
+
+def test_slice_content_by_tokens_within_budget_unchanged():
+    """Content at or below the budget is returned verbatim."""
+    content = "short content well under budget"
+    assert slice_content_by_tokens(content, 512) == content
+
+
+def test_slice_content_by_tokens_none_disables_slicing():
+    """A None budget disables slicing even for very long content."""
+    content = " ".join(str(i) for i in range(2000))
+    assert slice_content_by_tokens(content, None) == content
+
+
+def test_slice_content_by_tokens_empty_content():
+    """Empty content is returned unchanged regardless of budget."""
+    assert slice_content_by_tokens("", 512) == ""
+
+
+def test_slice_content_by_tokens_keeps_head_and_tail():
+    """Over-budget content keeps the first half + last half with a marker."""
+    encoding = _get_content_token_encoding()
+    content = " ".join(str(i) for i in range(2000))
+    tokens = encoding.encode(content)
+    assert len(tokens) > 512  # precondition: actually over budget
+
+    result = slice_content_by_tokens(content, 512)
+
+    head = encoding.decode(tokens[:256])
+    tail = encoding.decode(tokens[-256:])
+    expected = f"{head}{_CONTENT_TRUNCATION_MARKER}{tail}"
+    assert result == expected
+    assert _CONTENT_TRUNCATION_MARKER in result
+    # The sliced result is materially shorter than the original.
+    assert len(encoding.encode(result)) < len(tokens)
+
+
+def test_resolve_max_tokens_unset_uses_default(monkeypatch):
+    """Unset env falls back to the 512 default."""
+    monkeypatch.delenv(_ENV_MAX_TOKENS, raising=False)
+    assert (
+        _resolve_max_interaction_content_tokens()
+        == DEFAULT_MAX_INTERACTION_CONTENT_TOKENS
+    )
+
+
+def test_resolve_max_tokens_valid_override(monkeypatch):
+    """A positive integer env value is used as-is."""
+    monkeypatch.setenv(_ENV_MAX_TOKENS, "1024")
+    assert _resolve_max_interaction_content_tokens() == 1024
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "-512"])
+def test_resolve_max_tokens_non_positive_disables(monkeypatch, raw):
+    """A value <= 0 disables slicing (returns None)."""
+    monkeypatch.setenv(_ENV_MAX_TOKENS, raw)
+    assert _resolve_max_interaction_content_tokens() is None
+
+
+def test_resolve_max_tokens_invalid_falls_back_to_default(monkeypatch):
+    """A malformed env value falls back to the default."""
+    monkeypatch.setenv(_ENV_MAX_TOKENS, "not-an-int")
+    assert (
+        _resolve_max_interaction_content_tokens()
+        == DEFAULT_MAX_INTERACTION_CONTENT_TOKENS
+    )
+
+
+def test_format_interactions_slices_long_content(monkeypatch):
+    """format_interactions_to_history_string slices content over the budget."""
+    monkeypatch.setenv(_ENV_MAX_TOKENS, "8")
+    long_content = " ".join(str(i) for i in range(500))
+    interactions = [
+        _create_interaction(1, long_content, "user", 1_700_000_000),
+    ]
+
+    result = format_interactions_to_history_string(interactions)
+
+    assert _CONTENT_TRUNCATION_MARKER in result
+    assert long_content not in result  # full content was not emitted verbatim
+    assert result.startswith("user: ```")
+    assert result.endswith("```")
+
+
+def test_format_interactions_no_slice_when_disabled(monkeypatch):
+    """Disabling via <=0 leaves content verbatim."""
+    monkeypatch.setenv(_ENV_MAX_TOKENS, "0")
+    long_content = " ".join(str(i) for i in range(500))
+    interactions = [
+        _create_interaction(1, long_content, "user", 1_700_000_000),
+    ]
+
+    result = format_interactions_to_history_string(interactions)
+
+    assert _CONTENT_TRUNCATION_MARKER not in result
+    assert long_content in result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Slice long interaction content by a per-interaction token budget when formatting interactions into extraction/evaluation prompts. This caps the prompt-content cost of any single oversized interaction while preserving the most informative parts (head + tail).

## What changed

- **`slice_content_by_tokens(content, max_tokens)`** — keeps the first `max_tokens // 2` and last `max_tokens - max_tokens // 2` tokens, joined by a visible ` …[truncated] ` marker so the elision is apparent to the LLM. Uses a process-cached `cl100k_base` tiktoken encoder purely as a length heuristic (consistent proxy across providers, mirrors the embedding path).
- **`_resolve_max_interaction_content_tokens()`** — reads `REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS` (default **512**). A value `<= 0` disables slicing (returns `None`); unset or malformed values fall back to the default (malformed logged once).
- **`format_interactions_to_history_string`** — applies the budget per interaction.
- Documented the env var in `.env.example`.

## Tests

25 passing in `tests/server/services/test_service_utils.py`, covering within-budget passthrough, disabled slicing, empty content, head/tail correctness, env resolution (unset/valid/non-positive/malformed), and formatting integration.

## Config

| Env var | Default | Behavior |
|---|---|---|
| `REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS` | `512` | Per-interaction content token budget; `<= 0` disables slicing |
