### PR TITLE
feat: add tag filters to retrieval APIs

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -535,6 +535,7 @@ class ReflexioClient:
         source: str | None = None,
         custom_feature: str | None = None,
         extractor_name: str | None = None,
+        tags: list[str] | None = None,
         threshold: float | None = None,
         enable_reformulation: bool | None = None,
         search_mode: SearchMode | None = None,
@@ -552,6 +553,7 @@ class ReflexioClient:
             source (Optional[str]): Filter by source
             custom_feature (Optional[str]): Filter by custom feature
             extractor_name (Optional[str]): Deprecated compatibility field. Accepted but ignored.
+            tags (Optional[list[str]]): Match profiles having any of these tags.
             threshold (Optional[float]): Similarity threshold (default: 0.7)
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
 
@@ -570,6 +572,7 @@ class ReflexioClient:
             source=source,
             custom_feature=custom_feature,
             extractor_name=extractor_name,
+            tags=tags,
             threshold=threshold,
             enable_reformulation=enable_reformulation,
             search_mode=search_mode,
@@ -593,6 +596,7 @@ class ReflexioClient:
         source: str | None = None,
         custom_feature: str | None = None,
         extractor_name: str | None = None,
+        tags: list[str] | None = None,
         threshold: float | None = None,
         enable_reformulation: bool | None = None,
         search_mode: SearchMode | None = None,
@@ -615,6 +619,7 @@ class ReflexioClient:
             source=source,
             custom_feature=custom_feature,
             extractor_name=extractor_name,
+            tags=tags,
             threshold=threshold,
             enable_reformulation=enable_reformulation,
             search_mode=search_mode,
@@ -691,6 +696,7 @@ class ReflexioClient:
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         status_filter: list[Status | None] | None = None,
+        tags: list[str] | None = None,
         top_k: int | None = None,
         threshold: float | None = None,
         enable_reformulation: bool | None = None,
@@ -707,6 +713,7 @@ class ReflexioClient:
             start_time (Optional[datetime]): Start time for created_at filter
             end_time (Optional[datetime]): End time for created_at filter
             status_filter (Optional[list[Optional[Status]]]): Filter by status (None for CURRENT, PENDING, ARCHIVED)
+            tags (Optional[list[str]]): Match playbooks having any of these tags.
             top_k (Optional[int]): Maximum number of results to return (default: 10)
             threshold (Optional[float]): Similarity threshold for vector search (default: 0.4)
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
@@ -724,6 +731,7 @@ class ReflexioClient:
             start_time=start_time,
             end_time=end_time,
             status_filter=status_filter,
+            tags=tags,
             top_k=top_k,
             threshold=threshold,
             enable_reformulation=enable_reformulation,
@@ -745,6 +753,7 @@ class ReflexioClient:
         end_time: datetime | None = None,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: PlaybookStatus | None = None,
+        tags: list[str] | None = None,
         top_k: int | None = None,
         threshold: float | None = None,
         enable_reformulation: bool | None = None,
@@ -761,6 +770,7 @@ class ReflexioClient:
             end_time (Optional[datetime]): End time for created_at filter
             status_filter (Optional[list[Optional[Status]]]): Filter by status (None for CURRENT, PENDING, ARCHIVED)
             playbook_status_filter (Optional[PlaybookStatus]): Filter by playbook status (PENDING, APPROVED, REJECTED)
+            tags (Optional[list[str]]): Match playbooks having any of these tags.
             top_k (Optional[int]): Maximum number of results to return (default: 10)
             threshold (Optional[float]): Similarity threshold for vector search (default: 0.4)
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
@@ -778,6 +788,7 @@ class ReflexioClient:
             end_time=end_time,
             status_filter=status_filter,
             playbook_status_filter=playbook_status_filter,
+            tags=tags,
             top_k=top_k,
             threshold=threshold,
             enable_reformulation=enable_reformulation,
@@ -1141,6 +1152,7 @@ class ReflexioClient:
         end_time: datetime | None = None,
         top_k: int | None = None,
         status_filter: list[Status | str | None] | None = None,
