### PR TITLE
fix: clamp _epoch_to_iso to representable range; repair regen tests

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -351,9 +351,24 @@ def _iso_to_epoch(iso_str: str | None) -> int:
         return _epoch_now()
 
 
+# Bounds that ``datetime.fromtimestamp(tz=UTC)`` can represent (year 1..9999).
+# Callers pass sentinel "open" bounds — e.g. ``to_ts=10**12`` for "no upper
+# limit" or ``0`` for "from the beginning" — which would otherwise overflow
+# ``datetime.fromtimestamp`` with a ``ValueError``. Clamping to these bounds
+# yields the same query semantics (the ISO string still sorts before/after every
+# stored row) with a valid value.
+_MAX_SAFE_EPOCH_TS = 253_402_300_799  # 9999-12-31T23:59:59Z
+_MIN_SAFE_EPOCH_TS = 0  # 1970-01-01T00:00:00Z
+
+
 def _epoch_to_iso(ts: int) -> str:
-    """Convert a Unix timestamp to ISO 8601 string."""
-    return datetime.fromtimestamp(ts, tz=UTC).isoformat()
+    """Convert a Unix timestamp (seconds) to an ISO 8601 string.
+
+    Out-of-range sentinel bounds are clamped to the representable range so that
+    callers passing "open" window bounds never trigger a ``ValueError``.
+    """
+    clamped = max(_MIN_SAFE_EPOCH_TS, min(ts, _MAX_SAFE_EPOCH_TS))
+    return datetime.fromtimestamp(clamped, tz=UTC).isoformat()
 
 
 # ---------------------------------------------------------------------------

--- a/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
@@ -13,13 +13,6 @@ from reflexio.models.api_schema.eval_overview_schema import (
 
 from ._base import SQLiteStorageBase, _epoch_to_iso
 
-# Maximum epoch seconds that ``datetime.fromtimestamp`` can represent (year
-# 9999-12-31). Callers passing sentinel "open" upper bounds like
-# ``sys.maxsize`` or ``10**12`` would otherwise overflow ``_epoch_to_iso``;
-# clamping to this value yields the same query semantics (≥ everything) with
-# a valid ISO string.
-_MAX_SAFE_EPOCH_TS = 253_402_300_799  # 9999-12-31T23:59:59Z
-
 
 def _parse_dt(value: str) -> datetime:
     """
@@ -164,8 +157,8 @@ class ShadowVerdictsMixin:
             list[ShadowComparisonVerdict]: Verdicts in chronological order
                 (ascending ``created_at``).
         """
-        from_iso = _epoch_to_iso(max(0, min(from_ts, _MAX_SAFE_EPOCH_TS)))
-        to_iso = _epoch_to_iso(max(0, min(to_ts, _MAX_SAFE_EPOCH_TS)))
+        from_iso = _epoch_to_iso(from_ts)
+        to_iso = _epoch_to_iso(to_ts)
         rows = self._fetchall(
             """SELECT * FROM shadow_comparison_verdicts
                WHERE created_at >= ? AND created_at <= ?
@@ -183,8 +176,8 @@ class ShadowVerdictsMixin:
         judge_prompt_version: str,
         limit: int,
     ) -> list[ShadowComparisonVerdict]:
-        from_iso = _epoch_to_iso(max(0, min(from_ts, _MAX_SAFE_EPOCH_TS)))
-        to_iso = _epoch_to_iso(max(0, min(to_ts, _MAX_SAFE_EPOCH_TS)))
+        from_iso = _epoch_to_iso(from_ts)
+        to_iso = _epoch_to_iso(to_ts)
         safe_limit = max(0, limit)
         rows = self._fetchall(
             """SELECT * FROM shadow_comparison_verdicts

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
@@ -129,6 +129,12 @@ def _make_storage(
         _make_interaction("req_1", "user_a")
     ]
     storage.get_agent_success_evaluation_results.return_value = prior_results or []
+    # The runner captures prior result ids via the targeted, indexed lookup
+    # get_agent_success_evaluation_result_ids (added in the evaluation-overview
+    # read optimization) — seed it with the ids of the supplied prior rows.
+    storage.get_agent_success_evaluation_result_ids.return_value = [
+        r.result_id for r in (prior_results or [])
+    ]
     storage.delete_agent_success_evaluation_results_by_ids.return_value = len(
         prior_results or []
     )
@@ -452,10 +458,17 @@ def test_regenerate_happy_path_with_real_sqlite_storage(tmp_path) -> None:
                 ]
             )
 
