### PR TITLE
fix(server): harden embedding routing and publish queueing

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -606,6 +606,7 @@ def publish_user_interaction(
                 fn=lambda: publisher_api.add_user_interaction(
                     org_id=org_id, request=payload
                 ),
+                wait_forever=True,
             )
         except TimeoutError:
             logger.warning(

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -236,9 +236,9 @@ def embedding_provider_mode(model: str | None = None) -> EmbeddingProviderMode:
     """Resolve the embedding provider mode for a model.
 
     Explicit legacy env modes keep their historical behavior. With no explicit
-    env mode, routing is model-driven: ``local/*`` uses the local daemon when it
-    is reachable and otherwise falls back to the in-process embedder; cloud
-    models use their provider directly.
+    env mode, routing is model-driven: ``local/*`` uses a configured daemon host
+    authoritatively, otherwise it uses the local daemon when reachable and falls
+    back to the in-process embedder. Cloud models use their provider directly.
     """
     configured = os.environ.get(_ENV_PROVIDER)
     if configured:
@@ -255,6 +255,9 @@ def embedding_provider_mode(model: str | None = None) -> EmbeddingProviderMode:
 
     if os.environ.get(_ENV_SERVICE_URL):
         return "internal_service"
+
+    if _is_local_model(model) and os.environ.get(_ENV_DAEMON_HOST, "").strip():
+        return "local_service"
 
     if _is_local_model(model):
         return "local_service" if _local_service_supports_model(model) else "inprocess"

--- a/reflexio/server/operation_limiter.py
+++ b/reflexio/server/operation_limiter.py
@@ -105,17 +105,26 @@ def operation_limit(
     operation: OperationName,
     *,
     timeout_seconds: float | None = None,
+    wait_forever: bool = False,
 ) -> Any:
     """Acquire the per-org limiter for an operation, recording wait metrics."""
     state = _state_for(org_id, operation)
-    timeout = _timeout_for(operation) if timeout_seconds is None else timeout_seconds
+    timeout = (
+        None
+        if wait_forever
+        else (_timeout_for(operation) if timeout_seconds is None else timeout_seconds)
+    )
     start = time.perf_counter()
     with _limiters_lock:
         state.waiting += 1
         waiting = state.waiting
     acquired = False
     try:
-        acquired = state.semaphore.acquire(timeout=timeout)
+        acquired = (
+            state.semaphore.acquire()
+            if timeout is None
+            else state.semaphore.acquire(timeout=timeout)
+        )
         wait_ms = int((time.perf_counter() - start) * 1000)
         with _limiters_lock:
             state.waiting -= 1
@@ -154,8 +163,14 @@ def run_with_operation_limit[T](
     operation: OperationName,
     fn: Callable[[], T],
     timeout_seconds: float | None = None,
+    wait_forever: bool = False,
 ) -> T:
-    with operation_limit(org_id, operation, timeout_seconds=timeout_seconds):
+    with operation_limit(
+        org_id,
+        operation,
+        timeout_seconds=timeout_seconds,
+        wait_forever=wait_forever,
+    ):
         return fn()
 
 

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -85,6 +85,33 @@ class TestPublishInteraction:
         assert data["success"] is True
         assert "queued" in data["message"].lower()
 
+    def test_async_publish_waits_for_limiter_capacity(self, client, patched_reflexio):
+        captured: dict[str, bool] = {}
+
+        def _fake_run_with_limit(**kwargs):
+            captured["wait_forever"] = kwargs["wait_forever"]
+            return kwargs["fn"]()
+
+        with (
+            patch(
+                "reflexio.server.api.run_with_operation_limit",
+                side_effect=_fake_run_with_limit,
+            ),
+            patch(
+                "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
+                return_value=PublishUserInteractionResponse(
+                    success=True, message="Interaction processed"
+                ),
+            ),
+        ):
+            response = client.post(
+                "/api/publish_interaction",
+                json=self._publish_payload(),
+            )
+
+        assert response.status_code == 200
+        assert captured["wait_forever"] is True
+
     def test_publish_missing_body_returns_422(self, client):
         response = client.post("/api/publish_interaction")
         assert response.status_code == 422

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -113,6 +113,21 @@ def test_local_model_auto_avoids_reachable_mismatched_daemon(monkeypatch) -> Non
     assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
 
 
+def test_configured_daemon_host_forces_local_service_without_probe(monkeypatch) -> None:
+    class _Client:
+        def get(self, *_args, **_kwargs):  # pragma: no cover - should not be called
+            raise AssertionError("configured daemon host should not be health-probed")
+
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_DAEMON_HOST", "embedding.internal")
+    monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
+
+    assert embedding_provider_mode("local/nomic-embed-text-v1.5") == "local_service"
+
+
 def test_local_service_probe_timeout_env_is_honored(monkeypatch) -> None:
     class _HealthResponse:
         status_code = 200
@@ -237,6 +252,7 @@ def test_service_response_is_sorted_by_index(monkeypatch) -> None:
 
     monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("EMBEDDING_PORT", raising=False)
     monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert get_service_embeddings(["a", "b"], model="local/nomic-embed-v1.5") == [
@@ -262,9 +278,35 @@ def test_local_service_daemon_host_override_changes_url(monkeypatch) -> None:
     monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "local_service")
     monkeypatch.setenv("REFLEXIO_EMBEDDING_DAEMON_HOST", "embedding.internal")
     monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("EMBEDDING_PORT", raising=False)
     monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
     assert get_service_embeddings(["a"], model="local/nomic-embed-v1.5") == [[0.1, 0.2]]
+
+
+def test_daemon_host_auto_mode_uses_embedding_port(monkeypatch) -> None:
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"data": [{"index": 0, "embedding": [0.1, 0.2]}]}
+
+    class _Client:
+        def post(self, url: str, *, json: dict, timeout: float) -> _Response:  # noqa: A002, ARG002
+            assert url == "http://embedding.internal:80/v1/embeddings"
+            assert json["model"] == "local/nomic-embed-text-v1.5"
+            return _Response()
+
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_DAEMON_HOST", "embedding.internal")
+    monkeypatch.setenv("EMBEDDING_PORT", "80")
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
+
+    assert get_service_embeddings(["a"], model="local/nomic-embed-text-v1.5") == [
+        [0.1, 0.2]
+    ]
 
 
 def test_service_response_rejects_index_mismatch(monkeypatch) -> None:

