### PR TITLE
fix: skip missing local optimizer assistants

### DIFF
--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from pathlib import Path
 from typing import Any, Literal, cast
 
 from pydantic import BaseModel
@@ -331,6 +333,13 @@ class PlaybookOptimizer:
                 backoff_base_s=config.webhook_backoff_base_seconds,
             )
         if config.assistant_script_path:
+            if not _is_executable_file(config.assistant_script_path):
+                logger.warning(
+                    "Skipping playbook optimization: assistant_script_path is not "
+                    "an executable file path=%s",
+                    config.assistant_script_path,
+                )
+                return None
             return LocalScriptAssistant(
                 script_path=config.assistant_script_path,
                 script_args=config.assistant_script_args,
@@ -625,6 +634,11 @@ def _split_metadata(
             window.user_playbook_id for window in validation_windows
         ],
     }
+
+
+def _is_executable_file(path: str) -> bool:
+    candidate = Path(path)
+    return candidate.is_file() and os.access(candidate, os.X_OK)
 
 
 def _result_metadata(result: Any, split_metadata: dict[str, Any]) -> dict[str, Any]:

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -498,6 +498,25 @@ def test_optimizer_selects_local_script_assistant(tmp_path):
     assert assistant.command == [sys.executable, "assistant.py"]
 
 
+def test_optimizer_skips_missing_local_script_assistant(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = PlaybookOptimizerConfig(
+        enabled=True,
+        assistant_script_path=str(tmp_path / "missing-assistant"),
+    )
+    optimizer = _optimizer_for_test(
+        storage,
+        Config(
+            storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+            playbook_optimizer_config=config,
+        ),
+    )
+
+    assistant = optimizer._create_assistant(config)
+
+    assert assistant is None
+
+
 def test_optimizer_splits_train_and_validation_windows(tmp_path):
     storage = _sqlite_storage(tmp_path)
     optimizer = _optimizer_for_test(


### PR DESCRIPTION
## Summary
- Make the playbook optimizer skip invalid local-script backends instead of trying to spawn them.
- Prevent stale or host-specific `assistant_script_path` values from surfacing as subprocess failures.

## Changes
- Validate `assistant_script_path` exists and is executable before constructing a `LocalScriptAssistant`.
- Add a regression test for missing local assistant scripts.

## Test Plan
- `uv run ruff check reflexio/server/services/playbook_optimizer/optimizer.py tests/server/services/playbook_optimizer/test_playbook_optimizer.py`
- `uv run ruff format --check reflexio/server/services/playbook_optimizer/optimizer.py tests/server/services/playbook_optimizer/test_playbook_optimizer.py`
- `uv run pytest --no-cov tests/server/services/playbook_optimizer/test_playbook_optimizer.py`
