### PR TITLE
Lineage Phase A — content-free provenance + forward-resolution (OSS/SQLite)

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -119,6 +119,9 @@ __all__ = [
     "AdminInvalidateCacheRequest",
     "AdminInvalidateCacheResponse",
     "PlaybookRetrievalLog",
+    "LineageEvent",
+    "LineageContext",
+    "RecordRef",
 ]
 
 # ===============================
@@ -227,6 +230,8 @@ class UserProfile(BaseModel):
     source_span: str | None = None
     notes: str | None = None
     reader_angle: str | None = None
+    merged_into: str | None = None
+    superseded_by: str | None = None
 
 
 # user playbook for agents
@@ -252,6 +257,8 @@ class UserPlaybook(BaseModel):
     source_span: str | None = None
     notes: str | None = None
     reader_angle: str | None = None
+    merged_into: int | None = None
+    superseded_by: int | None = None
 
 
 class ProfileChangeLog(BaseModel):
@@ -281,6 +288,8 @@ class AgentPlaybook(BaseModel):
     status: Status | None = (
         None  # used for tracking intermediate states during playbook aggregation. Status.ARCHIVED for playbooks during aggregation process, None for current playbooks
     )
+    merged_into: int | None = None
+    superseded_by: int | None = None
 
 
 class PlaybookOptimizationJob(BaseModel):
@@ -410,6 +419,56 @@ class PlaybookRetrievalLog(BaseModel):
     shown_playbook_ids: list[int] = []  # ids only (v1); scores deferred to v2 (M1)
     agent_version: str | None = None
     created_at: int = 0
+
+
+class LineageEvent(BaseModel):
+    """Append-only, content-free provenance record. NEVER carries content/PII.
+
+    Attributes:
+        event_id (int): PK assigned by storage (0 = not yet persisted).
+        org_id (str): Owning org (tenant) — required for RLS / isolation.
+        entity_type (str): One of "profile" | "user_playbook" | "agent_playbook".
+        entity_id (str): The affected record's id, stringified (profile_id is str).
+        op (str): create|revise|merge|aggregate|archive|soft_delete|hard_delete|purge|status_change.
+        prov_relation (str): W3C PROV relation (see spec §14).
+        source_ids (list[str]): Records merged/superseded into entity_id.
+        actor (str): Who/what triggered it (consolidator|reflection|offline_optimizer|...).
+        request_id (str): Triggering request — part of the idempotency key.
+        reason (str): Free-text rationale (no PII).
+        created_at (int): Unix epoch seconds (0 = unset; storage stamps it).
+    """
+
+    event_id: int = 0
+    org_id: str
+    entity_type: str
+    entity_id: str
+    op: str
+    prov_relation: str = ""
+    source_ids: list[str] = []
+    actor: str = ""
+    request_id: str = ""
+    reason: str = ""
+    created_at: int = 0
+
+
+class LineageContext(BaseModel):
+    """Caller-supplied intent the storage layer can't infer.
+
+    Required for merge/supersede/aggregate; optional for create/revise/archive.
+    """
+
+    op_kind: str
+    actor: str = ""
+    source_ids: list[str] = []
+    reason: str = ""
+    request_id: str | None = None
+
+
+class RecordRef(BaseModel):
+    """Result of resolve_current — the live survivor's id and whether its body was purged."""
+
+    id: str
+    is_purged: bool = False
 
 
 class ShareLink(BaseModel):

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -118,6 +118,7 @@ __all__ = [
     "ShareLink",
     "AdminInvalidateCacheRequest",
     "AdminInvalidateCacheResponse",
+    "PlaybookRetrievalLog",
 ]
 
 # ===============================
@@ -383,6 +384,32 @@ class AgentSuccessEvaluationResult(BaseModel):
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
     embedding: EmbeddingVector = []
+
+
+class PlaybookRetrievalLog(BaseModel):
+    """A log entry recording which playbooks were shown to a user during a request.
+
+    Used by the offline playbook tuner to correlate retrieval decisions with
+    downstream outcomes. ``retrieval_log_id`` is assigned by the storage layer;
+    ``shown_playbook_ids`` carries agent-playbook ids only (scores deferred to v2).
+
+    Attributes:
+        retrieval_log_id (int): Primary key assigned by storage (0 = not yet persisted).
+        request_id (str): The request during which playbooks were retrieved.
+        session_id (str): The session that owns the request.
+        user_id (str): The user the request belongs to.
+        shown_playbook_ids (list[int]): Ordered list of agent_playbook_id values shown.
+        agent_version (str | None): Agent version string at retrieval time, if available.
+        created_at (int): Unix epoch seconds at log creation time (0 = unset).
+    """
+
+    retrieval_log_id: int = 0
+    request_id: str
+    session_id: str
+    user_id: str
+    shown_playbook_ids: list[int] = []  # ids only (v1); scores deferred to v2 (M1)
+    agent_version: str | None = None
+    created_at: int = 0
 
 
 class ShareLink(BaseModel):

--- a/reflexio/models/api_schema/domain/enums.py
+++ b/reflexio/models/api_schema/domain/enums.py
@@ -42,6 +42,8 @@ class Status(str, Enum):  # noqa: UP042 - CURRENT=None is not compatible with St
     ARCHIVE_IN_PROGRESS = (
         "archive_in_progress"  # temporary status during downgrade operation
     )
+    MERGED = "merged"  # tombstone: consolidated into a survivor (merged_into set)
+    SUPERSEDED = "superseded"  # tombstone: replaced by a new version (superseded_by set)
 
 
 class OperationStatus(StrEnum):

--- a/reflexio/server/services/lineage/resolve.py
+++ b/reflexio/server/services/lineage/resolve.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from reflexio.models.api_schema.domain.entities import RecordRef
+
+_GETTER = {
+    "user_playbook": lambda s, i: s.get_user_playbook_by_id(int(i), include_tombstones=True),
+    "agent_playbook": lambda s, i: s.get_agent_playbook_by_id(int(i), include_tombstones=True),
+    "profile": lambda s, i: s.get_profile_by_id(str(i), include_tombstones=True),
+}
+_MAX_HOPS = 8  # Phase A: chains are 1-hop; cap guards malformed pointers
+
+
+def resolve_current(storage, entity_type: str, id) -> RecordRef | None:
+    """Follow merged_into/superseded_by pointers to the live survivor.
+
+    Args:
+        storage: Any storage backend exposing get_*_by_id with include_tombstones.
+        entity_type: One of "user_playbook", "agent_playbook", "profile".
+        id: The primary key of the record to resolve (int for playbooks, str for profiles).
+
+    Returns:
+        RecordRef pointing to the live survivor (is_purged=True if its body is blank),
+        or None if the record doesn't exist, there's a cycle, or the chain exceeds _MAX_HOPS.
+    """
+    get = _GETTER[entity_type]
+    visited: set[str] = set()
+    cur = get(storage, id)
+    if cur is None:
+        return None
+    while True:
+        cur_id = str(_pk(cur, entity_type))
+        if cur_id in visited or len(visited) >= _MAX_HOPS:
+            return None  # cycle or runaway chain
+        visited.add(cur_id)
+        nxt = cur.merged_into if cur.merged_into is not None else cur.superseded_by
+        if nxt is None:
+            return RecordRef(id=cur_id, is_purged=(not cur.content))
+        nxt_row = get(storage, nxt)
+        if nxt_row is None:
+            return RecordRef(id=cur_id, is_purged=(not cur.content))  # dangling pointer — stop here
+        cur = nxt_row
+
+
+def _pk(row, entity_type: str):
+    """Extract the primary key from a row based on its entity type.
+
+    Args:
+        row: The entity row object.
+        entity_type: One of "user_playbook", "agent_playbook", "profile".
+
+    Returns:
+        The primary key value.
+    """
+    return {
+        "user_playbook": row.user_playbook_id,
+        "agent_playbook": getattr(row, "agent_playbook_id", None),
+        "profile": getattr(row, "profile_id", None),
+    }[entity_type]

--- a/reflexio/server/services/lineage/resolve.py
+++ b/reflexio/server/services/lineage/resolve.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from reflexio.models.api_schema.domain.entities import RecordRef
+from reflexio.server.tracing import capture_anomaly
 
 EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
@@ -43,6 +44,16 @@ def resolve_current(storage: Any, entity_type: EntityType, id: Any) -> RecordRef
     while True:
         cur_id = str(_pk(cur, entity_type))
         if cur_id in visited or len(visited) >= _MAX_HOPS:
+            # A cycle or an over-long chain means a malformed pointer graph;
+            # we return None (callers treat as unresolvable) but surface it to
+            # Sentry so the otherwise-silent breakage is observable.
+            reason = "cycle" if cur_id in visited else "max_hops_exceeded"
+            capture_anomaly(
+                f"lineage.resolve_current.{reason}",
+                entity_type=entity_type,
+                entity_id=str(id),
+                hops=len(visited),
+            )
             return None  # cycle or runaway chain
         visited.add(cur_id)
         nxt = cur.merged_into if cur.merged_into is not None else cur.superseded_by

--- a/reflexio/server/services/lineage/resolve.py
+++ b/reflexio/server/services/lineage/resolve.py
@@ -19,13 +19,15 @@ _GETTER = {
 _MAX_HOPS = 8  # Phase A: chains are 1-hop; cap guards malformed pointers
 
 
-def resolve_current(storage: Any, entity_type: EntityType, id: Any) -> RecordRef | None:
+def resolve_current(
+    storage: Any, entity_type: EntityType, record_id: Any
+) -> RecordRef | None:
     """Follow merged_into/superseded_by pointers to the live survivor.
 
     Args:
         storage: Any storage backend exposing get_*_by_id with include_tombstones.
         entity_type: One of "user_playbook", "agent_playbook", "profile".
-        id: The primary key of the record to resolve (int for playbooks, str for profiles).
+        record_id: The primary key of the record to resolve (int for playbooks, str for profiles).
 
     Returns:
         RecordRef pointing to the live survivor (is_purged=True if its body is blank),
@@ -38,7 +40,7 @@ def resolve_current(storage: Any, entity_type: EntityType, id: Any) -> RecordRef
     if get is None:
         raise ValueError(f"unknown entity_type: {entity_type!r}")
     visited: set[str] = set()
-    cur = get(storage, id)
+    cur = get(storage, record_id)
     if cur is None:
         return None
     while True:
@@ -51,7 +53,7 @@ def resolve_current(storage: Any, entity_type: EntityType, id: Any) -> RecordRef
             capture_anomaly(
                 f"lineage.resolve_current.{reason}",
                 entity_type=entity_type,
-                entity_id=str(id),
+                entity_id=str(record_id),
                 hops=len(visited),
             )
             return None  # cycle or runaway chain

--- a/reflexio/server/services/lineage/resolve.py
+++ b/reflexio/server/services/lineage/resolve.py
@@ -1,16 +1,24 @@
 from __future__ import annotations
 
+from typing import Any, Literal
+
 from reflexio.models.api_schema.domain.entities import RecordRef
 
+EntityType = Literal["user_playbook", "agent_playbook", "profile"]
+
 _GETTER = {
-    "user_playbook": lambda s, i: s.get_user_playbook_by_id(int(i), include_tombstones=True),
-    "agent_playbook": lambda s, i: s.get_agent_playbook_by_id(int(i), include_tombstones=True),
+    "user_playbook": lambda s, i: s.get_user_playbook_by_id(
+        int(i), include_tombstones=True
+    ),
+    "agent_playbook": lambda s, i: s.get_agent_playbook_by_id(
+        int(i), include_tombstones=True
+    ),
     "profile": lambda s, i: s.get_profile_by_id(str(i), include_tombstones=True),
 }
 _MAX_HOPS = 8  # Phase A: chains are 1-hop; cap guards malformed pointers
 
 
-def resolve_current(storage, entity_type: str, id) -> RecordRef | None:
+def resolve_current(storage: Any, entity_type: EntityType, id: Any) -> RecordRef | None:
     """Follow merged_into/superseded_by pointers to the live survivor.
 
     Args:
@@ -21,8 +29,13 @@ def resolve_current(storage, entity_type: str, id) -> RecordRef | None:
     Returns:
         RecordRef pointing to the live survivor (is_purged=True if its body is blank),
         or None if the record doesn't exist, there's a cycle, or the chain exceeds _MAX_HOPS.
+
+    Raises:
+        ValueError: If ``entity_type`` is not a recognized entity type.
     """
-    get = _GETTER[entity_type]
+    get = _GETTER.get(entity_type)
+    if get is None:
+        raise ValueError(f"unknown entity_type: {entity_type!r}")
     visited: set[str] = set()
     cur = get(storage, id)
     if cur is None:
@@ -37,11 +50,13 @@ def resolve_current(storage, entity_type: str, id) -> RecordRef | None:
             return RecordRef(id=cur_id, is_purged=(not cur.content))
         nxt_row = get(storage, nxt)
         if nxt_row is None:
-            return RecordRef(id=cur_id, is_purged=(not cur.content))  # dangling pointer — stop here
+            return RecordRef(
+                id=cur_id, is_purged=(not cur.content)
+            )  # dangling pointer — stop here
         cur = nxt_row
 
 
-def _pk(row, entity_type: str):
+def _pk(row: Any, entity_type: EntityType) -> Any:
     """Extract the primary key from a row based on its entity type.
 
     Args:
@@ -50,9 +65,15 @@ def _pk(row, entity_type: str):
 
     Returns:
         The primary key value.
+
+    Raises:
+        ValueError: If ``entity_type`` is not a recognized entity type.
     """
-    return {
-        "user_playbook": row.user_playbook_id,
-        "agent_playbook": getattr(row, "agent_playbook_id", None),
-        "profile": getattr(row, "profile_id", None),
-    }[entity_type]
+    pk = {
+        "user_playbook": "user_playbook_id",
+        "agent_playbook": "agent_playbook_id",
+        "profile": "profile_id",
+    }.get(entity_type)
+    if pk is None:
+        raise ValueError(f"unknown entity_type: {entity_type!r}")
+    return getattr(row, pk)

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -514,7 +514,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         request_id: str,
         agent_version: str,
         user_id: str | None = None,
-    ) -> tuple[list[UserPlaybook], list[int]]:
+    ) -> tuple[list[UserPlaybook], list[int], list[tuple[int, list[int]]]]:
         """
         Consolidate user playbook entries across extractors and against existing entries in DB.
 
@@ -525,7 +525,18 @@ class PlaybookConsolidator(BaseDeduplicator):
             user_id: Optional user ID to scope the existing entry search
 
         Returns:
-            Tuple of (consolidated entries, list of existing entry IDs to delete after save)
+            Tuple of ``(consolidated entries, existing ids to delete after save,
+            merge_groups)``. ``merge_groups`` is a list of
+            ``(survivor_index, source_existing_ids)`` where ``survivor_index``
+            indexes into the returned entries list and identifies the row that
+            supersedes the given existing source ids (one entry per ``unify``
+            decision that archives at least one existing row). Callers persist
+            the entries first (assigning survivor ids), then route each merge
+            group through ``storage.merge_records`` so each source becomes a
+            MERGED tombstone pointing at its survivor. The "existing ids to
+            delete" set still includes ALL archived ids (merge sources +
+            non-merge archives such as ``differentiate``'s split source); the
+            caller subtracts the merge-covered ids to find pure-delete leftovers.
         """
         # Check if mock mode is enabled
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
@@ -534,7 +545,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             for result in results:
                 if isinstance(result, list):
                     all_playbooks.extend(result)
-            return all_playbooks, []
+            return all_playbooks, [], []
 
         # Flatten all new entries
         new_playbooks: list[UserPlaybook] = []
@@ -543,7 +554,7 @@ class PlaybookConsolidator(BaseDeduplicator):
                 new_playbooks.extend(result)
 
         if not new_playbooks:
-            return [], []
+            return [], [], []
 
         # Retrieve existing entries via hybrid search
         existing_playbooks = self._retrieve_existing_playbooks(
@@ -566,13 +577,13 @@ class PlaybookConsolidator(BaseDeduplicator):
                 error_type=type(e).__name__,
             ):
                 logger.exception("Failed to identify duplicates")
-            return new_playbooks, []
+            return new_playbooks, [], []
 
         if not dedup_output.decisions:
             logger.info(
                 "No consolidation decisions returned for request %s", request_id
             )
-            return new_playbooks, []
+            return new_playbooks, [], []
 
         logger.info(
             "Received %d consolidation decisions for request %s",
@@ -600,7 +611,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         dedup_output: PlaybookConsolidationOutput,
         request_id: str,
         agent_version: str,  # noqa: ARG002
-    ) -> tuple[list[UserPlaybook], list[int]]:
+    ) -> tuple[list[UserPlaybook], list[int], list[tuple[int, list[int]]]]:
         """
         Build the deduplicated entry list from LLM decisions.
 
@@ -617,7 +628,16 @@ class PlaybookConsolidator(BaseDeduplicator):
             agent_version: Agent version (currently unused, kept for symmetry).
 
         Returns:
-            Tuple of (entries ready to save, existing entry IDs to delete).
+            Tuple of ``(entries ready to save, existing entry IDs to delete,
+            merge_groups)``. ``merge_groups`` carries one
+            ``(survivor_index, source_existing_ids)`` per ``unify`` decision
+            that archives >= 1 existing row, where ``survivor_index`` indexes
+            into the returned entries list (the unified survivor row) and the
+            second element is the existing ids that decision supersedes. Only
+            ``unify`` produces merge groups — it collapses N existing rows into
+            one survivor. ``differentiate`` archives its split source but emits
+            two rows (no single survivor), so its archived id appears in the
+            delete set but NOT in any merge group.
         """
         candidates_by_id = {
             f"NEW-{idx}": playbook for idx, playbook in enumerate(new_playbooks)
@@ -637,10 +657,11 @@ class PlaybookConsolidator(BaseDeduplicator):
         seen_archive: set[int] = set()
         new_rows: list[UserPlaybook] = []
         handled_new_ids: set[str] = set()
+        merge_groups: list[tuple[int, list[int]]] = []
 
         for decision in dedup_output.decisions:
             try:
-                rows, marked_new_ids = self._apply_one(
+                rows, marked_new_ids, merge_source_ids = self._apply_one(
                     decision=decision,
                     candidates_by_id=candidates_by_id,
                     existing_by_id=existing_by_id,
@@ -670,6 +691,11 @@ class PlaybookConsolidator(BaseDeduplicator):
                         existing_id_str,
                     )
                 continue
+            # Record the merge group BEFORE extending: the unified survivor is
+            # the first (and only) row a ``unify`` decision emits, so its index
+            # in the final list is the current length of ``new_rows``.
+            if merge_source_ids:
+                merge_groups.append((len(new_rows), merge_source_ids))
             new_rows.extend(rows)
             handled_new_ids.update(marked_new_ids)
             self._bump_counter(result_counters, decision.kind)
@@ -697,7 +723,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             result_counters.failed_count,
         )
 
-        return new_rows, archive_ids
+        return new_rows, archive_ids, merge_groups
 
     def _apply_one(
         self,
@@ -709,7 +735,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         archive_ids: list[int],
         seen_archive: set[int],
         request_id: str,
-    ) -> tuple[list[UserPlaybook], list[str]]:
+    ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Dispatch a single decision to its kind-specific apply method.
 
         Args:
@@ -725,9 +751,14 @@ class PlaybookConsolidator(BaseDeduplicator):
             request_id: Request ID stamped onto newly-built rows.
 
         Returns:
-            Tuple of ``(rows_to_insert, handled_new_ids)`` where the second
-            element is the set of ``"NEW-N"`` candidate ids consumed by this
-            decision (used to suppress the safety fallback).
+            Tuple of ``(rows_to_insert, handled_new_ids, merge_source_ids)``.
+            ``handled_new_ids`` is the set of ``"NEW-N"`` candidate ids consumed
+            by this decision (used to suppress the safety fallback).
+            ``merge_source_ids`` is non-empty ONLY for a ``unify`` decision that
+            collapses >= 1 existing row into its single survivor (the first row
+            in ``rows_to_insert``); for all other kinds it is ``[]`` because they
+            either archive nothing or split into multiple rows with no single
+            survivor.
         """
         if isinstance(decision, UnifyDecision):
             return self._apply_unify(
@@ -767,7 +798,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         archive_ids: list[int],
         seen_archive: set[int],
         request_id: str,
-    ) -> tuple[list[UserPlaybook], list[str]]:
+    ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Collapse / compose NEW (+ 0..N EXISTING) into one row.
 
         Looks up each ``archive_existing_ids`` entry by position
@@ -789,7 +820,11 @@ class PlaybookConsolidator(BaseDeduplicator):
             request_id: Request ID stamped on the unified row.
 
         Returns:
-            Tuple of ([unified_row], [consumed NEW-N ids]).
+            Tuple of ``([unified_row], [consumed NEW-N ids], merge_source_ids)``
+            where ``merge_source_ids`` are the existing ids collapsed into the
+            unified survivor (the returned row). The survivor identity is not
+            known until the caller persists the row and reads its assigned id,
+            so the merge is materialized by the caller, not here.
 
         Raises:
             KeyError: If ``decision.new_id`` does not resolve to a known
@@ -810,11 +845,14 @@ class PlaybookConsolidator(BaseDeduplicator):
                 )
             existing_members.append(existing)
 
