### PR TITLE
test: fix stale/environment-fragile tests (nightly check-and-test)

### DIFF
--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from reflexio.server.usage_metrics import record_usage_event
 
-_INTERNAL = "internal"   # == BillingCallerType.INTERNAL.value (kept literal; OSS stays clean)
+_INTERNAL = (
+    "internal"  # == BillingCallerType.INTERNAL.value (kept literal; OSS stays clean)
+)
 
 
 def record_extraction_tokens(

--- a/reflexio/server/services/extraction/outcome.py
+++ b/reflexio/server/services/extraction/outcome.py
@@ -26,7 +26,9 @@ class ExtractionOutcome[T]:
         run_id: str | None = None,
         token_totals: RunTokenTotals | None = None,
     ) -> ExtractionOutcome[T]:
-        return cls(status="completed", items=items, run_id=run_id, token_totals=token_totals)
+        return cls(
+            status="completed", items=items, run_id=run_id, token_totals=token_totals
+        )
 
     @classmethod
     def empty(cls, *, run_id: str | None = None) -> ExtractionOutcome[T]:

--- a/tests/cli/test_env_loader_mode.py
+++ b/tests/cli/test_env_loader_mode.py
@@ -34,6 +34,11 @@ def test_mode_filename(tmp_path, monkeypatch):
         "DEPLOYMENT_MODE=platform\nBACKEND_PORT=8091\n"
     )
     monkeypatch.setenv("DEPLOYMENT_MODE", "platform")
+    # The loader uses override=False, so an ambient BACKEND_PORT already present in
+    # the process environment (e.g. exported by the shell running the test suite)
+    # would win over the file value. Clear it first so this test exercises file
+    # loading rather than whatever the surrounding shell happens to export.
+    monkeypatch.delenv("BACKEND_PORT", raising=False)
     loaded = env_loader.load_reflexio_env_for_mode()
     assert loaded is not None and loaded.name == ".env.platform"
     assert os.environ["BACKEND_PORT"] == "8091"

--- a/tests/e2e_tests/test_interaction_workflows.py
+++ b/tests/e2e_tests/test_interaction_workflows.py
@@ -19,7 +19,13 @@ from reflexio.server.services.agent_success_evaluation.group_evaluation_runner i
 )
 from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
-pytestmark = pytest.mark.e2e
+# These workflows publish a full 16-interaction conversation, which triggers
+# cold loading of the local embedder + cross-encoder on first use. Under the
+# default parallel run (-n auto) on a contended CI box, several workers load
+# models at once and a single publish can exceed the global per-test timeout
+# (120s), turning a correct test into a spurious timeout failure. Give them a
+# generous per-test budget so only genuine hangs fail.
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(300)]
 
 
 @skip_in_precommit

--- a/tests/server/llm/test_embedding_service_concurrency.py
+++ b/tests/server/llm/test_embedding_service_concurrency.py
@@ -106,10 +106,12 @@ def test_embed_texts_caps_and_queues(monkeypatch: pytest.MonkeyPatch) -> None:
     # All six requests completed — they queued, none were rejected.
     assert errors == []
     assert recorder.calls == 6
-    # The semaphore never let more than the configured limit run at once.
-    assert recorder.peak <= 2
-    # ...and concurrency was actually exercised (not accidentally serialized).
-    assert recorder.peak >= 2
+    # Model inference itself is serialized by _MODEL_ENCODE_LOCK (see PR #153:
+    # concurrent .embed() calls on the shared, non-thread-safe model corrupt each
+    # other's tensors). The semaphore only bounds how many requests sit waiting
+    # for that lock; the recorder counts time inside embed(), which the lock
+    # makes mutually exclusive, so the peak simultaneous-encode count is exactly 1.
+    assert recorder.peak == 1
 
 
 def test_micro_batches_concurrent_requests(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/server/services/test_unified_search_floor.py
+++ b/tests/server/services/test_unified_search_floor.py
@@ -47,7 +47,9 @@ def test_floor_applied_per_arm(monkeypatch):
             storage=cast(BaseStorage, _FakeStorage()),
             llm_client=cast(LiteLLMClient, object()),
             prompt_manager=cast(PromptManager, object()),
-            retrieval_floor=RetrievalFloorConfig(user_playbook_floor=-5.0),
+            retrieval_floor=RetrievalFloorConfig(
+                enabled=True, user_playbook_floor=-5.0
+            ),
         )
 
     assert resp.success is True

--- a/tests/server/test_recycle_smoke_integration.py
+++ b/tests/server/test_recycle_smoke_integration.py
@@ -82,7 +82,9 @@ def test_daemon_mode_recycles_worker_after_max_requests() -> None:
     )
     try:
         url = f"http://127.0.0.1:{port}/healthz"
-        _wait_for_healthz(url, timeout=45.0)
+        # Cold start loads the local embedder + cross-encoder reranker into each
+        # worker, which is slow on a contended CI box — give it a generous budget.
+        _wait_for_healthz(url, timeout=90.0)
         # Collect an initial set of worker PIDs by hammering the endpoint a few times.
         initial_pids: set[int] = set()
         for _ in range(10):
@@ -96,9 +98,11 @@ def test_daemon_mode_recycles_worker_after_max_requests() -> None:
             with contextlib.suppress(httpx.HTTPError):
                 httpx.get(url, timeout=2.0)
 
-        # Let the supervisor respawn any recycled workers.
+        # Let the supervisor respawn any recycled workers. A respawned worker
+        # reloads the embedder + reranker models from scratch, so it can take far
+        # longer than a warm request to start serving again — wait accordingly.
         time.sleep(3.0)
-        _wait_for_healthz(url, timeout=15.0)
+        _wait_for_healthz(url, timeout=90.0)
 
         # Now collect post-traffic PIDs.
         post_pids: set[int] = set()


### PR DESCRIPTION
Companion to ReflexioAI/reflexio-enterprise#240, opened by the nightly **check-and-test** run.

These tests passed in isolation but failed in the full run because they were stale relative to intentional behavior changes, or fragile to the CI environment:

- **test_env_loader_mode**: isolate ambient `BACKEND_PORT` — the loader is `override=False`, so a `BACKEND_PORT` exported by the suite's shell wins over the file value.
- **test_unified_search_floor**: enable the relevance floor explicitly; its default was flipped to off in #161.
- **test_embedding_service_concurrency**: assert serialized model inference (`peak == 1`); #153 added `_MODEL_ENCODE_LOCK` to stop the concurrent-encode tensor race, so encodes no longer overlap.
- **test_recycle_smoke_integration**: raise the `/healthz` readiness timeouts — a recycled worker reloads the embedder + cross-encoder, which exceeds the old budget on a contended box.
- **test_interaction_workflows**: add a `timeout(300)` marker so cold embedder + reranker loads under the default `-n auto` run don't spuriously hit the 120s per-test timeout.

Also includes ruff-format normalization of two source files.

Verified: the fixed tests pass with and without the ambient env that originally broke them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by isolating environment variables and strengthening assertions for concurrency control and unified search configuration.
  * Increased timeout budgets for end-to-end workflows and integration tests to accommodate model loading under resource constraints.

* **Refactor**
  * Restructured internal billing constant and reformatted code for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->