### PR TITLE
fix(server): harden runtime defaults

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -583,7 +583,7 @@ class RetrievalFloorConfig(BaseModel):
     weak tail that drives false-positive citations. Calibrate per arm on real data.
     """
 
-    enabled: bool = True
+    enabled: bool = False
     pool_size: int = Field(
         default=30,
         gt=0,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -267,8 +267,41 @@ def get_rate_limit_key(request: Request) -> str:
     return get_remote_address(request)
 
 
+def _storage_backend_name(limiter_obj: Limiter) -> str:
+    storage = getattr(limiter_obj, "_storage", None)
+    if storage is None:
+        return "unknown"
+    return storage.__class__.__name__
+
+
+def _trace_external_rate_limit_backend(limiter_obj: Limiter) -> None:
+    """Trace rate-limit storage hits when the backend is an external service."""
+    backend = _storage_backend_name(limiter_obj)
+    if backend == "MemoryStorage":
+        return
+
+    strategy = getattr(limiter_obj, "limiter", None)
+    if strategy is None or getattr(strategy, "_reflexio_traced", False):
+        return
+
+    original_hit = strategy.hit
+
+    def traced_hit(item: Any, *identifiers: str, cost: int = 1) -> bool:
+        with profile_step(
+            "rate_limit.backend_hit",
+            storage_backend=backend,
+            strategy=strategy.__class__.__name__,
+            cost=cost,
+        ):
+            return original_hit(item, *identifiers, cost=cost)
+
+    strategy.hit = traced_hit
+    strategy._reflexio_traced = True
+
+
 # Initialize rate limiter
 limiter = Limiter(key_func=get_rate_limit_key)
+_trace_external_rate_limit_backend(limiter)
 
 
 def _run_limited_api[T](

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -521,7 +521,7 @@ def root() -> dict[str, str]:
 
 
 @core_router.get("/health")
-def health_check() -> dict[str, str]:
+async def health_check() -> dict[str, str]:
     """Health check endpoint for ECS/container orchestration."""
     return {"status": "healthy"}
 
@@ -607,7 +607,7 @@ def publish_user_interaction(
                 fn=lambda: publisher_api.add_user_interaction(
                     org_id=org_id, request=payload
                 ),
-                wait_forever=True,
+                wait_forever=False,
             )
         except TimeoutError:
             logger.warning(

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -6,6 +6,7 @@ fixture from conftest to isolate tests from real storage/LLM calls.
 """
 
 import tempfile
+from inspect import iscoroutinefunction
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -35,6 +36,11 @@ class TestHealthEndpoints:
         response = client.get("/health")
         assert response.status_code == 200
         assert response.json()["status"] == "healthy"
+
+    def test_health_check_is_async(self, client):
+        """Keep container healthchecks off the shared sync worker threadpool."""
+        route = next(route for route in client.app.routes if route.path == "/health")
+        assert iscoroutinefunction(route.endpoint)
 
 
 class TestPublishInteraction:
@@ -85,7 +91,9 @@ class TestPublishInteraction:
         assert data["success"] is True
         assert "queued" in data["message"].lower()
 
-    def test_async_publish_waits_for_limiter_capacity(self, client, patched_reflexio):
+    def test_async_publish_does_not_wait_forever_for_limiter_capacity(
+        self, client, patched_reflexio
+    ):
         captured: dict[str, bool] = {}
 
         def _fake_run_with_limit(**kwargs):
@@ -110,7 +118,7 @@ class TestPublishInteraction:
             )
 
         assert response.status_code == 200
-        assert captured["wait_forever"] is True
+        assert captured["wait_forever"] is False
 
     def test_publish_missing_body_returns_422(self, client):
         response = client.post("/api/publish_interaction")


### PR DESCRIPTION
## Summary
- Harden default runtime behavior for server endpoints that can affect production responsiveness.
- Disable the retrieval relevance floor by default until it is calibrated per arm.
- Keep `/health` async, make publish queueing fail fast, and trace external rate-limit backend latency.

## Changes
- Set `RetrievalFloorConfig.enabled` default to `False`.
- Convert the `/health` route handler to `async` so healthchecks avoid the shared sync worker pool.
- Pass `wait_forever=False` when publishing interactions through the operation limiter.
- Wrap non-memory rate-limit strategy hits in `profile_step("rate_limit.backend_hit")` for backend latency visibility.
- Update API route tests to lock in the async healthcheck and non-blocking publish behavior.

## Test Plan
- `uv run ruff check --fix reflexio/models/config_schema.py reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- `uv run ruff format reflexio/models/config_schema.py reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- `uv run ruff check --fix reflexio/server/api.py`
- `uv run ruff format reflexio/server/api.py`
- `uv run pyright reflexio/server/api.py`
- `uv run pytest --no-cov tests/server/api_endpoints/test_api_routes.py`
- `git diff --check origin/main...HEAD`

Note: `uv run pytest tests/server/api_endpoints/test_api_routes.py` previously passed all 20 tests but failed the repo-wide coverage threshold because only one test file was selected.
