### PR TITLE
fix(llm): make the configured fallback reachable on a hung primary

### DIFF
--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -232,14 +232,17 @@ class LiteLLMConfig:
         temperature: Temperature for response generation (0.0 to 2.0).
         max_tokens: Maximum tokens to generate.
         timeout: Request timeout in seconds.
-        max_retries: Maximum retry attempts on the primary model. Passed
-            directly to litellm's num_retries. Default 3.
+        max_retries: Maximum same-model retry attempts. Used by the embedding
+            path (litellm's num_retries) and clamped in _build_completion_params.
+            NOT used on the chat-completion path — that forces num_retries=0 so a
+            hung primary can't be retried before the fallback (PYTHON-FASTAPI-62).
+            Default 3.
         retry_delay: Currently unused — LiteLLM owns retry backoff. Kept for
             backward compatibility; remove in a follow-up sweep.
         top_p: Top-p sampling parameter.
         api_key_config: Optional API key configuration from Config (overrides env vars).
-        fallback_models: Models LiteLLM tries in order after the primary
-            exhausts num_retries. Passed directly to litellm's fallbacks param.
+        fallback_models: Models LiteLLM tries in order after the primary's single
+            attempt. Passed directly to litellm's fallbacks param.
             Default is an empty list (no fallback) so local reflexio and the
             claude-smart integration are never silently routed to an unintended
             provider. Production opts in via the env var
@@ -1125,6 +1128,14 @@ class LiteLLMClient:
         except Exception:
             return None
 
+    def _coerce_timeout_seconds(self, params: dict[str, Any]) -> float:
+        """Coerce ``params['timeout']`` to a float, falling back to the config
+        default when it is missing or non-numeric."""
+        try:
+            return float(params.get("timeout", self.config.timeout))
+        except (TypeError, ValueError):
+            return float(self.config.timeout)
+
     def _completion_with_hard_timeout(
         self, params: dict[str, Any], hard_timeout: float
     ) -> Any:
@@ -1142,10 +1153,11 @@ class LiteLLMClient:
         reaches a fallback (the root cause of Sentry PYTHON-FASTAPI-62).
         """
         provider_timeout = params.get("timeout", self.config.timeout)
-        try:
-            timeout_seconds = float(provider_timeout)
-        except (TypeError, ValueError):
-            timeout_seconds = float(self.config.timeout)
+        # timeout_seconds + grace_seconds below only classify test doubles in
+        # _should_process_isolate_completion (real litellm vs a monkeypatched
+        # closure) — they do NOT size the kill bound, which is the caller's
+        # ladder-wide ``hard_timeout``.
+        timeout_seconds = self._coerce_timeout_seconds(params)
         grace_seconds = self._hard_timeout_grace_seconds()
         hard_timeout = max(0.001, hard_timeout)
 
@@ -1320,14 +1332,15 @@ class LiteLLMClient:
         self, messages: list[dict[str, Any]], **kwargs: Any
     ) -> str | BaseModel | ToolCallingChatResponse:
         """
-        Make a request to the LLM, delegating retries and fallback to litellm.
+        Make a request to the LLM, delegating cross-model fallback to litellm.
 
-        Retry and fallback semantics are handed to ``litellm.completion`` via
-        the native ``num_retries`` and ``fallbacks`` kwargs. Per the documented
-        flow at https://docs.litellm.ai/docs/router_architecture, the primary
-        model is tried ``num_retries+1`` times, then each fallback gets a single
-        attempt. The one piece we still own at the client level is a single
-        retry for ``StructuredOutputParseError``: LiteLLM cannot detect a
+        Fallback is handed to ``litellm.completion`` via the native ``fallbacks``
+        kwarg, but ``num_retries`` is forced to 0: same-model retry of a *hung*
+        primary is what made the fallback unreachable and produced the 490s in
+        Sentry PYTHON-FASTAPI-62 (see the body comment). So the primary is tried
+        once, then each fallback once. The subprocess hard timeout is sized to
+        cover that whole ladder. The one retry we still own at the client level
+        is a single ``StructuredOutputParseError`` retry: LiteLLM cannot detect a
         post-hoc Pydantic re-validation failure because it sees a successful
         HTTP response.
 
@@ -1360,15 +1373,21 @@ class LiteLLMClient:
         if fallbacks:
             params["fallbacks"] = fallbacks
 
-        # Size the hard (wall-clock) timeout to cover the WHOLE ladder. Each of
-        # the ``1 + len(fallbacks)`` rungs gets up to ``params["timeout"]`` seconds
-        # (litellm copies it unchanged), so the subprocess must be allowed to run
-        # that long, plus one grace buffer, before being killed — otherwise it is
-        # killed before litellm can reach a fallback.
-        try:
-            per_attempt_timeout = float(params.get("timeout", self.config.timeout))
-        except (TypeError, ValueError):
-            per_attempt_timeout = float(self.config.timeout)
+        # Size the hard (wall-clock) timeout to cover the WHOLE ladder. litellm
+        # copies this single ``params["timeout"]`` into EVERY rung (primary + each
+        # fallback), so every rung shares the primary's per-attempt budget and the
+        # subprocess must be allowed to run ``(1 + len(fallbacks))`` of them plus
+        # one grace buffer before being killed — otherwise it is killed before
+        # litellm can reach a fallback.
+        #
+        # ASYMMETRIC-FLOOR FOOTGUN: because every rung shares one timeout, a
+        # fallback whose _MODEL_TIMEOUT_FLOOR_SECONDS floor is HIGHER than the
+        # primary's would run — and be killed — at the primary's shorter timeout,
+        # reintroducing the "fallback killed early" failure this fix removes. The
+        # floor table is single-valued today (MiniMax-M3 == the 120 default), so
+        # this is latent; revisit the sizing (e.g. max floor across rungs, passed
+        # as ``params["timeout"]``) before adding an asymmetric floor entry.
+        per_attempt_timeout = self._coerce_timeout_seconds(params)
         hard_timeout = (
             1 + len(fallbacks)
         ) * per_attempt_timeout + self._hard_timeout_grace_seconds()
@@ -1428,6 +1447,13 @@ class LiteLLMClient:
                 # mitigation. (A hard timeout is NOT retried here: same-model
                 # retry of a hang is what produced the 490s in PYTHON-FASTAPI-62;
                 # the fallback ladder inside _call_and_parse handles it instead.)
+                #
+                # This second pass re-walks the full ladder, so the worst-case
+                # wall clock is ~2x the ladder bound. That ceiling is only reached
+                # if a model returns a malformed-but-successful 200 AND runs near
+                # the timeout on BOTH passes — a hang (the common case) raises
+                # LLMHardTimeoutError, which is not caught here and exits after a
+                # single ladder.
                 self.logger.warning(
                     "event=llm_parse_retry model=%s — primary returned malformed structured output, retrying once",
                     params.get("model"),

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -264,12 +264,18 @@ class LiteLLMConfig:
     )
 
 
-# Reasoning models that routinely exceed the default 120s provider timeout on
-# large extraction contexts. Values are floors, not overrides: the effective
-# timeout is max(configured, floor), and an explicit per-call timeout kwarg
-# always wins.
+# Per-model provider-timeout floors. Values are floors, not overrides: the
+# effective timeout is max(configured, floor), and an explicit per-call timeout
+# kwarg always wins.
+#
+# MiniMax-M3 was pinned to 240s when it was the sole model. That let a *hung*
+# primary block ~240s before falling back, dominating the wasted time behind
+# Sentry PYTHON-FASTAPI-62. It is now floored at the 120s default so a hang is
+# abandoned sooner and the fallback (e.g. gpt-5-mini) is reached faster. This is
+# the key post-deploy tuning knob: raise it if legitimately-slow calls start
+# timing out, lower it to cut more waste.
 _MODEL_TIMEOUT_FLOOR_SECONDS: dict[str, int] = {
-    "minimax/MiniMax-M3": 240,
+    "minimax/MiniMax-M3": 120,
 }
 
 
@@ -1119,12 +1125,21 @@ class LiteLLMClient:
         except Exception:
             return None
 
-    def _completion_with_hard_timeout(self, params: dict[str, Any]) -> Any:
+    def _completion_with_hard_timeout(
+        self, params: dict[str, Any], hard_timeout: float
+    ) -> Any:
         """Run ``litellm.completion`` with a client-side wall-clock bound.
 
         Some providers can exceed LiteLLM's ``timeout`` kwarg. Run the blocking
         call in a child process so the caller can fail, release locks, and
         terminate the in-flight provider request instead of waiting indefinitely.
+
+        ``hard_timeout`` is the wall-clock kill bound for the whole subprocess.
+        Because LiteLLM walks ``[primary, *fallbacks]`` inside this one call
+        (copying ``timeout`` unchanged into each rung), the caller sizes
+        ``hard_timeout`` to cover the entire fallback ladder, not a single
+        attempt — otherwise the subprocess would be killed before LiteLLM ever
+        reaches a fallback (the root cause of Sentry PYTHON-FASTAPI-62).
         """
         provider_timeout = params.get("timeout", self.config.timeout)
         try:
@@ -1132,7 +1147,7 @@ class LiteLLMClient:
         except (TypeError, ValueError):
             timeout_seconds = float(self.config.timeout)
         grace_seconds = self._hard_timeout_grace_seconds()
-        hard_timeout = max(0.001, timeout_seconds) + max(0.0, grace_seconds)
+        hard_timeout = max(0.001, hard_timeout)
 
         if not self._should_process_isolate_completion(timeout_seconds, grace_seconds):
             return litellm.completion(**params)
@@ -1329,28 +1344,47 @@ class LiteLLMClient:
             LiteLLMClientError: If the request fails after all retries and
                 fallbacks have been exhausted by litellm.
         """
-        params, response_format, parse_structured_output, max_retries, fallbacks = (
+        params, response_format, parse_structured_output, _max_retries, fallbacks = (
             self._build_completion_params(messages, **kwargs)
         )
 
-        # Hand retries + fallbacks to litellm. ``num_retries`` is the documented
-        # alias for max_retries on litellm.completion.
-        params["num_retries"] = max_retries
+        # Hand the fallback ladder to litellm, but DISABLE same-model retries.
+        # litellm walks [primary, *fallbacks] inside one litellm.completion call,
+        # copying ``timeout`` unchanged into each rung. With num_retries>=1 it
+        # retries a *hung* primary num_retries+1 times (each up to a full
+        # provider timeout) before ever reaching a fallback — making the fallback
+        # unreachable within any sane wall-clock bound (root cause of Sentry
+        # PYTHON-FASTAPI-62). num_retries=0 makes the fallback LIST the resilience
+        # mechanism: each model is tried once, in order.
+        params["num_retries"] = 0
         if fallbacks:
             params["fallbacks"] = fallbacks
 
+        # Size the hard (wall-clock) timeout to cover the WHOLE ladder. Each of
+        # the ``1 + len(fallbacks)`` rungs gets up to ``params["timeout"]`` seconds
+        # (litellm copies it unchanged), so the subprocess must be allowed to run
+        # that long, plus one grace buffer, before being killed — otherwise it is
+        # killed before litellm can reach a fallback.
+        try:
+            per_attempt_timeout = float(params.get("timeout", self.config.timeout))
+        except (TypeError, ValueError):
+            per_attempt_timeout = float(self.config.timeout)
+        hard_timeout = (
+            1 + len(fallbacks)
+        ) * per_attempt_timeout + self._hard_timeout_grace_seconds()
+
         request_start = time.perf_counter()
         self.logger.info(
-            "event=llm_request_start model=%s timeout=%s has_response_format=%s num_retries=%d fallbacks=%s",
+            "event=llm_request_start model=%s timeout=%s has_response_format=%s num_retries=0 fallbacks=%s hard_timeout=%.3f",
             params.get("model"),
             params.get("timeout"),
             response_format is not None,
-            max_retries,
             fallbacks,
+            hard_timeout,
         )
 
         def _call_and_parse() -> str | BaseModel | ToolCallingChatResponse:
-            response = self._completion_with_hard_timeout(params)
+            response = self._completion_with_hard_timeout(params, hard_timeout)
             self._emit_fallback_observability(response, params)
             message = response.choices[0].message  # type: ignore[reportAttributeAccessIssue]
             content = message.content
@@ -1387,22 +1421,15 @@ class LiteLLMClient:
             try:
                 return _call_and_parse()
             except StructuredOutputParseError:
-                # LiteLLM's num_retries covers API errors, but a Pydantic
-                # re-validation failure happens AFTER litellm sees a
-                # successful 200 — so we owe one explicit second attempt at
-                # the model. PR #121 documented this as a MiniMax-M3
-                # mitigation.
+                # litellm's fallbacks cover API/timeout errors, but a Pydantic
+                # re-validation failure happens AFTER litellm sees a successful
+                # 200 — litellm can't detect it, so we owe one explicit second
+                # attempt at the model. PR #121 documented this as a MiniMax-M3
+                # mitigation. (A hard timeout is NOT retried here: same-model
+                # retry of a hang is what produced the 490s in PYTHON-FASTAPI-62;
+                # the fallback ladder inside _call_and_parse handles it instead.)
                 self.logger.warning(
                     "event=llm_parse_retry model=%s — primary returned malformed structured output, retrying once",
-                    params.get("model"),
-                )
-                return _call_and_parse()
-            except LLMHardTimeoutError:
-                # The hard timeout kills the litellm subprocess, so litellm's
-                # num_retries never gets a chance — we owe one explicit retry
-                # at this level to cover transient provider hangs.
-                self.logger.warning(
-                    "event=llm_hard_timeout_retry model=%s — request hit hard timeout, retrying once",
                     params.get("model"),
                 )
                 return _call_and_parse()

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -38,9 +38,6 @@ from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.llm.providers.claude_code_provider import (
     register_if_enabled as _register_claude_code,
 )
-from reflexio.server.llm.providers.openclaw_provider import (
-    register_if_enabled as _register_openclaw,
-)
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
     embedding_provider_mode,
@@ -64,6 +61,9 @@ from reflexio.server.llm.providers.nomic_embedding_provider import (
 )
 from reflexio.server.llm.providers.nomic_embedding_provider import (
     register_if_enabled as _register_nomic_embedder,
+)
+from reflexio.server.llm.providers.openclaw_provider import (
+    register_if_enabled as _register_openclaw,
 )
 
 # Suppress LiteLLM's verbose logging

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1554,14 +1554,16 @@ class TestBuildCompletionParams:
         assert "top_p" not in call_kwargs
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_model_timeout_floor_raises_default(self, mock_completion):
-        """MiniMax-M3 has a 240s floor; the default 120s config is raised to it."""
+    def test_minimax_m3_floor_is_120(self, mock_completion):
+        """MiniMax-M3's floor was lowered from 240s to the 120s default
+        (Sentry PYTHON-FASTAPI-62) so a hung primary is abandoned sooner and the
+        fallback is reached faster."""
         mock_completion.return_value = _make_completion_response("ok")
         client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
 
         client.generate_response("hi")
 
-        assert mock_completion.call_args.kwargs["timeout"] == 240
+        assert mock_completion.call_args.kwargs["timeout"] == 120
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
     def test_model_timeout_floor_does_not_lower_higher_config(self, mock_completion):
@@ -1930,32 +1932,30 @@ class TestCreateLiteLLMClient:
 class TestMaxRetriesClamping:
     """max_retries clamping in _build_completion_params.
 
-    Retry orchestration itself is delegated to litellm; we only sanity-check
-    that the value forwarded into ``num_retries`` is at least 1 even when the
-    config holds a degenerate value.
+    The completion path now forces ``num_retries=0`` on litellm (the fallback
+    list, not same-model retry, is the resilience mechanism — see
+    PYTHON-FASTAPI-62), so the clamped value is no longer forwarded. We assert
+    the clamp on the value ``_build_completion_params`` returns, which the
+    per-call ``max_retries`` override API still validates.
     """
 
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_max_retries_zero_treated_as_one(self, mock_completion):
-        """max_retries=0 should be clamped to at least 1."""
-        mock_completion.return_value = _make_completion_response("ok")
-        config = LiteLLMConfig(model="gpt-4o", max_retries=0)
-        client = LiteLLMClient(config)
+    def test_max_retries_zero_treated_as_one(self):
+        """max_retries=0 should be clamped to at least 1 in the returned value."""
+        client = LiteLLMClient(LiteLLMConfig(model="gpt-4o", max_retries=0))
 
-        result = client._make_request([{"role": "user", "content": "hi"}])
-        assert result == "ok"
-        assert mock_completion.call_args.kwargs["num_retries"] == 1
+        _, _, _, max_retries, _ = client._build_completion_params(
+            [{"role": "user", "content": "hi"}]
+        )
+        assert max_retries == 1
 
-    @patch("reflexio.server.llm.litellm_client.litellm.completion")
-    def test_negative_max_retries_treated_as_one(self, mock_completion):
+    def test_negative_max_retries_treated_as_one(self):
         """Negative max_retries should be clamped to at least 1."""
-        mock_completion.return_value = _make_completion_response("ok")
-        config = LiteLLMConfig(model="gpt-4o", max_retries=-1)
-        client = LiteLLMClient(config)
+        client = LiteLLMClient(LiteLLMConfig(model="gpt-4o", max_retries=-1))
 
-        result = client._make_request([{"role": "user", "content": "hi"}])
-        assert result == "ok"
-        assert mock_completion.call_args.kwargs["num_retries"] == 1
+        _, _, _, max_retries, _ = client._build_completion_params(
+            [{"role": "user", "content": "hi"}]
+        )
+        assert max_retries == 1
 
 
 class TestTokenUsageLoggingEdgeCases:
@@ -2138,7 +2138,11 @@ class TestLitellmIntegration:
     def _messages() -> list[dict[str, Any]]:
         return [{"role": "user", "content": "hi"}]
 
-    def test_passes_num_retries_from_config(self, monkeypatch):
+    def test_completion_forces_num_retries_zero(self, monkeypatch):
+        """The completion path disables litellm same-model retries regardless of
+        config: retrying a *hung* primary num_retries+1 times is what made the
+        fallback unreachable and produced the 490s in PYTHON-FASTAPI-62. The
+        fallback list is the resilience mechanism instead."""
         client = LiteLLMClient(LiteLLMConfig(model="x", max_retries=3))
         captured: dict[str, Any] = {}
 
@@ -2148,7 +2152,7 @@ class TestLitellmIntegration:
 
         monkeypatch.setattr("litellm.completion", _fake)
         client.generate_chat_response(self._messages())
-        assert captured.get("num_retries") == 3
+        assert captured.get("num_retries") == 0
 
     def test_passes_fallbacks_from_config(self, monkeypatch):
         # Config-explicit fallback (opt-in at construction)
@@ -2207,7 +2211,9 @@ class TestLitellmIntegration:
         client.generate_chat_response(
             self._messages(), max_retries=7, fallback_models=["gpt-5.4-mini"]
         )
-        assert captured.get("num_retries") == 7
+        # The per-call fallback override wins; num_retries is forced to 0 on the
+        # completion path regardless of the max_retries override.
+        assert captured.get("num_retries") == 0
         assert captured.get("fallbacks") == ["gpt-5.4-mini"]
 
     def test_fallback_self_reference_deduped(self, monkeypatch):
@@ -2254,8 +2260,8 @@ class TestLitellmIntegration:
         start = time.perf_counter()
         with pytest.raises(LiteLLMClientError, match="hard timeout"):
             client.generate_chat_response(self._messages())
-        # Two subprocess spawn/kill cycles (initial attempt + one hard-timeout
-        # retry) — still far below the 1s the blocked call would take.
+        # A single subprocess spawn/kill cycle (the blind same-model hard-timeout
+        # retry was removed) — still far below the 1s the blocked call would take.
         assert time.perf_counter() - start < 1.0
 
     def test_worker_snapshots_litellm_api_connection_error(self, monkeypatch):
@@ -2286,32 +2292,15 @@ class TestLitellmIntegration:
         assert payload.model == "gpt-5-mini"
         assert payload.llm_provider == "openai"
 
-    def test_hard_timeout_retried_once_then_succeeds(self, monkeypatch):
-        """A transient hard timeout is retried exactly once at the client level
-        (litellm's num_retries dies with the killed subprocess, so it can never
-        cover this case)."""
+    def test_hard_timeout_not_retried_at_client_level(self, monkeypatch):
+        """A hard timeout is NOT retried at the client level. Same-model retry of
+        a hang is exactly what produced the 490s in PYTHON-FASTAPI-62; the
+        fallback ladder inside the litellm call is the resilience path instead.
+        The timeout surfaces as LiteLLMClientError after a single attempt."""
         client = LiteLLMClient(LiteLLMConfig(model="x"))
         attempts: list[int] = []
 
-        def _flaky(params):
-            attempts.append(1)
-            if len(attempts) == 1:
-                raise LLMHardTimeoutError("LLM request exceeded hard timeout")
-            return _make_completion_response("recovered")
-
-        monkeypatch.setattr(client, "_completion_with_hard_timeout", _flaky)
-
-        result = client.generate_chat_response(self._messages())
-
-        assert result == "recovered"
-        assert len(attempts) == 2
-
-    def test_hard_timeout_not_retried_more_than_once(self, monkeypatch):
-        """A second consecutive hard timeout propagates as LiteLLMClientError."""
-        client = LiteLLMClient(LiteLLMConfig(model="x"))
-        attempts: list[int] = []
-
-        def _always_timeout(params):
+        def _always_timeout(params, hard_timeout):
             attempts.append(1)
             raise LLMHardTimeoutError("LLM request exceeded hard timeout")
 
@@ -2319,7 +2308,37 @@ class TestLitellmIntegration:
 
         with pytest.raises(LiteLLMClientError, match="hard timeout"):
             client.generate_chat_response(self._messages())
-        assert len(attempts) == 2
+        assert len(attempts) == 1
+
+    def test_hard_timeout_sized_to_full_ladder(self, monkeypatch):
+        """The fix: the hard timeout passed to the subprocess covers the WHOLE
+        ladder (one slice per model), num_retries is 0, and the fallback list is
+        forwarded — together these make the fallback reachable on a hung primary.
+        """
+        monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "5")
+        client = LiteLLMClient(
+            LiteLLMConfig(
+                model="minimax/MiniMax-M3", fallback_models=["gpt-5-mini"]
+            )
+        )
+        captured: dict[str, Any] = {}
+
+        def _capture(params, hard_timeout):
+            captured["hard_timeout"] = hard_timeout
+            captured["timeout"] = params.get("timeout")
+            captured["num_retries"] = params.get("num_retries")
+            captured["fallbacks"] = params.get("fallbacks")
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr(client, "_completion_with_hard_timeout", _capture)
+        client.generate_chat_response(self._messages())
+
+        # MiniMax-M3 floor is 120s; litellm copies that timeout to each rung, so
+        # two rungs (primary + one fallback) → 2 * 120 + 5 grace.
+        assert captured["timeout"] == 120
+        assert captured["num_retries"] == 0
+        assert captured["fallbacks"] == ["gpt-5-mini"]
+        assert captured["hard_timeout"] == pytest.approx(2 * 120 + 5)
 
     def test_invalid_hard_timeout_grace_env_falls_back(self, monkeypatch, caplog):
         monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "not-a-float")

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2317,9 +2317,7 @@ class TestLitellmIntegration:
         """
         monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "5")
         client = LiteLLMClient(
-            LiteLLMConfig(
-                model="minimax/MiniMax-M3", fallback_models=["gpt-5-mini"]
-            )
+            LiteLLMConfig(model="minimax/MiniMax-M3", fallback_models=["gpt-5-mini"])
         )
         captured: dict[str, Any] = {}
 
