### PR TITLE
fix: optimize evaluation overview reads

### DIFF
--- a/reflexio/models/api_schema/internal_schema.py
+++ b/reflexio/models/api_schema/internal_schema.py
@@ -26,3 +26,21 @@ class SessionDescriptor(NamedTuple):
     session_id: str
     agent_version: str
     source: str
+
+
+class SessionFirstRequest(NamedTuple):
+    """Earliest request metadata for one session."""
+
+    session_id: str
+    user_id: str
+    source: str
+    created_at: int
+
+
+class SessionCitation(NamedTuple):
+    """One cited rule/profile occurrence, keyed by session."""
+
+    session_id: str
+    kind: str
+    real_id: str
+    title: str

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -2257,10 +2257,8 @@ def _read_grade_on_demand_cache(
 def _resolve_session_user_id(storage: Any, session_id: str) -> str | None:
     """Look up the user_id that owns a session_id without requiring it as input.
 
-    Uses ``get_sessions(session_id=...)`` because it's the only storage
-    method on ``BaseStorage`` that accepts session_id alone — every other
-    request-fetcher requires a user_id paired with it. Returns None when
-    the session has no requests, signalling NO_REQUESTS to the caller.
+    Uses the first-request bulk helper even for this single-session path so the
+    lookup can use the same indexed query shape as evaluation overview.
 
     Args:
         storage: The request's storage backend.
@@ -2270,12 +2268,11 @@ def _resolve_session_user_id(storage: Any, session_id: str) -> str | None:
         str | None: The user_id of the earliest request in the session,
         or None when no requests exist.
     """
-    sessions = storage.get_sessions(session_id=session_id, top_k=100)
-    rows = sessions.get(session_id) or []
-    if not rows:
+    first_requests = storage.get_first_requests_by_session_ids([session_id])
+    first = first_requests.get(session_id)
+    if first is None:
         return None
-    earliest = min(rows, key=lambda r: r.request.created_at)
-    return earliest.request.user_id
+    return first.user_id
 
 
 def _find_fresh_result_id(
@@ -2288,9 +2285,8 @@ def _find_fresh_result_id(
 ) -> int | None:
     """Locate the result_id written by the most-recent grade for this session.
 
-    The runner writes rows but doesn't return the id. Reading back through
-    ``get_agent_success_evaluation_results`` matches the pattern used by
-    the regen worker's prior-row capture (group_evaluation_runner step 5).
+    The runner writes rows but doesn't return the id. Use the targeted result-id
+    lookup so this path does not scan broad evaluation windows.
 
     Args:
         storage: The request's storage backend.
@@ -2303,20 +2299,15 @@ def _find_fresh_result_id(
         int | None: result_id of the latest matching row, or None if the
         runner wrote nothing.
     """
-    rows = storage.get_agent_success_evaluation_results(
-        limit=1000, agent_version=agent_version
+    result_ids = storage.get_agent_success_evaluation_result_ids(
+        session_id=session_id,
+        evaluation_name=evaluation_name,
+        agent_version=agent_version,
     )
-    matched = [
-        r
-        for r in rows
-        if r.session_id == session_id
-        and r.evaluation_name == evaluation_name
-        and r.result_id not in previous_result_ids
-    ]
-    if not matched:
+    fresh_result_ids = [rid for rid in result_ids if rid not in previous_result_ids]
+    if not fresh_result_ids:
         return None
-    latest = max(matched, key=lambda r: r.created_at)
-    return latest.result_id
+    return max(fresh_result_ids)
 
 
 @core_router.post(
@@ -2387,13 +2378,13 @@ def grade_on_demand(
             skipped_reason="NO_REQUESTS",
         )
 
-    previous_result_ids = {
-        r.result_id
-        for r in storage.get_agent_success_evaluation_results(
-            limit=1000, agent_version=payload.agent_version
+    previous_result_ids = set(
+        storage.get_agent_success_evaluation_result_ids(
+            session_id=payload.session_id,
+            evaluation_name=evaluation_name,
+            agent_version=payload.agent_version,
         )
-        if r.session_id == payload.session_id and r.evaluation_name == evaluation_name
-    }
+    )
 
     # Two operation_state rows are intentionally written for this session:
     #   1) `grade_on_demand::{org_id}::{session_id}::{agent_version}::{evaluation_name}`
@@ -2470,8 +2461,8 @@ def get_recent_shadow_comparisons(
     Filters to the org's currently pinned
     ``Config.shadow_comparison_judge_prompt_version`` so verdicts produced
     under an older rubric do not mix into the drawer or the Top 10
-    disagreements widget. Storage returns verdicts in ascending ``created_at``
-    order; we reverse to "newest first" and cap at ``limit``.
+    disagreements widget. Storage returns verdicts newest-first and caps the
+    read at ``limit``.
 
     Args:
         limit (int): Max verdicts to return. Clamped to ``[1, 100]``.
@@ -2503,10 +2494,11 @@ def get_recent_shadow_comparisons(
 
     now = int(datetime.now(UTC).timestamp())
     try:
-        verdicts = storage.get_shadow_comparison_verdicts(
+        verdicts = storage.get_recent_shadow_comparison_verdicts(
             from_ts=now - _RECENT_SHADOW_COMPARISONS_LOOKBACK_SECONDS,
             to_ts=now,
             judge_prompt_version=pinned_version,
+            limit=clamped_limit,
         )
     except NotImplementedError:
         # Backends that don't support shadow verdicts (e.g., Disk) should
@@ -2514,9 +2506,7 @@ def get_recent_shadow_comparisons(
         # "no data yet" in the UI.
         return GetRecentShadowComparisonsResponse(verdicts=[])
 
-    # Storage contract returns ascending — flip to "newest first" and cap.
-    newest_first = list(reversed(verdicts))[:clamped_limit]
-    return GetRecentShadowComparisonsResponse(verdicts=newest_first)
+    return GetRecentShadowComparisonsResponse(verdicts=verdicts)
 
 
 @core_router.post(

--- a/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
+++ b/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
@@ -24,6 +24,7 @@ from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_
 from reflexio.server.services.agent_success_evaluation.delayed_group_evaluator import (
     _EFFECTIVE_DELAY_SECONDS,
 )
+from reflexio.server.services.extractor_config_utils import get_extractor_name
 from reflexio.server.services.shadow_comparison.judge import ShadowComparisonJudge
 
 logger = logging.getLogger(__name__)
@@ -166,13 +167,12 @@ def run_group_evaluation(
     # afterwards cannot remove the new rows.
     old_result_ids: list[int] = []
     if force_regenerate:
-        # Eval rows per session are tiny (usually 1), so pulling a
-        # generous limit and filtering in-process is cheap and avoids adding
-        # a third query shape to the storage contract.
-        prior_rows = storage.get_agent_success_evaluation_results(  # type: ignore[reportOptionalMemberAccess]
-            limit=10000, agent_version=agent_version
+        config = request_context.configurator.get_config()
+        old_result_ids = storage.get_agent_success_evaluation_result_ids(  # type: ignore[reportOptionalMemberAccess]
+            session_id=session_id,
+            evaluation_name=get_extractor_name(config),
+            agent_version=agent_version,
         )
-        old_result_ids = [r.result_id for r in prior_rows if r.session_id == session_id]
 
     logger.info(
         "Running group evaluation for session=%s with %d requests and %d interactions"

--- a/reflexio/server/services/agent_success_evaluation/regen_jobs.py
+++ b/reflexio/server/services/agent_success_evaluation/regen_jobs.py
@@ -170,72 +170,16 @@ class RegenJobRegistry:
 REGEN_JOBS = RegenJobRegistry()
 
 
-def _load_first_request(
-    storage: BaseStorage,
-    user_id: str,
-    session_id: str,
-    cache: dict[str, tuple[int, str]],
-) -> tuple[int, str]:
-    """Return the (created_at, source) of a session's earliest request, memoized.
-
-    The regen worker can see multiple SessionDescriptors for the same
-    session_id (one per distinct agent_version/source tuple). This
-    helper guarantees each session_id triggers at most one storage call.
-
-    Args:
-        storage (BaseStorage): Storage backend bound to the request_context.
-        user_id (str): Owner of the session's requests.
-        session_id (str): Session whose first-request data to return.
-        cache (dict[str, tuple[int, str]]): Memoization dict keyed by
-            session_id; updated in place.
-
-    Returns:
-        tuple[int, str]: ``(first_created_at, first_source)``. Falls back
-        to ``(0, "")`` when the session has no requests (the
-        descriptor is still kept so the regen worker can attempt
-        evaluation; the sampler simply treats it as the epoch-zero day
-        bucket and the empty-source stratum).
-    """
-    cached = cache.get(session_id)
-    if cached is not None:
-        return cached
-    try:
-        requests = storage.get_requests_by_session(user_id, session_id)
-    except Exception as e:  # noqa: BLE001 — per-session resilience boundary
-        logger.warning(
-            "Failed to fetch requests for session %s during F3 sampler candidate "
-            "discovery (%s); falling back to (created_at=0, source=''). The "
-            "session will be retried in the per-session loop below.",
-            session_id,
-            e,
-        )
-        cache[session_id] = (0, "")
-        return cache[session_id]
-    if not requests:
-        logger.warning(
-            "Session %s has no requests in storage despite being returned by "
-            "get_session_ids_in_window (possible race or contract violation); "
-            "falling back to (created_at=0, source='').",
-            session_id,
-        )
-        cache[session_id] = (0, "")
-        return cache[session_id]
-    first = min(requests, key=lambda r: r.created_at)
-    cache[session_id] = (first.created_at, first.source or "")
-    return cache[session_id]
-
-
 def _build_sample_candidates(
     storage: BaseStorage,
     descriptors: list[SessionDescriptor],
 ) -> list[SampleCandidate]:
     """Convert raw SessionDescriptors into SampleCandidates.
 
-    Reads the first-request data for each distinct session_id at most
-    once via ``_load_first_request``'s cache, then assembles one
-    ``SampleCandidate`` per descriptor. ``created_at`` is sourced from
-    the first request's timestamp so the day-bucket stratum aligns with
-    the session's wall clock (not the regen window's edges).
+    Reads first-request data for all distinct session_ids in one storage call,
+    then assembles one ``SampleCandidate`` per descriptor. ``created_at`` is
+    sourced from the first request's timestamp so the day-bucket stratum aligns
+    with the session's wall clock (not the regen window's edges).
 
     Args:
         storage (BaseStorage): Storage backend used to load per-session data.
@@ -246,20 +190,34 @@ def _build_sample_candidates(
         list[SampleCandidate]: One candidate per descriptor, ready for the
         pure ``sample_candidates`` function.
     """
-    cache: dict[str, tuple[int, str]] = {}
+    session_ids = sorted({sd.session_id for sd in descriptors})
+    try:
+        first_requests = storage.get_first_requests_by_session_ids(session_ids)
+    except Exception as e:  # noqa: BLE001 — discovery should not abort the whole job
+        logger.warning(
+            "Failed to bulk fetch first requests during F3 sampler candidate "
+            "discovery (%s); falling back to epoch-zero source buckets.",
+            e,
+        )
+        first_requests = {}
+
     candidates: list[SampleCandidate] = []
     for sd in descriptors:
-        created_at, first_source = _load_first_request(
-            storage, sd.user_id, sd.session_id, cache
-        )
+        first = first_requests.get(sd.session_id)
+        if first is None:
+            logger.warning(
+                "Session %s has no first request in storage despite being returned by "
+                "get_session_ids_in_window; falling back to (created_at=0, source='').",
+                sd.session_id,
+            )
         candidates.append(
             SampleCandidate(
                 session_id=sd.session_id,
                 user_id=sd.user_id,
                 agent_version=sd.agent_version,
                 source=sd.source,
-                created_at=created_at,
-                first_request_source=first_source,
+                created_at=first.created_at if first else 0,
+                first_request_source=(first.source or "") if first else "",
             )
         )
     return candidates

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -1,13 +1,16 @@
 """Aggregator that composes hero, tiles, rule attribution, and distribution.
 
-The service does three reads (results, citations, playbook stats)
-and returns a GetEvaluationOverviewResponse. It's invoked from the FastAPI
-route handler; the storage is the same BaseStorage the rest of the server
-uses, so the same instance is reused via request_context.
+The service bulk-loads the requested evaluation window plus related source,
+citation, Braintrust, and optional shadow verdict rows, then returns a
+GetEvaluationOverviewResponse. It's invoked from the FastAPI route handler; the
+storage is the same BaseStorage the rest of the server uses, so the same
+instance is reused via request_context.
 """
 
 from __future__ import annotations
 
+import logging
+import time
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -16,7 +19,6 @@ from datetime import UTC, datetime
 from reflexio.models.api_schema.braintrust_schema import ImportedScore
 from reflexio.models.api_schema.domain.entities import (
     AgentSuccessEvaluationResult,
-    Request,
 )
 from reflexio.models.api_schema.eval_overview_schema import (
     BraintrustTileRow,
@@ -53,6 +55,7 @@ from reflexio.server.services.evaluation_overview.shadow_aggregation import (
 _DAY_SECONDS = 24 * 60 * 60
 _WEEK_SECONDS = 7 * 24 * 60 * 60
 _TOP_N_RULES = 5
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -84,46 +87,92 @@ class EvaluationOverviewService:
             so every tile would display "no baseline" regardless of how much
             data the org has.
         """
-        all_results = self.storage.get_agent_success_evaluation_results(  # type: ignore[attr-defined]
-            agent_version=None, limit=10_000
-        )
-        results = [
-            r for r in all_results if request.from_ts <= r.created_at <= request.to_ts
-        ]
-
-        # Tile + distribution baselines are always last-7d-vs-prior-7d, anchored
-        # to ``request.to_ts`` (which is "now" from the frontend's perspective).
+        # Tile + distribution baselines are always last-7d-vs-prior-7d,
+        # anchored to ``request.to_ts`` (which is "now" from the frontend's
+        # perspective).
         cur_7d_from = max(request.from_ts, request.to_ts - _WEEK_SECONDS)
         prev_to = cur_7d_from
         prev_from = max(0, prev_to - _WEEK_SECONDS)
+        load_from = min(request.from_ts, prev_from)
+
+        start = time.perf_counter()
+        all_results = self.storage.get_agent_success_evaluation_results_in_window(  # type: ignore[attr-defined]
+            from_ts=load_from,
+            to_ts=request.to_ts,
+            agent_version=None,
+        )
+        self._log_phase("eval_results", start, rows=len(all_results))
+
+        results = [
+            r for r in all_results if request.from_ts <= r.created_at <= request.to_ts
+        ]
         results_current_7d = [
             r for r in all_results if cur_7d_from <= r.created_at <= request.to_ts
         ]
         results_prev_7d = [
             r for r in all_results if prev_from <= r.created_at < prev_to
         ]
-        session_sources = self._build_first_request_sources(
-            [
-                r.session_id
-                for r in (*results, *results_current_7d, *results_prev_7d)
-                if r.session_id
-            ]
-        )
 
         earliest_eval_ts = min((r.created_at for r in all_results), default=None)
+        result_session_ids = list(
+            dict.fromkeys(r.session_id for r in results if r.session_id)
+        )
+        if request.source_sets:
+            source_session_ids = list(
+                dict.fromkeys(
+                    r.session_id
+                    for r in (*results, *results_current_7d, *results_prev_7d)
+                    if r.session_id
+                )
+            )
+        else:
+            source_session_ids = result_session_ids
+        start = time.perf_counter()
+        session_sources = self._build_first_request_sources(source_session_ids)
+        self._log_phase(
+            "session_sources",
+            start,
+            sessions=len(set(source_session_ids)),
+            rows=len(session_sources),
+        )
+
+        start = time.perf_counter()
+        citations_by_session, rule_titles = self._load_citations(result_session_ids)
+        self._log_phase(
+            "citations",
+            start,
+            sessions=len(set(result_session_ids)),
+            rows=sum(len(v) for v in citations_by_session.values()),
+        )
+
         hero = self._build_hero(request, results, earliest_eval_ts)
         tiles = self._build_tiles(results_current_7d, results_prev_7d)
-        attribution = self._build_attribution(results)
+        attribution = self._build_attribution(
+            results, citations_by_session, rule_titles
+        )
         distribution = self._build_distribution(results_current_7d, results_prev_7d)
-        braintrust_tiles = self._build_braintrust_tiles(
+        start = time.perf_counter()
+        current_scores, prior_scores = self._load_braintrust_scores(
             cur_7d_from, request.to_ts, prev_from, prev_to
         )
-        # F1: per-turn shadow win-rate trend. Filters verdicts to the org's
-        # pinned judge prompt version so a future rubric bump doesn't
-        # silently mix epochs into the headline.
-        shadow_win_rate_trend = self._build_shadow_win_rate_trend(
-            request.from_ts, request.to_ts
+        self._log_phase(
+            "braintrust",
+            start,
+            current_rows=len(current_scores),
+            prior_rows=len(prior_scores),
         )
+        braintrust_tiles = self._build_braintrust_tiles_from_scores(
+            current_scores, prior_scores
+        )
+        start = time.perf_counter()
+        shadow_win_rate_trend = (
+            self._build_shadow_win_rate_trend(request.from_ts, request.to_ts)
+            if request.include_shadow
+            else ShadowWinRateTrend(
+                judge_prompt_version=self.config.shadow_comparison_judge_prompt_version
+            )
+        )
+        self._log_phase("shadow", start, enabled=request.include_shadow)
         source_set_comparison = self._build_source_set_comparison(
             source_sets=request.source_sets,
             results=results,
@@ -131,10 +180,10 @@ class EvaluationOverviewService:
             previous=results_prev_7d,
             session_sources=session_sources,
             bucket=request.bucket,
-            current_from=cur_7d_from,
-            current_to=request.to_ts,
-            previous_from=prev_from,
-            previous_to=prev_to,
+            citations_by_session=citations_by_session,
+            rule_titles=rule_titles,
+            current_scores=current_scores,
+            prior_scores=prior_scores,
         )
 
         return GetEvaluationOverviewResponse(
@@ -211,12 +260,12 @@ class EvaluationOverviewService:
         )
 
     def _build_attribution(
-        self, results: list[AgentSuccessEvaluationResult]
+        self,
+        results: list[AgentSuccessEvaluationResult],
+        citations_by_session: dict[str, list[tuple[str, str]]],
+        rule_titles: dict[tuple[str, str], str],
     ) -> list[RuleAttributionRow]:
         is_success_by_session = {r.session_id: r.is_success for r in results}
-        citations_by_session, rule_titles = self._load_citations(
-            list(is_success_by_session.keys())
-        )
         rows = compute_net_sessions(
             citations_by_session=citations_by_session,
             is_success_by_session=is_success_by_session,
@@ -246,49 +295,41 @@ class EvaluationOverviewService:
         implemented `get_interactions_by_session`).
         """
         citations_by_session: dict[str, list[tuple[str, str]]] = defaultdict(list)
-        for sid in session_ids:
-            interactions = self.storage.get_interactions_by_session(sid)  # type: ignore[attr-defined]
-            for interaction in interactions:
-                for cite in getattr(interaction, "citations", []) or []:
-                    # Citations may arrive as Pydantic Citation objects (from
-                    # the normal storage path) or as plain dicts (e.g. when
-                    # tests stub the storage). Handle both shapes.
-                    if isinstance(cite, dict):
-                        kind = cite.get("kind")
-                        rid = cite.get("real_id")
-                    else:
-                        kind = getattr(cite, "kind", None)
-                        rid = getattr(cite, "real_id", None)
-                    if kind and rid:
-                        citations_by_session[sid].append((kind, str(rid)))
-        # Titles via existing playbook_application_stats lookup
-        stats = self.storage.get_playbook_application_stats(days_back=30)  # type: ignore[attr-defined]
-        rule_titles = {(s.kind, s.real_id): s.title for s in stats}
+        rule_titles: dict[tuple[str, str], str] = {}
+        for citation in self.storage.get_citations_by_session_ids(session_ids):  # type: ignore[attr-defined]
+            key = (citation.kind, citation.real_id)
+            citations_by_session[citation.session_id].append(key)
+            if citation.title and key not in rule_titles:
+                rule_titles[key] = citation.title
         return citations_by_session, rule_titles
 
-    def _build_braintrust_tiles(
+    def _load_braintrust_scores(
         self,
         from_ts: int,
         to_ts: int,
         prev_from: int,
         prev_to: int,
-        session_ids: set[str] | None = None,
-    ) -> list[BraintrustTileRow]:
-        """Aggregate imported_score rows per scorer_name for current + prior windows.
-
-        Returns [] when the org has no Braintrust connection (default no-op
-        storage returns []). The frontend treats an empty list as "not
-        connected" and hides the Braintrust strip entirely.
-        """
+    ) -> tuple[list[ImportedScore], list[ImportedScore]]:
         org_id = self._org_id()
         if not org_id:
-            return []
+            return [], []
         current = self.storage.get_imported_scores(org_id, from_ts, to_ts)  # type: ignore[attr-defined]
+        if not current:
+            return [], []
+        prior = self.storage.get_imported_scores(org_id, prev_from, prev_to)  # type: ignore[attr-defined]
+        return current, prior
+
+    def _build_braintrust_tiles_from_scores(
+        self,
+        current: list[ImportedScore],
+        prior: list[ImportedScore],
+        session_ids: set[str] | None = None,
+    ) -> list[BraintrustTileRow]:
+        """Aggregate imported_score rows per scorer_name for current + prior windows."""
         if session_ids is not None:
             current = [s for s in current if s.session_id in session_ids]
         if not current:
             return []
-        prior = self.storage.get_imported_scores(org_id, prev_from, prev_to)  # type: ignore[attr-defined]
         if session_ids is not None:
             prior = [s for s in prior if s.session_id in session_ids]
         cur_agg = _aggregate_imported_scores(current)
@@ -319,10 +360,10 @@ class EvaluationOverviewService:
         previous: list[AgentSuccessEvaluationResult],
         session_sources: dict[str, str],
         bucket: BucketLiteral,
-        current_from: int,
-        current_to: int,
-        previous_from: int,
-        previous_to: int,
+        citations_by_session: dict[str, list[tuple[str, str]]],
+        rule_titles: dict[tuple[str, str], str],
+        current_scores: list[ImportedScore],
+        prior_scores: list[ImportedScore],
     ) -> SourceSetComparison:
         """Build request-source cohort metrics for the evaluation page."""
         available_sources = sorted(
@@ -368,12 +409,12 @@ class EvaluationOverviewService:
                     score_distribution=self._build_distribution(
                         set_current, set_previous
                     ),
-                    rule_attribution=self._build_attribution(set_results),
-                    braintrust_tiles=self._build_braintrust_tiles(
-                        current_from,
-                        current_to,
-                        previous_from,
-                        previous_to,
+                    rule_attribution=self._build_attribution(
+                        set_results, citations_by_session, rule_titles
+                    ),
+                    braintrust_tiles=self._build_braintrust_tiles_from_scores(
+                        current_scores,
+                        prior_scores,
                         session_ids=session_ids,
                     ),
                 )
@@ -427,45 +468,10 @@ class EvaluationOverviewService:
             verdicts, judge_prompt_version=pinned_version
         )
 
-    def _build_first_request_sources(
-        self, session_ids: Iterable[str]
-    ) -> dict[str, str]:
+    def _build_first_request_sources(self, session_ids: list[str]) -> dict[str, str]:
         """Map each session to its earliest request's source."""
-        sources: dict[str, str] = {}
-        for sid in set(session_ids):
-            reqs = self._get_session_requests(sid)
-            if reqs:
-                first = min(reqs, key=lambda r: r.created_at)
-                sources[sid] = first.source or ""
-            else:
-                sources[sid] = ""
-        return sources
-
-    def _get_session_requests(self, session_id: str) -> list[Request]:
-        """Return every request in ``session_id`` regardless of user.
-
-        Uses ``BaseStorage.get_sessions(session_id=...)`` because the
-        per-session, user-id-required ``get_requests_by_session`` doesn't
-        fit our caller (eval results don't carry ``user_id``). All locally
-        testable backends ignore the ``user_id`` filter when it's ``None``,
-        and ``top_k`` is raised well above realistic per-session counts so
-        we don't truncate.
-
-        Args:
-            session_id (str): The session whose requests to fetch.
-
-        Returns:
-            list[Request]: All requests in the session, in storage order.
-        """
-        grouped = self.storage.get_sessions(  # type: ignore[attr-defined]
-            session_id=session_id, top_k=1000
-        )
-        return [
-            entry.request
-            for entries in grouped.values()
-            for entry in entries
-            if entry.request is not None
-        ]
+        first_requests = self.storage.get_first_requests_by_session_ids(session_ids)  # type: ignore[attr-defined]
+        return {sid: row.source or "" for sid, row in first_requests.items()}
 
     def _build_distribution(
         self,
@@ -482,6 +488,16 @@ class EvaluationOverviewService:
             current_bins=list(cur_bins),
             baseline_bins=list(prev_bins),
             labels=list(BUCKET_LABELS),
+        )
+
+    def _log_phase(self, phase: str, started_at: float, **metadata: object) -> None:
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        fields = " ".join(f"{key}={value}" for key, value in metadata.items())
+        _LOGGER.info(
+            "evaluation_overview phase=%s duration_ms=%d %s",
+            phase,
+            duration_ms,
+            fields,
         )
 
 

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1693,6 +1693,8 @@ CREATE TABLE IF NOT EXISTS requests (
 CREATE INDEX IF NOT EXISTS idx_requests_user_id ON requests(user_id);
 CREATE INDEX IF NOT EXISTS idx_requests_session_id ON requests(session_id);
 CREATE INDEX IF NOT EXISTS idx_requests_created_at ON requests(created_at);
+CREATE INDEX IF NOT EXISTS idx_requests_session_created_at_asc
+    ON requests(session_id, created_at ASC, request_id ASC);
 
 CREATE TABLE IF NOT EXISTS user_playbooks (
     user_playbook_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1756,6 +1758,12 @@ CREATE TABLE IF NOT EXISTS agent_success_evaluation_result (
 );
 CREATE INDEX IF NOT EXISTS idx_eval_agent_version ON agent_success_evaluation_result(agent_version);
 CREATE INDEX IF NOT EXISTS idx_eval_created_at ON agent_success_evaluation_result(created_at);
+CREATE INDEX IF NOT EXISTS idx_eval_created_at_desc
+    ON agent_success_evaluation_result(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_eval_agent_version_created_at_desc
+    ON agent_success_evaluation_result(agent_version, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_eval_identity_created_at_desc
+    ON agent_success_evaluation_result(session_id, evaluation_name, agent_version, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS profile_change_logs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2011,5 +2019,7 @@ CREATE INDEX IF NOT EXISTS idx_shadow_verdicts_created_at
     ON shadow_comparison_verdicts (created_at);
 CREATE INDEX IF NOT EXISTS idx_shadow_verdicts_prompt_v
     ON shadow_comparison_verdicts (judge_prompt_version);
+CREATE INDEX IF NOT EXISTS idx_shadow_verdicts_prompt_created_at_desc
+    ON shadow_comparison_verdicts (judge_prompt_version, created_at DESC);
 
 """

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -8,6 +8,7 @@ from reflexio.models.api_schema.braintrust_schema import (
     BraintrustConnection,
     ImportedScore,
 )
+from reflexio.models.api_schema.internal_schema import SessionCitation
 from reflexio.models.api_schema.retriever_schema import PlaybookApplicationStat
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
@@ -477,6 +478,49 @@ class ExtrasMixin:
             (session_id,),
         )
         return [_row_to_interaction(r) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_citations_by_session_ids(
+        self,
+        session_ids: list[str],
+    ) -> list[SessionCitation]:
+        if not session_ids:
+            return []
+        out: list[SessionCitation] = []
+        ids = sorted(set(session_ids))
+        chunk_size = 500
+        for i in range(0, len(ids), chunk_size):
+            chunk = ids[i : i + chunk_size]
+            ph = ",".join("?" for _ in chunk)
+            rows = self._fetchall(
+                f"""SELECT r.session_id, i.citations
+                    FROM requests r
+                    JOIN interactions i ON i.request_id = r.request_id
+                    WHERE r.session_id IN ({ph})
+                      AND i.citations IS NOT NULL
+                      AND i.citations != '[]'
+                    ORDER BY r.session_id ASC, i.created_at ASC""",  # noqa: S608
+                chunk,
+            )
+            for row in rows:
+                citations = _json_loads(row["citations"]) or []
+                if not isinstance(citations, list):
+                    continue
+                for citation in citations:
+                    if not isinstance(citation, dict):
+                        continue
+                    kind = citation.get("kind")
+                    real_id = citation.get("real_id")
+                    if kind and real_id:
+                        out.append(
+                            SessionCitation(
+                                session_id=row["session_id"],
+                                kind=str(kind),
+                                real_id=str(real_id),
+                                title=str(citation.get("title") or ""),
+                            )
+                        )
+        return out
 
     # ------------------------------------------------------------------
     # Braintrust connector storage (Plan C-backend + Plan C-overview)

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -498,6 +498,7 @@ class ExtrasMixin:
                     JOIN interactions i ON i.request_id = r.request_id
                     WHERE r.session_id IN ({ph})
                       AND i.citations IS NOT NULL
+                      AND i.citations != ''
                       AND i.citations != '[]'
                     ORDER BY r.session_id ASC, i.created_at ASC""",  # noqa: S608
                 chunk,

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1328,6 +1328,44 @@ class PlaybookMixin:
         return [_row_to_eval_result(r) for r in rows]
 
     @SQLiteStorageBase.handle_exceptions
+    def get_agent_success_evaluation_results_in_window(
+        self,
+        from_ts: int,
+        to_ts: int,
+        agent_version: str | None = None,
+        limit: int | None = None,
+    ) -> list[AgentSuccessEvaluationResult]:
+        sql = """SELECT * FROM agent_success_evaluation_result
+                 WHERE created_at >= ? AND created_at <= ?"""
+        params: list[Any] = [_epoch_to_iso(from_ts), _epoch_to_iso(to_ts)]
+        if agent_version is not None:
+            sql += " AND agent_version = ?"
+            params.append(agent_version)
+        sql += " ORDER BY created_at DESC"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        rows = self._fetchall(sql, params)
+        return [_row_to_eval_result(r) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_agent_success_evaluation_result_ids(
+        self,
+        session_id: str,
+        evaluation_name: str,
+        agent_version: str,
+    ) -> list[int]:
+        rows = self._fetchall(
+            """SELECT result_id FROM agent_success_evaluation_result
+               WHERE session_id = ?
+                 AND evaluation_name = ?
+                 AND agent_version = ?
+               ORDER BY created_at DESC""",
+            (session_id, evaluation_name, agent_version),
+        )
+        return [int(r["result_id"]) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_success_evaluation_results(self) -> None:
         self._execute("DELETE FROM agent_success_evaluation_result")
 

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -6,6 +6,7 @@ from typing import Any
 from reflexio.models.api_schema.internal_schema import (
     RequestInteractionDataModel,
     SessionDescriptor,
+    SessionFirstRequest,
 )
 from reflexio.models.api_schema.service_schemas import (
     Request,
@@ -14,6 +15,7 @@ from reflexio.models.api_schema.service_schemas import (
 from ._base import (
     SQLiteStorageBase,
     _epoch_to_iso,
+    _iso_to_epoch,
     _row_to_interaction,
     _row_to_request,
 )
@@ -260,3 +262,39 @@ class RequestMixin:
             )
             for r in rows
         ]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_first_requests_by_session_ids(
+        self, session_ids: list[str]
+    ) -> dict[str, SessionFirstRequest]:
+        if not session_ids:
+            return {}
+        out: dict[str, SessionFirstRequest] = {}
+        ids = sorted(set(session_ids))
+        chunk_size = 500
+        for i in range(0, len(ids), chunk_size):
+            chunk = ids[i : i + chunk_size]
+            ph = ",".join("?" for _ in chunk)
+            rows = self._fetchall(
+                f"""SELECT session_id, user_id, source, created_at
+                    FROM (
+                        SELECT session_id, user_id, source, created_at,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY session_id
+                                   ORDER BY created_at ASC, request_id ASC
+                               ) AS rn
+                        FROM requests
+                        WHERE session_id IN ({ph})
+                    )
+                    WHERE rn = 1""",  # noqa: S608
+                chunk,
+            )
+            for row in rows:
+                session_id = row["session_id"]
+                out[session_id] = SessionFirstRequest(
+                    session_id=session_id,
+                    user_id=row["user_id"],
+                    source=row["source"] or "",
+                    created_at=_iso_to_epoch(row["created_at"]),
+                )
+        return out

--- a/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
@@ -185,13 +185,14 @@ class ShadowVerdictsMixin:
     ) -> list[ShadowComparisonVerdict]:
         from_iso = _epoch_to_iso(max(0, min(from_ts, _MAX_SAFE_EPOCH_TS)))
         to_iso = _epoch_to_iso(max(0, min(to_ts, _MAX_SAFE_EPOCH_TS)))
+        safe_limit = max(0, limit)
         rows = self._fetchall(
             """SELECT * FROM shadow_comparison_verdicts
                WHERE created_at >= ? AND created_at <= ?
                  AND judge_prompt_version = ?
                ORDER BY created_at DESC
                LIMIT ?""",
-            (from_iso, to_iso, judge_prompt_version, limit),
+            (from_iso, to_iso, judge_prompt_version, safe_limit),
         )
         return [_row_to_verdict(r) for r in rows]
 

--- a/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
@@ -176,6 +176,26 @@ class ShadowVerdictsMixin:
         return [_row_to_verdict(r) for r in rows]
 
     @SQLiteStorageBase.handle_exceptions
+    def get_recent_shadow_comparison_verdicts(
+        self,
+        from_ts: int,
+        to_ts: int,
+        judge_prompt_version: str,
+        limit: int,
+    ) -> list[ShadowComparisonVerdict]:
+        from_iso = _epoch_to_iso(max(0, min(from_ts, _MAX_SAFE_EPOCH_TS)))
+        to_iso = _epoch_to_iso(max(0, min(to_ts, _MAX_SAFE_EPOCH_TS)))
+        rows = self._fetchall(
+            """SELECT * FROM shadow_comparison_verdicts
+               WHERE created_at >= ? AND created_at <= ?
+                 AND judge_prompt_version = ?
+               ORDER BY created_at DESC
+               LIMIT ?""",
+            (from_iso, to_iso, judge_prompt_version, limit),
+        )
+        return [_row_to_verdict(r) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
     def delete_shadow_comparison_verdicts_by_session(self, session_id: str) -> int:
         """
         Delete all verdicts for one session.

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -9,6 +9,7 @@ from reflexio.models.api_schema.domain import (
     PlaybookAggregationChangeLog,
     ProfileChangeLog,
 )
+from reflexio.models.api_schema.internal_schema import SessionCitation
 from reflexio.models.api_schema.retriever_schema import PlaybookApplicationStat
 
 
@@ -170,6 +171,39 @@ class ExtrasMixin:
         Default implementation returns []; concrete backends should override.
         """
         return []
+
+    def get_citations_by_session_ids(
+        self,
+        session_ids: list[str],
+    ) -> list[SessionCitation]:
+        """Return rule/profile citations for the requested sessions.
+
+        Default implementation uses ``get_interactions_by_session`` so legacy
+        backends keep working. SQL backends should override with a bulk
+        request/interactions join.
+        """
+        out: list[SessionCitation] = []
+        for session_id in set(session_ids):
+            for interaction in self.get_interactions_by_session(session_id):
+                for cite in getattr(interaction, "citations", []) or []:
+                    if isinstance(cite, dict):
+                        kind = cite.get("kind")
+                        real_id = cite.get("real_id")
+                        title = cite.get("title") or ""
+                    else:
+                        kind = getattr(cite, "kind", None)
+                        real_id = getattr(cite, "real_id", None)
+                        title = getattr(cite, "title", "") or ""
+                    if kind and real_id:
+                        out.append(
+                            SessionCitation(
+                                session_id=session_id,
+                                kind=str(kind),
+                                real_id=str(real_id),
+                                title=str(title),
+                            )
+                        )
+        return out
 
     # ==============================
     # Braintrust connector (default no-ops; backends override)

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -634,6 +634,42 @@ class PlaybookMixin:
         """
         raise NotImplementedError
 
+    def get_agent_success_evaluation_results_in_window(
+        self,
+        from_ts: int,
+        to_ts: int,
+        agent_version: str | None = None,
+        limit: int | None = None,
+    ) -> list[AgentSuccessEvaluationResult]:
+        """Return eval results in ``[from_ts, to_ts]``.
+
+        Default implementation filters the existing latest-results method.
+        SQL backends should override so callers do not depend on an arbitrary
+        latest-row cap.
+        """
+        rows = self.get_agent_success_evaluation_results(
+            limit=limit or 10_000,
+            agent_version=agent_version,
+        )
+        return [r for r in rows if from_ts <= r.created_at <= to_ts]
+
+    def get_agent_success_evaluation_result_ids(
+        self,
+        session_id: str,
+        evaluation_name: str,
+        agent_version: str,
+    ) -> list[int]:
+        """Return result ids for one eval identity tuple."""
+        rows = self.get_agent_success_evaluation_results(
+            limit=10_000,
+            agent_version=agent_version,
+        )
+        return [
+            r.result_id
+            for r in rows
+            if r.session_id == session_id and r.evaluation_name == evaluation_name
+        ]
+
     @abstractmethod
     def delete_all_agent_success_evaluation_results(self) -> None:
         """Delete all agent success evaluation results from storage."""

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -165,9 +165,20 @@ class RequestMixin:
         """
         out: dict[str, SessionFirstRequest] = {}
         for session_id in set(session_ids):
-            grouped = self.get_sessions(session_id=session_id, top_k=1000)
-            rows = grouped.get(session_id) or []
-            requests = [r.request for r in rows if r.request is not None]
+            requests = []
+            page_size = 1000
+            offset = 0
+            while True:
+                grouped = self.get_sessions(
+                    session_id=session_id,
+                    top_k=page_size,
+                    offset=offset,
+                )
+                rows = grouped.get(session_id) or []
+                requests.extend(r.request for r in rows if r.request is not None)
+                if len(rows) < page_size:
+                    break
+                offset += page_size
             if not requests:
                 continue
             first = min(requests, key=lambda r: r.created_at)

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -4,6 +4,7 @@ from reflexio.models.api_schema.domain import Request
 from reflexio.models.api_schema.internal_schema import (
     RequestInteractionDataModel,
     SessionDescriptor,
+    SessionFirstRequest,
 )
 
 
@@ -152,3 +153,28 @@ class RequestMixin:
             list[SessionDescriptor]: Deduped descriptors ordered by session_id.
         """
         raise NotImplementedError
+
+    def get_first_requests_by_session_ids(
+        self, session_ids: list[str]
+    ) -> dict[str, SessionFirstRequest]:
+        """Return earliest-request metadata for each requested session.
+
+        Default implementation preserves the historical storage contract by
+        calling ``get_sessions`` per session. SQL backends should override with
+        a set-based query.
+        """
+        out: dict[str, SessionFirstRequest] = {}
+        for session_id in set(session_ids):
+            grouped = self.get_sessions(session_id=session_id, top_k=1000)
+            rows = grouped.get(session_id) or []
+            requests = [r.request for r in rows if r.request is not None]
+            if not requests:
+                continue
+            first = min(requests, key=lambda r: r.created_at)
+            out[session_id] = SessionFirstRequest(
+                session_id=session_id,
+                user_id=first.user_id,
+                source=first.source or "",
+                created_at=first.created_at,
+            )
+        return out

--- a/reflexio/server/services/storage/storage_base/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/storage_base/_shadow_verdicts.py
@@ -116,6 +116,8 @@ class ShadowVerdictsMixin:
         limit: int,
     ) -> list[ShadowComparisonVerdict]:
         """Fetch newest verdicts in descending ``created_at`` order."""
+        if limit <= 0:
+            return []
         verdicts = self.get_shadow_comparison_verdicts(
             from_ts=from_ts,
             to_ts=to_ts,

--- a/reflexio/server/services/storage/storage_base/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/storage_base/_shadow_verdicts.py
@@ -108,6 +108,21 @@ class ShadowVerdictsMixin:
             f"{type(self).__name__} does not support shadow_comparison_verdicts"
         )
 
+    def get_recent_shadow_comparison_verdicts(
+        self,
+        from_ts: int,
+        to_ts: int,
+        judge_prompt_version: str,
+        limit: int,
+    ) -> list[ShadowComparisonVerdict]:
+        """Fetch newest verdicts in descending ``created_at`` order."""
+        verdicts = self.get_shadow_comparison_verdicts(
+            from_ts=from_ts,
+            to_ts=to_ts,
+            judge_prompt_version=judge_prompt_version,
+        )
+        return list(reversed(verdicts))[:limit]
+
     def delete_shadow_comparison_verdicts_by_session(self, session_id: str) -> int:
         """Remove all verdicts for one session.
 

--- a/tests/server/services/agent_success_evaluation/test_regen_jobs_sampling_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_regen_jobs_sampling_integration.py
@@ -242,27 +242,46 @@ def test_run_regen_uses_first_request_source_for_sampling(
     assert job.sampled_count == len(calls)
 
 
-def test_run_regen_continues_when_one_session_storage_lookup_fails(
+def test_build_sample_candidates_uses_one_bulk_first_request_lookup(
     monkeypatch: pytest.MonkeyPatch, storage: SQLiteStorage
 ) -> None:
-    """A storage glitch on one session's source lookup must not abort
-    the whole job — the session is sampled with fallback source and the
+    ts = 1_700_000_000
+    for i in range(5):
+        _seed(storage, f"bulk-{i}", ts, "candidate")
+
+    real_get = storage.get_first_requests_by_session_ids
+    calls: list[list[str]] = []
+
+    def spy(session_ids: list[str]):
+        calls.append(session_ids)
+        return real_get(session_ids)
+
+    monkeypatch.setattr(storage, "get_first_requests_by_session_ids", spy)
+
+    descriptors = storage.get_session_ids_in_window(ts - 1, ts + 1)
+    candidates = regen_jobs._build_sample_candidates(storage, descriptors)  # noqa: SLF001
+
+    assert len(candidates) == 5
+    assert len(calls) == 1
+    assert sorted(calls[0]) == [f"bulk-{i}" for i in range(5)]
+
+
+def test_run_regen_continues_when_bulk_first_request_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch, storage: SQLiteStorage
+) -> None:
+    """A storage glitch on bulk source lookup must not abort
+    the whole job — sessions are sampled with fallback source and the
     per-session loop reports its own failure (or success) for it.
     """
     ts = 1_700_000_000
     for i in range(5):
         _seed(storage, f"ok-{i}", ts, "candidate")
 
-    real_get = storage.get_requests_by_session
-    poison_session = "ok-2"
-
-    def flaky_get_requests_by_session(user_id: str, session_id: str) -> list[Request]:
-        if session_id == poison_session:
-            raise RuntimeError("simulated transient DB error")
-        return real_get(user_id, session_id)
+    def flaky_first_requests(session_ids: list[str]) -> dict:
+        raise RuntimeError("simulated transient DB error")
 
     monkeypatch.setattr(
-        storage, "get_requests_by_session", flaky_get_requests_by_session
+        storage, "get_first_requests_by_session_ids", flaky_first_requests
     )
 
     calls: list[str] = []

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -360,7 +360,6 @@ def test_service_handles_5k_sessions_with_bulk_call_shape() -> None:
     config = Config(storage_config=StorageConfigSQLite())
 
     svc = EvaluationOverviewService(storage=storage, config=config)
-    started = time.perf_counter()
     response = svc.run(
         GetEvaluationOverviewRequest(
             from_ts=now - 7200,
@@ -368,10 +367,8 @@ def test_service_handles_5k_sessions_with_bulk_call_shape() -> None:
             include_shadow=False,
         )
     )
-    elapsed = time.perf_counter() - started
 
     assert response.hero.regular_success_rate_pp == 50.0
-    assert elapsed < 2.0
     storage.get_agent_success_evaluation_results_in_window.assert_called_once()
     storage.get_first_requests_by_session_ids.assert_called_once()
     storage.get_citations_by_session_ids.assert_called_once()

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -7,7 +7,12 @@ from unittest.mock import MagicMock
 
 from reflexio.models.api_schema.domain.entities import AgentSuccessEvaluationResult
 from reflexio.models.api_schema.eval_overview_schema import (
+    EvaluationSourceSetRequest,
     GetEvaluationOverviewRequest,
+)
+from reflexio.models.api_schema.internal_schema import (
+    SessionCitation,
+    SessionFirstRequest,
 )
 from reflexio.models.config_schema import Config, StorageConfigSQLite
 from reflexio.server.services.evaluation_overview.service import (
@@ -34,15 +39,35 @@ def _eval_result(
     )
 
 
-def test_service_returns_full_response_with_shadow_enabled_and_data() -> None:
+def _storage_with_results(
+    results: list[AgentSuccessEvaluationResult],
+) -> MagicMock:
     storage = MagicMock()
-    storage.get_agent_success_evaluation_results.return_value = [
-        _eval_result(result_id=1, session_id="s1", is_success=True, corrections=0),
-        _eval_result(result_id=2, session_id="s2", is_success=True, corrections=1),
-        _eval_result(result_id=3, session_id="s3", is_success=False, corrections=3),
-    ]
-    storage.get_playbook_application_stats.return_value = []
-    storage.get_interactions_by_session.return_value = []
+    storage.org_id = ""
+    storage.get_agent_success_evaluation_results_in_window.return_value = results
+    storage.get_first_requests_by_session_ids.return_value = {
+        r.session_id: SessionFirstRequest(
+            session_id=r.session_id,
+            user_id="u1",
+            source="api",
+            created_at=r.created_at,
+        )
+        for r in results
+    }
+    storage.get_citations_by_session_ids.return_value = []
+    storage.get_imported_scores.return_value = []
+    storage.get_shadow_comparison_verdicts.return_value = []
+    return storage
+
+
+def test_service_returns_full_response_with_shadow_enabled_and_data() -> None:
+    storage = _storage_with_results(
+        [
+            _eval_result(result_id=1, session_id="s1", is_success=True, corrections=0),
+            _eval_result(result_id=2, session_id="s2", is_success=True, corrections=1),
+            _eval_result(result_id=3, session_id="s3", is_success=False, corrections=3),
+        ]
+    )
     config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=True)
 
     svc = EvaluationOverviewService(storage=storage, config=config)
@@ -61,13 +86,12 @@ def test_service_hero_shadow_fields_always_null_after_direct_grade_removal() -> 
     See docs/superpowers/specs/2026-05-27-shadow-mode-validity-and-alternatives.md
     for the rationale (multi-turn trajectory contamination + applicability gap).
     """
-    storage = MagicMock()
-    storage.get_agent_success_evaluation_results.return_value = [
-        _eval_result(result_id=1, session_id="s1", is_success=True),
-        _eval_result(result_id=2, session_id="s2", is_success=False),
-    ]
-    storage.get_playbook_application_stats.return_value = []
-    storage.get_interactions_by_session.return_value = []
+    storage = _storage_with_results(
+        [
+            _eval_result(result_id=1, session_id="s1", is_success=True),
+            _eval_result(result_id=2, session_id="s2", is_success=False),
+        ]
+    )
     config = Config(storage_config=StorageConfigSQLite())
 
     svc = EvaluationOverviewService(storage=storage, config=config)
@@ -81,10 +105,7 @@ def test_service_hero_shadow_fields_always_null_after_direct_grade_removal() -> 
 
 
 def test_service_returns_empty_state_when_no_results() -> None:
-    storage = MagicMock()
-    storage.get_agent_success_evaluation_results.return_value = []
-    storage.get_playbook_application_stats.return_value = []
-    storage.get_interactions_by_session.return_value = []
+    storage = _storage_with_results([])
     config = Config(storage_config=StorageConfigSQLite(), shadow_mode_enabled=False)
 
     svc = EvaluationOverviewService(storage=storage, config=config)
@@ -97,19 +118,16 @@ def test_service_returns_empty_state_when_no_results() -> None:
 
 def test_service_reports_single_recent_success_as_100_percent() -> None:
     now = int(time.time())
-    storage = MagicMock()
-    storage.get_agent_success_evaluation_results.return_value = [
-        _eval_result(
-            result_id=1,
-            session_id="recent-success",
-            is_success=True,
-            created_at=now - 60,
-        ),
-    ]
-    storage.get_playbook_application_stats.return_value = []
-    storage.get_interactions_by_session.return_value = []
-    storage.get_imported_scores.return_value = []
-    storage.get_sessions.return_value = {}
+    storage = _storage_with_results(
+        [
+            _eval_result(
+                result_id=1,
+                session_id="recent-success",
+                is_success=True,
+                created_at=now - 60,
+            ),
+        ]
+    )
     config = Config(storage_config=StorageConfigSQLite())
 
     svc = EvaluationOverviewService(storage=storage, config=config)
@@ -124,22 +142,19 @@ def test_service_reports_single_recent_success_as_100_percent() -> None:
 def test_service_uses_first_ever_eval_for_hero_age() -> None:
     """A narrow window should not make a mature org look newly onboarded."""
     now = int(time.time())
-    storage = MagicMock()
-    storage.get_agent_success_evaluation_results.return_value = [
-        _eval_result(
-            result_id=1,
-            session_id="old",
-            is_success=True,
-            created_at=now - 10 * 24 * 60 * 60,
-        ),
-        _eval_result(
-            result_id=2, session_id="current", is_success=True, created_at=now
-        ),
-    ]
-    storage.get_playbook_application_stats.return_value = []
-    storage.get_interactions_by_session.return_value = []
-    storage.get_imported_scores.return_value = []
-    storage.get_sessions.return_value = {}
+    storage = _storage_with_results(
+        [
+            _eval_result(
+                result_id=1,
+                session_id="old",
+                is_success=True,
+                created_at=now - 10 * 24 * 60 * 60,
+            ),
+            _eval_result(
+                result_id=2, session_id="current", is_success=True, created_at=now
+            ),
+        ]
+    )
     config = Config(storage_config=StorageConfigSQLite())
 
     svc = EvaluationOverviewService(storage=storage, config=config)
@@ -150,26 +165,23 @@ def test_service_uses_first_ever_eval_for_hero_age() -> None:
 
 def test_service_honors_day_bucket_for_hero_trend() -> None:
     day = 24 * 60 * 60
-    storage = MagicMock()
-    storage.get_agent_success_evaluation_results.return_value = [
-        _eval_result(result_id=1, session_id="s1", is_success=True, created_at=day),
-        _eval_result(
-            result_id=2,
-            session_id="s2",
-            is_success=False,
-            created_at=day + 3600,
-        ),
-        _eval_result(
-            result_id=3,
-            session_id="s3",
-            is_success=True,
-            created_at=2 * day,
-        ),
-    ]
-    storage.get_playbook_application_stats.return_value = []
-    storage.get_interactions_by_session.return_value = []
-    storage.get_imported_scores.return_value = []
-    storage.get_sessions.return_value = {}
+    storage = _storage_with_results(
+        [
+            _eval_result(result_id=1, session_id="s1", is_success=True, created_at=day),
+            _eval_result(
+                result_id=2,
+                session_id="s2",
+                is_success=False,
+                created_at=day + 3600,
+            ),
+            _eval_result(
+                result_id=3,
+                session_id="s3",
+                is_success=True,
+                created_at=2 * day,
+            ),
+        ]
+    )
     config = Config(storage_config=StorageConfigSQLite())
 
     svc = EvaluationOverviewService(storage=storage, config=config)
@@ -179,3 +191,189 @@ def test_service_honors_day_bucket_for_hero_trend() -> None:
 
     assert [bucket.ts for bucket in response.hero.buckets] == [day, 2 * day]
     assert [bucket.regular_n for bucket in response.hero.buckets] == [2, 1]
+
+
+def test_service_uses_bulk_storage_methods_without_per_session_reads() -> None:
+    storage = _storage_with_results(
+        [
+            _eval_result(result_id=1, session_id="s1", is_success=True),
+            _eval_result(result_id=2, session_id="s2", is_success=False),
+        ]
+    )
+    storage.get_citations_by_session_ids.return_value = [
+        SessionCitation(
+            session_id="s1",
+            kind="playbook",
+            real_id="42",
+            title="Keep answers short",
+        )
+    ]
+    config = Config(storage_config=StorageConfigSQLite())
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(GetEvaluationOverviewRequest(from_ts=0, to_ts=int(time.time())))
+
+    assert response.rule_attribution[0].rule_id == "42"
+    storage.get_agent_success_evaluation_results.assert_not_called()
+    storage.get_sessions.assert_not_called()
+    storage.get_interactions_by_session.assert_not_called()
+    storage.get_playbook_application_stats.assert_not_called()
+    storage.get_first_requests_by_session_ids.assert_called_once()
+    storage.get_citations_by_session_ids.assert_called_once()
+
+
+def test_service_limits_source_lookup_to_window_when_no_source_sets() -> None:
+    now = int(time.time())
+    day = 24 * 60 * 60
+    storage = _storage_with_results(
+        [
+            _eval_result(
+                result_id=1,
+                session_id="current",
+                is_success=True,
+                created_at=now,
+            ),
+            _eval_result(
+                result_id=2,
+                session_id="previous",
+                is_success=False,
+                created_at=now - 10 * day,
+            ),
+        ]
+    )
+    storage.get_first_requests_by_session_ids.return_value = {
+        "current": SessionFirstRequest(
+            session_id="current",
+            user_id="u1",
+            source="current-source",
+            created_at=now,
+        ),
+        "previous": SessionFirstRequest(
+            session_id="previous",
+            user_id="u1",
+            source="previous-source",
+            created_at=now - 10 * day,
+        ),
+    }
+    config = Config(storage_config=StorageConfigSQLite())
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(
+            from_ts=now - 60,
+            to_ts=now,
+            include_shadow=False,
+        )
+    )
+
+    assert response.source_set_comparison.available_sources == ["current-source"]
+    storage.get_first_requests_by_session_ids.assert_called_once_with(["current"])
+
+
+def test_service_loads_baseline_sources_when_source_sets_requested() -> None:
+    now = int(time.time())
+    day = 24 * 60 * 60
+    storage = _storage_with_results(
+        [
+            _eval_result(
+                result_id=1,
+                session_id="current",
+                is_success=True,
+                created_at=now,
+            ),
+            _eval_result(
+                result_id=2,
+                session_id="previous",
+                is_success=False,
+                created_at=now - 10 * day,
+            ),
+        ]
+    )
+    storage.get_first_requests_by_session_ids.return_value = {
+        "current": SessionFirstRequest(
+            session_id="current",
+            user_id="u1",
+            source="candidate",
+            created_at=now,
+        ),
+        "previous": SessionFirstRequest(
+            session_id="previous",
+            user_id="u1",
+            source="candidate",
+            created_at=now - 10 * day,
+        ),
+    }
+    config = Config(storage_config=StorageConfigSQLite())
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(
+            from_ts=now - 7 * day,
+            to_ts=now,
+            include_shadow=False,
+            source_sets=[
+                EvaluationSourceSetRequest(label="Candidate", sources=["candidate"])
+            ],
+        )
+    )
+
+    assert (
+        response.source_set_comparison.sets[0].context_tiles.success.delta_pp == 100.0
+    )
+    storage.get_first_requests_by_session_ids.assert_called_once_with(
+        ["current", "previous"]
+    )
+
+
+def test_service_skips_shadow_storage_when_shadow_excluded() -> None:
+    storage = _storage_with_results(
+        [_eval_result(result_id=1, session_id="s1", is_success=True)]
+    )
+    config = Config(storage_config=StorageConfigSQLite())
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    response = svc.run(
+        GetEvaluationOverviewRequest(
+            from_ts=0,
+            to_ts=int(time.time()),
+            include_shadow=False,
+        )
+    )
+
+    assert response.shadow_win_rate_trend.window_total.n == 0
+    storage.get_shadow_comparison_verdicts.assert_not_called()
+
+
+def test_service_handles_5k_sessions_with_bulk_call_shape() -> None:
+    now = int(time.time())
+    results = [
+        _eval_result(
+            result_id=i + 1,
+            session_id=f"s{i}",
+            is_success=(i % 2 == 0),
+            corrections=i % 6,
+            created_at=now - (i % 3600),
+        )
+        for i in range(5000)
+    ]
+    storage = _storage_with_results(results)
+    config = Config(storage_config=StorageConfigSQLite())
+
+    svc = EvaluationOverviewService(storage=storage, config=config)
+    started = time.perf_counter()
+    response = svc.run(
+        GetEvaluationOverviewRequest(
+            from_ts=now - 7200,
+            to_ts=now,
+            include_shadow=False,
+        )
+    )
+    elapsed = time.perf_counter() - started
+
+    assert response.hero.regular_success_rate_pp == 50.0
+    assert elapsed < 2.0
+    storage.get_agent_success_evaluation_results_in_window.assert_called_once()
+    storage.get_first_requests_by_session_ids.assert_called_once()
+    storage.get_citations_by_session_ids.assert_called_once()
+    storage.get_sessions.assert_not_called()
+    storage.get_interactions_by_session.assert_not_called()

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 import tempfile
 from collections.abc import Generator
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -41,6 +42,27 @@ def _seed_request(storage: BaseStorage, user_id: str, session_id: str, ts: int) 
         user_id=user_id,
         created_at=ts,
         source="test",
+        agent_version="v1",
+        session_id=session_id,
+    )
+    storage.add_request(req)
+    return req.request_id
+
+
+def _seed_request_with_source(
+    storage: BaseStorage,
+    *,
+    user_id: str,
+    session_id: str,
+    ts: int,
+    source: str,
+    request_id: str,
+) -> str:
+    req = Request(
+        request_id=request_id,
+        user_id=user_id,
+        created_at=ts,
+        source=source,
         agent_version="v1",
         session_id=session_id,
     )
@@ -90,7 +112,7 @@ def test_null_session_rejected_by_request_model() -> None:
             created_at=1000,
             source="test",
             agent_version="v1",
-            session_id=None,
+            session_id=cast(Any, None),
         )
 
 
@@ -179,6 +201,7 @@ def _seed_eval_result(
     session_id: str,
     evaluation_name: str,
     agent_version: str = "v1",
+    created_at: int = 1000,
 ) -> None:
     """Save one ``AgentSuccessEvaluationResult`` row with minimal fields set."""
     result = AgentSuccessEvaluationResult(
@@ -193,9 +216,91 @@ def _seed_eval_result(
         user_turns_to_resolution=None,
         is_escalated=False,
         embedding=[],
-        created_at=1000,
+        created_at=created_at,
     )
     storage.save_agent_success_evaluation_results([result])
+
+
+def test_first_requests_by_session_ids_returns_earliest_request(
+    storage: BaseStorage,
+) -> None:
+    _seed_request_with_source(
+        storage,
+        user_id="u1",
+        session_id="s1",
+        ts=2000,
+        source="later",
+        request_id="req_s1_later",
+    )
+    _seed_request_with_source(
+        storage,
+        user_id="u1",
+        session_id="s1",
+        ts=1000,
+        source="first",
+        request_id="req_s1_first",
+    )
+    _seed_request_with_source(
+        storage,
+        user_id="u2",
+        session_id="s2",
+        ts=1500,
+        source="only",
+        request_id="req_s2_only",
+    )
+
+    out = storage.get_first_requests_by_session_ids(["s2", "s1", "missing", "s1"])
+
+    assert set(out) == {"s1", "s2"}
+    assert out["s1"].user_id == "u1"
+    assert out["s1"].source == "first"
+    assert out["s1"].created_at == 1000
+    assert out["s2"].user_id == "u2"
+    assert out["s2"].source == "only"
+
+
+def test_eval_result_window_read_filters_in_storage_contract(
+    storage: BaseStorage,
+) -> None:
+    _seed_eval_result(storage, "old", "overall_success", created_at=100)
+    _seed_eval_result(storage, "inside", "overall_success", created_at=200)
+    _seed_eval_result(storage, "new", "overall_success", created_at=300)
+    _seed_eval_result(
+        storage, "inside_v2", "overall_success", agent_version="v2", created_at=250
+    )
+
+    all_inside = storage.get_agent_success_evaluation_results_in_window(150, 260)
+    v1_inside = storage.get_agent_success_evaluation_results_in_window(
+        150, 260, agent_version="v1"
+    )
+
+    assert {r.session_id for r in all_inside} == {"inside", "inside_v2"}
+    assert {r.session_id for r in v1_inside} == {"inside"}
+
+
+def test_targeted_eval_result_id_lookup(
+    storage: BaseStorage,
+) -> None:
+    _seed_eval_result(storage, "s1", "overall_success", agent_version="v1")
+    _seed_eval_result(storage, "s1", "safety", agent_version="v1")
+    _seed_eval_result(storage, "s1", "overall_success", agent_version="v2")
+    _seed_eval_result(storage, "s2", "overall_success", agent_version="v1")
+
+    ids = storage.get_agent_success_evaluation_result_ids(
+        session_id="s1",
+        evaluation_name="overall_success",
+        agent_version="v1",
+    )
+
+    assert len(ids) == 1
+    row = [
+        r
+        for r in storage.get_agent_success_evaluation_results(limit=100)
+        if r.result_id == ids[0]
+    ][0]
+    assert row.session_id == "s1"
+    assert row.evaluation_name == "overall_success"
+    assert row.agent_version == "v1"
 
 
 def test_delete_scoped_to_session_and_name(storage: BaseStorage) -> None:

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -11,13 +11,17 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-from reflexio.models.api_schema.internal_schema import SessionDescriptor
+from reflexio.models.api_schema.internal_schema import (
+    RequestInteractionDataModel,
+    SessionDescriptor,
+)
 from reflexio.models.api_schema.service_schemas import (
     AgentSuccessEvaluationResult,
     Request,
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base import BaseStorage
+from reflexio.server.services.storage.storage_base._requests import RequestMixin
 
 pytestmark = pytest.mark.integration
 
@@ -257,6 +261,59 @@ def test_first_requests_by_session_ids_returns_earliest_request(
     assert out["s1"].created_at == 1000
     assert out["s2"].user_id == "u2"
     assert out["s2"].source == "only"
+
+
+def test_base_first_request_fallback_paginates_all_session_rows() -> None:
+    class PaginatedSessionStorage:
+        def __init__(self) -> None:
+            self.calls: list[tuple[int | None, int]] = []
+            self.requests = [
+                Request(
+                    request_id=f"req-{i}",
+                    user_id="u1",
+                    created_at=1_700_000_000 + i,
+                    source=f"source-{i}",
+                    agent_version="v1",
+                    session_id="big-session",
+                )
+                for i in range(1001)
+            ]
+
+        def get_sessions(
+            self,
+            user_id: str | None = None,
+            request_id: str | None = None,
+            session_id: str | None = None,
+            start_time: int | None = None,
+            end_time: int | None = None,
+            top_k: int | None = 30,
+            offset: int = 0,
+        ) -> dict[str, list[RequestInteractionDataModel]]:
+            del user_id, request_id, start_time, end_time
+            self.calls.append((top_k, offset))
+            matching = [r for r in self.requests if r.session_id == session_id]
+            rows = sorted(matching, key=lambda r: r.created_at, reverse=True)
+            page = rows[offset : offset + (top_k or 0)]
+            return {
+                session_id or "": [
+                    RequestInteractionDataModel(
+                        session_id=r.session_id,
+                        request=r,
+                        interactions=[],
+                    )
+                    for r in page
+                ]
+            }
+
+    storage = PaginatedSessionStorage()
+
+    out = RequestMixin.get_first_requests_by_session_ids(
+        cast(Any, storage), ["big-session"]
+    )
+
+    assert out["big-session"].created_at == 1_700_000_000
+    assert out["big-session"].source == "source-0"
+    assert storage.calls == [(1000, 0), (1000, 1000)]
 
 
 def test_eval_result_window_read_filters_in_storage_contract(

--- a/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
+++ b/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
@@ -157,6 +157,27 @@ def test_get_recent_verdicts_orders_descending_and_limits(
     assert [r.interaction_id for r in result] == ["cv-i-4", "cv-i-3", "cv-i-2"]
 
 
+def test_get_recent_verdicts_negative_limit_returns_empty(
+    storage: BaseStorage,
+) -> None:
+    base_ts = int(datetime.now(UTC).timestamp())
+    storage.save_shadow_comparison_verdict(
+        _make_verdict(
+            interaction_id="cv-i-negative-limit",
+            created_at=datetime.fromtimestamp(base_ts, tz=UTC),
+        )
+    )
+
+    result = storage.get_recent_shadow_comparison_verdicts(
+        from_ts=base_ts - 1,
+        to_ts=base_ts + 1,
+        judge_prompt_version="v1.0.0",
+        limit=-1,
+    )
+
+    assert result == []
+
+
 def test_delete_by_session_returns_count(storage: BaseStorage) -> None:
     base_ts = datetime.now(UTC)
     storage.save_shadow_comparison_verdict(

--- a/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
+++ b/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
@@ -128,6 +128,35 @@ def test_get_in_window_orders_ascending_by_created_at(
     assert [r.interaction_id for r in result] == ["cv-i-early", "cv-i-late"]
 
 
+def test_get_recent_verdicts_orders_descending_and_limits(
+    storage: BaseStorage,
+) -> None:
+    base_ts = int(datetime.now(UTC).timestamp())
+    for offset in range(5):
+        storage.save_shadow_comparison_verdict(
+            _make_verdict(
+                interaction_id=f"cv-i-{offset}",
+                created_at=datetime.fromtimestamp(base_ts + offset, tz=UTC),
+            )
+        )
+    storage.save_shadow_comparison_verdict(
+        _make_verdict(
+            interaction_id="cv-i-other-prompt",
+            judge_prompt_version="v2.0.0",
+            created_at=datetime.fromtimestamp(base_ts + 10, tz=UTC),
+        )
+    )
+
+    result = storage.get_recent_shadow_comparison_verdicts(
+        from_ts=base_ts - 1,
+        to_ts=base_ts + 20,
+        judge_prompt_version="v1.0.0",
+        limit=3,
+    )
+
+    assert [r.interaction_id for r in result] == ["cv-i-4", "cv-i-3", "cv-i-2"]
+
+
 def test_delete_by_session_returns_count(storage: BaseStorage) -> None:
     base_ts = datetime.now(UTC)
     storage.save_shadow_comparison_verdict(

--- a/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
+++ b/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
@@ -24,6 +24,9 @@ from reflexio.models.api_schema.eval_overview_schema import (
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base import BaseStorage
+from reflexio.server.services.storage.storage_base._shadow_verdicts import (
+    ShadowVerdictsMixin,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -176,6 +179,33 @@ def test_get_recent_verdicts_negative_limit_returns_empty(
     )
 
     assert result == []
+
+
+def test_base_recent_verdicts_nonpositive_limit_skips_window_read() -> None:
+    class GuardedShadowStorage(ShadowVerdictsMixin):
+        def get_shadow_comparison_verdicts(
+            self,
+            from_ts: int,
+            to_ts: int,
+            judge_prompt_version: str,
+        ) -> list[ShadowComparisonVerdict]:
+            del from_ts, to_ts, judge_prompt_version
+            raise AssertionError("limit guard should avoid full window read")
+
+    storage = GuardedShadowStorage()
+
+    assert storage.get_recent_shadow_comparison_verdicts(
+        from_ts=0,
+        to_ts=1,
+        judge_prompt_version="v1.0.0",
+        limit=0,
+    ) == []
+    assert storage.get_recent_shadow_comparison_verdicts(
+        from_ts=0,
+        to_ts=1,
+        judge_prompt_version="v1.0.0",
+        limit=-1,
+    ) == []
 
 
 def test_delete_by_session_returns_count(storage: BaseStorage) -> None:

--- a/tests/server/services/storage/test_sqlite_storage_bc_extras.py
+++ b/tests/server/services/storage/test_sqlite_storage_bc_extras.py
@@ -203,9 +203,19 @@ def test_get_citations_by_session_ids_extracts_cited_rows(
         "UPDATE interactions SET citations = NULL WHERE request_id = ? AND role = ?",
         (null_request_id, "Assistant"),
     )
+    blank_request_id = _add_request_with_interactions(
+        storage,
+        session_id="blank",
+        request_id="req_blank",
+        assistant_citations=[Citation(kind="playbook", real_id="100")],
+    )
+    storage.conn.execute(
+        "UPDATE interactions SET citations = '' WHERE request_id = ? AND role = ?",
+        (blank_request_id, "Assistant"),
+    )
 
     out = storage.get_citations_by_session_ids(
-        ["s1", "s2", "empty", "nullish", "missing"]
+        ["s1", "s2", "empty", "nullish", "blank", "missing"]
     )
 
     by_session = {}

--- a/tests/server/services/storage/test_sqlite_storage_bc_extras.py
+++ b/tests/server/services/storage/test_sqlite_storage_bc_extras.py
@@ -21,6 +21,7 @@ from reflexio.models.api_schema.braintrust_schema import (
     BraintrustConnection,
     ImportedScore,
 )
+from reflexio.models.api_schema.domain.entities import Citation
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
     Request,
@@ -51,6 +52,7 @@ def _add_request_with_interactions(
     request_id: str | None = None,
     shadow_content_for_assistant: str = "",
     created_at: int | None = None,
+    assistant_citations: list[Citation] | None = None,
 ) -> str:
     """Create a request + 2 interactions (1 user, 1 assistant); return request_id."""
     request_id = request_id or f"req_{uuid.uuid4().hex[:8]}"
@@ -84,6 +86,7 @@ def _add_request_with_interactions(
                 content="hi back",
                 shadow_content=shadow_content_for_assistant,
                 created_at=ts + 1,
+                citations=assistant_citations or [],
             ),
         ],
     )
@@ -166,6 +169,57 @@ def test_get_interactions_by_session_unknown_session_returns_empty(
     storage: SQLiteStorage,
 ) -> None:
     assert storage.get_interactions_by_session("never_existed") == []
+
+
+def test_get_citations_by_session_ids_extracts_cited_rows(
+    storage: SQLiteStorage,
+) -> None:
+    _add_request_with_interactions(
+        storage,
+        session_id="s1",
+        request_id="req_s1",
+        assistant_citations=[
+            Citation(kind="playbook", real_id="42", title="Keep it short"),
+            Citation(kind="profile", real_id="p9", title="Prefers email"),
+        ],
+    )
+    _add_request_with_interactions(
+        storage,
+        session_id="s2",
+        request_id="req_s2",
+        assistant_citations=[
+            Citation(kind="playbook", real_id="42", title="Keep it short"),
+            Citation(kind="playbook", real_id="42", title="Keep it short"),
+        ],
+    )
+    _add_request_with_interactions(storage, session_id="empty", request_id="req_empty")
+    null_request_id = _add_request_with_interactions(
+        storage,
+        session_id="nullish",
+        request_id="req_nullish",
+        assistant_citations=[Citation(kind="playbook", real_id="99")],
+    )
+    storage.conn.execute(
+        "UPDATE interactions SET citations = NULL WHERE request_id = ? AND role = ?",
+        (null_request_id, "Assistant"),
+    )
+
+    out = storage.get_citations_by_session_ids(
+        ["s1", "s2", "empty", "nullish", "missing"]
+    )
+
+    by_session = {}
+    for citation in out:
+        by_session.setdefault(citation.session_id, []).append(citation)
+    assert set(by_session) == {"s1", "s2"}
+    assert [(c.kind, c.real_id, c.title) for c in by_session["s1"]] == [
+        ("playbook", "42", "Keep it short"),
+        ("profile", "p9", "Prefers email"),
+    ]
+    assert [(c.kind, c.real_id) for c in by_session["s2"]] == [
+        ("playbook", "42"),
+        ("playbook", "42"),
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Make evaluation overview reads scale with bulk, indexed storage calls instead of per-session request and interaction loops.
- Add storage contracts for windowed evaluation results, first-request lookup, citation extraction, targeted eval-result IDs, and recent shadow verdicts.
- Patch related evaluation paths that had the same scan-on-demand pattern while preserving public API response shapes.

## Changes
- Evaluation overview now loads only the requested/baseline evaluation windows and reuses in-memory data for attribution, source cohorts, Braintrust, and shadow aggregation.
- SQLite storage implements the new bulk methods with indexed query paths and migration-compatible fallbacks.
- Regeneration candidate discovery, forced group evaluation, grade-on-demand, and recent shadow comparisons use targeted reads.
- Added regression and scale-oriented tests for the new storage contracts and overview service call shape.

## Test Plan
- `uv run ruff check` on touched OSS files
- `uv run pyright` on touched OSS files
- `uv run pytest --no-cov tests/server/services/evaluation_overview/test_service_integration.py tests/server/services/evaluation_overview/test_service_grouping_integration.py tests/server/services/storage/test_session_window_contract.py tests/server/services/storage/test_sqlite_storage_bc_extras.py tests/server/services/storage/test_shadow_verdicts_contract_integration.py tests/server/services/agent_success_evaluation/test_regen_jobs_sampling_integration.py`
- Local self-host Supabase smoke with 1000 seeded evaluation sessions: `/api/get_evaluation_overview` returned 200 in ~0.28-0.33s after optimization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved evaluation overview and dashboard loading with more efficient bulk data retrieval.
  * Added database indexes to speed up session, evaluation-result, and shadow-verdict queries.
* **Bug Fixes**
  * Corrected “recent” shadow verdict retrieval to consistently return newest-first results with proper time-window filtering and enforced limits.
* **Improvements**
  * Streamlined attribution data by bulk-loading session earliest-request metadata and citations.
  * Improved resilience for regeneration jobs when session metadata lookups fail, avoiding job error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->