### PR TITLE
fix(cli): surface server failure on `user-profiles delete` instead of faking success

### DIFF
--- a/reflexio/cli/commands/profiles.py
+++ b/reflexio/cli/commands/profiles.py
@@ -157,15 +157,22 @@ def delete(
     ],
     profile_id: Annotated[
         str,
-        typer.Option("--profile-id", help="Specific profile ID to delete"),
+        typer.Option(
+            "--profile-id",
+            help="Specific profile ID to delete (required; use 'delete-all' for bulk)",
+        ),
     ] = "",
 ) -> None:
-    """Delete a user profile.
+    """Delete a specific user profile.
+
+    A ``--profile-id`` is required: the server rejects an empty profile id
+    with "Profile id or search query is required". To remove every profile
+    for an org, use ``reflexio user-profiles delete-all`` instead.
 
     Args:
         ctx: Typer context with CliState in ctx.obj
         user_id: User ID owning the profile
-        profile_id: Specific profile ID to delete (empty string for all user profiles)
+        profile_id: Specific profile ID to delete
     """
     client = get_client(ctx)
     resp = client.delete_profile(
@@ -178,10 +185,8 @@ def delete(
     if json_mode:
         render(resp, json_mode=True)
     else:
-        label = (
-            f"profile {profile_id}" if profile_id else f"profiles for user {user_id}"
-        )
-        print_info(f"Deleted {label}")
+        raise_if_failed(resp, default="Failed to delete user profile")
+        print_info(f"Deleted profile {profile_id} for user {user_id}")
 
 
 @app.command(name="delete-all")

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -168,6 +168,38 @@ class TestProfilesAdd:
         assert result.exit_code != 0
 
 
+class TestProfilesDelete:
+    """Tests for 'user-profiles delete'."""
+
+    def test_delete_profile_success(self, runner, app, mock_client) -> None:
+        mock_client.delete_profile.return_value = MagicMock(success=True, message="")
+        result = runner.invoke(
+            app,
+            ["user-profiles", "delete", "--user-id", "alice", "--profile-id", "p1"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Deleted profile p1" in result.output
+
+    def test_delete_profile_failure_does_not_report_success(
+        self, runner, app, mock_client
+    ) -> None:
+        """A ``success=False`` envelope must surface as a CLI error, not a fake
+        'Deleted' confirmation.
+
+        Regression guard: the server rejects an empty ``profile_id`` with
+        "Profile id or search query is required", but the CLI previously
+        printed "Deleted profiles for user <id>" unconditionally, masking the
+        no-op.
+        """
+        mock_client.delete_profile.return_value = MagicMock(
+            success=False, message="Profile id or search query is required"
+        )
+        result = runner.invoke(app, ["user-profiles", "delete", "--user-id", "alice"])
+        assert result.exit_code != 0, result.output
+        assert "Deleted" not in result.output
+        assert "Profile id or search query is required" in result.output
+
+
 class TestProfilesRegenerate:
     """Tests for the renamed 'user-profiles regenerate' command."""
 
@@ -461,7 +493,7 @@ class TestPublishUserIdResolution:
             "interactions": [
                 {"role": "user", "content": "hi"},
                 {"role": "assistant", "content": "hello"},
-            ]
+            ],
         }
         if include_user_id:
             payload["user_id"] = extras.pop("payload_user_id", "payload-user")


### PR DESCRIPTION
## Summary

Found during a `/test-e2e-cli --quick` run (SQLite + self-hosted Supabase, MiniMax generation + local embedder). `reflexio user-profiles delete` unconditionally printed `Deleted profiles for user <id>` regardless of the server response.

When `--profile-id` is omitted, the server's `validate_delete_user_profile_request` rejects the call with `success=false, message="Profile id or search query is required"` and deletes nothing — but the CLI still reported success. The user sees "Deleted" while the profile count is unchanged. Reproduced identically on both SQLite and self-hosted Supabase.

The CLI's `add` / `update` mutation commands already guard against this with `raise_if_failed(resp, ...)`; `delete` was missing it.

## Issues Found and Fixed

| # | Phase | Issue | Severity | Root Cause | Fix |
|---|-------|-------|----------|------------|-----|
| 1 | 2f (Deletions, both modes) | `user-profiles delete` reports success on a server-side failure / no-op | P2 | CLI prints a fixed "Deleted ..." message and never inspects `resp.success`; help text wrongly claims empty `--profile-id` means "all" | Add `raise_if_failed(resp, ...)` in non-JSON mode; correct help/docstring; point to `delete-all` for bulk; add regression tests |

## Changes

- `reflexio/cli/commands/profiles.py` — `delete` now calls `raise_if_failed(resp, default="Failed to delete user profile")` before printing the confirmation, so a `success=False` envelope exits non-zero with the server message. Corrected the `--profile-id` help and docstring (empty is rejected, not "all").
- `tests/cli/test_commands.py` — `TestProfilesDelete`: success path prints the confirmation; failure path exits non-zero and never prints "Deleted".

## Test Results

`/test-e2e-cli --quick` — all phases PASS after the fix.

- **Phase 0** Prerequisites/install (reflexio-ai 0.2.26, Python 3.13.7) — PASS
- **Phase 1a** SQLite setup init + Schema Gate (doctor exit 0) — PASS
- **Phase 1b** Self-hosted Supabase setup init + Schema Gate (A: no migration warnings; B: 27 data rows = 27 files, auth benign orphan only; B': auth tables reachable; C: doctor exit 0) — PASS
- **Phase 2** Publish + extraction (real MiniMax + local/Nomic embeddings, non-zero profiles), interactions/profiles/search/regenerate, playbook-path schema probe (no drift), context, deletions — PASS on both SQLite and Supabase
- **Phase 2 (additional CLI)** doctor / config show / auth status / logout / login / status check — PASS
- **Restore** — PASS

## Test plan

- [x] Storage modes: Local SQLite (OSS server), Self-hosted Supabase (`DEPLOYMENT_MODE=self_host`)
- [x] LLM: MiniMax generation + local MiniLM/Nomic embedder (no OpenAI key on host)
- [x] Verified the bug pre-fix (false "Deleted", count unchanged) and post-fix (error surfaced, real delete-by-id works) on both backends
- [x] `ruff check` / `ruff format` / `pyright` clean on changed files
- [x] `pytest tests/cli/test_commands.py tests/cli/test_app.py` — 42 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `delete` command for user profiles to require a specific profile ID, clarifying that bulk deletion should use the `delete-all` command instead.
  * Improved error handling and messaging when profile deletion fails, now displaying direct feedback with clear success/failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->