### PR TITLE
fix: add default search_settings site var to silence missing-var warning

### DIFF
--- a/reflexio/server/site_var/site_var_sources/search_settings.json
+++ b/reflexio/server/site_var/site_var_sources/search_settings.json
@@ -1,0 +1,5 @@
+{
+    "search_mode": "hybrid",
+    "vector_weight": 1.0,
+    "fts_weight": 1.0
+}


### PR DESCRIPTION
## Summary
Enterprise `SupabaseStorage` and `PostgresStorage` read the `search_settings` site var (search mode + hybrid vector/FTS weights) during init. No default file shipped under `reflexio/server/site_var/site_var_sources/`, so `SiteVarManager` logged:

```
Site var search_settings not found in Redis or files
```

on **every** storage instantiation (a fresh `SiteVarManager()` is built per call, so its in-memory cache never helps). On deployed servers this floods the logs.

## Change
Ship the default `search_settings.json` with the exact values the code already falls back to:

```json
{ "search_mode": "hybrid", "vector_weight": 1.0, "fts_weight": 1.0 }
```

The lookup now resolves to this dict instead of returning `None`, eliminating the warning. **Runtime behavior is unchanged** — the values match the existing fallback. Mirrors the sibling default files `feature_flags.json` and `llm_model_setting.json`.

## Note
The companion enterprise change renames the site-var key `supabase_settings` → `search_settings` (the var governs search for both Supabase and Postgres backends, so the old name was a misnomer) and bumps the submodule pointer to this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search functionality with hybrid mode that intelligently combines vector and full-text search capabilities. Both methods are equally weighted for optimal result relevance, providing more comprehensive search coverage and improved accuracy across all searchable content in the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->