### PR TITLE
fix: reject unknown config fields

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -1304,7 +1304,7 @@ class ReflexioClient:
 
         Args:
             partial: Top-level fields to overlay on the existing config.
-                Unknown keys are dropped server-side by Pydantic.
+                Unknown keys are rejected server-side.
 
         Returns:
             dict: ``{"success": bool, "msg": str}`` from the server.

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -757,6 +757,8 @@ def _default_user_playbook_extractor_config() -> UserPlaybookExtractorConfig:
 
 
 class Config(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     # define where user configuration is stored at
     storage_config: StorageConfig
     storage_config_test: StorageConfigTest | None = StorageConfigTest.UNKNOWN

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1550,7 +1550,7 @@ def run_playbook_aggregation(
 @limiter.limit("10/minute")
 def set_config(
     request: Request,
-    config: dict[str, Any],
+    config: Config,
     org_id: str = Depends(default_get_org_id),
 ) -> SetConfigResponse:
     """Set configuration for the organization.

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -203,6 +203,26 @@ class TestUpdateUserProfileRoute:
         assert response.status_code == 422
 
 
+class TestSetConfigRoute:
+    """Tests for POST /api/set_config (full replacement semantics)."""
+
+    def test_unknown_field_returns_422_before_set_config(
+        self, client, patched_reflexio, mock_reflexio
+    ):
+        response = client.post(
+            "/api/set_config",
+            json={
+                "storage_config": {
+                    "db_path": str(Path(tempfile.gettempdir()) / "set-config.db")
+                },
+                "agent_sucess_config": None,
+            },
+        )
+
+        assert response.status_code == 422, response.text
+        mock_reflexio.set_config.assert_not_called()
+
+
 class TestUpdateConfigRoute:
     """Tests for POST /api/update_config (PATCH-style partial update).
 
@@ -255,16 +275,10 @@ class TestUpdateConfigRoute:
         # Cache invalidated on success.
         mock_invalidate.assert_called_once_with(org_id="test-org")
 
-    def test_unknown_field_does_not_leak_to_set_config(
+    def test_unknown_field_returns_422_before_set_config(
         self, client, patched_reflexio, mock_reflexio
     ):
-        """Unknown top-level keys never reach reflexio.set_config.
-
-        ``Config`` doesn't enable strict ``extra='forbid'`` validation,
-        so Pydantic silently drops unknown fields rather than raising —
-        but the merged ``Config`` instance handed to ``set_config`` must
-        not carry the bogus attribute either way.
-        """
+        """Unknown top-level keys never reach reflexio.set_config."""
         existing = self._existing_config()
         self._wire_mock(mock_reflexio, existing)
 
@@ -273,18 +287,8 @@ class TestUpdateConfigRoute:
             json={"definitely_not_a_field": 42},
         )
 
-        # If the model later switches to extra='forbid', this becomes
-        # a 4xx (FastAPI rejects in request validation) and we'd still
-        # want to assert set_config was not called. Pin to client-error
-        # codes specifically so a 5xx regression here trips the test
-        # instead of silently passing the >= 400 check.
-        if response.status_code == 200:
-            merged = mock_reflexio.set_config.call_args.args[0]
-            assert isinstance(merged, Config)
-            assert not hasattr(merged, "definitely_not_a_field")
-        else:
-            assert response.status_code in {400, 422}
-            mock_reflexio.set_config.assert_not_called()
+        assert response.status_code == 422, response.text
+        mock_reflexio.set_config.assert_not_called()
 
     def test_replaces_nested_object_wholesale(
         self, client, patched_reflexio, mock_reflexio


### PR DESCRIPTION
## Summary
- Reject unknown top-level config fields instead of silently dropping them.
- Move `/api/set_config` request validation to FastAPI's `Config` body parsing so typos return 422 before config replacement runs.
- Keep `update_config` partial updates strict after server-side merge.

## Changes
- Added `extra="forbid"` to the root `Config` model.
- Changed `/api/set_config` to accept `Config` instead of `dict[str, Any]`.
- Updated config route tests to assert unknown fields return 422 and never reach `set_config`.
- Refreshed client docstring language for unknown partial keys.

## Test Plan
- `uv run python -c "import reflexio"`
- `uv run ruff check open_source/reflexio/reflexio/models/config_schema.py open_source/reflexio/reflexio/server/api.py open_source/reflexio/reflexio/client/client.py open_source/reflexio/tests/server/api_endpoints/test_api_routes.py`
- `uv run pyright open_source/reflexio/reflexio/client/client.py open_source/reflexio/reflexio/models/config_schema.py open_source/reflexio/reflexio/server/api.py open_source/reflexio/tests/server/api_endpoints/test_api_routes.py`
- `uv run pytest --no-cov open_source/reflexio/tests/server/api_endpoints/test_api_routes.py -k "ConfigRoute"`
- `uv run pytest --no-cov open_source/reflexio/tests/client/test_update_config.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now strictly rejects unknown fields, returning HTTP 422 for invalid configurations.
  * API endpoint configuration parameter handling improved for consistency.

* **Tests**
  * Added and refined test coverage to verify unknown configuration fields are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->