### PR TITLE
feat: add generated entity tagging

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -221,7 +221,7 @@ class UserProfile(BaseModel):
         None  # Retained provenance data column (merged on dedup); new profiles write None.
     )
     expanded_terms: str | None = None
-    tags: list[str] = Field(default_factory=list)
+    tags: list[str] | None = None  # None = not yet tagged; [] = tagged, no match
     embedding: EmbeddingVector = []
     source_span: str | None = None
     notes: str | None = None
@@ -246,7 +246,7 @@ class UserPlaybook(BaseModel):
     source: str | None = None  # source of the interaction that generated this playbook
     source_interaction_ids: list[int] = Field(default_factory=list)
     expanded_terms: str | None = None
-    tags: list[str] = Field(default_factory=list)
+    tags: list[str] | None = None  # None = not yet tagged; [] = tagged, no match
     embedding: EmbeddingVector = []
     source_span: str | None = None
     notes: str | None = None
@@ -275,7 +275,7 @@ class AgentPlaybook(BaseModel):
     playbook_status: PlaybookStatus = PlaybookStatus.PENDING
     playbook_metadata: str = ""
     expanded_terms: str | None = None
-    tags: list[str] = Field(default_factory=list)
+    tags: list[str] | None = None  # None = not yet tagged; [] = tagged, no match
     embedding: EmbeddingVector = []
     status: Status | None = (
         None  # used for tracking intermediate states during playbook aggregation. Status.ARCHIVED for playbooks during aggregation process, None for current playbooks

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -221,6 +221,7 @@ class UserProfile(BaseModel):
         None  # Retained provenance data column (merged on dedup); new profiles write None.
     )
     expanded_terms: str | None = None
+    tags: list[str] = Field(default_factory=list)
     embedding: EmbeddingVector = []
     source_span: str | None = None
     notes: str | None = None
@@ -245,6 +246,7 @@ class UserPlaybook(BaseModel):
     source: str | None = None  # source of the interaction that generated this playbook
     source_interaction_ids: list[int] = Field(default_factory=list)
     expanded_terms: str | None = None
+    tags: list[str] = Field(default_factory=list)
     embedding: EmbeddingVector = []
     source_span: str | None = None
     notes: str | None = None
@@ -273,6 +275,7 @@ class AgentPlaybook(BaseModel):
     playbook_status: PlaybookStatus = PlaybookStatus.PENDING
     playbook_metadata: str = ""
     expanded_terms: str | None = None
+    tags: list[str] = Field(default_factory=list)
     embedding: EmbeddingVector = []
     status: Status | None = (
         None  # used for tracking intermediate states during playbook aggregation. Status.ARCHIVED for playbooks during aggregation process, None for current playbooks

--- a/reflexio/models/api_schema/ui/converters.py
+++ b/reflexio/models/api_schema/ui/converters.py
@@ -78,7 +78,7 @@ def to_profile_view(profile: UserProfile) -> ProfileView:
         status=profile.status,
         extractor_names=profile.extractor_names,
         source_span=profile.source_span,
-        tags=profile.tags,
+        tags=profile.tags or [],
     )
 
 
@@ -105,7 +105,7 @@ def to_user_playbook_view(rf: UserPlaybook) -> UserPlaybookView:
         source=rf.source,
         source_interaction_ids=rf.source_interaction_ids,
         source_span=rf.source_span,
-        tags=rf.tags,
+        tags=rf.tags or [],
     )
 
 
@@ -129,7 +129,7 @@ def to_agent_playbook_view(fb: AgentPlaybook) -> AgentPlaybookView:
         playbook_status=fb.playbook_status,
         playbook_metadata=fb.playbook_metadata,
         status=fb.status,
-        tags=fb.tags,
+        tags=fb.tags or [],
     )
 
 

--- a/reflexio/models/api_schema/ui/converters.py
+++ b/reflexio/models/api_schema/ui/converters.py
@@ -78,6 +78,7 @@ def to_profile_view(profile: UserProfile) -> ProfileView:
         status=profile.status,
         extractor_names=profile.extractor_names,
         source_span=profile.source_span,
+        tags=profile.tags,
     )
 
 
@@ -104,6 +105,7 @@ def to_user_playbook_view(rf: UserPlaybook) -> UserPlaybookView:
         source=rf.source,
         source_interaction_ids=rf.source_interaction_ids,
         source_span=rf.source_span,
+        tags=rf.tags,
     )
 
 
@@ -127,6 +129,7 @@ def to_agent_playbook_view(fb: AgentPlaybook) -> AgentPlaybookView:
         playbook_status=fb.playbook_status,
         playbook_metadata=fb.playbook_metadata,
         status=fb.status,
+        tags=fb.tags,
     )
 
 

--- a/reflexio/models/api_schema/ui/entities.py
+++ b/reflexio/models/api_schema/ui/entities.py
@@ -65,6 +65,7 @@ class ProfileView(BaseModel):
     status: Status | None = None
     extractor_names: list[str] | None = None
     source_span: str | None = None
+    tags: list[str] = Field(default_factory=list)
 
 
 class UserPlaybookView(BaseModel):
@@ -83,6 +84,7 @@ class UserPlaybookView(BaseModel):
     source: str | None = None
     source_interaction_ids: list[int] = Field(default_factory=list)
     source_span: str | None = None
+    tags: list[str] = Field(default_factory=list)
 
 
 class AgentPlaybookView(BaseModel):
@@ -98,6 +100,7 @@ class AgentPlaybookView(BaseModel):
     playbook_status: PlaybookStatus = PlaybookStatus.PENDING
     playbook_metadata: str = ""
     status: Status | None = None
+    tags: list[str] = Field(default_factory=list)
 
 
 class EvaluationResultView(BaseModel):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -415,7 +415,7 @@ class ProfileExtractorConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     extractor_name: NonEmptyStr | None = None
     extraction_definition_prompt: SanitizedNonEmptyStr
     context_prompt: str | None = None