+        tags: list[str] | None = None,
     ) -> GetProfilesViewResponse:
         """Get user profiles.
 
@@ -1152,6 +1164,7 @@ class ReflexioClient:
             end_time (Optional[datetime]): Filter by end time
             top_k (Optional[int]): Maximum number of results to return (default: 30)
             status_filter (Optional[list[Optional[Union[Status, str]]]]): Filter by profile status. Accepts Status enum or string values (e.g., "archived", "pending").
+            tags (Optional[list[str]]): Match profiles having any of these tags.
 
         Returns:
             GetProfilesViewResponse: Response containing list of profiles
@@ -1176,6 +1189,7 @@ class ReflexioClient:
             end_time=end_time,
             top_k=top_k,
             status_filter=converted_status_filter,
+            tags=tags,
         )
 
         # Check cache if not forcing refresh
@@ -1187,6 +1201,7 @@ class ReflexioClient:
                 end_time=req.end_time,
                 top_k=req.top_k,
                 status_filter=req.status_filter,
+                tags=req.tags,
             )
             if cached_result is not None:
                 return cached_result
@@ -1208,6 +1223,7 @@ class ReflexioClient:
             end_time=req.end_time,
             top_k=req.top_k,
             status_filter=req.status_filter,
+            tags=req.tags,
         )
 
         return result
@@ -1354,6 +1370,7 @@ class ReflexioClient:
         playbook_name: str | None = None,
         agent_version: str | None = None,
         status_filter: list[Status | None] | None = None,
+        tags: list[str] | None = None,
     ) -> GetUserPlaybooksViewResponse:
         """Get user playbooks.
 
@@ -1364,6 +1381,7 @@ class ReflexioClient:
             playbook_name (Optional[str]): Filter by playbook name
             agent_version (Optional[str]): Filter by agent version
             status_filter (Optional[list[Optional[Status]]]): Filter by status
+            tags (Optional[list[str]]): Match playbooks having any of these tags.
 
         Returns:
             GetUserPlaybooksViewResponse: Response containing user playbooks
@@ -1376,6 +1394,7 @@ class ReflexioClient:
             playbook_name=playbook_name,
             agent_version=agent_version,
             status_filter=status_filter,
