### PR TITLE
feat: support evaluation-only interactions

### DIFF
--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -142,6 +142,7 @@ Apply to all three modes:
 | `--source`          | Free-form source tag (defaults to `cli`).                                |
 | `--skip-aggregation`| Extract profiles/playbooks but skip playbook aggregation.                |
 | `--force-extraction`| Bypass all extraction gates (`stride_size`, cheap pre-filter, LLM `should_run`) and always run extractors. |
+| `--evaluation-only` | Store the request for session-level evaluation only; requires `--session-id` and skips profile/playbook extraction. |
 
 Full options via `uv run reflexio interactions publish --help`.
 

--- a/reflexio/cli/commands/interactions.py
+++ b/reflexio/cli/commands/interactions.py
@@ -279,6 +279,13 @@ def publish(
             help="Bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors",
         ),
     ] = False,
+    evaluation_only: Annotated[
+        bool,
+        typer.Option(
+            "--evaluation-only",
+            help="Store for session-level evaluation only and skip profile/playbook extraction",
+        ),
+    ] = False,
     override_learning_stall: Annotated[
         bool,
         typer.Option(
@@ -340,6 +347,7 @@ def publish(
             wait_for_response=wait,
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
+            evaluation_only=evaluation_only,
             override_learning_stall=override_learning_stall,
         )
         if json_mode:
@@ -401,6 +409,7 @@ def publish(
             wait_for_response=wait,
             skip_aggregation=payload.get("skip_aggregation", skip_aggregation),
             force_extraction=payload.get("force_extraction", force_extraction),
+            evaluation_only=payload.get("evaluation_only", evaluation_only),
             override_learning_stall=payload.get(
                 "override_learning_stall", override_learning_stall
             ),
@@ -462,7 +471,7 @@ def search(
 @handle_errors
 def delete(
     ctx: typer.Context,
-    interaction_id: Annotated[str, typer.Option(help="Interaction ID to delete")],
+    interaction_id: Annotated[int, typer.Option(help="Interaction ID to delete")],
     user_id: Annotated[str, typer.Option(help="User ID that owns the interaction")],
 ) -> None:
     """Delete a single interaction by ID."""

--- a/reflexio/cli/commands/shortcuts.py
+++ b/reflexio/cli/commands/shortcuts.py
@@ -39,6 +39,7 @@ def _build_publish_args(
     stdin: bool,
     skip_aggregation: bool,
     force_extraction: bool,
+    evaluation_only: bool,
 ) -> list[str]:
     """Assemble the argv the ``interactions publish`` command expects.
 
@@ -61,6 +62,8 @@ def _build_publish_args(
         skip_aggregation: When True, skip post-extract aggregation.
         force_extraction: When True, bypass all extraction gates
             (stride_size, cheap pre-filter, LLM should_run).
+        evaluation_only: When True, store for session-level evaluation
+            only and skip profile/playbook extraction.
 
     Returns:
         list[str]: argv list ready to hand to ``interactions_app(...)``.
@@ -89,6 +92,8 @@ def _build_publish_args(
         args.append("--skip-aggregation")
     if force_extraction:
         args.append("--force-extraction")
+    if evaluation_only:
+        args.append("--evaluation-only")
     return args
 
 
@@ -147,6 +152,13 @@ def register_shortcuts(app: typer.Typer) -> None:
                 help="Bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors",
             ),
         ] = False,
+        evaluation_only: Annotated[
+            bool,
+            typer.Option(
+                "--evaluation-only",
+                help="Store for session-level evaluation only and skip profile/playbook extraction",
+            ),
+        ] = False,
     ) -> None:
         """Publish interactions (shortcut for: interactions publish)."""
         from reflexio.cli.commands.interactions import app as interactions_app
@@ -164,6 +176,7 @@ def register_shortcuts(app: typer.Typer) -> None:
             stdin=stdin,
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
+            evaluation_only=evaluation_only,
         )
 
         # Propagate context

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -391,6 +391,7 @@ class ReflexioClient:
         wait_for_response: bool = False,
         skip_aggregation: bool = False,
         force_extraction: bool = False,
+        evaluation_only: bool = False,
         override_learning_stall: bool = False,
         metadata: dict[str, Any] | None = None,
     ) -> PublishUserInteractionResponse:
@@ -430,6 +431,9 @@ class ReflexioClient:
             force_extraction: If True, bypass all extraction gates
                 (stride_size, cheap pre-filter, LLM should_run) and
                 always run extractors.
+            evaluation_only: If True, store the interaction for
+                session-level evaluation only and permanently exclude it
+                from profile/playbook extraction.
             override_learning_stall: If True, run extraction even when
                 Reflexio has recorded a provider auth/billing stall. Keep
                 this False for automatic hook publishes; use it only for an
@@ -467,6 +471,7 @@ class ReflexioClient:
             agent_version=agent_version,
             skip_aggregation=skip_aggregation,
             force_extraction=force_extraction,
+            evaluation_only=evaluation_only,
             override_learning_stall=override_learning_stall,
             metadata=metadata or {},
         )

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -193,6 +193,9 @@ class Request(BaseModel):
         source (str): Free-form origin tag (integration name, etc.).
         agent_version (str): The agent version that handled this request.
         session_id (str): Non-empty session this request belongs to.
+        evaluation_only (bool): Whether this request is stored for
+            session-level evaluation only and must be excluded from
+            profile/playbook learning windows.
         metadata (dict[str, Any]): Free-form per-request annotations.
             Always a dict — never None. Conventional keys:
 
@@ -215,6 +218,7 @@ class Request(BaseModel):
     source: str = ""
     agent_version: str = ""
     session_id: NonEmptyStr
+    evaluation_only: bool = False
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -567,6 +571,7 @@ class PublishUserInteractionRequest(BaseModel):
         False  # when True, extract profiles/playbooks but skip aggregation
     )
     force_extraction: bool = False  # when True, bypass all extraction gates (stride_size, cheap pre-filter, LLM should_run) and always run extractors
+    evaluation_only: bool = False  # when True, store for evaluation and permanently exclude from profile/playbook extraction
     override_learning_stall: bool = False  # when True, run extraction even if a provider auth/billing stall is recorded
     metadata: dict[str, Any] = Field(default_factory=dict)
     """Per-request annotations stamped by customer integration code.
@@ -582,6 +587,14 @@ class PublishUserInteractionRequest(BaseModel):
     Defaults to ``{}`` (never None) for backward compatibility — existing
     callers that don't pass ``metadata`` keep working unchanged.
     """
+
+    @model_validator(mode="after")
+    def validate_evaluation_only(self) -> Self:
+        if self.evaluation_only and self.force_extraction:
+            raise ValueError("evaluation_only cannot be combined with force_extraction")
+        if self.evaluation_only and not self.session_id:
+            raise ValueError("evaluation_only publishes require session_id")
+        return self
 
 
 # publish user interaction response

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -403,11 +403,9 @@ DEFAULT_AGENT_SUCCESS_DEFINITION_PROMPT = (
     "Mark the session successful when, by the end of the conversation, the agent:\n"
     "1. Identified and addressed the user's main goal or question.\n"
     "2. Provided a correct, useful, and actionable response or completed the requested action.\n"
-    "3. Handled necessary clarification, tool use, or limitations transparently.\n"
-    "4. Left the user with a resolved issue, clear next step, or appropriate escalation.\n\n"
     "Mark the session unsuccessful when the agent failed to understand the request,\n"
     "gave incorrect or unhelpful guidance, did not complete an available action,\n"
-    "ignored important constraints, or left the user without a useful path forward."
+    "ignored important constraints, or left the user unsatisfied."
 )
 
 

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -397,6 +397,18 @@ class DeduplicationConfig(BaseModel):
 SINGLETON_PROFILE_EXTRACTOR_NAME = "profile"
 SINGLETON_USER_PLAYBOOK_NAME = "playbook"
 SINGLETON_AGENT_SUCCESS_EVALUATION_NAME = "agent_success"
+DEFAULT_AGENT_SUCCESS_SAMPLING_RATE = 0.05
+DEFAULT_AGENT_SUCCESS_DEFINITION_PROMPT = (
+    "Evaluate whether the AI agent successfully handled the user's session.\n\n"
+    "Mark the session successful when, by the end of the conversation, the agent:\n"
+    "1. Identified and addressed the user's main goal or question.\n"
+    "2. Provided a correct, useful, and actionable response or completed the requested action.\n"
+    "3. Handled necessary clarification, tool use, or limitations transparently.\n"
+    "4. Left the user with a resolved issue, clear next step, or appropriate escalation.\n\n"
+    "Mark the session unsuccessful when the agent failed to understand the request,\n"
+    "gave incorrect or unhelpful guidance, did not complete an available action,\n"
+    "ignored important constraints, or left the user without a useful path forward."
+)
 
 
 class ProfileExtractorConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
@@ -488,9 +500,15 @@ class AgentSuccessConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     evaluation_name: NonEmptyStr | None = None
     success_definition_prompt: SanitizedNonEmptyStr
     metadata_definition_prompt: str | None = None
+    request_sources_enabled: list[str] | None = (
+        None  # default enabled for all sources, if set, only evaluate requests from the enabled request sources
+    )
     sampling_rate: float = Field(
-        default=1.0, ge=0.0, le=1.0
-    )  # fraction of window of interactions to be sampled for success evaluation
+        default=DEFAULT_AGENT_SUCCESS_SAMPLING_RATE,
+        ge=0.0,
+        le=1.0,
+        description="Fraction of sessions to evaluate automatically.",
+    )
     window_size_override: int | None = Field(default=None, gt=0)
     stride_size_override: int | None = Field(default=None, gt=0)
 
@@ -498,6 +516,14 @@ class AgentSuccessConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     @classmethod
     def _migrate_field_names(cls, data: Any) -> Any:
         return _migrate_dict(data, _EXTRACTOR_OVERRIDE_MIGRATION)
+
+
+def _default_agent_success_config() -> AgentSuccessConfig:
+    return AgentSuccessConfig(
+        evaluation_name=SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
+        success_definition_prompt=DEFAULT_AGENT_SUCCESS_DEFINITION_PROMPT,
+        sampling_rate=DEFAULT_AGENT_SUCCESS_SAMPLING_RATE,
+    )
 
 
 class ReflectionConfig(BaseModel):
@@ -749,7 +775,9 @@ class Config(BaseModel):
         default_factory=_default_user_playbook_extractor_config
     )
     # agent level success
-    agent_success_config: AgentSuccessConfig | None = None
+    agent_success_config: AgentSuccessConfig | None = Field(
+        default_factory=_default_agent_success_config
+    )
     # extraction preset — selects bundled window_size/stride_size values
     extraction_preset: ExtractionPreset | None = None
     # extraction parameters

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import random
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -104,7 +103,7 @@ class AgentSuccessEvaluator:
 
         Treats all request_interaction_data_models as a single conversation.
         Applies source filtering based on extractor config.
-        Applies sampling rate once per group.
+        Sampling is handled by callers before invoking the evaluator.
 
         Returns:
             List of AgentSuccessEvaluationResult objects (single result for the group)
@@ -129,19 +128,6 @@ class AgentSuccessEvaluator:
         if not request_interaction_data_models:
             # No matching interactions after source filter
             return []
-
-        # Check sampling rate once per group
-        if self.config.sampling_rate < 1.0:
-            random_value = random.random()  # noqa: S311
-            if random_value >= self.config.sampling_rate:
-                logger.info(
-                    "Skipping evaluation for session %s due to sampling rate. "
-                    "sampling_rate=%s, random_value=%.3f",
-                    self.service_config.session_id,
-                    self.config.sampling_rate,
-                    random_value,
-                )
-                return []
 
         result = self._evaluate_group(request_interaction_data_models)
         return [result] if result else []

--- a/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 # Delay in seconds before evaluating a group after the last request
 GROUP_EVALUATION_DELAY_SECONDS = 600  # 10 minutes
 
+# Kept as a patch point for tests. Production should use the full inactivity
+# delay unless a test deliberately lowers this constant.
 IS_TEST_ENV = os.environ.get("IS_TEST_ENV", "false").strip() == "true"
 _EFFECTIVE_DELAY_SECONDS = 30 if IS_TEST_ENV else GROUP_EVALUATION_DELAY_SECONDS
 

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextvars
+import hashlib
 import logging
 import os
 import threading
@@ -77,6 +78,13 @@ def _retention_cleanup_interval_seconds() -> float:
 _RETENTION_CLEANUP_INTERVAL_SECONDS = _retention_cleanup_interval_seconds()
 _retention_cleanup_last_run: dict[tuple[str, str], float] = {}
 _retention_cleanup_lock = threading.Lock()
+
+
+def _stable_group_sampling_fraction(org_id: str, user_id: str, session_id: str) -> float:
+    """Return a deterministic [0, 1) sample value for one session."""
+    key = f"{org_id}\0{user_id}\0{session_id}".encode()
+    digest = hashlib.sha256(key).digest()
+    return int.from_bytes(digest[:8], "big") / 2**64
 
 
 @dataclass
@@ -222,6 +230,7 @@ class GenerationService:
                 source=publish_user_interaction_request.source,
                 agent_version=agent_version,
                 session_id=publish_user_interaction_request.session_id,
+                evaluation_only=publish_user_interaction_request.evaluation_only,
                 metadata=publish_user_interaction_request.metadata,
             )
             self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
@@ -233,6 +242,33 @@ class GenerationService:
 
             # Extract source (empty string treated as None)
             source = publish_user_interaction_request.source or None
+
+            if publish_user_interaction_request.evaluation_only:
+                self._schedule_group_evaluation_if_needed(
+                    new_request=new_request,
+                    user_id=user_id,
+                    agent_version=agent_version,
+                    source=source,
+                )
+                record_usage_event(
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    session_id=new_request.session_id,
+                    source=source,
+                    agent_version=agent_version,
+                    backend="evaluation_only",
+                    event_name="publish_request_succeeded",
+                    event_category="publish",
+                    outcome="success",
+                    count_value=len(new_interactions),
+                    duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                    metadata={
+                        "evaluation_only": True,
+                        "warning_count": len(result.warnings),
+                    },
+                )
+                return result
 
             if (
                 not publish_user_interaction_request.override_learning_stall
@@ -423,6 +459,14 @@ class GenerationService:
             source (str | None): Optional source label.
         """
         session_id = new_request.session_id
+        if not self._should_sample_group_evaluation(user_id=user_id, session_id=session_id):
+            logger.info(
+                "Skipping group evaluation scheduling for unsampled session=%s user=%s",
+                session_id,
+                user_id,
+            )
+            return
+
         scheduler = GroupEvaluationScheduler.get_instance()
         key = (self.org_id, user_id, session_id)
 
@@ -459,6 +503,23 @@ class GenerationService:
                 self.request_context,
                 self.client,
             ),
+        )
+
+    def _should_sample_group_evaluation(self, *, user_id: str, session_id: str) -> bool:
+        config = self.configurator.get_config()
+        agent_success_config = getattr(config, "agent_success_config", None)
+        if agent_success_config is None:
+            return False
+
+        sampling_rate = agent_success_config.sampling_rate
+        if sampling_rate >= 1.0:
+            return True
+        if sampling_rate <= 0.0:
+            return False
+
+        return (
+            _stable_group_sampling_fraction(self.org_id, user_id, session_id)
+            < sampling_rate
         )
 
     def _maybe_run_reflection(

--- a/reflexio/server/services/storage/sqlite_storage/_agent_run.py
+++ b/reflexio/server/services/storage/sqlite_storage/_agent_run.py
@@ -26,7 +26,10 @@ from ._base import SQLiteStorageBase, _json_dumps, _json_loads
 def _dt(value: str | None) -> datetime | None:
     if value is None:
         return None
-    return datetime.fromisoformat(value)
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 def _dt_str(value: datetime | None) -> str | None:

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -14,7 +14,7 @@ import math
 import re
 import sqlite3
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar, Literal
@@ -185,10 +185,10 @@ def _effective_search_mode(
 
 
 def _vector_rank_rows(
-    rows: list[sqlite3.Row],
+    rows: Sequence[Any],
     query_embedding: list[float],
     match_count: int,
-) -> list[sqlite3.Row]:
+) -> list[Any]:
     """Rank rows by cosine similarity to the query embedding.
 
     Args:
@@ -199,7 +199,7 @@ def _vector_rank_rows(
     Returns:
         Top ``match_count`` rows sorted by cosine similarity descending.
     """
-    scored: list[tuple[sqlite3.Row, float]] = []
+    scored: list[tuple[Any, float]] = []
     for row in rows:
         raw_emb = row["embedding"] if "embedding" in row.keys() else None  # noqa: SIM118
         emb = _json_loads(raw_emb) if raw_emb else None
@@ -228,14 +228,14 @@ def _vector_rank_rows(
 
 
 def _true_rrf_merge(
-    fts_rows: list[sqlite3.Row],
-    vec_rows: list[sqlite3.Row],
+    fts_rows: Sequence[Any],
+    vec_rows: Sequence[Any],
     id_column: str,
     match_count: int,
     rrf_k: int = 60,
     vector_weight: float = 1.0,
     fts_weight: float = 1.0,
-) -> list[sqlite3.Row]:
+) -> list[Any]:
     """Merge independent FTS and vector result sets via Reciprocal Rank Fusion.
 
     Unlike ``_rrf_rerank`` (which re-ranks FTS results only), this function
@@ -258,7 +258,7 @@ def _true_rrf_merge(
         return []
 
     # Collect unique rows by ID (first-seen wins for the Row object)
-    row_by_id: dict[str | int, sqlite3.Row] = {}
+    row_by_id: dict[str | int, Any] = {}
     for row in (*fts_rows, *vec_rows):
         rid = row[id_column]
         if rid not in row_by_id:
@@ -274,7 +274,7 @@ def _true_rrf_merge(
     fts_penalty = len(fts_rows) + 1
     vec_penalty = len(vec_rows) + 1
 
-    scored: list[tuple[sqlite3.Row, float]] = []
+    scored: list[tuple[Any, float]] = []
     for rid, row in row_by_id.items():
         f_rank = fts_rank.get(rid, fts_penalty)
         v_rank = vec_rank.get(rid, vec_penalty)
@@ -343,7 +343,10 @@ def _iso_to_epoch(iso_str: str | None) -> int:
         return _epoch_now()
     try:
         cleaned = iso_str.replace("Z", "+00:00")
-        return int(datetime.fromisoformat(cleaned).timestamp())
+        parsed = datetime.fromisoformat(cleaned)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return int(parsed.timestamp())
     except (ValueError, TypeError):
         return _epoch_now()
 
@@ -429,6 +432,7 @@ def _row_to_request(row: sqlite3.Row) -> Request:
         source=d.get("source") or "",
         agent_version=d.get("agent_version") or "",
         session_id=require_non_empty_session_id(d.get("session_id")),
+        evaluation_only=bool(d.get("evaluation_only", 0)),
         metadata=metadata,
     )
 
@@ -669,6 +673,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_agentic_signals()
         self._migrate_agent_playbook_source_windows()
         self._migrate_request_metadata()
+        self._migrate_request_evaluation_only()
         self._migrate_request_session_id_required()
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
@@ -1227,6 +1232,21 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             logger.info("Added metadata column to requests")
         self.conn.commit()
 
+    def _migrate_request_evaluation_only(self) -> None:
+        """Add evaluation_only column to requests for learning exclusion."""
+        cols = {
+            row["name"]
+            for row in self.conn.execute("PRAGMA table_info(requests)").fetchall()
+        }
+        if not cols:
+            return
+        if "evaluation_only" not in cols:
+            self.conn.execute(
+                "ALTER TABLE requests ADD COLUMN evaluation_only INTEGER NOT NULL DEFAULT 0"
+            )
+            logger.info("Added evaluation_only column to requests")
+        self.conn.commit()
+
     def _migrate_request_session_id_required(self) -> None:
         """Require non-empty session ids on ``requests``.
 
@@ -1256,8 +1276,9 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         if has_required_schema and blank_count == 0:
             return
 
-        metadata_expr = (
-            "COALESCE(metadata, '{}')" if "metadata" in cols else "'{}'"
+        metadata_expr = "COALESCE(metadata, '{}')" if "metadata" in cols else "'{}'"
+        evaluation_only_expr = (
+            "COALESCE(evaluation_only, 0)" if "evaluation_only" in cols else "0"
         )
         # NOTE: this rebuild hardcodes the full `requests` column set. If a
         # future migration adds a column to `requests`, it MUST be added here
@@ -1271,10 +1292,20 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 source TEXT NOT NULL DEFAULT '',
                 agent_version TEXT NOT NULL DEFAULT '',
                 session_id TEXT NOT NULL CHECK (trim(session_id) != ''),
+                evaluation_only INTEGER NOT NULL DEFAULT 0,
                 metadata TEXT NOT NULL DEFAULT '{{}}'
             );
             INSERT INTO requests_new
-                (request_id, user_id, created_at, source, agent_version, session_id, metadata)
+                (
+                    request_id,
+                    user_id,
+                    created_at,
+                    source,
+                    agent_version,
+                    session_id,
+                    evaluation_only,
+                    metadata
+                )
             SELECT
                 request_id,
                 user_id,
@@ -1286,6 +1317,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     THEN 'legacy-' || lower(hex(randomblob(16)))
                     ELSE trim(session_id)
                 END,
+                {evaluation_only_expr},
                 {metadata_expr}
             FROM requests;
             DROP TABLE requests;
@@ -1693,6 +1725,7 @@ CREATE TABLE IF NOT EXISTS requests (
     source TEXT NOT NULL DEFAULT '',
     agent_version TEXT NOT NULL DEFAULT '',
     session_id TEXT NOT NULL CHECK (trim(session_id) != ''),
+    evaluation_only INTEGER NOT NULL DEFAULT 0,
     metadata TEXT NOT NULL DEFAULT '{}'
 );
 CREATE INDEX IF NOT EXISTS idx_requests_user_id ON requests(user_id);

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -87,10 +87,11 @@ class OperationMixin:
         sql = """
             SELECT i.*, r.request_id as r_request_id, r.user_id as r_user_id,
                    r.created_at as r_created_at, r.source as r_source,
-                   r.agent_version as r_agent_version, r.session_id as r_session_id
+                   r.agent_version as r_agent_version, r.session_id as r_session_id,
+                   r.evaluation_only as r_evaluation_only
             FROM interactions i
             JOIN requests r ON i.request_id = r.request_id
-            WHERE 1=1
+            WHERE r.evaluation_only = 0
         """
         params: list[Any] = []
 
@@ -130,6 +131,7 @@ class OperationMixin:
                     source=d.get("r_source") or "",
                     agent_version=d.get("r_agent_version") or "",
                     session_id=require_non_empty_session_id(d.get("r_session_id")),
+                    evaluation_only=bool(d.get("r_evaluation_only", 0)),
                 )
                 interactions_by_request[req_id] = []
             interactions_by_request[req_id].append(_row_to_interaction(row))
@@ -168,10 +170,11 @@ class OperationMixin:
         sql = """
             SELECT i.*, r.request_id as r_request_id, r.user_id as r_user_id,
                    r.created_at as r_created_at, r.source as r_source,
-                   r.agent_version as r_agent_version, r.session_id as r_session_id
+                   r.agent_version as r_agent_version, r.session_id as r_session_id,
+                   r.evaluation_only as r_evaluation_only
             FROM interactions i
             JOIN requests r ON i.request_id = r.request_id
-            WHERE 1=1
+            WHERE r.evaluation_only = 0
         """
         params: list[Any] = []
 
@@ -212,6 +215,7 @@ class OperationMixin:
                     source=d.get("r_source") or "",
                     agent_version=d.get("r_agent_version") or "",
                     session_id=require_non_empty_session_id(d.get("r_session_id")),
+                    evaluation_only=bool(d.get("r_evaluation_only", 0)),
                 )
                 interactions_by_request[req_id] = []
 

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -39,8 +39,8 @@ class RequestMixin:
         created_at_iso = _epoch_to_iso(request.created_at)
         self._execute(
             """INSERT OR REPLACE INTO requests
-               (request_id, user_id, created_at, source, agent_version, session_id, metadata)
-               VALUES (?,?,?,?,?,?,?)""",
+               (request_id, user_id, created_at, source, agent_version, session_id, evaluation_only, metadata)
+               VALUES (?,?,?,?,?,?,?,?)""",
             (
                 request.request_id,
                 request.user_id,
@@ -48,6 +48,7 @@ class RequestMixin:
                 request.source,
                 request.agent_version,
                 request.session_id,
+                1 if request.evaluation_only else 0,
                 json.dumps(request.metadata, sort_keys=True),
             ),
         )

--- a/reflexio/server/services/storage/sqlite_storage/_stall_state.py
+++ b/reflexio/server/services/storage/sqlite_storage/_stall_state.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from reflexio.models.api_schema.stall_state_schema import StallReason
@@ -163,10 +163,13 @@ def _parse_ts(raw: str | None) -> datetime | None:
     if raw is None:
         return None
     try:
-        return datetime.fromisoformat(raw)
+        parsed = datetime.fromisoformat(raw)
     except ValueError:
         _LOGGER.warning("Malformed timestamp in stall_state: %r", raw)
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
 
 
 class SQLiteStallStateMixin:

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -618,3 +618,52 @@ class TestPublishUserIdResolution:
         assert result.exit_code != 0
         assert "session_id" in result.output
         mock_client.publish_interaction.assert_not_called()
+
+    def test_single_turn_evaluation_only_flag_forwarded(
+        self, runner, app, mock_client
+    ) -> None:
+        mock_client.publish_interaction.return_value = MagicMock(
+            counts={"interactions": 2}, user_id="flag-user"
+        )
+
+        result = runner.invoke(
+            app,
+            [
+                "interactions",
+                "publish",
+                "--user-id",
+                "flag-user",
+                "--session-id",
+                "session-1",
+                "--evaluation-only",
+                "--user-message",
+                "hi",
+                "--agent-response",
+                "hello",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["evaluation_only"] is True
+        )
+
+    def test_payload_evaluation_only_beats_flag_default(
+        self, runner, app, mock_client, tmp_path
+    ) -> None:
+        mock_client.publish_interaction.return_value = MagicMock(
+            counts={"interactions": 2}, user_id="payload-user"
+        )
+        payload_file = self._write_payload(
+            tmp_path,
+            include_user_id=True,
+            session_id="session-1",
+            evaluation_only=True,
+        )
+
+        result = runner.invoke(app, ["interactions", "publish", "--file", payload_file])
+
+        assert result.exit_code == 0, result.output
+        assert (
+            mock_client.publish_interaction.call_args.kwargs["evaluation_only"] is True
+        )

--- a/tests/models/test_config_f3_fields.py
+++ b/tests/models/test_config_f3_fields.py
@@ -4,7 +4,12 @@ documented defaults."""
 import pytest
 from pydantic import ValidationError
 
-from reflexio.models.config_schema import Config, StorageConfigSQLite
+from reflexio.models.config_schema import (
+    DEFAULT_AGENT_SUCCESS_DEFINITION_PROMPT,
+    DEFAULT_AGENT_SUCCESS_SAMPLING_RATE,
+    Config,
+    StorageConfigSQLite,
+)
 
 
 def _minimal_config(**overrides) -> Config:
@@ -19,6 +24,24 @@ def test_eval_sample_n_per_stratum_defaults_to_200():
 def test_eval_concurrency_limit_defaults_to_10():
     c = _minimal_config()
     assert c.eval_concurrency_limit == 10
+
+
+def test_agent_success_evaluation_defaults_on_at_five_percent():
+    c = _minimal_config()
+
+    assert c.agent_success_config is not None
+    assert c.agent_success_config.sampling_rate == DEFAULT_AGENT_SUCCESS_SAMPLING_RATE
+    assert c.agent_success_config.sampling_rate == 0.05
+    assert (
+        c.agent_success_config.success_definition_prompt
+        == DEFAULT_AGENT_SUCCESS_DEFINITION_PROMPT
+    )
+
+
+def test_agent_success_evaluation_can_be_disabled_explicitly():
+    c = _minimal_config(agent_success_config=None)
+
+    assert c.agent_success_config is None
 
 
 def test_eval_sample_n_per_stratum_must_be_positive():

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
@@ -3,7 +3,6 @@ Unit tests for AgentSuccessEvaluator.
 
 Tests the evaluator's responsibilities for:
 - Source filtering on provided interactions
-- Sampling rate filtering
 - Running evaluations on provided interactions
 """
 
@@ -183,14 +182,13 @@ class TestRun:
         assert result is not None
         assert isinstance(result, list)
 
-    def test_run_respects_sampling_rate(
+    def test_run_does_not_apply_sampling_rate(
         self,
         request_context,
         mock_llm_client,
         sample_request_interaction_models,
     ):
-        """Test that run() respects sampling rate."""
-        # Config with 0% sampling rate - should skip all
+        """Sampling is handled before evaluator invocation, not inside run()."""
         config = AgentSuccessConfig(
             evaluation_name="task_completion",
             success_definition_prompt="Evaluate if task was completed",
@@ -214,18 +212,17 @@ class TestRun:
 
         result = evaluator.run()
 
-        # With 0% sampling rate, should skip all and return empty
-        assert result == []
+        assert len(result) == 1
+        mock_llm_client.generate_chat_response.assert_called_once()
 
-    def test_run_with_100_percent_sampling_rate(
+    def test_run_evaluates_default_config(
         self,
         request_context,
         mock_llm_client,
         extractor_config,
         service_config,
     ):
-        """Test that run() processes all with 100% sampling rate."""
-        # Default sampling_rate is 1.0 (100%)
+        """Test that run() processes the provided interaction group."""
         evaluator = AgentSuccessEvaluator(
             request_context=request_context,
             llm_client=mock_llm_client,
@@ -289,7 +286,7 @@ class TestSourceFiltering:
         config = AgentSuccessConfig(
             evaluation_name="task_completion",
             success_definition_prompt="Evaluate if task was completed",
-            source_filter="api",
+            request_sources_enabled=["api"],
         )
 
         service_config = AgentSuccessGenerationServiceConfig(

--- a/tests/server/services/agent_success_evaluation/test_delayed_group_evaluator.py
+++ b/tests/server/services/agent_success_evaluation/test_delayed_group_evaluator.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from reflexio.server.services.agent_success_evaluation import delayed_group_evaluator
 from reflexio.server.services.agent_success_evaluation.delayed_group_evaluator import (
     GroupEvaluationScheduler,
     GroupKey,
@@ -94,6 +95,22 @@ class TestSchedule:
         # Fire time should be roughly now + delay
         assert fire_time >= before
         assert fire_time <= after + 700  # generous upper bound
+
+    def test_schedule_uses_configured_delay(self, monkeypatch: pytest.MonkeyPatch):
+        """schedule() waits for the configured inactivity delay before firing."""
+        monkeypatch.setattr(delayed_group_evaluator, "_EFFECTIVE_DELAY_SECONDS", 5)
+        scheduler = GroupEvaluationScheduler.get_instance()
+        callback = MagicMock()
+        key: GroupKey = ("org_1", "user_1", "session_1")
+
+        before = time.monotonic()
+        scheduler.schedule(key, callback)
+        after = time.monotonic()
+
+        fire_time, stored_callback = scheduler._scheduled[key]
+        assert stored_callback is callback
+        assert fire_time >= before + 5
+        assert fire_time <= after + 5.1
 
     def test_reschedule_updates_fire_time(self):
         """Rescheduling the same key updates the fire time forward."""

--- a/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py
@@ -1,0 +1,156 @@
+"""Integration coverage for evaluation-only publish scheduling."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterator
+
+import pytest
+
+from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.models.api_schema.service_schemas import InteractionData
+from reflexio.models.config_schema import (
+    AgentSuccessConfig,
+    Config,
+    StorageConfigSQLite,
+)
+from reflexio.server.services.agent_success_evaluation import (
+    delayed_group_evaluator,
+    group_evaluation_runner,
+)
+from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_service import (
+    AgentSuccessEvaluationService,
+)
+from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_utils import (
+    AgentSuccessEvaluationRequest,
+)
+from reflexio.server.services.agent_success_evaluation.delayed_group_evaluator import (
+    GroupEvaluationScheduler,
+)
+from reflexio.server.services.configurator.configurator import DefaultConfigurator
+from reflexio.test_support.llm_mock import patched_litellm
+
+
+def _wait_until(assertion: Callable[[], None], timeout_s: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    last_error: AssertionError | None = None
+    while time.monotonic() < deadline:
+        try:
+            assertion()
+            return
+        except AssertionError as exc:
+            last_error = exc
+            time.sleep(0.05)
+    if last_error is not None:
+        raise last_error
+    assertion()
+
+
+def _interaction_pair(label: str) -> list[InteractionData]:
+    return [
+        InteractionData(content=f"Please help with {label}", role="User"),
+        InteractionData(content=f"Resolved {label} with steps A and B.", role="Assistant"),
+    ]
+
+
+@pytest.fixture(autouse=True)
+def _reset_group_scheduler() -> Iterator[None]:
+    GroupEvaluationScheduler._instance = None
+    yield
+    GroupEvaluationScheduler._instance = None
+
+
+def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Evaluation-only publishes wait for inactivity and evaluate the session."""
+    monkeypatch.setattr(delayed_group_evaluator, "_EFFECTIVE_DELAY_SECONDS", 1)
+    monkeypatch.setattr(group_evaluation_runner, "_EFFECTIVE_DELAY_SECONDS", 1)
+
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        agent_context_prompt="this is a coding assistant",
+        agent_success_config=AgentSuccessConfig(
+            evaluation_name="overall_success",
+            success_definition_prompt="agent completes the requested task",
+            sampling_rate=1.0,
+        ),
+    )
+    instance = Reflexio(
+        org_id="org_eval_only_delay",
+        configurator=DefaultConfigurator("org_eval_only_delay", config=config),
+    )
+    storage = instance.request_context.storage
+    assert storage is not None
+
+    user_id = "user_eval_only_delay"
+    session_id = "session_eval_only_delay"
+    agent_version = "agent_eval_only_delay"
+    observed_request_model_counts: list[int] = []
+    original_run = AgentSuccessEvaluationService.run
+
+    def recording_run(
+        self: AgentSuccessEvaluationService,
+        request: AgentSuccessEvaluationRequest,
+    ) -> None:
+        observed_request_model_counts.append(len(request.request_interaction_data_models))
+        return original_run(self, request)
+
+    monkeypatch.setattr(AgentSuccessEvaluationService, "run", recording_run)
+
+    with patched_litellm():
+        first = instance.publish_interaction(
+            {
+                "user_id": user_id,
+                "interaction_data_list": _interaction_pair("first issue"),
+                "source": "integration",
+                "agent_version": agent_version,
+                "session_id": session_id,
+                "evaluation_only": True,
+            }
+        )
+        assert first.success is True
+        assert (
+            storage.get_agent_success_evaluation_results(
+                agent_version=agent_version, limit=10
+            )
+            == []
+        )
+
+        time.sleep(0.55)
+        second = instance.publish_interaction(
+            {
+                "user_id": user_id,
+                "interaction_data_list": _interaction_pair("follow-up issue"),
+                "source": "integration",
+                "agent_version": agent_version,
+                "session_id": session_id,
+                "evaluation_only": True,
+            }
+        )
+        assert second.success is True
+
+        # This passes the first publish's original fire time but is still before
+        # the second publish's rescheduled fire time.
+        time.sleep(0.65)
+        assert (
+            storage.get_agent_success_evaluation_results(
+                agent_version=agent_version, limit=10
+            )
+            == []
+        )
+
+        def assert_evaluated_once() -> None:
+            results = storage.get_agent_success_evaluation_results(
+                agent_version=agent_version, limit=10
+            )
+            assert len(results) == 1
+            assert results[0].session_id == session_id
+
+        _wait_until(assert_evaluated_once)
+
+    stored_requests = storage.get_requests_by_session(user_id, session_id)
+    assert len(stored_requests) == 2
+    assert all(request.evaluation_only is True for request in stored_requests)
+    assert observed_request_model_counts == [2]

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner.py
@@ -21,6 +21,24 @@ def _make_request(request_id: str, user_id: str, session_id: str) -> Request:
     )
 
 
+def _make_recent_request(
+    request_id: str,
+    user_id: str,
+    session_id: str,
+    *,
+    evaluation_only: bool = False,
+) -> Request:
+    """Create a request too recent to pass completion delay checks."""
+    now = int(datetime.now(UTC).timestamp())
+    return Request(
+        request_id=request_id,
+        user_id=user_id,
+        session_id=session_id,
+        created_at=now,
+        evaluation_only=evaluation_only,
+    )
+
+
 def _make_interaction(request_id: str, user_id: str) -> Interaction:
     """Create an interaction object tied to a request."""
     now = int(datetime.now(UTC).timestamp())
@@ -152,6 +170,45 @@ def test_effective_delay_seconds_symbol_exists() -> None:
         "symbol name in sync if you rename it."
     )
     assert isinstance(group_evaluation_runner._EFFECTIVE_DELAY_SECONDS, int)
+
+
+def test_run_group_evaluation_waits_for_recent_evaluation_only_session() -> None:
+    """Evaluation-only publishes still wait for session inactivity."""
+    org_id = "org_a"
+    user_id = "user_a"
+    session_id = "group_a"
+
+    storage = MagicMock()
+    storage.get_operation_state.return_value = None
+    storage.get_requests_by_session.return_value = [
+        _make_recent_request(
+            "req_1",
+            user_id,
+            session_id,
+            evaluation_only=True,
+        )
+    ]
+
+    request_context = MagicMock()
+    request_context.storage = storage
+    llm_client = MagicMock()
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation.group_evaluation_runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        run_group_evaluation(
+            org_id=org_id,
+            user_id=user_id,
+            session_id=session_id,
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=llm_client,
+        )
+
+    service_cls.assert_not_called()
+    storage.get_interactions_by_request_ids.assert_not_called()
+    storage.upsert_operation_state.assert_not_called()
 
 
 def test_run_group_evaluation_skips_mark_when_nothing_saved() -> None:

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -95,6 +95,32 @@ def test_service_returns_empty_state_when_no_results() -> None:
     assert response.rule_attribution == []
 
 
+def test_service_reports_single_recent_success_as_100_percent() -> None:
+    now = int(time.time())
+    storage = MagicMock()
+    storage.get_agent_success_evaluation_results.return_value = [
+        _eval_result(
+            result_id=1,
+            session_id="recent-success",
+            is_success=True,
+            created_at=now - 60,
+        ),
+    ]
+    storage.get_playbook_application_stats.return_value = []
+    storage.get_interactions_by_session.return_value = []
+    storage.get_imported_scores.return_value = []
+    storage.get_sessions.return_value = {}
+    config = Config(storage_config=StorageConfigSQLite())
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=now - 3600, to_ts=now, bucket="day")
+    )
+
+    assert response.hero.regular_success_rate_pp == 100.0
+    assert response.context_tiles.success.current == 100.0
+
+
 def test_service_uses_first_ever_eval_for_hero_age() -> None:
     """A narrow window should not make a mature org look newly onboarded."""
     now = int(time.time())

--- a/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage._agent_run import _dt
 from reflexio.server.services.storage.storage_base import (
     AgentBinding,
     AgentRunRecord,
@@ -26,6 +27,12 @@ def storage():
         patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
     ):
         yield SQLiteStorage(org_id="org_1", db_path=f"{temp_dir}/reflexio.db")
+
+
+def test_sqlite_agent_run_parser_treats_offsetless_timestamp_as_utc():
+    parsed = _dt("2026-06-10T23:47:07.50016")
+
+    assert parsed == datetime(2026, 6, 10, 23, 47, 7, 500160, tzinfo=UTC)
 
 
 def _agent_run(

--- a/tests/server/services/storage/test_request_metadata_contract_integration.py
+++ b/tests/server/services/storage/test_request_metadata_contract_integration.py
@@ -8,7 +8,11 @@ from unittest.mock import patch
 
 import pytest
 
-from reflexio.models.api_schema.domain.entities import Request
+from reflexio.models.api_schema.domain.entities import (
+    Interaction,
+    Request,
+    UserActionType,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base import BaseStorage
 
@@ -90,3 +94,68 @@ def test_request_metadata_nested_values_roundtrip(storage: BaseStorage) -> None:
         "reflexio_retrieval_enabled": True,
         "nested": {"k": [1, 2, 3]},
     }
+
+
+def test_evaluation_only_requests_are_excluded_from_learning_windows(
+    storage: BaseStorage,
+) -> None:
+    normal = Request(
+        request_id="contract-eval-normal",
+        user_id="contract-eval-u1",
+        created_at=1000,
+        source="api",
+        agent_version="v1",
+        session_id="contract-eval-s1",
+    )
+    evaluation_only = Request(
+        request_id="contract-eval-only",
+        user_id="contract-eval-u1",
+        created_at=1001,
+        source="api",
+        agent_version="v1",
+        session_id="contract-eval-s1",
+        evaluation_only=True,
+    )
+    storage.add_request(normal)
+    storage.add_request(evaluation_only)
+    storage.add_user_interactions_bulk(
+        "contract-eval-u1",
+        [
+            Interaction(
+                user_id="contract-eval-u1",
+                request_id=normal.request_id,
+                created_at=1000,
+                content="Normal interaction can teach extraction",
+                user_action=UserActionType.NONE,
+            ),
+            Interaction(
+                user_id="contract-eval-u1",
+                request_id=evaluation_only.request_id,
+                created_at=1001,
+                content="Evaluation-only interaction must not teach extraction",
+                user_action=UserActionType.NONE,
+            ),
+        ],
+    )
+
+    got = storage.get_request(evaluation_only.request_id)
+    assert got is not None
+    assert got.evaluation_only is True
+    session_requests = storage.get_requests_by_session(
+        "contract-eval-u1", "contract-eval-s1"
+    )
+    assert {request.request_id for request in session_requests} == {
+        normal.request_id,
+        evaluation_only.request_id,
+    }
+
+    _, new_groups = storage.get_operation_state_with_new_request_interaction(
+        "contract-eval-state", "contract-eval-u1", sources=["api"]
+    )
+    grouped, flat = storage.get_last_k_interactions_grouped(
+        "contract-eval-u1", 10, sources=["api"]
+    )
+
+    assert {group.request.request_id for group in new_groups} == {normal.request_id}
+    assert {group.request.request_id for group in grouped} == {normal.request_id}
+    assert {interaction.request_id for interaction in flat} == {normal.request_id}

--- a/tests/server/services/storage/test_sqlite_storage.py
+++ b/tests/server/services/storage/test_sqlite_storage.py
@@ -29,6 +29,7 @@ from reflexio.server.services.storage.sqlite_storage import (
     _true_rrf_merge,
     _vector_rank_rows,
 )
+from reflexio.server.services.storage.sqlite_storage._base import _iso_to_epoch
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -54,6 +55,12 @@ def storage():
 # ---------------------------------------------------------------------------
 # _sanitize_fts_query tests
 # ---------------------------------------------------------------------------
+
+
+def test_iso_to_epoch_treats_offsetless_timestamp_as_utc():
+    result = _iso_to_epoch("2026-06-10T23:47:07.50016")
+    expected = int(datetime(2026, 6, 10, 23, 47, 7, 500160, tzinfo=UTC).timestamp())
+    assert result == expected
 
 
 class TestSanitizeFtsQuery:

--- a/tests/server/services/storage/test_stall_state.py
+++ b/tests/server/services/storage/test_stall_state.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
+from reflexio.server.services.storage.sqlite_storage._stall_state import _parse_ts
+
+
+def test_parse_ts_treats_offsetless_timestamp_as_utc():
+    parsed = _parse_ts("2026-06-10T23:47:07.50016")
+
+    assert parsed == datetime(2026, 6, 10, 23, 47, 7, 500160, tzinfo=UTC)
+
 
 def test_default_is_clean(storage):
     """A fresh DB returns stalled=False with all fields default-null."""

--- a/tests/server/services/test_generation_service_scheduling.py
+++ b/tests/server/services/test_generation_service_scheduling.py
@@ -6,10 +6,16 @@ silently bypassed the scheduler call, leaving /evaluations permanently empty.
 
 from __future__ import annotations
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
+from reflexio.models.config_schema import (
+    AgentSuccessConfig,
+    Config,
+    StorageConfigSQLite,
+)
 from reflexio.server.services.generation_service import GenerationService
 
 
@@ -25,6 +31,14 @@ def service() -> GenerationService:
     svc.org_id = "org_test"
     svc.request_context = MagicMock(name="request_context")
     svc.client = MagicMock(name="llm_client")
+    svc.configurator = MagicMock(name="configurator")
+    svc.configurator.get_config.return_value = Config(
+        storage_config=StorageConfigSQLite(),
+        agent_success_config=AgentSuccessConfig(
+            success_definition_prompt="Evaluate whether the agent succeeded.",
+            sampling_rate=1.0,
+        ),
+    )
     return svc
 
 
@@ -75,3 +89,31 @@ def test_schedules_with_correct_key_when_session_id_present(
     )
     assert key == ("org_test", "user_test", "sess_42")
     assert callable(callback)
+
+
+def test_evaluation_only_does_not_bypass_sampling_rate(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 0% sample rate skips scheduling even for evaluation-only requests."""
+    cast(Any, service.configurator.get_config).return_value = Config(
+        storage_config=StorageConfigSQLite(),
+        agent_success_config=AgentSuccessConfig(
+            success_definition_prompt="Evaluate whether the agent succeeded.",
+            sampling_rate=0.0,
+        ),
+    )
+    scheduler = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
+        lambda: scheduler,
+    )
+    request_with_session = MagicMock(session_id="sess_42", evaluation_only=True)
+
+    service._schedule_group_evaluation_if_needed(
+        new_request=request_with_session,
+        user_id="user_test",
+        agent_version="v_test",
+        source="ide",
+    )
+
+    scheduler.schedule.assert_not_called()


### PR DESCRIPTION
## Summary
- add `evaluation_only` publishing support for stored interactions
- exclude evaluation-only requests from profile/playbook learning windows while still allowing delayed session evaluation
- enable default agent success evaluation at 5% deterministic session sampling with a concise built-in AI-agent success rubric
- keep sampling in generation scheduling only, not inside the evaluator

## Tests
- `uv run pytest -n 0 open_source/reflexio/tests/cli/test_commands.py open_source/reflexio/tests/models/test_config_f3_fields.py open_source/reflexio/tests/models/test_validators.py open_source/reflexio/tests/server/services/test_generation_service_scheduling.py open_source/reflexio/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py open_source/reflexio/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py open_source/reflexio/tests/server/services/agent_success_evaluation/test_group_evaluation_runner.py open_source/reflexio/tests/server/services/agent_success_evaluation/test_delayed_group_evaluator.py open_source/reflexio/tests/server/services/storage/test_sqlite_storage.py open_source/reflexio/tests/server/services/storage/test_request_metadata_contract_integration.py open_source/reflexio/tests/server/services/storage/test_stall_state.py --no-cov`
- `uv run pytest -n 0 open_source/reflexio/tests/models/test_config_f3_fields.py open_source/reflexio/tests/models/test_validators.py open_source/reflexio/tests/server/services/test_generation_service_scheduling.py open_source/reflexio/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py --no-cov`
- `uv run ruff check ...`
- `uv run pyright ...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added --evaluation-only publish option to store interactions for session-level evaluation only and opt them out of profile/playbook extraction
  * Agent success evaluation now enabled by default with configurable sampling and definition prompt

* **Bug Fixes**
  * Treat offset-less timestamps as UTC when parsing
  * Tightened validation for interaction deletion identifiers

* **Documentation**
  * CLI docs updated to explain --evaluation-only

* **Tests**
  * New and updated tests covering evaluation-only behavior and sampling/config defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->