-    metadata_definition_prompt: str | None = None
+    tagging_definition_prompt: str | None = None
     should_extract_profile_prompt_override: str | None = None
     request_sources_enabled: list[str] | None = (
         None  # default enabled for all sources, if set, only extract profiles from the enabled request sources
@@ -466,7 +466,7 @@ class UserPlaybookExtractorConfig(_ExtractorWindowOverrideCompatMixin, BaseModel
     extractor_name: NonEmptyStr | None = None
     extraction_definition_prompt: SanitizedNonEmptyStr
     context_prompt: str | None = None
-    metadata_definition_prompt: str | None = None
+    tagging_definition_prompt: str | None = None
     aggregation_config: PlaybookAggregatorConfig | None = None
     deduplication_config: DeduplicationConfig | None = None
     request_sources_enabled: list[str] | None = (

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -349,6 +349,21 @@ class _CompletionResponseSnapshot:
 class _CompletionErrorSnapshot:
     type_name: str
     message: str
+    model: str | None = None
+    llm_provider: str | None = None
+
+
+def _snapshot_completion_error(
+    exc: BaseException, params: dict[str, Any]
+) -> _CompletionErrorSnapshot:
+    model = getattr(exc, "model", None) or params.get("model")
+    llm_provider = getattr(exc, "llm_provider", None)
+    return _CompletionErrorSnapshot(
+        type_name=type(exc).__name__,
+        message=str(exc),
+        model=str(model) if model else None,
+        llm_provider=str(llm_provider) if llm_provider else None,
+    )
 
 
 def _ensure_picklable(value: Any) -> Any:
@@ -421,14 +436,7 @@ def _litellm_completion_worker(
             ("ok", _picklable_completion_result(litellm.completion(**params)))
         )
     except BaseException as exc:
-        try:
-            pickle.dumps(exc)
-        except Exception:
-            result_queue.put(
-                ("error", _CompletionErrorSnapshot(type(exc).__name__, str(exc)))
-            )
-        else:
-            result_queue.put(("error", exc))
+        result_queue.put(("error", _snapshot_completion_error(exc, params)))
 
 
 class LiteLLMClient:
@@ -1156,11 +1164,15 @@ class LiteLLMClient:
 
             if status == "ok":
                 return payload
-            if isinstance(payload, _CompletionErrorSnapshot):
-                raise LiteLLMClientError(
-                    f"litellm.completion raised {payload.type_name}: {payload.message}"
-                )
-            raise payload
+            # The worker always reports errors as a picklable snapshot.
+            context_parts = [f"model={payload.model}"]
+            if payload.llm_provider:
+                context_parts.append(f"provider={payload.llm_provider}")
+            raise LiteLLMClientError(
+                "litellm.completion failed in isolated worker: "
+                f"{payload.type_name}: {payload.message} "
+                f"({', '.join(context_parts)})"
+            )
         finally:
             result_queue.close()
             result_queue.join_thread()

--- a/reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.0.0.prompt.md
@@ -6,7 +6,6 @@ variables:
   - agent_context_prompt
   - context_prompt
   - extraction_definition_prompt
-  - metadata_definition_prompt
 ---
 [Context of user interactions]
 {agent_context_prompt}
@@ -50,7 +49,6 @@ STEP 2: Decide what to extract:
 STEP 3: For each profile you extract, you must assign:
 - "content": The profile information (what you learned about the user)
 - "time_to_live": How long this information stays valid (see rules below)
-- "metadata": Extra categorization based on the metadata definition (only if metadata definition is provided)
 
 [Time to Live - Choose One]
 - "infinity" → Facts that rarely change (name, birthday, gender, phone number)
@@ -62,8 +60,6 @@ STEP 3: For each profile you extract, you must assign:
 [What to Extract - Definitions]
 Only extract profiles that match this content definition: {extraction_definition_prompt}
 
-Only extract metadata that matches this definition (if provided): {metadata_definition_prompt}
-
 [Output Format]
 Return a JSON object. If nothing to extract, return {{"profiles": null}}.
 
@@ -72,8 +68,7 @@ Return a JSON object. If nothing to extract, return {{"profiles": null}}.
     "profiles": [
         {{
             "content": "the new profile information",
-            "time_to_live": "such as one_month",
-            "metadata": "metadata value if definition provided"
+            "time_to_live": "such as one_month"
         }}
     ]
 }}
@@ -83,12 +78,11 @@ Return a JSON object. If nothing to extract, return {{"profiles": null}}.
 
 Example 1 - Extracting a new profile:
 - Content definition: "food preferences"
-- Metadata definition: "cuisine type (pizza, sushi, pasta, salad, steak)"
 - Existing profiles: []
 - Interaction: "i like to eat pizza"
 - Reasoning: User revealed a food preference. This is new (not in existing profiles). Food preference changes monthly, so time_to_live is "one_month".
 ```json
-{{"profiles": [{{"content": "likes pizza", "time_to_live": "one_month", "metadata": "pizza"}}]}}
+{{"profiles": [{{"content": "likes pizza", "time_to_live": "one_month"}}]}}
 ```
 
 Example 2 - Extracting a permanent profile:
@@ -135,6 +129,5 @@ Note: if the same session surfaces a behavioral rule (e.g., "verify column types
 1. Only extract profiles matching the content definition provided above
 2. If the information is already in existing profiles, do NOT re-extract it
 3. Always include time_to_live for new profiles
-4. Only include metadata if a metadata definition is provided
-5. **Forget / delete / remove requests.** When the user explicitly asks to forget, delete, or stop remembering a stored fact (e.g. "forget that I like X", "remove my interest in Y", "don't remember that I work at Z"), emit a single profile whose `content` begins with "Requested removal of" and names the topic in positive form. Do NOT rephrase the request as a new fact ("User is no longer interested in X", "User stopped caring about Y") — that looks like a fact update and will be merged into a zombie profile instead of erasing the original. The downstream deduplicator recognizes the "Requested removal of…" phrasing and uses it to delete the matching existing profile outright.
-6. Return {{"profiles": null}} if there is nothing to extract
+4. **Forget / delete / remove requests.** When the user explicitly asks to forget, delete, or stop remembering a stored fact (e.g. "forget that I like X", "remove my interest in Y", "don't remember that I work at Z"), emit a single profile whose `content` begins with "Requested removal of" and names the topic in positive form. Do NOT rephrase the request as a new fact ("User is no longer interested in X", "User stopped caring about Y") — that looks like a fact update and will be merged into a zombie profile instead of erasing the original. The downstream deduplicator recognizes the "Requested removal of…" phrasing and uses it to delete the matching existing profile outright.
+5. Return {{"profiles": null}} if there is nothing to extract

--- a/reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.1.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/profile_update_instruction_start/v1.1.0.prompt.md
@@ -6,7 +6,6 @@ variables:
   - agent_context_prompt
   - context_prompt
   - extraction_definition_prompt
-  - metadata_definition_prompt
 ---
 [Context of user interactions]
 {agent_context_prompt}
@@ -57,7 +56,6 @@ STEP 2: Decide what to extract:
 STEP 3: For each profile you extract, you must assign:
 - "content": The profile information (what you learned about the user)
 - "time_to_live": How long this information stays valid (see rules below)
-- "metadata": Extra categorization based on the metadata definition (only if metadata definition is provided)
 
 [Time to Live - Choose One]
 - "infinity" → Facts that rarely change (name, birthday, gender, phone number)
@@ -69,8 +67,6 @@ STEP 3: For each profile you extract, you must assign:
 [What to Extract - Definitions]
 Only extract profiles that match this content definition: {extraction_definition_prompt}
 
-Only extract metadata that matches this definition (if provided): {metadata_definition_prompt}
-
 [Output Format]
 Report your result by calling the `finish_extraction` tool with a single JSON argument of the shape below. Put the JSON in the tool call — do not write it as a plain-text reply. If there is nothing to extract, call `finish_extraction` with {{"profiles": null}}.
 
@@ -81,8 +77,7 @@ In the rare case described under Resumable Extraction Mode above, you may call `
     "profiles": [
         {{
             "content": "the new profile information",
-            "time_to_live": "such as one_month",
-            "metadata": "metadata value if definition provided"
+            "time_to_live": "such as one_month"
         }}
     ]
 }}
@@ -93,12 +88,11 @@ In each example, the JSON shown is the argument you pass to `finish_extraction` 
 
 Example 1 - Extracting a new profile:
 - Content definition: "food preferences"
-- Metadata definition: "cuisine type (pizza, sushi, pasta, salad, steak)"
 - Existing profiles: []
 - Interaction: "i like to eat pizza"
 - Reasoning: User revealed a food preference. This is new (not in existing profiles). Food preference changes monthly, so time_to_live is "one_month".
 ```json
-{{"profiles": [{{"content": "likes pizza", "time_to_live": "one_month", "metadata": "pizza"}}]}}
+{{"profiles": [{{"content": "likes pizza", "time_to_live": "one_month"}}]}}
 ```
 
 Example 2 - Extracting a permanent profile:
@@ -155,6 +149,5 @@ Example 6 - `attach_pending_info_request` when the question is already pending, 
 1. Only extract profiles matching the content definition provided above
 2. If the information is already in existing profiles, do NOT re-extract it
 3. Always include time_to_live for new profiles
-4. Only include metadata if a metadata definition is provided
-5. **Forget / delete / remove requests.** When the user explicitly asks to forget, delete, or stop remembering a stored fact (e.g. "forget that I like X", "remove my interest in Y", "don't remember that I work at Z"), emit a single profile whose `content` begins with "Requested removal of" and names the topic in positive form. Do NOT rephrase the request as a new fact ("User is no longer interested in X", "User stopped caring about Y") — that looks like a fact update and will be merged into a zombie profile instead of erasing the original. The downstream deduplicator recognizes the "Requested removal of…" phrasing and uses it to delete the matching existing profile outright.
-6. Call `finish_extraction` with {{"profiles": null}} if there is nothing to extract
+4. **Forget / delete / remove requests.** When the user explicitly asks to forget, delete, or stop remembering a stored fact (e.g. "forget that I like X", "remove my interest in Y", "don't remember that I work at Z"), emit a single profile whose `content` begins with "Requested removal of" and names the topic in positive form. Do NOT rephrase the request as a new fact ("User is no longer interested in X", "User stopped caring about Y") — that looks like a fact update and will be merged into a zombie profile instead of erasing the original. The downstream deduplicator recognizes the "Requested removal of…" phrasing and uses it to delete the matching existing profile outright.
+5. Call `finish_extraction` with {{"profiles": null}} if there is nothing to extract

--- a/reflexio/server/prompt/prompt_bank/tagging/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/tagging/v1.0.0.prompt.md
@@ -1,0 +1,17 @@
+---
+active: true
+description: "Assign first-class tags to generated Reflexio entities"
+changelog: "v1.0.0: Initial prompt for post-generation tagging."
+variables:
+  - tagging_definition_prompt
+  - content
+---
+You assign concise tags to a generated Reflexio entity.
+
+Tagging definition:
+{tagging_definition_prompt}
+
+Entity content:
+{content}
+
+Return only tags that match the tagging definition in the "tags" field. Prefer short lowercase tags.

--- a/reflexio/server/prompt/prompt_bank/tagging/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/tagging/v1.0.0.prompt.md
@@ -8,10 +8,16 @@ variables:
 ---
 You assign concise tags to a generated Reflexio entity.
 
+Tagging is optional. Only assign a tag when the entity content clearly matches the
+tagging definition below. Do not force, invent, or guess tags, and do not stretch a
+loose association into a tag.
+
 Tagging definition:
 {tagging_definition_prompt}
 
 Entity content:
 {content}
 
-Return only tags that match the tagging definition in the "tags" field. Prefer short lowercase tags.
+Return the matching tags in the "tags" field, preferring short lowercase tags. If
+nothing in the content matches the tagging definition, return an empty list:
+{{"tags": []}}.

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -786,10 +786,17 @@ class ExtractionResumeWorker:
         # Defer tagging off this worker's drain loop. The pass is idempotent
         # (skips already-tagged entities), so running both profile and playbook
         # tagging is safe regardless of this run's extractor kind.
-        schedule_tagging(
-            org_id=self.request_context.org_id,
-            user_id=user_id,
-            agent_version=run.binding.agent_version or "",
-            request_context=self.request_context,
-            llm_client=self.client,
-        )
+        try:
+            schedule_tagging(
+                org_id=self.request_context.org_id,
+                user_id=user_id,
+                agent_version=run.binding.agent_version or "",
+                request_context=self.request_context,
+                llm_client=self.client,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to schedule tagging for finalized %s run %s",
+                run.binding.extractor_kind,
+                run.id,
+            )

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -61,6 +61,7 @@ from reflexio.server.services.storage.storage_base import (
     PendingToolCallRecord,
     PendingToolCallStatus,
 )
+from reflexio.server.services.tagging.tagging_scheduler import schedule_tagging
 from reflexio.server.site_var.site_var_manager import SiteVarManager
 from reflexio.server.tracing import sentry_tags
 
@@ -272,6 +273,7 @@ class ExtractionResumeWorker:
         try:
             self.storage.update_agent_run_status(run.id, AgentRunStatus.FINALIZING)
             self._finalize_items(run, items)
+            self._schedule_finalized_tagging(run)
             self.storage.consume_run_tool_dependencies(run.id)
             finalized_status = (
                 AgentRunStatus.FINALIZED_PENDING_TOOL
@@ -315,6 +317,7 @@ class ExtractionResumeWorker:
         try:
             items, pending_tool_call_ids = self._items_from_committed_output(run)
             self._finalize_items(run, items)
+            self._schedule_finalized_tagging(run)
             self.storage.consume_run_tool_dependencies(run.id)
             finalized_status = (
                 AgentRunStatus.FINALIZED_PENDING_TOOL
@@ -460,11 +463,6 @@ class ExtractionResumeWorker:
                 else ""
             ),
             extraction_definition_prompt=extractor_config.extraction_definition_prompt.strip(),
-            metadata_definition_prompt=(
-                extractor_config.metadata_definition_prompt.strip()
-                if extractor_config.metadata_definition_prompt
-                else None
-            ),
             existing_profiles=context_profiles,
         )
         result = self._resume_agent(
@@ -776,4 +774,22 @@ class ExtractionResumeWorker:
             return
         raise ResumeWorkerError(
             f"Unsupported extractor kind {run.binding.extractor_kind!r}"
+        )
+
+    def _schedule_finalized_tagging(self, run: AgentRunRecord) -> None:
+        user_id = run.binding.user_id
+        if not user_id:
+            return
+        if run.binding.extractor_kind not in ("profile", "playbook"):
+            return
+
+        # Defer tagging off this worker's drain loop. The pass is idempotent
+        # (skips already-tagged entities), so running both profile and playbook
+        # tagging is safe regardless of this run's extractor kind.
+        schedule_tagging(
+            org_id=self.request_context.org_id,
+            user_id=user_id,
+            agent_version=run.binding.agent_version or "",
+            request_context=self.request_context,
+            llm_client=self.client,
         )

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -383,13 +383,19 @@ class GenerationService:
             # Tagging runs an LLM call per newly generated entity, so defer it off
             # the publish path. The scheduler debounces bursts and is idempotent
             # (already-tagged entities are skipped).
-            schedule_tagging(
-                org_id=self.org_id,
-                user_id=user_id,
-                agent_version=agent_version,
-                request_context=self.request_context,
-                llm_client=self.client,
-            )
+            try:
+                schedule_tagging(
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    agent_version=agent_version,
+                    request_context=self.request_context,
+                    llm_client=self.client,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to schedule tagging for publish request %s",
+                    request_id,
+                )
 
             # Schedule delayed group evaluation for the required session.
             self._schedule_group_evaluation_if_needed(

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -49,6 +49,7 @@ from reflexio.server.services.storage.retention import (
     delete_count_for_retention,
     get_row_retention_limits,
 )
+from reflexio.server.services.tagging.tagging_scheduler import schedule_tagging
 from reflexio.server.tracing import sentry_tags
 from reflexio.server.usage_metrics import record_usage_event
 
@@ -378,6 +379,17 @@ class GenerationService:
                         result.warnings.append(msg)
             finally:
                 executor.shutdown(wait=False, cancel_futures=True)
+
+            # Tagging runs an LLM call per newly generated entity, so defer it off
+            # the publish path. The scheduler debounces bursts and is idempotent
+            # (already-tagged entities are skipped).
+            schedule_tagging(
+                org_id=self.org_id,
+                user_id=user_id,
+                agent_version=agent_version,
+                request_context=self.request_context,
+                llm_client=self.client,
+            )
 
             # Schedule delayed group evaluation for the required session.
             self._schedule_group_evaluation_if_needed(

--- a/reflexio/server/services/profile/profile_extractor.py
+++ b/reflexio/server/services/profile/profile_extractor.py
@@ -348,11 +348,6 @@ class ProfileExtractor:
                 self.config.context_prompt.strip() if self.config.context_prompt else ""
             ),
             extraction_definition_prompt=self.config.extraction_definition_prompt.strip(),
-            metadata_definition_prompt=(
-                self.config.metadata_definition_prompt.strip()
-                if self.config.metadata_definition_prompt
-                else None
-            ),
             existing_profiles=existing_profiles,
         )
 
@@ -461,9 +456,5 @@ class ProfileExtractor:
             "content": " ".join(summary_parts),
             "time_to_live": "one_month",
         }
-
-        # If metadata definition exists, add mock metadata
-        if self.config.metadata_definition_prompt:
-            mock_profile["metadata"] = "mock_metadata_value"
 
         return [mock_profile]

--- a/reflexio/server/services/profile/profile_generation_service_utils.py
+++ b/reflexio/server/services/profile/profile_generation_service_utils.py
@@ -74,7 +74,6 @@ class ProfileAddItem(BaseModel):
     Attributes:
         content (str): The profile content based on content definition
         time_to_live (str): Time to live for the profile - one of: 'one_day', 'one_week', 'one_month', 'one_quarter', 'one_year', 'infinity'
-        metadata (str, optional): Metadata extracted for the profile based on metadata definition
     """
 
     content: str = Field(description="Profile content based on content definition")
@@ -82,10 +81,6 @@ class ProfileAddItem(BaseModel):
         "one_day", "one_week", "one_month", "one_quarter", "one_year", "infinity"
     ] = Field(
         description="Time to live for the profile - determines when the profile expires"
-    )
-    metadata: str | None = Field(
-        default=None,
-        description="Metadata extracted for the profile based on metadata definition",
     )
     source_span: str | None = Field(
         default=None,
@@ -120,7 +115,7 @@ class ProfileUpdateOutput(BaseModel):
 
     add: list[ProfileAddItem] | None = Field(
         default=None,
-        description="List of new profiles to be added with their content, time to live, and optional metadata",
+        description="List of new profiles to be added with their content and time to live",
     )
     delete: list[str] | None = Field(
         default=None,
@@ -144,12 +139,12 @@ class StructuredProfilesOutput(BaseModel):
     Only extracts profiles — no delete/mention operations.
 
     Attributes:
-        profiles (list[ProfileAddItem], optional): List of extracted profiles with content, time_to_live, and optional metadata
+        profiles (list[ProfileAddItem], optional): List of extracted profiles with content and time_to_live
     """
 
     profiles: list[ProfileAddItem] | None = Field(
         default=None,
-        description="List of extracted profiles with content, time_to_live, and optional metadata",
+        description="List of extracted profiles with content and time_to_live",
     )
 
     model_config = ConfigDict(
@@ -225,7 +220,6 @@ def construct_profile_extraction_messages_from_sessions(
     agent_context_prompt: str,
     context_prompt: str,
     extraction_definition_prompt: str,
-    metadata_definition_prompt: str | None = None,
 ) -> list[dict]:
     """
     Construct LLM messages for profile extraction from sessions.
@@ -241,7 +235,6 @@ def construct_profile_extraction_messages_from_sessions(
         agent_context_prompt: Context about the agent for system message
         context_prompt: Additional context for system message
         extraction_definition_prompt: Definition of what profiles should contain
-        metadata_definition_prompt: Optional definition for profile metadata
 
     Returns:
         list[dict]: List of messages ready for profile extraction
@@ -259,7 +252,6 @@ def construct_profile_extraction_messages_from_sessions(
             "agent_context_prompt": agent_context_prompt,
             "context_prompt": context_prompt,
             "extraction_definition_prompt": extraction_definition_prompt,
-            "metadata_definition_prompt": metadata_definition_prompt,
         },
     )
 

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -379,7 +379,7 @@ def _row_to_profile(row: sqlite3.Row) -> UserProfile:
         source_span=d.get("source_span"),
         notes=d.get("notes"),
         reader_angle=d.get("reader_angle"),
-        tags=_json_loads(d.get("tags")) or [],
+        tags=_json_loads(d.get("tags")),
     )
 
 
@@ -452,7 +452,7 @@ def _row_to_user_playbook(
         status=Status(d["status"]) if d.get("status") else None,
         source=d.get("source"),
         source_interaction_ids=_json_loads(d.get("source_interaction_ids")) or [],
-        tags=_json_loads(d.get("tags")) or [],
+        tags=_json_loads(d.get("tags")),
         embedding=embedding,
         expanded_terms=d.get("expanded_terms"),
         source_span=d.get("source_span"),
@@ -478,7 +478,7 @@ def _row_to_agent_playbook(row: sqlite3.Row) -> AgentPlaybook:
         if d.get("playbook_status")
         else PlaybookStatus.PENDING,
         playbook_metadata=d.get("playbook_metadata") or "",
-        tags=_json_loads(d.get("tags")) or [],
+        tags=_json_loads(d.get("tags")),
         embedding=[],
         status=Status(d["status"]) if d.get("status") else None,
         expanded_terms=d.get("expanded_terms"),

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -379,6 +379,7 @@ def _row_to_profile(row: sqlite3.Row) -> UserProfile:
         source_span=d.get("source_span"),
         notes=d.get("notes"),
         reader_angle=d.get("reader_angle"),
+        tags=_json_loads(d.get("tags")) or [],
     )
 
 
@@ -451,6 +452,7 @@ def _row_to_user_playbook(
         status=Status(d["status"]) if d.get("status") else None,
         source=d.get("source"),
         source_interaction_ids=_json_loads(d.get("source_interaction_ids")) or [],
+        tags=_json_loads(d.get("tags")) or [],
         embedding=embedding,
         expanded_terms=d.get("expanded_terms"),
         source_span=d.get("source_span"),
@@ -476,6 +478,7 @@ def _row_to_agent_playbook(row: sqlite3.Row) -> AgentPlaybook:
         if d.get("playbook_status")
         else PlaybookStatus.PENDING,
         playbook_metadata=d.get("playbook_metadata") or "",
+        tags=_json_loads(d.get("tags")) or [],
         embedding=[],
         status=Status(d["status"]) if d.get("status") else None,
         expanded_terms=d.get("expanded_terms"),
@@ -659,6 +662,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_agent_runs_schema()
         self._migrate_pending_tool_calls_schema()
         self._migrate_expanded_terms()
+        self._migrate_tags()
         self._migrate_agentic_signals()
         self._migrate_agent_playbook_source_windows()
         self._migrate_request_evaluation_only()
@@ -1104,6 +1108,18 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             if "expanded_terms" not in cols:
                 self.conn.execute(f"ALTER TABLE {table} ADD COLUMN expanded_terms TEXT")
                 logger.info("Added expanded_terms column to %s", table)
+        self.conn.commit()
+
+    def _migrate_tags(self) -> None:
+        """Add tags column if missing."""
+        for table in ("profiles", "user_playbooks", "agent_playbooks"):
+            cols = {
+                row["name"]
+                for row in self.conn.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            if "tags" not in cols:
+                self.conn.execute(f"ALTER TABLE {table} ADD COLUMN tags TEXT")
+                logger.info("Added tags column to %s", table)
         self.conn.commit()
 
     def _migrate_agent_runs_schema(self) -> None:
@@ -1653,6 +1669,7 @@ CREATE TABLE IF NOT EXISTS profiles (
     status TEXT,
     extractor_names TEXT,
     expanded_terms TEXT,
+    tags TEXT,
     source_span TEXT,
     notes TEXT,
     reader_angle TEXT,
@@ -1712,6 +1729,7 @@ CREATE TABLE IF NOT EXISTS user_playbooks (
     source TEXT,
     embedding TEXT,
     expanded_terms TEXT,
+    tags TEXT,
     source_span TEXT,
     notes TEXT,
     reader_angle TEXT
@@ -1734,6 +1752,7 @@ CREATE TABLE IF NOT EXISTS agent_playbooks (
     playbook_metadata TEXT NOT NULL DEFAULT '',
     embedding TEXT,
     expanded_terms TEXT,
+    tags TEXT,
     status TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_agent_playbooks_playbook_name ON agent_playbooks(playbook_name);

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -147,7 +147,7 @@ class PlaybookMixin:
                         up.source_span,
                         up.notes,
                         up.reader_angle,
-                        _json_dumps(up.tags or None),
+                        _json_dumps(up.tags),
                     ),
                 )
                 upid = cur.lastrowid or 0
@@ -609,7 +609,7 @@ class PlaybookMixin:
                         ap.playbook_metadata,
                         _json_dumps(ap.embedding),
                         ap.expanded_terms,
-                        _json_dumps(ap.tags or None),
+                        _json_dumps(ap.tags),
                         ap.status.value if ap.status else None,
                     ),
                 )
@@ -788,7 +788,7 @@ class PlaybookMixin:
             params.append(playbook_status.value)
         if tags is not None:
             updates.append("tags = ?")
-            params.append(_json_dumps(tags or None))
+            params.append(_json_dumps(tags))
         if updates:
             params.append(agent_playbook_id)
             self._execute(
@@ -832,7 +832,7 @@ class PlaybookMixin:
             params.append(json.dumps(blocking_issue.model_dump()))
         if tags is not None:
             updates.append("tags = ?")
-            params.append(_json_dumps(tags or None))
+            params.append(_json_dumps(tags))
         if updates:
             params.append(user_playbook_id)
             self._execute(

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -125,8 +125,8 @@ class PlaybookMixin:
                         content, trigger, rationale, blocking_issue,
                         source_interaction_ids,
                         status, source, embedding, expanded_terms,
-                        source_span, notes, reader_angle)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        source_span, notes, reader_angle, tags)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     (
                         up.user_id,
                         up.playbook_name,
@@ -147,6 +147,7 @@ class PlaybookMixin:
                         up.source_span,
                         up.notes,
                         up.reader_angle,
+                        _json_dumps(up.tags or None),
                     ),
                 )
                 upid = cur.lastrowid or 0
@@ -590,8 +591,8 @@ class PlaybookMixin:
                        (playbook_name, created_at, agent_version, content,
                         trigger, rationale, blocking_issue,
                         playbook_status, playbook_metadata, embedding,
-                        expanded_terms, status)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        expanded_terms, tags, status)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     (
                         ap.playbook_name,
                         created_at_iso,
@@ -608,6 +609,7 @@ class PlaybookMixin:
                         ap.playbook_metadata,
                         _json_dumps(ap.embedding),
                         ap.expanded_terms,
+                        _json_dumps(ap.tags or None),
                         ap.status.value if ap.status else None,
                     ),
                 )
@@ -756,6 +758,7 @@ class PlaybookMixin:
         rationale: str | None = None,
         blocking_issue: BlockingIssue | None = None,
         playbook_status: PlaybookStatus | None = None,
+        tags: list[str] | None = None,
     ) -> None:
         row = self._fetchone(
             "SELECT agent_playbook_id FROM agent_playbooks WHERE agent_playbook_id = ?",
@@ -783,6 +786,9 @@ class PlaybookMixin:
         if playbook_status is not None:
             updates.append("playbook_status = ?")
             params.append(playbook_status.value)
+        if tags is not None:
+            updates.append("tags = ?")
+            params.append(_json_dumps(tags or None))
         if updates:
             params.append(agent_playbook_id)
             self._execute(
@@ -799,6 +805,7 @@ class PlaybookMixin:
         trigger: str | None = None,
         rationale: str | None = None,
         blocking_issue: BlockingIssue | None = None,
+        tags: list[str] | None = None,
     ) -> None:
         row = self._fetchone(
             "SELECT user_playbook_id FROM user_playbooks WHERE user_playbook_id = ?",
@@ -823,6 +830,9 @@ class PlaybookMixin:
         if blocking_issue is not None:
             updates.append("blocking_issue = ?")
             params.append(json.dumps(blocking_issue.model_dump()))
+        if tags is not None:
+            updates.append("tags = ?")
+            params.append(_json_dumps(tags or None))
         if updates:
             params.append(user_playbook_id)
             self._execute(

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -131,7 +131,7 @@ class ProfileMixin:
                     profile.source_span,
                     profile.notes,
                     profile.reader_angle,
-                    _json_dumps(profile.tags or None),
+                    _json_dumps(profile.tags),
                     _iso_now(),
                 ),
             )
@@ -190,7 +190,7 @@ class ProfileMixin:
                 new_profile.source_span,
                 new_profile.notes,
                 new_profile.reader_angle,
-                _json_dumps(new_profile.tags or None),
+                _json_dumps(new_profile.tags),
                 profile_id,
             ),
         )
@@ -212,7 +212,7 @@ class ProfileMixin:
     ) -> None:
         self._execute(
             "UPDATE profiles SET tags=? WHERE user_id=? AND profile_id=?",
-            (_json_dumps(tags or None), user_id, profile_id),
+            (_json_dumps(tags), user_id, profile_id),
         )
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -112,8 +112,8 @@ class ProfileMixin:
                     generated_from_request_id, profile_time_to_live,
                     expiration_timestamp, custom_features, embedding, source,
                     status, extractor_names, expanded_terms,
-                    source_span, notes, reader_angle, created_at)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    source_span, notes, reader_angle, tags, created_at)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     profile.profile_id,
                     profile.user_id,
@@ -131,6 +131,7 @@ class ProfileMixin:
                     profile.source_span,
                     profile.notes,
                     profile.reader_angle,
+                    _json_dumps(profile.tags or None),
                     _iso_now(),
                 ),
             )
@@ -172,7 +173,7 @@ class ProfileMixin:
                generated_from_request_id=?, profile_time_to_live=?,
                expiration_timestamp=?, custom_features=?, embedding=?,
                source=?, status=?, extractor_names=?, expanded_terms=?,
-               source_span=?, notes=?, reader_angle=?
+               source_span=?, notes=?, reader_angle=?, tags=?
                WHERE profile_id=?""",
             (
                 new_profile.content,
@@ -189,6 +190,7 @@ class ProfileMixin:
                 new_profile.source_span,
                 new_profile.notes,
                 new_profile.reader_angle,
+                _json_dumps(new_profile.tags or None),
                 profile_id,
             ),
         )
@@ -203,6 +205,15 @@ class ProfileMixin:
         )
         if rowid_row and embedding:
             self._vec_upsert("profiles_vec", rowid_row["rowid"], embedding)
+
+    @SQLiteStorageBase.handle_exceptions
+    def update_user_profile_tags(
+        self, user_id: str, profile_id: str, tags: list[str]
+    ) -> None:
+        self._execute(
+            "UPDATE profiles SET tags=? WHERE user_id=? AND profile_id=?",
+            (_json_dumps(tags or None), user_id, profile_id),
+        )
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_profile(self, request: DeleteUserProfileRequest) -> None:

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -354,6 +354,7 @@ class PlaybookMixin:
         rationale: str | None = None,
         blocking_issue: BlockingIssue | None = None,
         playbook_status: PlaybookStatus | None = None,
+        tags: list[str] | None = None,
     ) -> None:
         """Update editable fields of an agent playbook. Only non-None fields are updated.
 
@@ -365,6 +366,7 @@ class PlaybookMixin:
             rationale (str, optional): New rationale text
             blocking_issue (BlockingIssue, optional): New blocking issue
             playbook_status (PlaybookStatus, optional): New playbook status
+            tags (list[str], optional): Replacement tags
 
         Raises:
             ValueError: If agent playbook with the given ID is not found
@@ -380,6 +382,7 @@ class PlaybookMixin:
         trigger: str | None = None,
         rationale: str | None = None,
         blocking_issue: BlockingIssue | None = None,
+        tags: list[str] | None = None,
     ) -> None:
         """Update editable fields of a user playbook. Only non-None fields are updated.
 
@@ -390,6 +393,7 @@ class PlaybookMixin:
             trigger (str, optional): New trigger text
             rationale (str, optional): New rationale text
             blocking_issue (BlockingIssue, optional): New blocking issue
+            tags (list[str], optional): Replacement tags
 
         Raises:
             ValueError: If user playbook with the given ID is not found

--- a/reflexio/server/services/storage/storage_base/_profiles.py
+++ b/reflexio/server/services/storage/storage_base/_profiles.py
@@ -79,6 +79,13 @@ class ProfileMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def update_user_profile_tags(
+        self, user_id: str, profile_id: str, tags: list[str]
+    ) -> None:
+        """Replace only the tags of a profile, leaving content and embedding untouched."""
+        raise NotImplementedError
+
+    @abstractmethod
     def delete_all_interactions_for_user(self, user_id: str) -> None:
         raise NotImplementedError
 

--- a/reflexio/server/services/tagging/__init__.py
+++ b/reflexio/server/services/tagging/__init__.py
@@ -1,0 +1,1 @@
+"""Post-generation entity tagging services."""

--- a/reflexio/server/services/tagging/tagging_scheduler.py
+++ b/reflexio/server/services/tagging/tagging_scheduler.py
@@ -1,0 +1,149 @@
+"""Singleton scheduler for deferred, off-publish-path entity tagging.
+
+Tagging runs an LLM call per newly generated profile/playbook, so it must not
+block the publish request. This scheduler mirrors
+:class:`GroupEvaluationScheduler`: a single daemon thread with a min-heap, where
+each publish upserts the fire time for its ``(org_id, user_id, agent_version)``
+key. Rapid successive publishes for the same key debounce into a single tagging
+pass; when the timer fires, the tagging callback runs on its own daemon thread.
+
+Tagging is idempotent (already-tagged entities are skipped), so a deferred pass
+naturally handles both newly generated entities and the one-time backfill that
+happens when a tagging definition is first configured.
+"""
+
+from __future__ import annotations
+
+import heapq
+import logging
+import os
+import threading
+import time
+from collections.abc import Callable
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.tagging.tagging_service import TaggingService
+
+logger = logging.getLogger(__name__)
+
+# Delay before a tagging pass fires after the last publish for a key. Long enough
+# to debounce a burst of publishes into one pass, short enough that tags appear
+# promptly. Kept as a patch point for tests.
+TAGGING_DELAY_SECONDS = 15
+IS_TEST_ENV = os.environ.get("IS_TEST_ENV", "false").strip().lower() == "true"
+_EFFECTIVE_DELAY_SECONDS = 1 if IS_TEST_ENV else TAGGING_DELAY_SECONDS
+
+# (org_id, user_id, agent_version)
+TaggingKey = tuple[str, str, str]
+
+
+class TaggingScheduler:
+    """Singleton scheduler that fires entity tagging after a short debounce."""
+
+    _instance = None
+    _lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> TaggingScheduler:
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._scheduled: dict[TaggingKey, tuple[float, Callable]] = {}
+        self._heap: list[tuple[float, TaggingKey]] = []
+        self._mutex = threading.Lock()
+        self._wake_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._scheduler_loop, daemon=True, name="tagging-scheduler"
+        )
+        self._thread.start()
+        logger.info("TaggingScheduler started")
+
+    def schedule(self, key: TaggingKey, callback: Callable) -> None:
+        """Schedule or reschedule a tagging pass for ``key`` (slides the fire time forward)."""
+        fire_time = time.monotonic() + _EFFECTIVE_DELAY_SECONDS
+        with self._mutex:
+            self._scheduled[key] = (fire_time, callback)
+            heapq.heappush(self._heap, (fire_time, key))
+        self._wake_event.set()
+
+    def _scheduler_loop(self) -> None:
+        while True:
+            try:
+                with self._mutex:
+                    next_fire_time = self._heap[0][0] if self._heap else None
+
+                if next_fire_time is None:
+                    self._wake_event.wait()
+                    self._wake_event.clear()
+                    continue
+
+                wait_seconds = next_fire_time - time.monotonic()
+                if wait_seconds > 0:
+                    self._wake_event.wait(timeout=wait_seconds)
+                    self._wake_event.clear()
+                    continue
+
+                with self._mutex:
+                    while self._heap and self._heap[0][0] <= time.monotonic():
+                        fire_time, key = heapq.heappop(self._heap)
+
+                        current = self._scheduled.get(key)
+                        if current is None:
+                            continue
+                        current_fire_time, callback = current
+                        if abs(current_fire_time - fire_time) > 0.001:
+                            # Superseded by a newer schedule for the same key.
+                            continue
+
+                        del self._scheduled[key]
+                        t = threading.Thread(
+                            target=self._run_callback,
+                            args=(key, callback),
+                            daemon=True,
+                            name=f"tagging-{key[1][:20]}",
+                        )
+                        t.start()
+            except Exception:
+                logger.exception("Error in tagging scheduler loop")
+                time.sleep(1)
+
+    @staticmethod
+    def _run_callback(key: TaggingKey, callback: Callable) -> None:
+        try:
+            logger.info("Firing tagging for key=%s", key)
+            callback()
+            logger.info("Completed tagging for key=%s", key)
+        except Exception:
+            logger.exception("Tagging callback failed for key=%s", key)
+
+
+def schedule_tagging(
+    *,
+    org_id: str,
+    user_id: str,
+    agent_version: str,
+    request_context: RequestContext,
+    llm_client: LiteLLMClient,
+) -> None:
+    """Enqueue a deferred tagging pass for the given user/agent off the publish path."""
+    if not user_id:
+        return
+
+    key: TaggingKey = (org_id, user_id, agent_version)
+    storage_base_dir = getattr(request_context, "storage_base_dir", None)
+
+    def callback() -> None:
+        fresh_context = RequestContext(
+            org_id=org_id,
+            storage_base_dir=storage_base_dir,
+        )
+        TaggingService(llm_client=llm_client, request_context=fresh_context).run(
+            user_id=user_id, agent_version=agent_version
+        )
+
+    TaggingScheduler.get_instance().schedule(key, callback)

--- a/reflexio/server/services/tagging/tagging_service.py
+++ b/reflexio/server/services/tagging/tagging_service.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import logging
+import os
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
+from reflexio.server.services.service_utils import log_llm_messages, log_model_response
+from reflexio.server.site_var.site_var_manager import SiteVarManager
+
+logger = logging.getLogger(__name__)
+
+TAGGING_PROMPT_ID = "tagging"
+
+# Upper bound on how many current playbooks a single tagging pass will scan for
+# untagged entries. Tagging is idempotent (already-tagged entities are skipped),
+# so steady-state passes only tag newly generated entities; this bound just keeps
+# a one-time backfill from being silently truncated at the storage default of 100.
+_TAGGING_FETCH_LIMIT = 1000
+
+
+class TagsOutput(BaseModel):
+    tags: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(
+        extra="allow",
+        json_schema_extra={"additionalProperties": False},
+    )
+
+
+class TaggingService:
+    def __init__(
+        self,
+        llm_client: LiteLLMClient,
+        request_context: RequestContext,
+    ) -> None:
+        self.client = llm_client
+        self.request_context = request_context
+        self.configurator = request_context.configurator
+        self.storage = request_context.storage
+
+        model_setting = SiteVarManager().get_site_var("llm_model_setting")
+        site_var = model_setting if isinstance(model_setting, dict) else {}
+        config = self.configurator.get_config()
+        llm_config = config.llm_config if config else None
+        api_key_config = config.api_key_config if config else None
+        self.model_name = resolve_model_name(
+            ModelRole.GENERATION,
+            site_var_value=site_var.get("default_generation_model_name"),
+            config_override=llm_config.generation_model_name if llm_config else None,
+            api_key_config=api_key_config,
+        )
+
+    def run(
+        self,
+        *,
+        user_id: str,
+        agent_version: str,
+        tag_profiles: bool = True,
+        tag_playbooks: bool = True,
+    ) -> None:
+        if self.storage is None:
+            return
+
+        config = self.configurator.get_config()
+        if config is None:
+            return
+
+        profile_prompt = getattr(
+            config.profile_extractor_config, "tagging_definition_prompt", None
+        )
+        user_playbook_prompt = getattr(
+            config.user_playbook_extractor_config, "tagging_definition_prompt", None
+        )
+
+        if tag_profiles and profile_prompt:
+            self._tag_profiles(user_id=user_id, tagging_definition_prompt=profile_prompt)
+        if tag_playbooks and user_playbook_prompt:
+            self._tag_user_playbooks(
+                user_id=user_id,
+                agent_version=agent_version,
+                tagging_definition_prompt=user_playbook_prompt,
+            )
+            self._tag_agent_playbooks(
+                agent_version=agent_version,
+                tagging_definition_prompt=user_playbook_prompt,
+            )
+
+    def _tag_profiles(self, *, user_id: str, tagging_definition_prompt: str) -> None:
+        profiles = self.storage.get_user_profile(user_id)  # type: ignore[union-attr]
+        for profile in profiles:
+            if profile.tags:
+                continue  # already tagged — only tag newly generated profiles
+            tags = self._generate_tags(
+                tagging_definition_prompt=tagging_definition_prompt,
+                content=self._profile_content(profile),
+            )
+            self.storage.update_user_profile_tags(  # type: ignore[union-attr]
+                user_id, profile.profile_id, tags
+            )
+
+    def _tag_user_playbooks(
+        self,
+        *,
+        user_id: str,
+        agent_version: str,
+        tagging_definition_prompt: str,
+    ) -> None:
+        playbooks = self.storage.get_user_playbooks(  # type: ignore[union-attr]
+            limit=_TAGGING_FETCH_LIMIT,
+            user_id=user_id,
+            agent_version=agent_version,
+            status_filter=[None],
+        )
+        for playbook in playbooks:
+            if playbook.tags:
+                continue  # already tagged — only tag newly generated playbooks
+            tags = self._generate_tags(
+                tagging_definition_prompt=tagging_definition_prompt,
+                content=self._playbook_content(playbook),
+            )
+            self.storage.update_user_playbook(  # type: ignore[union-attr]
+                playbook.user_playbook_id,
+                tags=tags,
+            )
+
+    def _tag_agent_playbooks(
+        self,
+        *,
+        agent_version: str,
+        tagging_definition_prompt: str,
+    ) -> None:
+        playbooks = self.storage.get_agent_playbooks(  # type: ignore[union-attr]
+            limit=_TAGGING_FETCH_LIMIT,
+            agent_version=agent_version,
+            status_filter=[None],
+        )
+        for playbook in playbooks:
+            if playbook.tags:
+                continue  # already tagged — only tag newly generated playbooks
+            tags = self._generate_tags(
+                tagging_definition_prompt=tagging_definition_prompt,
+                content=self._playbook_content(playbook),
+            )
+            self.storage.update_agent_playbook(  # type: ignore[union-attr]
+                playbook.agent_playbook_id,
+                tags=tags,
+            )
+
+    def _generate_tags(self, *, tagging_definition_prompt: str, content: str) -> list[str]:
+        if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
+            return ["example_tag"]
+
+        prompt = self.request_context.prompt_manager.render_prompt(
+            TAGGING_PROMPT_ID,
+            {
+                "tagging_definition_prompt": tagging_definition_prompt.strip(),
+                "content": content,
+            },
+        )
+        messages = [{"role": "user", "content": prompt}]
+        log_llm_messages(logger, "Tagging", messages)
+        response = self.client.generate_chat_response(
+            messages=messages,
+            model=self.model_name,
+            response_format=TagsOutput,
+        )
+        log_model_response(logger, "Tagging response", response)
+        if not isinstance(response, TagsOutput):
+            logger.warning("Unexpected response type from tagging LLM: %s", type(response))
+            return []
+        return [tag.strip() for tag in response.tags if tag.strip()]
+
+    @staticmethod
+    def _profile_content(profile: UserProfile) -> str:
+        return profile.content
+
+    @staticmethod
+    def _playbook_content(playbook: UserPlaybook | AgentPlaybook) -> str:
+        parts = [playbook.content]
+        if playbook.trigger:
+            parts.append(f"Trigger: {playbook.trigger}")
+        if playbook.rationale:
+            parts.append(f"Rationale: {playbook.rationale}")
+        return "\n".join(part for part in parts if part)

--- a/reflexio/server/services/tagging/tagging_service.py
+++ b/reflexio/server/services/tagging/tagging_service.py
@@ -82,7 +82,9 @@ class TaggingService:
         )
 
         if tag_profiles and profile_prompt:
-            self._tag_profiles(user_id=user_id, tagging_definition_prompt=profile_prompt)
+            self._tag_profiles(
+                user_id=user_id, tagging_definition_prompt=profile_prompt
+            )
         if tag_playbooks and user_playbook_prompt:
             self._tag_user_playbooks(
                 user_id=user_id,
@@ -97,8 +99,8 @@ class TaggingService:
     def _tag_profiles(self, *, user_id: str, tagging_definition_prompt: str) -> None:
         profiles = self.storage.get_user_profile(user_id)  # type: ignore[union-attr]
         for profile in profiles:
-            if profile.tags:
-                continue  # already tagged — only tag newly generated profiles
+            if profile.tags is not None:
+                continue  # already tagged (incl. empty result) — tag each entity once
             tags = self._generate_tags(
                 tagging_definition_prompt=tagging_definition_prompt,
                 content=self._profile_content(profile),
@@ -121,8 +123,8 @@ class TaggingService:
             status_filter=[None],
         )
         for playbook in playbooks:
-            if playbook.tags:
-                continue  # already tagged — only tag newly generated playbooks
+            if playbook.tags is not None:
+                continue  # already tagged (incl. empty result) — tag each entity once
             tags = self._generate_tags(
                 tagging_definition_prompt=tagging_definition_prompt,
                 content=self._playbook_content(playbook),
@@ -144,8 +146,8 @@ class TaggingService:
             status_filter=[None],
         )
         for playbook in playbooks:
-            if playbook.tags:
-                continue  # already tagged — only tag newly generated playbooks
+            if playbook.tags is not None:
+                continue  # already tagged (incl. empty result) — tag each entity once
             tags = self._generate_tags(
                 tagging_definition_prompt=tagging_definition_prompt,
                 content=self._playbook_content(playbook),
@@ -155,7 +157,9 @@ class TaggingService:
                 tags=tags,
             )
 
-    def _generate_tags(self, *, tagging_definition_prompt: str, content: str) -> list[str]:
+    def _generate_tags(
+        self, *, tagging_definition_prompt: str, content: str
+    ) -> list[str]:
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
             return ["example_tag"]
 
@@ -175,7 +179,9 @@ class TaggingService:
         )
         log_model_response(logger, "Tagging response", response)
         if not isinstance(response, TagsOutput):
-            logger.warning("Unexpected response type from tagging LLM: %s", type(response))
+            logger.warning(
+                "Unexpected response type from tagging LLM: %s", type(response)
+            )
             return []
         return [tag.strip() for tag in response.tags if tag.strip()]
 

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -69,6 +69,8 @@ def _create_mock_completion(
         # intrinsic to the schema, not stylistic, so it survives prompt
         # rewrites better than matching on a tagline like "policy mining".
         content = json.dumps(registry["playbook_extraction"].minimal_valid)
+    elif '"tags"' in prompt_content:
+        content = json.dumps(registry["tagging"].minimal_valid)
     elif parse_structured_output:
         content = json.dumps(registry["profile_extraction"].minimal_valid)
     else:

--- a/reflexio/test_support/llm_model_registry.py
+++ b/reflexio/test_support/llm_model_registry.py
@@ -46,6 +46,7 @@ def _build_registry() -> dict[str, ModelRegistryEntry]:
         ProfileUpdateOutput,
         StructuredProfilesOutput,
     )
+    from reflexio.server.services.tagging.tagging_service import TagsOutput
 
     return {
         "playbook_extraction": ModelRegistryEntry(
@@ -107,6 +108,10 @@ def _build_registry() -> dict[str, ModelRegistryEntry]:
                 "is_success": True,
                 "is_escalated": False,
             },
+        ),
+        "tagging": ModelRegistryEntry(
+            model_class=TagsOutput,
+            minimal_valid={"tags": ["example_tag"]},
         ),
         # F1 cleanup: ``agent_success_evaluation_comparison`` was removed along
         # with the session-level shadow comparison branch. Per-turn shadow

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -79,7 +79,7 @@ def reflexio_instance(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
         # Single configured profile extractor (the list-valued field is retired and
-        # the Config constructor would ignore it, dropping metadata_definition_prompt
+        # the Config constructor would ignore it, dropping tagging_definition_prompt
         # and with it the mock's custom_features["metadata"]).
         profile_extractor_config=ProfileExtractorConfig(
             extractor_name="test_profile_extractor",
@@ -89,7 +89,7 @@ Conversation between sales agent and user, extract any information from the inte
             extraction_definition_prompt="""
 name, age, intent of the conversations
 """,
-            metadata_definition_prompt="""
+            tagging_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
         ),
@@ -140,7 +140,7 @@ Conversation between sales agent and user, extract any information from the inte
             extraction_definition_prompt="""
 name, age, intent of the conversations
 """,
-            metadata_definition_prompt="""
+            tagging_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
         ),
@@ -174,7 +174,7 @@ dietary habits and preferences (e.g., "vegetarian", "loves beef"),
 location and living situation (e.g., "lives in Austin"),
 hobbies and interests, work style, health conditions
 """,
-            metadata_definition_prompt="""
+            tagging_definition_prompt="""
 choice of ['diet', 'location', 'hobby', 'work', 'health']
 """,
         ),
@@ -458,7 +458,7 @@ Conversation between sales agent and user, extract any information from the inte
             extraction_definition_prompt="""
 name, age, intent of the conversations
 """,
-            metadata_definition_prompt="""
+            tagging_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
             allow_manual_trigger=True,  # Required for manual generation
@@ -531,19 +531,19 @@ def reflexio_instance_multiple_profile_extractors(
                 extractor_name="extractor_basic_info",
                 context_prompt="Extract basic information about the user.",
                 extraction_definition_prompt="name, company, role",
-                metadata_definition_prompt="choice of ['basic_info']",
+                tagging_definition_prompt="choice of ['basic_info']",
             ),
             ProfileExtractorConfig(
                 extractor_name="extractor_preferences",
                 context_prompt="Extract user preferences from the conversation.",
                 extraction_definition_prompt="communication style, preferred contact method",
-                metadata_definition_prompt="choice of ['preferences']",
+                tagging_definition_prompt="choice of ['preferences']",
             ),
             ProfileExtractorConfig(
                 extractor_name="extractor_intent",
                 context_prompt="Extract user intent from the conversation.",
                 extraction_definition_prompt="conversation goal, buying intent",
-                metadata_definition_prompt="choice of ['intent']",
+                tagging_definition_prompt="choice of ['intent']",
             ),
         ],
     )

--- a/tests/e2e_tests/test_configuration.py
+++ b/tests/e2e_tests/test_configuration.py
@@ -60,7 +60,7 @@ def test_set_config_end_to_end(
             extraction_definition_prompt="""
             Test profile content definition.
             """,
-            metadata_definition_prompt="""
+            tagging_definition_prompt="""
             Test metadata definition.
             """,
         ),
@@ -105,7 +105,7 @@ def test_set_config_end_to_end(
             "extractor_name": "dict_test_extractor",
             "context_prompt": "Updated test configuration from dict.",
             "extraction_definition_prompt": "Updated profile content from dict.",
-            "metadata_definition_prompt": "Updated metadata from dict.",
+            "tagging_definition_prompt": "Updated metadata from dict.",
         },
         "user_playbook_extractor_config": {
             "extractor_name": "dict_test_playbook",
@@ -187,7 +187,7 @@ def test_get_config_end_to_end(
             extractor_name="get_config_test_extractor",
             context_prompt="Get config test: Extract key information.",
             extraction_definition_prompt="Get config test profile content.",
-            metadata_definition_prompt="Get config test metadata.",
+            tagging_definition_prompt="Get config test metadata.",
         ),
         user_playbook_extractor_config=PlaybookConfig(
             extractor_name="get_config_test_playbook",

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -141,7 +141,7 @@ def _make_reflexio_with_profile(
                 extraction_definition_prompt=(
                     "coding language preferences, tool preferences, workflow preferences"
                 ),
-                metadata_definition_prompt="choice of ['preference', 'workflow']",
+                tagging_definition_prompt="choice of ['preference', 'workflow']",
             )
         ],
     )

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -64,7 +64,7 @@ def reflexio_with_config(temp_storage, ensure_mock_env):
         extractor_name="test_profile",
         context_prompt="Extract user preferences",
         extraction_definition_prompt="User likes and dislikes",
-        metadata_definition_prompt="Metadata about preferences",
+        tagging_definition_prompt="Metadata about preferences",
         stride_size_override=1,
     )
     reflexio.request_context.configurator.set_config_by_name(

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -8,6 +8,7 @@ prompt caching. All LiteLLM SDK calls are mocked -- no real API requests are mad
 import base64
 import json
 import logging
+import multiprocessing
 import struct
 import tempfile
 import time
@@ -18,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import litellm
 import pytest
+from litellm.exceptions import APIConnectionError
 from pydantic import BaseModel, Field
 
 from reflexio.models.config_schema import (
@@ -43,8 +45,10 @@ from reflexio.server.llm.litellm_client import (
     LiteLLMConfig,
     LLMHardTimeoutError,
     StructuredOutputParseError,
+    _CompletionErrorSnapshot,
     _get_embedding_encoding,
     _get_embedding_limit,
+    _litellm_completion_worker,
     _truncate_for_embedding,
     create_litellm_client,
 )
@@ -1288,7 +1292,7 @@ class TestExtractJsonFromString:
         assert result == '{"answer": 42, "why": "{kept}"}'
 
     def test_json_array_ignores_stray_brackets_in_text(self, client):
-        content = "Candidates [not json] then [{\"answer\": 42}] trailing [x]"
+        content = 'Candidates [not json] then [{"answer": 42}] trailing [x]'
         result = client._extract_json_from_string(content)
         assert result == '[{"answer": 42}]'
 
@@ -2253,6 +2257,34 @@ class TestLitellmIntegration:
         # Two subprocess spawn/kill cycles (initial attempt + one hard-timeout
         # retry) — still far below the 1s the blocked call would take.
         assert time.perf_counter() - start < 1.0
+
+    def test_worker_snapshots_litellm_api_connection_error(self, monkeypatch):
+        """LiteLLM exceptions can dump but fail to load across process queues."""
+
+        def _raise_connection_error(**_params):
+            raise APIConnectionError(
+                "connection failed",
+                llm_provider="openai",
+                model="gpt-5-mini",
+            )
+
+        monkeypatch.setattr("litellm.completion", _raise_connection_error)
+        process_context = multiprocessing.get_context()
+        result_queue = process_context.Queue(maxsize=1)
+
+        try:
+            _litellm_completion_worker({"model": "gpt-5-mini"}, result_queue)
+            status, payload = result_queue.get(timeout=1.0)
+        finally:
+            result_queue.close()
+            result_queue.join_thread()
+
+        assert status == "error"
+        assert isinstance(payload, _CompletionErrorSnapshot)
+        assert payload.type_name == "APIConnectionError"
+        assert "connection failed" in payload.message
+        assert payload.model == "gpt-5-mini"
+        assert payload.llm_provider == "openai"
 
     def test_hard_timeout_retried_once_then_succeeds(self, monkeypatch):
         """A transient hard timeout is retried exactly once at the client level

--- a/tests/server/services/extraction/test_resumable_agent.py
+++ b/tests/server/services/extraction/test_resumable_agent.py
@@ -83,7 +83,7 @@ def test_profile_instruction_prompt_is_resumable_by_default():
             "agent_context_prompt": "agent context",
             "context_prompt": "",
             "extraction_definition_prompt": "user facts",
-            "metadata_definition_prompt": None,
+            "tagging_definition_prompt": None,
         },
     )
 
@@ -147,12 +147,11 @@ def test_resumable_agent_finishes_profile_output(
     assert stored.max_steps_remaining == 7
     assert stored.committed_output == {
         "profiles": [
-            {
-                "content": "User prefers AWS ECS deployments.",
-                "time_to_live": "infinity",
-                "metadata": None,
-                "source_span": None,
-                "notes": None,
+                    {
+                        "content": "User prefers AWS ECS deployments.",
+                        "time_to_live": "infinity",
+                        "source_span": None,
+                        "notes": None,
                 "reader_angle": None,
             }
         ]

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -262,6 +262,31 @@ def test_resume_worker_retries_finalization_without_rerunning_agent(
     assert storage.list_run_tool_dependencies("run_1")[0].consumed_at is not None
 
 
+def test_resume_worker_tagging_schedule_failure_is_best_effort(
+    request_context,
+):
+    run = AgentRunRecord(
+        id="run_tagging",
+        binding=AgentBinding(
+            org_id="org_1",
+            extractor_kind="profile",
+            user_id="user_1",
+            request_id="request_1",
+            agent_version="v1",
+            source="api",
+        ),
+        status=AgentRunStatus.FINALIZED_PENDING_TOOL,
+        generation_request_snapshot={"request_id": "request_1"},
+    )
+    worker = ExtractionResumeWorker(request_context=request_context)
+
+    with patch(
+        "reflexio.server.services.extraction.resume_worker.schedule_tagging",
+        side_effect=RuntimeError("scheduler unavailable"),
+    ):
+        worker._schedule_finalized_tagging(run)
+
+
 def test_resume_worker_fails_run_when_step_budget_exhausted(
     monkeypatch,
     request_context,

--- a/tests/server/services/profile/test_profile_generation_service_utils.py
+++ b/tests/server/services/profile/test_profile_generation_service_utils.py
@@ -83,7 +83,6 @@ def test_construct_profile_extraction_messages_with_sessions():
         agent_context_prompt="Test agent context",
         context_prompt="Test context",
         extraction_definition_prompt="food preferences",
-        metadata_definition_prompt="cuisine type",
     )
 
     # Validate that messages were created
@@ -152,7 +151,6 @@ def test_construct_profile_extraction_messages_with_empty_sessions():
         agent_context_prompt="Test agent context",
         context_prompt="Test context",
         extraction_definition_prompt="food preferences",
-        metadata_definition_prompt="cuisine type",
     )
 
     # Should still create messages (system message + user message with prompt)

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -70,7 +70,7 @@ class TestUserPlaybookCRUD:
     def test_update_user_playbook_tags_round_trip(self, storage):
         storage.save_user_playbooks([_make_user_playbook(1, "u1", "fb", "v1")])
         saved = storage.get_user_playbooks(user_id="u1", status_filter=[None])
-        assert saved[0].tags == []
+        assert saved[0].tags is None  # untagged until the tagging pass runs
 
         storage.update_user_playbook(saved[0].user_playbook_id, tags=["safety", "ux"])
 
@@ -79,9 +79,9 @@ class TestUserPlaybookCRUD:
         assert result[0].content == saved[0].content
 
         storage.update_user_playbook(saved[0].user_playbook_id, tags=[])
-        assert storage.get_user_playbooks(user_id="u1", status_filter=[None])[
-            0
-        ].tags == []
+        assert (
+            storage.get_user_playbooks(user_id="u1", status_filter=[None])[0].tags == []
+        )
 
     def test_count_user_playbooks(self, storage):
         rfs = [
@@ -320,7 +320,7 @@ class TestAgentPlaybookCRUD:
     def test_update_agent_playbook_tags_round_trip(self, storage):
         storage.save_agent_playbooks([_make_agent_playbook(1, "fb", "v1")])
         saved = storage.get_agent_playbooks(playbook_name="fb")
-        assert saved[0].tags == []
+        assert saved[0].tags is None  # untagged until the tagging pass runs
 
         storage.update_agent_playbook(saved[0].agent_playbook_id, tags=["a", "b"])
 

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -67,6 +67,22 @@ class TestUserPlaybookCRUD:
         result = storage.get_user_playbooks(playbook_name="fb")
         assert len(result) == 2
 
+    def test_update_user_playbook_tags_round_trip(self, storage):
+        storage.save_user_playbooks([_make_user_playbook(1, "u1", "fb", "v1")])
+        saved = storage.get_user_playbooks(user_id="u1", status_filter=[None])
+        assert saved[0].tags == []
+
+        storage.update_user_playbook(saved[0].user_playbook_id, tags=["safety", "ux"])
+
+        result = storage.get_user_playbooks(user_id="u1", status_filter=[None])
+        assert result[0].tags == ["safety", "ux"]
+        assert result[0].content == saved[0].content
+
+        storage.update_user_playbook(saved[0].user_playbook_id, tags=[])
+        assert storage.get_user_playbooks(user_id="u1", status_filter=[None])[
+            0
+        ].tags == []
+
     def test_count_user_playbooks(self, storage):
         rfs = [
             _make_user_playbook(1, "u1", "fb", "v1"),
@@ -300,6 +316,20 @@ class TestAgentPlaybookCRUD:
 
         result = storage.get_agent_playbooks(playbook_name="fb")
         assert len(result) == 2
+
+    def test_update_agent_playbook_tags_round_trip(self, storage):
+        storage.save_agent_playbooks([_make_agent_playbook(1, "fb", "v1")])
+        saved = storage.get_agent_playbooks(playbook_name="fb")
+        assert saved[0].tags == []
+
+        storage.update_agent_playbook(saved[0].agent_playbook_id, tags=["a", "b"])
+
+        result = storage.get_agent_playbooks(playbook_name="fb")
+        assert result[0].tags == ["a", "b"]
+        assert result[0].content == saved[0].content
+
+        storage.update_agent_playbook(saved[0].agent_playbook_id, tags=[])
+        assert storage.get_agent_playbooks(playbook_name="fb")[0].tags == []
 
     def test_delete_agent_playbook(self, storage):
         storage.save_agent_playbooks([_make_agent_playbook(1, "fb", "v1")])

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -61,7 +61,7 @@ class TestProfileCRUD:
 
     def test_update_user_profile_tags_round_trip(self, storage: BaseStorage) -> None:
         storage.add_user_profile("u1", [_make_profile("u1", "p1", "likes sushi")])
-        assert storage.get_user_profile("u1")[0].tags == []
+        assert storage.get_user_profile("u1")[0].tags is None  # untagged until tagged
 
         storage.update_user_profile_tags("u1", "p1", ["food", "japanese"])
 

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -59,6 +59,20 @@ class TestProfileCRUD:
         assert result[0].content == "likes sushi"
         assert result[0].profile_id == "p1"
 
+    def test_update_user_profile_tags_round_trip(self, storage: BaseStorage) -> None:
+        storage.add_user_profile("u1", [_make_profile("u1", "p1", "likes sushi")])
+        assert storage.get_user_profile("u1")[0].tags == []
+
+        storage.update_user_profile_tags("u1", "p1", ["food", "japanese"])
+
+        result = storage.get_user_profile("u1")
+        assert result[0].tags == ["food", "japanese"]
+        # Tags-only update must not disturb content.
+        assert result[0].content == "likes sushi"
+
+        storage.update_user_profile_tags("u1", "p1", [])
+        assert storage.get_user_profile("u1")[0].tags == []
+
     def test_get_nonexistent_user_returns_empty(self, storage: BaseStorage) -> None:
         assert storage.get_user_profile("nonexistent") == []
 

--- a/tests/server/services/tagging/test_tagging_scheduler.py
+++ b/tests/server/services/tagging/test_tagging_scheduler.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from reflexio.server.services.tagging import tagging_scheduler
+from reflexio.server.services.tagging.tagging_scheduler import (
+    TaggingScheduler,
+    schedule_tagging,
+)
+
+
+class _FakeScheduler:
+    def __init__(self, sink: list[tuple[Any, Any]]) -> None:
+        self._sink = sink
+
+    def schedule(self, key: Any, callback: Any) -> None:
+        self._sink.append((key, callback))
+
+
+def test_scheduler_fires_scheduled_callback(monkeypatch: Any) -> None:
+    # Keep the debounce tiny so the test does not wait on the real delay.
+    monkeypatch.setattr(tagging_scheduler, "_EFFECTIVE_DELAY_SECONDS", 0.01)
+    fired = threading.Event()
+    TaggingScheduler.get_instance().schedule(("org", "user", "v1"), fired.set)
+    assert fired.wait(timeout=5)
+
+
+def test_schedule_tagging_skips_when_no_user(monkeypatch: Any) -> None:
+    scheduled: list[tuple[Any, Any]] = []
+    monkeypatch.setattr(
+        TaggingScheduler,
+        "get_instance",
+        classmethod(lambda _cls: _FakeScheduler(scheduled)),
+    )
+
+    # Empty user_id must not enqueue anything (and must not touch the deps).
+    schedule_tagging(
+        org_id="o",
+        user_id="",
+        agent_version="v",
+        request_context=None,  # type: ignore[arg-type]
+        llm_client=None,  # type: ignore[arg-type]
+    )
+    assert scheduled == []
+
+    schedule_tagging(
+        org_id="o",
+        user_id="u",
+        agent_version="v",
+        request_context=None,  # type: ignore[arg-type]
+        llm_client=None,  # type: ignore[arg-type]
+    )
+    assert len(scheduled) == 1
+    assert scheduled[0][0] == ("o", "u", "v")

--- a/tests/server/services/tagging/test_tagging_service.py
+++ b/tests/server/services/tagging/test_tagging_service.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from typing import Any
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.config_schema import (
+    Config,
+    LLMConfig,
+    ProfileExtractorConfig,
+    StorageConfigSQLite,
+    UserPlaybookExtractorConfig,
+)
+from reflexio.server.services.tagging.tagging_service import TaggingService, TagsOutput
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self.profiles = [
+            UserProfile(
+                profile_id="profile-1",
+                user_id="user-1",
+                content="User prefers concise answers.",
+                last_modified_timestamp=1,
+                generated_from_request_id="request-1",
+            )
+        ]
+        self.user_playbooks = [
+            UserPlaybook(
+                user_playbook_id=10,
+                user_id="user-1",
+                agent_version="agent-1",
+                request_id="request-1",
+                content="Ask a clarifying question before destructive actions.",
+                trigger="Dangerous command requested",
+                rationale="The user values explicit confirmation.",
+            )
+        ]
+        self.agent_playbooks = [
+            AgentPlaybook(
+                agent_playbook_id=20,
+                agent_version="agent-1",
+                content="Summarize validation evidence in final responses.",
+                trigger="After code changes",
+                rationale="It helps reviewers trust the change.",
+            )
+        ]
+        self.profile_updates: list[tuple[str, str, list[str]]] = []
+        self.user_playbook_updates: list[tuple[int, list[str] | None]] = []
+        self.agent_playbook_updates: list[tuple[int, list[str] | None]] = []
+
+    def get_user_profile(self, user_id: str) -> list[UserProfile]:
+        assert user_id == "user-1"
+        return self.profiles
+
+    def update_user_profile_tags(
+        self, user_id: str, profile_id: str, tags: list[str]
+    ) -> None:
+        self.profile_updates.append((user_id, profile_id, tags))
+
+    def get_user_playbooks(
+        self,
+        *,
+        limit: int = 100,
+        user_id: str,
+        agent_version: str,
+        status_filter: list[Any],
+    ) -> list[UserPlaybook]:
+        assert (user_id, agent_version, status_filter) == ("user-1", "agent-1", [None])
+        return self.user_playbooks
+
+    def update_user_playbook(
+        self, user_playbook_id: int, *, tags: list[str] | None = None, **_: Any
+    ) -> None:
+        self.user_playbook_updates.append((user_playbook_id, tags))
+
+    def get_agent_playbooks(
+        self, *, limit: int = 100, agent_version: str, status_filter: list[Any]
+    ) -> list[AgentPlaybook]:
+        assert (agent_version, status_filter) == ("agent-1", [None])
+        return self.agent_playbooks
+
+    def update_agent_playbook(
+        self, agent_playbook_id: int, *, tags: list[str] | None = None, **_: Any
+    ) -> None:
+        self.agent_playbook_updates.append((agent_playbook_id, tags))
+
+
+class FakeConfigurator:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    def get_config(self) -> Config:
+        return self.config
+
+
+class FakePromptManager:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    def render_prompt(self, prompt_id: str, variables: dict[str, str]) -> str:
+        self.calls.append((prompt_id, variables))
+        return f"{variables['tagging_definition_prompt']}::{variables['content']}"
+
+
+class FakeRequestContext:
+    def __init__(self, config: Config, storage: FakeStorage) -> None:
+        self.configurator = FakeConfigurator(config)
+        self.storage = storage
+        self.prompt_manager = FakePromptManager()
+
+
+class FakeLLMClient:
+    def __init__(self, responses: list[list[str]]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    def generate_chat_response(self, **kwargs: Any) -> TagsOutput:
+        self.calls.append(kwargs)
+        return TagsOutput(tags=self.responses.pop(0))
+
+
+def make_config(
+    *,
+    profile_tagging_prompt: str | None = "profile tagging rules",
+    playbook_tagging_prompt: str | None = "playbook tagging rules",
+) -> Config:
+    return Config(
+        storage_config=StorageConfigSQLite(db_path=":memory:"),
+        profile_extractor_config=ProfileExtractorConfig(
+            extraction_definition_prompt="profile extraction rules",
+            tagging_definition_prompt=profile_tagging_prompt,
+        ),
+        user_playbook_extractor_config=UserPlaybookExtractorConfig(
+            extraction_definition_prompt="playbook extraction rules",
+            tagging_definition_prompt=playbook_tagging_prompt,
+        ),
+        llm_config=LLMConfig(generation_model_name="test-model"),
+    )
+
+
+def test_tagging_service_updates_profiles_and_playbooks(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.tagging_service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    context = FakeRequestContext(make_config(), storage)
+    client = FakeLLMClient(
+        [["profile-tag"], ["user-playbook-tag"], ["agent-playbook-tag"]]
+    )
+
+    TaggingService(client, context).run(user_id="user-1", agent_version="agent-1")  # type: ignore[arg-type]
+
+    assert storage.profile_updates == [("user-1", "profile-1", ["profile-tag"])]
+    assert storage.user_playbook_updates == [(10, ["user-playbook-tag"])]
+    assert storage.agent_playbook_updates == [(20, ["agent-playbook-tag"])]
+    assert [call[0] for call in context.prompt_manager.calls] == [
+        "tagging",
+        "tagging",
+        "tagging",
+    ]
+    assert [
+        call[1]["tagging_definition_prompt"] for call in context.prompt_manager.calls
+    ] == [
+        "profile tagging rules",
+        "playbook tagging rules",
+        "playbook tagging rules",
+    ]
+    assert [call["model"] for call in client.calls] == [
+        "test-model",
+        "test-model",
+        "test-model",
+    ]
+
+
+def test_tagging_service_skips_entity_types_without_tagging_prompts(
+    monkeypatch: Any,
+) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.tagging_service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    context = FakeRequestContext(
+        make_config(profile_tagging_prompt=None, playbook_tagging_prompt=None), storage
+    )
+    client = FakeLLMClient([])
+
+    TaggingService(client, context).run(user_id="user-1", agent_version="agent-1")  # type: ignore[arg-type]
+
+    assert storage.profile_updates == []
+    assert storage.user_playbook_updates == []
+    assert storage.agent_playbook_updates == []
+    assert context.prompt_manager.calls == []
+    assert client.calls == []
+
+
+def test_tagging_service_can_scope_to_profiles_only(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.tagging_service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    context = FakeRequestContext(make_config(), storage)
+    client = FakeLLMClient([["profile-tag"]])
+
+    TaggingService(client, context).run(  # type: ignore[arg-type]
+        user_id="user-1",
+        agent_version="agent-1",
+        tag_playbooks=False,
+    )
+
+    assert storage.profile_updates == [("user-1", "profile-1", ["profile-tag"])]
+    assert storage.user_playbook_updates == []
+    assert storage.agent_playbook_updates == []
+    assert len(context.prompt_manager.calls) == 1
+
+
+def test_tagging_service_skips_already_tagged_entities(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.tagging_service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    # Pre-tag every entity so the service should treat them as already processed.
+    storage.profiles[0].tags = ["existing"]
+    storage.user_playbooks[0].tags = ["existing"]
+    storage.agent_playbooks[0].tags = ["existing"]
+    context = FakeRequestContext(make_config(), storage)
+    client = FakeLLMClient([])
+
+    TaggingService(client, context).run(user_id="user-1", agent_version="agent-1")  # type: ignore[arg-type]
+
+    assert storage.profile_updates == []
+    assert storage.user_playbook_updates == []
+    assert storage.agent_playbook_updates == []
+    assert context.prompt_manager.calls == []
+    assert client.calls == []

--- a/tests/server/services/tagging/test_tagging_service.py
+++ b/tests/server/services/tagging/test_tagging_service.py
@@ -230,10 +230,11 @@ def test_tagging_service_skips_already_tagged_entities(monkeypatch: Any) -> None
         lambda *_: {},
     )
     storage = FakeStorage()
-    # Pre-tag every entity so the service should treat them as already processed.
-    storage.profiles[0].tags = ["existing"]
+    # An empty list means tagging already ran and matched nothing — a final state.
+    # The service must NOT re-tag these (only tags is None means "never tagged").
+    storage.profiles[0].tags = []
     storage.user_playbooks[0].tags = ["existing"]
-    storage.agent_playbooks[0].tags = ["existing"]
+    storage.agent_playbooks[0].tags = []
     context = FakeRequestContext(make_config(), storage)
     client = FakeLLMClient([])
 

--- a/tests/server/services/test_configurator.py
+++ b/tests/server/services/test_configurator.py
@@ -67,7 +67,7 @@ def test_set_and_get_config_by_name(configurator):
                 should_extract_profile_prompt_override="test",
                 context_prompt="test",
                 extraction_definition_prompt="test",
-                metadata_definition_prompt="test",
+                tagging_definition_prompt="test",
             ),
         ),
     ]

--- a/tests/server/services/test_generation_service.py
+++ b/tests/server/services/test_generation_service.py
@@ -107,6 +107,41 @@ def test_publish_request_honors_caller_request_id(mock_llm_responses):
         assert stored_request.request_id == request_id
 
 
+def test_publish_request_tagging_schedule_failure_is_best_effort(mock_llm_responses):
+    user_id = "test_user_id"
+    org_id = "test_org"
+    request_id = "tagging-schedule-failure"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        llm_config = LiteLLMConfig(model="gpt-4o-mini")
+        llm_client = LiteLLMClient(llm_config)
+        generation_service = GenerationService(
+            llm_client=llm_client,
+            request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
+        )
+
+        interaction = InteractionData(
+            content="test interaction",
+            created_at=int(datetime.datetime.now(UTC).timestamp()),
+        )
+        request = PublishUserInteractionRequest(
+            request_id=request_id,
+            user_id=user_id,
+            interaction_data_list=[interaction],
+            session_id="test_session_id",
+        )
+
+        with patch(
+            "reflexio.server.services.generation_service.schedule_tagging",
+            side_effect=RuntimeError("scheduler unavailable"),
+        ):
+            result = generation_service.run(request)
+
+        assert result.request_id == request_id
+        assert generation_service.storage is not None
+        assert generation_service.storage.get_request(request_id) is not None
+
+
 def test_publish_request_rejects_empty_caller_request_id():
     interaction = InteractionData(
         content="test interaction",

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -117,7 +117,7 @@ def test_refresh_profiles_for_user(mock_chat_completion):
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config
@@ -191,7 +191,7 @@ def test_test_refresh_profiles_for_user_with_image_encoding(mock_chat_completion
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config
@@ -280,7 +280,7 @@ def test_profile_extraction_message_construction():
                 should_extract_profile_prompt_override="test",
                 context_prompt="test context",
                 extraction_definition_prompt="food preferences",
-                metadata_definition_prompt="cuisine type",
+                tagging_definition_prompt="cuisine type",
             )
             profile_generation_service.configurator.set_config_by_name(
                 "profile_extractor_config", profile_extractor_config
@@ -447,7 +447,7 @@ def test_refresh_profiles_with_output_pending_status(mock_chat_completion):
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config
@@ -591,7 +591,7 @@ def test_run_manual_regular_no_window_size(mock_chat_completion):
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config
@@ -649,7 +649,7 @@ def test_run_manual_regular_no_interactions(mock_chat_completion):
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config
@@ -690,7 +690,7 @@ def test_run_manual_regular_with_interactions(mock_chat_completion):
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config
@@ -766,7 +766,7 @@ def test_run_manual_regular_with_source_filter(mock_chat_completion):
             should_extract_profile_prompt_override="test",
             context_prompt="test",
             extraction_definition_prompt="test",
-            metadata_definition_prompt="test",
+            tagging_definition_prompt="test",
         )
         profile_generation_service.configurator.set_config_by_name(
             "profile_extractor_config", profile_extractor_config

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -44,6 +44,7 @@ PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     "profile_should_generate": ("v1.0.0", "boolean_evaluation"),
     "profile_should_generate_override": ("v1.0.0", "boolean_evaluation"),
     "profile_deduplication": ("v1.0.0", "profile_deduplication"),
+    "tagging": ("v1.0.0", "tagging"),
     "agent_success_evaluation": ("v1.0.0", "agent_success_evaluation"),
     # F1 cleanup: the session-level shadow comparison branch was retracted.
     # The prompt directories remain on disk (marked active: false in their


### PR DESCRIPTION
## Summary
- Adds generated tags to profiles, user playbooks, and agent playbooks.
- Introduces a deferred tagging service/scheduler so publish paths can tag newly generated entities after extraction and aggregation.
- Keeps tagging idempotent by distinguishing `None` as not-yet-tagged from `[]` as tagged-with-no-matches.

## Changes
- Adds tag fields to API/domain/UI models and storage contract surfaces.
- Adds SQLite tag storage and tags-only profile updates to avoid embedding recomputation.
- Preserves the untagged sentinel through domain models, SQLite row conversion, and UI conversion.
- Adds tagging prompt, mock support, scheduler tests, service tests, and storage round-trip tests.
- Removes inline profile metadata extraction from profile prompts in favor of post-generation tagging.

## Test Plan
- uv run ruff check --fix reflexio/models/api_schema/domain/entities.py reflexio/models/api_schema/ui/converters.py reflexio/server/services/storage/sqlite_storage/_base.py reflexio/server/services/storage/sqlite_storage/_playbook.py reflexio/server/services/storage/sqlite_storage/_profiles.py reflexio/server/services/tagging/tagging_service.py tests/server/services/storage/test_storage_contract_playbook.py tests/server/services/storage/test_storage_contract_profiles.py tests/server/services/tagging/test_tagging_service.py
- uv run ruff format reflexio/models/api_schema/domain/entities.py reflexio/models/api_schema/ui/converters.py reflexio/server/services/storage/sqlite_storage/_base.py reflexio/server/services/storage/sqlite_storage/_playbook.py reflexio/server/services/storage/sqlite_storage/_profiles.py reflexio/server/services/tagging/tagging_service.py tests/server/services/storage/test_storage_contract_playbook.py tests/server/services/storage/test_storage_contract_profiles.py tests/server/services/tagging/test_tagging_service.py
- uv run pyright reflexio/models/api_schema/domain/entities.py reflexio/models/api_schema/ui/converters.py reflexio/server/services/storage/sqlite_storage/_base.py reflexio/server/services/storage/sqlite_storage/_playbook.py reflexio/server/services/storage/sqlite_storage/_profiles.py reflexio/server/services/tagging/tagging_service.py tests/server/services/storage/test_storage_contract_playbook.py tests/server/services/storage/test_storage_contract_profiles.py tests/server/services/tagging/test_tagging_service.py
- uv run pytest --no-cov tests/server/services/storage/test_storage_contract_playbook.py tests/server/services/storage/test_storage_contract_profiles.py tests/server/services/tagging/test_tagging_service.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tagging support for profiles and playbooks with automatic LLM-powered tag generation
  * Tags now persist and are visible in API responses

* **Configuration**
  * Renamed configuration parameter `metadata_definition_prompt` to `tagging_definition_prompt` for profile extraction

* **Breaking Changes**
  * Profile responses now include `tags` field instead of `metadata`
  * Extracted profiles no longer contain metadata content—only profile content and tags

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