+        merge_source_ids: list[int] = []
         for existing in existing_members:
             pid = existing.user_playbook_id
             if pid and pid not in seen_archive:
                 seen_archive.add(pid)
                 archive_ids.append(pid)
+            if pid:
+                merge_source_ids.append(pid)
 
         budget = self._dedup_config.max_unified_content_chars
         content_len = len(decision.content)
@@ -845,7 +883,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             source=candidate.source,
             source_interaction_ids=combined_source_ids,
         )
-        return [unified_row], [decision.new_id]
+        return [unified_row], [decision.new_id], merge_source_ids
 
     def _apply_reject_new(
         self,
@@ -853,7 +891,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         *,
         existing_by_id: dict[int, UserPlaybook],
         existing_by_position: dict[str, UserPlaybook],
-    ) -> tuple[list[UserPlaybook], list[str]]:
+    ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """No-op apply: the existing row wins and the new candidate is dropped.
 
         Resolve the integer against the rendered ``EXISTING-N`` position first,
@@ -870,8 +908,10 @@ class PlaybookConsolidator(BaseDeduplicator):
             existing_by_position: Mapping ``"EXISTING-M"`` -> existing playbook.
 
         Returns:
-            Tuple of ([], [consumed NEW-N id]) when the existing id resolves,
-            or ``([], [])`` when the existing id is unknown.
+            Tuple of ``([], [consumed NEW-N id], [])`` when the existing id
+            resolves, or ``([], [], [])`` when the existing id is unknown.
+            Never produces a merge group — the existing row is kept as-is (no
+            archive, no survivor).
         """
         existing = self._resolve_existing_reference(
             decision.superseded_by_existing_id,
@@ -884,13 +924,13 @@ class PlaybookConsolidator(BaseDeduplicator):
                 decision.new_id,
                 decision.superseded_by_existing_id,
             )
-            return [], []
+            return [], [], []
         logger.info(
             "event=consolidation_reject_new new_id=%s existing_id=%d",
             decision.new_id,
             decision.superseded_by_existing_id,
         )
-        return [], [decision.new_id]
+        return [], [decision.new_id], []
 
     def _apply_differentiate(
         self,
@@ -902,7 +942,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         archive_ids: list[int],
         seen_archive: set[int],
         request_id: str,
-    ) -> tuple[list[UserPlaybook], list[str]]:
+    ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Archive the existing row and emit two refined rows in its place.
 
         Builds one ``UserPlaybook`` from the candidate's content/polarity with
@@ -920,7 +960,10 @@ class PlaybookConsolidator(BaseDeduplicator):
             request_id: Request ID stamped on both new rows.
 
         Returns:
-            Tuple of ([refined_new_row, refined_existing_row], [NEW-N id]).
+            Tuple of ``([refined_new_row, refined_existing_row], [NEW-N id],
+            [])``. ``differentiate`` is a SPLIT, not a merge: the existing row
+            is archived but maps to no single survivor, so it produces NO merge
+            group (its archived id is a pure-delete leftover for the caller).
         """
         candidate = candidates_by_id.get(decision.new_id)
         if candidate is None:
@@ -960,14 +1003,14 @@ class PlaybookConsolidator(BaseDeduplicator):
                 "source_interaction_ids": list(existing.source_interaction_ids),
             }
         )
-        return [refined_candidate, refined_existing], [decision.new_id]
+        return [refined_candidate, refined_existing], [decision.new_id], []
 
     def _apply_independent(
         self,
         decision: IndependentDecision,
         *,
         candidates_by_id: dict[str, UserPlaybook],
-    ) -> tuple[list[UserPlaybook], list[str]]:
+    ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Insert the new candidate unchanged; no archive.
 
         Args:
@@ -975,12 +1018,13 @@ class PlaybookConsolidator(BaseDeduplicator):
             candidates_by_id: Mapping ``"NEW-N"`` -> candidate playbook.
 
         Returns:
-            Tuple of ([candidate row], [consumed NEW-N id]).
+            Tuple of ``([candidate row], [consumed NEW-N id], [])`` — no archive,
+            so never a merge group.
         """
         candidate = candidates_by_id.get(decision.new_id)
         if candidate is None:
             raise KeyError(f"independent references unknown NEW id: {decision.new_id}")
-        return [candidate], [decision.new_id]
+        return [candidate], [decision.new_id], []
 
     @staticmethod
     def _merge_source_ids(playbooks: list[UserPlaybook]) -> list[int]:

--- a/reflexio/server/services/playbook/playbook_edit_apply.py
+++ b/reflexio/server/services/playbook/playbook_edit_apply.py
@@ -1,13 +1,12 @@
-"""Shared archive+insert primitive for applying a playbook edit.
+"""Shared atomic supersede primitive for applying a playbook edit.
 
 Extracted from ReflectionService._replace_playbook so the offline tuner and
-the online reflection path share one lifecycle (insert-then-archive, optimistic
-concurrency).
+the online reflection path share one lifecycle (insert-then-supersede, no orphan).
 """
 
 from typing import TYPE_CHECKING
 
-from reflexio.models.api_schema.domain.entities import UserPlaybook
+from reflexio.models.api_schema.domain.entities import LineageContext, UserPlaybook
 
 if TYPE_CHECKING:
     from reflexio.server.services.storage.storage_base import BaseStorage
@@ -21,44 +20,46 @@ def apply_playbook_edit(
     source: str,
     expect_current: bool = True,
 ) -> int:
-    """Insert a replacement playbook then archive the incumbent.
+    """Insert a replacement playbook then atomically supersede the incumbent.
+
+    Uses ``storage.supersede_record`` (atomic conditional CAS) so a lost race
+    never leaves an orphan CURRENT row:
+
+    - Insert the new playbook as CURRENT.
+    - Call ``supersede_record(incumbent_id → new_id)``, which only succeeds when
+      the incumbent is still CURRENT (``status IS NULL``).
+    - If ``supersede_record`` returns ``False`` (incumbent already gone), delete
+      the just-inserted successor and return ``-1``.
 
     Args:
         storage: A BaseStorage instance providing ``save_user_playbooks``,
-            ``get_user_playbook_by_id``, and ``archive_user_playbook_by_id``.
+            ``supersede_record``, and ``delete_user_playbooks_by_ids``.
         incumbent_id: ``user_playbook_id`` of the playbook being replaced.
         new_playbook: The replacement playbook (inserted as CURRENT, i.e.
             ``status=None``).
-        source: Provenance label stored on the new playbook row.
-        expect_current: When ``True`` (default), check that the incumbent is
-            still CURRENT before archiving; if it has already been archived by
-            a concurrent writer, skip the archive and return ``-1``.  Pass
-            ``False`` to always archive regardless (reflection's existing
-            behaviour).
+        source: Provenance label stored on the new playbook row and in the
+            lineage event actor field.
+        expect_current: Retained for caller compatibility; the atomic
+            ``supersede_record`` guard makes this always-correct regardless of
+            its value — the parameter is effectively ignored.
 
     Returns:
         The ``user_playbook_id`` of the newly inserted playbook, or ``-1`` if
-        ``expect_current`` is ``True`` and the incumbent was no longer CURRENT.
-
-    Note:
-        With ``expect_current=False`` the new playbook is inserted unconditionally
-        *before* archiving; if ``archive_user_playbook_by_id`` returns False
-        (incumbent missing or already archived), the inserted row remains CURRENT
-        (an orphan) and the function returns -1. Callers must pass a ``new_playbook``
-        with a non-None ``user_id`` (archive guards on ``user_id``).
+        the incumbent was not CURRENT (no mutation; no orphan left behind).
     """
     new_playbook.source = source
     storage.save_user_playbooks([new_playbook])
     new_id: int = new_playbook.user_playbook_id
 
-    if expect_current:
-        incumbent = storage.get_user_playbook_by_id(incumbent_id)
-        if incumbent is None or incumbent.status is not None:
-            return -1
-
-    user_id = new_playbook.user_id or ""
-    archived = storage.archive_user_playbook_by_id(
-        user_id=user_id,
-        user_playbook_id=incumbent_id,
+    ctx = LineageContext(op_kind="revise", actor=source, request_id=new_playbook.request_id)
+    superseded = storage.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(incumbent_id),
+        successor_id=str(new_id),
+        context=ctx,
     )
-    return new_id if archived else -1
+    if not superseded:
+        # lost the race: delete the just-inserted successor so no orphan CURRENT row remains
+        storage.delete_user_playbooks_by_ids([new_id])
+        return -1
+    return new_id

--- a/reflexio/server/services/playbook/playbook_edit_apply.py
+++ b/reflexio/server/services/playbook/playbook_edit_apply.py
@@ -1,0 +1,57 @@
+"""Shared archive+insert primitive for applying a playbook edit.
+
+Extracted from ReflectionService._replace_playbook so the offline tuner and
+the online reflection path share one lifecycle (insert-then-archive, optimistic
+concurrency).
+"""
+
+from typing import TYPE_CHECKING
+
+from reflexio.models.api_schema.domain.entities import UserPlaybook
+
+if TYPE_CHECKING:
+    from reflexio.server.services.storage.storage_base import BaseStorage
+
+
+def apply_playbook_edit(
+    storage: "BaseStorage",
+    *,
+    incumbent_id: int,
+    new_playbook: UserPlaybook,
+    source: str,
+    expect_current: bool = True,
+) -> int:
+    """Insert a replacement playbook then archive the incumbent.
+
+    Args:
+        storage: A BaseStorage instance providing ``save_user_playbooks``,
+            ``get_user_playbook_by_id``, and ``archive_user_playbook_by_id``.
+        incumbent_id: ``user_playbook_id`` of the playbook being replaced.
+        new_playbook: The replacement playbook (inserted as CURRENT, i.e.
+            ``status=None``).
+        source: Provenance label stored on the new playbook row.
+        expect_current: When ``True`` (default), check that the incumbent is
+            still CURRENT before archiving; if it has already been archived by
+            a concurrent writer, skip the archive and return ``-1``.  Pass
+            ``False`` to always archive regardless (reflection's existing
+            behaviour).
+
+    Returns:
+        The ``user_playbook_id`` of the newly inserted playbook, or ``-1`` if
+        ``expect_current`` is ``True`` and the incumbent was no longer CURRENT.
+    """
+    new_playbook.source = source
+    storage.save_user_playbooks([new_playbook])
+    new_id: int = new_playbook.user_playbook_id
+
+    if expect_current:
+        incumbent = storage.get_user_playbook_by_id(incumbent_id)
+        if incumbent is None or incumbent.status is not None:
+            return -1
+
+    user_id = new_playbook.user_id or ""
+    archived = storage.archive_user_playbook_by_id(
+        user_id=user_id,
+        user_playbook_id=incumbent_id,
+    )
+    return new_id if archived else -1

--- a/reflexio/server/services/playbook/playbook_edit_apply.py
+++ b/reflexio/server/services/playbook/playbook_edit_apply.py
@@ -18,7 +18,6 @@ def apply_playbook_edit(
     incumbent_id: int,
     new_playbook: UserPlaybook,
     source: str,
-    expect_current: bool = True,
 ) -> int:
     """Insert a replacement playbook then atomically supersede the incumbent.
 
@@ -39,9 +38,6 @@ def apply_playbook_edit(
             ``status=None``).
         source: Provenance label stored on the new playbook row and in the
             lineage event actor field.
-        expect_current: Retained for caller compatibility; the atomic
-            ``supersede_record`` guard makes this always-correct regardless of
-            its value — the parameter is effectively ignored.
 
     Returns:
         The ``user_playbook_id`` of the newly inserted playbook, or ``-1`` if
@@ -51,7 +47,9 @@ def apply_playbook_edit(
     storage.save_user_playbooks([new_playbook])
     new_id: int = new_playbook.user_playbook_id
 
-    ctx = LineageContext(op_kind="revise", actor=source, request_id=new_playbook.request_id)
+    ctx = LineageContext(
+        op_kind="revise", actor=source, request_id=new_playbook.request_id
+    )
     superseded = storage.supersede_record(
         entity_type="user_playbook",
         incumbent_id=str(incumbent_id),
@@ -59,7 +57,8 @@ def apply_playbook_edit(
         context=ctx,
     )
     if not superseded:
-        # lost the race: delete the just-inserted successor so no orphan CURRENT row remains
-        storage.delete_user_playbooks_by_ids([new_id])
+        # lost the race: delete the just-inserted successor so no orphan CURRENT row
+        # remains. It was never live, so this is a rollback — not an audited erasure.
+        storage.delete_user_playbooks_by_ids([new_id], emit_hard_delete=False)
         return -1
     return new_id

--- a/reflexio/server/services/playbook/playbook_edit_apply.py
+++ b/reflexio/server/services/playbook/playbook_edit_apply.py
@@ -39,6 +39,13 @@ def apply_playbook_edit(
     Returns:
         The ``user_playbook_id`` of the newly inserted playbook, or ``-1`` if
         ``expect_current`` is ``True`` and the incumbent was no longer CURRENT.
+
+    Note:
+        With ``expect_current=False`` the new playbook is inserted unconditionally
+        *before* archiving; if ``archive_user_playbook_by_id`` returns False
+        (incumbent missing or already archived), the inserted row remains CURRENT
+        (an orphan) and the function returns -1. Callers must pass a ``new_playbook``
+        with a non-None ``user_id`` (archive guards on ``user_id``).
     """
     new_playbook.source = source
     storage.save_user_playbooks([new_playbook])

