### PR TITLE
fix(embedding): serialize model inference to stop concurrent-encode tensor race

### DIFF
--- a/reflexio/server/llm/embedding_service.py
+++ b/reflexio/server/llm/embedding_service.py
@@ -34,6 +34,16 @@ _SUPPORTED_MODELS = {
 _ACTIVE_MODEL: str | None = None
 _ACTIVE_MODEL_LOCK = threading.Lock()
 
+# The underlying sentence-transformers / ONNX embedders share internal buffers
+# and are NOT thread-safe: concurrent ``.embed()`` calls interleave and corrupt
+# each other's padding/attention tensors (observed under concurrent publishes as
+# ``RuntimeError: The size of tensor a (62) must match the size of tensor b (61)
+# at non-singleton dimension 1``). The ``_ENCODE_SEMAPHORE`` below only caps how
+# many requests run at once (for memory), it does NOT serialize them, so this
+# lock guards the actual model inference. Throughput comes from micro-batch
+# coalescing (many texts per encode), not from parallel encodes on one model.
+_MODEL_ENCODE_LOCK = threading.Lock()
+
 DEFAULT_OSS_EMBEDDING_MODEL = MINILM_MODEL
 
 # Bound how many embed/encode calls run at once. The endpoint is a sync ``def``
@@ -314,10 +324,15 @@ def _encode_texts_now(model: str, texts: list[str]) -> list[list[float]]:
         )
         semaphore.acquire()
     try:
-        if is_nomic_model(model):
-            return NomicEmbedder.get().embed(texts)
-        if model == MINILM_MODEL:
-            return LocalEmbedder.get().embed(texts)
+        # Serialize the actual inference: the shared embedder models are not
+        # thread-safe, so concurrent encodes race and produce tensor-shape
+        # errors. The semaphore (above) bounds memory; this lock bounds the
+        # model to one in-flight encode at a time.
+        with _MODEL_ENCODE_LOCK:
+            if is_nomic_model(model):
+                return NomicEmbedder.get().embed(texts)
+            if model == MINILM_MODEL:
+                return LocalEmbedder.get().embed(texts)
         raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
     finally:
         semaphore.release()


### PR DESCRIPTION
## Summary

The local embedding daemon (`embedding_service.py`) crashed intermittently under **concurrent** embedding requests, returning `500` from `/v1/embeddings`.

### Root cause
`_encode_texts_now` guarded encodes with `BoundedSemaphore(_max_concurrency())` (default **4**). A semaphore of 4 **bounds** concurrency (for memory) but does **not serialize** it — so up to 4 micro-batch processor threads called the **shared, non-thread-safe** sentence-transformers / ONNX model's `.embed()` in parallel. Interleaved encodes corrupt each other's padding/attention tensors:

```
RuntimeError: The size of tensor a (62) must match the size of tensor b (61) at non-singleton dimension 1
```

which surfaced as a `500` → `EmbeddingUnavailableError` → `StorageError`, failing concurrent publishes.

### Fix
Add a dedicated `_MODEL_ENCODE_LOCK` around the actual model inference so only one encode runs at a time on the shared model. Throughput is preserved by the existing **micro-batch coalescing** (many texts per encode) — the broken assumption was that parallel encodes on one model instance are safe; they aren't.

## How it was found / verified
Found by running the **concurrent-sessions** test against a live server (scenario B failed with the tensor-mismatch 500). After the fix, all four scenarios (A/B/C/D) pass with no embedding errors under concurrency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safety for embedding inference to prevent potential data corruption during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->