### PR TITLE
style: ruff-format openclaw_provider.py (check-and-test)

### DIFF
--- a/reflexio/server/llm/providers/openclaw_provider.py
+++ b/reflexio/server/llm/providers/openclaw_provider.py
@@ -149,7 +149,9 @@ def _call_cli(*, prompt: str, model: str | None, timeout_s: int) -> str:
         raise OpenClawCLIError(f"openclaw timed out after {timeout_s}s") from exc
 
     if proc.returncode != 0:
-        raise OpenClawCLIError(proc.stderr.strip() or f"openclaw exit {proc.returncode}")
+        raise OpenClawCLIError(
+            proc.stderr.strip() or f"openclaw exit {proc.returncode}"
+        )
 
     try:
         payload = json.loads(proc.stdout)
@@ -202,7 +204,9 @@ class OpenClawLLM(CustomLLM):
         raw_timeout = os.environ.get(ENV_TIMEOUT)
         try:
             timeout_s = (
-                int(raw_timeout) if raw_timeout is not None else _DEFAULT_TIMEOUT_SECONDS
+                int(raw_timeout)
+                if raw_timeout is not None
+                else _DEFAULT_TIMEOUT_SECONDS
             )
         except ValueError:
             _LOGGER.warning(
@@ -240,9 +244,7 @@ def _messages_to_prompt(messages: list[dict[str, Any]]) -> str:
         role = m.get("role", "user")
         content = m.get("content", "")
         if isinstance(content, list):
-            content = "".join(
-                c.get("text", "") for c in content if isinstance(c, dict)
-            )
+            content = "".join(c.get("text", "") for c in content if isinstance(c, dict))
         parts.append(f"{role}: {content}")
     return "\n\n".join(parts)
 


### PR DESCRIPTION
## Summary
Single formatter-only change surfaced by the `/check-and-test` run: `uv run ruff format` rewraps three expressions in `reflexio/server/llm/providers/openclaw_provider.py` that exceeded the configured line width. No behavior change.

## check-and-test findings (recorded here; not fixed in this PR)
The full lint + type-check + pytest pass was otherwise green. Remaining items are environmental, not application bugs:

1. **Ruff 566 "errors" in `reflexio/integrations/openclaw/plugin/`** — that vendored sub-package has its own `pyproject.toml` (a separate ruff config root), so the enterprise root `per-file-ignores` (S101/ANN for `tests/**`) don't apply to its test files. Project-scope code (`ruff check ... --exclude .../plugin`) is clean. Not touched here to avoid churning vendored test style.

2. **OS e2e: 1 content-assertion failure** — `tests/e2e_tests/test_interaction_workflows.py::test_publish_interaction_end_to_end` expects `custom_features["metadata"]`, but e2e bypasses the LLM mock and (this host has no provider key) was run via `CLAUDE_SMART_USE_LOCAL_CLI=1` against the real `claude` CLI, which returns the real extraction schema (`notes`/`reader_angle`/`source_span`) instead of the mock's `metadata`. Passes under the CI mock path. 40 passed / 1 failed / 47 skipped.

3. **Enterprise tenant-isolation: 3 failures only in the full integration run** — `test_tenant_isolation_integration.py::{test_tier1_http_cross_org_get_requests, test_tier2_sql_schema_isolation, test_tier4_token_cache_does_not_cross_bind}` fail when the whole integration suite runs against the shared local data DB, but the file passes 6/6 in isolation. This is the documented "integration tests assume a clean DB" cross-test state drift, not a tenant-isolation leak.

### Green tiers
- ruff (project scope), pyright (0 errors), biome (warnings only), tsc (website + docs): clean
- OS unit + integration: 3092 passed / 71 skipped
- Enterprise unit: 1798 passed / 10 skipped
- Enterprise integration (local data DB): 581 passed / 3 env-flaky (above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization for improved readability in the OpenClaw provider. No changes to functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->