### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -405,10 +405,10 @@ Key files:
 - `reflection/reflection_extractor.py`: LLM extractor used by the reflection service
 - `extraction/resumable_agent.py`: Resumable extraction agent runtime
 - `extraction/resume_scheduler.py` and `extraction/resume_worker.py`: Background scheduling/worker loop for paused extraction runs
-- `extraction/tools.py` and `extraction/prior_answer_search.py`: Tool surface for async extraction agents
-- `extraction/agent_run_records.py`: Persistence helpers for extraction-agent run state
+- `extraction/pending_tool_call_dispatch.py` and `extraction/prior_answer_search.py`: Human-clarification dispatch plus prior-answer lookup helpers for async extraction
+- `extraction/agent_run_records.py` and `extraction/outcome.py`: Persistence helpers and outcome models for extraction-agent run state
 
-**Pattern**: Synchronous profile/playbook/evaluation services still follow `BaseGenerationService`; async extraction uses resumable agent-run records and worker scheduling so long-running or tool-mediated extraction can continue outside the request path.
+**Pattern**: Synchronous profile/playbook/evaluation services still follow `BaseGenerationService`; async extraction uses resumable agent-run records, pending tool-call dispatch, and worker scheduling so long-running or tool-mediated extraction can continue outside the request path.
 
 ### Shadow Comparison and Evaluation Overview
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -28,7 +28,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 
 | Directory | Purpose |
 |-----------|---------|
-| `extraction/` | Resumable extraction agent: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `tools.py`, `plan.py`, `agent_run_records.py`, `invariants.py`. Long-horizon / tool-mediated extraction continues outside the request path. |
+| `extraction/` | Resumable extraction agent: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `prior_answer_search.py`, `agent_run_records.py`, `outcome.py`. Long-horizon / tool-mediated extraction continues outside the request path. |
 
 ## Evaluation, Search & Integrations
 


### PR DESCRIPTION
## Summary
- Updates code-map README references for `reflexio/server/services/extraction/` after the latest main branch removed `tools.py`, `plan.py`, and `invariants.py` and retained the current resumable-agent helpers.
- Keeps the changes concise and navigation-focused per `how_to_write_readme.md`.

## Repositories/submodules reviewed
- Parent: `yyiilluu/reflexio-enterprise`
- Submodule: `ReflexioAI/reflexio`

## README files updated
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- `git diff --check`
- Practical relative Markdown link/path check for the updated README files

## Notes/Risks
- `open_source/reflexio/README.md` is the user-facing public README and was intentionally not restructured as a code map.
- Parent repository submodule pointer was not committed; this PR is limited to the submodule repository README updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined server documentation to clarify async extraction components and their roles in the extraction workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->