### PR TITLE
fix(tests): use singular agent_success_config in e2e conftest fixtures

### DIFF
--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -105,12 +105,10 @@ if user mentions "I don't like the way you talked to me", summarize conversation
                 min_cluster_size=3,
             ),
         ),
-        agent_success_configs=[
-            AgentSuccessConfig(
-                evaluation_name="test_agent_success",
-                success_definition_prompt="sales agent is responding to user apporperately",
-            )
-        ],
+        agent_success_config=AgentSuccessConfig(
+            evaluation_name="test_agent_success",
+            success_definition_prompt="sales agent is responding to user apporperately",
+        ),
         tool_can_use=[
             ToolUseConfig(
                 tool_name="search",
@@ -253,12 +251,10 @@ def reflexio_instance_agent_success_only(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
-        agent_success_configs=[
-            AgentSuccessConfig(
-                evaluation_name="test_agent_success",
-                success_definition_prompt="sales agent is responding to user apporperately",
-            )
-        ],
+        agent_success_config=AgentSuccessConfig(
+            evaluation_name="test_agent_success",
+            success_definition_prompt="sales agent is responding to user apporperately",
+        ),
         tool_can_use=[
             ToolUseConfig(
                 tool_name="search",


### PR DESCRIPTION
## Summary

The single-extractor config refactor renamed the list-valued `agent_success_configs` field to singular `agent_success_config` (tracked in `_LEGACY_SINGLE_CONFIG_FIELDS` / `normalize_legacy_config_shape` in `config_schema.py`). Two e2e conftest fixtures were missed in that migration and still pass the retired plural list form **directly to the `Config(...)` constructor**, which rejects it with pydantic `extra_forbidden`:

- `reflexio_instance`
- `reflexio_instance_agent_success_only`

The legacy-key remapping only runs during dict deserialization at storage load boundaries — not direct kwarg construction — so these fixtures must use the current singular field name. This broke `test_complete_workflows.py` and `test_agent_success_workflows.py` at fixture construction time.

## Fix

Change `agent_success_configs=[AgentSuccessConfig(...)]` to `agent_success_config=AgentSuccessConfig(...)` in both fixtures, matching how the rest of the file was already migrated (the profile/playbook extractor fixtures already use the singular form).

## Verification

```
uv run pytest open_source/reflexio/tests/e2e_tests/test_complete_workflows.py -o 'addopts=' -q
# 4 passed, 7 skipped (skipped = @skip_low_priority real-API tests, no key available)
```

Ruff lint + format clean. No new pyright errors introduced.

## Out of scope (separate follow-up needed)

The same single-extractor refactor left **additional** drift in this conftest that this PR does **not** touch, because it requires a semantic decision (delete vs. rewrite tests of removed functionality), not a mechanical rename:

- `reflexio_instance_multiple_profile_extractors` (line ~525) — `profile_extractor_configs=[...3 items...]`
- `reflexio_instance_multiple_playbook_extractors` (line ~575) — `user_playbook_extractor_configs=[...3 items...]`
- `reflexio_instance_playbook_source_filtering` (line ~396) — `user_playbook_extractor_configs=[...]`

These fixtures (and the `test_profile_workflows` / `test_playbook_workflows` tests that use them) exercise multi-extractor behavior that the single-extractor model removed; they cannot be expressed with the singular field and need their tests reviewed for deletion or redesign. They are `@skip_in_precommit` / `@skip_low_priority`, which is why this drift went undetected in normal CI gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test configuration to improve agent success evaluation handling.

---

**Note:** This release contains internal test updates with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