@@ -2339,6 +2337,61 @@ class TestLitellmIntegration:
         assert captured["num_retries"] == 0
         assert captured["fallbacks"] == ["gpt-5-mini"]
         assert captured["hard_timeout"] == pytest.approx(2 * 120 + 5)
+
+    @pytest.mark.parametrize(
+        "fallback_models, expected_rungs",
+        [([], 1), (["a"], 2), (["a", "b"], 3)],
+    )
+    def test_hard_timeout_scales_with_rung_count(
+        self, monkeypatch, fallback_models, expected_rungs
+    ):
+        """hard_timeout == (1 + len(fallbacks)) * per_attempt + ONE grace.
+
+        Pinning n=0/1/2 catches the ``1 + len(...)`` off-by-one and that grace is
+        added once (not per rung) — at n=1 alone, several wrong formulas collapse
+        to the same number, so a single case proves nothing.
+        """
+        monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "5")
+        client = LiteLLMClient(
+            LiteLLMConfig(model="x", timeout=30, fallback_models=fallback_models)
+        )
+        captured: dict[str, Any] = {}
+
+        def _capture(params, hard_timeout):
+            captured["hard_timeout"] = hard_timeout
+            return _make_completion_response("ok")
+
+        monkeypatch.setattr(client, "_completion_with_hard_timeout", _capture)
+        client.generate_chat_response(self._messages())
+
+        assert captured["hard_timeout"] == pytest.approx(expected_rungs * 30 + 5)
+
+    def test_fallback_response_returned_when_primary_fails(self, monkeypatch):
+        """End-to-end: when the primary fails and a fallback is configured, the
+        fallback's response is what _make_request returns.
+
+        The fake stands in for litellm's native fallback dispatch (which our code
+        ENABLES by forwarding ``fallbacks`` and ``num_retries=0``): it serves the
+        fallback whenever the primary is invoked with a non-empty ``fallbacks``
+        list, and otherwise fails. If a regression dropped the ``fallbacks``
+        kwarg, the fake would raise instead and this test would fail — so it
+        guards the headline "fallback is reachable" behavior, not just plumbing
+        values.
+        """
+        client = LiteLLMClient(
+            LiteLLMConfig(model="minimax/MiniMax-M3", fallback_models=["gpt-5-mini"])
+        )
+
+        def _fake(**params):
+            if params["model"] == "minimax/MiniMax-M3" and params.get("fallbacks"):
+                return _make_completion_response("from-fallback")
+            raise APIConnectionError(
+                "primary down", llm_provider="minimax", model=params["model"]
+            )
+
+        monkeypatch.setattr("litellm.completion", _fake)
+        result = client.generate_chat_response(self._messages())
+        assert result == "from-fallback"
 
     def test_invalid_hard_timeout_grace_env_falls_back(self, monkeypatch, caplog):
         monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "not-a-float")