+            tags=tags,
         )
         response = self._make_request(
             "POST",
@@ -1629,6 +1648,7 @@ class ReflexioClient:
         agent_version: str | None = None,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: PlaybookStatus | None = None,
+        tags: list[str] | None = None,
     ) -> GetAgentPlaybooksViewResponse:
         """Get agent playbooks.
 
@@ -1640,6 +1660,7 @@ class ReflexioClient:
             agent_version (Optional[str]): Filter by agent version
             status_filter (Optional[list[Optional[Status]]]): Filter by status
             playbook_status_filter (Optional[PlaybookStatus]): Filter by playbook status (default: APPROVED)
+            tags (Optional[list[str]]): Match playbooks having any of these tags.
 
         Returns:
             GetAgentPlaybooksViewResponse: Response containing agent playbooks
@@ -1652,6 +1673,7 @@ class ReflexioClient:
             agent_version=agent_version,
             status_filter=status_filter,
             playbook_status_filter=playbook_status_filter,
+            tags=tags,
         )
 
         # Check cache if not forcing refresh
@@ -1660,8 +1682,10 @@ class ReflexioClient:
                 "get_agent_playbooks",
                 limit=req.limit,
                 playbook_name=req.playbook_name,
+                agent_version=req.agent_version,
                 status_filter=req.status_filter,
                 playbook_status_filter=req.playbook_status_filter,
+                tags=req.tags,
             )
             if cached_result is not None:
                 return cached_result
@@ -1680,8 +1704,10 @@ class ReflexioClient:
             result,
             limit=req.limit,
             playbook_name=req.playbook_name,
+            agent_version=req.agent_version,
             status_filter=req.status_filter,
             playbook_status_filter=req.playbook_status_filter,
+            tags=req.tags,
         )
 
         return result

--- a/reflexio/lib/_agent_playbook.py
+++ b/reflexio/lib/_agent_playbook.py
@@ -193,6 +193,7 @@ class AgentPlaybookMixin(ReflexioBase):
                 playbook_status_filter=[request.playbook_status_filter]
                 if request.playbook_status_filter
                 else None,
+                tags=request.tags,
             )
             return GetAgentPlaybooksResponse(
                 success=True,

--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -401,7 +401,7 @@ class ProfilesMixin(ReflexioBase):
                 status_filter = [None]  # Default to current profiles
 
         profiles = self._get_storage().get_user_profile(
-            request.user_id, status_filter=status_filter
+            request.user_id, status_filter=status_filter, tags=request.tags
         )
         profiles = sorted(
             profiles, key=lambda x: x.last_modified_timestamp, reverse=True

--- a/reflexio/lib/_user_playbook.py
+++ b/reflexio/lib/_user_playbook.py
@@ -57,6 +57,7 @@ class UserPlaybookMixin(ReflexioBase):
                 playbook_name=request.playbook_name,
                 agent_version=request.agent_version,
                 status_filter=request.status_filter,
+                tags=request.tags,
             )
             return GetUserPlaybooksResponse(
                 success=True,

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -64,6 +64,7 @@ class SearchUserProfileRequest(BaseModel):
     extractor_name: str | None = (
         None  # Deprecated compatibility field; accepted but ignored.
     )
+    tags: list[str] | None = None
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
@@ -190,6 +191,7 @@ class GetUserProfilesRequest(BaseModel):
     end_time: datetime | None = None
     top_k: int | None = Field(default=30, gt=0)
     status_filter: list[Status | None] | None = None
+    tags: list[str] | None = None
 
     @model_validator(mode="after")
     def check_time_range(self) -> Self:
@@ -224,6 +226,7 @@ class GetUserPlaybooksRequest(BaseModel):
     playbook_name: str | None = None
     agent_version: str | None = None
     status_filter: list[Status | None] | None = None
+    tags: list[str] | None = None
 
 
 class GetUserPlaybooksResponse(BaseModel):
@@ -238,6 +241,7 @@ class GetAgentPlaybooksRequest(BaseModel):
     agent_version: str | None = None
     status_filter: list[Status | None] | None = None
     playbook_status_filter: PlaybookStatus | None = None
+    tags: list[str] | None = None
     # Caller correlation IDs for billing attribution on the Application line.
     # Optional; consumed by _meter_applied_learnings in server/api.py.
     request_id: str | None = None
@@ -272,6 +276,7 @@ class SearchUserPlaybookRequest(BaseModel):
     start_time: datetime | None = None
     end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
+    tags: list[str] | None = None
     top_k: int | None = Field(default=10, gt=0)
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
@@ -329,6 +334,7 @@ class SearchAgentPlaybookRequest(BaseModel):
     end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
     playbook_status_filter: PlaybookStatus | list[PlaybookStatus] | None = None
+    tags: list[str] | None = None
     top_k: int | None = Field(default=10, gt=0)
     threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -77,6 +77,16 @@ def _row_to_playbook_optimization_evaluation(
     )
 
 
+def _build_tags_sql(alias: str, tags: list[str] | None) -> tuple[str, list[Any]]:
+    if not tags:
+        return "", []
+    placeholders = ",".join("?" for _ in tags)
+    return (
+        f"EXISTS (SELECT 1 FROM json_each({alias}.tags) WHERE value IN ({placeholders}))",
+        list(tags),
+    )
+
+
 class PlaybookMixin:
     """Mixin providing user playbook, agent playbook, and evaluation CRUD + search."""
 
@@ -176,6 +186,7 @@ class PlaybookMixin:
         start_time: int | None = None,
         end_time: int | None = None,
         include_embedding: bool = False,
+        tags: list[str] | None = None,
     ) -> list[UserPlaybook]:
         sql = "SELECT * FROM user_playbooks WHERE 1=1"
         params: list[Any] = []
@@ -199,6 +210,10 @@ class PlaybookMixin:
             frag, sparams = _build_status_sql(status_filter)
             sql += f" AND {frag}"
             params.extend(sparams)
+        tag_frag, tag_params = _build_tags_sql("user_playbooks", tags)
+        if tag_frag:
+            sql += f" AND {tag_frag}"
+            params.extend(tag_params)
 
         sql += " ORDER BY created_at DESC LIMIT ?"
         params.append(limit)
@@ -471,6 +486,10 @@ class PlaybookMixin:
             frag, sparams = _build_status_sql(status_filter)
             conditions.append(frag)
             params.extend(sparams)
+        tag_frag, tag_params = _build_tags_sql("up", request.tags)
+        if tag_frag:
+            conditions.append(tag_frag)
+            params.extend(tag_params)
 
         where_extra = (" AND " + " AND ".join(conditions)) if conditions else ""
         overfetch = match_count * 5 if mode != SearchMode.FTS else match_count
@@ -639,6 +658,7 @@ class PlaybookMixin:
         agent_version: str | None = None,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
+        tags: list[str] | None = None,
     ) -> list[AgentPlaybook]:
         sql = "SELECT * FROM agent_playbooks WHERE 1=1"
         params: list[Any] = []
@@ -662,6 +682,10 @@ class PlaybookMixin:
             ph = ",".join("?" for _ in playbook_status_filter)
             sql += f" AND playbook_status IN ({ph})"
             params.extend(ps.value for ps in playbook_status_filter)
+        tag_frag, tag_params = _build_tags_sql("agent_playbooks", tags)
+        if tag_frag:
+            sql += f" AND {tag_frag}"
+            params.extend(tag_params)
 
         sql += " ORDER BY created_at DESC LIMIT ?"
         params.append(limit)
@@ -1219,6 +1243,10 @@ class PlaybookMixin:
             frag, sparams = _build_status_sql(status_filter)
             conditions.append(frag)
             params.extend(sparams)
+        tag_frag, tag_params = _build_tags_sql("ap", request.tags)
+        if tag_frag:
+            conditions.append(tag_frag)
+            params.extend(tag_params)
 
         where_extra = (" AND " + " AND ".join(conditions)) if conditions else ""
         overfetch = match_count * 5 if mode != SearchMode.FTS else match_count

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -39,6 +39,16 @@ from ._base import (
 )
 
 
+def _build_tags_sql(alias: str, tags: list[str] | None) -> tuple[str, list[Any]]:
+    if not tags:
+        return "", []
+    placeholders = ",".join("?" for _ in tags)
+    return (
+        f"EXISTS (SELECT 1 FROM json_each({alias}.tags) WHERE value IN ({placeholders}))",
+        list(tags),
+    )
+
+
 class ProfileMixin:
     """Mixin providing profile and interaction CRUD + search."""
 
@@ -84,13 +94,19 @@ class ProfileMixin:
         self,
         user_id: str,
         status_filter: list[Status | None] | None = None,
+        tags: list[str] | None = None,
     ) -> list[UserProfile]:
         if status_filter is None:
             status_filter = [None]
         current_ts = _epoch_now()
         frag, params = _build_status_sql(status_filter)
-        sql = f"SELECT * FROM profiles WHERE user_id = ? AND expiration_timestamp >= ? AND {frag}"
+        conditions = ["user_id = ?", "expiration_timestamp >= ?", frag]
         all_params: list[Any] = [user_id, current_ts, *params]
+        tag_frag, tag_params = _build_tags_sql("profiles", tags)
+        if tag_frag:
+            conditions.append(tag_frag)
+            all_params.extend(tag_params)
+        sql = f"SELECT * FROM profiles WHERE {' AND '.join(conditions)}"
         return [_row_to_profile(r) for r in self._fetchall(sql, all_params)]
 
     @SQLiteStorageBase.handle_exceptions
@@ -668,6 +684,10 @@ class ProfileMixin:
             frag, sparams = _build_status_sql(status_filter)
             conditions.append(frag)
             params.extend(sparams)
+        tag_frag, tag_params = _build_tags_sql("p", req.tags)
+        if tag_frag:
+            conditions.append(tag_frag)
+            params.extend(tag_params)
 
         where_clause = " AND ".join(conditions)
         overfetch = match_count * 5 if mode != SearchMode.FTS else match_count

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -42,6 +42,7 @@ class PlaybookMixin:
         start_time: int | None = None,
         end_time: int | None = None,
         include_embedding: bool = False,
+        tags: list[str] | None = None,
     ) -> list[UserPlaybook]:
         """Get user playbooks from storage.
 
