### PR TITLE
Require session IDs and stabilize tool-call history

### DIFF
--- a/AI_AGENT_INTEGRATION.md
+++ b/AI_AGENT_INTEGRATION.md
@@ -180,7 +180,7 @@ Publish request fields:
 | `interactions` / `interaction_data_list` | Yes | Ordered conversation turns to publish. Include at least one turn; multi-turn correction examples are best for learning. | `[{"role": "User", "content": "Use pnpm here."}, {"role": "Assistant", "content": "Got it, I will use pnpm."}]` |
 | `source` | No | Integration label for debugging and filtering. Use a stable name for the plugin, framework, or adapter. | `"my-agent-plugin"`, `"vscode-assistant"`, `"support-chatbot"` |
 | `agent_version` | Strongly recommended | The shared-agent learning boundary. Use the same value when playbooks should transfer across users. Change it when old playbooks should not transfer. | `"support-agent-v1"`, `"coding-agent-2026-05"` |
-| `session_id` | Strongly recommended | Host conversation/session id. Generate a UUID if the host has no session id. | `"sess_01HX8Y..."`, `"3f02b7f8-..."` |
+| `session_id` | Yes | Host conversation/session id. Generate a UUID if the host has no session id, and reuse it for all turns in that conversation. | `"sess_01HX8Y..."`, `"3f02b7f8-..."` |
 | `skip_aggregation` | No | `False` when user playbooks should be eligible to roll up into shared agent playbooks. `True` when you want user-level extraction only. | `false` |
 | `force_extraction` | No | `False` for normal background publishing. `True` for manual learn-now, tests, or final flushes where you intentionally want extraction to run immediately. | `false` |
 | `wait_for_response` | SDK/query option | `False` on interactive paths. `True` only when the caller is prepared to wait for extraction results. | `false` |
@@ -445,7 +445,8 @@ Run these checks before considering the integration complete:
 
 ## Common Mistakes
 
-- Publishing without a stable `session_id`, which makes later auditing harder.
+- Publishing without a stable `session_id`; new publishes require a non-empty
+  value, and unstable one-off ids make later auditing harder.
 - Using a global `user_id` when project/user isolation is required.
 - Changing `agent_version` on every build and accidentally hiding shared
   playbooks from future searches.

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ client.publish_interaction(
         {"role": "assistant", "content": "..."},
     ],
     agent_version="v1",       # optional: track agent versions
-    session_id="session-abc", # optional: group requests into sessions
+    session_id="session-abc", # required: stable conversation/session id
 )
 
 # Search profiles

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -92,6 +92,7 @@ Reflexio learns most from interactions that contain a **signal** — a user corr
 ```shell
 uv run reflexio publish \
   --user-id alice \
+  --session-id style-session-1 \
   --user-message "Stop adding disclaimers and caveats. Give me the answer in one line." \
   --agent-response "Understood — I'll drop the boilerplate from now on." \
   --wait
@@ -102,7 +103,7 @@ uv run reflexio publish \
 For real dialogues (3+ turns, tool calls, corrections mid-conversation), pass a JSON object whose `interactions` field is a list of `{role, content}` items. Each item becomes one turn, in order. Roles are `user` and `assistant`; `system` and `tool` turns are also accepted.
 
 ```shell
-uv run reflexio publish --user-id alice --wait --data '{
+uv run reflexio publish --user-id alice --session-id deploy-session-1 --wait --data '{
   "interactions": [
     {"role": "user",      "content": "Deploy the payments service to us-east-1."},
     {"role": "assistant", "content": "Starting deployment to us-east-1..."},
@@ -123,11 +124,11 @@ You can also load inline JSON from a file with `@`: `--data @conversation.json`.
 For bulk publishing or conversations you already have on disk, point at a file. A `.json` file should be a single object (or a list of objects); a `.jsonl` file is one JSON object per line, one conversation per line.
 
 ```shell
-uv run reflexio publish --file conversations.jsonl --user-id alice --wait
-cat conversations.jsonl | uv run reflexio publish --stdin --user-id alice
+uv run reflexio publish --file conversations.jsonl --user-id alice --session-id bulk-session --wait
+cat conversations.jsonl | uv run reflexio publish --stdin --user-id alice --session-id bulk-session
 ```
 
-Each payload object accepts the same fields as Mode 2 (`interactions`, and optionally per-payload overrides for `user_id`, `session_id`, `source`, `agent_version`). A payload's own `user_id` wins over the `--user-id` flag, so you can publish a mixed-user JSONL file in a single call.
+Each payload object accepts the same fields as Mode 2 (`interactions`, `session_id`, and optionally per-payload overrides for `user_id`, `source`, `agent_version`). A payload's own `user_id` and `session_id` win over the corresponding flags, so you can publish a mixed-user or mixed-session JSONL file in a single call.
 
 ### Common flags
 
@@ -136,7 +137,7 @@ Apply to all three modes:
 | Flag                | Purpose                                                                 |
 | ------------------- | ----------------------------------------------------------------------- |
 | `--wait`            | Block until server-side extraction finishes (returns real counts).      |
-| `--session-id`      | Group multiple `publish` calls into one session.                         |
+| `--session-id`      | Required unless each payload includes `session_id`; group publishes into one session. |
 | `--agent-version`   | Tag the interaction with an agent version (used by playbook filtering). |
 | `--source`          | Free-form source tag (defaults to `cli`).                                |
 | `--skip-aggregation`| Extract profiles/playbooks but skip playbook aggregation.                |

--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -122,6 +122,20 @@ def _interactions_from_payload(payload: dict) -> list[InteractionData]:
         ) from exc
 
 
+def _resolve_session_id(raw_session_id: object, *, source_hint: str) -> str:
+    """Return a non-empty session id or raise a CLI validation error."""
+    if not isinstance(raw_session_id, str) or not raw_session_id.strip():
+        raise CliError(
+            error_type="validation",
+            message=(
+                "session_id is required and cannot be empty "
+                f"({source_hint}; pass --session-id or include 'session_id' in the payload)"
+            ),
+            exit_code=EXIT_VALIDATION,
+        )
+    return raw_session_id.strip()
+
+
 def _read_data_arg(data: str) -> str:
     """Read inline JSON or from a file path prefixed with ``@``.
 
@@ -233,7 +247,7 @@ def publish(
         ),
     ] = None,
     session_id: Annotated[
-        str | None, typer.Option(help="Session ID for grouping")
+        str | None, typer.Option(help="Required session ID for grouping")
     ] = None,
     source: Annotated[str, typer.Option(help="Source tag")] = "cli",
     agent_version: Annotated[
@@ -310,6 +324,9 @@ def publish(
                 message="--user-id is required with --user-message (or set REFLEXIO_USER_ID)",
                 exit_code=EXIT_VALIDATION,
             )
+        resolved_session_id = _resolve_session_id(
+            session_id, source_hint="single-turn publish"
+        )
         interactions: list[InteractionData | dict] = [
             InteractionData(role="user", content=user_message),
             InteractionData(role="assistant", content=agent_response),
@@ -319,7 +336,7 @@ def publish(
             interactions=interactions,
             source=source,
             agent_version=resolve_agent_version(agent_version),
-            session_id=session_id,
+            session_id=resolved_session_id,
             wait_for_response=wait,
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
@@ -371,12 +388,16 @@ def publish(
                 ),
                 exit_code=EXIT_VALIDATION,
             )
+        resolved_session_id = _resolve_session_id(
+            payload.get("session_id", session_id),
+            source_hint="payload publish",
+        )
         result = client.publish_interaction(
             user_id=resolved_user_id,
             interactions=interaction_items,  # type: ignore[arg-type]
             source=payload.get("source", source),
             agent_version=payload.get("agent_version", resolved_version),
-            session_id=payload.get("session_id", session_id),
+            session_id=resolved_session_id,
             wait_for_response=wait,
             skip_aggregation=payload.get("skip_aggregation", skip_aggregation),
             force_extraction=payload.get("force_extraction", force_extraction),

--- a/reflexio/cli/commands/shortcuts.py
+++ b/reflexio/cli/commands/shortcuts.py
@@ -49,7 +49,7 @@ def _build_publish_args(
 
     Args:
         user_id: Optional user identifier.
-        session_id: Optional session identifier.
+        session_id: Required session identifier for publish requests.
         source: Source tag recorded on the interaction.
         agent_version: Optional agent version tag.
         wait: When True, wait for processing to complete.
@@ -108,7 +108,7 @@ def register_shortcuts(app: typer.Typer) -> None:
             typer.Option("--user-id", help="User identifier (optional if in payload)"),
         ] = None,
         session_id: Annotated[
-            str | None, typer.Option("--session-id", help="Session ID")
+            str | None, typer.Option("--session-id", help="Required session ID")
         ] = None,
         source: Annotated[str, typer.Option(help="Source tag")] = "cli",
         agent_version: Annotated[

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -418,7 +418,7 @@ class ReflexioClient:
             interactions: List of interaction data.
             source: The source of the interaction.
             agent_version: The agent version.
-            session_id: Optional session ID for grouping requests.
+            session_id: Required non-empty session ID for grouping requests.
             wait_for_response: If True, the **server** waits for
                 extraction to complete before returning (longer HTTP
                 call, response includes real profile/playbook counts).
@@ -448,6 +448,9 @@ class ReflexioClient:
                 mode it includes request_id, storage routing, and
                 deltas.
         """
