### PR TITLE
feat: reduce search response latency

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -2,11 +2,13 @@ import asyncio
 import inspect
 import logging
 import os
+import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from typing import Any
 
+from anyio.to_thread import current_default_thread_limiter
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -493,12 +495,27 @@ class CorrelationIdMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         cid = generate_correlation_id()
         correlation_id_var.set(cid)
+        try:
+            stats = current_default_thread_limiter().statistics()
+            request.state.tp_borrowed = stats.borrowed_tokens
+            request.state.tp_total = stats.total_tokens
+            request.state.tp_waiting = stats.tasks_waiting
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Failed to snapshot threadpool limiter stats: %s", exc)
+            request.state.tp_borrowed = None
+            request.state.tp_total = None
+            request.state.tp_waiting = None
         response = await call_next(request)
         response.headers["X-Correlation-ID"] = cid
         return response
 
 
 core_router = APIRouter()
+
+
+def _stamp_search_dependencies_done(request: Request) -> None:
+    """Stamp when dependency resolution reaches its final search dependency."""
+    request.state.search_deps_done_monotonic = time.monotonic()
 
 
 def _meter_applied_learnings(
@@ -950,9 +967,11 @@ def search_agent_playbooks_endpoint(
 def unified_search_endpoint(
     request: Request,
     payload: UnifiedSearchRequest,
+    background_tasks: BackgroundTasks,
     org_id: str = Depends(default_get_org_id),
     caller_type: str = Depends(default_get_caller_type),
     _gate: None = Depends(default_billing_gate("application")),  # noqa: B008
+    _deps_done: None = Depends(_stamp_search_dependencies_done),
 ) -> UnifiedSearchViewResponse:
     """Search across all entity types (profiles, agent playbooks, user playbooks).
 
@@ -969,12 +988,22 @@ def unified_search_endpoint(
     Returns:
         UnifiedSearchViewResponse: Combined search results
     """
+    deps_done = getattr(request.state, "search_deps_done_monotonic", None)
+    deps_to_body_ms = (
+        int((time.monotonic() - deps_done) * 1000) if deps_done is not None else None
+    )
     with profile_step(
         "search.endpoint",
         enabled=bool(payload.enable_reformulation),
         has_conversation_history=bool(payload.conversation_history),
         search_mode=payload.search_mode,
-    ):
+    ) as endpoint_span:
+        endpoint_span.set_data("deps_to_body_ms", deps_to_body_ms)
+        endpoint_span.set_data(
+            "tp_borrowed", getattr(request.state, "tp_borrowed", None)
+        )
+        endpoint_span.set_data("tp_total", getattr(request.state, "tp_total", None))
+        endpoint_span.set_data("tp_waiting", getattr(request.state, "tp_waiting", None))
 
         def run_search() -> Any:
             with profile_step("search.reflexio_cache"):
@@ -997,16 +1026,16 @@ def unified_search_endpoint(
                 agent_trace=response.agent_trace,
                 rehydrated_text=response.rehydrated_text,
             )
-        with profile_step("search.meter_applied_learnings"):
-            _meter_applied_learnings(
-                org_id=org_id,
-                caller_type=caller_type,
-                surfaced_count=len(resp.profiles)
-                + len(resp.agent_playbooks)
-                + len(resp.user_playbooks),
-                request_id=getattr(payload, "request_id", None),
-                session_id=getattr(payload, "session_id", None),
-            )
+        background_tasks.add_task(
+            _meter_applied_learnings,
+            org_id=org_id,
+            caller_type=caller_type,
+            surfaced_count=len(resp.profiles)
+            + len(resp.agent_playbooks)
+            + len(resp.user_playbooks),
+            request_id=getattr(payload, "request_id", None),
+            session_id=getattr(payload, "session_id", None),
+        )
     return resp
 
 

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -17,6 +17,7 @@ from reflexio.models.api_schema.ui.entities import (
     UserPlaybookView,
 )
 from reflexio.server.api import create_app
+from reflexio.server.tracing import configure_tracer
 from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
 
 
@@ -86,6 +87,38 @@ def _capture() -> list[UsageEvent]:
     return events
 
 
+class _RecordingSpan:
+    def __init__(self, name: str, data: dict[str, object]) -> None:
+        self.name = name
+        self.data = data
+
+    def set_data(self, key: str, value: object) -> None:
+        self.data[key] = value
+
+
+class _SpanContext:
+    def __init__(
+        self, spans: list[_RecordingSpan], name: str, data: dict[str, object]
+    ) -> None:
+        self._spans = spans
+        self._span = _RecordingSpan(name, data)
+
+    def __enter__(self) -> _RecordingSpan:
+        self._spans.append(self._span)
+        return self._span
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class _RecordingTracer:
+    def __init__(self) -> None:
+        self.spans: list[_RecordingSpan] = []
+
+    def span(self, name: str, **data: object) -> _SpanContext:
+        return _SpanContext(self.spans, name, dict(data))
+
+
 def test_production_agent_search_meters_surfaced_count() -> None:
     """A production-agent call with results emits one learning_applied event."""
     events = _capture()
@@ -135,6 +168,27 @@ def test_empty_result_meters_nothing() -> None:
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+def test_unified_search_records_threadpool_diagnostics_on_endpoint_span() -> None:
+    """The search span carries deps-to-body and threadpool snapshot diagnostics."""
+    tracer = _RecordingTracer()
+    configure_tracer(tracer)
+    try:
+        with _patch_unified_search([], [], []):
+            resp = _client("dashboard").post(
+                "/api/search", json={"query": "x", "user_id": "u1"}
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_tracer(None)
+
+    search_spans = [span for span in tracer.spans if span.name == "search.endpoint"]
+    assert search_spans
+    data = search_spans[-1].data
+    assert "deps_to_body_ms" in data
+    assert isinstance(data["deps_to_body_ms"], int)
+    assert {"tp_borrowed", "tp_total", "tp_waiting"} <= data.keys()
 
 
 def test_get_billing_gate_override_seam() -> None:


### PR DESCRIPTION
## Summary
- Move best-effort applied-learning metering for unified search into a FastAPI background task so it no longer blocks the response.
- Add `search.endpoint` diagnostics for dependency-to-body latency and anyio threadpool saturation signals.
- Preserve existing metering behavior while adding focused coverage for the new tracing data.

## Changes
- `reflexio/server/api.py`
  - Adds request-entry threadpool limiter snapshots in `CorrelationIdMiddleware`.
  - Adds a final search dependency stamp and records `deps_to_body_ms` plus `tp_*` fields on the `search.endpoint` span.
  - Schedules `_meter_applied_learnings` with `BackgroundTasks` after response construction.
- `tests/server/api_endpoints/test_applied_learnings_metering.py`
  - Adds a fake tracer assertion for the new search endpoint diagnostics.

## Test Plan
- `uv run ruff check open_source/reflexio/reflexio/server/api.py open_source/reflexio/tests/server/api_endpoints/test_applied_learnings_metering.py reflexio_ext/server/api.py reflexio_ext/server/api_endpoints/auth_utils.py reflexio_ext/server/services/billing/enforcement/gate.py reflexio_ext/tests/server/test_central_token_auth.py reflexio_ext/tests/server/services/billing/enforcement/test_gate_observability.py`
- `uv run pyright open_source/reflexio/reflexio/server/api.py reflexio_ext/server/api.py reflexio_ext/server/api_endpoints/auth_utils.py reflexio_ext/server/services/billing/enforcement/gate.py`
- `uv run pytest --no-cov open_source/reflexio/tests/server/api_endpoints/test_applied_learnings_metering.py reflexio_ext/tests/server/test_central_token_auth.py reflexio_ext/tests/server/services/billing/enforcement/test_gate_observability.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search endpoint now captures request lifecycle timing metrics and thread-pool resource diagnostics.
  * Dependency resolution completion timing is tracked and recorded with search telemetry data.
  * Applied learnings metering now executes asynchronously after response completion.

* **Tests**
  * Added test coverage for endpoint diagnostics, verifying thread-pool statistics and timing measurements are correctly recorded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->