### PR TITLE
fix(tests): align 3 stale OSS test assertions with intentional defaults

### DIFF
--- a/tests/server/llm/test_litellm_client.py
+++ b/tests/server/llm/test_litellm_client.py
@@ -574,7 +574,7 @@ class TestLiteLLMClientEdgeCases:
         assert config.temperature == 0.7
         assert config.max_tokens is None
         assert config.timeout == 120
-        assert config.max_retries == 1
+        assert config.max_retries == 3
         assert config.retry_delay == 1.0
         assert config.top_p == 1.0
 


### PR DESCRIPTION
## Summary

Nightly `/check-and-test` run found 3 OSS unit-test failures that were **stale assertions lagging intentional behavior changes on main**. The application code is correct; the tests are fixed to match.

| Test | Was | Now | Why |
|------|-----|-----|-----|
| `test_unified_search_floor::test_floor_applied_per_arm` | `RetrievalFloorConfig(user_playbook_floor=-5.0)` | adds `enabled=True` | The `enabled` default flipped `True`→`False`; the floor-applied test must opt in. |
| `test_litellm_client::test_config_defaults` | `max_retries == 1` | `max_retries == 3` | #124 adopted native litellm `num_retries`; default is now 3. |
| `test_embedding_service_concurrency::test_embed_texts_caps_and_queues` | `peak >= 2` | `peak == 1` | #153 added `_MODEL_ENCODE_LOCK` serializing inference (tensor-race fix); encode peak is always 1. |

Also includes pre-existing ruff-format drift in `billing_meter.py` and `extraction/outcome.py` (formatting only).

## Verification
Full OSS unit + integration suite: **3061 passed, 0 failed** (`pytest tests/ --ignore=tests/e2e_tests/`, mocked LLM).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for concurrency behavior and configuration defaults
* **Refactor**
  * Improved internal code structure and formatting for maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->