### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/server/prompt/prompt_bank/README.md
+++ b/reflexio/server/prompt/prompt_bank/README.md
@@ -14,12 +14,18 @@ File-based versioned prompt templates for LLM operations.
 ```
 prompt_bank/
 ├── README.md
+├── memory_reflection/
+│   └── v1.7.0.prompt.md      ← active: true
 ├── playbook_aggregation/
-│   ├── v1.0.0.prompt.md
-│   ├── v1.1.0.prompt.md
-│   └── v2.1.0.prompt.md      ← active: true in frontmatter
+│   └── v2.3.0.prompt.md      ← active: true
+├── playbook_consolidation/
+│   └── v2.3.3.prompt.md      ← active: true
+├── playbook_extraction_context/
+│   └── v4.3.0.prompt.md      ← active: true
+├── playbook_extraction_main/
+│   └── v1.3.0.prompt.md      ← active: true
 ├── query_reformulation/
-│   └── v1.0.0.prompt.md      ← active: true (only version)
+│   └── v1.0.0.prompt.md      ← active: true
 └── ...
 ```
 

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -8,7 +8,7 @@ Description: Playbook extraction, aggregation, and consolidation pipeline
 - **Service Orchestrator**: `playbook_generation_service.py` - Manages playbook extraction lifecycle (regular, rerun, manual modes)
 - **Playbook Extractor**: `playbook_extractor.py` - Extracts user playbooks from interactions via LLM
 - **Playbook Aggregator**: `playbook_aggregator.py` - Clusters similar user playbooks and generates aggregated insights
-- **Playbook Consolidator**: `playbook_consolidator.py` - Reconciles newly extracted playbooks against existing storage via LLM. Decides per pair to merge as duplicates, prefer the new entry, prefer the existing entry, differentiate (split with refined triggers), or keep both as independent
+- **Playbook Consolidator**: `playbook_consolidator.py` - Reconciles newly extracted playbooks against existing storage via hybrid search + LLM. Decisions are `unify`, `reject_new`, `differentiate`, or `independent`.
 
 ## Supporting Files
 
@@ -56,13 +56,12 @@ Triggered manually via `/api/run_playbook_aggregation`. Clusters user playbooks 
 
 ### Playbook Consolidation (`playbook_consolidator.py`)
 
-Consolidates newly extracted playbooks against existing playbooks in the database via LLM semantic matching. For each NEW vs EXISTING pair the LLM returns one of five decision kinds, and the consolidator applies the chosen kind:
+Consolidates newly extracted playbooks against existing playbooks in the database. It first retrieves likely matches with hybrid search (embedding + text), then asks the LLM for one of four decision kinds:
 
-- `duplicate` — merge multiple rows into one, archiving members and emitting one merged row.
-- `prefer_new` — archive the existing row and insert the new candidate unchanged.
-- `prefer_existing` — drop the new candidate; the existing row wins.
-- `differentiate` — archive the existing row and emit two refined rows (one per side) with sharpened triggers.
-- `independent` — both rows are kept; the new candidate is inserted alongside the existing row.
+- `unify` — combine duplicate/overlapping entries into one row and archive referenced existing rows.
+- `reject_new` — drop the new candidate because an existing row already covers it.
+- `differentiate` — archive the existing row and emit two refined rows with sharpened triggers.
+- `independent` — keep the new candidate as a separate row.
 
 A safety fallback inserts any new candidate that no decision consumed, so extracted data is never silently dropped on a malformed LLM response.
 


### PR DESCRIPTION
## Summary
- Syncs code-map README content with the latest repo state following `/root/reflexio-enterprise/how_to_write_readme.md`.
- Updates the prompt bank map to show current active prompt versions for recently changed prompt families.
- Updates the playbook service map to reflect the current four-kind consolidation decision contract and hybrid search + LLM flow.

## Repositories/submodules reviewed
- Parent: `yyiilluu/reflexio-enterprise`
- Submodule: `ReflexioAI/reflexio`

## README files updated
- `reflexio/server/prompt/prompt_bank/README.md`
- `reflexio/server/services/playbook/README.md`

## Validation
- `git diff --check`
- Practical local README path/link check for the changed README files

## Notes/Risks
- `open_source/reflexio/README.md` was treated as a user-facing public README and was not restructured as a code map.
- Changes are documentation-only and intentionally limited to code-map READMEs.
- The parent repository submodule pointer was not committed; this PR is scoped to the submodule repository only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prompt bank documentation with current directory structure, including new memory reflection prompt directory and latest active prompt versions.
  * Revised Playbook Consolidator documentation to describe the hybrid-search matching approach followed by LLM-based decision classification system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->