### PR TITLE
test: fix stale custom_features metadata assertion in interaction e2e

### DIFF
--- a/tests/e2e_tests/test_interaction_workflows.py
+++ b/tests/e2e_tests/test_interaction_workflows.py
@@ -78,10 +78,12 @@ def test_publish_interaction_end_to_end(
     final_profiles = reflexio_instance.request_context.storage.get_all_profiles()
     assert len(final_profiles) > 0
     assert final_profiles[0].content.strip() != ""
-    assert (
-        final_profiles[0].custom_features is not None
-        and final_profiles[0].custom_features.get("metadata") is not None
-    )
+    # The extractor enriches each profile with structured-evidence fields
+    # (source_span / notes / reader_angle) carried in custom_features. The
+    # legacy ``metadata`` key was retired alongside the list-valued tagging
+    # extractor, so assert the profile carries non-empty custom_features rather
+    # than pinning to a key the current schema no longer emits.
+    assert final_profiles[0].custom_features
 
     # Verify profile change logs were created
     final_change_logs = (


### PR DESCRIPTION
## Summary

Found while running the **test-backend-pipeline** skill (Phase 10 — SQLite direct-library e2e). `test_publish_interaction_end_to_end` failed on a healthy pipeline due to a stale assertion.

The test asserted `final_profiles[0].custom_features.get("metadata") is not None`. The legacy `metadata` key was retired alongside the list-valued tagging extractor (documented in `tests/e2e_tests/conftest.py`). The current profile-extraction schema (`ProfileAddItem`) enriches `custom_features` with structured-evidence fields — `source_span`, `notes`, `reader_angle` — and never emits `metadata`. So the assertion checked a key the current schema no longer produces.

**This is a stale test, not an application regression.** The production extraction path is healthy: profiles are correctly enriched with the new structured fields (verified — extracted profile had `custom_features = {'notes', 'reader_angle', 'source_span'}`).

## Fix

Assert the profile carries non-empty `custom_features` (the extractor attached structured metadata) rather than pinning to the removed `metadata` key — schema-version-agnostic.

## Verification

`uv run pytest open_source/reflexio/tests/e2e_tests/test_interaction_workflows.py -o 'addopts=' -q` → **4 passed, 1 skipped** (was 1 failed). Full Phase 10 SQLite e2e suite green:
- complete_workflows: 4 passed
- profile_workflows: 7 passed
- playbook_workflows: 8 passed
- interaction_workflows: 4 passed (this fix)
- agent_success_workflows: 2 passed

Ruff lint + format clean.

## Base-branch note

The enterprise repo pins this submodule at commit `008115d`, which is **diverged** from `origin/main` (the #176 litellm-fallback fix landed upstream as a squash `543049f`, while enterprise pins the 3 pre-squash commits). To isolate just the test fix, this PR is opened against `base/enterprise-pinned-008115d` (= the pinned commit) instead of `main`. The submodule-pointer divergence is a pre-existing issue, out of scope for this fix.
