### PR TITLE
test: fix session_id/embedding drift and isolate e2e SQLite DB

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -132,20 +132,18 @@ def reflexio_instance_profile_only(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
         user_playbook_extractor_config=None,
-        profile_extractor_configs=[
-            ProfileExtractorConfig(
-                extractor_name="test_profile_extractor",
-                context_prompt="""
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="test_profile_extractor",
+            context_prompt="""
 Conversation between sales agent and user, extract any information from the interaction if contains any information listed under definition
 """,
-                extraction_definition_prompt="""
+            extraction_definition_prompt="""
 name, age, intent of the conversations
 """,
-                metadata_definition_prompt="""
+            metadata_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
-            )
-        ],
+        ),
     )
     configurator = DefaultConfigurator(org_id=test_org_id, config=config)
     return Reflexio(org_id=test_org_id, configurator=configurator)
@@ -165,23 +163,21 @@ def reflexio_instance_lifestyle_profile(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a personal assistant that learns about the user over time",
-        profile_extractor_configs=[
-            ProfileExtractorConfig(
-                extractor_name="lifestyle_extractor",
-                context_prompt="""
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="lifestyle_extractor",
+            context_prompt="""
 Extract enduring facts about the user's lifestyle, habits, preferences, and personal context
 from the conversation. Focus on things that describe who the user is and how they live.
 """,
-                extraction_definition_prompt="""
+            extraction_definition_prompt="""
 dietary habits and preferences (e.g., "vegetarian", "loves beef"),
 location and living situation (e.g., "lives in Austin"),
 hobbies and interests, work style, health conditions
 """,
-                metadata_definition_prompt="""
+            metadata_definition_prompt="""
 choice of ['diet', 'location', 'hobby', 'work', 'health']
 """,
-            )
-        ],
+        ),
     )
     configurator = DefaultConfigurator(org_id=test_org_id, config=config)
     return Reflexio(org_id=test_org_id, configurator=configurator)
