### PR TITLE
feat: add search latency tracing spans

### DIFF
--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -13,6 +13,7 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.site_var.site_var_manager import SiteVarManager
+from reflexio.server.tracing import profile_step
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -136,32 +137,40 @@ class SearchMixin(ReflexioBase):
         if isinstance(request, dict):
             request = UnifiedSearchRequest(**request)
 
-        config = self.request_context.configurator.get_config()
+        with profile_step(
+            "search.prepare",
+            enabled=bool(request.enable_reformulation),
+            has_conversation_history=bool(request.conversation_history),
+            search_mode=request.search_mode,
+        ):
+            config = self.request_context.configurator.get_config()
+            config_llm_config = config.llm_config if config else None
+
+            # Resolve pre_retrieval_model_name: config override -> site var -> auto-detect.
+            model_setting = SiteVarManager().get_site_var("llm_model_setting")
+            site_var = model_setting if isinstance(model_setting, dict) else {}
+            api_key_config = config.api_key_config if config else None
+
+            pre_retrieval_model_name = resolve_model_name(
+                ModelRole.PRE_RETRIEVAL,
+                site_var_value=site_var.get("pre_retrieval_model_name"),
+                config_override=config_llm_config.pre_retrieval_model_name
+                if config_llm_config
+                else None,
+                api_key_config=api_key_config,
+            )
+            storage = self._get_storage()
+            prompt_manager = self.request_context.prompt_manager
+            retrieval_floor = config.retrieval_floor if config else None
 
         from reflexio.server.services.unified_search_service import run_unified_search
-
-        config_llm_config = config.llm_config if config else None
-
-        # Resolve pre_retrieval_model_name: config override → site var → auto-detect
-        model_setting = SiteVarManager().get_site_var("llm_model_setting")
-        site_var = model_setting if isinstance(model_setting, dict) else {}
-        api_key_config = config.api_key_config if config else None
-
-        pre_retrieval_model_name = resolve_model_name(
-            ModelRole.PRE_RETRIEVAL,
-            site_var_value=site_var.get("pre_retrieval_model_name"),
-            config_override=config_llm_config.pre_retrieval_model_name
-            if config_llm_config
-            else None,
-            api_key_config=api_key_config,
-        )
 
         return run_unified_search(
             request=request,
             org_id=org_id,
-            storage=self._get_storage(),
+            storage=storage,
             llm_client=self.llm_client,
-            prompt_manager=self.request_context.prompt_manager,
+            prompt_manager=prompt_manager,
             pre_retrieval_model_name=pre_retrieval_model_name,
-            retrieval_floor=config.retrieval_floor if config else None,
+            retrieval_floor=retrieval_floor,
         )

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -186,6 +186,7 @@ from reflexio.server.services.agent_success_evaluation.regen_jobs import (
     REGEN_JOBS,
     run_regen,
 )
+from reflexio.server.tracing import profile_step
 
 logger = logging.getLogger(__name__)
 
