### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -100,6 +100,7 @@ Key files:
 - **Gemini support**: Model names with `gemini/` prefix route through Google Gemini; API key from `api_key_config.gemini`
 - **OpenRouter support**: Model names with `openrouter/` prefix (e.g., `openrouter/openai/gpt-5-nano`) route through OpenRouter; API key from `api_key_config.openrouter`
 - API keys read from environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY) or `ApiKeyConfig`
+- **Embedding routing**: `providers/embedding_service_provider.py` routes `local/*` embedding models to the shared OpenAI-compatible embedding daemon when available, falls back to in-process local embedders, and supports `REFLEXIO_EMBEDDING_PROVIDER` modes (`cloud`, `local_service`, `internal_service`, `inprocess`, `off`).
 - Interface: `generate_response()`, `generate_chat_response()`, `get_embedding()`
 - **Structured Outputs**: Supports Pydantic models via `response_format` parameter
 - Return types: `str` for text, or `BaseModel` for Pydantic models
@@ -222,7 +223,7 @@ Called by API endpoints via `Reflexio`
 - `extractor_interaction_utils.py`: Per-extractor utilities for stride_size checking and source filtering
 - `operation_state_utils.py`: Centralized `OperationStateManager` for all `_operation_state` table interactions (progress tracking, concurrency locks, extractor/aggregator bookmarks, simple locks)
 - `deduplication_utils.py`: Shared utilities for LLM-based deduplication (used by ProfileDeduplicator and PlaybookConsolidator)
-- `service_utils.py`: Utilities (`construct_messages_from_interactions()`, `format_interactions_to_history_string()` (prepends tool usage info when `tools_used` is present), `extract_json_from_string()`, `log_model_response()` for colored LLM response logging)
+- `service_utils.py`: Utilities (`construct_messages_from_interactions()`, `format_interactions_to_history_string()` (prepends tool usage info and slices long interaction content via `REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS`), `extract_json_from_string()`, `log_model_response()` for colored LLM response logging)
 
 **Operation State Management** (via `OperationStateManager` in `operation_state_utils.py`):
 - Centralized manager for all `_operation_state` table interactions with 6 use cases:

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -13,7 +13,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 | `base_generation_service.py` | `BaseGenerationService` — abstract base; the **Service Pattern** (load configs → create actors → run in parallel → save results). Per-extractor timeout `EXTRACTOR_TIMEOUT_SECONDS = 300`. |
 | `operation_state_utils.py` | `OperationStateManager` — all `_operation_state` access (progress, concurrency locks, extractor/aggregator bookmarks, cluster fingerprints, cancellation). |
 | `extractor_config_utils.py`, `extractor_interaction_utils.py` | Filter extractors by source / `allow_manual_trigger` / names; per-extractor stride + window + bookmark handling. |
-| `deduplication_utils.py`, `service_utils.py`, `embedding_text.py` | LLM dedup helpers (used by `ProfileDeduplicator` + `PlaybookConsolidator`), message construction / JSON extraction / response logging, embedding text builders. |
+| `deduplication_utils.py`, `service_utils.py`, `embedding_text.py` | LLM dedup helpers (used by `ProfileDeduplicator` + `PlaybookConsolidator`), message construction / JSON extraction / response logging, per-interaction content slicing via `REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS`, embedding text builders. |
 
 ## Generation Services
 
@@ -41,6 +41,8 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 | `pre_retrieval/` | `QueryReformulator` (`_query_reformulator.py`) + `_document_expander.py` — query rewrite & doc expansion for recall. |
 | `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks. |
 | `retrieval/` | `relevance_floor.py` — result relevance thresholding. |
+
+Embedding requests leave the service layer through `llm/litellm_client.py`; local models (`local/minilm-l6-v2`, `local/nomic-embed-v1.5`) are routed by `llm/providers/embedding_service_provider.py` to the shared embedding daemon when reachable, otherwise to the in-process embedder.
 
 ## Persistence & Config
 


### PR DESCRIPTION
## Summary
- Updates code-map README navigation for the latest server embedding routing architecture.
- Documents long-interaction prompt slicing via `REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS` in the service-layer maps.

## Repositories/submodules reviewed
- Parent: `yyiilluu/reflexio-enterprise`
- Submodule: `ReflexioAI/reflexio`

## README files updated
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- `git diff --check`
- Local README relative link check for changed files

## Notes/Risks
- Updates follow `/root/reflexio-enterprise/how_to_write_readme.md` and are limited to model-facing code-map README files.
- No parent submodule pointer commit is included; this PR is scoped to the submodule repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added documentation on embedding provider configuration modes: `cloud`, `local_service`, `internal_service`, `inprocess`, and `off`.
* Clarified local embedding model routing with automatic fallback support when services are unavailable.
* Updated documentation on interaction content token limits for embedding processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->