--- a/reflexio/server/services/playbook/playbook_generation_service.py
+++ b/reflexio/server/services/playbook/playbook_generation_service.py
@@ -268,6 +268,7 @@ class PlaybookGenerationService(
 
         # Deduplicate against existing entries in DB when deduplicator is enabled
         existing_ids_to_delete: list[int] = []
+        merge_groups: list[tuple[int, list[int]]] = []
         from reflexio.server.site_var.feature_flags import is_deduplicator_enabled
 
         if is_deduplicator_enabled(self.org_id):
@@ -285,7 +286,11 @@ class PlaybookGenerationService(
                 llm_client=self.client,
                 dedup_config=dedup_config,
             )
-            deduplicated_playbooks, existing_ids_to_delete = consolidator.deduplicate(
+            (
+                deduplicated_playbooks,
+                existing_ids_to_delete,
+                merge_groups,
+            ) = consolidator.deduplicate(
                 [all_playbooks],
                 self.service_config.request_id,  # type: ignore[reportOptionalMemberAccess]
                 self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
@@ -317,21 +322,9 @@ class PlaybookGenerationService(
             try:
                 self.storage.save_user_playbooks(all_playbooks)  # type: ignore[reportOptionalMemberAccess]
                 self._enqueue_user_playbook_optimization(all_playbooks)
-
-                # Delete superseded existing entries only after save succeeds
-                if existing_ids_to_delete:
-                    try:
-                        deleted_count = self.storage.delete_user_playbooks_by_ids(  # type: ignore[reportOptionalMemberAccess]
-                            existing_ids_to_delete
-                        )
-                        logger.info(
-                            "Deleted %d superseded existing entries", deleted_count
-                        )
-                    except Exception as e:
-                        logger.error(
-                            "Failed to delete superseded existing entries: %s",
-                            str(e),
-                        )
+                self._apply_consolidation_lineage(
+                    all_playbooks, merge_groups, existing_ids_to_delete
+                )
             except Exception as e:
                 logger.error(
                     "Failed to save %s results for request id: %s due to %s, exception type: %s",
@@ -345,6 +338,62 @@ class PlaybookGenerationService(
             if not self.output_pending_status and not self.skip_aggregation:
                 logger.info("Trigger playbook aggregation")
                 self._trigger_playbook_aggregation()
+
+    def _apply_consolidation_lineage(
+        self,
+        saved_playbooks: list[UserPlaybook],
+        merge_groups: list[tuple[int, list[int]]],
+        existing_ids_to_delete: list[int],
+    ) -> None:
+        """Materialize consolidation merges as lineage tombstones; hard-delete leftovers.
+
+        Runs AFTER ``save_user_playbooks`` has assigned survivor ids. For each
+        ``unify`` merge group, routes the sources atomically through
+        ``storage.merge_records`` so each becomes a MERGED tombstone pointing at
+        its survivor with a ``merge`` lineage event (``resolve_current`` then
+        follows the pointer). Any archived id NOT covered by a merge group
+        (e.g. a ``differentiate`` split source, which has no single survivor) is
+        a pure delete and is hard-removed via ``delete_user_playbooks_by_ids`` —
+        the legacy behaviour, preserved for correctness until Task 11 makes that
+        path emit a ``hard_delete`` event.
+
+        Args:
+            saved_playbooks: The just-persisted entries (survivor ids assigned).
+            merge_groups: ``(survivor_index, source_existing_ids)`` per merge.
+            existing_ids_to_delete: ALL archived ids (merge sources + leftovers).
+        """
+        from reflexio.models.api_schema.domain.entities import LineageContext
+
+        merged_source_ids: set[int] = set()
+        for survivor_idx, source_ids in merge_groups:
+            survivor_id = saved_playbooks[survivor_idx].user_playbook_id
+            merged_source_ids.update(source_ids)
+            self.storage.merge_records(  # type: ignore[reportOptionalMemberAccess]
+                entity_type="user_playbook",
+                survivor_id=str(survivor_id),
+                source_ids=[str(s) for s in source_ids],
+                context=LineageContext(
+                    op_kind="merge",
+                    actor="consolidator",
+                    source_ids=[str(s) for s in source_ids],
+                    reason="dedup-merge",
+                    request_id=self.service_config.request_id,  # type: ignore[reportOptionalMemberAccess]
+                ),
+            )
+
+        # Leftover archives not covered by any merge group (e.g. differentiate
+        # split sources) are pure deletes — hard-remove them.
+        leftover_ids = [
+            pid for pid in existing_ids_to_delete if pid not in merged_source_ids
+        ]
+        if leftover_ids:
+            try:
+                deleted_count = self.storage.delete_user_playbooks_by_ids(  # type: ignore[reportOptionalMemberAccess]
+                    leftover_ids
+                )
+                logger.info("Deleted %d superseded existing entries", deleted_count)
+            except Exception as e:
+                logger.error("Failed to delete superseded existing entries: %s", str(e))
 
     def _enqueue_user_playbook_optimization(
         self, saved_playbooks: list[UserPlaybook]

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -16,6 +16,7 @@ from reflexio.models.api_schema.domain import (
     PlaybookStatus,
     UserPlaybook,
 )
+from reflexio.models.api_schema.domain.entities import LineageContext
 from reflexio.models.config_schema import PlaybookOptimizerConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
@@ -441,49 +442,34 @@ class PlaybookOptimizer:
                 or current.playbook_status != PlaybookStatus.PENDING
             ):
                 return None
-            self.storage.archive_agent_playbooks_by_ids([target.target_id])
-            successor = incumbent.model_copy(
-                update={
-                    "agent_playbook_id": 0,
-                    "content": best_content,
-                    "status": None,
-                    "playbook_status": PlaybookStatus.PENDING,
-                    "playbook_metadata": _append_optimizer_metadata(
-                        incumbent.playbook_metadata, target.target_id
-                    ),
-                }
+            metadata = _append_optimizer_metadata(
+                incumbent.playbook_metadata, target.target_id
             )
-            saved = self.storage.save_agent_playbooks([successor])
-            if saved and saved[0].agent_playbook_id:
+            successor_id = _supersede_agent_playbook(
+                self.storage,
+                incumbent,
+                best_content,
+                "playbook_optimizer",
+                playbook_metadata=metadata,
+            )
+            if successor_id is not None:
                 self.storage.set_source_windows_for_agent_playbook(
-                    saved[0].agent_playbook_id, source_windows
+                    successor_id, source_windows
                 )
-                return saved[0].agent_playbook_id
-            return None
+            return successor_id
         current_user = self.storage.get_user_playbook_by_id(target.target_id)
         if current_user is None or current_user.status is not None:
             return None
         if current_user.user_id is None:
-            return None
-        archived = self.storage.archive_user_playbook_by_id(
-            current_user.user_id, current_user.user_playbook_id
-        )
-        if not archived:
             return None
         # The optimizer can legitimately flip framing (positive guidance ->
         # negative anti-pattern or vice versa). Orientation lives entirely in
         # the rule wording, so writing ``best_content`` is sufficient — there
         # is no derived polarity label or separate polarity field to keep in
         # sync.
-        successor_user = current_user.model_copy(
-            update={
-                "user_playbook_id": 0,
-                "content": best_content,
-                "status": None,
-            }
+        return _supersede_user_playbook(
+            self.storage, current_user, best_content, "playbook_optimizer"
         )
-        self.storage.save_user_playbooks([successor_user])
-        return successor_user.user_playbook_id or None
 
 
 def _agent_like_playbook(playbook: UserPlaybook) -> AgentPlaybook:
@@ -513,6 +499,103 @@ def _append_optimizer_metadata(existing: str, predecessor_id: int) -> str:
     if not existing:
         return suffix
     return f"{existing}; {suffix}"
+
+
+def _supersede_user_playbook(
+    storage: Any,
+    incumbent: UserPlaybook,
+    best_content: str,
+    source: str,
+) -> int | None:
+    """Insert a user-playbook successor then atomically supersede the incumbent.
+
+    Returns the new ``user_playbook_id`` on success, or ``None`` when the
+    incumbent is no longer CURRENT (lost race / already superseded).
+
+    Args:
+        storage: A storage instance implementing ``save_user_playbooks``,
+            ``supersede_record``, and ``delete_user_playbooks_by_ids``.
+        incumbent: The current user playbook to replace.
+        best_content: Content for the successor playbook.
+        source: Provenance label written to the lineage event actor field.
+
+    Returns:
+        int | None: ``user_playbook_id`` of the successor, or ``None`` if the
+            incumbent was not CURRENT.
+    """
+    successor = incumbent.model_copy(
+        update={"user_playbook_id": 0, "content": best_content, "status": None}
+    )
+    storage.save_user_playbooks([successor])
+    ctx = LineageContext(
+        op_kind="revise",
+        actor=source,
+        request_id=incumbent.request_id,
+    )
+    ok = storage.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(incumbent.user_playbook_id),
+        successor_id=str(successor.user_playbook_id),
+        context=ctx,
+    )
+    if not ok:
+        storage.delete_user_playbooks_by_ids([successor.user_playbook_id])
+        return None
+    return successor.user_playbook_id
+
+
+def _supersede_agent_playbook(
+    storage: Any,
+    incumbent: AgentPlaybook,
+    best_content: str,
+    source: str,
+    playbook_metadata: str = "",
+) -> int | None:
+    """Insert an agent-playbook successor then atomically supersede the incumbent.
+
+    Returns the new ``agent_playbook_id`` on success, or ``None`` when the
+    incumbent is no longer CURRENT.
+
+    Args:
+        storage: A storage instance implementing ``save_agent_playbooks``,
+            ``supersede_record``, and ``delete_agent_playbooks_by_ids``.
+        incumbent: The current agent playbook to replace.
+        best_content: Content for the successor playbook.
+        source: Provenance label written to the lineage event actor field.
+        playbook_metadata: Optional metadata string for the successor row.
+
+    Returns:
+        int | None: ``agent_playbook_id`` of the successor, or ``None`` if the
+            incumbent was not CURRENT.
+    """
+    successor = incumbent.model_copy(
+        update={
+            "agent_playbook_id": 0,
+            "content": best_content,
+            "status": None,
+            "playbook_status": PlaybookStatus.PENDING,
+            "playbook_metadata": playbook_metadata,
+        }
+    )
+    saved = storage.save_agent_playbooks([successor])
+    if not saved or not saved[0].agent_playbook_id:
+        return None
+    successor_id = saved[0].agent_playbook_id
+    ctx = LineageContext(
+        op_kind="revise",
+        actor=source,
+        request_id=None,
+    )
+    ok = storage.supersede_record(
+        entity_type="agent_playbook",
+        incumbent_id=str(incumbent.agent_playbook_id),
+        successor_id=str(successor_id),
+        context=ctx,
+    )
+    if not ok:
+        storage.delete_agent_playbooks_by_ids([successor_id])
+        return None
+    return successor_id
 
 
 class _GEPAStorageCallback:

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -539,7 +539,10 @@ def _supersede_user_playbook(
         context=ctx,
     )
     if not ok:
-        storage.delete_user_playbooks_by_ids([successor.user_playbook_id])
+        # Lost CAS: remove the never-live successor without auditing it as erasure.
+        storage.delete_user_playbooks_by_ids(
+            [successor.user_playbook_id], emit_hard_delete=False
+        )
         return None
     return successor.user_playbook_id
 
@@ -593,7 +596,8 @@ def _supersede_agent_playbook(
         context=ctx,
     )
     if not ok:
-        storage.delete_agent_playbooks_by_ids([successor_id])
+        # Lost CAS: remove the never-live successor without auditing it as erasure.
+        storage.delete_agent_playbooks_by_ids([successor_id], emit_hard_delete=False)
         return None
     return successor_id
 

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -586,7 +586,6 @@ class ReflectionService:
                 incumbent_id=cited.user_playbook_id,
                 new_playbook=new_playbook,
                 source=new_playbook.source or "reflection",
-                expect_current=False,
             )
         except Exception as exc:  # noqa: BLE001
             with sentry_tags(

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -39,6 +39,7 @@ from reflexio.models.api_schema.domain.entities import (
 )
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.operation_state_utils import OperationStateManager
+from reflexio.server.services.playbook.playbook_edit_apply import apply_playbook_edit
 from reflexio.server.services.reflection.reflection_extractor import (
     ReflectionExtractor,
 )
@@ -579,11 +580,13 @@ class ReflectionService:
                 (cited.content or "")[:120].replace('"', "'"),
                 (decision.new_rationale or "")[:120].replace('"', "'"),
             )
-        storage.save_user_playbooks([new_playbook])
         try:
-            archived = storage.archive_user_playbook_by_id(
-                user_id=owning_user_id,
-                user_playbook_id=cited.user_playbook_id,
+            archived = apply_playbook_edit(
+                storage,
+                incumbent_id=cited.user_playbook_id,
+                new_playbook=new_playbook,
+                source=new_playbook.source or "reflection",
+                expect_current=False,
             )
         except Exception as exc:  # noqa: BLE001
             with sentry_tags(
@@ -603,7 +606,7 @@ class ReflectionService:
                     new_playbook.user_playbook_id,
                 )
             return True
-        if not archived:
+        if archived < 0:
             with sentry_tags(
                 subsystem="reflection",
                 op="archive_after_insert_noop",

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -8,6 +8,7 @@ from ._base import (
     _vector_rank_rows,
 )
 from ._extras import ExtrasMixin
+from ._lineage import SQLiteLineageMixin
 from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
@@ -31,6 +32,7 @@ class SQLiteStorage(
     ProfileMixin,
     RequestMixin,
     PlaybookMixin,
+    SQLiteLineageMixin,
     OperationMixin,
     ExtrasMixin,
     SQLiteShareLinkMixin,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -698,6 +698,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
         self._migrate_lineage()
+        self._migrate_lineage_event_table()
         init_stall_state_table(self.conn)
         return True
 
@@ -1240,6 +1241,29 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     )
                     logger.info("Added %s column to %s", col, table)
         self.conn.commit()
+
+    def _migrate_lineage_event_table(self) -> None:
+        """Create the lineage_event table + index for existing databases (idempotent)."""
+        with self._lock:
+            self.conn.executescript("""
+                CREATE TABLE IF NOT EXISTS lineage_event (
+                    event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+                    org_id        TEXT NOT NULL,
+                    entity_type   TEXT NOT NULL,
+                    entity_id     TEXT NOT NULL,
+                    op            TEXT NOT NULL,
+                    prov_relation TEXT NOT NULL DEFAULT '',
+                    source_ids    TEXT NOT NULL DEFAULT '[]',
+                    actor         TEXT NOT NULL DEFAULT '',
+                    request_id    TEXT NOT NULL DEFAULT '',
+                    reason        TEXT NOT NULL DEFAULT '',
+                    created_at    INTEGER NOT NULL,
+                    UNIQUE (entity_id, op, request_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_lineage_entity
+                    ON lineage_event (entity_type, entity_id);
+            """)
+            self.conn.commit()
 
     def _migrate_agent_playbook_source_windows(self) -> None:
         """Add source window snapshots to existing agent source mappings."""
@@ -2096,5 +2120,25 @@ CREATE INDEX IF NOT EXISTS idx_shadow_verdicts_prompt_v
     ON shadow_comparison_verdicts (judge_prompt_version);
 CREATE INDEX IF NOT EXISTS idx_shadow_verdicts_prompt_created_at_desc
     ON shadow_comparison_verdicts (judge_prompt_version, created_at DESC);
+
+-- ============================================================================
+-- Append-only, content-free lineage event log
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS lineage_event (
+    event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    org_id        TEXT NOT NULL,
+    entity_type   TEXT NOT NULL,
+    entity_id     TEXT NOT NULL,
+    op            TEXT NOT NULL,
+    prov_relation TEXT NOT NULL DEFAULT '',
+    source_ids    TEXT NOT NULL DEFAULT '[]',
+    actor         TEXT NOT NULL DEFAULT '',
+    request_id    TEXT NOT NULL DEFAULT '',
+    reason        TEXT NOT NULL DEFAULT '',
+    created_at    INTEGER NOT NULL,
+    UNIQUE (entity_id, op, request_id)
+);
+CREATE INDEX IF NOT EXISTS idx_lineage_entity ON lineage_event (entity_type, entity_id);
 
 """

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -285,6 +285,13 @@ def _true_rrf_merge(
     return [row for row, _ in scored[:match_count]]
 
 
+# Tombstone statuses: rows with these values are excluded from default reads.
+# Tasks 5/9/10 create tombstones; this constant ensures they stay hidden unless
+# explicitly requested via include_tombstones=True on by-id getters, or an
+# explicit status_filter on list/count methods.
+_TOMBSTONE_STATUS_VALUES = (Status.MERGED.value, Status.SUPERSEDED.value)
+
+
 def _status_value(status: Status | None) -> str | None:
     """Convert a Status enum (or None) to its DB string value."""
     if status is None:

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1258,7 +1258,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     request_id    TEXT NOT NULL DEFAULT '',
                     reason        TEXT NOT NULL DEFAULT '',
                     created_at    INTEGER NOT NULL,
-                    UNIQUE (org_id, entity_id, op, request_id)
+                    UNIQUE (org_id, entity_type, entity_id, op, request_id)
                 );
                 CREATE INDEX IF NOT EXISTS idx_lineage_entity
                     ON lineage_event (entity_type, entity_id);
@@ -2137,7 +2137,7 @@ CREATE TABLE IF NOT EXISTS lineage_event (
     request_id    TEXT NOT NULL DEFAULT '',
     reason        TEXT NOT NULL DEFAULT '',
     created_at    INTEGER NOT NULL,
-    UNIQUE (org_id, entity_id, op, request_id)
+    UNIQUE (org_id, entity_type, entity_id, op, request_id)
 );
 CREATE INDEX IF NOT EXISTS idx_lineage_entity ON lineage_event (entity_type, entity_id);
 

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1258,7 +1258,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     request_id    TEXT NOT NULL DEFAULT '',
                     reason        TEXT NOT NULL DEFAULT '',
                     created_at    INTEGER NOT NULL,
-                    UNIQUE (entity_id, op, request_id)
+                    UNIQUE (org_id, entity_id, op, request_id)
                 );
                 CREATE INDEX IF NOT EXISTS idx_lineage_entity
                     ON lineage_event (entity_type, entity_id);
@@ -2137,7 +2137,7 @@ CREATE TABLE IF NOT EXISTS lineage_event (
     request_id    TEXT NOT NULL DEFAULT '',
     reason        TEXT NOT NULL DEFAULT '',
     created_at    INTEGER NOT NULL,
-    UNIQUE (entity_id, op, request_id)
+    UNIQUE (org_id, entity_id, op, request_id)
 );
 CREATE INDEX IF NOT EXISTS idx_lineage_entity ON lineage_event (entity_type, entity_id);
 

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -395,6 +395,8 @@ def _row_to_profile(row: sqlite3.Row) -> UserProfile:
         notes=d.get("notes"),
         reader_angle=d.get("reader_angle"),
         tags=_json_loads(d.get("tags")),
+        merged_into=d.get("merged_into"),
+        superseded_by=d.get("superseded_by"),
     )
 
 
@@ -473,6 +475,8 @@ def _row_to_user_playbook(
         source_span=d.get("source_span"),
         notes=d.get("notes"),
         reader_angle=d.get("reader_angle"),
+        merged_into=d.get("merged_into"),
+        superseded_by=d.get("superseded_by"),
     )
 
 
@@ -497,6 +501,8 @@ def _row_to_agent_playbook(row: sqlite3.Row) -> AgentPlaybook:
         embedding=[],
         status=Status(d["status"]) if d.get("status") else None,
         expanded_terms=d.get("expanded_terms"),
+        merged_into=d.get("merged_into"),
+        superseded_by=d.get("superseded_by"),
     )
 
 
@@ -684,6 +690,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_request_session_id_required()
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
+        self._migrate_lineage()
         init_stall_state_table(self.conn)
         return True
 
@@ -1206,6 +1213,27 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             logger.info("Dropped legacy polarity column from user_playbooks")
         self.conn.commit()
 
+    def _migrate_lineage(self) -> None:
+        """Add merged_into/superseded_by forward-pointer columns if missing.
+
+        Backfill-safe: columns are nullable with no default. INTEGER for playbook
+        tables (int foreign-key pointers), TEXT for profiles (str profile_id pointers).
+        """
+        int_tables = {"user_playbooks": "INTEGER", "agent_playbooks": "INTEGER"}
+        str_tables = {"profiles": "TEXT"}
+        for table, coltype in {**int_tables, **str_tables}.items():
+            cols = {
+                row["name"]
+                for row in self.conn.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            for col in ("merged_into", "superseded_by"):
+                if col not in cols:
+                    self.conn.execute(
+                        f"ALTER TABLE {table} ADD COLUMN {col} {coltype}"  # noqa: S608
+                    )
+                    logger.info("Added %s column to %s", col, table)
+        self.conn.commit()
+
     def _migrate_agent_playbook_source_windows(self) -> None:
         """Add source window snapshots to existing agent source mappings."""
         cols = {
@@ -1688,6 +1716,8 @@ CREATE TABLE IF NOT EXISTS profiles (
     source_span TEXT,
     notes TEXT,
     reader_angle TEXT,
+    merged_into TEXT,
+    superseded_by TEXT,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
 CREATE INDEX IF NOT EXISTS idx_profiles_user_id ON profiles(user_id);
@@ -1747,7 +1777,9 @@ CREATE TABLE IF NOT EXISTS user_playbooks (
     tags TEXT,
     source_span TEXT,
     notes TEXT,
-    reader_angle TEXT
+    reader_angle TEXT,
+    merged_into INTEGER,
+    superseded_by INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_user_playbooks_playbook_name ON user_playbooks(playbook_name);
 CREATE INDEX IF NOT EXISTS idx_user_playbooks_agent_version ON user_playbooks(agent_version);
@@ -1768,7 +1800,9 @@ CREATE TABLE IF NOT EXISTS agent_playbooks (
     embedding TEXT,
     expanded_terms TEXT,
     tags TEXT,
-    status TEXT
+    status TEXT,
+    merged_into INTEGER,
+    superseded_by INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_agent_playbooks_playbook_name ON agent_playbooks(playbook_name);
 CREATE INDEX IF NOT EXISTS idx_agent_playbooks_agent_version ON agent_playbooks(agent_version);

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -1,0 +1,109 @@
+import json
+import sqlite3
+import threading
+import time
+from typing import Any
+
+from reflexio.models.api_schema.domain.entities import LineageEvent
+
+
+class SQLiteLineageMixin:
+    """SQLite implementation of the append-only, content-free lineage event log."""
+
+    # Type hints for instance attributes provided by SQLiteStorageBase via MRO.
+    conn: sqlite3.Connection
+    _lock: threading.RLock
+
+    def append_lineage_event(self, event: LineageEvent) -> int:
+        """Append an event; idempotent on (entity_id, op, request_id). Return the row id.
+
+        Args:
+            event (LineageEvent): The fully-formed event to persist. ``event_id``
+                may be 0; the storage layer assigns a real id on insert. On a
+                duplicate ``(entity_id, op, request_id)`` the existing row is
+                returned unchanged.
+
+        Returns:
+            int: The assigned or existing ``event_id``.
+        """
+        created = event.created_at or int(time.time())
+        with self._lock:
+            cur = self.conn.execute(
+                "INSERT OR IGNORE INTO lineage_event "
+                "(org_id, entity_type, entity_id, op, prov_relation, source_ids, "
+                "actor, request_id, reason, created_at) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?)",
+                (
+                    event.org_id,
+                    event.entity_type,
+                    event.entity_id,
+                    event.op,
+                    event.prov_relation,
+                    json.dumps(event.source_ids),
+                    event.actor,
+                    event.request_id,
+                    event.reason,
+                    created,
+                ),
+            )
+            if cur.rowcount == 0:  # duplicate (entity_id, op, request_id)
+                row = self.conn.execute(
+                    "SELECT event_id FROM lineage_event "
+                    "WHERE entity_id=? AND op=? AND request_id=?",
+                    (event.entity_id, event.op, event.request_id),
+                ).fetchone()
+                eid = row[0] if row else None
+                self.conn.commit()
+                return int(eid) if eid is not None else 0
+            last = cur.lastrowid
+            self.conn.commit()
+            return int(last) if last is not None else 0
+
+    def get_lineage_events(
+        self,
+        *,
+        entity_type: str | None = None,
+        entity_id: str | None = None,
+        org_id: str | None = None,
+    ) -> list[LineageEvent]:
+        """Retrieve lineage events, optionally filtered.
+
+        Args:
+            entity_type (str | None): Filter to events for this entity type.
+            entity_id (str | None): Filter to events for this entity id.
+            org_id (str | None): Filter to events for this org.
+
+        Returns:
+            list[LineageEvent]: Matching events ordered by ``event_id`` ascending.
+        """
+        clauses: list[str] = []
+        params: list[Any] = []
+        for col, val in (
+            ("entity_type", entity_type),
+            ("entity_id", entity_id),
+            ("org_id", org_id),
+        ):
+            if val is not None:
+                clauses.append(f"{col}=?")
+                params.append(val)
+        where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+        rows = self.conn.execute(
+            f"SELECT * FROM lineage_event{where} ORDER BY event_id",  # noqa: S608
+            params,
+        ).fetchall()
+        return [
+            LineageEvent(
+                event_id=r["event_id"],
+                org_id=r["org_id"],
+                entity_type=r["entity_type"],
+                entity_id=r["entity_id"],
+                op=r["op"],
+                prov_relation=r["prov_relation"],
+                source_ids=json.loads(r["source_ids"]),
+                actor=r["actor"],
+                request_id=r["request_id"],
+                reason=r["reason"],
+                created_at=r["created_at"],
+            )
+            for r in rows
+        ]

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -2,10 +2,12 @@ import json
 import sqlite3
 import threading
 import time
-from typing import Any
+from typing import Any, Literal
 
 from reflexio.models.api_schema.domain.entities import LineageContext, LineageEvent
 from reflexio.models.api_schema.domain.enums import Status
+
+EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
 # Tombstone statuses — rows with these statuses are skipped by merge_records guard.
 _TOMBSTONE = (Status.MERGED.value, Status.SUPERSEDED.value)
@@ -16,6 +18,14 @@ _TABLE: dict[str, tuple[str, str]] = {
     "agent_playbook": ("agent_playbooks", "agent_playbook_id"),
     "profile": ("profiles", "profile_id"),
 }
+
+
+def _resolve_table(entity_type: str) -> tuple[str, str]:
+    """Map an entity_type to its (table, primary_key), raising on bad input."""
+    table = _TABLE.get(entity_type)
+    if table is None:
+        raise ValueError(f"unknown entity_type: {entity_type!r}")
+    return table
 
 
 def _append_event_stmt(
@@ -30,9 +40,13 @@ def _append_event_stmt(
     actor: str,
     request_id: str,
     reason: str,
-) -> None:
-    """Insert a lineage event row; silently no-ops on (entity_id, op, request_id) duplicate."""
-    conn.execute(
+    created_at: int | None = None,
+) -> sqlite3.Cursor:
+    """Insert a lineage event row; no-ops on (org_id, entity_id, op, request_id) duplicate.
+
+    Returns the cursor so callers can inspect ``rowcount``/``lastrowid``.
+    """
+    return conn.execute(
         "INSERT OR IGNORE INTO lineage_event "
         "(org_id, entity_type, entity_id, op, prov_relation, source_ids, "
         "actor, request_id, reason, created_at) "
@@ -47,7 +61,7 @@ def _append_event_stmt(
             actor,
             request_id,
             reason,
-            int(time.time()),
+            created_at if created_at is not None else int(time.time()),
         ),
     )
 
@@ -61,42 +75,37 @@ class SQLiteLineageMixin:
     org_id: str
 
     def append_lineage_event(self, event: LineageEvent) -> int:
-        """Append an event; idempotent on (entity_id, op, request_id). Return the row id.
+        """Append an event; idempotent on (org_id, entity_id, op, request_id).
 
         Args:
             event (LineageEvent): The fully-formed event to persist. ``event_id``
                 may be 0; the storage layer assigns a real id on insert. On a
-                duplicate ``(entity_id, op, request_id)`` the existing row is
-                returned unchanged.
+                duplicate ``(org_id, entity_id, op, request_id)`` the existing row
+                is returned unchanged.
 
         Returns:
             int: The assigned or existing ``event_id``.
         """
         created = event.created_at or int(time.time())
         with self._lock:
-            cur = self.conn.execute(
-                "INSERT OR IGNORE INTO lineage_event "
-                "(org_id, entity_type, entity_id, op, prov_relation, source_ids, "
-                "actor, request_id, reason, created_at) "
-                "VALUES (?,?,?,?,?,?,?,?,?,?)",
-                (
-                    event.org_id,
-                    event.entity_type,
-                    event.entity_id,
-                    event.op,
-                    event.prov_relation,
-                    json.dumps(event.source_ids),
-                    event.actor,
-                    event.request_id,
-                    event.reason,
-                    created,
-                ),
+            cur = _append_event_stmt(
+                self.conn,
+                org_id=event.org_id,
+                entity_type=event.entity_type,
+                entity_id=event.entity_id,
+                op=event.op,
+                prov=event.prov_relation,
+                source_ids=event.source_ids,
+                actor=event.actor,
+                request_id=event.request_id,
+                reason=event.reason,
+                created_at=created,
             )
-            if cur.rowcount == 0:  # duplicate (entity_id, op, request_id)
+            if cur.rowcount == 0:  # duplicate (org_id, entity_id, op, request_id)
                 row = self.conn.execute(
                     "SELECT event_id FROM lineage_event "
-                    "WHERE entity_id=? AND op=? AND request_id=?",
-                    (event.entity_id, event.op, event.request_id),
+                    "WHERE org_id=? AND entity_id=? AND op=? AND request_id=?",
+                    (event.org_id, event.entity_id, event.op, event.request_id),
                 ).fetchone()
                 eid = row[0] if row else None
                 self.conn.commit()
@@ -157,7 +166,7 @@ class SQLiteLineageMixin:
     def merge_records(
         self,
         *,
-        entity_type: str,
+        entity_type: EntityType,
         survivor_id: str,
         source_ids: list[str],
         context: LineageContext,
@@ -175,8 +184,11 @@ class SQLiteLineageMixin:
             survivor_id (str): The id of the record that survives the merge.
             source_ids (list[str]): Ids of records to tombstone as merged.
             context (LineageContext): Caller-supplied intent (actor, reason, etc.).
+
+        Raises:
+            ValueError: If ``entity_type`` is not a recognized entity type.
         """
-        table, pk = _TABLE[entity_type]
+        table, pk = _resolve_table(entity_type)
         with self._lock:
             for sid in source_ids:
                 self.conn.execute(
@@ -201,7 +213,7 @@ class SQLiteLineageMixin:
     def supersede_record(
         self,
         *,
-        entity_type: str,
+        entity_type: EntityType,
         incumbent_id: str,
         successor_id: str,
         context: LineageContext,
@@ -223,8 +235,11 @@ class SQLiteLineageMixin:
         Returns:
             bool: ``True`` if the incumbent was CURRENT and was superseded;
                 ``False`` if the incumbent was not CURRENT and no mutation occurred.
+
+        Raises:
+            ValueError: If ``entity_type`` is not a recognized entity type.
         """
-        table, pk = _TABLE[entity_type]
+        table, pk = _resolve_table(entity_type)
         with self._lock:
             cur = self.conn.execute(
                 f"UPDATE {table} SET status=?, superseded_by=? "  # noqa: S608

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -4,7 +4,52 @@ import threading
 import time
 from typing import Any
 
-from reflexio.models.api_schema.domain.entities import LineageEvent
+from reflexio.models.api_schema.domain.entities import LineageContext, LineageEvent
+from reflexio.models.api_schema.domain.enums import Status
+
+# Tombstone statuses — rows with these statuses are skipped by merge_records guard.
+_TOMBSTONE = (Status.MERGED.value, Status.SUPERSEDED.value)
+
+# Mapping from entity_type string to (table_name, primary_key_column).
+_TABLE: dict[str, tuple[str, str]] = {
+    "user_playbook": ("user_playbooks", "user_playbook_id"),
+    "agent_playbook": ("agent_playbooks", "agent_playbook_id"),
+    "profile": ("profiles", "profile_id"),
+}
+
+
+def _append_event_stmt(
+    conn: sqlite3.Connection,
+    *,
+    org_id: str,
+    entity_type: str,
+    entity_id: str,
+    op: str,
+    prov: str,
+    source_ids: list[str],
+    actor: str,
+    request_id: str,
+    reason: str,
+) -> None:
+    """Insert a lineage event row; silently no-ops on (entity_id, op, request_id) duplicate."""
+    conn.execute(
+        "INSERT OR IGNORE INTO lineage_event "
+        "(org_id, entity_type, entity_id, op, prov_relation, source_ids, "
+        "actor, request_id, reason, created_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (
+            org_id,
+            entity_type,
+            entity_id,
+            op,
+            prov,
+            json.dumps(source_ids),
+            actor,
+            request_id,
+            reason,
+            int(time.time()),
+        ),
+    )
 
 
 class SQLiteLineageMixin:
@@ -13,6 +58,7 @@ class SQLiteLineageMixin:
     # Type hints for instance attributes provided by SQLiteStorageBase via MRO.
     conn: sqlite3.Connection
     _lock: threading.RLock
+    org_id: str
 
     def append_lineage_event(self, event: LineageEvent) -> int:
         """Append an event; idempotent on (entity_id, op, request_id). Return the row id.
@@ -107,3 +153,98 @@ class SQLiteLineageMixin:
             )
             for r in rows
         ]
+
+    def merge_records(
+        self,
+        *,
+        entity_type: str,
+        survivor_id: str,
+        source_ids: list[str],
+        context: LineageContext,
+    ) -> None:
+        """Soft-delete each source into the survivor in one atomic transaction.
+
+        Sets ``status=MERGED`` and ``merged_into=survivor_id`` on each source
+        whose status is not already a tombstone. Appends a single ``merge``
+        lineage event keyed on ``survivor_id``. Idempotent — re-running on
+        already-tombstoned sources is a no-op.
+
+        Args:
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            survivor_id (str): The id of the record that survives the merge.
+            source_ids (list[str]): Ids of records to tombstone as merged.
+            context (LineageContext): Caller-supplied intent (actor, reason, etc.).
+        """
+        table, pk = _TABLE[entity_type]
+        with self._lock:
+            for sid in source_ids:
+                self.conn.execute(
+                    f"UPDATE {table} SET status=?, merged_into=? "  # noqa: S608
+                    f"WHERE {pk}=? AND (status IS NULL OR status NOT IN (?, ?))",
+                    (Status.MERGED.value, survivor_id, sid, *_TOMBSTONE),
+                )
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type=entity_type,
+                entity_id=survivor_id,
+                op="merge",
+                prov="wasDerivedFrom",
+                source_ids=source_ids,
+                actor=context.actor,
+                request_id=context.request_id or "",
+                reason=context.reason,
+            )
+            self.conn.commit()
+
+    def supersede_record(
+        self,
+        *,
+        entity_type: str,
+        incumbent_id: str,
+        successor_id: str,
+        context: LineageContext,
+    ) -> bool:
+        """Atomically replace the incumbent with the successor if incumbent is CURRENT.
+
+        Sets ``status=SUPERSEDED`` and ``superseded_by=successor_id`` on the
+        incumbent **only** when its ``status IS NULL`` (CURRENT). Appends a
+        ``revise`` lineage event when the guard succeeds. Returns ``False``
+        without mutating anything when the incumbent is not CURRENT.
+
+        Args:
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            incumbent_id (str): The id of the record to supersede.
+            successor_id (str): The id of the record that replaces the incumbent.
+            context (LineageContext): Caller-supplied intent (actor, reason, etc.).
+
+        Returns:
+            bool: ``True`` if the incumbent was CURRENT and was superseded;
+                ``False`` if the incumbent was not CURRENT and no mutation occurred.
+        """
+        table, pk = _TABLE[entity_type]
+        with self._lock:
+            cur = self.conn.execute(
+                f"UPDATE {table} SET status=?, superseded_by=? "  # noqa: S608
+                f"WHERE {pk}=? AND status IS NULL",
+                (Status.SUPERSEDED.value, successor_id, incumbent_id),
+            )
+            if cur.rowcount == 0:
+                self.conn.commit()
+                return False
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type=entity_type,
+                entity_id=successor_id,
+                op="revise",
+                prov="wasRevisionOf",
+                source_ids=[incumbent_id],
+                actor=context.actor,
+                request_id=context.request_id or "",
+                reason=context.reason,
+            )
+            self.conn.commit()
+            return True

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -42,7 +42,7 @@ def _append_event_stmt(
     reason: str,
     created_at: int | None = None,
 ) -> sqlite3.Cursor:
-    """Insert a lineage event row; no-ops on (org_id, entity_id, op, request_id) duplicate.
+    """Insert a lineage event row; no-ops on (org_id, entity_type, entity_id, op, request_id) duplicate.
 
     Returns the cursor so callers can inspect ``rowcount``/``lastrowid``.
     """
@@ -75,13 +75,13 @@ class SQLiteLineageMixin:
     org_id: str
 
     def append_lineage_event(self, event: LineageEvent) -> int:
-        """Append an event; idempotent on (org_id, entity_id, op, request_id).
+        """Append an event; idempotent on (org_id, entity_type, entity_id, op, request_id).
 
         Args:
             event (LineageEvent): The fully-formed event to persist. ``event_id``
                 may be 0; the storage layer assigns a real id on insert. On a
-                duplicate ``(org_id, entity_id, op, request_id)`` the existing row
-                is returned unchanged.
+                duplicate ``(org_id, entity_type, entity_id, op, request_id)`` the
+                existing row is returned unchanged.
 
         Returns:
             int: The assigned or existing ``event_id``.
@@ -101,11 +101,19 @@ class SQLiteLineageMixin:
                 reason=event.reason,
                 created_at=created,
             )
-            if cur.rowcount == 0:  # duplicate (org_id, entity_id, op, request_id)
+            if (
+                cur.rowcount == 0
+            ):  # duplicate (org_id, entity_type, entity_id, op, request_id)
                 row = self.conn.execute(
-                    "SELECT event_id FROM lineage_event "
-                    "WHERE org_id=? AND entity_id=? AND op=? AND request_id=?",
-                    (event.org_id, event.entity_id, event.op, event.request_id),
+                    "SELECT event_id FROM lineage_event WHERE org_id=? AND entity_type=? "
+                    "AND entity_id=? AND op=? AND request_id=?",
+                    (
+                        event.org_id,
+                        event.entity_type,
+                        event.entity_id,
+                        event.op,
+                        event.request_id,
+                    ),
                 ).fetchone()
                 eid = row[0] if row else None
                 self.conn.commit()
@@ -142,10 +150,11 @@ class SQLiteLineageMixin:
                 clauses.append(f"{col}=?")
                 params.append(val)
         where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
-        rows = self.conn.execute(
-            f"SELECT * FROM lineage_event{where} ORDER BY event_id",  # noqa: S608
-            params,
-        ).fetchall()
+        with self._lock:
+            rows = self.conn.execute(
+                f"SELECT * FROM lineage_event{where} ORDER BY event_id",  # noqa: S608
+                params,
+            ).fetchall()
         return [
             LineageEvent(
                 event_id=r["event_id"],
@@ -191,10 +200,15 @@ class SQLiteLineageMixin:
         table, pk = _resolve_table(entity_type)
         with self._lock:
             for sid in source_ids:
+                if sid == survivor_id:
+                    # Never tombstone the survivor itself, even if it is
+                    # accidentally listed among the source ids.
+                    continue
                 self.conn.execute(
                     f"UPDATE {table} SET status=?, merged_into=? "  # noqa: S608
-                    f"WHERE {pk}=? AND (status IS NULL OR status NOT IN (?, ?))",
-                    (Status.MERGED.value, survivor_id, sid, *_TOMBSTONE),
+                    f"WHERE {pk}=? AND {pk}!=? "
+                    f"AND (status IS NULL OR status NOT IN (?, ?))",
+                    (Status.MERGED.value, survivor_id, sid, survivor_id, *_TOMBSTONE),
                 )
             _append_event_stmt(
                 self.conn,

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -135,8 +135,9 @@ class PlaybookMixin:
                         content, trigger, rationale, blocking_issue,
                         source_interaction_ids,
                         status, source, embedding, expanded_terms,
-                        source_span, notes, reader_angle, tags)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        source_span, notes, reader_angle, tags,
+                        merged_into, superseded_by)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     (
                         up.user_id,
                         up.playbook_name,
@@ -158,6 +159,8 @@ class PlaybookMixin:
                         up.notes,
                         up.reader_angle,
                         _json_dumps(up.tags),
+                        up.merged_into,
+                        up.superseded_by,
                     ),
                 )
                 upid = cur.lastrowid or 0
@@ -610,8 +613,9 @@ class PlaybookMixin:
                        (playbook_name, created_at, agent_version, content,
                         trigger, rationale, blocking_issue,
                         playbook_status, playbook_metadata, embedding,
-                        expanded_terms, tags, status)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        expanded_terms, tags, status,
+                        merged_into, superseded_by)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     (
                         ap.playbook_name,
                         created_at_iso,
@@ -630,6 +634,8 @@ class PlaybookMixin:
                         ap.expanded_terms,
                         _json_dumps(ap.tags),
                         ap.status.value if ap.status else None,
+                        ap.merged_into,
+                        ap.superseded_by,
                     ),
                 )
                 ap.agent_playbook_id = cur.lastrowid or 0

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -25,8 +25,8 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.models.config_schema import SearchMode, SearchOptions
 
 from ._base import (
-    SQLiteStorageBase,
     _TOMBSTONE_STATUS_VALUES,
+    SQLiteStorageBase,
     _build_status_sql,
     _effective_search_mode,
     _epoch_to_iso,
@@ -273,8 +273,9 @@ class PlaybookMixin:
         row = self._fetchone(
             """SELECT COUNT(*) as cnt FROM user_playbooks up
                JOIN requests r ON up.request_id = r.request_id
-               WHERE r.session_id = ?""",
-            (session_id,),
+               WHERE r.session_id = ?
+                 AND (up.status IS NULL OR up.status NOT IN (?, ?))""",
+            (session_id, *_TOMBSTONE_STATUS_VALUES),
         )
         return row["cnt"] if row else 0
 
@@ -319,24 +320,27 @@ class PlaybookMixin:
         self._execute(del_sql, del_params)
 
     @SQLiteStorageBase.handle_exceptions
-    def delete_user_playbooks_by_ids(self, user_playbook_ids: list[int]) -> int:
+    def delete_user_playbooks_by_ids(
+        self, user_playbook_ids: list[int], *, emit_hard_delete: bool = True
+    ) -> int:
         if not user_playbook_ids:
             return 0
         ph = ",".join("?" for _ in user_playbook_ids)
         with self._lock:
-            for upid in user_playbook_ids:
-                _append_event_stmt(
-                    self.conn,
-                    org_id=self.org_id,
-                    entity_type="user_playbook",
-                    entity_id=str(upid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="system",
-                    request_id="",
-                    reason="erasure",
-                )
+            if emit_hard_delete:
+                for upid in user_playbook_ids:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="user_playbook",
+                        entity_id=str(upid),
+                        op="hard_delete",
+                        prov="wasInvalidatedBy",
+                        source_ids=[],
+                        actor="system",
+                        request_id="",
+                        reason="erasure",
+                    )
             self.conn.execute(
                 f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
                 user_playbook_ids,
@@ -513,6 +517,10 @@ class PlaybookMixin:
             frag, sparams = _build_status_sql(status_filter)
             conditions.append(frag)
             params.extend(sparams)
+        else:
+            # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
+            conditions.append("(up.status IS NULL OR up.status NOT IN (?, ?))")
+            params.extend(_TOMBSTONE_STATUS_VALUES)
         tag_frag, tag_params = _build_tags_sql("up", request.tags)
         if tag_frag:
             conditions.append(tag_frag)
@@ -780,11 +788,27 @@ class PlaybookMixin:
         self._execute(del_sql, del_params)
 
     @SQLiteStorageBase.handle_exceptions
-    def delete_agent_playbooks_by_ids(self, agent_playbook_ids: list[int]) -> None:
+    def delete_agent_playbooks_by_ids(
+        self, agent_playbook_ids: list[int], *, emit_hard_delete: bool = True
+    ) -> None:
         if not agent_playbook_ids:
             return
         ph = ",".join("?" for _ in agent_playbook_ids)
         with self._lock:
+            if emit_hard_delete:
+                for apid in agent_playbook_ids:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="agent_playbook",
+                        entity_id=str(apid),
+                        op="hard_delete",
+                        prov="wasInvalidatedBy",
+                        source_ids=[],
+                        actor="system",
+                        request_id="",
+                        reason="erasure",
+                    )
             self.conn.execute(
                 f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})",
                 agent_playbook_ids,

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -39,6 +39,7 @@ from ._base import (
     _true_rrf_merge,
     _vector_rank_rows,
 )
+from ._lineage import _append_event_stmt
 
 
 def _row_to_playbook_optimization_candidate(
@@ -94,6 +95,7 @@ class PlaybookMixin:
     # Type hints for instance attributes/methods provided by SQLiteStorageBase via MRO
     _lock: Any
     conn: sqlite3.Connection
+    org_id: str
     _execute: Any
     _fetchone: Any
     _fetchall: Any
@@ -322,6 +324,19 @@ class PlaybookMixin:
             return 0
         ph = ",".join("?" for _ in user_playbook_ids)
         with self._lock:
+            for upid in user_playbook_ids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="user_playbook",
+                    entity_id=str(upid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="system",
+                    request_id="",
+                    reason="erasure",
+                )
             self.conn.execute(
                 f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
                 user_playbook_ids,

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -26,6 +26,7 @@ from reflexio.models.config_schema import SearchMode, SearchOptions
 
 from ._base import (
     SQLiteStorageBase,
+    _TOMBSTONE_STATUS_VALUES,
     _build_status_sql,
     _effective_search_mode,
     _epoch_to_iso,
@@ -213,6 +214,10 @@ class PlaybookMixin:
             frag, sparams = _build_status_sql(status_filter)
             sql += f" AND {frag}"
             params.extend(sparams)
+        else:
+            # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
+            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            params.extend(_TOMBSTONE_STATUS_VALUES)
         tag_frag, tag_params = _build_tags_sql("user_playbooks", tags)
         if tag_frag:
             sql += f" AND {tag_frag}"
@@ -253,6 +258,10 @@ class PlaybookMixin:
             frag, sparams = _build_status_sql(status_filter)
             sql += f" AND {frag}"
             params.extend(sparams)
+        else:
+            # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
+            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            params.extend(_TOMBSTONE_STATUS_VALUES)
 
         row = self._fetchone(sql, params)
         return row["cnt"] if row else 0
@@ -557,11 +566,15 @@ class PlaybookMixin:
         return [_row_to_user_playbook(r) for r in rows]
 
     @SQLiteStorageBase.handle_exceptions
-    def get_user_playbook_by_id(self, user_playbook_id: int) -> UserPlaybook | None:
-        row = self._fetchone(
-            "SELECT * FROM user_playbooks WHERE user_playbook_id = ?",
-            (user_playbook_id,),
-        )
+    def get_user_playbook_by_id(
+        self, user_playbook_id: int, *, include_tombstones: bool = False
+    ) -> UserPlaybook | None:
+        sql = "SELECT * FROM user_playbooks WHERE user_playbook_id = ?"
+        if not include_tombstones:
+            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            row = self._fetchone(sql, (user_playbook_id, *_TOMBSTONE_STATUS_VALUES))
+        else:
+            row = self._fetchone(sql, (user_playbook_id,))
         return _row_to_user_playbook(row) if row else None
 
     @SQLiteStorageBase.handle_exceptions
@@ -699,11 +712,15 @@ class PlaybookMixin:
         return [_row_to_agent_playbook(r) for r in rows]
 
     @SQLiteStorageBase.handle_exceptions
-    def get_agent_playbook_by_id(self, agent_playbook_id: int) -> AgentPlaybook | None:
-        row = self._fetchone(
-            "SELECT * FROM agent_playbooks WHERE agent_playbook_id = ?",
-            (agent_playbook_id,),
-        )
+    def get_agent_playbook_by_id(
+        self, agent_playbook_id: int, *, include_tombstones: bool = False
+    ) -> AgentPlaybook | None:
+        sql = "SELECT * FROM agent_playbooks WHERE agent_playbook_id = ?"
+        if not include_tombstones:
+            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            row = self._fetchone(sql, (agent_playbook_id, *_TOMBSTONE_STATUS_VALUES))
+        else:
+            row = self._fetchone(sql, (agent_playbook_id,))
         return _row_to_agent_playbook(row) if row else None
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -128,8 +128,9 @@ class ProfileMixin:
                     generated_from_request_id, profile_time_to_live,
                     expiration_timestamp, custom_features, embedding, source,
                     status, extractor_names, expanded_terms,
-                    source_span, notes, reader_angle, tags, created_at)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                    source_span, notes, reader_angle, tags, created_at,
+                    merged_into, superseded_by)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     profile.profile_id,
                     profile.user_id,
@@ -149,6 +150,8 @@ class ProfileMixin:
                     profile.reader_angle,
                     _json_dumps(profile.tags),
                     _iso_now(),
+                    profile.merged_into,
+                    profile.superseded_by,
                 ),
             )
             fts_parts = [profile.content or ""]

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -25,6 +25,7 @@ from reflexio.server.llm.providers.embedding_service_provider import (
 
 from ._base import (
     SQLiteStorageBase,
+    _TOMBSTONE_STATUS_VALUES,
     _build_status_sql,
     _effective_search_mode,
     _epoch_now,
@@ -323,6 +324,28 @@ class ProfileMixin:
         )
         params: list[Any] = [user_id, *profile_ids, current_ts, *sparams]
         return [_row_to_profile(r) for r in self._fetchall(sql, params)]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_profile_by_id(
+        self, profile_id: str, *, include_tombstones: bool = False
+    ) -> UserProfile | None:
+        """Fetch a single profile by primary key.
+
+        Args:
+            profile_id: The profile's primary key.
+            include_tombstones: When False (default), MERGED/SUPERSEDED profiles
+                return None. Set to True for lineage resolution (resolve_current).
+
+        Returns:
+            The UserProfile if found and not filtered, otherwise None.
+        """
+        sql = "SELECT * FROM profiles WHERE profile_id = ?"
+        if not include_tombstones:
+            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            row = self._fetchone(sql, (profile_id, *_TOMBSTONE_STATUS_VALUES))
+        else:
+            row = self._fetchone(sql, (profile_id,))
+        return _row_to_profile(row) if row else None
 
     @SQLiteStorageBase.handle_exceptions
     def archive_profile_by_id(self, user_id: str, profile_id: str) -> bool:

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -23,6 +23,7 @@ from ._agent_run import (
 )
 from ._base import BaseStorageCore, matches_status_filter
 from ._extras import ExtrasMixin
+from ._lineage import LineageEventMixin
 from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
@@ -39,6 +40,7 @@ class BaseStorage(
     RequestMixin,
     PlaybookMixin,
     RetrievalLogMixin,
+    LineageEventMixin,
     OperationMixin,
     ExtrasMixin,
     ShareLinkMixin,
@@ -129,6 +131,7 @@ class BaseStorage(
 __all__ = [
     "AgentBinding",
     "AgentRunMixin",
+    "LineageEventMixin",
     "AgentRunRecord",
     "AgentRunStatus",
     "BaseStorage",

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -27,6 +27,7 @@ from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
 from ._requests import RequestMixin
+from ._retrieval_log import RetrievalLogMixin
 from ._shadow_verdicts import ShadowVerdictsMixin
 from ._share_links import ShareLinkMixin
 from ._stall_state import StallStateMixin
@@ -37,6 +38,7 @@ class BaseStorage(
     ProfileMixin,
     RequestMixin,
     PlaybookMixin,
+    RetrievalLogMixin,
     OperationMixin,
     ExtrasMixin,
     ShareLinkMixin,
@@ -135,6 +137,7 @@ __all__ = [
     "PendingToolCallStatus",
     "PendingToolCallUpsertResult",
     "PlaybookMixin",
+    "RetrievalLogMixin",
     "PriorAnswerMatch",
     "RunToolDependencyKind",
     "RunToolDependencyRecord",

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 
-from reflexio.models.api_schema.domain.entities import LineageEvent
+from reflexio.models.api_schema.domain.entities import LineageContext, LineageEvent
 
 
 class LineageEventMixin:
@@ -41,5 +41,60 @@ class LineageEventMixin:
 
         Returns:
             list[LineageEvent]: Matching events ordered by ``event_id`` ascending.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def merge_records(
+        self,
+        *,
+        entity_type: str,
+        survivor_id: str,
+        source_ids: list[str],
+        context: LineageContext,
+    ) -> None:
+        """Soft-delete each source into the survivor in one atomic transaction.
+
+        Sets ``status=MERGED`` and ``merged_into=survivor_id`` on each source
+        whose status is not already a tombstone (MERGED or SUPERSEDED). Appends
+        a single ``merge`` lineage event keyed on ``survivor_id``. Idempotent —
+        re-running on already-tombstoned sources is a no-op.
+
+        Args:
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            survivor_id (str): The id of the record that survives the merge.
+            source_ids (list[str]): Ids of records to tombstone as merged.
+            context (LineageContext): Caller-supplied intent (actor, reason, etc.).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def supersede_record(
+        self,
+        *,
+        entity_type: str,
+        incumbent_id: str,
+        successor_id: str,
+        context: LineageContext,
+    ) -> bool:
+        """Atomically replace the incumbent with the successor if incumbent is CURRENT.
+
+        Sets ``status=SUPERSEDED`` and ``superseded_by=successor_id`` on the
+        incumbent **only** when its ``status IS NULL`` (CURRENT). Appends a
+        ``revise`` lineage event keyed on ``successor_id`` when the guard
+        succeeds. Returns ``False`` without mutating anything when the incumbent
+        is not CURRENT (its status is already set).
+
+        Args:
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            incumbent_id (str): The id of the record to supersede.
+            successor_id (str): The id of the record that replaces the incumbent.
+            context (LineageContext): Caller-supplied intent (actor, reason, etc.).
+
+        Returns:
+            bool: ``True`` if the incumbent was CURRENT and was superseded;
+                ``False`` if the incumbent was not CURRENT and no mutation occurred.
         """
         raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -1,0 +1,45 @@
+from abc import abstractmethod
+
+from reflexio.models.api_schema.domain.entities import LineageEvent
+
+
+class LineageEventMixin:
+    """Abstract storage interface for the append-only, content-free lineage log."""
+
+    @abstractmethod
+    def append_lineage_event(self, event: LineageEvent) -> int:
+        """Append an event; idempotent on (entity_id, op, request_id). Return the row id.
+
+        Args:
+            event (LineageEvent): The fully-formed event to persist. ``event_id``
+                may be 0; the storage layer assigns a real id on insert. On a
+                duplicate ``(entity_id, op, request_id)`` the existing row is
+                returned unchanged.
+
+        Returns:
+            int: The assigned or existing ``event_id``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_lineage_events(
+        self,
+        *,
+        entity_type: str | None = None,
+        entity_id: str | None = None,
+        org_id: str | None = None,
+    ) -> list[LineageEvent]:
+        """Retrieve lineage events, optionally filtered.
+
+        Args:
+            entity_type (str | None): Filter to events for this entity type. If
+                None, no entity_type filter is applied.
+            entity_id (str | None): Filter to events for this entity id. If None,
+                no entity_id filter is applied.
+            org_id (str | None): Filter to events for this org. If None, no
+                org_id filter is applied.
+
+        Returns:
+            list[LineageEvent]: Matching events ordered by ``event_id`` ascending.
+        """
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -1,6 +1,9 @@
 from abc import abstractmethod
+from typing import Literal
 
 from reflexio.models.api_schema.domain.entities import LineageContext, LineageEvent
+
+EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
 
 class LineageEventMixin:
@@ -8,13 +11,13 @@ class LineageEventMixin:
 
     @abstractmethod
     def append_lineage_event(self, event: LineageEvent) -> int:
-        """Append an event; idempotent on (entity_id, op, request_id). Return the row id.
+        """Append an event; idempotent on (org_id, entity_id, op, request_id).
 
         Args:
             event (LineageEvent): The fully-formed event to persist. ``event_id``
                 may be 0; the storage layer assigns a real id on insert. On a
-                duplicate ``(entity_id, op, request_id)`` the existing row is
-                returned unchanged.
+                duplicate ``(org_id, entity_id, op, request_id)`` the existing row
+                is returned unchanged.
 
         Returns:
             int: The assigned or existing ``event_id``.
@@ -48,7 +51,7 @@ class LineageEventMixin:
     def merge_records(
         self,
         *,
-        entity_type: str,
+        entity_type: EntityType,
         survivor_id: str,
         source_ids: list[str],
         context: LineageContext,
@@ -73,7 +76,7 @@ class LineageEventMixin:
     def supersede_record(
         self,
         *,
-        entity_type: str,
+        entity_type: EntityType,
         incumbent_id: str,
         successor_id: str,
         context: LineageContext,

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -11,12 +11,12 @@ class LineageEventMixin:
 
     @abstractmethod
     def append_lineage_event(self, event: LineageEvent) -> int:
-        """Append an event; idempotent on (org_id, entity_id, op, request_id).
+        """Append an event; idempotent on (org_id, entity_type, entity_id, op, request_id).
 
         Args:
             event (LineageEvent): The fully-formed event to persist. ``event_id``
                 may be 0; the storage layer assigns a real id on insert. On a
-                duplicate ``(org_id, entity_id, op, request_id)`` the existing row
+                duplicate ``(org_id, entity_type, entity_id, op, request_id)`` the existing row
                 is returned unchanged.
 
         Returns:

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -168,11 +168,17 @@ class PlaybookMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def delete_user_playbooks_by_ids(self, user_playbook_ids: list[int]) -> int:
+    def delete_user_playbooks_by_ids(
+        self, user_playbook_ids: list[int], *, emit_hard_delete: bool = True
+    ) -> int:
         """Delete user playbooks by their IDs.
 
         Args:
             user_playbook_ids: List of user_playbook_id values to delete
+            emit_hard_delete: When True (default), append a ``hard_delete``
+                lineage event per id (genuine erasure). Set False for rollback
+                cleanup of a never-live row (e.g. a lost supersede CAS), so no
+                spurious audit event is recorded.
 
         Returns:
             int: Number of user playbooks deleted
@@ -587,12 +593,18 @@ class PlaybookMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def delete_agent_playbooks_by_ids(self, agent_playbook_ids: list[int]) -> None:
+    def delete_agent_playbooks_by_ids(
+        self, agent_playbook_ids: list[int], *, emit_hard_delete: bool = True
+    ) -> None:
         """Permanently delete agent playbooks by their IDs.
         No-op if agent_playbook_ids is empty.
 
         Args:
             agent_playbook_ids (list[int]): List of agent playbook IDs to delete
+            emit_hard_delete: When True (default), append a ``hard_delete``
+                lineage event per id (genuine erasure). Set False for rollback
+                cleanup of a never-live row (e.g. a lost supersede CAS), so no
+                spurious audit event is recorded.
         """
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -208,8 +208,19 @@ class PlaybookMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def get_user_playbook_by_id(self, user_playbook_id: int) -> UserPlaybook | None:
-        """Fetch one user playbook by id, regardless of owner."""
+    def get_user_playbook_by_id(
+        self, user_playbook_id: int, *, include_tombstones: bool = False
+    ) -> UserPlaybook | None:
+        """Fetch one user playbook by primary key.
+
+        Args:
+            user_playbook_id: The user_playbook_id to look up.
+            include_tombstones: When False (default), MERGED/SUPERSEDED rows
+                return None. Set to True for lineage resolution (resolve_current).
+
+        Returns:
+            The UserPlaybook if found and not filtered, otherwise None.
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -303,8 +314,19 @@ class PlaybookMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def get_agent_playbook_by_id(self, agent_playbook_id: int) -> AgentPlaybook | None:
-        """Fetch one agent playbook by id."""
+    def get_agent_playbook_by_id(
+        self, agent_playbook_id: int, *, include_tombstones: bool = False
+    ) -> AgentPlaybook | None:
+        """Fetch one agent playbook by primary key.
+
+        Args:
+            agent_playbook_id: The agent_playbook_id to look up.
+            include_tombstones: When False (default), MERGED/SUPERSEDED rows
+                return None. Set to True for lineage resolution (resolve_current).
+
+        Returns:
+            The AgentPlaybook if found and not filtered, otherwise None.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/reflexio/server/services/storage/storage_base/_profiles.py
+++ b/reflexio/server/services/storage/storage_base/_profiles.py
@@ -187,6 +187,22 @@ class ProfileMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def get_profile_by_id(
+        self, profile_id: str, *, include_tombstones: bool = False
+    ) -> UserProfile | None:
+        """Fetch a single profile by primary key.
+
+        Args:
+            profile_id: The profile's primary key.
+            include_tombstones: When False (default), MERGED/SUPERSEDED profiles
+                return None. Set to True for lineage resolution (resolve_current).
+
+        Returns:
+            The UserProfile if found and not filtered, otherwise None.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def archive_profile_by_id(self, user_id: str, profile_id: str) -> bool:
         """Atomically archive a single profile by id, only if currently CURRENT.
 

--- a/reflexio/server/services/storage/storage_base/_retrieval_log.py
+++ b/reflexio/server/services/storage/storage_base/_retrieval_log.py
@@ -1,0 +1,41 @@
+from abc import abstractmethod
+
+from reflexio.models.api_schema.domain.entities import PlaybookRetrievalLog
+
+
+class RetrievalLogMixin:
+    """Mixin for playbook retrieval log storage methods."""
+
+    @abstractmethod
+    def save_playbook_retrieval_log(self, log: PlaybookRetrievalLog) -> int:
+        """Persist a retrieval log entry and return its assigned id.
+
+        Args:
+            log (PlaybookRetrievalLog): The log entry to save. ``retrieval_log_id``
+                may be 0; the storage layer assigns a real id on insert.
+
+        Returns:
+            int: The assigned ``retrieval_log_id``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_playbook_retrieval_logs(
+        self,
+        *,
+        session_id: str | None = None,
+        request_id: str | None = None,
+    ) -> list[PlaybookRetrievalLog]:
+        """Retrieve playbook retrieval log entries, optionally filtered.
+
+        Args:
+            session_id (str | None): Filter to logs for this session. If None,
+                no session filter is applied.
+            request_id (str | None): Filter to logs for this request. If None,
+                no request filter is applied.
+
+        Returns:
+            list[PlaybookRetrievalLog]: Matching log entries, ordered by
+                ``created_at`` ascending.
+        """
+        raise NotImplementedError

--- a/reflexio/server/tracing.py
+++ b/reflexio/server/tracing.py
@@ -156,3 +156,33 @@ def sentry_tags(**tags: Any) -> Iterator[None]:
             scope_cm.__exit__(None, None, None)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Failed to close Sentry scope: %s", exc)
+
+
+def capture_anomaly(message: str, *, level: str = "warning", **tags: Any) -> None:
+    """Report a non-fatal anomaly to Sentry, if the SDK is installed.
+
+    For silent-but-noteworthy conditions that return rather than raise — e.g.
+    lineage resolution hitting a cycle or the hop cap, or a best-effort
+    provenance append failing. No-op when ``sentry-sdk`` is absent (the OS
+    package does not depend on it; enterprise deployments pull it in). Never
+    raises — instrumentation must not turn a degraded-but-working path into a
+    failure.
+
+    Args:
+        message: short, low-cardinality description of the anomaly (the Sentry
+            issue title), e.g. ``"lineage.resolve_current.cycle"``.
+        level: Sentry severity ("warning", "error", ...). Defaults to "warning".
+        **tags: contextual tag name → value pairs (None values are skipped).
+    """
+    try:
+        import sentry_sdk  # type: ignore[import-not-found]
+    except ImportError:
+        return
+    try:
+        with sentry_sdk.new_scope() as scope:
+            for key, value in tags.items():
+                if value is not None:
+                    scope.set_tag(key, str(value))
+            sentry_sdk.capture_message(message, level=level)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Failed to capture Sentry anomaly %r: %s", message, exc)

--- a/tests/e2e_tests/test_contradiction_resolution_e2e.py
+++ b/tests/e2e_tests/test_contradiction_resolution_e2e.py
@@ -257,11 +257,12 @@ def _drive_consolidator(
         ),
         patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}),
     ):
-        return consolidator.deduplicate(
+        rows, archive_ids, _merge_groups = consolidator.deduplicate(
             results=[candidates],
             request_id=request_id,
             agent_version="v1",
         )
+    return rows, archive_ids
 
 
 def _apply_to_storage(

--- a/tests/models/test_lineage_models.py
+++ b/tests/models/test_lineage_models.py
@@ -1,0 +1,39 @@
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.models.api_schema.domain.entities import (
+    UserPlaybook, AgentPlaybook, UserProfile, LineageEvent, LineageContext, RecordRef,
+)
+
+
+def test_status_has_tombstone_values():
+    assert Status("merged") is Status.MERGED
+    assert Status("superseded") is Status.SUPERSEDED
+
+
+def test_playbook_pointers_default_none_and_are_int():
+    pb = UserPlaybook(agent_version="v1", request_id="r1")
+    assert pb.merged_into is None and pb.superseded_by is None
+    pb.merged_into = 7
+    assert UserPlaybook.model_validate(pb.model_dump()).merged_into == 7
+
+
+def test_profile_pointers_are_str():
+    p = UserProfile(profile_id="p1", user_id="u1", content="c",
+                    last_modified_timestamp=0, generated_from_request_id="r1")
+    assert p.merged_into is None
+    p.merged_into = "p2"
+    assert UserProfile.model_validate(p.model_dump()).merged_into == "p2"
+
+
+def test_lineage_event_is_content_free_and_idempotency_keyed():
+    e = LineageEvent(org_id="org-42", entity_type="user_playbook", entity_id="UP-1",
+                     op="merge", prov_relation="wasDerivedFrom", source_ids=["UP-1"],
+                     actor="consolidator", request_id="req-7", reason="dup")
+    assert e.event_id == 0  # storage assigns
+    assert not hasattr(e, "content")
+
+
+def test_lineage_context_and_record_ref():
+    ctx = LineageContext(op_kind="merge", actor="consolidator", source_ids=["UP-1"], reason="dup")
+    assert ctx.request_id is None or isinstance(ctx.request_id, str)
+    ref = RecordRef(id="UP-2", is_purged=False)
+    assert ref.id == "UP-2" and ref.is_purged is False

--- a/tests/server/services/lineage/test_resolve_current.py
+++ b/tests/server/services/lineage/test_resolve_current.py
@@ -1,48 +1,104 @@
 import pytest
-from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
-from reflexio.server.services.lineage.resolve import resolve_current
-from reflexio.models.api_schema.domain.entities import UserPlaybook, LineageContext
+
+from reflexio.models.api_schema.domain.entities import LineageContext, UserPlaybook
 from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.lineage.resolve import resolve_current
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
 
 
 def test_current_resolves_to_self(tmp_path):
-    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
     pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
     s.save_user_playbooks([pb])
     ref = resolve_current(s, "user_playbook", pb.user_playbook_id)
-    assert ref is not None and str(ref.id) == str(pb.user_playbook_id) and ref.is_purged is False
+    assert (
+        ref is not None
+        and str(ref.id) == str(pb.user_playbook_id)
+        and ref.is_purged is False
+    )
 
 
 def test_merged_resolves_to_survivor(tmp_path):
-    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
     surv = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="m")
     src = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="o")
     s.save_user_playbooks([surv, src])
-    s.merge_records(entity_type="user_playbook", survivor_id=str(surv.user_playbook_id),
-                    source_ids=[str(src.user_playbook_id)],
-                    context=LineageContext(op_kind="merge", actor="t", request_id="r"))
+    s.merge_records(
+        entity_type="user_playbook",
+        survivor_id=str(surv.user_playbook_id),
+        source_ids=[str(src.user_playbook_id)],
+        context=LineageContext(op_kind="merge", actor="t", request_id="r"),
+    )
     ref = resolve_current(s, "user_playbook", src.user_playbook_id)
     assert str(ref.id) == str(surv.user_playbook_id)
 
 
 def test_purged_survivor_flagged(tmp_path):
-    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
-    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="")  # blanked body
-    pb.status = Status.MERGED  # purged tombstone that points nowhere current -> itself, is_purged
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    pb = UserPlaybook(
+        user_id="u", agent_version="v", request_id="r", content=""
+    )  # blanked body
+    pb.status = (
+        Status.MERGED
+    )  # purged tombstone that points nowhere current -> itself, is_purged
     s.save_user_playbooks([pb])
     ref = resolve_current(s, "user_playbook", pb.user_playbook_id)
     assert ref is not None and ref.is_purged is True
 
 
+def test_superseded_resolves_to_successor(tmp_path):
+    # F005: follow a superseded_by pointer set by supersede_record.
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    incumbent = UserPlaybook(
+        user_id="u", agent_version="v", request_id="r", content="old"
+    )
+    successor = UserPlaybook(
+        user_id="u", agent_version="v", request_id="r", content="new"
+    )
+    s.save_user_playbooks([incumbent, successor])
+    ok = s.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(incumbent.user_playbook_id),
+        successor_id=str(successor.user_playbook_id),
+        context=LineageContext(op_kind="revise", actor="t", request_id="r"),
+    )
+    assert ok is True
+    ref = resolve_current(s, "user_playbook", incumbent.user_playbook_id)
+    assert ref is not None and str(ref.id) == str(successor.user_playbook_id)
+
+
 def test_cycle_returns_none(tmp_path):
-    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
-    a = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="a", status=Status.MERGED)
-    b = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="b", status=Status.MERGED)
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    a = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="a",
+        status=Status.MERGED,
+    )
+    b = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="b",
+        status=Status.MERGED,
+    )
     s.save_user_playbooks([a, b])
     # craft a cycle a->b->a via include-tombstone updates
-    s.conn.execute("UPDATE user_playbooks SET merged_into=? WHERE user_playbook_id=?", (b.user_playbook_id, a.user_playbook_id))
-    s.conn.execute("UPDATE user_playbooks SET merged_into=? WHERE user_playbook_id=?", (a.user_playbook_id, b.user_playbook_id))
+    s.conn.execute(
+        "UPDATE user_playbooks SET merged_into=? WHERE user_playbook_id=?",
+        (b.user_playbook_id, a.user_playbook_id),
+    )
+    s.conn.execute(
+        "UPDATE user_playbooks SET merged_into=? WHERE user_playbook_id=?",
+        (a.user_playbook_id, b.user_playbook_id),
+    )
     s.conn.commit()
     assert resolve_current(s, "user_playbook", a.user_playbook_id) is None

--- a/tests/server/services/lineage/test_resolve_current.py
+++ b/tests/server/services/lineage/test_resolve_current.py
@@ -1,0 +1,48 @@
+import pytest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.lineage.resolve import resolve_current
+from reflexio.models.api_schema.domain.entities import UserPlaybook, LineageContext
+from reflexio.models.api_schema.domain.enums import Status
+
+pytestmark = pytest.mark.integration
+
+
+def test_current_resolves_to_self(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    ref = resolve_current(s, "user_playbook", pb.user_playbook_id)
+    assert ref is not None and str(ref.id) == str(pb.user_playbook_id) and ref.is_purged is False
+
+
+def test_merged_resolves_to_survivor(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    surv = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="m")
+    src = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="o")
+    s.save_user_playbooks([surv, src])
+    s.merge_records(entity_type="user_playbook", survivor_id=str(surv.user_playbook_id),
+                    source_ids=[str(src.user_playbook_id)],
+                    context=LineageContext(op_kind="merge", actor="t", request_id="r"))
+    ref = resolve_current(s, "user_playbook", src.user_playbook_id)
+    assert str(ref.id) == str(surv.user_playbook_id)
+
+
+def test_purged_survivor_flagged(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="")  # blanked body
+    pb.status = Status.MERGED  # purged tombstone that points nowhere current -> itself, is_purged
+    s.save_user_playbooks([pb])
+    ref = resolve_current(s, "user_playbook", pb.user_playbook_id)
+    assert ref is not None and ref.is_purged is True
+
+
+def test_cycle_returns_none(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    a = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="a", status=Status.MERGED)
+    b = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="b", status=Status.MERGED)
+    s.save_user_playbooks([a, b])
+    # craft a cycle a->b->a via include-tombstone updates
+    s.conn.execute("UPDATE user_playbooks SET merged_into=? WHERE user_playbook_id=?", (b.user_playbook_id, a.user_playbook_id))
+    s.conn.execute("UPDATE user_playbooks SET merged_into=? WHERE user_playbook_id=?", (a.user_playbook_id, b.user_playbook_id))
+    s.conn.commit()
+    assert resolve_current(s, "user_playbook", a.user_playbook_id) is None

--- a/tests/server/services/playbook/test_apply_playbook_edit_integration.py
+++ b/tests/server/services/playbook/test_apply_playbook_edit_integration.py
@@ -1,0 +1,34 @@
+"""Integration tests for apply_playbook_edit() — atomic supersede path."""
+
+import pytest
+from reflexio.models.api_schema.domain.entities import UserPlaybook
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.playbook.playbook_edit_apply import apply_playbook_edit
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def test_apply_supersedes_incumbent_and_links(tmp_path):
+    s = SQLiteStorage(org_id="test_org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    inc = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v1")
+    s.save_user_playbooks([inc])
+    new = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v2")
+    new_id = apply_playbook_edit(s, incumbent_id=inc.user_playbook_id, new_playbook=new, source="offline_optimizer")
+    assert new_id > 0
+    tomb = s.get_user_playbook_by_id(inc.user_playbook_id, include_tombstones=True)
+    assert tomb.status is Status.SUPERSEDED and tomb.superseded_by == new_id
+
+
+def test_apply_no_orphan_when_incumbent_already_gone(tmp_path):
+    s = SQLiteStorage(org_id="test_org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    inc = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v1", status=Status.ARCHIVED)
+    s.save_user_playbooks([inc])
+    new = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v2")
+    rc = apply_playbook_edit(s, incumbent_id=inc.user_playbook_id, new_playbook=new, source="offline_optimizer")
+    assert rc == -1
+    # no orphan CURRENT row left behind
+    currents = [p for p in s.get_user_playbooks(user_id="u")]
+    assert all(p.content != "v2" for p in currents)

--- a/tests/server/services/playbook/test_consolidation_lineage_integration.py
+++ b/tests/server/services/playbook/test_consolidation_lineage_integration.py
@@ -1,0 +1,201 @@
+"""Integration test: consolidation merges route through atomic ``merge_records``.
+
+Drives the generation service's ``_finalize_extracted_items`` apply path against
+a real ``SQLiteStorage`` with the consolidation LLM step mocked to return ONE
+``unify`` decision ("merge new NEW-0 with existing EXISTING-0"). Asserts the
+lineage-aware outcome (Task 10):
+
+* the existing source becomes a ``MERGED`` tombstone with ``merged_into`` ->
+  survivor (not hard-deleted as in the legacy save-then-delete path),
+* a ``merge`` lineage event keyed on the survivor exists, and
+* ``resolve_current("user_playbook", old_id)`` returns the survivor id.
+
+Mirrors the real-SQLite + mocked-LLM fixture style of
+``test_playbook_consolidator_integration.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.lineage.resolve import resolve_current
+from reflexio.server.services.playbook.playbook_consolidator import (
+    PlaybookConsolidationOutput,
+    UnifyDecision,
+)
+from reflexio.server.services.playbook.playbook_generation_service import (
+    PlaybookGenerationService,
+    PlaybookGenerationServiceConfig,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def temp_storage_dir():
+    """Per-test temp directory for SQLite isolation."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+
+@pytest.fixture
+def sqlite_storage(temp_storage_dir, worker_id):
+    """Real SQLite storage in a per-test temp dir + per-worker org id."""
+    return SQLiteStorage(
+        org_id=f"test-consolidation-lineage-{worker_id}",
+        db_path=os.path.join(temp_storage_dir, "consolidation_lineage.db"),
+    )
+
+
+@pytest.fixture
+def request_context(sqlite_storage, temp_storage_dir, worker_id):
+    """RequestContext wired to real SQLite storage + a mocked prompt manager."""
+    context = RequestContext(
+        org_id=f"test-consolidation-lineage-{worker_id}",
+        storage_base_dir=temp_storage_dir,
+    )
+    context.storage = sqlite_storage
+    context.prompt_manager = MagicMock()
+    context.prompt_manager.render_prompt.return_value = "mock prompt"
+    context.configurator = MagicMock()
+    return context
+
+
+@pytest.fixture
+def generation_service(request_context):
+    """A PlaybookGenerationService with optimization/aggregation side effects stubbed."""
+    service = PlaybookGenerationService(
+        llm_client=MagicMock(), request_context=request_context
+    )
+    service.service_config = PlaybookGenerationServiceConfig(
+        request_id="req_merge",
+        agent_version="v0",
+        user_id="u1",
+        source="chat",
+    )
+    # Keep the test focused on the merge routing — stub the downstream side
+    # effects that need a fully-wired configurator / scheduler.
+    service._enqueue_user_playbook_optimization = MagicMock()  # type: ignore[method-assign]
+    service._trigger_playbook_aggregation = MagicMock()  # type: ignore[method-assign]
+    return service
+
+
+def _seed_existing(storage: SQLiteStorage) -> UserPlaybook:
+    """Insert one existing CURRENT user playbook and return the persisted row."""
+    pb = UserPlaybook(
+        user_playbook_id=0,
+        user_id="u1",
+        agent_version="v0",
+        request_id="r0",
+        playbook_name="default",
+        content="Recommend X.",
+        trigger="when Y",
+        rationale="r",
+        status=None,
+        source="chat",
+        source_interaction_ids=[],
+    )
+    storage.save_user_playbooks([pb])
+    saved = storage.get_user_playbooks(user_id="u1")
+    assert len(saved) == 1
+    return saved[0]
+
+
+def _candidate() -> UserPlaybook:
+    """Build a NEW (unpersisted) candidate user playbook."""
+    return UserPlaybook(
+        user_playbook_id=0,
+        user_id="u1",
+        agent_version="v0",
+        request_id="req_merge",
+        playbook_name="default",
+        content="Recommend X (canonical).",
+        trigger="when Y",
+        rationale="r",
+        status=None,
+        source="chat",
+        source_interaction_ids=[],
+    )
+
+
+def test_consolidation_merge_routes_through_merge_records(
+    sqlite_storage, generation_service
+):
+    """One ``unify`` decision tombstones the existing source into the survivor.
+
+    The legacy path hard-deleted the source (so it would be ``None`` even with
+    ``include_tombstones=True``). The lineage-aware path leaves a MERGED
+    tombstone whose ``merged_into`` points at the freshly-saved survivor, emits
+    a ``merge`` lineage event, and ``resolve_current`` follows the pointer.
+    """
+    existing = _seed_existing(sqlite_storage)
+    old_id = existing.user_playbook_id
+
+    decision_output = PlaybookConsolidationOutput(
+        decisions=[
+            UnifyDecision(
+                new_id="NEW-0",
+                archive_existing_ids=[0],
+                content="Recommend X (canonical).",
+                trigger="when Y",
+                rationale="merged",
+            )
+        ]
+    )
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
+            return_value=True,
+        ),
+        patch.object(
+            PlaybookGenerationService,
+            "_configured_playbook_config",
+            return_value=None,
+        ),
+        patch(
+            "reflexio.server.services.playbook.playbook_consolidator.PlaybookConsolidator._retrieve_existing_playbooks",
+            return_value=[existing],
+        ),
+        patch(
+            "reflexio.server.services.playbook.playbook_consolidator.PlaybookConsolidator._consolidation_decisions",
+            return_value=decision_output,
+        ),
+        patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}),
+    ):
+        generation_service._finalize_extracted_items([_candidate()])
+
+    # The survivor is the single surviving CURRENT row.
+    current = sqlite_storage.get_user_playbooks(user_id="u1")
+    assert len(current) == 1, [p.content for p in current]
+    survivor = current[0]
+    assert survivor.content == "Recommend X (canonical)."
+    assert survivor.user_playbook_id != old_id
+
+    # The old source is a MERGED tombstone pointing at the survivor — NOT
+    # hard-deleted (the legacy path would make this None).
+    tombstone = sqlite_storage.get_user_playbook_by_id(old_id, include_tombstones=True)
+    assert tombstone is not None, "source was hard-deleted, not tombstoned"
+    assert tombstone.status == Status.MERGED
+    assert tombstone.merged_into == survivor.user_playbook_id
+
+    # A merge lineage event keyed on the survivor exists.
+    events = sqlite_storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(survivor.user_playbook_id)
+    )
+    merge_events = [e for e in events if e.op == "merge"]
+    assert len(merge_events) == 1, events
+    assert str(old_id) in merge_events[0].source_ids
+
+    # resolve_current follows merged_into to the live survivor.
+    ref = resolve_current(sqlite_storage, "user_playbook", old_id)
+    assert ref is not None
+    assert ref.id == str(survivor.user_playbook_id)

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -292,7 +292,7 @@ class TestDeduplicate:
         fb2 = _make_user_playbook(1)
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "true"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb1], [fb2]], request_id="req1", agent_version="v1"
             )
 
@@ -302,7 +302,7 @@ class TestDeduplicate:
     def test_empty_results(self, mock_consolidator):
         """Test deduplication with no playbooks."""
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[]], request_id="req1", agent_version="v1"
             )
 
@@ -320,7 +320,7 @@ class TestDeduplicate:
         )
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb]], request_id="req1", agent_version="v1"
             )
 
@@ -360,7 +360,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -404,7 +404,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -441,7 +441,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=[],
             dedup_output=dedup_output,
@@ -472,7 +472,7 @@ class TestBuildDeduplicatedResults:
         )
 
         with caplog.at_level("WARNING"):
-            result, _ = mock_consolidator._build_deduplicated_results(
+            result, _, _ = mock_consolidator._build_deduplicated_results(
                 new_playbooks=new_playbooks,
                 existing_playbooks=[],
                 dedup_output=dedup_output,
@@ -535,7 +535,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, _ = mock_consolidator._build_deduplicated_results(
+        result, _, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=[],
             dedup_output=dedup_output,
@@ -556,7 +556,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -586,7 +586,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -613,7 +613,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -648,7 +648,7 @@ class TestBuildDeduplicatedResults:
             ],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -690,7 +690,7 @@ class TestBuildDeduplicatedResults:
             decisions=[IndependentDecision(new_id="NEW-0")],
         )
 
-        result, _ = mock_consolidator._build_deduplicated_results(
+        result, _, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=[],
             dedup_output=dedup_output,
@@ -739,7 +739,7 @@ class TestDeduplicateHappyPath:
         )
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb0], [fb1]], request_id="req_test", agent_version="v1"
             )
 
@@ -776,7 +776,7 @@ class TestDeduplicateHappyPath:
         )
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb0], [fb1], [fb2]], request_id="req_test", agent_version="v1"
             )
 
@@ -817,7 +817,7 @@ class TestDeduplicateHappyPath:
         )
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb0]], request_id="req_test", agent_version="v1"
             )
 
@@ -849,7 +849,7 @@ class TestBuildDeduplicatedResultsEdgeCases:
             decisions=[_unify("NEW-0", archive_existing_ids=[99])],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=[],
             dedup_output=dedup_output,
@@ -876,7 +876,7 @@ class TestBuildDeduplicatedResultsEdgeCases:
             decisions=[_unify("NEW-0", archive_existing_ids=[0], content="merged")],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -906,7 +906,7 @@ class TestBuildDeduplicatedResultsEdgeCases:
             decisions=[_unify("NEW-0", archive_existing_ids=[0], content="merged")],
         )
 
-        result, _ = mock_consolidator._build_deduplicated_results(
+        result, _, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
@@ -931,7 +931,7 @@ class TestBuildDeduplicatedResultsEdgeCases:
             decisions=[IndependentDecision(new_id="NEW-1")],
         )
 
-        result, _ = mock_consolidator._build_deduplicated_results(
+        result, _, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=[],
             dedup_output=dedup_output,
@@ -959,7 +959,7 @@ class TestBuildDeduplicatedResultsEdgeCases:
             decisions=[IndependentDecision(new_id="NEW-99")],
         )
 
-        result, delete_ids = mock_consolidator._build_deduplicated_results(
+        result, delete_ids, _ = mock_consolidator._build_deduplicated_results(
             new_playbooks=new_playbooks,
             existing_playbooks=[],
             dedup_output=dedup_output,
@@ -1024,7 +1024,7 @@ class TestMockModeCheck:
         fb = _make_user_playbook(0)
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "true"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb]], request_id="req1", agent_version="v1"
             )
 
@@ -1036,7 +1036,7 @@ class TestMockModeCheck:
         fb = _make_user_playbook(0)
 
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "True"}):
-            result, delete_ids = mock_consolidator.deduplicate(
+            result, delete_ids, _ = mock_consolidator.deduplicate(
                 results=[[fb]], request_id="req1", agent_version="v1"
             )
 
@@ -1055,7 +1055,7 @@ class TestMockModeCheck:
 
         fb = _make_user_playbook(0)
         with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
-            result, _ = mock_consolidator.deduplicate(
+            result, _, _ = mock_consolidator.deduplicate(
                 results=[[fb]], request_id="req1", agent_version="v1"
             )
 

--- a/tests/server/services/playbook/test_playbook_consolidator_integration.py
+++ b/tests/server/services/playbook/test_playbook_consolidator_integration.py
@@ -202,6 +202,12 @@ def _run_consolidator(
 ) -> tuple[list[UserPlaybook], list[int]]:
     """Drive ``deduplicate`` with a scripted LLM response and pre-fetched existing rows.
 
+    ``deduplicate`` returns a 3-tuple ``(rows, archive_ids, merge_groups)``; the
+    apply-path tests in this file assert only on ``(rows, archive_ids)``, so the
+    merge-group element is dropped here. Merge-group routing through
+    ``merge_records`` is covered by
+    ``test_consolidation_lineage_integration.py``.
+
     Patches ``_retrieve_existing_playbooks`` so the LLM-mock decisions can
     reference EXISTING-N ids by position without depending on the search
     backend's ranking.
@@ -228,11 +234,12 @@ def _run_consolidator(
         ),
         patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}),
     ):
-        return consolidator.deduplicate(
+        rows, archive_ids, _merge_groups = consolidator.deduplicate(
             results=[candidates],
             request_id=request_id,
             agent_version="v0",
         )
+    return rows, archive_ids
 
 
 def _apply_to_storage(

--- a/tests/server/services/playbook/test_playbook_edit_apply.py
+++ b/tests/server/services/playbook/test_playbook_edit_apply.py
@@ -93,7 +93,6 @@ def test_apply_expect_current_false_archives():
                 incumbent_id=old_id,
                 new_playbook=new,
                 source="offline_optimizer",
-                expect_current=False,
             )
         assert new_id > 0
 
@@ -131,7 +130,6 @@ def test_apply_expect_current_false_returns_minus1_and_no_orphan():
                 incumbent_id=old_id,
                 new_playbook=new,
                 source="offline_optimizer",
-                expect_current=False,
             )
         # supersede_record returned False → -1, successor cleaned up (no orphan)
         assert new_id == -1

--- a/tests/server/services/playbook/test_playbook_edit_apply.py
+++ b/tests/server/services/playbook/test_playbook_edit_apply.py
@@ -71,3 +71,70 @@ def test_apply_skips_archive_when_incumbent_not_current():
             )
         # Optimistic-concurrency: incumbent was already archived → skip and return -1
         assert new_id == -1
+
+
+def test_apply_expect_current_false_archives():
+    """With expect_current=False, new playbook is inserted and incumbent is archived."""
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+            assert old_id > 0
+
+            new = _playbook(content="new")
+            new_id = apply_playbook_edit(
+                s,
+                incumbent_id=old_id,
+                new_playbook=new,
+                source="offline_optimizer",
+                expect_current=False,
+            )
+        assert new_id > 0
+
+        # Only new_id should be CURRENT (status=None); old_id should be archived
+        all_pbs = s.get_user_playbooks(user_id="u1")
+        current_ids = {p.user_playbook_id for p in all_pbs if p.status is None}
+        assert new_id in current_ids
+        assert old_id not in current_ids
+
+
+def test_apply_expect_current_false_returns_minus1_when_archive_fails():
+    """With expect_current=False, if archive fails the new playbook remains CURRENT (orphan)."""
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+            assert old_id > 0
+
+            # Archive first, so archive_user_playbook_by_id will fail on second call
+            s.archive_user_playbook_by_id(user_id="u1", user_playbook_id=old_id)
+
+            new = _playbook(content="new")
+            new_id = apply_playbook_edit(
+                s,
+                incumbent_id=old_id,
+                new_playbook=new,
+                source="offline_optimizer",
+                expect_current=False,
+            )
+        # Archive fails, new playbook inserted but remains CURRENT (orphan)
+        assert new_id == -1
+
+        # Verify new playbook was inserted and is CURRENT (orphan)
+        all_pbs = s.get_user_playbooks(user_id="u1")
+        current_ids = {p.user_playbook_id for p in all_pbs if p.status is None}
+        # The new playbook ID would be old_id + 1 (or next available)
+        # Just verify there's at least one CURRENT playbook (the orphan)
+        assert len(current_ids) > 0

--- a/tests/server/services/playbook/test_playbook_edit_apply.py
+++ b/tests/server/services/playbook/test_playbook_edit_apply.py
@@ -104,8 +104,12 @@ def test_apply_expect_current_false_archives():
         assert old_id not in current_ids
 
 
-def test_apply_expect_current_false_returns_minus1_when_archive_fails():
-    """With expect_current=False, if archive fails the new playbook remains CURRENT (orphan)."""
+def test_apply_expect_current_false_returns_minus1_and_no_orphan():
+    """When incumbent is already archived, supersede_record returns False.
+
+    The new code deletes the just-inserted successor so no orphan CURRENT row
+    remains — the -1 return value indicates the lost race, not an orphan.
+    """
     from reflexio.server.services.playbook.playbook_edit_apply import (
         apply_playbook_edit,
     )
@@ -118,7 +122,7 @@ def test_apply_expect_current_false_returns_minus1_when_archive_fails():
             old_id = old.user_playbook_id
             assert old_id > 0
 
-            # Archive first, so archive_user_playbook_by_id will fail on second call
+            # Archive first so supersede_record will return False
             s.archive_user_playbook_by_id(user_id="u1", user_playbook_id=old_id)
 
             new = _playbook(content="new")
@@ -129,12 +133,10 @@ def test_apply_expect_current_false_returns_minus1_when_archive_fails():
                 source="offline_optimizer",
                 expect_current=False,
             )
-        # Archive fails, new playbook inserted but remains CURRENT (orphan)
+        # supersede_record returned False → -1, successor cleaned up (no orphan)
         assert new_id == -1
 
-        # Verify new playbook was inserted and is CURRENT (orphan)
+        # No orphan: the inserted successor was deleted
         all_pbs = s.get_user_playbooks(user_id="u1")
         current_ids = {p.user_playbook_id for p in all_pbs if p.status is None}
-        # The new playbook ID would be old_id + 1 (or next available)
-        # Just verify there's at least one CURRENT playbook (the orphan)
-        assert len(current_ids) > 0
+        assert len(current_ids) == 0

--- a/tests/server/services/playbook/test_playbook_edit_apply.py
+++ b/tests/server/services/playbook/test_playbook_edit_apply.py
@@ -1,0 +1,73 @@
+"""Tests for apply_playbook_edit() — the shared archive+insert primitive."""
+
+import tempfile
+from unittest.mock import patch
+
+from reflexio.models.api_schema.domain.entities import UserPlaybook
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+def _storage(tmp: str) -> SQLiteStorage:
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        return SQLiteStorage(org_id="org_apply_1", db_path=f"{tmp}/t.db")
+
+
+def _playbook(user_id: str = "u1", content: str = "old") -> UserPlaybook:
+    return UserPlaybook(
+        user_id=user_id,
+        agent_version="v1",
+        request_id="req_test",
+        playbook_name="refund",
+        content=content,
+        trigger="refund",
+    )
+
+
+def test_apply_inserts_new_and_archives_incumbent():
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+            assert old_id > 0
+
+            new = _playbook(content="new")
+            new_id = apply_playbook_edit(
+                s, incumbent_id=old_id, new_playbook=new, source="offline_optimizer"
+            )
+        assert new_id > 0
+
+        # Only new_id should be CURRENT (status=None); old_id should be archived
+        all_pbs = s.get_user_playbooks(user_id="u1")
+        current_ids = {p.user_playbook_id for p in all_pbs if p.status is None}
+        assert new_id in current_ids
+        assert old_id not in current_ids
+
+
+def test_apply_skips_archive_when_incumbent_not_current():
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+            assert old_id > 0
+
+            # Someone else archived it first
+            s.archive_user_playbook_by_id(user_id="u1", user_playbook_id=old_id)
+
+            new = _playbook(content="new")
+            new_id = apply_playbook_edit(
+                s, incumbent_id=old_id, new_playbook=new, source="offline_optimizer"
+            )
+        # Optimistic-concurrency: incumbent was already archived → skip and return -1
+        assert new_id == -1

--- a/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
+++ b/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
@@ -1,0 +1,211 @@
+"""Integration tests for the optimizer's atomic supersede helpers.
+
+Tests the ``_supersede_user_playbook`` and ``_supersede_agent_playbook`` helpers
+that were extracted from ``PlaybookOptimizer._commit_if_allowed`` as part of the
+lineage Phase A work.  These helpers are unit-tested directly against a real
+SQLite storage so no full PlaybookOptimizer construction is needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from reflexio.models.api_schema.domain import (
+    AgentPlaybook,
+    PlaybookStatus,
+    UserPlaybook,
+)
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.playbook_optimizer.optimizer import (
+    _supersede_agent_playbook,
+    _supersede_user_playbook,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _storage(tmp_path):
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage = SQLiteStorage(
+            org_id="opt-test", db_path=str(tmp_path / "reflexio.db")
+        )
+    storage._get_embedding = Mock(return_value=[0.0] * 512)  # noqa: SLF001
+    storage.llm_client.get_embeddings = Mock(return_value=[[0.0] * 512])
+    return storage
+
+
+# ---------------------------------------------------------------------------
+# User-playbook supersede helper
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_user_playbook_sets_superseded_by_and_revise_event(tmp_path):
+    """Happy path: incumbent becomes SUPERSEDED with superseded_by set; a revise lineage event is recorded."""
+    storage = _storage(tmp_path)
+    incumbent = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="req-1",
+        playbook_name="support",
+        content="old content",
+    )
+    storage.save_user_playbooks([incumbent])
+    incumbent_id = incumbent.user_playbook_id
+
+    result = _supersede_user_playbook(
+        storage, incumbent, "new content", "playbook_optimizer"
+    )
+
+    assert result is not None, "helper should return the successor id on success"
+
+    # Incumbent must now be SUPERSEDED
+    row = storage.conn.execute(
+        "SELECT status, superseded_by FROM user_playbooks WHERE user_playbook_id=?",
+        (incumbent_id,),
+    ).fetchone()
+    assert row["status"] == Status.SUPERSEDED.value
+    assert int(row["superseded_by"]) == result
+
+    # Successor must be CURRENT (status IS NULL)
+    successor_row = storage.conn.execute(
+        "SELECT status, content FROM user_playbooks WHERE user_playbook_id=?",
+        (result,),
+    ).fetchone()
+    assert successor_row["status"] is None
+    assert successor_row["content"] == "new content"
+
+    # A revise lineage event must exist for the successor
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(result)
+    )
+    assert len(events) == 1
+    assert events[0].op == "revise"
+    assert events[0].actor == "playbook_optimizer"
+    assert str(incumbent_id) in events[0].source_ids
+
+
+def test_supersede_user_playbook_returns_none_for_non_current_incumbent(tmp_path):
+    """If the incumbent is already SUPERSEDED (not CURRENT), the helper returns None and leaves no orphan."""
+    storage = _storage(tmp_path)
+    # Create an already-archived/superseded incumbent by inserting and immediately archiving
+    incumbent = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="req-2",
+        playbook_name="support",
+        content="stale content",
+        status=Status.ARCHIVED,  # not CURRENT
+    )
+    storage.save_user_playbooks([incumbent])
+
+    playbooks_before = storage.conn.execute(
+        "SELECT COUNT(*) as cnt FROM user_playbooks"
+    ).fetchone()["cnt"]
+
+    result = _supersede_user_playbook(
+        storage, incumbent, "new content", "playbook_optimizer"
+    )
+
+    assert result is None, "helper should return None when incumbent is not CURRENT"
+
+    # No orphan successor should have been left behind
+    playbooks_after = storage.conn.execute(
+        "SELECT COUNT(*) as cnt FROM user_playbooks"
+    ).fetchone()["cnt"]
+    assert playbooks_after == playbooks_before, "no orphan row should remain"
+
+    # No lineage events should exist
+    events = storage.get_lineage_events(entity_type="user_playbook")
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Agent-playbook supersede helper
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_agent_playbook_sets_superseded_by_and_revise_event(tmp_path):
+    """Happy path: agent incumbent becomes SUPERSEDED with superseded_by set; a revise lineage event is recorded."""
+    storage = _storage(tmp_path)
+    [incumbent] = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="old agent content",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+    incumbent_id = incumbent.agent_playbook_id
+
+    result = _supersede_agent_playbook(
+        storage, incumbent, "new agent content", "playbook_optimizer"
+    )
+
+    assert result is not None, "helper should return the successor id on success"
+
+    # Incumbent must now be SUPERSEDED
+    row = storage.conn.execute(
+        "SELECT status, superseded_by FROM agent_playbooks WHERE agent_playbook_id=?",
+        (incumbent_id,),
+    ).fetchone()
+    assert row["status"] == Status.SUPERSEDED.value
+    assert int(row["superseded_by"]) == result
+
+    # Successor must be CURRENT (status IS NULL)
+    successor_row = storage.conn.execute(
+        "SELECT status, content FROM agent_playbooks WHERE agent_playbook_id=?",
+        (result,),
+    ).fetchone()
+    assert successor_row["status"] is None
+    assert successor_row["content"] == "new agent content"
+
+    # A revise lineage event must exist for the successor
+    events = storage.get_lineage_events(
+        entity_type="agent_playbook", entity_id=str(result)
+    )
+    assert len(events) == 1
+    assert events[0].op == "revise"
+    assert events[0].actor == "playbook_optimizer"
+    assert str(incumbent_id) in events[0].source_ids
+
+
+def test_supersede_agent_playbook_returns_none_for_non_current_incumbent(tmp_path):
+    """If the agent incumbent is already SUPERSEDED, the helper returns None and leaves no orphan."""
+    storage = _storage(tmp_path)
+    # Insert a playbook then mark it as superseded manually so it is not CURRENT
+    [incumbent] = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="stale agent content",
+                playbook_status=PlaybookStatus.PENDING,
+                status=Status.ARCHIVED,  # not CURRENT
+            )
+        ]
+    )
+
+    agent_playbooks_before = storage.conn.execute(
+        "SELECT COUNT(*) as cnt FROM agent_playbooks"
+    ).fetchone()["cnt"]
+
+    result = _supersede_agent_playbook(
+        storage, incumbent, "new agent content", "playbook_optimizer"
+    )
+
+    assert result is None, "helper should return None when incumbent is not CURRENT"
+
+    agent_playbooks_after = storage.conn.execute(
+        "SELECT COUNT(*) as cnt FROM agent_playbooks"
+    ).fetchone()["cnt"]
+    assert agent_playbooks_after == agent_playbooks_before, (
+        "no orphan row should remain"
+    )
+
+    events = storage.get_lineage_events(entity_type="agent_playbook")
+    assert events == []

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -369,14 +369,14 @@ class TestReplacePlaybook:
         assert result.revised_count == 1
 
         current = storage.get_user_playbooks(user_id="u1", status_filter=[None])
-        archived = storage.get_user_playbooks(
-            user_id="u1", status_filter=[Status.ARCHIVED]
+        superseded = storage.get_user_playbooks(
+            user_id="u1", status_filter=[Status.SUPERSEDED]
         )
         assert len(current) == 1
-        assert len(archived) == 1
+        assert len(superseded) == 1
         assert current[0].user_playbook_id != 1
         assert current[0].content == "new rule"
-        # Trigger falls back to archived row's value; rationale is the supplied one.
+        # Trigger falls back to superseded row's value; rationale is the supplied one.
         assert current[0].trigger == "when X"
         assert current[0].rationale == "rewritten because Y was wrong"
         assert current[0].user_id == "u1"
@@ -686,7 +686,7 @@ class TestArchiveAfterInsertFailure:
         with (
             patch.object(
                 storage,
-                "archive_user_playbook_by_id",
+                "supersede_record",
                 side_effect=RuntimeError("disk full"),
             ),
             caplog.at_level(
@@ -698,7 +698,7 @@ class TestArchiveAfterInsertFailure:
         assert result.ran is True
         assert result.revised_count == 1
 
-        # Both rows still current — transient duplicate.
+        # Both rows still current — transient duplicate (supersede raised before cleanup).
         current = storage.get_user_playbooks(user_id="u1", status_filter=[None])
         assert len(current) == 2
         assert {p.content for p in current} == {"old rule", "new rule"}
@@ -762,14 +762,14 @@ class TestLLMReportedFlip:
         assert not hasattr(result, "flipped_count")
 
         current = storage.get_user_playbooks(user_id="u1", status_filter=[None])
-        archived = storage.get_user_playbooks(
-            user_id="u1", status_filter=[Status.ARCHIVED]
+        superseded = storage.get_user_playbooks(
+            user_id="u1", status_filter=[Status.SUPERSEDED]
         )
         assert len(current) == 1
-        assert len(archived) == 1
+        assert len(superseded) == 1
         assert current[0].content == "Avoid X when Y."
         assert current[0].rationale == "user pushed back when X was recommended"
-        assert archived[0].user_playbook_id == 1
+        assert superseded[0].user_playbook_id == 1
 
     def test_content_revision_without_rationale_counts_as_failed(
         self, request_context, service, llm_client
@@ -924,11 +924,11 @@ class TestPerPassCap:
         assert result.ran is True
         assert result.revised_count == 2
         assert result.capped_count == 1
-        # Exactly two archives happened.
-        archived = storage.get_user_playbooks(
-            user_id="u1", status_filter=[Status.ARCHIVED]
+        # Exactly two supersedes happened.
+        superseded = storage.get_user_playbooks(
+            user_id="u1", status_filter=[Status.SUPERSEDED]
         )
-        assert len(archived) == 2
+        assert len(superseded) == 2
 
     def test_no_change_decisions_do_not_count_against_cap(
         self, request_context, service, llm_client

--- a/tests/server/services/storage/test_hard_delete_events_integration.py
+++ b/tests/server/services/storage/test_hard_delete_events_integration.py
@@ -1,0 +1,16 @@
+import pytest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.models.api_schema.domain.entities import UserPlaybook
+
+pytestmark = pytest.mark.integration
+
+
+def test_hard_delete_emits_event_then_removes_row(tmp_path):
+    s = SQLiteStorage(org_id="org-test", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.delete_user_playbooks_by_ids([pb.user_playbook_id])
+    assert s.get_user_playbook_by_id(pb.user_playbook_id, include_tombstones=True) is None
+    events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert any(e.op == "hard_delete" for e in events)

--- a/tests/server/services/storage/test_lineage_contract.py
+++ b/tests/server/services/storage/test_lineage_contract.py
@@ -1,0 +1,68 @@
+"""Storage contract tests for the lineage mixin.
+
+Parametrized over locally-testable backends via the shared ``storage`` fixture
+in conftest.py (currently SQLite only).  Enterprise backends (postgres/supabase)
+are added in Task 12 when their gated suite is built.
+"""
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import (
+    LineageContext,
+    LineageEvent,
+    UserPlaybook,
+)
+from reflexio.models.api_schema.domain.enums import Status
+
+pytestmark = pytest.mark.integration
+
+
+def test_append_idempotent(storage) -> None:
+    """Calling append_lineage_event twice with the same event returns the same id."""
+    event = LineageEvent(
+        org_id=storage.org_id,
+        entity_type="user_playbook",
+        entity_id="X",
+        op="merge",
+        source_ids=["Y"],
+        request_id="r-idempotent",
+    )
+    first = storage.append_lineage_event(event)
+    second = storage.append_lineage_event(event)
+    assert first == second
+
+
+def test_merge_sets_pointer_tombstone_and_event(storage) -> None:
+    """merge_records sets status+merged_into on the source and appends a merge event."""
+    survivor = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-merge-survivor",
+        content="survivor content",
+    )
+    source = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-merge-source",
+        content="source content",
+    )
+    storage.save_user_playbooks([survivor, source])
+
+    storage.merge_records(
+        entity_type="user_playbook",
+        survivor_id=str(survivor.user_playbook_id),
+        source_ids=[str(source.user_playbook_id)],
+        context=LineageContext(op_kind="merge", actor="test", request_id="r-merge"),
+    )
+
+    # Source row must be tombstoned with a back-pointer to the survivor.
+    tombstone = storage.get_user_playbook_by_id(
+        source.user_playbook_id, include_tombstones=True
+    )
+    assert tombstone is not None
+    assert tombstone.status is Status.MERGED
+    assert str(tombstone.merged_into) == str(survivor.user_playbook_id)
+
+    # A merge event must be recorded against the survivor's id.
+    events = storage.get_lineage_events(entity_id=str(survivor.user_playbook_id))
+    assert any(e.op == "merge" for e in events)

--- a/tests/server/services/storage/test_lineage_contract.py
+++ b/tests/server/services/storage/test_lineage_contract.py
@@ -30,6 +30,11 @@ def test_append_idempotent(storage) -> None:
     first = storage.append_lineage_event(event)
     second = storage.append_lineage_event(event)
     assert first == second
+    # F012: the duplicate must not create a second row.
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id="X"
+    )
+    assert len(events) == 1
 
 
 def test_merge_sets_pointer_tombstone_and_event(storage) -> None:
@@ -66,3 +71,65 @@ def test_merge_sets_pointer_tombstone_and_event(storage) -> None:
     # A merge event must be recorded against the survivor's id.
     events = storage.get_lineage_events(entity_id=str(survivor.user_playbook_id))
     assert any(e.op == "merge" for e in events)
+
+
+def test_merge_multi_source_skips_already_tombstoned(storage) -> None:
+    """F013: merging a CURRENT + an already-MERGED source tombstones only the CURRENT one.
+
+    The already-MERGED source keeps its original ``merged_into`` (it is skipped by
+    the guard, not re-pointed), no error is raised, and exactly one merge event is
+    recorded for the survivor.
+    """
+    survivor = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-multi-survivor",
+        content="survivor content",
+    )
+    current_source = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-multi-current",
+        content="current source",
+    )
+    # Pre-tombstoned source already merged into some OTHER id (999).
+    already_merged = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-multi-old",
+        content="already merged",
+        status=Status.MERGED,
+        merged_into=999,
+    )
+    storage.save_user_playbooks([survivor, current_source, already_merged])
+
+    storage.merge_records(
+        entity_type="user_playbook",
+        survivor_id=str(survivor.user_playbook_id),
+        source_ids=[
+            str(current_source.user_playbook_id),
+            str(already_merged.user_playbook_id),
+        ],
+        context=LineageContext(op_kind="merge", actor="test", request_id="r-multi"),
+    )
+
+    # The CURRENT source is now MERGED into the survivor.
+    current_tomb = storage.get_user_playbook_by_id(
+        current_source.user_playbook_id, include_tombstones=True
+    )
+    assert current_tomb is not None
+    assert current_tomb.status is Status.MERGED
+    assert str(current_tomb.merged_into) == str(survivor.user_playbook_id)
+
+    # The already-MERGED source is left intact (still points at 999, not the survivor).
+    skipped = storage.get_user_playbook_by_id(
+        already_merged.user_playbook_id, include_tombstones=True
+    )
+    assert skipped is not None
+    assert skipped.status is Status.MERGED
+    assert skipped.merged_into == 999
+
+    # Exactly one merge event for the survivor.
+    events = storage.get_lineage_events(entity_id=str(survivor.user_playbook_id))
+    merge_events = [e for e in events if e.op == "merge"]
+    assert len(merge_events) == 1

--- a/tests/server/services/storage/test_sqlite_base_status_filter_integration.py
+++ b/tests/server/services/storage/test_sqlite_base_status_filter_integration.py
@@ -1,0 +1,88 @@
+"""Integration tests for Task 3: tombstone status filtering in SQLite storage."""
+
+import pytest
+from reflexio.models.api_schema.service_schemas import Status, UserPlaybook
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _seed(tmp_path):
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    cur = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="cur")
+    tomb = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="r1",
+        content="old",
+        status=Status.MERGED,
+        merged_into=0,
+    )
+    s.save_user_playbooks([cur, tomb])
+    return s, cur.user_playbook_id, tomb.user_playbook_id
+
+
+def test_default_reads_exclude_tombstones(tmp_path):
+    s, cur_id, tomb_id = _seed(tmp_path)
+    ids = {p.user_playbook_id for p in s.get_user_playbooks(user_id="u1")}
+    assert cur_id in ids and tomb_id not in ids
+    assert s.count_user_playbooks(user_id="u1") == 1
+
+
+def test_get_by_id_excludes_tombstone_by_default_but_include_flag_returns_it(tmp_path):
+    s, cur_id, tomb_id = _seed(tmp_path)
+    assert s.get_user_playbook_by_id(tomb_id) is None
+    got = s.get_user_playbook_by_id(tomb_id, include_tombstones=True)
+    assert got is not None and got.status is Status.MERGED
+
+
+def test_superseded_tombstone_also_excluded_by_default(tmp_path):
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    superseded = UserPlaybook(
+        user_id="u2",
+        agent_version="v1",
+        request_id="r2",
+        content="old",
+        status=Status.SUPERSEDED,
+        superseded_by=99,
+    )
+    s.save_user_playbooks([superseded])
+    ids = {p.user_playbook_id for p in s.get_user_playbooks(user_id="u2")}
+    assert superseded.user_playbook_id not in ids
+    assert s.count_user_playbooks(user_id="u2") == 0
+
+
+def test_get_profile_by_id_excludes_tombstone_by_default(tmp_path):
+    """get_profile_by_id should hide MERGED profiles unless include_tombstones=True."""
+    from reflexio.models.api_schema.service_schemas import UserProfile, ProfileTimeToLive
+    import time
+
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    now = int(time.time())
+    far_future = now + 10_000_000
+    tomb_profile = UserProfile(
+        profile_id="profile-tomb-1",
+        user_id="u3",
+        content="old profile",
+        last_modified_timestamp=now,
+        generated_from_request_id="req-tomb-1",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        expiration_timestamp=far_future,
+        status=Status.MERGED,
+        merged_into="some-other-id",
+    )
+    s.add_user_profile("u3", [tomb_profile])
+
+    # Default: should return None (tombstone hidden)
+    result = s.get_profile_by_id(tomb_profile.profile_id)
+    assert result is None
+
+    # With flag: should return the tombstone
+    result_with_flag = s.get_profile_by_id(
+        tomb_profile.profile_id, include_tombstones=True
+    )
+    assert result_with_flag is not None
+    assert result_with_flag.status is Status.MERGED

--- a/tests/server/services/storage/test_sqlite_base_status_filter_integration.py
+++ b/tests/server/services/storage/test_sqlite_base_status_filter_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for Task 3: tombstone status filtering in SQLite storage."""
 
 import pytest
+
 from reflexio.models.api_schema.service_schemas import Status, UserPlaybook
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
@@ -54,10 +55,52 @@ def test_superseded_tombstone_also_excluded_by_default(tmp_path):
     assert s.count_user_playbooks(user_id="u2") == 0
 
 
+def test_get_agent_playbook_by_id_excludes_tombstone_by_default(tmp_path):
+    """F006: get_agent_playbook_by_id hides MERGED agent playbooks unless include_tombstones=True."""
+    from reflexio.models.api_schema.domain import AgentPlaybook, PlaybookStatus
+
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    [cur] = s.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="current",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+    [tomb] = s.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="old",
+                playbook_status=PlaybookStatus.PENDING,
+                status=Status.MERGED,
+                merged_into=cur.agent_playbook_id,
+            )
+        ]
+    )
+
+    # Default: tombstone hidden, current visible.
+    assert s.get_agent_playbook_by_id(tomb.agent_playbook_id) is None
+    assert s.get_agent_playbook_by_id(cur.agent_playbook_id) is not None
+
+    # With flag: tombstone returned.
+    got = s.get_agent_playbook_by_id(tomb.agent_playbook_id, include_tombstones=True)
+    assert got is not None and got.status is Status.MERGED
+
+
 def test_get_profile_by_id_excludes_tombstone_by_default(tmp_path):
     """get_profile_by_id should hide MERGED profiles unless include_tombstones=True."""
-    from reflexio.models.api_schema.service_schemas import UserProfile, ProfileTimeToLive
     import time
+
+    from reflexio.models.api_schema.service_schemas import (
+        ProfileTimeToLive,
+        UserProfile,
+    )
 
     s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
     s.migrate()

--- a/tests/server/services/storage/test_sqlite_lineage_columns_integration.py
+++ b/tests/server/services/storage/test_sqlite_lineage_columns_integration.py
@@ -1,6 +1,15 @@
+import time
+
 import pytest
+
+from reflexio.models.api_schema.domain import AgentPlaybook, PlaybookStatus
+from reflexio.models.api_schema.domain.entities import (
+    ProfileTimeToLive,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
-from reflexio.models.api_schema.domain.entities import UserPlaybook
 
 pytestmark = pytest.mark.integration
 
@@ -13,3 +22,48 @@ def test_user_playbook_pointers_roundtrip(tmp_path):
     s.save_user_playbooks([pb])
     got = s.get_user_playbook_by_id(pb.user_playbook_id)
     assert got is not None and got.merged_into == 42 and got.superseded_by is None
+
+
+def test_agent_playbook_pointers_roundtrip(tmp_path):
+    """F007: agent_playbook merged_into/superseded_by survive save -> _row_to_agent_playbook."""
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    [ap] = s.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="c",
+                playbook_status=PlaybookStatus.PENDING,
+                status=Status.SUPERSEDED,
+                merged_into=7,
+                superseded_by=11,
+            )
+        ]
+    )
+    got = s.get_agent_playbook_by_id(ap.agent_playbook_id, include_tombstones=True)
+    assert got is not None and got.merged_into == 7 and got.superseded_by == 11
+
+
+def test_profile_pointers_roundtrip(tmp_path):
+    """F007: profile merged_into/superseded_by (TEXT) survive save -> _row_to_profile."""
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    now = int(time.time())
+    profile = UserProfile(
+        profile_id="profile-ptr-1",
+        user_id="u1",
+        content="p",
+        last_modified_timestamp=now,
+        generated_from_request_id="req-ptr-1",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        expiration_timestamp=now + 10_000_000,
+        status=Status.SUPERSEDED,
+        merged_into="survivor-profile-id",
+        superseded_by="successor-profile-id",
+    )
+    s.add_user_profile("u1", [profile])
+    got = s.get_profile_by_id(profile.profile_id, include_tombstones=True)
+    assert got is not None
+    assert got.merged_into == "survivor-profile-id"
+    assert got.superseded_by == "successor-profile-id"