-        with patch(
-            "reflexio.server.services.agent_success_evaluation"
-            ".group_evaluation_runner.AgentSuccessEvaluationService"
-        ) as service_cls:
+        with (
+            patch(
+                "reflexio.server.services.agent_success_evaluation"
+                ".group_evaluation_runner.AgentSuccessEvaluationService"
+            ) as service_cls,
+            patch(
+                "reflexio.server.services.agent_success_evaluation"
+                ".group_evaluation_runner.get_extractor_name",
+                return_value="overall_success",
+            ),
+        ):
             service = MagicMock()
             service.run.side_effect = fake_run
             service.has_run_failures.return_value = False
@@ -546,10 +559,17 @@ def test_regenerate_failure_preserves_old_rows_with_real_sqlite_storage(
         request_context.storage = storage
         llm_client = MagicMock()
 
-        with patch(
-            "reflexio.server.services.agent_success_evaluation"
-            ".group_evaluation_runner.AgentSuccessEvaluationService"
-        ) as service_cls:
+        with (
+            patch(
+                "reflexio.server.services.agent_success_evaluation"
+                ".group_evaluation_runner.AgentSuccessEvaluationService"
+            ) as service_cls,
+            patch(
+                "reflexio.server.services.agent_success_evaluation"
+                ".group_evaluation_runner.get_extractor_name",
+                return_value="overall_success",
+            ),
+        ):
             service = MagicMock()
             # Simulate the LLM failure path. Service .run() is a no-op (no save).
             service.has_run_failures.return_value = True

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
@@ -129,12 +129,36 @@ def _make_storage(
         _make_interaction("req_1", "user_a")
     ]
     storage.get_agent_success_evaluation_results.return_value = prior_results or []
+
     # The runner captures prior result ids via the targeted, indexed lookup
     # get_agent_success_evaluation_result_ids (added in the evaluation-overview
-    # read optimization) — seed it with the ids of the supplied prior rows.
-    storage.get_agent_success_evaluation_result_ids.return_value = [
-        r.result_id for r in (prior_results or [])
-    ]
+    # read optimization). Mirror the storage layer's own (session_id,
+    # evaluation_name, agent_version) filtering instead of a static return — so
+    # the test fails if the runner wires the WRONG identity tuple, not merely if
+    # it forgets to call the method.
+    def _result_ids_for(
+        session_id: str, evaluation_name: str, agent_version: str
+    ) -> list[int]:
+        """Return seeded result_ids matching one eval identity tuple (mirrors storage).
+
+        Args:
+            session_id (str): Owning session to match.
+            evaluation_name (str): Evaluator identifier to match.
+            agent_version (str): Agent version scope to match.
+
+        Returns:
+            list[int]: result_ids of the seeded prior rows whose full identity
+                tuple matches the arguments.
+        """
+        return [
+            r.result_id
+            for r in (prior_results or [])
+            if r.session_id == session_id
+            and r.evaluation_name == evaluation_name
+            and r.agent_version == agent_version
+        ]
+
+    storage.get_agent_success_evaluation_result_ids.side_effect = _result_ids_for
     storage.delete_agent_success_evaluation_results_by_ids.return_value = len(
         prior_results or []
     )
@@ -224,10 +248,17 @@ def test_force_regenerate_deletes_prior_results() -> None:
     request_context.storage = storage
     llm_client = MagicMock()
 
-    with patch(
-        "reflexio.server.services.agent_success_evaluation"
-        ".group_evaluation_runner.AgentSuccessEvaluationService"
-    ) as service_cls:
+    with (
+        patch(
+            "reflexio.server.services.agent_success_evaluation"
+            ".group_evaluation_runner.AgentSuccessEvaluationService"
+        ) as service_cls,
+        patch(
+            "reflexio.server.services.agent_success_evaluation"
+            ".group_evaluation_runner.get_extractor_name",
+            return_value="overall_success",
+        ),
+    ):
         service = MagicMock()
         service.has_run_failures.return_value = False
         service.last_run_saved_result_count = 1
@@ -244,7 +275,9 @@ def test_force_regenerate_deletes_prior_results() -> None:
             force_regenerate=True,
         )
 
