### PR TITLE
perf(search): unified single-RPC Phase B + batched flooring + embedding client pooling

### DIFF
--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -139,6 +139,13 @@ def _http_client() -> httpx.Client:
     pid = os.getpid()
     with _http_client_lock:
         if _http_client_instance is None or _http_client_pid != pid:
+            if _http_client_instance is not None and _http_client_pid != pid:
+                try:
+                    _http_client_instance.close()
+                except Exception:
+                    _LOGGER.debug(
+                        "Failed to close stale embedding HTTP client", exc_info=True
+                    )
             _http_client_instance = httpx.Client(
                 limits=httpx.Limits(keepalive_expiry=_HTTP_KEEPALIVE_EXPIRY_SECONDS)
             )

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import time
 from typing import Any, Literal
 
 import httpx
+
+from reflexio.server.tracing import profile_step
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,10 +44,22 @@ _DEFAULT_LOCAL_SERVICE_PROBE_TIMEOUT_MS = 200
 # daemon. Cap texts per request and concatenate; encode batching is a separate
 # server-side knob (REFLEXIO_EMBED_BATCH_SIZE).
 _DEFAULT_MAX_TEXTS_PER_REQUEST = 32
-_LOCAL_SERVICE_PROBE_CACHE_SECONDS = 5.0
+# A reachable daemon is stable, so positive probe results are cached long
+# enough that steady-state requests skip the sequential /health round trip.
+# Failures stay short-lived so a restarted daemon is re-adopted quickly and
+# the inprocess-fallback window stays small.
+_LOCAL_SERVICE_PROBE_CACHE_SECONDS = 60.0
+_LOCAL_SERVICE_PROBE_FAILURE_CACHE_SECONDS = 5.0
+# Keep-alive must expire below the ALB's default 60s idle timeout so the pool
+# never hands out a connection the load balancer already closed.
+_HTTP_KEEPALIVE_EXPIRY_SECONDS = 50.0
+_EMBEDDING_RETRY_BACKOFF_SECONDS = 0.1
 _SERVICE_MODES = {"local_service", "internal_service"}
 _VALID_MODES = {"cloud", *_SERVICE_MODES, "inprocess", "off"}
 _local_service_probe_cache: tuple[float, bool, str | None] | None = None
+_http_client_lock = threading.Lock()
+_http_client_instance: httpx.Client | None = None
+_http_client_pid: int | None = None
 
 
 class EmbeddingUnavailableError(RuntimeError):
@@ -113,17 +128,39 @@ def _is_local_model(model: str | None) -> bool:
     return bool(model and model.startswith("local/"))
 
 
+def _http_client() -> httpx.Client:
+    """Shared keep-alive client for health probes and embedding POSTs.
+
+    A per-request client pays DNS resolution plus a TCP handshake on every
+    embedding call. The client is recreated after fork (PID check) so worker
+    children never reuse sockets inherited from the parent process.
+    """
+    global _http_client_instance, _http_client_pid
+    pid = os.getpid()
+    with _http_client_lock:
+        if _http_client_instance is None or _http_client_pid != pid:
+            _http_client_instance = httpx.Client(
+                limits=httpx.Limits(keepalive_expiry=_HTTP_KEEPALIVE_EXPIRY_SECONDS)
+            )
+            _http_client_pid = pid
+        return _http_client_instance
+
+
 def _local_service_status() -> tuple[bool, str | None]:
     global _local_service_probe_cache
     now = time.monotonic()
-    if (
-        _local_service_probe_cache is not None
-        and now - _local_service_probe_cache[0] < _LOCAL_SERVICE_PROBE_CACHE_SECONDS
-    ):
-        return _local_service_probe_cache[1], _local_service_probe_cache[2]
+    if _local_service_probe_cache is not None:
+        cached_at, cached_reachable, cached_model = _local_service_probe_cache
+        ttl = (
+            _LOCAL_SERVICE_PROBE_CACHE_SECONDS
+            if cached_reachable
+            else _LOCAL_SERVICE_PROBE_FAILURE_CACHE_SECONDS
+        )
+        if now - cached_at < ttl:
+            return cached_reachable, cached_model
 
     try:
