### PR TITLE
test: raise recycle smoke-test cold-start budget to 180s

### DIFF
--- a/tests/server/test_recycle_smoke_integration.py
+++ b/tests/server/test_recycle_smoke_integration.py
@@ -83,8 +83,13 @@ def test_daemon_mode_recycles_worker_after_max_requests() -> None:
     try:
         url = f"http://127.0.0.1:{port}/healthz"
         # Cold start loads the local embedder + cross-encoder reranker into each
-        # worker, which is slow on a contended CI box — give it a generous budget.
-        _wait_for_healthz(url, timeout=90.0)
+        # worker. With --workers 2 the manager brings workers up roughly serially,
+        # so a clean cold start already takes ~70s even with models cached; a
+        # worker death+respawn re-triggers a full model reload, and a contended box
+        # (this test runs at the tail of the parallel suite) stretches it further.
+        # Give it a generous budget so the recycle assertion isn't masked by a
+        # too-tight readiness deadline.
+        _wait_for_healthz(url, timeout=180.0)
         # Collect an initial set of worker PIDs by hammering the endpoint a few times.
         initial_pids: set[int] = set()
         for _ in range(10):
@@ -102,7 +107,7 @@ def test_daemon_mode_recycles_worker_after_max_requests() -> None:
         # reloads the embedder + reranker models from scratch, so it can take far
         # longer than a warm request to start serving again — wait accordingly.
         time.sleep(3.0)
-        _wait_for_healthz(url, timeout=90.0)
+        _wait_for_healthz(url, timeout=180.0)
 
         # Now collect post-traffic PIDs.
         post_pids: set[int] = set()


### PR DESCRIPTION
## What

`test_daemon_mode_recycles_worker_after_max_requests` flaked under `/check-and-test`: `RuntimeError: server ... did not become ready in 90.0s`.

## Root cause (not an app bug)

The server itself is healthy — a single worker starts reliably. With `--workers 2` the uvicorn manager brings workers up roughly serially, so even with the embedder + cross-encoder models **cached**, a clean cold start to first `/healthz` 200 already takes **~67s** (measured). A worker death+respawn during startup re-triggers a full model reload, and on a contended box (this test runs at the tail of the parallel suite) it blows past the old 90s readiness budget. The survivors always reach `Application startup complete`, so the recycle behavior under test is correct.

## Fix

Raise both `_wait_for_healthz` cold-start budgets from 90s → 180s. The behavioral assertion (a new worker PID appears after exceeding `--max-requests`) is unchanged.

## Verification

Passes in isolation after the change (`1 passed in 395.98s`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended timeout for backend health check endpoint polling from 90 to 180 seconds during initial cold start and worker recycling scenarios to improve integration test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->