### PR TITLE
fix(extraction): discard late outputs after timeout

### DIFF
--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -857,6 +857,10 @@ class BaseGenerationService(
                 f"for {self._get_service_name()} identifier={identifier}"
             )
             logger.error(error_msg)
+            self._fail_active_extraction_runs(
+                extractor_kind=get_extractor_name(extractor_config),
+                last_error=error_msg,
+            )
             raise ExtractorExecutionError(error_msg) from exc
         except Exception as exc:
             self._last_extractor_run_stats = {"total": 1, "failed": 1, "timed_out": 0}
@@ -869,6 +873,44 @@ class BaseGenerationService(
         finally:
             if executor is not None:
                 executor.shutdown(wait=False, cancel_futures=True)
+
+    def _fail_active_extraction_runs(
+        self,
+        *,
+        extractor_kind: str,
+        last_error: str,
+    ) -> None:
+        """Mark active agent-run rows failed when the service timeout fires."""
+        if self.storage is None or self.service_config is None:
+            return
+        request_id = getattr(self.service_config, "request_id", None)
+        if not request_id:
+            return
+        user_id = getattr(self.service_config, "user_id", None)
+        try:
+            failed_count = self.storage.fail_running_agent_runs_for_request(
+                org_id=self.request_context.org_id,
+                extractor_kind=extractor_kind,
+                user_id=user_id,
+                request_id=request_id,
+                last_error=last_error,
+            )
+        except NotImplementedError:
+            return
+        except Exception as exc:  # noqa: BLE001 - keep timeout error primary
+            logger.warning(
+                "Failed to mark timed-out %s agent runs failed: %s",
+                extractor_kind,
+                exc,
+            )
+            return
+        if failed_count:
+            logger.warning(
+                "Marked %d timed-out %s agent run(s) failed for request_id=%s",
+                failed_count,
+                extractor_kind,
+                request_id,
+            )
 
     def _finalize_extraction_runs(self) -> None:
         if self.storage is None:

--- a/reflexio/server/services/extraction/resumable_agent.py
+++ b/reflexio/server/services/extraction/resumable_agent.py
@@ -443,14 +443,39 @@ class ResumableExtractionAgent:
         committed_output = (
             finish_ctx.output.model_dump() if finish_ctx.output is not None else None
         )
+        active_statuses = (AgentRunStatus.RUNNING, AgentRunStatus.RESUMING)
         if result.finished_reason == "finish_tool" and committed_output is not None:
-            self.storage.update_agent_run_status(
+            stored_run = self.storage.update_agent_run_status(
                 run.id,
                 AgentRunStatus.AGENT_COMPLETED,
                 committed_output=committed_output,
                 pending_tool_call_ids=result.pending_tool_call_ids,
                 max_steps_remaining=result.max_steps_remaining,
+                expected_statuses=active_statuses,
             )
+            if (
+                stored_run is None
+                or stored_run.status != AgentRunStatus.AGENT_COMPLETED
+            ):
+                logger.warning(
+                    "event=extraction_agent_late_output_discarded org_id=%s "
+                    "user_id=%s extractor_kind=%s run_id=%s request_id=%s "
+                    "stored_status=%s",
+                    run.binding.org_id,
+                    run.binding.user_id,
+                    run.binding.extractor_kind,
+                    run.id,
+                    run.binding.request_id,
+                    stored_run.status if stored_run is not None else None,
+                )
+                return AgentRunResult(
+                    run_id=run.id,
+                    output=None,
+                    pending_tool_call_ids=[],
+                    messages=result.messages,
+                    trace=result.trace,
+                    finished_reason="late_output_discarded",
+                )
             logger.info(
                 "event=extraction_agent_finished org_id=%s user_id=%s "
                 "extractor_kind=%s run_id=%s request_id=%s "
@@ -478,6 +503,7 @@ class ResumableExtractionAgent:
                 AgentRunStatus.FAILED,
                 max_steps_remaining=result.max_steps_remaining,
                 last_error=last_error,
+                expected_statuses=active_statuses,
             )
             logger.warning(
                 "event=extraction_agent_failed org_id=%s user_id=%s "

--- a/reflexio/server/services/storage/sqlite_storage/_agent_run.py
+++ b/reflexio/server/services/storage/sqlite_storage/_agent_run.py
@@ -333,6 +333,7 @@ class SQLiteAgentRunMixin:
         next_resume_at: datetime | None = None,
         last_error: str | None = None,
         increment_finalization_attempts: bool = False,
+        expected_statuses: tuple[AgentRunStatus, ...] | None = None,
     ) -> AgentRunRecord | None:
         current_timestamp = self._current_timestamp()
         assignments = ["status = ?", "updated_at = ?"]
@@ -361,13 +362,57 @@ class SQLiteAgentRunMixin:
             assignments.append("finalized_at = ?")
             params.append(current_timestamp)
         params.append(run_id)
+        status_filter = ""
+        if expected_statuses:
+            placeholders = ",".join("?" for _ in expected_statuses)
+            status_filter = f" AND status IN ({placeholders})"
+            params.extend(expected.value for expected in expected_statuses)
         with self._lock:
             self.conn.execute(
-                f"UPDATE _agent_runs SET {', '.join(assignments)} WHERE id = ?",
+                f"UPDATE _agent_runs SET {', '.join(assignments)} WHERE id = ?{status_filter}",
                 params,
             )
             self.conn.commit()
         return self.get_agent_run(run_id)
+
+    @SQLiteStorageBase.handle_exceptions
+    def fail_running_agent_runs_for_request(
+        self,
+        *,
+        org_id: str,
+        extractor_kind: str,
+        user_id: str | None,
+        request_id: str,
+        last_error: str,
+    ) -> int:
+        current_timestamp = self._current_timestamp()
+        with self._lock:
+            cursor = self.conn.execute(
+                """
+                UPDATE _agent_runs
+                SET status = ?,
+                    updated_at = ?,
+                    last_error = ?
+                WHERE org_id = ?
+                  AND extractor_kind = ?
+                  AND user_id IS ?
+                  AND request_id = ?
+                  AND status IN (?, ?)
+                """,
+                (
+                    AgentRunStatus.FAILED.value,
+                    current_timestamp,
+                    last_error,
+                    org_id,
+                    extractor_kind,
+                    user_id,
+                    request_id,
+                    AgentRunStatus.RUNNING.value,
+                    AgentRunStatus.RESUMING.value,
+                ),
+            )
+            self.conn.commit()
+            return cursor.rowcount
 
     @SQLiteStorageBase.handle_exceptions
     def create_pending_tool_call(

--- a/reflexio/server/services/storage/storage_base/_agent_run.py
+++ b/reflexio/server/services/storage/storage_base/_agent_run.py
@@ -220,7 +220,19 @@ class AgentRunMixin:
         next_resume_at: datetime | None = None,
         last_error: str | None = None,
         increment_finalization_attempts: bool = False,
+        expected_statuses: tuple[AgentRunStatus, ...] | None = None,
     ) -> AgentRunRecord | None:
+        raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
+
+    def fail_running_agent_runs_for_request(
+        self,
+        *,
+        org_id: str,
+        extractor_kind: str,
+        user_id: str | None,
+        request_id: str,
+        last_error: str,
+    ) -> int:
         raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
 
     def create_pending_tool_call(

--- a/tests/server/services/extraction/test_resumable_agent.py
+++ b/tests/server/services/extraction/test_resumable_agent.py
@@ -159,6 +159,52 @@ def test_resumable_agent_finishes_profile_output(
     }
 
 
+def test_resumable_agent_discards_late_output_after_timeout_failure(
+    monkeypatch,
+    storage,
+    tool_call_completion,
+):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
+    make_tc, _make_stop = tool_call_completion
+    response = make_tc(
+        FINISH_EXTRACTION_TOOL_NAME,
+        {
+            "profiles": [
+                {
+                    "content": "User prefers AWS ECS deployments.",
+                    "time_to_live": "infinity",
+                }
+            ]
+        },
+    )
+    client = LiteLLMClient(LiteLLMConfig(model="claude-sonnet-4-6"))
+    agent = ResumableExtractionAgent(client=client, storage=storage)
+
+    def fail_then_return(*args, **kwargs):
+        storage.update_agent_run_status(
+            "run_late",
+            AgentRunStatus.FAILED,
+            last_error="Extractor timed out after 300 seconds",
+        )
+        return response
+
+    with patch("litellm.completion", side_effect=fail_then_return):
+        result = agent.start(
+            run=_agent_run("run_late"),
+            messages=[{"role": "user", "content": "extract profiles"}],
+            output_schema=StructuredProfilesOutput,
+        )
+
+    assert result.finished_reason == "late_output_discarded"
+    assert result.output is None
+    stored = storage.get_agent_run("run_late")
+    assert stored is not None
+    assert stored.status == AgentRunStatus.FAILED
+    assert stored.committed_output is None
+    assert stored.last_error == "Extractor timed out after 300 seconds"
+
+
 def test_resumable_agent_finishes_playbook_output(
     monkeypatch,
     storage,

--- a/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
@@ -110,6 +110,22 @@ def test_sqlite_update_agent_run_status_records_lifecycle_timestamps(storage):
     assert finalized.finalized_at is not None
 
 
+def test_sqlite_update_agent_run_status_honors_expected_statuses(storage):
+    storage.create_agent_run(_agent_run("run_1", AgentRunStatus.FAILED))
+
+    updated = storage.update_agent_run_status(
+        "run_1",
+        AgentRunStatus.AGENT_COMPLETED,
+        committed_output={"profiles": []},
+        expected_statuses=(AgentRunStatus.RUNNING, AgentRunStatus.RESUMING),
+    )
+
+    assert updated is not None
+    assert updated.status == AgentRunStatus.FAILED
+    assert updated.committed_output is None
+    assert updated.agent_completed_at is None
+
+
 def test_sqlite_pending_tool_call_active_dedup_lookup(storage):
     now = datetime(2026, 5, 28, tzinfo=UTC)
     pending = storage.create_pending_tool_call(_pending_call("ptc_1", now=now))


### PR DESCRIPTION
## Summary
- Mark active extraction agent runs failed when extractor service timeout handling fires for a request.
- Guard resumable extraction completion updates with expected active statuses so late LLM/tool output cannot commit after a run is already failed.
- Add SQLite storage and resumable-agent regression coverage for status-guarded updates and late-output discard.

## Context
This is the focused replacement for the useful remaining backend behavior from the now-closed #131. Prompt tuning, request-id, and hard-timeout work already landed separately in #136.

## Tests
- `uv run python -c "import reflexio"`
- `uv run ruff check reflexio/server/services/base_generation_service.py reflexio/server/services/extraction/resumable_agent.py reflexio/server/services/storage/sqlite_storage/_agent_run.py reflexio/server/services/storage/storage_base/_agent_run.py tests/server/services/extraction/test_resumable_agent.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py`
- `uv run pyright reflexio/server/services/base_generation_service.py reflexio/server/services/extraction/resumable_agent.py reflexio/server/services/storage/sqlite_storage/_agent_run.py reflexio/server/services/storage/storage_base/_agent_run.py tests/server/services/extraction/test_resumable_agent.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py`
- `uv run pytest tests/server/services/extraction/test_resumable_agent.py tests/server/services/storage/sqlite_storage/test_agent_run_storage.py -q --no-cov`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced extraction timeout management to properly mark failed extraction runs in the system
* Prevents processing and committing outputs that arrive after an extraction operation has timed out and been marked as failed

## Tests
* Added tests to verify extraction timeout handling and validation of late-output rejection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->