### PR TITLE
fix: include agent playbooks in dashboard series

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -168,8 +168,14 @@ class ExtrasMixin:
             "SELECT last_modified_timestamp FROM profiles WHERE last_modified_timestamp >= ? AND last_modified_timestamp <= ? ORDER BY last_modified_timestamp",
             (current_start, current_time),
         )
-        playbooks_ts = self._fetchall(
-            "SELECT created_at FROM user_playbooks WHERE created_at >= ? AND created_at <= ? ORDER BY created_at",
+        # Playbooks span two tables; mirror the total_playbooks count above
+        # (user_playbooks + agent_playbooks) so the chart matches the stat card.
+        user_playbooks_ts = self._fetchall(
+            "SELECT created_at FROM user_playbooks WHERE created_at >= ? AND created_at <= ?",
+            (current_start_iso, current_time_iso),
+        )
+        agent_playbooks_ts = self._fetchall(
+            "SELECT created_at FROM agent_playbooks WHERE created_at >= ? AND created_at <= ?",
             (current_start_iso, current_time_iso),
         )
         evals_ts = self._fetchall(
@@ -188,10 +194,13 @@ class ExtrasMixin:
                 {"timestamp": r["last_modified_timestamp"], "value": 1}
                 for r in profiles_ts
             ],
-            "playbooks_time_series": [
-                {"timestamp": _iso_to_epoch(r["created_at"]), "value": 1}
-                for r in playbooks_ts
-            ],
+            "playbooks_time_series": sorted(
+                [
+                    {"timestamp": _iso_to_epoch(r["created_at"]), "value": 1}
+                    for r in (*user_playbooks_ts, *agent_playbooks_ts)
+                ],
+                key=lambda x: x["timestamp"],
+            ),
             "evaluations_time_series": [
                 {
                     "timestamp": _iso_to_epoch(r["created_at"]),

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -1,5 +1,7 @@
 """Contract tests for AgentPlaybookMixin — run against every local storage backend."""
 
+import time
+
 import pytest
 
 from reflexio.models.api_schema.domain.enums import Status
@@ -350,3 +352,47 @@ class TestAgentPlaybookCRUD:
 
         storage.delete_all_agent_playbooks()
         assert storage.get_agent_playbooks() == []
+
+
+class TestDashboardPlaybooksTimeSeries:
+    """The dashboard playbooks chart must count both playbook tables."""
+
+    def test_playbooks_time_series_includes_agent_playbooks(self, storage):
+        # total_playbooks counts user_playbooks + agent_playbooks, so the time
+        # series that feeds the chart must include both — otherwise the chart
+        # undercounts versus the stat card. Use a current-time created_at so the
+        # rows fall inside the dashboard look-back window.
+        now = int(time.time())
+        storage.save_user_playbooks(
+            [
+                UserPlaybook(
+                    user_playbook_id=1,
+                    user_id="u1",
+                    playbook_name="fb",
+                    agent_version="v1",
+                    request_id="req-1",
+                    content="user pb",
+                    created_at=now,
+                    source="test",
+                    source_interaction_ids=[],
+                )
+            ]
+        )
+        storage.save_agent_playbooks(
+            [
+                AgentPlaybook(
+                    agent_playbook_id=1,
+                    playbook_name="fb",
+                    agent_version="v1",
+                    content="agent pb",
+                    created_at=now,
+                )
+            ]
+        )
+
+        stats = storage.get_dashboard_stats(days_back=30)
+
+        assert stats["current_period"]["total_playbooks"] == 2
+        # The series must contain BOTH playbooks (regression: it previously
+        # queried only user_playbooks and would have length 1 here).
+        assert len(stats["playbooks_time_series"]) == 2


### PR DESCRIPTION
## Summary
- Fix the dashboard playbooks time series so it matches the total playbooks stat card by counting both user and agent playbooks.
- Preserve chronological ordering after merging playbook events from both storage tables.

## Changes
- Storage: query user and agent playbook created_at values for dashboard playbook series.
- Tests: add a storage contract regression covering the combined playbook series count.

## Test Plan
- `uv run ruff check --fix reflexio/server/services/storage/sqlite_storage/_extras.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run ruff format reflexio/server/services/storage/sqlite_storage/_extras.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run ruff check reflexio/server/services/storage/sqlite_storage/_extras.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run pyright reflexio/server/services/storage/sqlite_storage/_extras.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run pytest --no-cov tests/server/services/storage/test_storage_contract_playbook.py -k 'playbooks_time_series'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the playbooks time series dashboard chart to display all playbook data with proper chronological ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->