### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -34,6 +34,7 @@ Description: FastAPI backend server that processes user interactions to generate
 - **API**: `api.py` - FastAPI routes (only place to expose endpoints)
 - **Endpoint Helpers**: `api_endpoints/` - Bridge between routes and business logic
 - **Core Service**: `services/generation_service.py` - Main orchestrator
+- **Auth/Billing Hooks**: `_auth.py`, `billing_meter.py`, `billing_signals.py`, `usage_metrics.py` - OSS-safe dependency hooks and usage-event emission points for enterprise overrides
 
 ## Cache
 
@@ -90,12 +91,16 @@ Description: FastAPI backend server that processes user interactions to generate
 
 Key files:
 - `litellm_client.py`: Unified LiteLLMClient using LiteLLM for multi-provider support
+- `embedding_service.py`: OpenAI-compatible local embedding daemon (`/v1/embeddings`) with bounded concurrency and micro-batching
+- `providers/embedding_service_provider.py`: Client-side provider for the local/internal embedding service
+- `token_accounting.py`: Dependency-free per-run token totals for extraction billing signals
 - `openai_client.py`: OpenAI implementation (legacy, do not use directly)
 - `claude_client.py`: Claude implementation (legacy, do not use directly)
 - `llm_utils.py`: Helper functions for Pydantic model conversion
 
 **Features**:
 - Uses LiteLLM for multi-provider support (OpenAI, Claude, Azure, OpenRouter, Gemini, custom endpoints, etc.)
+- Local embedding service supports `local/minilm-l6-v2`, `local/nomic-embed-v1.5`, and `local/nomic-embed-text-v1.5`; tune encode concurrency with `REFLEXIO_EMBED_MAX_CONCURRENCY` and burst batching with `REFLEXIO_EMBED_MICRO_BATCH_*`
 - **Custom endpoint support**: `CustomEndpointConfig` (model, api_key, api_base) takes priority over all other providers for LLM completion calls when configured with non-empty fields (but not embeddings)
 - **Gemini support**: Model names with `gemini/` prefix route through Google Gemini; API key from `api_key_config.gemini`
 - **OpenRouter support**: Model names with `openrouter/` prefix (e.g., `openrouter/openai/gpt-5-nano`) route through OpenRouter; API key from `api_key_config.openrouter`

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -15,6 +15,8 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 | `extractor_config_utils.py`, `extractor_interaction_utils.py` | Filter extractors by source / `allow_manual_trigger` / names; per-extractor stride + window + bookmark handling. |
 | `deduplication_utils.py`, `service_utils.py`, `embedding_text.py` | LLM dedup helpers (used by `ProfileDeduplicator` + `PlaybookConsolidator`), message construction / JSON extraction / response logging, embedding text builders. |
 
+Usage metering stays OSS-safe: `generation_service.py` and search endpoints call root-level `server/billing_meter.py` helpers, `server/billing_signals.py` owns canonical input-token counts and platform-LLM detection, and extraction actors expose per-run totals via `server/llm/token_accounting.py`.
+
 ## Generation Services
 
 | Directory | Entry class | Key files |
@@ -55,4 +57,5 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 - **NEVER import storage implementations directly** — use `request_context.storage` (`BaseStorage`).
 - **ALWAYS use `LiteLLMClient`** for completions/embeddings and `request_context.prompt_manager.render_prompt(...)` for prompts — no hardcoded prompts, no direct OpenAI/Claude clients.
 - **All `_operation_state` writes go through `OperationStateManager`** — don't touch the table directly (it backs locks, bookmarks, progress, and cancellation).
+- **Billing usage events go through `server/billing_meter.py`/`server/billing_signals.py`** — do not import enterprise billing types into OSS services.
 - **`tool_can_use` lives at root `Config`** — shared by playbook extraction and success evaluation, not per-service.


### PR DESCRIPTION
## Summary
- Updates server code-map README navigation for new OSS-safe auth/billing hooks, usage metering helpers, local embedding daemon, embedding-service provider, and extraction token accounting.
- Updates the services code-map README with the usage-metering boundary and the rule to keep enterprise billing types out of OSS services.

## Repositories/submodules reviewed
- Parent: `yyiilluu/reflexio-enterprise` (`/root/reflexio-enterprise`)
- Submodule: `ReflexioAI/reflexio` (`open_source/reflexio`)

## README files updated
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- Read and followed `/root/reflexio-enterprise/how_to_write_readme.md`.
- Ran `git diff --check` in the submodule.
- Ran a local README Markdown path/link existence check for the updated files.

## Notes/Risks
- `open_source/reflexio/README.md` was intentionally not restructured because it is the public/user-facing README excluded by the parent README policy.
- Parent repository submodule pointer is not committed; this PR lives only in the submodule repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for OSS-safe Auth/Billing hook modules under Main Entry Points.
  * Documented embedding-service-related components and local embedding model support.
  * Added configuration guidance for embedding service options (concurrency and micro-batching).
  * Clarified billing usage metering processes and routing requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->