@@ -935,30 +936,44 @@ def unified_search_endpoint(
     Returns:
         UnifiedSearchViewResponse: Combined search results
     """
-    response = _run_limited_api(
-        org_id,
-        "search",
-        lambda: get_reflexio(org_id=org_id).unified_search(payload, org_id=org_id),
-    )
-    resp = UnifiedSearchViewResponse(
-        success=response.success,
-        profiles=[to_profile_view(p) for p in response.profiles],
-        agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
-        user_playbooks=[to_user_playbook_view(rf) for rf in response.user_playbooks],
-        reformulated_query=response.reformulated_query,
-        msg=response.msg,
-        agent_trace=response.agent_trace,
-        rehydrated_text=response.rehydrated_text,
-    )
-    _meter_applied_learnings(
-        org_id=org_id,
-        caller_type=caller_type,
-        surfaced_count=len(resp.profiles)
-        + len(resp.agent_playbooks)
-        + len(resp.user_playbooks),
-        request_id=getattr(payload, "request_id", None),
-        session_id=getattr(payload, "session_id", None),
-    )
+    with profile_step(
+        "search.endpoint",
+        enabled=bool(payload.enable_reformulation),
+        has_conversation_history=bool(payload.conversation_history),
+        search_mode=payload.search_mode,
+    ):
+
+        def run_search() -> Any:
+            with profile_step("search.reflexio_cache"):
+                reflexio = get_reflexio(org_id=org_id)
+            return reflexio.unified_search(payload, org_id=org_id)
+
+        response = _run_limited_api(org_id, "search", run_search)
+        with profile_step("search.response_view"):
+            resp = UnifiedSearchViewResponse(
+                success=response.success,
+                profiles=[to_profile_view(p) for p in response.profiles],
+                agent_playbooks=[
+                    to_agent_playbook_view(fb) for fb in response.agent_playbooks
+                ],
+                user_playbooks=[
+                    to_user_playbook_view(rf) for rf in response.user_playbooks
+                ],
+                reformulated_query=response.reformulated_query,
+                msg=response.msg,
+                agent_trace=response.agent_trace,
+                rehydrated_text=response.rehydrated_text,
+            )
+        with profile_step("search.meter_applied_learnings"):
+            _meter_applied_learnings(
+                org_id=org_id,
+                caller_type=caller_type,
+                surfaced_count=len(resp.profiles)
+                + len(resp.agent_playbooks)
+                + len(resp.user_playbooks),
+                request_id=getattr(payload, "request_id", None),
+                session_id=getattr(payload, "session_id", None),
+            )
     return resp
 
 

--- a/reflexio/server/cache/reflexio_cache.py
+++ b/reflexio/server/cache/reflexio_cache.py
@@ -8,6 +8,7 @@ from typing import Any, Final
 from cachetools import TTLCache
 
 from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.server.tracing import profile_step
 
 logger = logging.getLogger(__name__)
 
@@ -112,8 +113,14 @@ def get_reflexio(org_id: str, storage_base_dir: str | None = None) -> Reflexio:
 
     # Cache lookup — held briefly to extract the entry, then released
     # before doing any I/O (file stat, DB query) for the version probe.
-    with _reflexio_cache_lock:
-        entry: _CacheEntry | None = _reflexio_cache.get(cache_key)
+    with profile_step("reflexio.cache.lookup") as span:
+        with _reflexio_cache_lock:
+            entry: _CacheEntry | None = _reflexio_cache.get(cache_key)
+        span.set_data("cache_hit", entry is not None)
+        span.set_data(
+            "has_cached_version",
+            entry is not None and entry.cached_version is not None,
+        )
 
     if entry is not None:
         cached_version = entry.cached_version
@@ -122,7 +129,13 @@ def get_reflexio(org_id: str, storage_base_dir: str | None = None) -> Reflexio:
         # rely on TTL + explicit invalidation instead.
         if cached_version is None:
             return entry.reflexio
-        current_version = _probe_version_safe(entry.reflexio)
+        with profile_step("reflexio.cache.version_probe", cache_state="hit") as span:
+            current_version = _probe_version_safe(entry.reflexio)
+            span.set_data("probe_failed", current_version is _PROBE_FAILED)
+            span.set_data(
+                "probe_supported",
+                current_version is not None and current_version is not _PROBE_FAILED,
+            )
         # Transient probe failure: keep the cached instance for this
         # request but DON'T mutate the stamp — the next request will
         # try again, so a brief outage doesn't permanently disable
@@ -134,15 +147,27 @@ def get_reflexio(org_id: str, storage_base_dir: str | None = None) -> Reflexio:
         # Stale entry. Evict only if the cached version still matches
         # the one we just compared against — another thread may have
         # already replaced the entry while we were probing.
-        with _reflexio_cache_lock:
-            existing = _reflexio_cache.get(cache_key)
-            if existing is not None and existing.cached_version == cached_version:
-                del _reflexio_cache[cache_key]
+        with profile_step("reflexio.cache.evict_stale") as span:
+            with _reflexio_cache_lock:
+                existing = _reflexio_cache.get(cache_key)
+                evicted = (
+                    existing is not None and existing.cached_version == cached_version
+                )
+                if evicted:
+                    del _reflexio_cache[cache_key]
+            span.set_data("evicted", evicted)
 
     # Cache miss (or just-evicted stale entry) - create a new instance
     # outside the lock to avoid blocking concurrent requests for other orgs.
-    reflexio = Reflexio(org_id=org_id, storage_base_dir=storage_base_dir)
-    new_version = _probe_version_safe(reflexio)
+    with profile_step("reflexio.cache.construct"):
+        reflexio = Reflexio(org_id=org_id, storage_base_dir=storage_base_dir)
+    with profile_step("reflexio.cache.version_probe", cache_state="miss") as span:
+        new_version = _probe_version_safe(reflexio)
+        span.set_data("probe_failed", new_version is _PROBE_FAILED)
+        span.set_data(
+            "probe_supported",
+            new_version is not None and new_version is not _PROBE_FAILED,
+        )
 
     # Construction-time probe failure: serve this request from the
     # newly-built instance but DON'T cache it. Caching with
@@ -159,13 +184,18 @@ def get_reflexio(org_id: str, storage_base_dir: str | None = None) -> Reflexio:
         cached_version=new_version,  # type: ignore[arg-type]
     )
 
-    with _reflexio_cache_lock:
-        # Double-check in case another thread populated while we were constructing.
-        existing = _reflexio_cache.get(cache_key)
-        if existing is None:
-            _reflexio_cache[cache_key] = new_entry
-            return reflexio
-        return existing.reflexio
+    with profile_step("reflexio.cache.store") as span:
+        with _reflexio_cache_lock:
+            # Double-check in case another thread populated while we were constructing.
+            existing = _reflexio_cache.get(cache_key)
+            stored = existing is None
+            if stored:
+                _reflexio_cache[cache_key] = new_entry
+                result = reflexio
+            else:
+                result = existing.reflexio
+        span.set_data("stored", stored)
+        return result
 
 
 def invalidate_reflexio_cache(org_id: str, storage_base_dir: str | None = None) -> bool:

--- a/reflexio/server/operation_limiter.py
+++ b/reflexio/server/operation_limiter.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 
 from fastapi import HTTPException, status
 
+from reflexio.server.tracing import profile_step
 from reflexio.server.usage_metrics import record_usage_event
 
 OperationName = Literal["search", "publish", "aggregation"]
@@ -120,12 +121,20 @@ def operation_limit(
         waiting = state.waiting
     acquired = False
     try:
-        acquired = (
-            state.semaphore.acquire()
-            if timeout is None
-            else state.semaphore.acquire(timeout=timeout)
-        )
-        wait_ms = int((time.perf_counter() - start) * 1000)
+        with profile_step(
+            f"{operation}.operation_limit.acquire",
+            limit=state.limit,
+            waiting=waiting,
+            wait_forever=wait_forever,
+        ) as span:
+            acquired = (
+                state.semaphore.acquire()
+                if timeout is None
+                else state.semaphore.acquire(timeout=timeout)
+            )
+            wait_ms = int((time.perf_counter() - start) * 1000)
+            span.set_data("wait_ms", wait_ms)
+            span.set_data("acquired", acquired)
         with _limiters_lock:
             state.waiting -= 1
             waiting_after = state.waiting

--- a/tests/lib/test_search_unit.py
+++ b/tests/lib/test_search_unit.py
@@ -4,6 +4,8 @@ Tests get_agent_success_evaluation_results, get_requests, and
 unified_search with mocked storage.
 """
 
+from contextlib import contextmanager
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from reflexio.lib._search import SearchMixin
@@ -15,6 +17,7 @@ from reflexio.models.api_schema.retriever_schema import (
     UnifiedSearchResponse,
 )
 from reflexio.models.api_schema.service_schemas import Interaction, Request
+from reflexio.server.tracing import configure_tracer
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,7 +39,7 @@ def _make_mixin(*, storage_configured: bool = True) -> SearchMixin:
 
 
 def _get_storage(mixin: SearchMixin) -> MagicMock:
-    return mixin.request_context.storage
+    return cast(MagicMock, mixin.request_context.storage)
 
 
 # ---------------------------------------------------------------------------
@@ -198,7 +201,9 @@ class TestUnifiedSearch:
         mixin.llm_client = MagicMock()
         mock_config = MagicMock()
         mock_config.llm_config = None
-        mixin.request_context.configurator.get_config.return_value = mock_config
+        cast(Any, mixin.request_context.configurator.get_config).return_value = (
+            mock_config
+        )
 
         expected_response = UnifiedSearchResponse(success=True)
 
@@ -215,6 +220,59 @@ class TestUnifiedSearch:
         assert call_kwargs["org_id"] == "org_1"
         assert call_kwargs["llm_client"] is mixin.llm_client
         assert "pre_retrieval_model_name" in call_kwargs
+
+    def test_prepare_span_wraps_setup_before_service_dispatch(self):
+        """Emits a setup span before the first phase-A search span."""
+        mixin = _make_mixin()
+        mixin.llm_client = MagicMock()
+        mock_config = MagicMock()
+        mock_config.llm_config = None
+        cast(Any, mixin.request_context.configurator.get_config).return_value = (
+            mock_config
+        )
+
+        events: list[tuple[str, str, dict[str, object] | None]] = []
+
+        class RecordingTracer:
+            @contextmanager
+            def span(self, name: str, **data: object):
+                events.append(("span_start", name, data))
+                yield MagicMock()
+                events.append(("span_end", name, None))
+
+        expected_response = UnifiedSearchResponse(success=True)
+
+        def run_service(**_kwargs):
+            events.append(("run_service", "run_unified_search", None))
+            return expected_response
+
+        configure_tracer(RecordingTracer())
+        try:
+            with patch(
+                "reflexio.server.services.unified_search_service.run_unified_search",
+                side_effect=run_service,
+            ):
+                request = UnifiedSearchRequest(
+                    query="test query", enable_reformulation=True
+                )
+                response = mixin.unified_search(request, org_id="org_1")
+        finally:
+            configure_tracer(None)
+
+        assert response is expected_response
+        assert events == [
+            (
+                "span_start",
+                "search.prepare",
+                {
+                    "enabled": True,
+                    "has_conversation_history": False,
+                    "search_mode": request.search_mode,
+                },
+            ),
+            ("span_end", "search.prepare", None),
+            ("run_service", "run_unified_search", None),
+        ]
 
     def test_storage_not_configured(self):
         """Returns success with message when storage is not configured."""
@@ -237,7 +295,9 @@ class TestUnifiedSearch:
         mixin.llm_client = MagicMock()
         mock_config = MagicMock()
         mock_config.llm_config = None
-        mixin.request_context.configurator.get_config.return_value = mock_config
+        cast(Any, mixin.request_context.configurator.get_config).return_value = (
+            mock_config
+        )
 
         expected_response = UnifiedSearchResponse(success=True)
 

--- a/tests/server/cache/test_reflexio_cache.py
+++ b/tests/server/cache/test_reflexio_cache.py
@@ -11,6 +11,7 @@ Covers:
 7. Version-based auto-invalidation: stale entries are evicted on next get
 """
 
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ from reflexio.server.cache.reflexio_cache import (
     get_reflexio,
     invalidate_reflexio_cache,
 )
+from reflexio.server.tracing import configure_tracer
 
 # =============================================================================
 # Fixtures
@@ -31,8 +33,31 @@ from reflexio.server.cache.reflexio_cache import (
 def _clean_cache():
     """Clear the module-level cache before and after every test."""
     clear_reflexio_cache()
+    configure_tracer(None)
     yield
     clear_reflexio_cache()
+    configure_tracer(None)
+
+
+class _RecordingSpan:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def set_data(self, key: str, value: object) -> None:
+        self.data[key] = value
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.started: list[tuple[str, dict[str, object]]] = []
+        self.spans: list[_RecordingSpan] = []
+
+    @contextmanager
+    def span(self, name: str, **data: object):
+        span = _RecordingSpan()
+        self.started.append((name, data))
+        self.spans.append(span)
+        yield span
 
 
 # =============================================================================
@@ -117,6 +142,37 @@ class TestGetReflexio:
         mock_reflexio_cls.assert_called_once_with(
             org_id="org-1", storage_base_dir="/custom/dir"
         )
+
+    @patch("reflexio.server.cache.reflexio_cache.Reflexio")
+    def test_cache_lookup_and_probe_emit_spans(self, mock_reflexio_cls: MagicMock):
+        """Cache misses and hits are visible as separate trace spans."""
+        tracer = _RecordingTracer()
+        configure_tracer(tracer)
+        mock_reflexio_cls.return_value = _stub_reflexio(("config", 1))
+
+        first = get_reflexio("org-1")
+        second = get_reflexio("org-1")
+
+        assert first is second
+        names = [name for name, _data in tracer.started]
+        assert names == [
+            "reflexio.cache.lookup",
+            "reflexio.cache.construct",
+            "reflexio.cache.version_probe",
+            "reflexio.cache.store",
+            "reflexio.cache.lookup",
+            "reflexio.cache.version_probe",
+        ]
+        assert tracer.spans[0].data == {
+            "cache_hit": False,
+            "has_cached_version": False,
+        }
+        assert tracer.started[2][1] == {"cache_state": "miss"}
+        assert tracer.spans[4].data == {
+            "cache_hit": True,
+            "has_cached_version": True,
+        }
+        assert tracer.started[5][1] == {"cache_state": "hit"}
 
 
 # =============================================================================

--- a/tests/server/test_operation_limiter.py
+++ b/tests/server/test_operation_limiter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+from contextlib import contextmanager
 
 import pytest
 from fastapi import status
@@ -10,16 +11,40 @@ from reflexio.server.operation_limiter import (
     operation_limit,
     reset_operation_limiters_for_tests,
 )
+from reflexio.server.tracing import configure_tracer
 from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
 
 
 @pytest.fixture(autouse=True)
 def _reset_limiters_and_metrics():
     reset_operation_limiters_for_tests()
+    configure_tracer(None)
     configure_usage_event_recorder(None)
     yield
     reset_operation_limiters_for_tests()
+    configure_tracer(None)
     configure_usage_event_recorder(None)
+
+
+class _RecordingSpan:
+    def __init__(self) -> None:
+        self.data: dict[str, object] = {}
+
+    def set_data(self, key: str, value: object) -> None:
+        self.data[key] = value
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.started: list[tuple[str, dict[str, object]]] = []
+        self.spans: list[_RecordingSpan] = []
+
+    @contextmanager
+    def span(self, name: str, **data: object):
+        span = _RecordingSpan()
+        self.started.append((name, data))
+        self.spans.append(span)
+        yield span
 
 
 def test_operation_limiter_records_success_and_timeout(monkeypatch):
@@ -54,6 +79,24 @@ def test_operation_limiter_records_success_and_timeout(monkeypatch):
     assert timeout_event.event_category == "limiter"
     assert timeout_event.pipeline == "search"
     assert timeout_event.metadata["operation"] == "search"
+
+
+def test_operation_limiter_emits_acquire_span(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_SEARCH_CONCURRENCY_LIMIT", "3")
+    tracer = _RecordingTracer()
+    configure_tracer(tracer)
+
+    with operation_limit("org_1", "search", timeout_seconds=0.1):
+        pass
+
+    assert tracer.started == [
+        (
+            "search.operation_limit.acquire",
+            {"limit": 3, "waiting": 1, "wait_forever": False},
+        )
+    ]
+    assert tracer.spans[0].data["acquired"] is True
+    assert isinstance(tracer.spans[0].data["wait_ms"], int)
 
 
 def test_operation_limiter_wait_forever_queues_until_slot_available(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds trace visibility for the blank time before `/api/search` reaches reformulation.
- Breaks the search path into spans for endpoint work, operation limiting, Reflexio cache lookup, and unified-search preparation.
- Keeps span attributes low-cardinality and avoids query text or other sensitive payload data.

## Changes
- Wrap `/api/search` endpoint setup, response shaping, and usage-metering work in `profile_step` spans.
- Add Reflexio cache lookup, version-probe, construction, eviction, and store spans.
- Add operation limiter acquire timing and unified search prepare-phase instrumentation.
- Add focused tracer tests for the new spans.

## Test Plan
- `uv run ruff check --fix reflexio/lib/_search.py reflexio/server/api.py reflexio/server/cache/reflexio_cache.py reflexio/server/operation_limiter.py tests/lib/test_search_unit.py tests/server/cache/test_reflexio_cache.py tests/server/test_operation_limiter.py`
- `uv run pyright reflexio/lib/_search.py reflexio/server/api.py reflexio/server/cache/reflexio_cache.py reflexio/server/operation_limiter.py tests/lib/test_search_unit.py tests/server/cache/test_reflexio_cache.py tests/server/test_operation_limiter.py`
- `uv run pytest tests/lib/test_search_unit.py tests/server/cache/test_reflexio_cache.py tests/server/test_operation_limiter.py -q --no-cov`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added comprehensive observability instrumentation across search operations, API endpoints, cache management, and concurrency limiting to enhance system monitoring and performance diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->