--- a/tests/server/services/playbook/test_playbook_consolidator_integration.py
+++ b/tests/server/services/playbook/test_playbook_consolidator_integration.py
@@ -952,14 +952,15 @@ def _build_real_client_consolidator(
 
 
 class TestConsolidatorNativeFallbackEndToEnd:
-    """End-to-end: ``_consolidation_decisions`` forwards retry + fallback into ``litellm.completion``.
+    """End-to-end: ``_consolidation_decisions`` forwards the fallback list into ``litellm.completion``.
 
     The consolidator was the original production incident site (structured
-    output parse path on top of native retry + fallback), so this is the
-    highest-fidelity exercise of the Task 1-4 plumbing. Pinning both the
-    "env var on => fallback configured" and "env var unset => no fallback"
-    branches at this level prevents regressions where the plumbing works in
-    isolation but breaks once a structured-output wrapper sits on top.
+    output parse path on top of native fallback; same-model retry of a hung
+    primary is disabled — PYTHON-FASTAPI-62), so this is the highest-fidelity
+    exercise of the plumbing. Pinning both the "env var on => fallback
+    configured" and "env var unset => no fallback" branches at this level
+    prevents regressions where the plumbing works in isolation but breaks once
+    a structured-output wrapper sits on top.
     """
 
     def test_consolidator_calls_litellm_with_fallback_configured(
@@ -968,8 +969,9 @@ class TestConsolidatorNativeFallbackEndToEnd:
         """Production-style: ``REFLEXIO_LLM_FALLBACK_MODELS`` set globally.
 
         Asserts the consolidator's call into ``litellm.completion`` carries
