### PR TITLE
fix(rerank): default cross-encoder to CPU to stop unbounded MPS memory growth

### DIFF
--- a/reflexio/server/llm/rerank/cross_encoder_reranker.py
+++ b/reflexio/server/llm/rerank/cross_encoder_reranker.py
@@ -21,6 +21,7 @@ this module never triggers a model download.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from typing import Any
 
@@ -30,6 +31,13 @@ _LOGGER = logging.getLogger(__name__)
 # size/quality trade-off: 22M parameters, ~50 ms for K=30 on CPU,
 # well-known MS-MARCO benchmark performance.
 _MODEL_NAME = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# Device override for the cross-encoder. Defaults to CPU: without an
+# explicit device sentence-transformers auto-selects MPS on Apple
+# Silicon, where torch's caching allocator accumulates gigabytes of
+# GPU buffers it never returns to the OS — and the 22M-param model
+# gains nothing from GPU at K=30 pairs. Mirrors NOMIC_EMBED_DEVICE.
+_DEVICE_ENV_VAR = "REFLEXIO_RERANK_DEVICE"
 
 # Singleton state — never accessed directly outside ``_get_model``.
 _MODEL: Any | None = None
@@ -107,9 +115,10 @@ def _get_model() -> Any:
         if _MODEL is not None:
             return _MODEL
         cross_encoder_cls = _import_cross_encoder()
+        device = os.environ.get(_DEVICE_ENV_VAR, "cpu")
         try:
-            _LOGGER.info("Loading reranker model %s", _MODEL_NAME)
-            _MODEL = cross_encoder_cls(_MODEL_NAME)
+            _LOGGER.info("Loading reranker model %s (device=%s)", _MODEL_NAME, device)
+            _MODEL = cross_encoder_cls(_MODEL_NAME, device=device)
         except Exception as e:  # noqa: BLE001 — surface as a typed failure
             raise CrossEncoderUnavailableError(
                 f"Failed to load cross-encoder model {_MODEL_NAME!r}: {e}"
@@ -141,7 +150,7 @@ def score_pairs(query: str, docs: list[str]) -> list[float]:
         return []
     model = _get_model()
     pairs = [(query, doc) for doc in docs]
-    raw_scores = model.predict(pairs)
+    raw_scores = model.predict(pairs, show_progress_bar=False)
     # ``predict`` returns a numpy array; convert to plain Python floats so
     # the caller can serialise the result without numpy as a dependency.
     return [float(s) for s in raw_scores]

--- a/tests/server/llm/rerank/test_cross_encoder_device.py
+++ b/tests/server/llm/rerank/test_cross_encoder_device.py
@@ -1,0 +1,44 @@
+"""Device selection for the cross-encoder reranker singleton."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import reflexio.server.llm.rerank.cross_encoder_reranker as reranker
+
+
+@pytest.fixture(autouse=True)
+def _reset_model_singleton():
+    """Isolate each test from the process-wide model singleton."""
+    reranker._MODEL = None
+    yield
+    reranker._MODEL = None
+
+
+def _load_model_with_mock() -> MagicMock:
+    cross_encoder_cls = MagicMock()
+    with patch.object(
+        reranker, "_import_cross_encoder", return_value=cross_encoder_cls
+    ):
+        reranker._get_model()
+    return cross_encoder_cls
+
+
+def test_default_device_is_cpu(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_RERANK_DEVICE", raising=False)
+    cross_encoder_cls = _load_model_with_mock()
+    cross_encoder_cls.assert_called_once_with(reranker._MODEL_NAME, device="cpu")
+
+
+def test_device_env_override(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_RERANK_DEVICE", "mps")
+    cross_encoder_cls = _load_model_with_mock()
+    cross_encoder_cls.assert_called_once_with(reranker._MODEL_NAME, device="mps")
+
+
+def test_score_pairs_disables_progress_bar():
+    model = MagicMock()
+    model.predict.return_value = [0.5]
+    reranker._MODEL = model
+    reranker.score_pairs("query", ["doc"])
+    model.predict.assert_called_once_with([("query", "doc")], show_progress_bar=False)


### PR DESCRIPTION
## Problem

The relevance-floor cross-encoder is loaded with `CrossEncoder(_MODEL_NAME)` — no `device` argument — so sentence-transformers auto-selects MPS on Apple Silicon. Torch's MPS caching allocator then accumulates GPU buffers across `/api/search` requests and never returns them to the OS.

Measured on a claude-smart backend (macOS, Apple Silicon): **4.4 GB physical footprint, 3.0 GB of it IOAccelerator (MPS) memory**, while `ps` RSS showed only ~450 MB (GPU-backed memory is invisible to RSS).

The 22M-param MiniLM model was chosen for CPU speed (~50 ms at K=30 per the module docstring), so MPS buys nothing here.

## Fix

- Load the cross-encoder with `device` from `REFLEXIO_RERANK_DEVICE`, defaulting to `cpu` — mirroring the `NOMIC_EMBED_DEVICE` pattern in the Nomic embedding provider. GPU deployments can opt in with `REFLEXIO_RERANK_DEVICE=cuda`.
- Pass `show_progress_bar=False` to `predict()` so tqdm `Batches:` bars stop flooding server logs.

## Verification

- Unit tests added: default device is cpu, env override passes through, progress bar disabled (`tests/server/llm/rerank/test_cross_encoder_device.py`).
- Live verification on a claude-smart backend running this change: after a 12-query `/api/search` burst exercising the relevance floor, `vmmap` shows **no IOAccelerator region at all** and a 982 MB physical footprint (peak 1.2 GB) vs 4.4 GB before — a ~3.4 GB reduction. `event=relevance_floor` lines confirm the reranker still scores and filters normally, with no `Batches:` log spam.

No behavior change on CPU-only deployments (ECS Fargate): auto-selection already resolved to CPU there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reranker now supports configurable device selection via environment variable
  * Progress bar output is suppressed during prediction operations for cleaner console output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->