### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -6,24 +6,24 @@ Describe the code structure and component dependencies for source code of reflex
 - [Overview](#overview)
 - [models and client](#models-and-client)
 - [cli](#cli)
-- [reflexio_lib](#reflexio_lib)
+- [lib](#lib)
 - [server](#server)
-- [data](#data)
+- [supporting packages](#supporting-packages)
 - [See Also](#see-also)
 
 ## Overview
 Reflexio is a user profiling and agent playbook system with three main access patterns:
 
 1. **Remote API Access** (`client`) - Applications use Python SDK to call REST API
-2. **Local Library Access** (`reflexio_lib`) - Direct synchronous access without HTTP layer
+2. **Local Library Access** (`lib`) - Direct synchronous access without HTTP layer
 3. **CLI Access** (`cli`) - Local command-line workflows for services, publishing, search, auth, config, and diagnostics
 
 **Core Flow**: User Interactions → Server Processing → Profile/Playbook/Evaluation → Storage
 
 **Shared Components**:
 - `models` - API and internal schemas shared by client, CLI, and server
+- `lib` - Local `Reflexio` facade and synchronous operations
 - `server` - FastAPI backend with LLM-based processing services
-- `data` - Bundled configs and local fixtures
 - `docs` - Next.js API documentation site
 
 ## models and client
@@ -80,11 +80,11 @@ Local operator interface to:
 ### Architecture Pattern
 Thin Typer layer over the Python client and local service manager. Use `uv run reflexio --help` to inspect command groups.
 
-## reflexio_lib
+## lib
 Description: Local Python library interface for direct (non-API) access to Reflexio functionality
 
 ### Main Entry Point
-- **Library**: `reflexio_lib.py` - `Reflexio` class
+- **Library**: `lib/reflexio_lib.py` - `Reflexio` class
 
 ### Purpose
 Direct programmatic access without HTTP/API layer:
@@ -93,7 +93,7 @@ Direct programmatic access without HTTP/API layer:
 3. **Testing/debugging** - Useful for local development and testing
 
 ### Architecture Pattern
-Creates `RequestContext` and directly calls `GenerationService` - bypasses FastAPI layer. Methods are **synchronous** unlike `ReflexioClient`.
+Creates `RequestContext` and directly calls server services - bypasses FastAPI layer. Methods are **synchronous** unlike `ReflexioClient`.
 
 ## server
 Description: FastAPI backend server that processes user interactions to generate profiles, extract playbooks, and evaluate agent success
@@ -101,9 +101,9 @@ Description: FastAPI backend server that processes user interactions to generate
 **Detailed Documentation**: See [`reflexio/server/README.md`](server/README.md) for component details, including the [Prompt Bank](server/prompt/prompt_bank/README.md), [Playbook Service](server/services/playbook/README.md), and [Site Variables](server/site_var/README.md)
 
 ### Main Entry Points
-- **API**: `api.py` - FastAPI routes
-- **Endpoint Helpers**: `api_endpoints/` - Request handlers calling `Reflexio` (reflexio_lib)
-- **Core Service**: `services/generation_service.py` - Main orchestrator
+- **API**: `server/api.py` - FastAPI routes
+- **Endpoint Helpers**: `server/api_endpoints/` - Request handlers calling `Reflexio` (`lib/reflexio_lib.py`)
+- **Core Service**: `server/services/generation_service.py` - Main orchestrator
 
 ### Purpose
 Receives user interactions from clients and processes them to:
@@ -114,19 +114,18 @@ Receives user interactions from clients and processes them to:
 ### Component Relationships
 ```
 client (Python SDK)
-  -> api.py (FastAPI routes)
-    -> api_endpoints/ (request handlers)
-      -> reflexio_lib.Reflexio (main entry)
-        -> services/generation_service.py (orchestrator)
-          ├─> services/profile/ -> storage (BaseStorage)
-          ├─> services/playbook/ (playbook extraction) -> storage (BaseStorage)
-          └─> services/agent_success_evaluation/ -> storage (BaseStorage)
+  -> server/api.py (FastAPI routes)
+    -> server/api_endpoints/ (request handlers)
+      -> lib/reflexio_lib.Reflexio (main entry)
+        -> server/services/generation_service.py (orchestrator)
+          ├─> server/services/profile/ -> storage (BaseStorage)
+          ├─> server/services/playbook/ (playbook extraction) -> storage (BaseStorage)
+          └─> server/services/agent_success_evaluation/ -> storage (BaseStorage)
 ```
 
 ### Key Components
 - **`api_endpoints/`**: Request handling, `RequestContext` (bundles storage/config/prompts), auth
-- **`db/`**: Auth & config storage only (SQLite) - NOT for profiles/interactions
-- **`llm/`**: Unified LLM client (auto-detects OpenAI/Claude from model name)
+- **`llm/`**: Unified LiteLLM client plus embedding providers, rerankers, token accounting, and tool helpers
 - **`prompt/`**: Versioned prompt templates in `prompt_bank/`
 - **`services/`**: Core business logic
   - `generation_service.py` - Orchestrator (runs profile/playbook/success services)
@@ -140,7 +139,7 @@ client (Python SDK)
   - `evaluation_overview/` - Evaluation-page aggregates and hero metrics
   - `playbook_optimizer/` - Scenario-based playbook optimization experiments
   - `braintrust/` - Braintrust eval export/sync support
-  - `storage/` - Abstract layer (SQLite prod, LocalJSON test)
+  - `storage/` - Abstract layer (SQLite implementation plus domain-split BaseStorage interfaces)
   - `pre_retrieval/` - Query rewriting and document expansion helpers
   - `configurator/` - YAML config loader
 - **`site_var/`**: Global settings singleton
@@ -157,22 +156,22 @@ client (Python SDK)
 **Data Flow**: `User Interaction -> Storage (save) -> Services (parallel: LLM + Prompts) -> Results -> Storage (save)`
 
 
-## data
-Description: Local storage directory for configuration files and SQLite databases
+## supporting packages
+Description: Small support modules used by tests, examples, and default configuration
 
 ### Main Entry Points
-- **Configs**: `configs/` - YAML configuration files for extractors and evaluators
-- **Database**: `sql_app.db` - SQLite database for auth and config storage
-- **JSON Storage**: `user_profiles_*.json` - Local JSON files for testing
+- **Defaults**: `defaults.py` - package-level defaults shared by CLI/server startup
+- **Test Support**: `test_support/` - LLM mocks and model registries for tests
+- **Benchmarks**: `benchmarks/` - package-local benchmark helpers and reports
 
 ### Purpose
-Local data storage for:
-1. **Configuration files** - YAML configs defining extraction/evaluation behavior
-2. **Authentication database** - User credentials and API tokens (SQLite/Postgres)
-3. **Test data** - LocalJsonStorage files for development/testing
+Support development and evaluation without becoming primary application entry points:
+1. **Defaults** - Keep startup constants near the package
+2. **Testing** - Provide mocks/fixtures for deterministic service tests
+3. **Benchmarking** - Package retrieval-latency benchmark code under importable modules
 
 ### Architecture Pattern
-Referenced by `SimpleConfigurator` for loading configs and by database operations for auth/config persistence. Not directly accessed by application code.
+Application code should enter through `client/`, `cli/`, `lib/`, or `server/`; support modules are imported only by those layers or by tests/benchmarks.
 
 ## See Also
 

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -9,7 +9,6 @@ Description: FastAPI backend server that processes user interactions to generate
 - [LLM Client](#llm-client)
 - [Prompts](#prompts)
 - [Site Variables](#site-variables)
-- [Scripts](#scripts)
 - [Services](#services)
   - [Orchestrator](#orchestrator)
   - [Base Infrastructure](#base-infrastructure)
@@ -90,8 +89,10 @@ Description: FastAPI backend server that processes user interactions to generate
 
 Key files:
 - `litellm_client.py`: Unified LiteLLMClient using LiteLLM for multi-provider support
-- `openai_client.py`: OpenAI implementation (legacy, do not use directly)
-- `claude_client.py`: Claude implementation (legacy, do not use directly)
+- `embedding_service.py`: Local OpenAI-compatible embedding service used by the CLI-managed embedding daemon
+- `providers/`: Optional provider adapters (`local_embedding_provider.py`, `nomic_embedding_provider.py`, `embedding_service_provider.py`, Claude Code provider/stream parser)
+- `rerank/`: Cross-encoder and LLM rerankers used by search flows
+- `token_accounting.py`, `tools.py`: Shared LLM token/tool helpers
 - `llm_utils.py`: Helper functions for Pydantic model conversion
 
 **Features**:
@@ -99,6 +100,7 @@ Key files:
 - **Custom endpoint support**: `CustomEndpointConfig` (model, api_key, api_base) takes priority over all other providers for LLM completion calls when configured with non-empty fields (but not embeddings)
 - **Gemini support**: Model names with `gemini/` prefix route through Google Gemini; API key from `api_key_config.gemini`
 - **OpenRouter support**: Model names with `openrouter/` prefix (e.g., `openrouter/openai/gpt-5-nano`) route through OpenRouter; API key from `api_key_config.openrouter`
+- **Embedding routing**: Embeddings can route through LiteLLM, local providers, or the local embedding service; use `embedding_service.py` / `providers/` rather than adding ad hoc embedding clients.
 - API keys read from environment variables (OPENAI_API_KEY, ANTHROPIC_API_KEY) or `ApiKeyConfig`
 - Interface: `generate_response()`, `generate_chat_response()`, `get_embedding()`
 - **Structured Outputs**: Supports Pydantic models via `response_format` parameter
@@ -152,23 +154,6 @@ Key components:
 **Feature Flags**: Config in `site_var_sources/feature_flags.json`. Each flag has global `enabled` toggle and per-org `enabled_org_ids` allowlist. Unknown flags default to enabled (fail-open). Currently gates: `invitation_only` (global flag, gates registration to require invitation codes), `deduplicator` (gates playbook deduplication).
 
 Access: `SiteVarManager().get_site_var(key)` for raw values, `feature_flags.is_feature_enabled(org_id, name)` for flag checks
-
-## Scripts
-
-**Directory**: `scripts/`
-
-| File | Purpose |
-|------|---------|
-| `manage_invitation_codes.py` | CLI to generate and list invitation codes |
-| `show_raw_feedback_with_interactions.py` | Debug script to display user playbook alongside interaction context |
-
-**Usage**:
-```shell
-python -m reflexio.server.scripts.manage_invitation_codes generate --count 5
-python -m reflexio.server.scripts.manage_invitation_codes generate --count 3 --expires-in-days 30
-python -m reflexio.server.scripts.manage_invitation_codes list
-python -m reflexio.server.scripts.manage_invitation_codes list --show-used
-```
 
 ## Services
 
@@ -242,12 +227,12 @@ Called by API endpoints via `Reflexio`
 **Directory**: `services/profile/`
 
 Key files:
-- `profile_generation_service.py`: Service orchestrator
+- `profile_generation_service.py`: Service orchestrator; finalizes extracted items and writes profile add/delete operations to storage
 - `profile_extractor.py`: Extractor that generates profile updates
-- `profile_updater.py`: Applies updates (add/delete/mention) to storage
+- `profile_generation_service_utils.py`: Profile-generation request/output models and message construction helpers
 - `profile_deduplicator.py`: Deduplicates newly extracted profiles against existing DB profiles using LLM
 
-**Flow**: Interactions → ProfileExtractor (extraction-only) → ProfileDeduplicator (deduplicates new vs existing DB profiles) → ProfileUpdater → Storage
+**Flow**: Interactions → ProfileExtractor (extraction-only) → ProfileDeduplicator (deduplicates new vs existing DB profiles) → ProfileGenerationService finalization → Storage
 
 **Generation Modes** (detailed comparison):
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -28,7 +28,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 
 | Directory | Purpose |
 |-----------|---------|
-| `extraction/` | Resumable extraction agent: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `tools.py`, `plan.py`, `agent_run_records.py`, `invariants.py`. Long-horizon / tool-mediated extraction continues outside the request path. |
+| `extraction/` | Resumable extraction agent: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `prior_answer_search.py`, `agent_run_records.py`, `outcome.py`. Long-horizon / tool-mediated extraction continues outside the request path. |
 
 ## Evaluation, Search & Integrations
 


### PR DESCRIPTION
## Summary
- Syncs model-facing code-map READMEs with the current Reflexio package/server layout, following `how_to_write_readme.md`.
- Removes stale references to deleted server scripts, legacy LLM client files, `profile_updater.py`, and nonexistent `reflexio/db` / `reflexio/data` areas.
- Updates navigation for `lib/reflexio_lib.py`, LLM embedding/provider/rerank modules, and the current async extraction files.

## Repositories/submodules reviewed
- Parent: `yyiilluu/reflexio-enterprise`
- Submodule: `ReflexioAI/reflexio`

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- `git diff --check`
- Targeted stale-token check for removed/nonexistent paths mentioned above

## Notes/Risks
- `open_source/reflexio/README.md` was intentionally not restructured because it is the user-facing public README and is excluded by the parent repository README policy.
- Parent repository submodule pointer was not committed; this PR is scoped to the submodule docs only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comprehensive architecture documentation to reflect revised component structure and organizational paths
  * Enhanced documentation clarity for library, server, and service modules with clarified relationships
  * Refined service pipeline flow descriptions and component dependency documentation
  * Removed outdated configuration sections from service documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->