-        response = httpx.get(
+        response = _http_client().get(
             f"{_local_service_url()}/health",
             timeout=_local_service_probe_timeout_seconds(),
         )
@@ -286,17 +323,29 @@ def _post_embedding_batch(
     last_error: Exception | None = None
     for attempt in range(2):
         try:
-            with httpx.Client(timeout=timeout) as client:
-                response = client.post(url, json=payload)
+            response = _http_client().post(url, json=payload, timeout=timeout)
             response.raise_for_status()
             body = response.json()
             return _ordered_embeddings_from_response(body.get("data"), len(texts))
-        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
-            # Connection never established — the request never reached the
-            # server, so a single retry is safe and cannot duplicate work.
+        except (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.RemoteProtocolError,
+        ) as exc:
+            # Connection never established, or the server closed a pooled
+            # keep-alive connection before sending a response (stale-reuse
+            # race) — the request was not processed, so a single retry is
+            # safe and cannot duplicate work.
             last_error = exc
             if attempt == 0:
-                time.sleep(0.1)
+                with profile_step(
+                    "search.embedding.api.retry_backoff",
+                    retry_reason=type(exc).__name__,
+                    retry_backoff_ms=int(_EMBEDDING_RETRY_BACKOFF_SECONDS * 1000),
+                    attempt=attempt + 1,
+                    max_attempts=2,
+                ):
+                    time.sleep(_EMBEDDING_RETRY_BACKOFF_SECONDS)
         except (httpx.HTTPError, json.JSONDecodeError, ValueError) as exc:
             # The server already received the request: a read timeout means it
             # is still encoding, and retrying would queue a second identical

--- a/reflexio/server/services/retrieval/relevance_floor.py
+++ b/reflexio/server/services/retrieval/relevance_floor.py
@@ -9,7 +9,8 @@ never crashes, never silently returns the full unfiltered list.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from typing import Any
 
 from reflexio.server.llm.rerank import score_pairs
 from reflexio.server.llm.rerank.cross_encoder_reranker import (
@@ -18,6 +19,14 @@ from reflexio.server.llm.rerank.cross_encoder_reranker import (
 from reflexio.server.tracing import profile_step
 
 logger = logging.getLogger(__name__)
+
+
+def _floor_and_sort[T](items: list[T], scores: list[float], floor: float) -> list[T]:
+    """Return items scoring >= ``floor``, sorted by score descending."""
+    ranked = sorted(
+        zip(items, scores, strict=True), key=lambda pair: pair[1], reverse=True
+    )
+    return [item for item, score in ranked if score >= floor]
 
 
 def apply_relevance_floor[T](
@@ -62,11 +71,8 @@ def apply_relevance_floor[T](
             return items[:top_k]
         span.set_data("available", True)
 
-        ranked = sorted(
-            zip(items, scores, strict=True), key=lambda pair: pair[1], reverse=True
-        )
-        survivors = [item for item, score in ranked if score >= floor]
-        dropped = len(ranked) - len(survivors)
+        survivors = _floor_and_sort(items, scores, floor)
+        dropped = len(items) - len(survivors)
         span.set_data("kept", len(survivors))
         span.set_data("dropped", dropped)
         if dropped:
@@ -78,3 +84,74 @@ def apply_relevance_floor[T](
                 floor,
             )
         return survivors[:top_k]
+
+
+def apply_relevance_floors(
+    query: str,
+    arms: Sequence[tuple[str, list[Any], float]],
+    top_k: int,
+    *,
+    content_of: Callable[[Any], str] = lambda item: item.content,
+) -> list[list[Any]]:
+    """Floor every arm with a single cross-encoder batch.
+
+    CPU cross-encoder inference does not parallelize across threads, so
+    scoring all arms in one ``score_pairs`` call beats one call per arm:
+    the model runs one batched forward pass and per-call overhead is paid
+    once.
+
+    Args:
+        query: The search query.
+        arms: ``(arm_name, items, floor)`` per arm; items must expose
+            ``.content`` or supply ``content_of``.
+        top_k: Max items to return per arm after flooring.
+        content_of: Extracts the text to score for an item.
+
+    Returns:
+        One survivor list per arm, in input order — each sorted by score
+        descending and capped at ``top_k``. On reranker unavailability,
+        every arm returns ``items[:top_k]`` unchanged (logged).
+    """
+    if not any(items for _, items, _ in arms):
+        return [[] for _ in arms]
+    arm_names = [name for name, _, _ in arms]
+    contents: list[str] = []
+    for _, items, _ in arms:
+        contents.extend(content_of(item) for item in items)
+    with profile_step(
+        "search.rerank.relevance_floor",
+        arm="all",
+        arms=arm_names,
+        items=len(contents),
+    ) as span:
+        try:
+            scores = score_pairs(query, contents)
+        except CrossEncoderUnavailableError:
+            span.set_data("available", False)
+            logger.warning(
+                "event=relevance_floor_unavailable arms=%s items=%d (returning unfiltered top_k)",
+                arm_names,
+                len(contents),
+            )
+            return [items[:top_k] for _, items, _ in arms]
+        span.set_data("available", True)
+
+        results: list[list[Any]] = []
+        offset = 0
+        for name, items, floor in arms:
+            arm_scores = scores[offset : offset + len(items)]
+            offset += len(items)
+            survivors = _floor_and_sort(items, arm_scores, floor)
+            dropped = len(items) - len(survivors)
+            span.set_data(f"kept_{name}", len(survivors))
+            span.set_data(f"dropped_{name}", dropped)
+            if dropped:
+                logger.info(
+                    "event=relevance_floor arm=%s kept=%d dropped=%d floor=%.2f",
+                    name,
+                    len(survivors),
+                    dropped,
+                    floor,
+                )
+            results.append(survivors[:top_k])
+        return results

--- a/reflexio/server/services/storage/storage_base/_base.py
+++ b/reflexio/server/services/storage/storage_base/_base.py
@@ -40,6 +40,11 @@ class BaseStorageCore(ABC):  # noqa: B024
     # Capability flag — backends that implement `_get_embedding` set this to True.
     supports_embedding: ClassVar[bool] = False
 
+    # Capability flag — backends that can serve every unified-search arm in a
+    # single database round trip expose a `unified_hybrid_search` method and
+    # set this to True (see reflexio.server.services.unified_search_service).
+    supports_unified_hybrid_search: ClassVar[bool] = False
+
     def __init__(self, org_id: str, base_dir: str | None = None) -> None:
         self.org_id = org_id
         if base_dir is None:

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -409,9 +409,15 @@ def _run_phase_b_single_rpc(
         if allowed_agent_statuses
         else list(_DEFAULT_AGENT_PLAYBOOK_STATUSES)
     )
+    # Resolve storage.unified_hybrid_search before submit so missing or stale
+    # capability flags can fall back to the fan-out path.
+    unified_hybrid_search = getattr(storage, "unified_hybrid_search", None)
+    if not callable(unified_hybrid_search):
+        return None
+
     future = _submit_with_current_context(
         _SEARCH_FANOUT_EXECUTOR,
-        storage.unified_hybrid_search,  # type: ignore[reportAttributeAccessIssue]
+        unified_hybrid_search,
         query=query,
         query_embedding=embedding,
         top_k=top_k,

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -41,7 +41,7 @@ from reflexio.models.config_schema import (
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.pre_retrieval import QueryReformulator
-from reflexio.server.services.retrieval.relevance_floor import apply_relevance_floor
+from reflexio.server.services.retrieval.relevance_floor import apply_relevance_floors
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.tracing import profile_step, set_span_data
 
@@ -66,6 +66,7 @@ _SEARCH_FANOUT_EXECUTOR = ThreadPoolExecutor(
     max_workers=_SEARCH_FANOUT_MAX_WORKERS,
     thread_name_prefix="reflexio-search",
 )
+_ENV_SINGLE_RPC = "REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC"
 _EMBEDDING_CACHE_TTL_SECONDS = max(
     0, int(os.getenv("REFLEXIO_QUERY_EMBEDDING_CACHE_TTL_SECONDS", "300") or "300")
 )
@@ -266,6 +267,33 @@ def _run_phase_b(
             entity_types=sorted(entity_types),
             top_k=top_k,
         ) as span:
+            if (
+                getattr(storage, "supports_unified_hybrid_search", False)
+                and _unified_single_rpc_enabled()
+            ):
+                combined = _run_phase_b_single_rpc(
+                    request=request,
+                    storage=storage,
+                    embedding=embedding,
+                    query=query,
+                    top_k=top_k,
+                    threshold=threshold,
+                    entity_types=entity_types,
+                    allowed_agent_statuses=allowed_agent_statuses,
+                )
+                if combined is not None:
+                    profiles, agent_playbooks, user_playbooks = combined
+                    set_span_data(
+                        span,
+                        {
+                            "single_rpc": True,
+                            "profiles_count": len(profiles),
+                            "agent_playbooks_count": len(agent_playbooks),
+                            "user_playbooks_count": len(user_playbooks),
+                        },
+                    )
+                    return profiles, agent_playbooks, user_playbooks
+                span.set_data("single_rpc_fallback", True)
             profiles_future = (
                 _submit_with_current_context(
                     _SEARCH_FANOUT_EXECUTOR,
@@ -347,6 +375,80 @@ def _run_phase_b(
     return profiles, agent_playbooks, user_playbooks
 
 
+def _unified_single_rpc_enabled() -> bool:
+    """Kill switch for the combined Phase B RPC (default on)."""
+    return os.getenv(_ENV_SINGLE_RPC, "1").strip().lower() not in {"0", "false", "off"}
+
+
+def _run_phase_b_single_rpc(
+    *,
+    request: UnifiedSearchRequest,
+    storage: BaseStorage,
+    embedding: list[float] | None,
+    query: str,
+    top_k: int,
+    threshold: float,
+    entity_types: set[str],
+    allowed_agent_statuses: list[PlaybookStatus] | None,
+) -> tuple[list[UserProfile], list[AgentPlaybook], list[UserPlaybook]] | None:
+    """Run all Phase B arms through one combined storage round trip.
+
+    Trades the per-arm round-trip overhead for serialized execution of the
+    three queries inside one database session — a win when round-trip
+    overhead dominates per-arm query time (toggle via
+    ``REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC`` to compare).
+
+    Returns:
+        The three result lists, or None when the combined call fails so the
+        caller can fall back to the per-arm fan-out (e.g. the SQL function
+        is not yet migrated on this deployment). Timeouts propagate like the
+        fan-out path so a hung database is not retried.
+    """
+    statuses = (
+        list(allowed_agent_statuses)
+        if allowed_agent_statuses
+        else list(_DEFAULT_AGENT_PLAYBOOK_STATUSES)
+    )
+    future = _submit_with_current_context(
+        _SEARCH_FANOUT_EXECUTOR,
+        storage.unified_hybrid_search,  # type: ignore[reportAttributeAccessIssue]
+        query=query,
+        query_embedding=embedding,
+        top_k=top_k,
+        threshold=threshold,
+        user_id=request.user_id,
+        agent_version=request.agent_version,
+        playbook_name=request.playbook_name,
+        agent_playbook_statuses=statuses,
+        search_mode=request.search_mode,
+        include_profiles="profiles" in entity_types and bool(request.user_id),
+        include_agent_playbooks="agent_playbooks" in entity_types,
+        include_user_playbooks="user_playbooks" in entity_types,
+    )
+    try:
+        profiles, agent_playbooks, user_playbooks = future.result(timeout=30)
+    except FuturesTimeoutError:
+        raise
+    except Exception:
+        logger.warning(
+            "Unified single-RPC search failed; falling back to per-arm fan-out",
+            exc_info=True,
+        )
+        return None
+
+    # Mirror _search_agent_playbooks_via_storage: dedupe by id, cap at top_k.
+    deduped: list[AgentPlaybook] = []
+    seen_ids: set[str] = set()
+    for playbook in agent_playbooks:
+        playbook_id = str(getattr(playbook, "agent_playbook_id", ""))
+        if playbook_id and playbook_id not in seen_ids:
+            seen_ids.add(playbook_id)
+            deduped.append(playbook)
+            if len(deduped) >= top_k:
+                break
+    return profiles, deduped, user_playbooks
+
+
 def _apply_floors(
     query: str,
     profiles: list[UserProfile],
@@ -355,36 +457,17 @@ def _apply_floors(
     top_k: int,
     cfg: RetrievalFloorConfig,
 ) -> tuple[list[UserProfile], list[AgentPlaybook], list[UserPlaybook]]:
-    """Apply the per-arm relevance floor to each entity arm in parallel."""
-    with ThreadPoolExecutor(max_workers=3) as ex:
-        f_profiles = _submit_with_current_context(
-            ex,
-            apply_relevance_floor,
-            query,
-            profiles,
-            cfg.profile_floor,
-            top_k,
-            arm="profiles",
-        )
-        f_agent = _submit_with_current_context(
-            ex,
-            apply_relevance_floor,
-            query,
-            agent_playbooks,
-            cfg.agent_playbook_floor,
-            top_k,
-            arm="agent_playbooks",
-        )
-        f_user = _submit_with_current_context(
-            ex,
-            apply_relevance_floor,
-            query,
-            user_playbooks,
-            cfg.user_playbook_floor,
-            top_k,
-            arm="user_playbooks",
-        )
-        return f_profiles.result(), f_agent.result(), f_user.result()
+    """Apply the per-arm relevance floor with one batched cross-encoder call."""
+    floored_profiles, floored_agent, floored_user = apply_relevance_floors(
+        query,
+        [
+            ("profiles", profiles, cfg.profile_floor),
+            ("agent_playbooks", agent_playbooks, cfg.agent_playbook_floor),
+            ("user_playbooks", user_playbooks, cfg.user_playbook_floor),
+        ],
+        top_k,
+    )
+    return floored_profiles, floored_agent, floored_user
 
 
 def _get_cached_query_embedding(

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -326,6 +326,32 @@ def test_shared_client_is_constructed_once_and_reused(monkeypatch) -> None:
     assert constructed["n"] == 1
 
 
+def test_shared_client_closes_stale_client_after_pid_change(monkeypatch) -> None:
+    clients = []
+    pid = {"value": 100}
+
+    class _Client:
+        def __init__(self, **_kwargs) -> None:
+            self.closed = False
+            clients.append(self)
+
+        def close(self) -> None:
+            self.closed = True
+
+    monkeypatch.setattr(esp.httpx, "Client", _Client)
+    monkeypatch.setattr(esp.os, "getpid", lambda: pid["value"])
+    monkeypatch.setattr(esp, "_http_client_instance", None)
+    monkeypatch.setattr(esp, "_http_client_pid", None)
+
+    first = esp._http_client()
+    pid["value"] = 200
+    second = esp._http_client()
+
+    assert first is clients[0]
+    assert second is clients[1]
+    assert clients[0].closed is True
+
+
 class TestEmbeddingServiceExceptionScope:
     """Narrow exception scope: real transient errors retry, programming bugs propagate raw.
 

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import httpx
@@ -17,6 +19,32 @@ from reflexio.server.llm.providers.embedding_service_provider import (
     embedding_service_timeout_seconds,
     get_service_embeddings,
 )
+from reflexio.server.tracing import configure_tracer
+
+
+class _UnreachableHttpClient:
+    """Stands in for the shared client when the daemon is down."""
+
+    def get(self, *_args, **_kwargs):
+        raise httpx.RequestError("connection refused")
+
+
+class _RecordingSpan:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def set_data(self, key: str, value: object) -> None:
+        self.data[key] = value
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.started: list[tuple[str, dict[str, object]]] = []
+
+    @contextmanager
+    def span(self, name: str, **data: object):
+        self.started.append((name, data))
+        yield _RecordingSpan()
 
 
 def test_claude_smart_legacy_flag_defaults_to_local_service(monkeypatch) -> None:
@@ -40,13 +68,7 @@ def test_local_model_without_opt_in_preserves_inprocess_mode(monkeypatch) -> Non
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
     monkeypatch.setattr(esp, "_local_service_probe_cache", None)
-    monkeypatch.setattr(
-        esp.httpx,
-        "get",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            httpx.RequestError("connection refused")
-        ),
-    )
+    monkeypatch.setattr(esp, "_http_client", lambda: _UnreachableHttpClient())
 
     assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
 
@@ -58,11 +80,15 @@ def test_local_model_auto_uses_reachable_matching_daemon(monkeypatch) -> None:
         def json(self) -> dict[str, str]:
             return {"active_model": "local/nomic-embed-text-v1.5"}
 
+    class _Client:
+        def get(self, *_args, **_kwargs) -> _HealthResponse:
+            return _HealthResponse()
+
     monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
     monkeypatch.setattr(esp, "_local_service_probe_cache", None)
-    monkeypatch.setattr(esp.httpx, "get", lambda *_args, **_kwargs: _HealthResponse())
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert embedding_provider_mode("local/nomic-embed-text-v1.5") == "local_service"
 
@@ -74,11 +100,15 @@ def test_local_model_auto_avoids_reachable_mismatched_daemon(monkeypatch) -> Non
         def json(self) -> dict[str, str]:
             return {"active_model": "local/nomic-embed-text-v1.5"}
 
+    class _Client:
+        def get(self, *_args, **_kwargs) -> _HealthResponse:
+            return _HealthResponse()
+
     monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
     monkeypatch.setattr(esp, "_local_service_probe_cache", None)
-    monkeypatch.setattr(esp.httpx, "get", lambda *_args, **_kwargs: _HealthResponse())
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
 
@@ -92,19 +122,52 @@ def test_local_service_probe_timeout_env_is_honored(monkeypatch) -> None:
 
     observed: dict[str, float] = {}
 
-    def _get(_url: str, *, timeout: float) -> _HealthResponse:
-        observed["timeout"] = timeout
-        return _HealthResponse()
+    class _Client:
+        def get(self, _url: str, *, timeout: float) -> _HealthResponse:
+            observed["timeout"] = timeout
+            return _HealthResponse()
 
     monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
     monkeypatch.setenv("REFLEXIO_EMBEDDING_LOCAL_SERVICE_PROBE_TIMEOUT_MS", "1250")
     monkeypatch.setattr(esp, "_local_service_probe_cache", None)
-    monkeypatch.setattr(esp.httpx, "get", _get)
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert embedding_provider_mode("local/nomic-embed-text-v1.5") == "local_service"
     assert observed["timeout"] == 1.25
+
+
+def test_probe_success_cache_outlives_failure_cache(monkeypatch) -> None:
+    """A cached success skips the /health round trip for up to 60s; a cached
+    failure is retried after 5s so a restarted daemon is re-adopted quickly.
+    """
+
+    class _HealthResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"active_model": "local/m"}
+
+    probes = {"n": 0}
+
+    class _Client:
+        def get(self, *_args, **_kwargs) -> _HealthResponse:
+            probes["n"] += 1
+            return _HealthResponse()
+
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
+
+    now = time.monotonic()
+    # A 30s-old success is still fresh under the 60s success TTL: no probe.
+    monkeypatch.setattr(esp, "_local_service_probe_cache", (now - 30, True, "local/m"))
+    assert esp._local_service_status() == (True, "local/m")
+    assert probes["n"] == 0
+
+    # A 30s-old failure has outlived the 5s failure TTL: re-probe.
+    monkeypatch.setattr(esp, "_local_service_probe_cache", (now - 30, False, None))
+    assert esp._local_service_status() == (True, "local/m")
+    assert probes["n"] == 1
 
 
 def test_local_service_default_timeout_allows_cold_start(monkeypatch) -> None:
@@ -166,27 +229,15 @@ def test_service_response_is_sorted_by_index(monkeypatch) -> None:
             }
 
     class _Client:
-        def __init__(self, timeout: float) -> None:
-            assert timeout == 30
-            self.timeout = timeout
-
-        def __enter__(self) -> _Client:
-            return self
-
-        def __exit__(self, *args) -> None:
-            return None
-
-        def post(self, url: str, json: dict) -> _Response:  # noqa: A002
+        def post(self, url: str, *, json: dict, timeout: float) -> _Response:  # noqa: A002
             assert url == "http://127.0.0.1:8072/v1/embeddings"
             assert json["model"] == "local/nomic-embed-v1.5"
+            assert timeout == 30
             return _Response()
 
     monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
-    monkeypatch.setattr(
-        "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-        _Client,
-    )
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert get_service_embeddings(["a", "b"], model="local/nomic-embed-v1.5") == [
         [0.1, 0.2],
@@ -203,16 +254,7 @@ def test_local_service_daemon_host_override_changes_url(monkeypatch) -> None:
             return {"data": [{"index": 0, "embedding": [0.1, 0.2]}]}
 
     class _Client:
-        def __init__(self, timeout: float) -> None:
-            self.timeout = timeout
-
-        def __enter__(self) -> _Client:
-            return self
-
-        def __exit__(self, *args) -> None:
-            return None
-
-        def post(self, url: str, json: dict) -> _Response:  # noqa: A002
+        def post(self, url: str, *, json: dict, timeout: float) -> _Response:  # noqa: A002, ARG002
             assert url == "http://embedding.internal:8072/v1/embeddings"
             assert json["model"] == "local/nomic-embed-v1.5"
             return _Response()
@@ -220,10 +262,7 @@ def test_local_service_daemon_host_override_changes_url(monkeypatch) -> None:
     monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
     monkeypatch.setenv("REFLEXIO_EMBEDDING_DAEMON_HOST", "embedding.internal")
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
-    monkeypatch.setattr(
-        "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-        _Client,
-    )
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert get_service_embeddings(["a"], model="local/nomic-embed-v1.5") == [[0.1, 0.2]]
 
@@ -242,27 +281,49 @@ def test_service_response_rejects_index_mismatch(monkeypatch) -> None:
             }
 
     class _Client:
-        def __init__(self, timeout: float) -> None:
-            self.timeout = timeout
-
-        def __enter__(self) -> _Client:
-            return self
-
-        def __exit__(self, *args) -> None:
-            return None
-
-        def post(self, url: str, json: dict) -> _Response:  # noqa: A002, ARG002
+        def post(self, url: str, *, json: dict, timeout: float) -> _Response:  # noqa: A002, ARG002
             return _Response()
 
     monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
-    monkeypatch.setattr(
-        "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-        _Client,
-    )
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     with pytest.raises(EmbeddingUnavailableError, match="duplicate index 1"):
         get_service_embeddings(["a", "b"], model="local/nomic-embed-v1.5")
+
+
+def test_shared_client_is_constructed_once_and_reused(monkeypatch) -> None:
+    """`_http_client` must hand back one keep-alive client across calls so
+    embedding requests stop paying DNS + TCP setup per call.
+    """
+    constructed = {"n": 0}
+
+    class _Response:
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+        @staticmethod
+        def json() -> dict:
+            return {"data": [{"index": 0, "embedding": [0.1]}]}
+
+    class _Client:
+        def __init__(self, **_kwargs) -> None:
+            constructed["n"] += 1
+
+        def post(self, _url, *, json, timeout):  # noqa: A002, ARG002
+            return _Response()
+
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.setattr(esp.httpx, "Client", _Client)
+    monkeypatch.setattr(esp, "_http_client_instance", None)
+    monkeypatch.setattr(esp, "_http_client_pid", None)
+
+    get_service_embeddings(["a"], model="local/nomic-embed-v1.5")
+    get_service_embeddings(["b"], model="local/nomic-embed-v1.5")
+
+    assert constructed["n"] == 1
 
 
 class TestEmbeddingServiceExceptionScope:
@@ -287,32 +348,32 @@ class TestEmbeddingServiceExceptionScope:
         monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
         monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
 
+    @staticmethod
+    def _install_posting_client(monkeypatch, post) -> dict[str, int]:
+        """Route ``_http_client`` to a fake whose ``post`` calls ``post`` after
+        bumping a shared call counter; returns the counter dict.
+        """
+        call_count = {"n": 0}
+
+        class _Client:
+            def post(self, *_a, **_k):
+                call_count["n"] += 1
+                return post()
+
+        monkeypatch.setattr(esp, "_http_client", lambda: _Client())
+        return call_count
+
     def test_programming_bug_propagates_raw_without_retry(self, monkeypatch) -> None:
         """An ``AttributeError`` inside the call body must propagate raw on
         the first attempt — not be caught, retried, and re-wrapped as
         ``EmbeddingUnavailableError``.
         """
         self._route_to_local_service(monkeypatch)
-        call_count = {"n": 0}
 
-        class _BrokenClient:
-            def __init__(self, timeout: float) -> None:
-                self.timeout = timeout
+        def _post():
+            raise AttributeError("simulated programming bug")
 
-            def __enter__(self) -> _BrokenClient:
-                return self
-
-            def __exit__(self, *_args) -> None:
-                return None
-
-            def post(self, *_a, **_k):
-                call_count["n"] += 1
-                raise AttributeError("simulated programming bug")
-
-        monkeypatch.setattr(
-            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-            _BrokenClient,
-        )
+        call_count = self._install_posting_client(monkeypatch, _post)
 
         with pytest.raises(AttributeError, match="simulated programming bug"):
             get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
@@ -323,30 +384,65 @@ class TestEmbeddingServiceExceptionScope:
         server) retries once, then surfaces as ``EmbeddingUnavailableError``.
         """
         self._route_to_local_service(monkeypatch)
-        call_count = {"n": 0}
 
-        class _FlakyClient:
-            def __init__(self, timeout: float) -> None:
-                self.timeout = timeout
+        def _post():
+            raise httpx.ConnectError("connection refused")
 
-            def __enter__(self) -> _FlakyClient:
-                return self
-
-            def __exit__(self, *_args) -> None:
-                return None
-
-            def post(self, *_a, **_k):
-                call_count["n"] += 1
-                raise httpx.ConnectError("connection refused")
-
-        monkeypatch.setattr(
-            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-            _FlakyClient,
-        )
+        call_count = self._install_posting_client(monkeypatch, _post)
 
         with pytest.raises(EmbeddingUnavailableError):
             get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
         assert call_count["n"] == 2, "connection error must retry once"
+
+    def test_retry_backoff_is_traced(self, monkeypatch) -> None:
+        """Retry backoff should be visible as a child search span so the
+        parent embedding API span does not contain unexplained latency.
+        """
+        self._route_to_local_service(monkeypatch)
+
+        def _post():
+            raise httpx.ConnectError("connection refused")
+
+        self._install_posting_client(monkeypatch, _post)
+        slept: list[float] = []
+        monkeypatch.setattr(esp.time, "sleep", slept.append)
+
+        tracer = _RecordingTracer()
+        configure_tracer(tracer)
+        try:
+            with pytest.raises(EmbeddingUnavailableError):
+                get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
+        finally:
+            configure_tracer(None)
+
+        assert slept == [esp._EMBEDDING_RETRY_BACKOFF_SECONDS]
+        assert tracer.started == [
+            (
+                "search.embedding.api.retry_backoff",
+                {
+                    "retry_reason": "ConnectError",
+                    "retry_backoff_ms": 100,
+                    "attempt": 1,
+                    "max_attempts": 2,
+                },
+            )
+        ]
+
+    def test_remote_protocol_error_retries_once(self, monkeypatch) -> None:
+        """The server closing a pooled keep-alive connection before sending a
+        response (stale-reuse race) means the request was not processed, so a
+        single retry is safe.
+        """
+        self._route_to_local_service(monkeypatch)
+
+        def _post():
+            raise httpx.RemoteProtocolError("Server disconnected")
+
+        call_count = self._install_posting_client(monkeypatch, _post)
+
+        with pytest.raises(EmbeddingUnavailableError):
+            get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
+        assert call_count["n"] == 2, "stale keep-alive disconnect must retry once"
 
     def test_read_timeout_does_not_retry(self, monkeypatch) -> None:
         """A read timeout means the server already received the request and may
@@ -354,26 +450,11 @@ class TestEmbeddingServiceExceptionScope:
         amplify load on a saturated daemon, so it must fail fast (one call).
         """
         self._route_to_local_service(monkeypatch)
-        call_count = {"n": 0}
 
-        class _SlowClient:
-            def __init__(self, timeout: float) -> None:
-                self.timeout = timeout
+        def _post():
+            raise httpx.ReadTimeout("timed out")
 
-            def __enter__(self) -> _SlowClient:
-                return self
-
-            def __exit__(self, *_args) -> None:
-                return None
-
-            def post(self, *_a, **_k):
-                call_count["n"] += 1
-                raise httpx.ReadTimeout("timed out")
-
-        monkeypatch.setattr(
-            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-            _SlowClient,
-        )
+        call_count = self._install_posting_client(monkeypatch, _post)
 
         with pytest.raises(EmbeddingUnavailableError):
             get_service_embeddings(["text"], model="local/nomic-embed-v1.5")
@@ -415,16 +496,7 @@ class TestRequestChunking:
                 }
 
         class _Client:
-            def __init__(self, timeout: float) -> None:
-                self.timeout = timeout
-
-            def __enter__(self) -> _Client:
-                return self
-
-            def __exit__(self, *_args) -> None:
-                return None
-
-            def post(self, _url, *, json):
+            def post(self, _url, *, json, timeout):  # noqa: A002, ARG002
                 payloads.append(json)
                 return _Response()
 
@@ -436,10 +508,8 @@ class TestRequestChunking:
         self._route_to_local_service(monkeypatch)
         monkeypatch.setenv("REFLEXIO_EMBEDDING_SERVICE_MAX_TEXTS_PER_REQUEST", "2")
         payloads: list[dict] = []
-        monkeypatch.setattr(
-            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-            self._client_recording_payloads(payloads),
-        )
+        client_cls = self._client_recording_payloads(payloads)
+        monkeypatch.setattr(esp, "_http_client", lambda: client_cls())
 
         result = get_service_embeddings(
             ["t0", "t1", "t2", "t3", "t4"], model="local/nomic-embed-v1.5"
@@ -458,15 +528,12 @@ class TestRequestChunking:
         good_client = self._client_recording_payloads(payloads)
 
         class _FailsOnSecondChunk(good_client):
-            def post(self, _url, *, json):
+            def post(self, _url, *, json, timeout):  # noqa: A002
                 if len(payloads) >= 1:
                     raise httpx.ReadTimeout("timed out")
-                return super().post(_url, json=json)
+                return super().post(_url, json=json, timeout=timeout)
 
-        monkeypatch.setattr(
-            "reflexio.server.llm.providers.embedding_service_provider.httpx.Client",
-            _FailsOnSecondChunk,
-        )
+        monkeypatch.setattr(esp, "_http_client", lambda: _FailsOnSecondChunk())
 
         with pytest.raises(EmbeddingUnavailableError):
             get_service_embeddings(["t0", "t1", "t2"], model="local/nomic-embed-v1.5")
@@ -499,13 +566,7 @@ def test_nomic_inprocess_fallback_uses_nomic_embedder(monkeypatch) -> None:
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
     monkeypatch.setattr(esp, "_local_service_probe_cache", None)
-    monkeypatch.setattr(
-        esp.httpx,
-        "get",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            httpx.RequestError("connection refused")
-        ),
-    )
+    monkeypatch.setattr(esp, "_http_client", lambda: _UnreachableHttpClient())
     monkeypatch.setattr(
         "reflexio.server.llm.litellm_client.NomicEmbedder",
         _NomicFactory,
@@ -538,13 +599,7 @@ def test_nomic_inprocess_fallback_does_not_use_minilm(monkeypatch) -> None:
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
     monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
     monkeypatch.setattr(esp, "_local_service_probe_cache", None)
-    monkeypatch.setattr(
-        esp.httpx,
-        "get",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            httpx.RequestError("connection refused")
-        ),
-    )
+    monkeypatch.setattr(esp, "_http_client", lambda: _UnreachableHttpClient())
     monkeypatch.setattr(
         "reflexio.server.llm.litellm_client.NomicEmbedder",
         _NomicFactory,

--- a/tests/server/services/retrieval/test_relevance_floor.py
+++ b/tests/server/services/retrieval/test_relevance_floor.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass
 from unittest.mock import patch
 
-from reflexio.server.services.retrieval.relevance_floor import apply_relevance_floor
+from reflexio.server.services.retrieval.relevance_floor import (
+    apply_relevance_floor,
+    apply_relevance_floors,
+)
 
 
 @dataclass
@@ -64,3 +67,69 @@ def test_unavailable_reranker_degrades_to_unfiltered():
     ):
         out = apply_relevance_floor("q", items, floor=-5.0, top_k=2, arm="test")
     assert [i.content for i in out] == ["a", "b"]
+
+
+def test_batched_floors_score_once_and_apply_per_arm_floors():
+    arms = [
+        ("a1", _items("p1", "p2"), -5.0),
+        ("a2", _items("q1"), 0.5),
+    ]
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        return_value=[1.0, -7.0, 0.0],
+    ) as mock_score:
+        out = apply_relevance_floors("q", arms, top_k=10)
+    mock_score.assert_called_once_with("q", ["p1", "p2", "q1"])
+    assert [i.content for i in out[0]] == ["p1"]  # -7.0 below -5.0 floor
+    assert out[1] == []  # 0.0 below the 0.5 floor
+
+
+def test_batched_floors_sort_desc_and_cap_per_arm():
+    arms = [("a", _items("x", "y", "z"), -5.0)]
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        return_value=[1.0, 3.0, 2.0],
+    ):
+        out = apply_relevance_floors("q", arms, top_k=2)
+    assert [i.content for i in out[0]] == ["y", "z"]
+
+
+def test_batched_floors_unavailable_degrades_each_arm():
+    from reflexio.server.llm.rerank.cross_encoder_reranker import (
+        CrossEncoderUnavailableError,
+    )
+
+    arms = [
+        ("a1", _items("a", "b", "c"), -5.0),
+        ("a2", _items("d"), -5.0),
+    ]
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        side_effect=CrossEncoderUnavailableError("no model"),
+    ):
+        out = apply_relevance_floors("q", arms, top_k=2)
+    assert [i.content for i in out[0]] == ["a", "b"]
+    assert [i.content for i in out[1]] == ["d"]
+
+
+def test_batched_floors_all_empty_skips_scoring():
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs"
+    ) as mock_score:
+        out = apply_relevance_floors("q", [("a1", [], -5.0), ("a2", [], -5.0)], top_k=5)
+    assert out == [[], []]
+    mock_score.assert_not_called()
+
+
+def test_batched_floors_empty_arm_keeps_offsets_aligned():
+    arms = [
+        ("a1", [], -5.0),
+        ("a2", _items("x"), -5.0),
+    ]
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        return_value=[2.0],
+    ):
+        out = apply_relevance_floors("q", arms, top_k=5)
+    assert out[0] == []
+    assert [i.content for i in out[1]] == ["x"]

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -1,0 +1,129 @@
+"""Phase B single-RPC routing: combined storage call, fallback, kill switch."""
+
+from typing import Any, cast
+
+from reflexio.models.api_schema.retriever_schema import UnifiedSearchRequest
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    PlaybookStatus,
+    UserPlaybook,
+)
+from reflexio.server.services import unified_search_service as uss
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+
+def _agent_playbook(playbook_id: int, content: str) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=playbook_id, agent_version="v1", content=content
+    )
+
+
+class _CombinedStorage:
+    """Fake storage advertising the combined Phase B capability."""
+
+    supports_embedding = True
+    supports_unified_hybrid_search = True
+
+    def __init__(
+        self,
+        result: tuple[list[Any], list[Any], list[Any]] = ([], [], []),
+        raise_on_combined: bool = False,
+    ) -> None:
+        self.result = result
+        self.raise_on_combined = raise_on_combined
+        self.combined_calls: list[dict[str, Any]] = []
+        self.fanout_calls: list[str] = []
+
+    def unified_hybrid_search(self, **kwargs: Any):
+        self.combined_calls.append(kwargs)
+        if self.raise_on_combined:
+            raise RuntimeError("function public.unified_hybrid_search does not exist")
+        return self.result
+
+    # Per-arm methods used by the fan-out fallback path.
+    def search_user_profile(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.fanout_calls.append("profiles")
+        return []
+
+    def search_agent_playbooks(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.fanout_calls.append("agent_playbooks")
+        return []
+
+    def search_user_playbooks(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.fanout_calls.append("user_playbooks")
+        return []
+
+
+def _run_phase_b(storage: _CombinedStorage, *, user_id: str | None = "u"):
+    return uss._run_phase_b(
+        request=UnifiedSearchRequest(query="q", user_id=user_id, top_k=5),
+        org_id="o",
+        storage=cast(BaseStorage, storage),
+        embedding=[0.1, 0.2],
+        query="q",
+        top_k=5,
+        threshold=0.3,
+    )
+
+
+def test_single_rpc_used_when_supported(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    playbooks = [_agent_playbook(1, "a"), _agent_playbook(1, "dup"), _agent_playbook(2, "b")]
+    user_playbooks = [UserPlaybook(agent_version="v1", request_id="r1", content="up")]
+    storage = _CombinedStorage(result=([], playbooks, user_playbooks))
+
+    profiles, agent_playbooks, returned_user_playbooks = _run_phase_b(storage)
+
+    assert len(storage.combined_calls) == 1
+    assert storage.fanout_calls == []
+    call = storage.combined_calls[0]
+    assert call["include_profiles"] is True
+    assert call["include_agent_playbooks"] is True
+    assert call["include_user_playbooks"] is True
+    assert call["agent_playbook_statuses"] == [
+        PlaybookStatus.APPROVED,
+        PlaybookStatus.PENDING,
+    ]
+    # Duplicate agent playbook ids are deduped, mirroring the fan-out path.
+    assert agent_playbooks is not None
+    assert [p.agent_playbook_id for p in agent_playbooks] == [1, 2]
+    assert profiles == []
+    assert returned_user_playbooks == user_playbooks
+
+
+def test_single_rpc_skips_profiles_without_user_id(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _CombinedStorage()
+
+    _run_phase_b(storage, user_id=None)
+
+    assert storage.combined_calls[0]["include_profiles"] is False
+
+
+def test_single_rpc_failure_falls_back_to_fanout(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _CombinedStorage(raise_on_combined=True)
+
+    profiles, agent_playbooks, user_playbooks = _run_phase_b(storage)
+
+    assert len(storage.combined_calls) == 1
+    assert set(storage.fanout_calls) == {
+        "profiles",
+        "agent_playbooks",
+        "user_playbooks",
+    }
+    assert (profiles, agent_playbooks, user_playbooks) == ([], [], [])
+
+
+def test_single_rpc_kill_switch_disables_combined_path(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", "0")
+    storage = _CombinedStorage()
+
+    _run_phase_b(storage)
+
+    assert storage.combined_calls == []
+    assert set(storage.fanout_calls) == {
+        "profiles",
+        "agent_playbooks",
+        "user_playbooks",
+    }

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -54,6 +54,26 @@ class _CombinedStorage:
         return []
 
 
+class _MissingCombinedMethodStorage:
+    supports_embedding = True
+    supports_unified_hybrid_search = True
+
+    def __init__(self) -> None:
+        self.fanout_calls: list[str] = []
+
+    def search_user_profile(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.fanout_calls.append("profiles")
+        return []
+
+    def search_agent_playbooks(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.fanout_calls.append("agent_playbooks")
+        return []
+
+    def search_user_playbooks(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+        self.fanout_calls.append("user_playbooks")
+        return []
+
+
 def _run_phase_b(storage: _CombinedStorage, *, user_id: str | None = "u"):
     return uss._run_phase_b(
         request=UnifiedSearchRequest(query="q", user_id=user_id, top_k=5),
@@ -68,7 +88,11 @@ def _run_phase_b(storage: _CombinedStorage, *, user_id: str | None = "u"):
 
 def test_single_rpc_used_when_supported(monkeypatch):
     monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
-    playbooks = [_agent_playbook(1, "a"), _agent_playbook(1, "dup"), _agent_playbook(2, "b")]
+    playbooks = [
+        _agent_playbook(1, "a"),
+        _agent_playbook(1, "dup"),
+        _agent_playbook(2, "b"),
+    ]
     user_playbooks = [UserPlaybook(agent_version="v1", request_id="r1", content="up")]
     storage = _CombinedStorage(result=([], playbooks, user_playbooks))
 
@@ -107,6 +131,28 @@ def test_single_rpc_failure_falls_back_to_fanout(monkeypatch):
     profiles, agent_playbooks, user_playbooks = _run_phase_b(storage)
 
     assert len(storage.combined_calls) == 1
+    assert set(storage.fanout_calls) == {
+        "profiles",
+        "agent_playbooks",
+        "user_playbooks",
+    }
+    assert (profiles, agent_playbooks, user_playbooks) == ([], [], [])
+
+
+def test_single_rpc_missing_callable_falls_back_to_fanout(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _MissingCombinedMethodStorage()
+
+    profiles, agent_playbooks, user_playbooks = uss._run_phase_b(
+        request=UnifiedSearchRequest(query="q", user_id="u", top_k=5),
+        org_id="o",
+        storage=cast(BaseStorage, storage),
+        embedding=[0.1, 0.2],
+        query="q",
+        top_k=5,
+        threshold=0.3,
+    )
+
     assert set(storage.fanout_calls) == {
         "profiles",
         "agent_playbooks",


### PR DESCRIPTION
## Summary

Search-latency optimizations for the unified search path, plus the calling side of the enterprise single-RPC Phase B work.

- **Unified single-RPC Phase B** — when the storage backend advertises `supports_unified_hybrid_search` (default `False` on `BaseStorage`), all three search arms (profiles, agent playbooks, user playbooks) are served in one storage round trip instead of three parallel RPCs. Gated by `REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC` (default on) with automatic fallback to the per-arm fan-out when the combined call fails (e.g. the SQL function is not yet migrated on a deployment). Timeouts propagate like the fan-out so a hung DB is not retried.
- **Batched relevance flooring** — `apply_relevance_floors()` scores every arm in a single cross-encoder forward pass instead of one `score_pairs` call per arm. CPU cross-encoder inference doesn't parallelize across threads, so batching pays per-call overhead once.
- **Embedding HTTP client pooling** — share one keep-alive `httpx.Client` for health probes and embedding POSTs instead of paying DNS + TCP handshake per call. Keep-alive expiry (50s) stays under the ALB 60s idle timeout; positive `/health` probes cache 60s (failures stay 5s). Retry once on `RemoteProtocolError` (pooled connection closed before response) under a traced backoff span.
- **Follow-up hardening** — close the stale shared embedding `httpx.Client` before replacing it after PID rollover, and resolve `storage.unified_hybrid_search` as a callable before executor submission so stale capability flags fall back to fan-out instead of failing outside the fallback path.

## Testing

- `uv run pytest --no-cov open_source/reflexio/tests/server/llm/test_embedding_service_provider.py -q` — 30 passed
- `uv run pytest --no-cov open_source/reflexio/tests/server/services/test_unified_search_single_rpc.py -q` — 5 passed
- `uv run ruff check open_source/reflexio/reflexio/server/llm/providers/embedding_service_provider.py open_source/reflexio/reflexio/server/services/unified_search_service.py open_source/reflexio/tests/server/llm/test_embedding_service_provider.py open_source/reflexio/tests/server/services/test_unified_search_single_rpc.py`
- `uv run ruff format --check open_source/reflexio/reflexio/server/llm/providers/embedding_service_provider.py open_source/reflexio/reflexio/server/services/unified_search_service.py open_source/reflexio/tests/server/llm/test_embedding_service_provider.py open_source/reflexio/tests/server/services/test_unified_search_single_rpc.py`
- `uv run pyright open_source/reflexio/reflexio/server/llm/providers/embedding_service_provider.py open_source/reflexio/reflexio/server/services/unified_search_service.py open_source/reflexio/tests/server/llm/test_embedding_service_provider.py open_source/reflexio/tests/server/services/test_unified_search_single_rpc.py`
- `uv run python -c "import reflexio"`

The enterprise-side Supabase implementation (the `unified_hybrid_search` SQL function + `ProfileMixin.unified_hybrid_search`) lands in a companion enterprise PR that bumps this submodule pointer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional single-RPC unified hybrid search path for supported backends with deduplication and top-k capping; falls back to per-entity fan-out on failure.

* **Refactor**
  * Shared keep-alive HTTP client for embedding calls and health probes with improved retry handling and backoff tracing.
  * Batched application of relevance floors across arms for a single scoring pass.

* **Tests**
  * Expanded unit tests covering embedding client behavior, retry/backoff, relevance-floor batching, and single-RPC fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