--- a/tests/server/services/storage/test_sqlite_lineage_columns_integration.py
+++ b/tests/server/services/storage/test_sqlite_lineage_columns_integration.py
@@ -1,0 +1,15 @@
+import pytest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.models.api_schema.domain.entities import UserPlaybook
+
+pytestmark = pytest.mark.integration
+
+
+def test_user_playbook_pointers_roundtrip(tmp_path):
+    s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    pb = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1",
+                      content="c", merged_into=42, superseded_by=None)
+    s.save_user_playbooks([pb])
+    got = s.get_user_playbook_by_id(pb.user_playbook_id)
+    assert got is not None and got.merged_into == 42 and got.superseded_by is None

--- a/tests/server/services/storage/test_sqlite_lineage_event_integration.py
+++ b/tests/server/services/storage/test_sqlite_lineage_event_integration.py
@@ -1,0 +1,40 @@
+import pytest
+
+from reflexio.models.api_schema.domain.entities import LineageEvent
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _evt(**kw):
+    base = {
+        "org_id": "org-42",
+        "entity_type": "user_playbook",
+        "entity_id": "UP-1",
+        "op": "merge",
+        "prov_relation": "wasDerivedFrom",
+        "source_ids": ["UP-1"],
+        "actor": "consolidator",
+        "request_id": "req-7",
+        "reason": "dup",
+    }
+    base.update(kw)
+    return LineageEvent(**base)
+
+
+def test_append_then_get(tmp_path):
+    s = SQLiteStorage(org_id="org-42", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    eid = s.append_lineage_event(_evt())
+    assert eid > 0
+    rows = s.get_lineage_events(entity_type="user_playbook", entity_id="UP-1")
+    assert len(rows) == 1 and rows[0].op == "merge" and rows[0].created_at > 0
+
+
+def test_append_is_idempotent_on_unique_key(tmp_path):
+    s = SQLiteStorage(org_id="org-42", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    first = s.append_lineage_event(_evt())
+    again = s.append_lineage_event(_evt())  # same (entity_id, op, request_id)
+    assert first == again
+    assert len(s.get_lineage_events(entity_id="UP-1")) == 1

--- a/tests/server/services/storage/test_sqlite_merge_records_integration.py
+++ b/tests/server/services/storage/test_sqlite_merge_records_integration.py
@@ -1,13 +1,15 @@
 import pytest
-from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
-from reflexio.models.api_schema.domain.entities import UserPlaybook, LineageContext
+
+from reflexio.models.api_schema.domain.entities import LineageContext, UserPlaybook
 from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
 
 
 def test_merge_records_tombstones_sources_sets_pointer_and_logs(tmp_path):
-    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
     survivor = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="merged")
     src = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="old")
     s.save_user_playbooks([survivor, src])