-    # By-id delete called once with the captured prior result_ids.
+    # By-id delete called once with the captured prior result_ids — proving the
+    # runner passed the matching (session_a, overall_success, 1.0.0) identity to
+    # get_agent_success_evaluation_result_ids (the mock now filters on it).
     storage.delete_agent_success_evaluation_results_by_ids.assert_called_once_with([42])
     # The old triple-scoped delete must NOT be called by the new flow.
     storage.delete_agent_success_evaluation_results_for_session.assert_not_called()


### PR DESCRIPTION
## Summary
Found by `/check-and-test` (nightly CI). Two related fixes surfaced by the new evaluation-overview query added in #168.

**Application fix — clamp `_epoch_to_iso` to a representable range:**
- `_epoch_to_iso` raised `ValueError` when callers passed sentinel "open" window bounds (e.g. `to_ts=10**12`, used by the evaluation-overview API as a far-future upper bound) because `datetime.fromtimestamp` cannot represent year > 9999.
- The new `get_agent_success_evaluation_results_in_window` query (#168) hit this and **500'd the evaluation overview endpoint on a fresh app**.
- Clamp the input to `[0, 253402300799]` centrally in `_epoch_to_iso` so all current and future callers are protected. `_shadow_verdicts.py` had already worked around this at two call sites with a local `_MAX_SAFE_EPOCH_TS` clamp; that constant now lives in `_base.py` and the redundant per-call clamps are removed.

**Test fix — stale drift from #168:**
- The `force_regenerate` runner now captures prior result ids via the targeted `get_agent_success_evaluation_result_ids` lookup instead of reading full result rows. `test_group_evaluation_runner_regen.py` still mocked the old method, so the by-id delete asserted the wrong argument (MagicMock tests) or bound a `MagicMock` into SQL (real-sqlite tests). Seed the new lookup and patch `get_extractor_name` so the capture query's `evaluation_name` matches the seeded rows.

## Changes
- `reflexio/services/storage/sqlite_storage/_base.py` — central clamp in `_epoch_to_iso`; host `_MAX_SAFE_EPOCH_TS`.
- `reflexio/services/storage/sqlite_storage/_shadow_verdicts.py` — drop the now-redundant local clamps.
- `tests/.../test_group_evaluation_runner_regen.py` — align mocks with the by-id lookup path.

## Test Plan
- `test_group_evaluation_runner_regen.py` passes under both MagicMock and real-sqlite paths.
- Evaluation-overview endpoint no longer 500s with an open far-future `to_ts` on a fresh app.

## Provenance
Generated by the nightly AI-driven CI run on 2026-06-18. The enterprise-side submodule bump + companion test changes are in ReflexioAI/reflexio-enterprise#263 — that PR's `open_source/reflexio` pointer should be repointed to this PR's **merged** `main` commit once it lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed query failures when requesting results with extreme or boundary timestamp values by safely handling out-of-range epochs in SQLite-backed storage.

* **Tests**
  * Improved coverage for agent success evaluation “force regenerate” flows, including correct identity matching and deletion/preservation behavior across both mocked and real SQLite scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->