### PR TITLE
Keep production console logs quiet

### DIFF
--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -128,10 +128,39 @@ class _LLMIOFormatter(_TZAwareFormatter):
         )
 
 
-DEBUG_LOG_TO_CONSOLE = os.environ.get("DEBUG_LOG_TO_CONSOLE", "").strip().lower()
+def _truthy_env(name: str) -> bool:
+    """Return whether an environment variable is explicitly truthy."""
+    raw = os.environ.get(name, "").strip().lower()
+    return bool(raw) and raw not in ("false", "0", "no", "off")
+
+
+def _is_production_environment() -> bool:
+    """Return whether this process is running in a production deployment."""
+    return os.environ.get("SENTRY_ENVIRONMENT", "").strip().lower() in (
+        "prod",
+        "production",
+    )
+
+
+def _debug_log_to_console_enabled() -> bool:
+    """Return whether verbose console logging should be enabled.
+
+    ``DEBUG_LOG_TO_CONSOLE`` is a local/dev switch. Production deployments must
+    stay quiet by default even if a copied local env file accidentally sets it;
+    use ``REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS=true`` for a deliberate incident
+    override.
+    """
+    if not _truthy_env("DEBUG_LOG_TO_CONSOLE"):
+        return False
+    return not _is_production_environment() or _truthy_env(
+        "REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS"
+    )
+
+
+DEBUG_LOG_TO_CONSOLE = _debug_log_to_console_enabled()
 root_logger = logging.getLogger()
 
-if DEBUG_LOG_TO_CONSOLE and DEBUG_LOG_TO_CONSOLE not in ("false", "0", "no"):
+if DEBUG_LOG_TO_CONSOLE:
     # Correlation ID filter — injects %(correlation_id)s into every record
     from reflexio.server.correlation import CorrelationIdFilter
 

--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -131,7 +131,7 @@ class _LLMIOFormatter(_TZAwareFormatter):
 def _truthy_env(name: str) -> bool:
     """Return whether an environment variable is explicitly truthy."""
     raw = os.environ.get(name, "").strip().lower()
-    return bool(raw) and raw not in ("false", "0", "no", "off")
+    return raw in ("true", "yes", "1", "on")
 
 
 def _is_production_environment() -> bool:

--- a/tests/server/test_logging_timezone.py
+++ b/tests/server/test_logging_timezone.py
@@ -77,3 +77,12 @@ class TestConsoleDebugPolicy:
         monkeypatch.setenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", "true")
 
         assert _debug_log_to_console_enabled() is True
+
+    def test_debug_console_rejects_ambiguous_production_override(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
+        monkeypatch.setenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", "foo")
+
+        assert _debug_log_to_console_enabled() is False

--- a/tests/server/test_logging_timezone.py
+++ b/tests/server/test_logging_timezone.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import logging
 import re
 
-from reflexio.server import _LLMIOFormatter, _TZAwareFormatter
+from reflexio.server import (
+    _debug_log_to_console_enabled,
+    _LLMIOFormatter,
+    _TZAwareFormatter,
+)
 
 _TZ_PATTERN = re.compile(
     r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [+-]\d{2}:\d{2}(?: [A-Z]{1,5})?"
@@ -48,3 +52,28 @@ class TestLLMIOFormatter:
         record = _make_record("full message payload")
         out = formatter.format(record)
         assert _TZ_PATTERN.search(out), f"header missing TZ offset: {out!r}"
+
+
+class TestConsoleDebugPolicy:
+    def test_debug_console_enabled_in_development(self, monkeypatch) -> None:
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "development")
+        monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
+        monkeypatch.delenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", raising=False)
+
+        assert _debug_log_to_console_enabled() is True
+
+    def test_debug_console_disabled_in_production_by_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
+        monkeypatch.delenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", raising=False)
+
+        assert _debug_log_to_console_enabled() is False
+
+    def test_debug_console_allows_explicit_production_override(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
+        monkeypatch.setenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", "true")
+
+        assert _debug_log_to_console_enabled() is True


### PR DESCRIPTION
## Summary
- Treat DEBUG_LOG_TO_CONSOLE as a local/dev switch by default
- Ignore verbose console logging in production unless REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS=true is explicitly set
- Add tests for development, production, and explicit production override behavior

## Validation
- uv run ruff check open_source/reflexio/reflexio/server/__init__.py open_source/reflexio/tests/server/test_logging_timezone.py
- uv run pytest --no-cov open_source/reflexio/tests/server/test_logging_timezone.py
- uv run pyright open_source/reflexio/reflexio/server/__init__.py open_source/reflexio/tests/server/test_logging_timezone.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved debug logging configuration using explicit, boolean-style environment parsing.
  * Added support for enabling console debug logs in production via a new `REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS` flag.
* **Tests**
  * Expanded logging policy coverage with environment-driven checks for development and production behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->