@@ -24,7 +26,8 @@ def test_merge_records_tombstones_sources_sets_pointer_and_logs(tmp_path):
 
 
 def test_supersede_returns_false_when_incumbent_not_current(tmp_path):
-    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
     inc = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="v1",
                        status=Status.ARCHIVED)
     succ = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="v2")

--- a/tests/server/services/storage/test_sqlite_merge_records_integration.py
+++ b/tests/server/services/storage/test_sqlite_merge_records_integration.py
@@ -1,0 +1,35 @@
+import pytest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.models.api_schema.domain.entities import UserPlaybook, LineageContext
+from reflexio.models.api_schema.domain.enums import Status
+
+pytestmark = pytest.mark.integration
+
+
+def test_merge_records_tombstones_sources_sets_pointer_and_logs(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    survivor = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="merged")
+    src = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="old")
+    s.save_user_playbooks([survivor, src])
+    ctx = LineageContext(op_kind="merge", actor="consolidator", source_ids=[str(src.user_playbook_id)],
+                         reason="dup", request_id="r1")
+    s.merge_records(entity_type="user_playbook", survivor_id=str(survivor.user_playbook_id),
+                    source_ids=[str(src.user_playbook_id)], context=ctx)
+    tomb = s.get_user_playbook_by_id(src.user_playbook_id, include_tombstones=True)
+    assert tomb.status is Status.MERGED and tomb.merged_into == survivor.user_playbook_id
+    events = s.get_lineage_events(entity_id=str(survivor.user_playbook_id))
+    assert any(e.op == "merge" for e in events)
+    # survivor still current
+    assert s.get_user_playbook_by_id(survivor.user_playbook_id) is not None
+
+
+def test_supersede_returns_false_when_incumbent_not_current(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db")); s.migrate()
+    inc = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="v1",
+                       status=Status.ARCHIVED)
+    succ = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="v2")
+    s.save_user_playbooks([inc, succ])
+    ctx = LineageContext(op_kind="revise", actor="optimizer", request_id="r1")
+    ok = s.supersede_record(entity_type="user_playbook", incumbent_id=str(inc.user_playbook_id),
+                            successor_id=str(succ.user_playbook_id), context=ctx)
+    assert ok is False  # incumbent wasn't CURRENT — atomic guard rejects