@@ -454,21 +450,19 @@ def reflexio_instance_manual_profile(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
         window_size=10,  # Required for manual generation
-        profile_extractor_configs=[
-            ProfileExtractorConfig(
-                extractor_name="manual_trigger_extractor",
-                context_prompt="""
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="manual_trigger_extractor",
+            context_prompt="""
 Conversation between sales agent and user, extract any information from the interaction if contains any information listed under definition
 """,
-                extraction_definition_prompt="""
+            extraction_definition_prompt="""
 name, age, intent of the conversations
 """,
-                metadata_definition_prompt="""
+            metadata_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
-                allow_manual_trigger=True,  # Required for manual generation
-            )
-        ],
+            allow_manual_trigger=True,  # Required for manual generation
+        ),
     )
     configurator = DefaultConfigurator(org_id=test_org_id, config=config)
     return Reflexio(org_id=test_org_id, configurator=configurator)
@@ -496,16 +490,14 @@ def reflexio_instance_manual_playbook(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
         window_size=10,  # Required for manual generation
-        user_playbook_extractor_configs=[
-            PlaybookConfig(
-                extractor_name="manual_trigger_playbook",
-                extraction_definition_prompt="""
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="manual_trigger_playbook",
+            extraction_definition_prompt="""
 playbook should be something user told you to do differently in the next session. something sales rep did that makes user not satisfied.
 playbook content is what agent should do differently in the next session based on the conversation history and be actionable as much as possible.
 """,
-                allow_manual_trigger=True,  # Required for manual generation
-            )
-        ],
+            allow_manual_trigger=True,  # Required for manual generation
+        ),
     )
     configurator = DefaultConfigurator(org_id=test_org_id, config=config)
     return Reflexio(org_id=test_org_id, configurator=configurator)

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -78,20 +78,21 @@ def reflexio_instance(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
-        profile_extractor_configs=[
-            ProfileExtractorConfig(
-                extractor_name="test_profile_extractor",
-                context_prompt="""
+        # Single configured profile extractor (the list-valued field is retired and
+        # the Config constructor would ignore it, dropping metadata_definition_prompt
+        # and with it the mock's custom_features["metadata"]).
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="test_profile_extractor",
+            context_prompt="""
 Conversation between sales agent and user, extract any information from the interaction if contains any information listed under definition
 """,
-                extraction_definition_prompt="""
+            extraction_definition_prompt="""
 name, age, intent of the conversations
 """,
-                metadata_definition_prompt="""
+            metadata_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
-            )
-        ],
+        ),
         user_playbook_extractor_config=PlaybookConfig(
             extractor_name="test_playbook",
             extraction_definition_prompt="""

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -49,9 +49,14 @@ def _zero_group_evaluation_delay():
 
 
 @pytest.fixture
-def sqlite_storage_config() -> StorageConfigSQLite:
-    """Create a StorageConfigSQLite instance for e2e testing."""
-    return StorageConfigSQLite()
+def sqlite_storage_config(tmp_path) -> StorageConfigSQLite:
+    """Create a StorageConfigSQLite instance for e2e testing.
+
+    Each test gets its own SQLite DB in a temp dir so tests never share state
+    via the default ``~/.reflexio/data/reflexio.db`` path (which also avoids
+    stale-schema breakage when that shared DB predates a schema change).
+    """
+    return StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db"))
 
 
 @pytest.fixture

--- a/tests/e2e_tests/test_complete_workflows.py
+++ b/tests/e2e_tests/test_complete_workflows.py
@@ -188,6 +188,7 @@ def test_error_handling_end_to_end(
     empty_response = reflexio_instance.publish_interaction(
         {
             "user_id": "test_user_empty",
+            "session_id": "e2e_test_session",
             "interaction_data_list": [],
         }
     )
@@ -299,6 +300,7 @@ def test_profile_status_filtering(
     publish_response = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
             "agent_version": "v1",
@@ -358,6 +360,7 @@ def test_profile_upgrade_downgrade_workflow(
     publish_response = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
             "agent_version": "v1",
@@ -443,6 +446,7 @@ def test_time_filtering_and_pagination(
     publish_response = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
             "agent_version": "v1",
@@ -506,6 +510,7 @@ def test_dashboard_statistics(
     publish_response = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
             "agent_version": "v1",
@@ -550,6 +555,7 @@ def test_rerun_profile_generation_with_filters(
     publish_response_1 = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests[:2],
             "source": "source_a",
             "agent_version": "v1",
@@ -560,6 +566,7 @@ def test_rerun_profile_generation_with_filters(
     publish_response_2 = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests[2:4],
             "source": "source_b",
             "agent_version": "v1",
@@ -608,6 +615,7 @@ def test_get_all_operations(
         publish_response = reflexio_instance.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests[:2],
                 "source": "test_source",
                 "agent_version": "v1",

--- a/tests/e2e_tests/test_concurrent_playbook_extraction.py
+++ b/tests/e2e_tests/test_concurrent_playbook_extraction.py
@@ -101,7 +101,9 @@ def _publish_for_user(
     response = reflexio.publish_interaction(
         {
             "user_id": user_id,
-            "session_id": "e2e_test_session",
+            # Per-user session so concurrent users don't share session state —
+            # this test isolates cross-user lock-queue behavior.
+            "session_id": f"e2e_test_session_{user_id}",
             "interaction_data_list": interactions,
             "source": "concurrent_test",
             "agent_version": agent_version,

--- a/tests/e2e_tests/test_concurrent_playbook_extraction.py
+++ b/tests/e2e_tests/test_concurrent_playbook_extraction.py
@@ -101,6 +101,7 @@ def _publish_for_user(
     response = reflexio.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": interactions,
             "source": "concurrent_test",
             "agent_version": agent_version,

--- a/tests/e2e_tests/test_configuration.py
+++ b/tests/e2e_tests/test_configuration.py
@@ -52,31 +52,27 @@ def test_set_config_end_to_end(
     # Create a new configuration
     new_config = Config(
         storage_config=sqlite_storage_config,
-        profile_extractor_configs=[
-            ProfileExtractorConfig(
-                extractor_name="test_config_extractor",
-                context_prompt="""
-                Test configuration: Extract key information from conversations.
-                """,
-                extraction_definition_prompt="""
-                Test profile content definition.
-                """,
-                metadata_definition_prompt="""
-                Test metadata definition.
-                """,
-            )
-        ],
-        user_playbook_extractor_configs=[
-            PlaybookConfig(
-                extractor_name="test_config_playbook",
-                extraction_definition_prompt="""
-                Test playbook definition for configuration test.
-                """,
-                aggregation_config=PlaybookAggregatorConfig(
-                    min_cluster_size=3,
-                ),
-            )
-        ],
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="test_config_extractor",
+            context_prompt="""
+            Test configuration: Extract key information from conversations.
+            """,
+            extraction_definition_prompt="""
+            Test profile content definition.
+            """,
+            metadata_definition_prompt="""
+            Test metadata definition.
+            """,
+        ),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="test_config_playbook",
+            extraction_definition_prompt="""
+            Test playbook definition for configuration test.
+            """,
+            aggregation_config=PlaybookAggregatorConfig(
+                min_cluster_size=3,
+            ),
+        ),
     )
 
     # Test setting config with Config object
@@ -87,43 +83,37 @@ def test_set_config_end_to_end(
     # Verify configuration was actually set by checking the configurator
     current_config = reflexio.request_context.configurator.get_config()
     assert current_config is not None
-    assert len(current_config.profile_extractor_configs) == 1
+    assert current_config.profile_extractor_config is not None
     assert (
-        current_config.profile_extractor_configs[0].context_prompt.strip()
-        == new_config.profile_extractor_configs[0].context_prompt.strip()
+        current_config.profile_extractor_config.context_prompt.strip()
+        == new_config.profile_extractor_config.context_prompt.strip()
     )
-    assert len(current_config.user_playbook_extractor_configs) == 1
+    assert current_config.user_playbook_extractor_config is not None
     assert (
-        current_config.user_playbook_extractor_configs[0].extractor_name
+        current_config.user_playbook_extractor_config.extractor_name
         == "test_config_playbook"
     )
     assert (
-        current_config.user_playbook_extractor_configs[
-            0
-        ].aggregation_config.min_cluster_size
+        current_config.user_playbook_extractor_config.aggregation_config.min_cluster_size
         == 3
     )
 
     # Test setting config with dict input
     config_dict = {
         "storage_config": sqlite_storage_config.model_dump(),
-        "profile_extractor_configs": [
-            {
-                "extractor_name": "dict_test_extractor",
-                "context_prompt": "Updated test configuration from dict.",
-                "extraction_definition_prompt": "Updated profile content from dict.",
-                "metadata_definition_prompt": "Updated metadata from dict.",
-            }
-        ],
-        "user_playbook_extractor_configs": [
-            {
-                "extractor_name": "dict_test_playbook",
-                "extraction_definition_prompt": "Dict playbook definition.",
-                "aggregation_config": {
-                    "min_cluster_size": 5,
-                },
-            }
-        ],
+        "profile_extractor_config": {
+            "extractor_name": "dict_test_extractor",
+            "context_prompt": "Updated test configuration from dict.",
+            "extraction_definition_prompt": "Updated profile content from dict.",
+            "metadata_definition_prompt": "Updated metadata from dict.",
+        },
+        "user_playbook_extractor_config": {
+            "extractor_name": "dict_test_playbook",
+            "extraction_definition_prompt": "Dict playbook definition.",
+            "aggregation_config": {
+                "min_cluster_size": 5,
+            },
+        },
     }
 
     # Test setting config with dict
@@ -134,20 +124,18 @@ def test_set_config_end_to_end(
     # Verify dict configuration was set
     updated_config = reflexio.request_context.configurator.get_config()
     assert updated_config is not None
-    assert len(updated_config.profile_extractor_configs) == 1
+    assert updated_config.profile_extractor_config is not None
     assert (
         "Updated test configuration from dict"
-        in updated_config.profile_extractor_configs[0].context_prompt
+        in updated_config.profile_extractor_config.context_prompt
     )
-    assert len(updated_config.user_playbook_extractor_configs) == 1
+    assert updated_config.user_playbook_extractor_config is not None
     assert (
-        updated_config.user_playbook_extractor_configs[0].extractor_name
+        updated_config.user_playbook_extractor_config.extractor_name
         == "dict_test_playbook"
     )
     assert (
-        updated_config.user_playbook_extractor_configs[
-            0
-        ].aggregation_config.min_cluster_size
+        updated_config.user_playbook_extractor_config.aggregation_config.min_cluster_size
         == 5
     )
 
@@ -195,23 +183,19 @@ def test_get_config_end_to_end(
     # Step 2: Set a specific configuration
     new_config = Config(
         storage_config=sqlite_storage_config,
-        profile_extractor_configs=[
-            ProfileExtractorConfig(
-                extractor_name="get_config_test_extractor",
-                context_prompt="Get config test: Extract key information.",
-                extraction_definition_prompt="Get config test profile content.",
-                metadata_definition_prompt="Get config test metadata.",
-            )
-        ],
-        user_playbook_extractor_configs=[
-            PlaybookConfig(
-                extractor_name="get_config_test_playbook",
-                extraction_definition_prompt="Get config test playbook definition.",
-                aggregation_config=PlaybookAggregatorConfig(
-                    min_cluster_size=10,
-                ),
-            )
-        ],
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="get_config_test_extractor",
+            context_prompt="Get config test: Extract key information.",
+            extraction_definition_prompt="Get config test profile content.",
+            metadata_definition_prompt="Get config test metadata.",
+        ),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="get_config_test_playbook",
+            extraction_definition_prompt="Get config test playbook definition.",
+            aggregation_config=PlaybookAggregatorConfig(
+                min_cluster_size=10,
+            ),
+        ),
     )
 
     set_response = reflexio.set_config(new_config)
@@ -222,23 +206,18 @@ def test_get_config_end_to_end(
     assert retrieved_config is not None
     assert isinstance(retrieved_config, Config)
 
-    # Verify profile extractor configs
-    assert len(retrieved_config.profile_extractor_configs) == 1
-    assert (
-        "Get config test"
-        in retrieved_config.profile_extractor_configs[0].context_prompt
-    )
+    # Verify profile extractor config
+    assert retrieved_config.profile_extractor_config is not None
+    assert "Get config test" in retrieved_config.profile_extractor_config.context_prompt
 
-    # Verify agent playbook configs
-    assert len(retrieved_config.user_playbook_extractor_configs) == 1
+    # Verify agent playbook config
+    assert retrieved_config.user_playbook_extractor_config is not None
     assert (
-        retrieved_config.user_playbook_extractor_configs[0].extractor_name
+        retrieved_config.user_playbook_extractor_config.extractor_name
         == "get_config_test_playbook"
     )
     assert (
-        retrieved_config.user_playbook_extractor_configs[
-            0
-        ].aggregation_config.min_cluster_size
+        retrieved_config.user_playbook_extractor_config.aggregation_config.min_cluster_size
         == 10
     )
 

--- a/tests/e2e_tests/test_interaction_workflows.py
+++ b/tests/e2e_tests/test_interaction_workflows.py
@@ -123,6 +123,7 @@ def test_search_interactions_end_to_end(
     reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -161,6 +162,7 @@ def test_get_interactions_end_to_end(
     reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -201,6 +203,7 @@ def test_delete_interaction_end_to_end(
     response = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -267,6 +270,7 @@ def test_dict_input_handling_end_to_end(
     response = reflexio_instance.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": interaction_dicts,
             "source": "test_conversation",
         }

--- a/tests/e2e_tests/test_knowledge_gap_real_llm.py
+++ b/tests/e2e_tests/test_knowledge_gap_real_llm.py
@@ -68,6 +68,7 @@ def test_knowledge_gap_extraction_real_llm(
         response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": "knowledge_gap_user",
+                "session_id": "e2e_test_session",
                 "interaction_data_list": interactions,
                 "source": "test_knowledge_gap",
                 "agent_version": "v1.0",

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -26,10 +26,12 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
 )
 from reflexio.models.config_schema import (
+    SINGLETON_USER_PLAYBOOK_NAME,
     Config,
     PlaybookAggregatorConfig,
     PlaybookConfig,
     ProfileExtractorConfig,
+    RetrievalFloorConfig,
     StorageConfigSQLite,
 )
 from reflexio.server.services.configurator.configurator import DefaultConfigurator
@@ -44,7 +46,9 @@ pytestmark = pytest.mark.e2e
 _ALPHA_USER = "instance-alpha"
 _BETA_USER = "instance-beta"
 _AGENT_VERSION = "openclaw-v1"
-_PLAYBOOK_NAME = "openclaw_playbook"
+# Generated and aggregated playbooks are stored under the singleton name
+# regardless of the configured extractor_name, so seed and query under it.
+_PLAYBOOK_NAME = SINGLETON_USER_PLAYBOOK_NAME
 
 
 def _make_correction_interactions(topic: str) -> list[InteractionData]:
@@ -99,19 +103,24 @@ def _make_reflexio_with_playbook(
     config = Config(
         storage_config=storage_config,
         agent_context_prompt="AI coding assistant that helps developers",
-        user_playbook_extractor_configs=[
-            PlaybookConfig(
-                extractor_name=_PLAYBOOK_NAME,
-                extraction_definition_prompt=(
-                    "Extract any correction the user gave the assistant — "
-                    "something the assistant did wrong that the user asked to change. "
-                    "Playbook content should be an actionable instruction for the next session."
-                ),
-                aggregation_config=PlaybookAggregatorConfig(
-                    min_cluster_size=min_cluster_size,
-                ),
-            )
-        ],
+        # These tests seed a single playbook per arm and search with a generic query
+        # to verify search plumbing (both playbook types surface), not relevance
+        # ranking. Disable the read-path cross-encoder relevance floor so a lone
+        # weakly-scoring seed is not dropped before it can be returned.
+        retrieval_floor=RetrievalFloorConfig(enabled=False),
+        # Single configured playbook extractor (the list-valued field is retired and
+        # the Config constructor would ignore it, leaving aggregation_config unset).
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name=_PLAYBOOK_NAME,
+            extraction_definition_prompt=(
+                "Extract any correction the user gave the assistant — "
+                "something the assistant did wrong that the user asked to change. "
+                "Playbook content should be an actionable instruction for the next session."
+            ),
+            aggregation_config=PlaybookAggregatorConfig(
+                min_cluster_size=min_cluster_size,
+            ),
+        ),
     )
     configurator = DefaultConfigurator(org_id=org_id, config=config)
     return Reflexio(org_id=org_id, configurator=configurator)

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -216,6 +216,7 @@ class TestOpenClawMultiUser:
         alpha_resp = instance.publish_interaction(
             {
                 "user_id": _ALPHA_USER,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": alpha_turns,
                 "agent_version": _AGENT_VERSION,
                 "source": "openclaw",
@@ -226,6 +227,7 @@ class TestOpenClawMultiUser:
         beta_resp = instance.publish_interaction(
             {
                 "user_id": _BETA_USER,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": beta_turns,
                 "agent_version": _AGENT_VERSION,
                 "source": "openclaw",
@@ -625,6 +627,7 @@ class TestGracefulDegradation:
         resp = instance.publish_interaction(
             {
                 "user_id": _ALPHA_USER,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": single_turn,
                 "agent_version": _AGENT_VERSION,
                 "source": "openclaw",

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -775,6 +775,7 @@ def test_rerun_playbook_generation_end_to_end(
         publish_response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_rerun_source",
                 "agent_version": agent_version,
@@ -870,6 +871,7 @@ def test_rerun_playbook_generation_with_time_filters(
         publish_response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_rerun_time_source",
                 "agent_version": agent_version,
@@ -936,6 +938,7 @@ def test_playbook_source_filtering_with_matching_source(
     response_api = reflexio_instance_playbook_source_filtering.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "api",
             "agent_version": agent_version,
@@ -995,6 +998,7 @@ def test_playbook_source_filtering_with_non_matching_source(
     response = reflexio_instance_playbook_source_filtering.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "other",
             "agent_version": agent_version,
@@ -1052,6 +1056,7 @@ def test_playbook_source_filtering_webhook_source(
     response = reflexio_instance_playbook_source_filtering.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "webhook",
             "agent_version": agent_version,
@@ -1119,6 +1124,7 @@ def test_manual_playbook_generation_end_to_end(
         publish_response = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_manual_source",
                 "agent_version": agent_version,
@@ -1180,6 +1186,7 @@ def test_manual_playbook_generation_no_window_size(
     publish_response = reflexio_instance_playbook_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
             "agent_version": agent_version,
@@ -1223,6 +1230,7 @@ def test_manual_playbook_generation_with_source_filter(
         response_a = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "source_a",
                 "agent_version": agent_version,
@@ -1234,6 +1242,7 @@ def test_manual_playbook_generation_with_source_filter(
         response_b = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": [
                     InteractionData(
                         content="Simple message for source B",
@@ -1289,6 +1298,7 @@ def test_manual_playbook_generation_with_dict_input(
         publish_response = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
                 "agent_version": agent_version,
@@ -1336,6 +1346,7 @@ def test_manual_playbook_generation_with_playbook_name_filter(
         publish_response = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
                 "agent_version": agent_version,
@@ -1391,6 +1402,7 @@ def test_rerun_playbook_generation_with_source_filter(
             reflexio_instance_multiple_playbook_extractors.publish_interaction(
                 {
                     "user_id": user_id,
+                    "session_id": "e2e_test_session",
                     "interaction_data_list": sample_interaction_requests,
                     "source": "api",
                     "agent_version": agent_version,
@@ -1404,6 +1416,7 @@ def test_rerun_playbook_generation_with_source_filter(
             reflexio_instance_multiple_playbook_extractors.publish_interaction(
                 {
                     "user_id": user_id,
+                    "session_id": "e2e_test_session",
                     "interaction_data_list": [
                         InteractionData(
                             content="Webhook message",
@@ -1493,6 +1506,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "api",
                 "agent_version": agent_version,
@@ -1503,6 +1517,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": [
                     InteractionData(
                         content="Webhook interaction",
@@ -1518,6 +1533,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": [
                     InteractionData(
                         content="Other source interaction",
@@ -1592,6 +1608,7 @@ def test_rerun_playbook_generation_with_extractor_names_filter(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "api",
                 "agent_version": agent_version,
@@ -1680,6 +1697,7 @@ def test_playbook_pipeline_preserves_structured_fields(
         publish_response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_structured_data",
                 "agent_version": agent_version,
@@ -1725,6 +1743,7 @@ def test_playbook_pipeline_preserves_structured_fields(
             reflexio_instance_playbook_only.publish_interaction(
                 {
                     "user_id": f"{user_id}_{i}",
+                    "session_id": "e2e_test_session",
                     "interaction_data_list": sample_interaction_requests,
                     "source": "test_structured_data",
                     "agent_version": agent_version,
@@ -1812,6 +1831,7 @@ def test_knowledge_gap_playbook_extraction(
         response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": knowledge_gap_interactions,
                 "source": "test_knowledge_gap",
                 "agent_version": agent_version,

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -29,6 +29,9 @@ from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
 pytestmark = pytest.mark.e2e
 
+# Shared session id for publish payloads in this module (single source of truth).
+E2E_TEST_SESSION_ID = "e2e_test_session"
+
 
 @skip_in_precommit
 def test_publish_interaction_playbook_only(
@@ -777,7 +780,7 @@ def test_rerun_playbook_generation_end_to_end(
         publish_response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_rerun_source",
                 "agent_version": agent_version,
@@ -873,7 +876,7 @@ def test_rerun_playbook_generation_with_time_filters(
         publish_response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_rerun_time_source",
                 "agent_version": agent_version,
@@ -940,7 +943,7 @@ def test_playbook_source_filtering_with_matching_source(
     response_api = reflexio_instance_playbook_source_filtering.publish_interaction(
         {
             "user_id": user_id,
-            "session_id": "e2e_test_session",
+            "session_id": E2E_TEST_SESSION_ID,
             "interaction_data_list": sample_interaction_requests,
             "source": "api",
             "agent_version": agent_version,
@@ -1000,7 +1003,7 @@ def test_playbook_source_filtering_with_non_matching_source(
     response = reflexio_instance_playbook_source_filtering.publish_interaction(
         {
             "user_id": user_id,
-            "session_id": "e2e_test_session",
+            "session_id": E2E_TEST_SESSION_ID,
             "interaction_data_list": sample_interaction_requests,
             "source": "other",
             "agent_version": agent_version,
@@ -1058,7 +1061,7 @@ def test_playbook_source_filtering_webhook_source(
     response = reflexio_instance_playbook_source_filtering.publish_interaction(
         {
             "user_id": user_id,
-            "session_id": "e2e_test_session",
+            "session_id": E2E_TEST_SESSION_ID,
             "interaction_data_list": sample_interaction_requests,
             "source": "webhook",
             "agent_version": agent_version,
@@ -1128,7 +1131,7 @@ def test_manual_playbook_generation_end_to_end(
         publish_response = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_manual_source",
                 "agent_version": agent_version,
@@ -1190,7 +1193,7 @@ def test_manual_playbook_generation_no_window_size(
     publish_response = reflexio_instance_playbook_only.publish_interaction(
         {
             "user_id": user_id,
-            "session_id": "e2e_test_session",
+            "session_id": E2E_TEST_SESSION_ID,
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
             "agent_version": agent_version,
@@ -1234,7 +1237,7 @@ def test_manual_playbook_generation_with_source_filter(
         response_a = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "source_a",
                 "agent_version": agent_version,
@@ -1246,7 +1249,7 @@ def test_manual_playbook_generation_with_source_filter(
         response_b = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": [
                     InteractionData(
                         content="Simple message for source B",
@@ -1302,7 +1305,7 @@ def test_manual_playbook_generation_with_dict_input(
         publish_response = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
                 "agent_version": agent_version,
@@ -1350,7 +1353,7 @@ def test_manual_playbook_generation_with_playbook_name_filter(
         publish_response = reflexio_instance_manual_playbook.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
                 "agent_version": agent_version,
@@ -1406,7 +1409,7 @@ def test_rerun_playbook_generation_with_source_filter(
             reflexio_instance_multiple_playbook_extractors.publish_interaction(
                 {
                     "user_id": user_id,
-                    "session_id": "e2e_test_session",
+                    "session_id": E2E_TEST_SESSION_ID,
                     "interaction_data_list": sample_interaction_requests,
                     "source": "api",
                     "agent_version": agent_version,
@@ -1420,7 +1423,7 @@ def test_rerun_playbook_generation_with_source_filter(
             reflexio_instance_multiple_playbook_extractors.publish_interaction(
                 {
                     "user_id": user_id,
-                    "session_id": "e2e_test_session",
+                    "session_id": E2E_TEST_SESSION_ID,
                     "interaction_data_list": [
                         InteractionData(
                             content="Webhook message",
@@ -1510,7 +1513,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "api",
                 "agent_version": agent_version,
@@ -1521,7 +1524,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": [
                     InteractionData(
                         content="Webhook interaction",
@@ -1537,7 +1540,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": [
                     InteractionData(
                         content="Other source interaction",
@@ -1612,7 +1615,7 @@ def test_rerun_playbook_generation_with_extractor_names_filter(
         reflexio_instance_multiple_playbook_extractors.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "api",
                 "agent_version": agent_version,
@@ -1703,7 +1706,7 @@ def test_playbook_pipeline_preserves_structured_fields(
         publish_response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_structured_data",
                 "agent_version": agent_version,
@@ -1749,7 +1752,7 @@ def test_playbook_pipeline_preserves_structured_fields(
             reflexio_instance_playbook_only.publish_interaction(
                 {
                     "user_id": f"{user_id}_{i}",
-                    "session_id": "e2e_test_session",
+                    "session_id": E2E_TEST_SESSION_ID,
                     "interaction_data_list": sample_interaction_requests,
                     "source": "test_structured_data",
                     "agent_version": agent_version,
@@ -1845,7 +1848,7 @@ def test_knowledge_gap_playbook_extraction(
         response = reflexio_instance_playbook_only.publish_interaction(
             {
                 "user_id": user_id,
-                "session_id": "e2e_test_session",
+                "session_id": E2E_TEST_SESSION_ID,
                 "interaction_data_list": knowledge_gap_interactions,
                 "source": "test_knowledge_gap",
                 "agent_version": agent_version,

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -764,7 +764,9 @@ def test_rerun_playbook_generation_end_to_end(
     """
     user_id = "test_user_rerun_playbook"
     agent_version = "test_agent_rerun_playbook"
-    playbook_name = "test_playbook"
+    # Generated playbooks are stored under the singleton name regardless of the
+    # configured extractor_name, so query by the singleton to retrieve them.
+    playbook_name = SINGLETON_USER_PLAYBOOK_NAME
 
     # Use mock mode to ensure consistent LLM responses
     original_env = os.environ.get("MOCK_LLM_RESPONSE")
@@ -1113,7 +1115,9 @@ def test_manual_playbook_generation_end_to_end(
     """
     user_id = "test_user_manual_playbook"
     agent_version = "test_agent_manual_playbook"
-    playbook_name = "manual_trigger_playbook"
+    # Generated playbooks are stored under the singleton name regardless of the
+    # configured extractor_name, so query by the singleton to retrieve them.
+    playbook_name = SINGLETON_USER_PLAYBOOK_NAME
 
     # Use mock mode to ensure consistent LLM responses
     original_env = os.environ.get("MOCK_LLM_RESPONSE")
@@ -1687,7 +1691,9 @@ def test_playbook_pipeline_preserves_structured_fields(
     """
     user_id = "test_user_structured_data"
     agent_version = "test_agent_structured_data"
-    playbook_name = "test_playbook"
+    # Generated playbooks are stored under the singleton name regardless of the
+    # configured extractor_name, so query by the singleton to retrieve them.
+    playbook_name = SINGLETON_USER_PLAYBOOK_NAME
 
     original_env = os.environ.get("MOCK_LLM_RESPONSE")
     try:
@@ -1821,6 +1827,14 @@ def test_knowledge_gap_playbook_extraction(
             role="Agent",
             content="You're right, I apologize. I don't actually have access to look up real-time order tracking information. I was making assumptions based on general timelines. For accurate order status, I'd recommend checking the tracking link in your confirmation email or contacting our order support team directly.",
         ),
+        InteractionData(
+            role="User",
+            content="Okay, thank you for being honest about that. So just to be clear, you genuinely can't see my order or tracking details on your end at all?",
+        ),
+        InteractionData(
+            role="Agent",
+            content="That's correct. I don't have a connection to the order or tracking systems, so I can't see your order details. Rather than guess, the reliable path is the tracking link in your confirmation email or our order support team, who can see the live data.",
+        ),
     ]
 
     original_env = os.environ.get("MOCK_LLM_RESPONSE")
@@ -1842,7 +1856,7 @@ def test_knowledge_gap_playbook_extraction(
         # Retrieve extracted playbooks
         playbooks_response = reflexio_instance_playbook_only.get_user_playbooks(
             GetUserPlaybooksRequest(
-                playbook_name="test_playbook",
+                playbook_name=SINGLETON_USER_PLAYBOOK_NAME,
                 status_filter=[None],
             )
         )

--- a/tests/e2e_tests/test_profile_workflows.py
+++ b/tests/e2e_tests/test_profile_workflows.py
@@ -100,6 +100,7 @@ def test_search_profiles_end_to_end(
     reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -157,6 +158,7 @@ def test_get_profiles_end_to_end(
     reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -198,6 +200,7 @@ def test_delete_profile_end_to_end(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -246,6 +249,7 @@ def test_get_profile_change_logs_end_to_end(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -293,6 +297,7 @@ def test_rerun_profile_generation_end_to_end(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -384,6 +389,7 @@ def test_rerun_profile_generation_with_time_filters(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -462,6 +468,7 @@ def test_rerun_profile_generation_with_source_filter(
     response_a = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source_a",
         }
@@ -472,6 +479,7 @@ def test_rerun_profile_generation_with_source_filter(
     response_b = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": [
                 InteractionData(
                     content="Just a test message for source B",
@@ -541,6 +549,7 @@ def test_status_filter_in_get_all_profiles(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -589,6 +598,7 @@ def test_status_filter_in_search_user_profiles(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -643,6 +653,7 @@ def test_status_filter_in_get_profiles_request(
     response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_conversation",
         }
@@ -994,6 +1005,7 @@ def test_manual_profile_generation_end_to_end(
     publish_response = reflexio_instance_manual_profile.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_manual_source",
         }
@@ -1050,6 +1062,7 @@ def test_manual_profile_generation_no_window_size(
     publish_response = reflexio_instance_profile_only.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
         }
@@ -1086,6 +1099,7 @@ def test_manual_profile_generation_with_source_filter(
     response_a = reflexio_instance_manual_profile.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "source_a",
         }
@@ -1096,6 +1110,7 @@ def test_manual_profile_generation_with_source_filter(
     response_b = reflexio_instance_manual_profile.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": [
                 InteractionData(
                     content="Simple message for source B",
@@ -1139,6 +1154,7 @@ def test_manual_profile_generation_with_dict_input(
     publish_response = reflexio_instance_manual_profile.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": sample_interaction_requests,
             "source": "test_source",
         }
@@ -1173,6 +1189,7 @@ def test_rerun_profile_generation_with_extractor_names_filter(
         reflexio_instance_multiple_profile_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
             }
@@ -1224,6 +1241,7 @@ def test_rerun_profile_generation_with_single_extractor(
         reflexio_instance_multiple_profile_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
             }
@@ -1265,6 +1283,7 @@ def test_rerun_profile_generation_with_nonexistent_extractor_name(
         reflexio_instance_multiple_profile_extractors.publish_interaction(
             {
                 "user_id": user_id,
+                "session_id": "e2e_test_session",
                 "interaction_data_list": sample_interaction_requests,
                 "source": "test_source",
             }
@@ -1365,6 +1384,7 @@ def test_profile_dedup_resolves_contradiction(
     response = reflexio_instance_lifestyle_profile.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": batch_1,
             "source": "contradiction_test",
         }
@@ -1389,6 +1409,7 @@ def test_profile_dedup_resolves_contradiction(
     response = reflexio_instance_lifestyle_profile.publish_interaction(
         {
             "user_id": user_id,
+            "session_id": "e2e_test_session",
             "interaction_data_list": batch_2,
             "source": "contradiction_test",
         }

--- a/tests/lib/test_interactions_unit.py
+++ b/tests/lib/test_interactions_unit.py
@@ -452,6 +452,7 @@ class TestPublishInteraction:
         response = mixin.publish_interaction(
             {
                 "user_id": "user1",
+                "session_id": "test_session",
                 "interaction_data_list": [{"role": "User", "content": "hi"}],
             }
         )

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -162,6 +162,7 @@ def test_publish_interaction_dict_input(reflexio_with_config):
     # Publish interaction as dict
     request_dict = {
         "user_id": user_id,
+        "session_id": "test_session_dict",
         "interaction_data_list": [
             {
                 "content": "Dictionary input test",
@@ -214,7 +215,8 @@ def test_search_interactions(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -243,7 +245,8 @@ def test_search_profiles_current_only(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -272,7 +275,8 @@ def test_search_profiles_with_status_filter(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -302,7 +306,8 @@ def test_get_interactions_with_time_filters(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -334,7 +339,8 @@ def test_get_profiles_with_status_filter(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -361,7 +367,8 @@ def test_get_all_profiles_and_interactions(reflexio_with_config):
         )
 
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data],
+            user_id=user_id,
+            interaction_data_list=[interaction_data],
             session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
@@ -398,7 +405,8 @@ def test_rerun_profile_generation_single_user(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -425,7 +433,8 @@ def test_rerun_profile_generation_all_users(reflexio_with_config):
         )
 
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data],
+            user_id=user_id,
+            interaction_data_list=[interaction_data],
             session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
@@ -463,7 +472,8 @@ def test_rerun_profile_generation_with_time_filters(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -494,7 +504,9 @@ def test_rerun_profile_generation_with_source_filter(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data], source="test_source",
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
+        source="test_source",
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -542,7 +554,8 @@ def test_upgrade_all_profiles(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -587,7 +600,8 @@ def test_downgrade_all_profiles(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -625,7 +639,8 @@ def test_upgrade_only_affected_users(reflexio_with_config):
             created_at=int(datetime.datetime.now(UTC).timestamp()),
         )
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data],
+            user_id=user_id,
+            interaction_data_list=[interaction_data],
             session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
@@ -709,7 +724,8 @@ def test_downgrade_only_affected_users(reflexio_with_config):
             created_at=int(datetime.datetime.now(UTC).timestamp()),
         )
         publish_request = PublishUserInteractionRequest(
-            user_id=user_id, interaction_data_list=[interaction_data],
+            user_id=user_id,
+            interaction_data_list=[interaction_data],
             session_id="test_session",
         )
         reflexio.publish_interaction(publish_request)
@@ -786,7 +802,8 @@ def test_get_profile_statistics(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -816,7 +833,8 @@ def test_delete_profile_success(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -853,7 +871,8 @@ def test_delete_interaction_success(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -896,7 +915,8 @@ def test_get_profile_change_logs(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -956,7 +976,8 @@ def test_get_dashboard_stats(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)
@@ -1018,7 +1039,8 @@ def test_get_requests_with_filters(reflexio_with_config):
     )
 
     publish_request = PublishUserInteractionRequest(
-        user_id=user_id, interaction_data_list=[interaction_data],
+        user_id=user_id,
+        interaction_data_list=[interaction_data],
         session_id="test_session",
     )
     reflexio.publish_interaction(publish_request)

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -44,6 +44,7 @@ class TestPublishInteraction:
     def _publish_payload():
         return {
             "user_id": "user-1",
+            "session_id": "sess-1",
             "interaction_data_list": [
                 {
                     "user_id": "user-1",

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -232,10 +232,16 @@ class TestLiteLLMClientShortCircuit:
         from reflexio.server.llm import litellm_client
         from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 
-        _install_fake_chroma(monkeypatch)
+        # CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 selects the local embedding *service*
+        # (daemon) mode (see embedding_provider_mode). The request must route to
+        # that service and never reach litellm. Mock the service call so the test
+        # is hermetic (no running daemon required).
         monkeypatch.setenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", "1")
-        monkeypatch.setattr(lep.importlib.util, "find_spec", lambda _name: MagicMock())
-        register_if_enabled()
+        monkeypatch.setattr(
+            litellm_client,
+            "get_service_embeddings",
+            lambda texts, **_kwargs: [[0.0] * 512 for _ in texts],
+        )
 
         client = LiteLLMClient(LiteLLMConfig(model="claude-code/default"))
 
@@ -251,10 +257,14 @@ class TestLiteLLMClientShortCircuit:
         from reflexio.server.llm import litellm_client
         from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 
-        _install_fake_chroma(monkeypatch)
+        # CLAUDE_SMART_USE_LOCAL_EMBEDDING=1 routes the batch path to the local
+        # embedding *service* (daemon) too. Mock the service call for hermeticity.
         monkeypatch.setenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", "1")
-        monkeypatch.setattr(lep.importlib.util, "find_spec", lambda _name: MagicMock())
-        register_if_enabled()
+        monkeypatch.setattr(
+            litellm_client,
+            "get_service_embeddings",
+            lambda texts, **_kwargs: [[0.0] * 512 for _ in texts],
+        )
 
         client = LiteLLMClient(LiteLLMConfig(model="claude-code/default"))
 


### PR DESCRIPTION
## Summary

Fixes pre-existing test drift surfaced by `/check-and-test` on a clean `main`. **Test-only changes — no production code touched.**

### Unit + integration drift
- **`session_id` required (PR #144):** added a valid `session_id` to `publish_interaction` inputs across `tests/lib/`, `tests/server/api_endpoints/test_api_routes.py`, and the e2e publish blocks (it is now a required `NonEmptyStr`).
- **Embedding routing tests:** `CLAUDE_SMART_USE_LOCAL_EMBEDDING=1` now selects the local embedding *service* (`local_service` mode) per the daemon-first design (PRs #134/#141); updated the two routing tests to assert that (hermetically mocked) instead of the retired in-process-via-env-var behavior.
- **`test_configuration`:** switched to the singular `profile_extractor_config` / `user_playbook_extractor_config` fields (plural list fields retired).

### e2e isolation + singleton/single-config migration
- **DB isolation:** `sqlite_storage_config` uses a per-test `tmp_path` DB instead of the shared `~/.reflexio/data/reflexio.db` (fixes cross-test collisions + stale-schema breakage).
- **Singleton names:** extractor names are now singletons (`get_extractor_name` → `SINGLETON_USER_PLAYBOOK_NAME`, etc.); query playbooks by the singleton instead of stale custom names.
- **Single-config fixtures:** the `Config` constructor drops retired list-valued fields, so fixtures now use the singular config fields (this also restores the profile `custom_features["metadata"]` that `test_publish_interaction_end_to_end` asserts).
- Gave `test_knowledge_gap_playbook_extraction` enough interactions to clear the default `stride_size` extraction gate; disabled the read-path relevance floor in the unified-search **plumbing** test (relevance is covered by `test_search_relevance`).

## Verification
- OS unit + integration: **2997 passed, 0 failed**.
- OS e2e: **24 → 0 failed** (41 passed, 47 skipped).
- ruff + pyright clean. No assertions weakened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Per-test database files introduced for stronger isolation
  * Config tests updated to use singular extractor/playbook fields instead of list-based fields
  * Session ID explicitly included across many interaction and workflow tests for consistent session tracking
  * Playbook tests standardized to use singleton playbook naming
  * Local embedding routing tests simplified and verified with deterministic vectors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->