-        ``num_retries=3`` (the default ``LiteLLMConfig.max_retries``) and
-        ``fallbacks=["gpt-5.4-mini"]`` end-to-end — proving Task 1-3's native
+        ``num_retries=0`` (forced on the completion path so a hung primary
+        can't be same-model-retried before the fallback — PYTHON-FASTAPI-62)
+        and ``fallbacks=["gpt-5.4-mini"]`` end-to-end — proving native fallback
         delegation survives the structured-output parse wrapper.
         """
         monkeypatch.setenv("REFLEXIO_LLM_FALLBACK_MODELS", "gpt-5.4-mini")
@@ -999,8 +1001,10 @@ class TestConsolidatorNativeFallbackEndToEnd:
         assert isinstance(result, PlaybookConsolidationOutput)
         assert result.decisions == []
 
-        # Linchpin: native delegation forwarded both knobs to litellm.
-        assert captured.get("num_retries") == 3
+        # Linchpin: fallbacks forwarded; num_retries forced to 0 so a hung
+        # primary can't be same-model-retried before reaching the fallback
+        # (PYTHON-FASTAPI-62).
+        assert captured.get("num_retries") == 0
         assert captured.get("fallbacks") == ["gpt-5.4-mini"]
 
     def test_consolidator_uses_no_fallback_when_env_unset(
@@ -1034,7 +1038,7 @@ class TestConsolidatorNativeFallbackEndToEnd:
 
         assert isinstance(result, PlaybookConsolidationOutput)
         assert result.decisions == []
-        # ``num_retries`` still flows (default 3); only ``fallbacks`` must be
-        # absent so litellm has no fallback chain to traverse.
-        assert captured.get("num_retries") == 3
+        # ``num_retries`` is forced to 0 on the completion path; ``fallbacks``
+        # must be absent so litellm has no fallback chain to traverse.
+        assert captured.get("num_retries") == 0
         assert "fallbacks" not in captured


### PR DESCRIPTION
## Summary

Fixes a production LLM hard-timeout where the configured fallback model was **structurally unreachable** when the primary model hung — so playbook deduplication was silently skipped (fail-open) and ~8 min of worker time + tokens were burned per occurrence.

**Root cause** (verified against litellm 1.83.0): `litellm.completion` walks `[primary, *fallbacks]` inside one subprocess, copying `timeout` *unchanged* into each rung. Our hard-timeout kill switch in `_completion_with_hard_timeout` was sized to a **single** provider timeout (`provider_timeout + grace`), so when the primary hung it consumed the whole budget and the subprocess was killed **before** litellm reached the fallback. A blind same-model `LLMHardTimeoutError` retry then doubled the wall-clock (~245s → ~490s observed), still with no fallback.

## Changes

- **`num_retries = 0` on the completion path** — with `num_retries ≥ 1`, litellm retries a *hung* primary `num_retries+1` times (each a full provider timeout) before any fallback, defeating any sane wall-clock bound. The fallback list is the resilience mechanism instead. (Same-model transient retry is dropped; a transient primary error now demotes straight to the fallback. Embeddings are unaffected — separate path, still use `config.max_retries`.)
- **Hard timeout sized to the whole ladder** — `_completion_with_hard_timeout` now takes the bound as a parameter; `_make_request` computes `(1 + len(fallbacks)) × per-attempt timeout + grace` so the subprocess is allowed to run long enough for litellm to reach a fallback.
- **Deleted the blind `LLMHardTimeoutError` retry** — the source of the ~490s doubling.
- **Lowered the `minimax/MiniMax-M3` timeout floor 240 → 120** — a hung primary is abandoned sooner; this is the key tuning knob.
- **Sorted imports** (separate commit) — a pre-existing ruff `I001` introduced by an earlier import addition.

litellm's native fallback is kept, so per-model API keys, response formats, and the fallback observability tag continue to work.

### Before → after (one fallback, grace = 5s)

| | Before | After |
|---|---|---|
| Primary hangs | timeout at 240s | timeout at **120s** |
| Same-model retry | yes (hard-killed at 245s) | **none** |
| Reaches fallback? | **no** | **yes** |
| Total wall-clock | ~490s, **dedup skipped** | **~150s, dedup succeeds** |

## Test Plan

- Updated unit tests: `num_retries` is forced to `0` on the completion path; the clamping tests now target `_build_completion_params` (which still validates the value); the two hard-timeout-retry tests are replaced by a no-client-retry test plus a new behavioral proof that the hard timeout is sized to the full ladder.
- Updated the playbook-consolidator integration assertions (`num_retries == 0`) and the MiniMax floor assertion (240 → 120).
- ✅ `ruff` + `pyright` clean
- ✅ Unit tier: **2817 passed**
- ✅ Integration tier (mocked LLM): **238 passed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language model request timeout handling so the system fails over to fallback models sooner when the primary stalls.
  * Lowered the MiniMax-M3 minimum timeout floor from 240s to 120s for faster recovery.
  * Adjusted retry and fallback orchestration to avoid redundant retry behavior on the completion path and return fallback results more reliably.

* **Tests**
  * Updated unit and end-to-end tests to match the new retry, timeout, and fallback expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->