### PR TITLE
fix(tests): relax profile custom_features assertion in publish e2e

### DIFF
--- a/tests/e2e_tests/test_interaction_workflows.py
+++ b/tests/e2e_tests/test_interaction_workflows.py
@@ -78,10 +78,10 @@ def test_publish_interaction_end_to_end(
     final_profiles = reflexio_instance.request_context.storage.get_all_profiles()
     assert len(final_profiles) > 0
     assert final_profiles[0].content.strip() != ""
-    assert (
-        final_profiles[0].custom_features is not None
-        and final_profiles[0].custom_features.get("metadata") is not None
-    )
+    # Extraction attaches structured custom features (e.g. notes / source_span /
+    # reader_angle). The exact key set is LLM-driven, so assert that features were
+    # populated rather than pinning a specific key that a prompt revision may rename.
+    assert final_profiles[0].custom_features
 
     # Verify profile change logs were created
     final_change_logs = (


### PR DESCRIPTION
## Summary
Profile extraction now attaches LLM-driven custom features (`notes` / `source_span` / `reader_angle`) and no longer a fixed `metadata` key. The publish e2e test (`test_publish_interaction_end_to_end`) still asserted `custom_features.get("metadata") is not None`, so it failed under real-LLM extraction.

Relaxed the assertion to verify `custom_features` is populated rather than pinning a specific key a prompt revision may rename.

## Test
`pytest open_source/reflexio/tests/e2e_tests/test_interaction_workflows.py::test_publish_interaction_end_to_end` — passes against real LLM (1 passed in 101s).

Found via the `test-backend-pipeline` skill run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation for generated profile custom features to ensure they are properly populated, with updated test assertions to reflect LLM-driven feature generation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->