+        if session_id is None or not session_id.strip():
+            raise ValueError("session_id is required and cannot be empty")
+
         interaction_data_list = [
             (
                 InteractionData(**interaction_request)

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -179,7 +179,7 @@ class Request(BaseModel):
     """A user-issued request that begins or continues a session.
 
     A Request is the unit of work the agent reacts to. Multiple Requests
-    share a ``session_id`` to form a multi-turn session. The optional
+    share a ``session_id`` to form a multi-turn session. The
     ``metadata`` dict carries per-request key/value annotations stamped by
     customer integration code — distinct from ``playbook_metadata`` (a
     JSON-encoded string) used by ``Playbook``-family entities elsewhere in
@@ -192,8 +192,7 @@ class Request(BaseModel):
             to the current UTC time.
         source (str): Free-form origin tag (integration name, etc.).
         agent_version (str): The agent version that handled this request.
-        session_id (str | None): Session this request belongs to, or None
-            if the request is not part of a multi-turn session.
+        session_id (str): Non-empty session this request belongs to.
         metadata (dict[str, Any]): Free-form per-request annotations.
             Always a dict — never None. Conventional keys:
 
@@ -215,7 +214,7 @@ class Request(BaseModel):
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
     source: str = ""
     agent_version: str = ""
-    session_id: str | None = None
+    session_id: NonEmptyStr
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -563,7 +562,7 @@ class PublishUserInteractionRequest(BaseModel):
     agent_version: str = (
         ""  # this is used for aggregating interactions for generating agent playbooks
     )
-    session_id: str | None = None  # used for grouping requests together
+    session_id: NonEmptyStr  # used for grouping requests together
     skip_aggregation: bool = (
         False  # when True, extract profiles/playbooks but skip aggregation
     )

--- a/reflexio/server/api_endpoints/precondition_checks.py
+++ b/reflexio/server/api_endpoints/precondition_checks.py
@@ -20,6 +20,13 @@ def validate_publish_user_interaction_request(
     if not request.interaction_data_list:
         return False, "No interaction data provided"
 
+    # Defense-in-depth: session_id is a required NonEmptyStr on
+    # PublishUserInteractionRequest, so the normal validated API path already
+    # rejects empty/missing values with a 422. This guard additionally covers
+    # paths that bypass Pydantic validation (e.g. ``model_construct``).
+    if not request.session_id or not request.session_id.strip():
+        return False, "session_id is required and cannot be empty"
+
     for interaction_data in request.interaction_data_list:
         if (
             interaction_data.user_action != UserActionType.NONE

--- a/reflexio/server/llm/tools.py
+++ b/reflexio/server/llm/tools.py
@@ -268,6 +268,36 @@ def _serialize_tool_result_for_history(result: dict[str, Any]) -> str:
     return f"{payload[:_MULTI_STAGE_RESULT_CHAR_CAP]}... [truncated]"
 
 
+def _normalize_tool_call_for_history(tool_call: Any) -> dict[str, Any]:
+    """Return an OpenAI-compatible plain dict for assistant tool-call history."""
+
+    if isinstance(tool_call, dict):
+        function = tool_call.get("function") or {}
+        if not isinstance(function, dict):
+            function = {
+                "name": getattr(function, "name", None),
+                "arguments": getattr(function, "arguments", None),
+            }
+        return {
+            "id": tool_call.get("id"),
+            "type": tool_call.get("type") or "function",
+            "function": {
+                "name": function.get("name"),
+                "arguments": function.get("arguments") or "{}",
+            },
+        }
+
+    function = getattr(tool_call, "function", None)
+    return {
+        "id": getattr(tool_call, "id", None),
+        "type": getattr(tool_call, "type", None) or "function",
+        "function": {
+            "name": getattr(function, "name", None),
+            "arguments": getattr(function, "arguments", None) or "{}",
+        },
+    }
+
+
 def _run_multi_stage_fallback(
     *,
     client: LiteLLMClient,
@@ -627,21 +657,28 @@ def run_tool_loop(
                     pending_tool_call_ids=pending_tool_call_ids,
                     max_steps_remaining=max_steps - _step,
                 )
+            normalized_tool_calls = [
+                _normalize_tool_call_for_history(tc) for tc in tool_calls
+            ]
             # Emit ONE assistant message carrying ALL tool_calls from this turn.
             # OpenAI/Anthropic strict mode requires this shape.
             local_msgs.append(
-                {"role": "assistant", "content": None, "tool_calls": list(tool_calls)}
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": normalized_tool_calls,
+                }
             )
             # Process every tool call and append per-call tool result messages.
             # A single response's usage is attached to every turn it produced —
             # the summary helpers dedup by (model, prompt_tokens, completion_tokens).
-            for tc in tool_calls:
+            for tc in normalized_tool_calls:
                 # Time each tool individually — using the turn-start clock
                 # would inflate later tools' latencies with model time and
                 # earlier tools' work, masking the actual per-tool cost.
                 tool_t0 = time.monotonic()
-                name = tc.function.name
-                args_json = tc.function.arguments
+                name = tc["function"]["name"]
+                args_json = tc["function"]["arguments"]
                 outcome = registry.handle_outcome(name, args_json, ctx)
                 result = _tool_result_from_outcome(outcome, pending_tool_call_ids)
                 try:
@@ -664,13 +701,16 @@ def run_tool_loop(
                 local_msgs.append(
                     {
                         "role": "tool",
-                        "tool_call_id": tc.id,
+                        "tool_call_id": tc["id"],
                         "content": json.dumps(result),
                     }
                 )
             # After processing ALL tool calls, check whether the finish sentinel
             # appeared in this turn (may be alongside sibling calls).
-            if any(tc.function.name == finish_tool_name for tc in tool_calls):
+            if any(
+                tc["function"]["name"] == finish_tool_name
+                for tc in normalized_tool_calls
+            ):
                 trace.finished = True
                 return ToolLoopResult(
                     ctx=ctx,

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -133,7 +133,7 @@ def _request_interaction_models_from_ids(
             )
         models.append(
             RequestInteractionDataModel(
-                session_id=request.session_id or request.request_id,
+                session_id=request.session_id,
                 request=request,
                 interactions=ordered,
             )

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -204,7 +204,7 @@ class GenerationService:
                 org_id=self.org_id,
                 user_id=user_id,
                 request_id=request_id,
-                session_id=publish_user_interaction_request.session_id or None,
+                session_id=publish_user_interaction_request.session_id,
                 source=publish_user_interaction_request.source,
                 agent_version=agent_version,
                 event_name="publish_request_received",
@@ -221,7 +221,7 @@ class GenerationService:
                 user_id=user_id,
                 source=publish_user_interaction_request.source,
                 agent_version=agent_version,
-                session_id=publish_user_interaction_request.session_id or None,
+                session_id=publish_user_interaction_request.session_id,
                 metadata=publish_user_interaction_request.metadata,
             )
             self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
@@ -343,7 +343,7 @@ class GenerationService:
             finally:
                 executor.shutdown(wait=False, cancel_futures=True)
 
-            # Schedule delayed group evaluation if session_id is present
+            # Schedule delayed group evaluation for the required session.
             self._schedule_group_evaluation_if_needed(
                 new_request=new_request,
                 user_id=user_id,
@@ -373,7 +373,7 @@ class GenerationService:
                 org_id=self.org_id,
                 user_id=user_id,
                 request_id=result.request_id,
-                session_id=publish_user_interaction_request.session_id or None,
+                session_id=publish_user_interaction_request.session_id,
                 source=publish_user_interaction_request.source,
                 agent_version=agent_version,
                 event_name="publish_request_failed",
@@ -408,7 +408,7 @@ class GenerationService:
         agent_version: str,
         source: str | None,
     ) -> None:
-        """Enqueue agent-success evaluation for this session, if session_id is set.
+        """Enqueue agent-success evaluation for this session.
 
         Must be called once per publish — from BOTH the classic and the agentic
         extraction code paths — so that ``AgentSuccessEvaluationResult`` records
@@ -417,15 +417,12 @@ class GenerationService:
 
         Args:
             new_request (Request): The just-stored request whose session is being
-                published into. ``new_request.session_id`` gates scheduling.
+                published into.
             user_id (str): The user owning the session.
             agent_version (str): Agent version string carried into the evaluator.
             source (str | None): Optional source label.
         """
         session_id = new_request.session_id
-        if not session_id:
-            return
-
         scheduler = GroupEvaluationScheduler.get_instance()
         key = (self.org_id, user_id, session_id)
 

--- a/reflexio/server/services/storage/error.py
+++ b/reflexio/server/services/storage/error.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class StorageError(Exception):
     """
     Exception raised for storage errors
@@ -9,3 +12,27 @@ class StorageError(Exception):
 
     def __str__(self):
         return f"StorageError: {self.message}"
+
+
+def require_non_empty_session_id(value: Any) -> str:
+    """Return a stripped, non-empty request ``session_id`` or raise ``StorageError``.
+
+    ``Request.session_id`` is a required non-empty field. Rows persisted before
+    the session-id migration may still carry NULL/blank values; surfacing a
+    typed storage error (rather than a raw Pydantic ``ValidationError`` deep in
+    a read path) tells the operator to run the latest data migrations.
+
+    Args:
+        value (Any): The raw ``session_id`` value read from storage.
+
+    Returns:
+        str: The stripped, non-empty session id.
+
+    Raises:
+        StorageError: If ``value`` is missing or blank.
+    """
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise StorageError(
+        "requests.session_id is missing or empty; run the latest data migrations"
+    )

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -53,7 +53,10 @@ from reflexio.server.llm.model_defaults import (
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
 )
-from reflexio.server.services.storage.error import StorageError
+from reflexio.server.services.storage.error import (
+    StorageError,
+    require_non_empty_session_id,
+)
 from reflexio.server.services.storage.retention import RetentionTarget
 from reflexio.server.services.storage.retention_mixin import (
     RETENTION_DELETE_CHUNK,
@@ -425,7 +428,7 @@ def _row_to_request(row: sqlite3.Row) -> Request:
         created_at=_iso_to_epoch(d["created_at"]),
         source=d.get("source") or "",
         agent_version=d.get("agent_version") or "",
-        session_id=d.get("session_id"),
+        session_id=require_non_empty_session_id(d.get("session_id")),
         metadata=metadata,
     )
 
@@ -666,6 +669,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_agentic_signals()
         self._migrate_agent_playbook_source_windows()
         self._migrate_request_metadata()
+        self._migrate_request_session_id_required()
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
         init_stall_state_table(self.conn)
@@ -1223,6 +1227,77 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             logger.info("Added metadata column to requests")
         self.conn.commit()
 
+    def _migrate_request_session_id_required(self) -> None:
+        """Require non-empty session ids on ``requests``.
+
+        SQLite cannot add a ``NOT NULL`` or ``CHECK`` constraint to an
+        existing column, so existing databases are rebuilt in place. Historical
+        null/blank sessions are intentionally backfilled per request to avoid
+        inventing conversation groupings that were never recorded.
+        """
+        cols = {
+            row["name"]: row
+            for row in self.conn.execute("PRAGMA table_info(requests)").fetchall()
+        }
+        if not cols or "session_id" not in cols:
+            return
+
+        table_sql_row = self.conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'requests'"
+        ).fetchone()
+        table_sql = (table_sql_row["sql"] if table_sql_row else "") or ""
+        blank_count = self.conn.execute(
+            "SELECT COUNT(*) FROM requests WHERE session_id IS NULL OR trim(session_id) = ''"
+        ).fetchone()[0]
+        has_required_schema = (
+            bool(cols["session_id"]["notnull"])
+            and "CHECK (trim(session_id) != '')" in table_sql
+        )
+        if has_required_schema and blank_count == 0:
+            return
+
+        metadata_expr = (
+            "COALESCE(metadata, '{}')" if "metadata" in cols else "'{}'"
+        )
+        # NOTE: this rebuild hardcodes the full `requests` column set. If a
+        # future migration adds a column to `requests`, it MUST be added here
+        # too (and to the SELECT below) or the rebuild will silently drop it.
+        self.conn.executescript(
+            f"""
+            CREATE TABLE requests_new (
+                request_id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT '',
+                agent_version TEXT NOT NULL DEFAULT '',
+                session_id TEXT NOT NULL CHECK (trim(session_id) != ''),
+                metadata TEXT NOT NULL DEFAULT '{{}}'
+            );
+            INSERT INTO requests_new
+                (request_id, user_id, created_at, source, agent_version, session_id, metadata)
+            SELECT
+                request_id,
+                user_id,
+                created_at,
+                COALESCE(source, ''),
+                COALESCE(agent_version, ''),
+                CASE
+                    WHEN session_id IS NULL OR trim(session_id) = ''
+                    THEN 'legacy-' || lower(hex(randomblob(16)))
+                    ELSE trim(session_id)
+                END,
+                {metadata_expr}
+            FROM requests;
+            DROP TABLE requests;
+            ALTER TABLE requests_new RENAME TO requests;
+            CREATE INDEX IF NOT EXISTS idx_requests_user_id ON requests(user_id);
+            CREATE INDEX IF NOT EXISTS idx_requests_session_id ON requests(session_id);
+            CREATE INDEX IF NOT EXISTS idx_requests_created_at ON requests(created_at);
+            """
+        )
+        self.conn.commit()
+        logger.info("Migrated requests.session_id to required non-empty values")
+
     def _migrate_shadow_comparison_verdicts(self) -> None:
         """F1: create the shadow_comparison_verdicts table if missing.
 
@@ -1617,7 +1692,7 @@ CREATE TABLE IF NOT EXISTS requests (
     created_at TEXT NOT NULL,
     source TEXT NOT NULL DEFAULT '',
     agent_version TEXT NOT NULL DEFAULT '',
-    session_id TEXT,
+    session_id TEXT NOT NULL CHECK (trim(session_id) != ''),
     metadata TEXT NOT NULL DEFAULT '{}'
 );
 CREATE INDEX IF NOT EXISTS idx_requests_user_id ON requests(user_id);

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -9,6 +9,7 @@ from reflexio.models.api_schema.service_schemas import (
     Interaction,
     Request,
 )
+from reflexio.server.services.storage.error import require_non_empty_session_id
 
 from ._base import (
     SQLiteStorageBase,
@@ -128,7 +129,7 @@ class OperationMixin:
                     created_at=_iso_to_epoch(d["r_created_at"]),
                     source=d.get("r_source") or "",
                     agent_version=d.get("r_agent_version") or "",
-                    session_id=d.get("r_session_id"),
+                    session_id=require_non_empty_session_id(d.get("r_session_id")),
                 )
                 interactions_by_request[req_id] = []
             interactions_by_request[req_id].append(_row_to_interaction(row))
@@ -210,7 +211,7 @@ class OperationMixin:
                     created_at=_iso_to_epoch(d["r_created_at"]),
                     source=d.get("r_source") or "",
                     agent_version=d.get("r_agent_version") or "",
-                    session_id=d.get("r_session_id"),
+                    session_id=require_non_empty_session_id(d.get("r_session_id")),
                 )
                 interactions_by_request[req_id] = []
 

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -457,6 +457,7 @@ class TestPublishUserIdResolution:
     def _write_payload(tmp_path, include_user_id: bool = False, **extras) -> str:
         """Write a minimal publish payload JSON and return its path."""
         payload: dict[str, object] = {
+            "session_id": "payload-session",
             "interactions": [
                 {"role": "user", "content": "hi"},
                 {"role": "assistant", "content": "hello"},
@@ -484,6 +485,10 @@ class TestPublishUserIdResolution:
         assert result.exit_code == 0, result.output
         mock_client.publish_interaction.assert_called_once()
         assert mock_client.publish_interaction.call_args.kwargs["user_id"] == "env-user"
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["session_id"]
+            == "payload-session"
+        )
 
     def test_payload_user_id_beats_env(
         self, runner, app, mock_client, tmp_path, monkeypatch
@@ -522,12 +527,18 @@ class TestPublishUserIdResolution:
                 "flag-user",
                 "--file",
                 payload_file,
+                "--session-id",
+                "flag-session",
             ],
         )
 
         assert result.exit_code == 0, result.output
         assert (
             mock_client.publish_interaction.call_args.kwargs["user_id"] == "flag-user"
+        )
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["session_id"]
+            == "payload-session"
         )
 
     def test_error_when_all_sources_missing(
@@ -561,8 +572,49 @@ class TestPublishUserIdResolution:
                 "hi",
                 "--agent-response",
                 "hello",
+                "--session-id",
+                "single-turn-session",
             ],
         )
 
         assert result.exit_code == 0, result.output
         assert mock_client.publish_interaction.call_args.kwargs["user_id"] == "env-user"
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["session_id"]
+            == "single-turn-session"
+        )
+
+    def test_error_when_session_id_missing(
+        self, runner, app, mock_client, tmp_path, monkeypatch
+    ) -> None:
+        """Payload/file mode requires --session-id or payload session_id."""
+        monkeypatch.setenv("REFLEXIO_USER_ID", "env-user")
+        payload_file = self._write_payload(tmp_path, session_id=None)
+
+        result = runner.invoke(app, ["interactions", "publish", "--file", payload_file])
+
+        assert result.exit_code != 0
+        assert "session_id" in result.output
+        mock_client.publish_interaction.assert_not_called()
+
+    def test_single_turn_error_when_session_id_missing(
+        self, runner, app, mock_client, monkeypatch
+    ) -> None:
+        """Single-turn mode requires --session-id."""
+        monkeypatch.setenv("REFLEXIO_USER_ID", "env-user")
+
+        result = runner.invoke(
+            app,
+            [
+                "interactions",
+                "publish",
+                "--user-message",
+                "hi",
+                "--agent-response",
+                "hello",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "session_id" in result.output
+        mock_client.publish_interaction.assert_not_called()

--- a/tests/client/test_publish_interaction.py
+++ b/tests/client/test_publish_interaction.py
@@ -1,0 +1,38 @@
+"""ReflexioClient publish_interaction validation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.client import ReflexioClient
+
+
+@patch("reflexio.client.client.requests.Session")
+def test_publish_interaction_requires_session_id(mock_session_class):
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    client = ReflexioClient(api_key="test_key")
+
+    with pytest.raises(ValueError, match="session_id is required"):
+        client.publish_interaction(
+            user_id="user",
+            interactions=[{"role": "user", "content": "hello"}],
+        )
+
+    mock_session.request.assert_not_called()
+
+
+@patch("reflexio.client.client.requests.Session")
+def test_publish_interaction_rejects_blank_session_id(mock_session_class):
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    client = ReflexioClient(api_key="test_key")
+
+    with pytest.raises(ValueError, match="session_id is required"):
+        client.publish_interaction(
+            user_id="user",
+            interactions=[{"role": "user", "content": "hello"}],
+            session_id=" ",
+        )
+
+    mock_session.request.assert_not_called()

--- a/tests/e2e_tests/test_failure_path_polarity_e2e.py
+++ b/tests/e2e_tests/test_failure_path_polarity_e2e.py
@@ -178,6 +178,7 @@ def _seed_citation_window(storage, user_id: str, playbook_id: int) -> None:
         Request(
             request_id=request_id,
             user_id=user_id,
+            session_id="test_session",
             source="api",
             agent_version="v1",
         )

--- a/tests/eval/extraction/providers.py
+++ b/tests/eval/extraction/providers.py
@@ -97,6 +97,7 @@ def _sessions_to_ridm(
     request = Request(
         request_id=request_id,
         user_id=user_id,
+        session_id="test_session",
         created_at=0,
         source="api",
     )

--- a/tests/lib/test_interactions_unit.py
+++ b/tests/lib/test_interactions_unit.py
@@ -404,6 +404,7 @@ class TestPublishInteraction:
 
         request = PublishUserInteractionRequest(
             user_id="user1",
+            session_id="test_session",
             interaction_data_list=[{"role": "User", "content": "hi"}],
         )
         response = mixin.publish_interaction(request)
@@ -424,6 +425,7 @@ class TestPublishInteraction:
 
         request = PublishUserInteractionRequest(
             user_id="user1",
+            session_id="test_session",
             interaction_data_list=[{"role": "User", "content": "hi"}],
         )
         response = mixin.publish_interaction(request)
@@ -474,6 +476,7 @@ class TestPublishInteraction:
         response = mixin.publish_interaction(
             PublishUserInteractionRequest(
                 user_id="user1",
+                session_id="test_session",
                 interaction_data_list=[{"role": "User", "content": "hi"}],
             )
         )
@@ -505,6 +508,7 @@ class TestPublishInteraction:
         response = mixin.publish_interaction(
             PublishUserInteractionRequest(
                 user_id="user1",
+                session_id="test_session",
                 interaction_data_list=[{"role": "User", "content": "hi"}],
             )
         )
@@ -525,6 +529,7 @@ class TestPublishInteraction:
 
         request = PublishUserInteractionRequest(
             user_id="user1",
+            session_id="test_session",
             interaction_data_list=[{"role": "User", "content": "hi"}],
         )
         response = mixin.publish_interaction(request)

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -99,6 +99,7 @@ def test_publish_interaction_success(reflexio_with_config):
 
     request = PublishUserInteractionRequest(
         user_id=user_id,
+        session_id="test_session",
         interaction_data_list=[interaction_data],
         source="test_source",
         agent_version="v1.0",
@@ -213,7 +214,8 @@ def test_search_interactions(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -241,7 +243,8 @@ def test_search_profiles_current_only(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -269,7 +272,8 @@ def test_search_profiles_with_status_filter(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -298,7 +302,8 @@ def test_get_interactions_with_time_filters(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -329,7 +334,8 @@ def test_get_profiles_with_status_filter(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -355,7 +361,8 @@ def test_get_all_profiles_and_interactions(reflexio_with_config):
         )
 
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data]
+            user_id=user_id, interaction_data_list=[interaction_data],
+            session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
 
@@ -391,7 +398,8 @@ def test_rerun_profile_generation_single_user(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -417,7 +425,8 @@ def test_rerun_profile_generation_all_users(reflexio_with_config):
         )
 
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data]
+            user_id=user_id, interaction_data_list=[interaction_data],
+            session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
 
@@ -454,7 +463,8 @@ def test_rerun_profile_generation_with_time_filters(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -484,7 +494,8 @@ def test_rerun_profile_generation_with_source_filter(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data], source="test_source"
+        user_id=user_id, interaction_data_list=[interaction_data], source="test_source",
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -531,7 +542,8 @@ def test_upgrade_all_profiles(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -575,7 +587,8 @@ def test_downgrade_all_profiles(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -612,7 +625,8 @@ def test_upgrade_only_affected_users(reflexio_with_config):
             created_at=int(datetime.datetime.now(UTC).timestamp()),
         )
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data]
+            user_id=user_id, interaction_data_list=[interaction_data],
+            session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
 
@@ -695,7 +709,8 @@ def test_downgrade_only_affected_users(reflexio_with_config):
             created_at=int(datetime.datetime.now(UTC).timestamp()),
         )
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data]
+            user_id=user_id, interaction_data_list=[interaction_data],
+            session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
 
@@ -771,7 +786,8 @@ def test_get_profile_statistics(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -800,7 +816,8 @@ def test_delete_profile_success(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -836,7 +853,8 @@ def test_delete_interaction_success(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -878,7 +896,8 @@ def test_get_profile_change_logs(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -937,7 +956,8 @@ def test_get_dashboard_stats(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 
@@ -998,7 +1018,8 @@ def test_get_requests_with_filters(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data]
+        user_id=user_id, interaction_data_list=[interaction_data],
+        session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
 

--- a/tests/models/api_schema/test_request_metadata.py
+++ b/tests/models/api_schema/test_request_metadata.py
@@ -6,7 +6,7 @@ from reflexio.models.api_schema.domain.entities import Request
 
 def test_request_has_metadata_field_with_default_empty_dict():
     """Request gains a metadata field. Default is an empty dict, NOT None."""
-    r = Request(request_id="r1", user_id="u1")
+    r = Request(request_id="r1", user_id="u1", session_id="test_session")
     assert r.metadata == {}
 
 
@@ -14,6 +14,7 @@ def test_request_metadata_accepts_arbitrary_keys():
     r = Request(
         request_id="r1",
         user_id="u1",
+        session_id="test_session",
         metadata={"reflexio_retrieval_enabled": True, "custom_key": "v"},
     )
     assert r.metadata["reflexio_retrieval_enabled"] is True
@@ -24,6 +25,7 @@ def test_request_metadata_roundtrips_through_model_dump():
     r = Request(
         request_id="r1",
         user_id="u1",
+        session_id="test_session",
         metadata={"reflexio_retrieval_enabled": False},
     )
     parsed = Request(**r.model_dump())
@@ -33,7 +35,12 @@ def test_request_metadata_roundtrips_through_model_dump():
 def test_request_metadata_rejects_none():
     """metadata is always a dict — None is a ValidationError, not silently coerced."""
     with pytest.raises(ValidationError):
-        Request(request_id="r1", user_id="u1", metadata=None)  # type: ignore[arg-type]
+        Request(
+            request_id="r1",
+            user_id="u1",
+            session_id="test_session",
+            metadata=None,  # type: ignore[arg-type]
+        )
 
 
 def test_request_metadata_default_is_independent_per_instance():
@@ -41,8 +48,8 @@ def test_request_metadata_default_is_independent_per_instance():
 
     Mutating one instance's metadata must not bleed into another instance.
     """
-    r1 = Request(request_id="r1", user_id="u1")
-    r2 = Request(request_id="r2", user_id="u1")
+    r1 = Request(request_id="r1", user_id="u1", session_id="test_session")
+    r2 = Request(request_id="r2", user_id="u1", session_id="test_session")
     r1.metadata["k"] = "v"
     assert r2.metadata == {}
     assert r1.metadata is not r2.metadata
@@ -51,6 +58,11 @@ def test_request_metadata_default_is_independent_per_instance():
 def test_request_metadata_nested_values_roundtrip():
     """Arbitrarily nested values survive model_dump() -> Request(**...) roundtrip."""
     nested = {"a": {"b": [1, 2, {"c": True}]}, "list": ["x", "y"]}
-    r = Request(request_id="r1", user_id="u1", metadata=nested)
+    r = Request(
+        request_id="r1",
+        user_id="u1",
+        session_id="test_session",
+        metadata=nested,
+    )
     parsed = Request(**r.model_dump())
     assert parsed.metadata == nested

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -564,7 +564,20 @@ class TestListMinLength:
     def test_publish_interaction_requires_data(self):
         """PublishUserInteractionRequest requires at least one interaction."""
         with pytest.raises(ValidationError):
-            PublishUserInteractionRequest(user_id="test", interaction_data_list=[])
+            PublishUserInteractionRequest(
+                user_id="test", session_id="session", interaction_data_list=[]
+            )
+
+    def test_publish_interaction_requires_non_empty_session_id(self):
+        """PublishUserInteractionRequest requires a non-empty session id."""
+        interaction = InteractionData(content="hello")
+        for value in (None, "", "   "):
+            with pytest.raises(ValidationError):
+                PublishUserInteractionRequest(
+                    user_id="test",
+                    session_id=value,
+                    interaction_data_list=[interaction],
+                )
 
     def test_add_user_playbook_requires_data(self):
         """AddUserPlaybookRequest requires at least one user playbook."""

--- a/tests/server/api_endpoints/test_precondition_checks.py
+++ b/tests/server/api_endpoints/test_precondition_checks.py
@@ -16,11 +16,13 @@ def _make_publish_request(
     if interactions is not None:
         return PublishUserInteractionRequest(
             user_id="test-user",
+            session_id="test-session",
             interaction_data_list=interactions,
         )
     # Bypass Pydantic min_length=1 validation to test the precondition check
     return PublishUserInteractionRequest.model_construct(
         user_id="test-user",
+        session_id="test-session",
         interaction_data_list=[],
     )
 
@@ -42,6 +44,16 @@ class TestValidatePublishUserInteractionRequest:
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
         assert msg == "User action description is required for user action"
+
+    def test_empty_session_id(self):
+        request = PublishUserInteractionRequest.model_construct(
+            user_id="test-user",
+            session_id="",
+            interaction_data_list=[InteractionData(content="hello")],
+        )
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is False
+        assert msg == "session_id is required and cannot be empty"
 
     def test_both_image_url_and_image_encoding(self):
         interaction = InteractionData(

--- a/tests/server/llm/test_tools.py
+++ b/tests/server/llm/test_tools.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -271,6 +272,65 @@ def test_run_tool_loop_records_async_accepted_and_continues(
     assert [turn.tool_name for turn in result.trace.turns] == ["ask_human", "finish"]
     tool_messages = [m for m in result.messages if m.get("role") == "tool"]
     assert "ptc_1" in tool_messages[0]["content"]
+
+
+def test_run_tool_loop_sends_plain_dict_tool_calls_in_followup_request(monkeypatch):
+    """Provider tool-call objects should not be reused in the next request."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_CLI", raising=False)
+
+    emit_call = MagicMock()
+    emit_call.id = "call_emit"
+    emit_call.type = "function"
+    emit_call.function = MagicMock()
+    emit_call.function.name = "emit"
+    emit_call.function.arguments = json.dumps({"value": "hello"})
+
+    finish_call = MagicMock()
+    finish_call.id = "call_finish"
+    finish_call.type = "function"
+    finish_call.function = MagicMock()
+    finish_call.function.name = "finish"
+    finish_call.function.arguments = "{}"
+
+    calls: list[list[dict]] = []
+
+    def fake_generate_chat_response(**kwargs):
+        calls.append(deepcopy(kwargs["messages"]))
+        tool_calls = [emit_call] if len(calls) == 1 else [finish_call]
+        return ToolCallingChatResponse(
+            content=None,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls",
+        )
+
+    config = LiteLLMConfig(model="claude-sonnet-4-6")
+    client = LiteLLMClient(config)
+    monkeypatch.setattr(client, "generate_chat_response", fake_generate_chat_response)
+    ctx = LoopCtx()
+
+    result = run_tool_loop(
+        client=client,
+        messages=[{"role": "user", "content": "go"}],
+        registry=_make_registry(ctx),
+        model_role=ModelRole.EXTRACTION_AGENT,
+        ctx=ctx,
+    )
+
+    assert result.finished_reason == "finish_tool"
+    assistant_history = calls[1][-2]
+    assert assistant_history["role"] == "assistant"
+    assert assistant_history["tool_calls"] == [
+        {
+            "id": "call_emit",
+            "type": "function",
+            "function": {
+                "name": "emit",
+                "arguments": json.dumps({"value": "hello"}),
+            },
+        }
+    ]
+    assert assistant_history["tool_calls"][0] is not emit_call
 
 
 def test_run_tool_loop_honours_max_steps(monkeypatch, tool_call_completion):

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
@@ -116,12 +116,14 @@ def sample_request_interaction_models(sample_interactions):
     request1 = Request(
         request_id="req1",
         user_id="user1",
+        session_id="test_session",
         created_at=1000,
         source="api",
     )
     request2 = Request(
         request_id="req2",
         user_id="user2",
+        session_id="test_session",
         created_at=1002,
         source="api",
     )
@@ -259,12 +261,14 @@ class TestSourceFiltering:
         request1 = Request(
             request_id="req1",
             user_id="user1",
+            session_id="test_session",
             created_at=1000,
             source="api",
         )
         request2 = Request(
             request_id="req2",
             user_id="user2",
+            session_id="test_session",
             created_at=1002,
             source="web",
         )

--- a/tests/server/services/playbook/test_extractor_polarity_integration.py
+++ b/tests/server/services/playbook/test_extractor_polarity_integration.py
@@ -111,6 +111,7 @@ def neutral_request_interaction_models():
     request = Request(
         request_id="req_neutral",
         user_id="user_neutral",
+        session_id="test_session",
         created_at=1000,
         source="api",
     )
@@ -155,6 +156,7 @@ def failure_request_interaction_models():
     request = Request(
         request_id="req_failure",
         user_id="user_failure",
+        session_id="test_session",
         created_at=2000,
         source="api",
     )

--- a/tests/server/services/playbook/test_playbook_extractor.py
+++ b/tests/server/services/playbook/test_playbook_extractor.py
@@ -135,12 +135,14 @@ def sample_request_interaction_models(sample_interactions):
     request1 = Request(
         request_id="req1",
         user_id="user1",
+        session_id="test_session",
         created_at=1000,
         source="api",
     )
     request2 = Request(
         request_id="req2",
         user_id="user2",
+        session_id="test_session",
         created_at=1002,
         source="api",
     )

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -321,6 +321,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
         request_obj = Request(
             request_id="request_1",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         playbook_generation_service.storage.add_request(request_obj)
@@ -421,6 +422,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
         request_obj = Request(
             request_id="test_request_id",
             user_id=user_id,
+            session_id="test_session",
             source="",
             agent_version=agent_version,
         )
@@ -482,6 +484,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         request_a = Request(
             request_id="request_a",
             user_id=user_id,
+            session_id="test_session",
             source="source_a",
             agent_version=agent_version,
         )
@@ -500,6 +503,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         request_b = Request(
             request_id="request_b",
             user_id=user_id,
+            session_id="test_session",
             source="source_b",
             agent_version=agent_version,
         )
@@ -565,6 +569,7 @@ def test_run_manual_regular_output_pending_status_false(mock_chat_completion):
         request_obj = Request(
             request_id="test_request_id",
             user_id=user_id,
+            session_id="test_session",
             source="",
             agent_version=agent_version,
         )

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -102,6 +102,7 @@ def _seed_request_and_user_interaction(
         Request(
             request_id=request_id,
             user_id="u1",
+            session_id="test_session",
             source="test",
             agent_version="v1",
         )
@@ -831,6 +832,7 @@ json.dump({"content": "response for " + payload["playbooks"][0]["content"]}, sys
             Request(
                 request_id="request-1",
                 user_id="u1",
+                session_id="test_session",
                 source="test",
                 agent_version="v1",
             )

--- a/tests/server/services/profile/test_profile_extractor.py
+++ b/tests/server/services/profile/test_profile_extractor.py
@@ -136,6 +136,7 @@ def sample_request_interaction_models(sample_interactions):
     request = Request(
         request_id="req1",
         user_id="test_user",
+        session_id="test_session",
         created_at=1000,
         source="api",
     )

--- a/tests/server/services/profile/test_profile_generation_service.py
+++ b/tests/server/services/profile/test_profile_generation_service.py
@@ -130,6 +130,7 @@ def sample_request_interaction_models(sample_interactions):
     request = Request(
         request_id="req_1",
         user_id="user_1",
+        session_id="test_session",
         created_at=sample_interactions[0].created_at,
         source="api",
     )

--- a/tests/server/services/profile/test_profile_generation_service_utils.py
+++ b/tests/server/services/profile/test_profile_generation_service_utils.py
@@ -50,6 +50,7 @@ def test_construct_profile_extraction_messages_with_sessions():
     request = Request(
         request_id="req_1",
         user_id="user_123",
+        session_id="test_session",
         created_at=timestamp,
     )
     sessions = [

--- a/tests/server/services/reflection/test_generation_service_wiring.py
+++ b/tests/server/services/reflection/test_generation_service_wiring.py
@@ -47,6 +47,7 @@ def llm_client():
 def publish_request():
     return PublishUserInteractionRequest(
         user_id="u1",
+        session_id="test_session",
         interaction_data_list=[
             InteractionData(role="User", content="hello"),
             InteractionData(role="Assistant", content="hi"),

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -131,6 +131,7 @@ def _seed_request_with_interactions(
         Request(
             request_id=request_id,
             user_id=user_id,
+            session_id="test_session",
             source="cli",
             agent_version="v1",
         )

--- a/tests/server/services/storage/sqlite_storage/test_session_id_migration.py
+++ b/tests/server/services/storage/sqlite_storage/test_session_id_migration.py
@@ -1,0 +1,118 @@
+"""Migration test: requests.session_id becomes required and non-empty.
+
+Covers the in-place table rebuild in
+``SQLiteStorageBase._migrate_request_session_id_required`` — the riskiest part
+of the session-id-required change, since it drops and recreates ``requests``.
+"""
+
+import sqlite3
+
+import pytest
+
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+# The pre-migration ``requests`` schema: session_id was nullable.
+_LEGACY_REQUESTS_DDL = """
+CREATE TABLE requests (
+    request_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT '',
+    agent_version TEXT NOT NULL DEFAULT '',
+    session_id TEXT,
+    metadata TEXT NOT NULL DEFAULT '{}'
+);
+"""
+
+
+def _seed_legacy_db(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_LEGACY_REQUESTS_DDL)
+    conn.executemany(
+        "INSERT INTO requests (request_id, user_id, created_at, source, session_id) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("r-null", "u1", "2026-01-01T00:00:00+00:00", "web", None),
+            ("r-blank", "u1", "2026-01-01T00:00:01+00:00", "web", "   "),
+            ("r-valid", "u1", "2026-01-01T00:00:02+00:00", "web", "s-valid"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _session_ids(db_path: str) -> dict[str, str]:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return {
+            row["request_id"]: row["session_id"]
+            for row in conn.execute("SELECT request_id, session_id FROM requests")
+        }
+    finally:
+        conn.close()
+
+
+def test_migration_backfills_legacy_blank_sessions(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _seed_legacy_db(db_path)
+
+    SQLiteStorage(org_id="0", db_path=db_path)  # construction triggers migrate()
+
+    sessions = _session_ids(db_path)
+    assert len(sessions) == 3  # no rows dropped during the rebuild
+    assert sessions["r-valid"] == "s-valid"  # pre-existing value untouched
+    # NULL/blank rows are backfilled per-row (NOT grouped into a shared session).
+    assert sessions["r-null"].startswith("legacy-")
+    assert sessions["r-blank"].startswith("legacy-")
+    assert sessions["r-null"] != sessions["r-blank"]
+
+
+def test_migration_enforces_not_null_and_non_empty(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _seed_legacy_db(db_path)
+    SQLiteStorage(org_id="0", db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO requests (request_id, user_id, created_at, session_id) "
+                "VALUES ('x', 'u', '2026-01-01T00:00:00+00:00', NULL)"
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO requests (request_id, user_id, created_at, session_id) "
+                "VALUES ('y', 'u', '2026-01-01T00:00:00+00:00', '   ')"
+            )
+    finally:
+        conn.close()
+
+
+def test_migration_is_idempotent(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _seed_legacy_db(db_path)
+
+    SQLiteStorage(org_id="0", db_path=db_path)
+    first = _session_ids(db_path)
+
+    # Re-opening detects the required schema with no blanks and no-ops, so the
+    # backfilled legacy ids must be preserved (not regenerated).
+    SQLiteStorage(org_id="0", db_path=db_path)
+    second = _session_ids(db_path)
+    assert first == second
+
+
+def test_migration_noop_on_fresh_db(tmp_path):
+    """A fresh DB is created with the required schema; no rebuild needed."""
+    db_path = str(tmp_path / "fresh.db")
+    SQLiteStorage(org_id="0", db_path=db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        (sql,) = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='requests'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert "CHECK (trim(session_id) != '')" in sql

--- a/tests/server/services/storage/test_request_metadata_contract_integration.py
+++ b/tests/server/services/storage/test_request_metadata_contract_integration.py
@@ -42,7 +42,11 @@ def test_request_metadata_roundtrips(storage: BaseStorage) -> None:
 
 
 def test_request_metadata_empty_default(storage: BaseStorage) -> None:
-    r = Request(request_id="contract-meta-r2", user_id="contract-meta-u1")
+    r = Request(
+        request_id="contract-meta-r2",
+        user_id="contract-meta-u1",
+        session_id="test_session",
+    )
     storage.add_request(r)
     got = storage.get_request("contract-meta-r2")
     assert got is not None
@@ -76,6 +80,7 @@ def test_request_metadata_nested_values_roundtrip(storage: BaseStorage) -> None:
     r = Request(
         request_id="contract-meta-r5",
         user_id="contract-meta-u1",
+        session_id="test_session",
         metadata={"reflexio_retrieval_enabled": True, "nested": {"k": [1, 2, 3]}},
     )
     storage.add_request(r)

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import sqlite3
 import tempfile
 from collections.abc import Generator
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from reflexio.models.api_schema.internal_schema import SessionDescriptor
 from reflexio.models.api_schema.service_schemas import (
@@ -79,21 +81,67 @@ def test_window_boundaries_are_inclusive(storage: BaseStorage) -> None:
     assert {d.session_id for d in out} == {"edge_low", "edge_high"}
 
 
-def test_null_session_excluded(storage: BaseStorage) -> None:
-    """Requests with session_id=None must be excluded from the result."""
-    _seed_request(storage, "u1", "s1", ts=1000)
-    req = Request(
-        request_id="req_null",
-        user_id="u1",
-        created_at=1000,
-        source="test",
-        agent_version="v1",
-        session_id=None,
-    )
-    storage.add_request(req)
+def test_null_session_rejected_by_request_model() -> None:
+    """Requests must include a non-empty session_id."""
+    with pytest.raises(ValidationError):
+        Request(
+            request_id="req_null",
+            user_id="u1",
+            created_at=1000,
+            source="test",
+            agent_version="v1",
+            session_id=None,
+        )
 
-    out = storage.get_session_ids_in_window(from_ts=0, to_ts=5000)
-    assert {d.session_id for d in out} == {"s1"}
+
+def test_sqlite_migration_backfills_blank_session_ids_per_request() -> None:
+    """Old nullable request rows get distinct legacy sessions during migration."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        db_path = f"{temp_dir}/reflexio.db"
+        conn = sqlite3.connect(db_path)
+        conn.executescript(
+            """
+            CREATE TABLE requests (
+                request_id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT '',
+                agent_version TEXT NOT NULL DEFAULT '',
+                session_id TEXT
+            );
+            INSERT INTO requests
+                (request_id, user_id, created_at, source, agent_version, session_id)
+            VALUES
+                ('r_null', 'u1', '1970-01-01T00:16:40+00:00', 'test', 'v1', NULL),
+                ('r_blank', 'u1', '1970-01-01T00:16:41+00:00', 'test', 'v1', ''),
+                ('r_ok', 'u1', '1970-01-01T00:16:42+00:00', 'test', 'v1', 'existing');
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        storage = SQLiteStorage(
+            org_id="contract_test_session_migration",
+            db_path=db_path,
+        )
+
+        rows = {
+            row["request_id"]: row["session_id"]
+            for row in storage.conn.execute(
+                "SELECT request_id, session_id FROM requests"
+            ).fetchall()
+        }
+        assert rows["r_ok"] == "existing"
+        assert rows["r_null"].startswith("legacy-")
+        assert rows["r_blank"].startswith("legacy-")
+        assert rows["r_null"] != rows["r_blank"]
+
+        with pytest.raises(sqlite3.IntegrityError):
+            storage.conn.execute(
+                "INSERT INTO requests "
+                "(request_id, user_id, created_at, source, agent_version, session_id) "
+                "VALUES ('r_bad', 'u1', '1970-01-01T00:16:43+00:00', 'test', 'v1', '')"
+            )
 
 
 def test_distinct_agent_versions_split_into_separate_descriptors(

--- a/tests/server/services/storage/test_sqlite_request_metadata.py
+++ b/tests/server/services/storage/test_sqlite_request_metadata.py
@@ -37,6 +37,7 @@ def test_sqlite_metadata_accepts_nested_values(storage):
     r = Request(
         request_id="r3",
         user_id="u1",
+        session_id="test_session",
         metadata={"reflexio_retrieval_enabled": False, "tags": ["a", "b"]},
     )
     storage.add_request(r)

--- a/tests/server/services/storage/test_storage_contract_requests.py
+++ b/tests/server/services/storage/test_storage_contract_requests.py
@@ -17,7 +17,7 @@ pytestmark = pytest.mark.integration
 def _make_request(
     request_id: str,
     user_id: str,
-    session_id: str | None = None,
+    session_id: str = "s-default",
 ) -> Request:
     return Request(
         request_id=request_id,

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -20,6 +20,7 @@ def _make_request(request_id: str, created_at: int) -> Request:
     return Request(
         request_id=request_id,
         user_id="u1",
+        session_id="test_session",
         created_at=created_at,
         source="test",
         agent_version="v1",

--- a/tests/server/services/storage/test_storage_error.py
+++ b/tests/server/services/storage/test_storage_error.py
@@ -1,0 +1,18 @@
+"""Unit tests for the shared storage session-id contract helper."""
+
+import pytest
+
+from reflexio.server.services.storage.error import (
+    StorageError,
+    require_non_empty_session_id,
+)
+
+
+def test_require_non_empty_session_id_returns_stripped_value():
+    assert require_non_empty_session_id("  s-1  ") == "s-1"
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", 123, b"s-1"])
+def test_require_non_empty_session_id_rejects_missing_or_blank(value):
+    with pytest.raises(StorageError, match="run the latest data migrations"):
+        require_non_empty_session_id(value)

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -352,6 +352,7 @@ class TestFilterConfigByStride:
         request = Request(
             request_id="req1",
             user_id="test_user",
+            session_id="test_session",
             created_at=1000,
             source="api",
         )
@@ -2132,7 +2133,11 @@ class TestCheapShouldRunReject:
         return [
             RequestInteractionDataModel(
                 session_id="s",
-                request=Request(request_id="r", user_id="u"),
+                request=Request(
+                    request_id="r",
+                    user_id="u",
+                    session_id="test_session",
+                ),
                 interactions=[
                     Interaction(user_id="u", request_id="r", role="User", content=c)
                     for c in contents

--- a/tests/server/services/test_extractor_interaction_utils.py
+++ b/tests/server/services/test_extractor_interaction_utils.py
@@ -285,6 +285,7 @@ def _create_mock_request_interaction_model(
     """Helper to create a RequestInteractionDataModel with specified number of interactions."""
     request = Request(
         user_id="user1",
+        session_id="test_session",
         agent_version="v1",
         request_id=f"req_{num_interactions}",
         source=source,

--- a/tests/server/services/test_generation_service.py
+++ b/tests/server/services/test_generation_service.py
@@ -117,6 +117,7 @@ def test_publish_request_rejects_empty_caller_request_id():
         PublishUserInteractionRequest(
             request_id="",
             user_id="test_user_id",
+            session_id="test_session_id",
             interaction_data_list=[interaction],
         )
 
@@ -142,11 +143,13 @@ def test_publish_request_rejects_duplicate_caller_request_id(mock_llm_responses)
         first_request = PublishUserInteractionRequest(
             request_id=request_id,
             user_id=user_id,
+            session_id="test_session_id",
             interaction_data_list=[interaction],
         )
         second_request = PublishUserInteractionRequest(
             request_id=request_id,
             user_id=user_id,
+            session_id="test_session_id",
             interaction_data_list=[interaction],
         )
 
@@ -163,50 +166,19 @@ def test_publish_request_rejects_duplicate_caller_request_id(mock_llm_responses)
         )
 
 
-def test_empty_session_id_allows_multiple_requests(mock_llm_responses):
-    """
-    Test that multiple requests with empty session_id are allowed.
-    """
-    user_id = "test_user_id"
-    org_id = "test_org"
+def test_empty_session_id_is_rejected():
+    """Publish requests must include a non-empty session_id."""
+    interaction = InteractionData(
+        content="interaction without session",
+        created_at=int(datetime.datetime.now(UTC).timestamp()),
+    )
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        llm_config = LiteLLMConfig(model="gpt-4o-mini")
-        llm_client = LiteLLMClient(llm_config)
-        generation_service = GenerationService(
-            llm_client=llm_client,
-            request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
-        )
-
-        interaction = InteractionData(
-            content="interaction without session",
-            created_at=int(datetime.datetime.now(UTC).timestamp()),
-        )
-
-        # Request without session_id (empty string)
-        request = PublishUserInteractionRequest(
-            user_id=user_id,
+    with pytest.raises(ValidationError):
+        PublishUserInteractionRequest(
+            user_id="test_user_id",
             interaction_data_list=[interaction],
-            session_id="",  # Empty session
-        )
-
-        # Should not raise any exception
-        generation_service.run(request)
-
-        # Try another request with empty session_id - should also succeed
-        another_interaction = InteractionData(
-            content="another interaction without session",
-            created_at=int(datetime.datetime.now(UTC).timestamp()),
-        )
-
-        another_request = PublishUserInteractionRequest(
-            user_id=user_id,
-            interaction_data_list=[another_interaction],
             session_id="",
         )
-
-        # Should not raise any exception
-        generation_service.run(another_request)
 
 
 # NOTE: TestWindowSizeStrideOverrides class was removed because the global

--- a/tests/server/services/test_generation_service_scheduling.py
+++ b/tests/server/services/test_generation_service_scheduling.py
@@ -28,25 +28,25 @@ def service() -> GenerationService:
     return svc
 
 
-def test_no_schedule_when_session_id_is_none(
+def test_schedules_when_session_id_is_required(
     service: GenerationService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """When new_request.session_id is None, the helper short-circuits."""
+    """The helper schedules because publish requests require a session_id."""
     scheduler = MagicMock()
     monkeypatch.setattr(
         "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
         lambda: scheduler,
     )
-    request_with_no_session = MagicMock(session_id=None)
+    request_with_session = MagicMock(session_id="sess_required")
 
     service._schedule_group_evaluation_if_needed(
-        new_request=request_with_no_session,
+        new_request=request_with_session,
         user_id="user_test",
         agent_version="v_test",
         source=None,
     )
 
-    scheduler.schedule.assert_not_called()
+    scheduler.schedule.assert_called_once()
 
 
 def test_schedules_with_correct_key_when_session_id_present(

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -127,6 +127,7 @@ def test_refresh_profiles_for_user(mock_chat_completion):
         # Create a PublishUserInteractionRequest first
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_request],
         )
 
@@ -140,6 +141,7 @@ def test_refresh_profiles_for_user(mock_chat_completion):
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -199,6 +201,7 @@ def test_test_refresh_profiles_for_user_with_image_encoding(mock_chat_completion
         # Create a PublishUserInteractionRequest first
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_request],
         )
 
@@ -212,6 +215,7 @@ def test_test_refresh_profiles_for_user_with_image_encoding(mock_chat_completion
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -288,6 +292,7 @@ def test_profile_extraction_message_construction():
             # Create a PublishUserInteractionRequest
             publish_request = PublishUserInteractionRequest(
                 user_id=user_id,
+                session_id="test_session",
                 interaction_data_list=[interaction1, interaction2],
             )
 
@@ -301,6 +306,7 @@ def test_profile_extraction_message_construction():
             request_obj = Request(
                 request_id="1",
                 user_id=user_id,
+                session_id="test_session",
                 source="",
             )
             profile_generation_service.storage.add_request(request_obj)
@@ -451,6 +457,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
         # First, create CURRENT profiles (output_pending_status=False)
         publish_request1 = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction1],
         )
 
@@ -464,6 +471,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
         request_obj1 = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         profile_generation_service.storage.add_request(request_obj1)
@@ -493,6 +501,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
         # Add more interactions for the rerun
         publish_request2 = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction2],
         )
 
@@ -505,6 +514,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
         request_obj2 = Request(
             request_id="2",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         profile_generation_service.storage.add_request(request_obj2)
@@ -600,6 +610,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
         request_obj = Request(
             request_id="request_1",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -693,6 +704,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
         )
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction],
         )
         interactions = (
@@ -704,6 +716,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -767,6 +780,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         )
         publish_request_a = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_a],
             source="source_a",
         )
@@ -779,6 +793,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         request_a = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="source_a",
         )
         profile_generation_service.storage.add_request(request_a)
@@ -794,6 +809,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         )
         publish_request_b = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_b],
             source="source_b",
         )
@@ -806,6 +822,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
         request_b = Request(
             request_id="2",
             user_id=user_id,
+            session_id="test_session",
             source="source_b",
         )
         profile_generation_service.storage.add_request(request_b)

--- a/tests/server/services/test_profile_source_filtering.py
+++ b/tests/server/services/test_profile_source_filtering.py
@@ -82,6 +82,7 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
         # Create a PublishUserInteractionRequest
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_request],
         )
 
@@ -95,6 +96,7 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="api",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -148,6 +150,7 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
 
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_request],
         )
 
@@ -161,6 +164,7 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="webhook",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -214,6 +218,7 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
 
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_request],
         )
 
@@ -227,6 +232,7 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="random_source",
         )
         profile_generation_service.storage.add_request(request_obj)
@@ -280,6 +286,7 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
 
         publish_request = PublishUserInteractionRequest(
             user_id=user_id,
+            session_id="test_session",
             interaction_data_list=[interaction_request],
         )
 
@@ -293,6 +300,7 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
         request_obj = Request(
             request_id="1",
             user_id=user_id,
+            session_id="test_session",
             source="another_random_source",
         )
         profile_generation_service.storage.add_request(request_obj)

--- a/tests/server/services/test_service_utils.py
+++ b/tests/server/services/test_service_utils.py
@@ -213,6 +213,7 @@ def _create_request(request_id: str, created_at: int) -> Request:
     return Request(
         request_id=request_id,
         user_id="test_user",
+        session_id="test_session",
         created_at=created_at,
     )
 


### PR DESCRIPTION
## Summary
- require non-empty `session_id` values through the shared interaction schema, client, CLI, and SQLite storage path
- add SQLite migration and storage/precondition coverage for session ID enforcement
- normalize provider tool-call objects into plain dicts before appending native tool-loop history, fixing MiniMax follow-up turns after pending tool calls

## Validation
- `uv run pytest --no-cov open_source/reflexio/tests/server/llm/test_tools.py`
- `uv run pytest --no-cov reflexio_ext/tests/server/services/storage/test_agent_run_storage_wiring.py open_source/reflexio/tests/server/llm/test_tools.py` -> 35 passed
- launch-checklist phases 0-14 passed in the enterprise repo
- launch-checklist phase 15 passed after the native tool-loop fix

## Notes
- This PR is paired with the enterprise PR that bumps the submodule pointer and adds Supabase-side enforcement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `session_id` is now required when publishing interactions; previously it was optional. Publishing requests without a valid `session_id` will now fail with a validation error.

* **Documentation**
  * Updated CLI help text, integration guides, and documentation to clarify that `session_id` is required and must be a stable, consistent value across conversation turns.
  * Improved error messages to guide users when `session_id` is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->