@@ -56,6 +57,7 @@ class PlaybookMixin:
             start_time (int, optional): Unix timestamp. Only return playbooks created at or after this time.
             end_time (int, optional): Unix timestamp. Only return playbooks created at or before this time.
             include_embedding (bool): If True, fetch and parse embedding vectors. Defaults to False.
+            tags (list[str], optional): Match playbooks having any of these tags.
 
         Returns:
             list[UserPlaybook]: List of user playbook objects
@@ -282,6 +284,7 @@ class PlaybookMixin:
         agent_version: str | None = None,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
+        tags: list[str] | None = None,
     ) -> list[AgentPlaybook]:
         """Get agent playbooks from storage.
 
@@ -292,6 +295,7 @@ class PlaybookMixin:
             status_filter (list[Optional[Status]], optional): List of Status values to filter by. None in the list means CURRENT status.
             playbook_status_filter (Optional[list[PlaybookStatus]]): List of PlaybookStatus values to filter by.
                 If None, returns all playbook statuses.
+            tags (list[str], optional): Match playbooks having any of these tags.
 
         Returns:
             list[AgentPlaybook]: List of agent playbook objects

--- a/reflexio/server/services/storage/storage_base/_profiles.py
+++ b/reflexio/server/services/storage/storage_base/_profiles.py
@@ -34,6 +34,7 @@ class ProfileMixin:
         self,
         user_id: str,
         status_filter: list[Status | None] | None = None,
+        tags: list[str] | None = None,
     ) -> list[UserProfile]:
         raise NotImplementedError
 


### PR DESCRIPTION
## Summary
- Add optional tag filters to profile and playbook retrieval/search request schemas and client methods.
- Apply tag overlap filtering in the lib/storage paths before ranking or limiting results.
- Support tag predicates in SQLite storage for profiles, user playbooks, and agent playbooks.

## Changes
- Schemas/client: thread `tags` through profile and playbook search/list APIs.
- Library layer: pass tag filters from request models into storage calls.
- SQLite storage: add JSON tag overlap predicates for list and search operations.
- Storage contracts: extend abstract method signatures for tag-aware retrieval.

## Test Plan
- `uv run ruff check open_source/reflexio/reflexio/client/client.py open_source/reflexio/reflexio/lib/_agent_playbook.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_user_playbook.py open_source/reflexio/reflexio/models/api_schema/retriever_schema.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_playbook.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_profiles.py open_source/reflexio/reflexio/server/services/storage/storage_base/_playbook.py open_source/reflexio/reflexio/server/services/storage/storage_base/_profiles.py`
- `uv run ruff format --check open_source/reflexio/reflexio/client/client.py open_source/reflexio/reflexio/lib/_agent_playbook.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_user_playbook.py open_source/reflexio/reflexio/models/api_schema/retriever_schema.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_playbook.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_profiles.py open_source/reflexio/reflexio/server/services/storage/storage_base/_playbook.py open_source/reflexio/reflexio/server/services/storage/storage_base/_profiles.py`
- `uv run pyright open_source/reflexio/reflexio/client/client.py open_source/reflexio/reflexio/lib/_agent_playbook.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_user_playbook.py open_source/reflexio/reflexio/models/api_schema/retriever_schema.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_playbook.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_profiles.py open_source/reflexio/reflexio/server/services/storage/storage_base/_playbook.py open_source/reflexio/reflexio/server/services/storage/storage_base/_profiles.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag-based filtering is now available for user profiles, user playbooks, and agent playbooks. Filter search and retrieval results by providing optional tags in API requests. Cached results now appropriately vary based on applied tag filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->