### PR DESCRIPTION
## Lineage Phase A — OSS / SQLite half

Adds a **content-free lineage/provenance layer** so that when a user playbook / agent playbook / profile is **merged or superseded**, references resolve **forward to the survivor** instead of dangling. This is the OSS (shared, SQLite) half; the enterprise Postgres+Supabase half is in the corresponding `reflexio-enterprise` PR.

### What's here
- **Data model:** `MERGED`/`SUPERSEDED` statuses; `merged_into`/`superseded_by` pointers on the three entity types; a content-free, append-only `lineage_event` table (`UNIQUE(entity_id, op, request_id)` idempotency); `LineageEvent`/`LineageContext`/`RecordRef` models.
- **Atomic primitive:** `merge_records` / `supersede_record` — row mutation + forward pointer + one `lineage_event`, in a single `with self._lock:` transaction (no `_execute_atomic` helper exists; uses the `delete_user_playbooks_by_ids` pattern).
- **Write paths routed through it:** the consolidator `unify` merge, the shared `apply_playbook_edit` (reflection + tuner), and the optimizer supersede — each now atomic, lineage-recording, and orphan-free. `hard_delete` audit events emitted before physical deletes.
- **Reads:** universal base status filter hides tombstones from default reads (NULL-safe — CURRENT rows always shown), with `include_tombstones=True` on the by-id getters; `resolve_current()` follows the pointer to the live survivor (1-hop, cycle-safe, purged-aware).

