### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/server/site_var/README.md
+++ b/reflexio/server/site_var/README.md
@@ -11,7 +11,7 @@ Description: Global configuration manager for site-wide variables and per-org fe
 
 ## Purpose
 
-1. **Global settings** - Model names, embedding models
+1. **Global settings** - Model names, embedding models, and retrieval defaults
 2. **Feature flags** - Per-org feature gating (global enable or per-org allowlist)
 3. **Dual storage** - File-based with optional Redis caching
 4. **Auto-fallback** - Redis → File system graceful degradation
@@ -62,6 +62,7 @@ site_var/
 └── site_var_sources/
     ├── app_config.json        # JSON → parsed dict
     ├── model_config.json
+    ├── search_settings.json   # Default retrieval mode and hybrid search weights
     └── feature_flags.json     # Feature flag config (per-flag enable + org allowlist)
 ```
 


### PR DESCRIPTION
## Summary
- Updates the site-var code-map README to include the newly added `site_var_sources/search_settings.json` retrieval-default configuration.
- Changes follow `/root/reflexio-enterprise/how_to_write_readme.md`: concise, path-focused, and limited to material navigation drift.

## Repositories/submodules reviewed
- Parent: `ReflexioAI/reflexio-enterprise`
- Submodules: `ReflexioAI/claude-smart`, `ReflexioAI/reflexio`

## README files updated
- `reflexio/server/site_var/README.md`

## Validation
- `git diff --check`
- Local README path/link check for `reflexio/server/site_var/README.md`

## Notes/Risks
- `open_source/reflexio/README.md` was intentionally not restructured because it is the user-facing public README excluded by the policy.
- Parent repository submodule pointer was not committed; this PR is scoped to the submodule README only.
