### PR TITLE
fix(logging): gate production debug logs by runtime env

### DIFF
--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -136,17 +136,15 @@ def _truthy_env(name: str) -> bool:
 
 def _is_production_environment() -> bool:
     """Return whether this process is running in a production deployment."""
-    return os.environ.get("SENTRY_ENVIRONMENT", "").strip().lower() in (
-        "prod",
-        "production",
-    )
+    return os.environ.get("ENVIRONMENT", "").strip().lower() in ("prod", "production")
 
 
 def _debug_log_to_console_enabled() -> bool:
     """Return whether verbose console logging should be enabled.
 
-    ``DEBUG_LOG_TO_CONSOLE`` is a local/dev switch. Production deployments must
-    stay quiet by default even if a copied local env file accidentally sets it;
+    ``DEBUG_LOG_TO_CONSOLE`` is a local/dev switch. Deployments with
+    ``ENVIRONMENT=production`` must stay quiet by default even if a copied local
+    env file accidentally sets it;
     use ``REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS=true`` for a deliberate incident
     override.
     """

--- a/tests/server/test_logging_timezone.py
+++ b/tests/server/test_logging_timezone.py
@@ -56,14 +56,16 @@ class TestLLMIOFormatter:
 
 class TestConsoleDebugPolicy:
     def test_debug_console_enabled_in_development(self, monkeypatch) -> None:
-        monkeypatch.setenv("SENTRY_ENVIRONMENT", "development")
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "acme-dev")
         monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
         monkeypatch.delenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", raising=False)
 
         assert _debug_log_to_console_enabled() is True
 
     def test_debug_console_disabled_in_production_by_default(self, monkeypatch) -> None:
-        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "acme-corp")
         monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
         monkeypatch.delenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", raising=False)
 
@@ -72,7 +74,8 @@ class TestConsoleDebugPolicy:
     def test_debug_console_allows_explicit_production_override(
         self, monkeypatch
     ) -> None:
-        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "acme-corp")
         monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
         monkeypatch.setenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", "true")
 
@@ -81,8 +84,19 @@ class TestConsoleDebugPolicy:
     def test_debug_console_rejects_ambiguous_production_override(
         self, monkeypatch
     ) -> None:
-        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "acme-corp")
         monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
         monkeypatch.setenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", "foo")
 
         assert _debug_log_to_console_enabled() is False
+
+    def test_sentry_environment_does_not_define_production(
+        self, monkeypatch
+    ) -> None:
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
+        monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")
+        monkeypatch.delenv("REFLEXIO_ALLOW_PRODUCTION_DEBUG_LOGS", raising=False)
+
+        assert _debug_log_to_console_enabled() is True


### PR DESCRIPTION
## Summary
- gate DEBUG_LOG_TO_CONSOLE production behavior on ENVIRONMENT=production instead of SENTRY_ENVIRONMENT
- keep SENTRY_ENVIRONMENT as observability metadata so self-host deployments can use customer/deployment labels
- cover company-valued Sentry environments in logging policy tests

## Validation
- uv run pytest --no-cov open_source/reflexio/tests/server/test_logging_timezone.py -q
- uv run ruff check open_source/reflexio/reflexio/server/__init__.py open_source/reflexio/tests/server/test_logging_timezone.py
- uv run pyright open_source/reflexio/reflexio/server/__init__.py open_source/reflexio/tests/server/test_logging_timezone.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated environment detection mechanism for logging configuration
  * Console debug logs now controlled via environment variable settings
  
* **Tests**
  * Updated logging tests to align with new environment detection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->