--- a/tests/server/test_operation_limiter.py
+++ b/tests/server/test_operation_limiter.py
@@ -56,6 +56,39 @@ def test_operation_limiter_records_success_and_timeout(monkeypatch):
     assert timeout_event.metadata["operation"] == "search"
 
 
+def test_operation_limiter_wait_forever_queues_until_slot_available(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "1")
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    ready = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def _hold_limit() -> None:
+        with operation_limit("org_1", "publish", timeout_seconds=0.1):
+            ready.set()
+            release.wait(timeout=5)
+
+    def _wait_for_limit() -> None:
+        with operation_limit("org_1", "publish", wait_forever=True):
+            finished.set()
+
+    holder = threading.Thread(target=_hold_limit)
+    waiter = threading.Thread(target=_wait_for_limit)
+    holder.start()
+    try:
+        assert ready.wait(timeout=5)
+        waiter.start()
+        assert not finished.wait(timeout=0.05)
+    finally:
+        release.set()
+        holder.join(timeout=5)
+        waiter.join(timeout=5)
+
+    assert finished.is_set()
+    assert [event.event_name for event in events].count("limiter_acquired") == 2
+
+
 def test_limiter_http_exception_maps_search_to_429():
     exc = limiter_http_exception("search")
 


### PR DESCRIPTION
## Summary
- treat REFLEXIO_EMBEDDING_DAEMON_HOST as authoritative for local/* embedding models
- avoid silently falling back to in-process CPU embedding when a remote daemon host is explicitly configured
- allow async publish requests to wait for limiter capacity instead of timing out under publish contention
- add regression coverage for daemon-host routing and limiter queueing

## Validation
- uv run ruff check --fix reflexio/server/api.py reflexio/server/operation_limiter.py tests/server/api_endpoints/test_api_routes.py tests/server/test_operation_limiter.py
- uv run ruff format reflexio/server/api.py reflexio/server/operation_limiter.py tests/server/api_endpoints/test_api_routes.py tests/server/test_operation_limiter.py
- uv run ruff check reflexio/server/api.py reflexio/server/operation_limiter.py tests/server/api_endpoints/test_api_routes.py tests/server/test_operation_limiter.py
- uv run pyright reflexio/server/api.py reflexio/server/operation_limiter.py tests/server/api_endpoints/test_api_routes.py tests/server/test_operation_limiter.py
- uv run pytest --no-cov tests/server/test_operation_limiter.py tests/server/api_endpoints/test_api_routes.py
