### PR TITLE
feat(search): trace cross-encoder reranker latency on relevance-floor path

### DIFF
--- a/reflexio/server/services/retrieval/relevance_floor.py
+++ b/reflexio/server/services/retrieval/relevance_floor.py
@@ -15,6 +15,7 @@ from reflexio.server.llm.rerank import score_pairs
 from reflexio.server.llm.rerank.cross_encoder_reranker import (
     CrossEncoderUnavailableError,
 )
+from reflexio.server.tracing import profile_step
 
 logger = logging.getLogger(__name__)
 
@@ -44,27 +45,36 @@ def apply_relevance_floor[T](
     """
     if not items:
         return []
-    try:
-        scores = score_pairs(query, [content_of(item) for item in items])
-    except CrossEncoderUnavailableError:
-        logger.warning(
-            "event=relevance_floor_unavailable arm=%s items=%d (returning unfiltered top_k)",
-            arm,
-            len(items),
-        )
-        return items[:top_k]
+    with profile_step(
+        "search.rerank.relevance_floor",
+        arm=arm,
+        items=len(items),
+    ) as span:
+        try:
+            scores = score_pairs(query, [content_of(item) for item in items])
+        except CrossEncoderUnavailableError:
+            span.set_data("available", False)
+            logger.warning(
+                "event=relevance_floor_unavailable arm=%s items=%d (returning unfiltered top_k)",
+                arm,
+                len(items),
+            )
+            return items[:top_k]
+        span.set_data("available", True)
 
-    ranked = sorted(
-        zip(items, scores, strict=True), key=lambda pair: pair[1], reverse=True
-    )
-    survivors = [item for item, score in ranked if score >= floor]
-    dropped = len(ranked) - len(survivors)
-    if dropped:
-        logger.info(
-            "event=relevance_floor arm=%s kept=%d dropped=%d floor=%.2f",
-            arm,
-            len(survivors),
-            dropped,
-            floor,
+        ranked = sorted(
+            zip(items, scores, strict=True), key=lambda pair: pair[1], reverse=True
         )
-    return survivors[:top_k]
+        survivors = [item for item, score in ranked if score >= floor]
+        dropped = len(ranked) - len(survivors)
+        span.set_data("kept", len(survivors))
+        span.set_data("dropped", dropped)
+        if dropped:
+            logger.info(
+                "event=relevance_floor arm=%s kept=%d dropped=%d floor=%.2f",
+                arm,
+                len(survivors),
+                dropped,
+                floor,
+            )
+        return survivors[:top_k]

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -357,7 +357,8 @@ def _apply_floors(
 ) -> tuple[list[UserProfile], list[AgentPlaybook], list[UserPlaybook]]:
     """Apply the per-arm relevance floor to each entity arm in parallel."""
     with ThreadPoolExecutor(max_workers=3) as ex:
-        f_profiles = ex.submit(
+        f_profiles = _submit_with_current_context(
+            ex,
             apply_relevance_floor,
             query,
             profiles,
@@ -365,7 +366,8 @@ def _apply_floors(
             top_k,
             arm="profiles",
         )
-        f_agent = ex.submit(
+        f_agent = _submit_with_current_context(
+            ex,
             apply_relevance_floor,
             query,
             agent_playbooks,
@@ -373,7 +375,8 @@ def _apply_floors(
             top_k,
             arm="agent_playbooks",
         )
-        f_user = ex.submit(
+        f_user = _submit_with_current_context(
+            ex,
             apply_relevance_floor,
             query,
             user_playbooks,
@@ -533,9 +536,10 @@ def _submit_with_current_context(
     executor: ThreadPoolExecutor,
     fn: Callable[..., object],
     *args: object,
+    **kwargs: object,
 ) -> Future[Any]:
     context = contextvars.copy_context()
-    return executor.submit(context.run, fn, *args)
+    return executor.submit(context.run, fn, *args, **kwargs)
 
 
 def _storage_backend_name(storage: BaseStorage) -> str:


### PR DESCRIPTION
## What

Adds a dedicated latency span around the cross-encoder reranker on the read-path **relevance floor** — the reranking that runs on every unified search (`/api/search`) when `RetrievalFloorConfig.enabled` (default `True`).

Previously the cross-encoder scoring (`score_pairs` → `model.predict`) had **no timing instrumentation** of any kind — reranker latency was invisible to Sentry traces and logs (only kept/dropped counts were logged).

## Changes

- **`relevance_floor.py`** — wrap the scoring + sort/filter in `apply_relevance_floor` in a `profile_step("search.rerank.relevance_floor", arm=..., items=...)` span. The span duration is the reranker latency. Records `available` (cross-encoder reachable) and `kept`/`dropped` span data. One span per arm (`profiles` / `user_playbooks` / `agent_playbooks`), matching existing per-arm log granularity.
- **`unified_search_service.py`** — `_apply_floors` ran the three arms in a raw `ThreadPoolExecutor`, so spans created in those worker threads would not attach to the request transaction. Route it through the existing `_submit_with_current_context` helper (extended to forward `**kwargs` so the `arm=` keyword passes through), the same context-propagation pattern the Phase-B fan-out already uses.

## Why span name `search.rerank.relevance_floor`

Fits the existing `search.<area>.<detail>` convention (`search.embedding.api`, `search.branch.agent_playbooks`).

## Safety / behavior

- **No behavior change.** `profile_step` is a no-op when no tracer is configured (OSS default) and never lets instrumentation fail a request. Filter/sort logic is byte-for-byte identical.
- Cost is no-op for OSS; enterprise (which registers `SentryTracer`) gets the spans.

## Scope

Covers the **retriever / relevance-floor path** only. The agent-tool `rerank` flag path (`tools.py`, off by default) is intentionally not instrumented here.

## Testing

- `ruff check` + `ruff format --check`: clean
- `pyright`: 0 errors
- `pytest`: `test_relevance_floor.py`, `test_unified_search_floor.py`, `test_unified_search_service.py` — **17 passed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context preservation in concurrent relevance filtering operations across multiple entity types.

* **Chores**
  * Added tracing instrumentation to relevance filtering for improved observability and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->