### Incidental fixes found during the build
- `apply_playbook_edit` no longer leaves an orphan CURRENT row on a lost race.
- The `ARCHIVED → SUPERSEDED` shift fixes a latent `run_downgrade` bug that would restore reflection-archived rows to CURRENT.

### Testing
TDD throughout — 11 tasks, each with integration tests (real SQLite storage). New lineage suites + a parametrized storage contract test all green; broader storage/reflection/optimizer/consolidator suites pass with no regressions.

### Notes
- Foundation commits (`apply_playbook_edit` extraction, `PlaybookRetrievalLog`/`RetrievalLogMixin`) are included as the base this builds on.
- Per-spec deferred to Phase B/C: in-place `update_*` instrumentation, TTL GC, legacy-log retirement, multi-hop path-compression, the agent-aggregate erasure-linkage question.

Spec/plan live in the enterprise repo (`docs/superpowers/specs|plans/…lineage…`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Playbook consolidation now records merge/revise lineage end-to-end, including persisted lineage events and retrieval-log support.
  * Lineage-aware record replacement uses atomic supersede to maintain consistent “current” state.
  * Lineage resolution can follow merge chains to determine the current live record.

* **Improvements / Behavior Changes**
  * Storage reads are tombstone-aware by default (merged/superseded records are hidden unless explicitly included).
  * Hard-deleting playbooks can emit erasure lineage events.
  * Lineage-based anomaly reporting was improved for cycle/hop-resolution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->