### PR TITLE
Lineage Phase B1 — complete instrumentation (OSS/SQLite): update/hard_delete/status_change + reflection supersede + op=aggregate

### DIFF
--- a/.claude/rules/reflexio-patterns.md
+++ b/.claude/rules/reflexio-patterns.md
@@ -23,3 +23,8 @@ paths:
 
 ## Config
 - `tool_can_use` lives at root `Config` level — shared across success evaluation and feedback extraction (NOT per-`AgentSuccessConfig`)
+
+## SQLite storage: lineage events & atomicity (one connection = one transaction)
+- The `sqlite3` connection is shared and `autocommit=False`, so `conn.commit()` **anywhere flushes the entire pending transaction**, not just the adjacent statement. The FTS/vec helpers (`_fts_*`, `_vec_*` in `sqlite_storage/_base.py`) **self-commit** internally.
+- **NEVER** interleave a self-committing helper between two writes you need atomic. E.g. `emit lineage event → _fts_delete()/_vec_delete() → DELETE row → commit` looks atomic ("one `with self._lock:` block, one commit at the end") but the helper's commit durably writes the audit event **before** the row is deleted — so a crash or a no-op delete leaves a phantom `hard_delete`/`status_change` event for a row that still exists. This bit a whole family of B1 delete/update methods.
+- **ALWAYS** emit a lineage event only **after** (or in the same `conn.commit()` as) the mutation it attests to, guarded on `cur.rowcount > 0`; run `_fts_*`/`_vec_*` cleanup **after** that commit (index maintenance, not the audited fact). The existence/eligibility check must use the **same predicate** (including `user_id` scope) as the mutation — otherwise you audit erasures that never happened, including for another user's row in the same org.

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -449,6 +449,9 @@ class LineageEvent(BaseModel):
     request_id: str = ""
     reason: str = ""
     created_at: int = 0
+    from_status: str | None = None
+    to_status: str | None = None
+    status_namespace: str | None = None
 
 
 class LineageContext(BaseModel):

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -299,7 +299,10 @@ class GenerationService:
             # profile/playbook context. Wrapped in a broad except so a
             # reflection bug never breaks the publish.
             self._maybe_run_reflection(
-                user_id=user_id, agent_version=agent_version, source=source
+                user_id=user_id,
+                request_id=request_id,
+                agent_version=agent_version,
+                source=source,
             )
 
             # Create generation services and requests
@@ -543,7 +546,7 @@ class GenerationService:
         )
 
     def _maybe_run_reflection(
-        self, *, user_id: str, agent_version: str, source: str | None
+        self, *, user_id: str, request_id: str, agent_version: str, source: str | None
     ) -> None:
         """Best-effort reflection pass before extraction.
 
@@ -558,6 +561,7 @@ class GenerationService:
             service.run(
                 ReflectionServiceRequest(
                     user_id=user_id,
+                    request_id=request_id,
                     agent_version=agent_version,
                     source=source,
                 )

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -890,7 +890,7 @@ class PlaybookAggregator:
                         if fb.user_playbook_id
                     ]
                     try:
-                        self.storage.append_lineage_event(  # type: ignore[reportOptionalMemberAccess]
+                        self.storage.append_lineage_event(  # pyright: ignore[reportOptionalMemberAccess]
                             LineageEvent(
                                 org_id=self.request_context.org_id,
                                 entity_type="agent_playbook",

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -106,7 +106,7 @@ class PlaybookAggregator:
         # Count user playbooks with ID greater than last processed using efficient count query
         # Only count current user playbooks (status=None), not archived or pending ones.
         # Singleton aggregation operates on the user's whole playbook set — no name filter.
-        new_count = self.storage.count_user_playbooks(  # type: ignore[reportOptionalMemberAccess]
+        new_count = self.storage.count_user_playbooks(  # pyright: ignore[reportOptionalMemberAccess]
             min_user_playbook_id=last_processed_id,
             agent_version=self.agent_version,
             status_filter=[None],

--- a/reflexio/server/services/playbook/playbook_aggregator.py
+++ b/reflexio/server/services/playbook/playbook_aggregator.py
@@ -4,12 +4,14 @@ import hashlib
 import logging
 import os
 import time
+import uuid
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import numpy as np
 
+from reflexio.models.api_schema.domain.entities import LineageEvent
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     AgentPlaybookSnapshot,
@@ -36,6 +38,7 @@ from reflexio.server.services.playbook.playbook_service_utils import (
     ensure_playbook_content,
 )
 from reflexio.server.services.service_utils import log_model_response
+from reflexio.server.tracing import capture_anomaly
 from reflexio.server.usage_metrics import record_usage_event
 
 logger = logging.getLogger(__name__)
@@ -572,6 +575,8 @@ class PlaybookAggregator:
             dict: Aggregation stats with keys: clusters_found, user_playbooks_processed, playbooks_generated, skipped (optional)
         """
         aggregation_start = time.perf_counter()
+        # Stable id for this aggregation run — groups all lineage events produced below.
+        _run_id = str(uuid.uuid4())
         _empty_stats = {
             "clusters_found": 0,
             "user_playbooks_processed": 0,
@@ -875,6 +880,40 @@ class PlaybookAggregator:
                             )
                         ],
                     )
+                    # Emit set-level aggregate lineage event (W3C PROV wasDerivedFrom, M:N).
+                    # Best-effort (PB-7): save_agent_playbooks already committed; a transient
+                    # append failure must NOT abort the run. Gap is acceptable for B1 since
+                    # the legacy change log remains the source of record until B3.
+                    member_ids = [
+                        str(fb.user_playbook_id)
+                        for fb in cluster_playbooks
+                        if fb.user_playbook_id
+                    ]
+                    try:
+                        self.storage.append_lineage_event(  # type: ignore[reportOptionalMemberAccess]
+                            LineageEvent(
+                                org_id=self.request_context.org_id,
+                                entity_type="agent_playbook",
+                                entity_id=str(saved_fb.agent_playbook_id),
+                                op="aggregate",
+                                prov_relation="wasDerivedFrom",
+                                source_ids=member_ids,
+                                actor="aggregator",
+                                request_id=_run_id,
+                                reason="user->agent aggregation",
+                            )
+                        )
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "aggregate lineage event failed for agent_playbook %s",
+                            saved_fb.agent_playbook_id,
+                            exc_info=True,
+                        )
+                        capture_anomaly(
+                            "lineage.aggregate.append_failed",
+                            entity_id=str(saved_fb.agent_playbook_id),
+                            org_id=self.request_context.org_id,
+                        )
 
             # Store fingerprints in operation state
             mgr.update_cluster_fingerprints(

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -444,7 +444,7 @@ class ReflectionService:
 
     def _replace_profile(
         self,
-        _request: ReflectionServiceRequest,
+        request: ReflectionServiceRequest,
         decision: ReflectionDecision,
         cited: UserProfile,
     ) -> bool:
@@ -489,7 +489,7 @@ class ReflectionService:
         ctx = LineageContext(
             op_kind="revise",
             actor="reflection",
-            request_id=new_profile.generated_from_request_id,
+            request_id=request.request_id,
         )
         try:
             superseded = storage.supersede_record(
@@ -501,7 +501,7 @@ class ReflectionService:
         except Exception as exc:  # noqa: BLE001
             with sentry_tags(
                 subsystem="reflection",
-                op="archive_after_insert",
+                op="supersede_after_insert",
                 kind="profile",
                 org_id=self.request_context.org_id,
                 user_id=cited.user_id,

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -457,9 +457,10 @@ class ReflectionService:
         ``supersede_record``, which sets ``status=SUPERSEDED`` with a
         ``superseded_by`` pointer and appends a ``revise`` lineage event.
         If the CAS guard fails (incumbent no longer CURRENT), the
-        just-inserted successor is deleted (not audited) so no orphan row
-        remains. If ``supersede_record`` raises, log at ERROR and accept a
-        transient duplicate rather than silently dropping user data.
+        just-inserted successor is deleted (not audited); if that delete
+        itself raises the exception propagates to the caller. If
+        ``supersede_record`` raises, log at ERROR and accept a transient
+        duplicate rather than silently dropping user data.
         """
         storage = self.request_context.storage
         if storage is None:

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 from reflexio.models.api_schema.domain.entities import (
     Citation,
     Interaction,
+    LineageContext,
     UserPlaybook,
     UserProfile,
 )
@@ -443,19 +444,22 @@ class ReflectionService:
 
     def _replace_profile(
         self,
-        request: ReflectionServiceRequest,
+        _request: ReflectionServiceRequest,
         decision: ReflectionDecision,
         cited: UserProfile,
     ) -> bool:
-        """Insert the replacement profile, then archive the cited row.
+        """Insert the replacement profile, then supersede the cited row.
 
         Insert-first ordering means that if ``add_user_profile`` raises,
         the cited row stays current and the per-decision exception
         handler reports ``failed_count``. Only after the new row is
-        durable do we flip the cited row to ARCHIVED — and if *that*
-        fails we log at ERROR rather than silently dropping the user's
-        data, leaving a transient duplicate that downstream dedup can
-        clean up.
+        durable do we atomically supersede the cited row via
+        ``supersede_record``, which sets ``status=SUPERSEDED`` with a
+        ``superseded_by`` pointer and appends a ``revise`` lineage event.
+        If the CAS guard fails (incumbent no longer CURRENT), the
+        just-inserted successor is deleted (not audited) so no orphan row
+        remains. If ``supersede_record`` raises, log at ERROR and accept a
+        transient duplicate rather than silently dropping user data.
         """
         storage = self.request_context.storage
         if storage is None:
@@ -482,9 +486,17 @@ class ReflectionService:
             new_content=new_profile.content,
         )
         storage.add_user_profile(cited.user_id, [new_profile])
+        ctx = LineageContext(
+            op_kind="revise",
+            actor="reflection",
+            request_id=new_profile.generated_from_request_id,
+        )
         try:
-            archived = storage.archive_profile_by_id(
-                user_id=request.user_id, profile_id=cited.profile_id
+            superseded = storage.supersede_record(
+                entity_type="profile",
+                incumbent_id=str(cited.profile_id),
+                successor_id=str(new_profile.profile_id),
+                context=ctx,
             )
         except Exception as exc:  # noqa: BLE001
             with sentry_tags(
@@ -504,7 +516,12 @@ class ReflectionService:
                     new_profile.profile_id,
                 )
             return True
-        if not archived:
+        if not superseded:
+            # lost the CAS race: incumbent was no longer CURRENT — drop the
+            # just-added successor (never live) without emitting an audit event.
+            storage.delete_profiles_by_ids(
+                [new_profile.profile_id], emit_hard_delete=False
+            )
             with sentry_tags(
                 subsystem="reflection",
                 op="archive_after_insert_noop",

--- a/reflexio/server/services/reflection/reflection_service_utils.py
+++ b/reflexio/server/services/reflection/reflection_service_utils.py
@@ -29,6 +29,9 @@ class ReflectionServiceRequest(BaseModel):
 
     Args:
         user_id (str): User to scope the bookmark and window to.
+        request_id (str): The publish pass's own request id; used as the
+            lineage event ``request_id`` on revise events so B3
+            reconstruction can link revisions back to the triggering pass.
         agent_version (str): Agent version of the current publish; copied
             into replacement playbooks.
         source (str | None): Optional source filter for the window.
@@ -37,6 +40,7 @@ class ReflectionServiceRequest(BaseModel):
     """
 
     user_id: str
+    request_id: str = ""
     agent_version: str = ""
     source: str | None = None
 

--- a/reflexio/server/services/reflection/reflection_service_utils.py
+++ b/reflexio/server/services/reflection/reflection_service_utils.py
@@ -11,6 +11,7 @@ in light of how they were applied across the window.
 
 from __future__ import annotations
 
+import uuid
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -32,6 +33,8 @@ class ReflectionServiceRequest(BaseModel):
         request_id (str): The publish pass's own request id; used as the
             lineage event ``request_id`` on revise events so B3
             reconstruction can link revisions back to the triggering pass.
+            Defaults to a fresh UUID hex so two passes on the same profile
+            with no explicit request_id produce distinct lineage events.
         agent_version (str): Agent version of the current publish; copied
             into replacement playbooks.
         source (str | None): Optional source filter for the window.
@@ -40,7 +43,7 @@ class ReflectionServiceRequest(BaseModel):
     """
 
     user_id: str
-    request_id: str = ""
+    request_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
     agent_version: str = ""
     source: str | None = None
 

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1247,22 +1247,34 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         with self._lock:
             self.conn.executescript("""
                 CREATE TABLE IF NOT EXISTS lineage_event (
-                    event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
-                    org_id        TEXT NOT NULL,
-                    entity_type   TEXT NOT NULL,
-                    entity_id     TEXT NOT NULL,
-                    op            TEXT NOT NULL,
-                    prov_relation TEXT NOT NULL DEFAULT '',
-                    source_ids    TEXT NOT NULL DEFAULT '[]',
-                    actor         TEXT NOT NULL DEFAULT '',
-                    request_id    TEXT NOT NULL DEFAULT '',
-                    reason        TEXT NOT NULL DEFAULT '',
-                    created_at    INTEGER NOT NULL,
+                    event_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                    org_id           TEXT NOT NULL,
+                    entity_type      TEXT NOT NULL,
+                    entity_id        TEXT NOT NULL,
+                    op               TEXT NOT NULL,
+                    prov_relation    TEXT NOT NULL DEFAULT '',
+                    source_ids       TEXT NOT NULL DEFAULT '[]',
+                    actor            TEXT NOT NULL DEFAULT '',
+                    request_id       TEXT NOT NULL DEFAULT '',
+                    reason           TEXT NOT NULL DEFAULT '',
+                    created_at       INTEGER NOT NULL,
                     UNIQUE (org_id, entity_type, entity_id, op, request_id)
                 );
                 CREATE INDEX IF NOT EXISTS idx_lineage_entity
                     ON lineage_event (entity_type, entity_id);
             """)
+            existing_cols = {
+                row["name"]
+                for row in self.conn.execute(
+                    "PRAGMA table_info(lineage_event)"
+                ).fetchall()
+            }
+            for col in ("from_status", "to_status", "status_namespace"):
+                if col not in existing_cols:
+                    self.conn.execute(
+                        f"ALTER TABLE lineage_event ADD COLUMN {col} TEXT"  # noqa: S608
+                    )
+                    logger.info("Added %s column to lineage_event", col)
             self.conn.commit()
 
     def _migrate_agent_playbook_source_windows(self) -> None:
@@ -2126,17 +2138,20 @@ CREATE INDEX IF NOT EXISTS idx_shadow_verdicts_prompt_created_at_desc
 -- ============================================================================
 
 CREATE TABLE IF NOT EXISTS lineage_event (
-    event_id      INTEGER PRIMARY KEY AUTOINCREMENT,
-    org_id        TEXT NOT NULL,
-    entity_type   TEXT NOT NULL,
-    entity_id     TEXT NOT NULL,
-    op            TEXT NOT NULL,
-    prov_relation TEXT NOT NULL DEFAULT '',
-    source_ids    TEXT NOT NULL DEFAULT '[]',
-    actor         TEXT NOT NULL DEFAULT '',
-    request_id    TEXT NOT NULL DEFAULT '',
-    reason        TEXT NOT NULL DEFAULT '',
-    created_at    INTEGER NOT NULL,
+    event_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    org_id           TEXT NOT NULL,
+    entity_type      TEXT NOT NULL,
+    entity_id        TEXT NOT NULL,
+    op               TEXT NOT NULL,
+    prov_relation    TEXT NOT NULL DEFAULT '',
+    source_ids       TEXT NOT NULL DEFAULT '[]',
+    actor            TEXT NOT NULL DEFAULT '',
+    request_id       TEXT NOT NULL DEFAULT '',
+    reason           TEXT NOT NULL DEFAULT '',
+    created_at       INTEGER NOT NULL,
+    from_status      TEXT,
+    to_status        TEXT,
+    status_namespace TEXT,
     UNIQUE (org_id, entity_type, entity_id, op, request_id)
 );
 CREATE INDEX IF NOT EXISTS idx_lineage_entity ON lineage_event (entity_type, entity_id);

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -41,6 +41,9 @@ def _append_event_stmt(
     request_id: str,
     reason: str,
     created_at: int | None = None,
+    from_status: str | None = None,
+    to_status: str | None = None,
+    status_namespace: str | None = None,
 ) -> sqlite3.Cursor:
     """Insert a lineage event row; no-ops on (org_id, entity_type, entity_id, op, request_id) duplicate.
 
@@ -49,8 +52,9 @@ def _append_event_stmt(
     return conn.execute(
         "INSERT OR IGNORE INTO lineage_event "
         "(org_id, entity_type, entity_id, op, prov_relation, source_ids, "
-        "actor, request_id, reason, created_at) "
-        "VALUES (?,?,?,?,?,?,?,?,?,?)",
+        "actor, request_id, reason, created_at, "
+        "from_status, to_status, status_namespace) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
         (
             org_id,
             entity_type,
@@ -62,6 +66,9 @@ def _append_event_stmt(
             request_id,
             reason,
             created_at if created_at is not None else int(time.time()),
+            from_status,
+            to_status,
+            status_namespace,
         ),
     )
 
@@ -100,6 +107,9 @@ class SQLiteLineageMixin:
                 request_id=event.request_id,
                 reason=event.reason,
                 created_at=created,
+                from_status=event.from_status,
+                to_status=event.to_status,
+                status_namespace=event.status_namespace,
             )
             if (
                 cur.rowcount == 0
@@ -168,6 +178,9 @@ class SQLiteLineageMixin:
                 request_id=r["request_id"],
                 reason=r["reason"],
                 created_at=r["created_at"],
+                from_status=r["from_status"],
+                to_status=r["to_status"],
+                status_namespace=r["status_namespace"],
             )
             for r in rows
         ]

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -447,6 +447,8 @@ class PlaybookMixin:
                 f"UPDATE user_playbooks SET status = ? WHERE {where}",
                 [new_val] + select_params + extra_params,
             )
+            from_val = old_status.value if old_status else None
+            to_val = new_status.value if new_status else None
             for upid in affected:
                 _append_event_stmt(
                     self.conn,
@@ -459,6 +461,9 @@ class PlaybookMixin:
                     actor="api",
                     request_id=batch_request_id,
                     reason=reason,
+                    from_status=from_val,
+                    to_status=to_val,
+                    status_namespace="lifecycle_status",
                 )
             self.conn.commit()
         return cur.rowcount
@@ -945,7 +950,8 @@ class PlaybookMixin:
                 raise ValueError(
                     f"Agent playbook with ID {agent_playbook_id} not found"
                 )
-            old_status = row["playbook_status"] or "None"
+            prior_playbook_status = row["playbook_status"]
+            old_status = prior_playbook_status or "None"
             cur = self.conn.execute(
                 "UPDATE agent_playbooks SET playbook_status = ? WHERE agent_playbook_id = ?",
                 (playbook_status.value, agent_playbook_id),
@@ -962,6 +968,9 @@ class PlaybookMixin:
                     actor="api",
                     request_id=uuid.uuid4().hex,
                     reason=f"{old_status}->{playbook_status.value}",
+                    from_status=prior_playbook_status,
+                    to_status=playbook_status.value,
+                    status_namespace="playbook_status",
                 )
             self.conn.commit()
 
@@ -1126,6 +1135,9 @@ class PlaybookMixin:
                     actor="api",
                     request_id=batch_request_id,
                     reason=f"{prior}->archived",
+                    from_status=row["status"],
+                    to_status="archived",
+                    status_namespace="lifecycle_status",
                 )
             self.conn.commit()
 
@@ -1161,6 +1173,9 @@ class PlaybookMixin:
                     actor="api",
                     request_id=batch_request_id,
                     reason=f"{prior}->archived",
+                    from_status=row["status"],
+                    to_status="archived",
+                    status_namespace="lifecycle_status",
                 )
             self.conn.commit()
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -43,6 +43,29 @@ from ._base import (
 from ._lineage import _append_event_stmt
 
 
+def _emit_hard_delete_playbook(
+    conn: sqlite3.Connection,
+    *,
+    org_id: str,
+    entity_type: str,
+    entity_id: str,
+    request_id: str,
+) -> None:
+    """Emit a single hard_delete lineage event for a playbook entity."""
+    _append_event_stmt(
+        conn,
+        org_id=org_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        op="hard_delete",
+        prov="wasInvalidatedBy",
+        source_ids=[],
+        actor="api",
+        request_id=request_id,
+        reason="erasure",
+    )
+
+
 def _row_to_playbook_optimization_candidate(
     row: sqlite3.Row,
 ) -> PlaybookOptimizationCandidate:
@@ -282,24 +305,21 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_user_playbooks(self) -> None:
-        ids = [
-            r["user_playbook_id"]
-            for r in self._fetchall("SELECT user_playbook_id FROM user_playbooks")
-        ]
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            ids = [
+                r["user_playbook_id"]
+                for r in self.conn.execute(
+                    "SELECT user_playbook_id FROM user_playbooks"
+                ).fetchall()
+            ]
             for upid in ids:
-                _append_event_stmt(
+                _emit_hard_delete_playbook(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="user_playbook",
                     entity_id=str(upid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
             self.conn.execute("DELETE FROM user_playbooks_fts")
             self.conn.execute("DELETE FROM user_playbooks")
@@ -307,19 +327,13 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbook(self, user_playbook_id: int) -> None:
-        batch_request_id = uuid.uuid4().hex
         with self._lock:
-            _append_event_stmt(
+            _emit_hard_delete_playbook(
                 self.conn,
                 org_id=self.org_id,
                 entity_type="user_playbook",
                 entity_id=str(user_playbook_id),
-                op="hard_delete",
-                prov="wasInvalidatedBy",
-                source_ids=[],
-                actor="api",
-                request_id=batch_request_id,
-                reason="erasure",
+                request_id=uuid.uuid4().hex,
             )
             self._fts_delete("user_playbooks_fts", user_playbook_id)
             self._vec_delete("user_playbooks_vec", user_playbook_id)
@@ -338,24 +352,21 @@ class PlaybookMixin:
         if agent_version is not None:
             sql += " AND agent_version = ?"
             params.append(agent_version)
-        ids = [r["user_playbook_id"] for r in self._fetchall(sql, params)]
-        if not ids:
-            return
-        ph = ",".join("?" for _ in ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            ids = [
+                r["user_playbook_id"] for r in self.conn.execute(sql, params).fetchall()
+            ]
+            if not ids:
+                return
+            ph = ",".join("?" for _ in ids)
             for upid in ids:
-                _append_event_stmt(
+                _emit_hard_delete_playbook(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="user_playbook",
                     entity_id=str(upid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
             self.conn.execute(
                 f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})", ids
@@ -372,20 +383,16 @@ class PlaybookMixin:
         if not user_playbook_ids:
             return 0
         ph = ",".join("?" for _ in user_playbook_ids)
+        batch_request_id = uuid.uuid4().hex
         with self._lock:
             if emit_hard_delete:
                 for upid in user_playbook_ids:
-                    _append_event_stmt(
+                    _emit_hard_delete_playbook(
                         self.conn,
                         org_id=self.org_id,
                         entity_type="user_playbook",
                         entity_id=str(upid),
-                        op="hard_delete",
-                        prov="wasInvalidatedBy",
-                        source_ids=[],
-                        actor="system",
-                        request_id="",
-                        reason="erasure",
+                        request_id=batch_request_id,
                     )
             self.conn.execute(
                 f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
@@ -794,24 +801,21 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_playbooks(self) -> None:
-        ids = [
-            r["agent_playbook_id"]
-            for r in self._fetchall("SELECT agent_playbook_id FROM agent_playbooks")
-        ]
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            ids = [
+                r["agent_playbook_id"]
+                for r in self.conn.execute(
+                    "SELECT agent_playbook_id FROM agent_playbooks"
+                ).fetchall()
+            ]
             for apid in ids:
-                _append_event_stmt(
+                _emit_hard_delete_playbook(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="agent_playbook",
                     entity_id=str(apid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
             self.conn.execute("DELETE FROM agent_playbooks_fts")
             self.conn.execute("DELETE FROM agent_playbooks")
@@ -819,19 +823,13 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbook(self, agent_playbook_id: int) -> None:
-        batch_request_id = uuid.uuid4().hex
         with self._lock:
-            _append_event_stmt(
+            _emit_hard_delete_playbook(
                 self.conn,
                 org_id=self.org_id,
                 entity_type="agent_playbook",
                 entity_id=str(agent_playbook_id),
-                op="hard_delete",
-                prov="wasInvalidatedBy",
-                source_ids=[],
-                actor="api",
-                request_id=batch_request_id,
-                reason="erasure",
+                request_id=uuid.uuid4().hex,
             )
             self._fts_delete("agent_playbooks_fts", agent_playbook_id)
             self._vec_delete("agent_playbooks_vec", agent_playbook_id)
@@ -850,24 +848,22 @@ class PlaybookMixin:
         if agent_version is not None:
             sql += " AND agent_version = ?"
             params.append(agent_version)
-        ids = [r["agent_playbook_id"] for r in self._fetchall(sql, params)]
-        if not ids:
-            return
-        ph = ",".join("?" for _ in ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            ids = [
+                r["agent_playbook_id"]
+                for r in self.conn.execute(sql, params).fetchall()
+            ]
+            if not ids:
+                return
+            ph = ",".join("?" for _ in ids)
             for apid in ids:
-                _append_event_stmt(
+                _emit_hard_delete_playbook(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="agent_playbook",
                     entity_id=str(apid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
             self.conn.execute(
                 f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
@@ -884,20 +880,16 @@ class PlaybookMixin:
         if not agent_playbook_ids:
             return
         ph = ",".join("?" for _ in agent_playbook_ids)
+        batch_request_id = uuid.uuid4().hex
         with self._lock:
             if emit_hard_delete:
                 for apid in agent_playbook_ids:
-                    _append_event_stmt(
+                    _emit_hard_delete_playbook(
                         self.conn,
                         org_id=self.org_id,
                         entity_type="agent_playbook",
                         entity_id=str(apid),
-                        op="hard_delete",
-                        prov="wasInvalidatedBy",
-                        source_ids=[],
-                        actor="system",
-                        request_id="",
-                        reason="erasure",
+                        request_id=batch_request_id,
                     )
             self.conn.execute(
                 f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})",
@@ -1377,24 +1369,22 @@ class PlaybookMixin:
         if agent_version is not None:
             sql += " AND agent_version = ?"
             params.append(agent_version)
-        ids = [r["agent_playbook_id"] for r in self._fetchall(sql, params)]
-        if not ids:
-            return
-        ph = ",".join("?" for _ in ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            ids = [
+                r["agent_playbook_id"]
+                for r in self.conn.execute(sql, params).fetchall()
+            ]
+            if not ids:
+                return
+            ph = ",".join("?" for _ in ids)
             for apid in ids:
-                _append_event_stmt(
+                _emit_hard_delete_playbook(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="agent_playbook",
                     entity_id=str(apid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
             self.conn.execute(
                 f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -986,12 +986,6 @@ class PlaybookMixin:
         playbook_status: PlaybookStatus | None = None,
         tags: list[str] | None = None,
     ) -> None:
-        row = self._fetchone(
-            "SELECT agent_playbook_id FROM agent_playbooks WHERE agent_playbook_id = ?",
-            (agent_playbook_id,),
-        )
-        if not row:
-            raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
         updates: list[str] = []
         params: list[Any] = []
         if playbook_name is not None:
@@ -1020,11 +1014,30 @@ class PlaybookMixin:
             op = "revise" if content is not None else "status_change"
             prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
             with self._lock:
+                prior_row = self.conn.execute(
+                    "SELECT playbook_status FROM agent_playbooks WHERE agent_playbook_id = ?",
+                    (agent_playbook_id,),
+                ).fetchone()
+                if not prior_row:
+                    raise ValueError(
+                        f"Agent playbook with ID {agent_playbook_id} not found"
+                    )
+                prior_playbook_status = prior_row["playbook_status"]
                 cur = self.conn.execute(
                     f"UPDATE agent_playbooks SET {', '.join(updates)} WHERE agent_playbook_id = ?",
                     tuple(params),
                 )
                 if cur.rowcount > 0:
+                    # Populate structured status fields only when playbook_status is
+                    # among the updated fields and the op is status_change (not revise).
+                    if op == "status_change" and playbook_status is not None:
+                        from_status = prior_playbook_status
+                        to_status = playbook_status.value
+                        status_namespace: str | None = "playbook_status"
+                    else:
+                        from_status = None
+                        to_status = None
+                        status_namespace = None
                     _append_event_stmt(
                         self.conn,
                         org_id=self.org_id,
@@ -1036,6 +1049,9 @@ class PlaybookMixin:
                         actor="api",
                         request_id=uuid.uuid4().hex,
                         reason="in-place update",
+                        from_status=from_status,
+                        to_status=to_status,
+                        status_namespace=status_namespace,
                     )
                 self.conn.commit()
 
@@ -1049,13 +1065,8 @@ class PlaybookMixin:
         rationale: str | None = None,
         blocking_issue: BlockingIssue | None = None,
         tags: list[str] | None = None,
+        status: Status | None = None,
     ) -> None:
-        row = self._fetchone(
-            "SELECT user_playbook_id FROM user_playbooks WHERE user_playbook_id = ?",
-            (user_playbook_id,),
-        )
-        if not row:
-            raise ValueError(f"User playbook with ID {user_playbook_id} not found")
         updates: list[str] = []
         params: list[Any] = []
         if playbook_name is not None:
@@ -1076,16 +1087,38 @@ class PlaybookMixin:
         if tags is not None:
             updates.append("tags = ?")
             params.append(_json_dumps(tags))
+        if status is not None:
+            updates.append("status = ?")
+            params.append(status.value)
         if updates:
             params.append(user_playbook_id)
             op = "revise" if content is not None else "status_change"
             prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
             with self._lock:
+                prior_row = self.conn.execute(
+                    "SELECT status FROM user_playbooks WHERE user_playbook_id = ?",
+                    (user_playbook_id,),
+                ).fetchone()
+                if not prior_row:
+                    raise ValueError(
+                        f"User playbook with ID {user_playbook_id} not found"
+                    )
+                prior_status = prior_row["status"]
                 cur = self.conn.execute(
                     f"UPDATE user_playbooks SET {', '.join(updates)} WHERE user_playbook_id = ?",
                     tuple(params),
                 )
                 if cur.rowcount > 0:
+                    # Populate structured status fields only when the lifecycle status
+                    # field is among the updated fields and the op is status_change.
+                    if op == "status_change" and status is not None:
+                        from_status = prior_status
+                        to_status = status.value
+                        status_namespace: str | None = "lifecycle_status"
+                    else:
+                        from_status = None
+                        to_status = None
+                        status_namespace = None
                     _append_event_stmt(
                         self.conn,
                         org_id=self.org_id,
@@ -1097,6 +1130,9 @@ class PlaybookMixin:
                         actor="api",
                         request_id=uuid.uuid4().hex,
                         reason="in-place update",
+                        from_status=from_status,
+                        to_status=to_status,
+                        status_namespace=status_namespace,
                     )
                 self.conn.commit()
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -823,16 +824,35 @@ class PlaybookMixin:
     def update_agent_playbook_status(
         self, agent_playbook_id: int, playbook_status: PlaybookStatus
     ) -> None:
+        """Update an agent playbook's status and emit a status_change lineage event.
+
+        Each call generates a fresh request_id so every status change is recorded as
+        a distinct audit event (not collapsed by the idempotency key).
+        """
         row = self._fetchone(
             "SELECT agent_playbook_id FROM agent_playbooks WHERE agent_playbook_id = ?",
             (agent_playbook_id,),
         )
         if not row:
             raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
-        self._execute(
-            "UPDATE agent_playbooks SET playbook_status = ? WHERE agent_playbook_id = ?",
-            (playbook_status.value, agent_playbook_id),
-        )
+        with self._lock:
+            self.conn.execute(
+                "UPDATE agent_playbooks SET playbook_status = ? WHERE agent_playbook_id = ?",
+                (playbook_status.value, agent_playbook_id),
+            )
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type="agent_playbook",
+                entity_id=str(agent_playbook_id),
+                op="status_change",
+                prov="wasInvalidatedBy",
+                source_ids=[],
+                actor="api",
+                request_id=uuid.uuid4().hex,
+                reason="in-place update",
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def update_agent_playbook(
@@ -877,10 +897,26 @@ class PlaybookMixin:
             params.append(_json_dumps(tags))
         if updates:
             params.append(agent_playbook_id)
-            self._execute(
-                f"UPDATE agent_playbooks SET {', '.join(updates)} WHERE agent_playbook_id = ?",
-                tuple(params),
-            )
+            op = "revise" if content is not None else "status_change"
+            prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
+            with self._lock:
+                self.conn.execute(
+                    f"UPDATE agent_playbooks SET {', '.join(updates)} WHERE agent_playbook_id = ?",
+                    tuple(params),
+                )
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(agent_playbook_id),
+                    op=op,
+                    prov=prov,
+                    source_ids=[],
+                    actor="api",
+                    request_id=uuid.uuid4().hex,
+                    reason="in-place update",
+                )
+                self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def update_user_playbook(
@@ -921,10 +957,26 @@ class PlaybookMixin:
             params.append(_json_dumps(tags))
         if updates:
             params.append(user_playbook_id)
-            self._execute(
-                f"UPDATE user_playbooks SET {', '.join(updates)} WHERE user_playbook_id = ?",
-                tuple(params),
-            )
+            op = "revise" if content is not None else "status_change"
+            prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
+            with self._lock:
+                self.conn.execute(
+                    f"UPDATE user_playbooks SET {', '.join(updates)} WHERE user_playbook_id = ?",
+                    tuple(params),
+                )
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="user_playbook",
+                    entity_id=str(user_playbook_id),
+                    op=op,
+                    prov=prov,
+                    source_ids=[],
+                    actor="api",
+                    request_id=uuid.uuid4().hex,
+                    reason="in-place update",
+                )
+                self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def archive_agent_playbooks_by_playbook_name(

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1065,7 +1065,6 @@ class PlaybookMixin:
         rationale: str | None = None,
         blocking_issue: BlockingIssue | None = None,
         tags: list[str] | None = None,
-        status: Status | None = None,
     ) -> None:
         updates: list[str] = []
         params: list[Any] = []
@@ -1087,38 +1086,16 @@ class PlaybookMixin:
         if tags is not None:
             updates.append("tags = ?")
             params.append(_json_dumps(tags))
-        if status is not None:
-            updates.append("status = ?")
-            params.append(status.value)
         if updates:
             params.append(user_playbook_id)
             op = "revise" if content is not None else "status_change"
             prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
             with self._lock:
-                prior_row = self.conn.execute(
-                    "SELECT status FROM user_playbooks WHERE user_playbook_id = ?",
-                    (user_playbook_id,),
-                ).fetchone()
-                if not prior_row:
-                    raise ValueError(
-                        f"User playbook with ID {user_playbook_id} not found"
-                    )
-                prior_status = prior_row["status"]
                 cur = self.conn.execute(
                     f"UPDATE user_playbooks SET {', '.join(updates)} WHERE user_playbook_id = ?",
                     tuple(params),
                 )
                 if cur.rowcount > 0:
-                    # Populate structured status fields only when the lifecycle status
-                    # field is among the updated fields and the op is status_change.
-                    if op == "status_change" and status is not None:
-                        from_status = prior_status
-                        to_status = status.value
-                        status_namespace: str | None = "lifecycle_status"
-                    else:
-                        from_status = None
-                        to_status = None
-                        status_namespace = None
                     _append_event_stmt(
                         self.conn,
                         org_id=self.org_id,
@@ -1130,9 +1107,9 @@ class PlaybookMixin:
                         actor="api",
                         request_id=uuid.uuid4().hex,
                         reason="in-place update",
-                        from_status=from_status,
-                        to_status=to_status,
-                        status_namespace=status_namespace,
+                        from_status=None,
+                        to_status=None,
+                        status_namespace=None,
                     )
                 self.conn.commit()
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -131,6 +131,7 @@ class PlaybookMixin:
     _fts_delete: Any
     _vec_upsert: Any
     _vec_delete: Any
+    _delete_playbook_search_rows: Any
     _has_sqlite_vec: bool
 
     # ------------------------------------------------------------------
@@ -322,7 +323,7 @@ class PlaybookMixin:
                     entity_id=str(upid),
                     request_id=batch_request_id,
                 )
-            self.conn.execute("DELETE FROM user_playbooks_fts")
+            self._delete_playbook_search_rows("user", ids)
             self.conn.execute("DELETE FROM user_playbooks")
             self.conn.commit()
 
@@ -370,9 +371,7 @@ class PlaybookMixin:
                     entity_id=str(upid),
                     request_id=batch_request_id,
                 )
-            self.conn.execute(
-                f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})", ids
-            )
+            self._delete_playbook_search_rows("user", ids)
             self.conn.execute(
                 f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})", ids
             )
@@ -397,10 +396,7 @@ class PlaybookMixin:
                         request_id=batch_request_id,
                         actor="system",
                     )
-            self.conn.execute(
-                f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
-                user_playbook_ids,
-            )
+            self._delete_playbook_search_rows("user", user_playbook_ids)
             cur = self.conn.execute(
                 f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",
                 user_playbook_ids,
@@ -488,7 +484,7 @@ class PlaybookMixin:
             where += " AND playbook_name = ?"
             params.append(playbook_name)
 
-        # Clean up FTS
+        # Clean up FTS + vec
         ids = [
             r["user_playbook_id"]
             for r in self._fetchall(
@@ -496,11 +492,8 @@ class PlaybookMixin:
             )
         ]
         if ids:
-            ph = ",".join("?" for _ in ids)
             with self._lock:
-                self.conn.execute(
-                    f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})", ids
-                )
+                self._delete_playbook_search_rows("user", ids)
                 self.conn.commit()
 
         cur = self._execute(f"DELETE FROM user_playbooks WHERE {where}", params)
@@ -853,7 +846,7 @@ class PlaybookMixin:
                     entity_id=str(apid),
                     request_id=batch_request_id,
                 )
-            self.conn.execute("DELETE FROM agent_playbooks_fts")
+            self._delete_playbook_search_rows("agent", ids)
             self.conn.execute("DELETE FROM agent_playbooks")
             self.conn.commit()
 
@@ -902,9 +895,7 @@ class PlaybookMixin:
                     entity_id=str(apid),
                     request_id=batch_request_id,
                 )
-            self.conn.execute(
-                f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
-            )
+            self._delete_playbook_search_rows("agent", ids)
             self.conn.execute(
                 f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
             )
@@ -929,10 +920,7 @@ class PlaybookMixin:
                         request_id=batch_request_id,
                         actor="system",
                     )
-            self.conn.execute(
-                f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})",
-                agent_playbook_ids,
-            )
+            self._delete_playbook_search_rows("agent", agent_playbook_ids)
             self.conn.execute(
                 f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})",
                 agent_playbook_ids,
@@ -1023,22 +1011,23 @@ class PlaybookMixin:
             op = "revise" if content is not None else "status_change"
             prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
             with self._lock:
-                self.conn.execute(
+                cur = self.conn.execute(
                     f"UPDATE agent_playbooks SET {', '.join(updates)} WHERE agent_playbook_id = ?",
                     tuple(params),
                 )
-                _append_event_stmt(
-                    self.conn,
-                    org_id=self.org_id,
-                    entity_type="agent_playbook",
-                    entity_id=str(agent_playbook_id),
-                    op=op,
-                    prov=prov,
-                    source_ids=[],
-                    actor="api",
-                    request_id=uuid.uuid4().hex,
-                    reason="in-place update",
-                )
+                if cur.rowcount > 0:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="agent_playbook",
+                        entity_id=str(agent_playbook_id),
+                        op=op,
+                        prov=prov,
+                        source_ids=[],
+                        actor="api",
+                        request_id=uuid.uuid4().hex,
+                        reason="in-place update",
+                    )
                 self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -1083,29 +1072,33 @@ class PlaybookMixin:
             op = "revise" if content is not None else "status_change"
             prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
             with self._lock:
-                self.conn.execute(
+                cur = self.conn.execute(
                     f"UPDATE user_playbooks SET {', '.join(updates)} WHERE user_playbook_id = ?",
                     tuple(params),
                 )
-                _append_event_stmt(
-                    self.conn,
-                    org_id=self.org_id,
-                    entity_type="user_playbook",
-                    entity_id=str(user_playbook_id),
-                    op=op,
-                    prov=prov,
-                    source_ids=[],
-                    actor="api",
-                    request_id=uuid.uuid4().hex,
-                    reason="in-place update",
-                )
+                if cur.rowcount > 0:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="user_playbook",
+                        entity_id=str(user_playbook_id),
+                        op=op,
+                        prov=prov,
+                        source_ids=[],
+                        actor="api",
+                        request_id=uuid.uuid4().hex,
+                        reason="in-place update",
+                    )
                 self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def archive_agent_playbooks_by_playbook_name(
         self, playbook_name: str, agent_version: str | None = None
     ) -> None:
-        where = "playbook_name = ? AND playbook_status != ?"
+        where = (
+            "playbook_name = ? AND playbook_status != ?"
+            " AND (status IS NULL OR status != 'archived')"
+        )
         params: list[Any] = [playbook_name, PlaybookStatus.APPROVED.value]
         if agent_version is not None:
             where += " AND agent_version = ?"
@@ -1145,12 +1138,14 @@ class PlaybookMixin:
         with self._lock:
             affected = self.conn.execute(
                 f"SELECT agent_playbook_id, status FROM agent_playbooks"
-                f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
+                f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?"
+                f" AND (status IS NULL OR status != 'archived')",
                 [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
             ).fetchall()
             self.conn.execute(
                 f"UPDATE agent_playbooks SET status = 'archived'"
-                f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
+                f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?"
+                f" AND (status IS NULL OR status != 'archived')",
                 [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
             )
             for row in affected:
@@ -1475,9 +1470,7 @@ class PlaybookMixin:
                     entity_id=str(apid),
                     request_id=batch_request_id,
                 )
-            self.conn.execute(
-                f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
-            )
+            self._delete_playbook_search_rows("agent", ids)
             self.conn.execute(
                 f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
             )

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -282,18 +282,52 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_user_playbooks(self) -> None:
+        ids = [
+            r["user_playbook_id"]
+            for r in self._fetchall("SELECT user_playbook_id FROM user_playbooks")
+        ]
+        batch_request_id = uuid.uuid4().hex
         with self._lock:
+            for upid in ids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="user_playbook",
+                    entity_id=str(upid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
+                )
             self.conn.execute("DELETE FROM user_playbooks_fts")
             self.conn.execute("DELETE FROM user_playbooks")
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbook(self, user_playbook_id: int) -> None:
-        self._fts_delete("user_playbooks_fts", user_playbook_id)
-        self._vec_delete("user_playbooks_vec", user_playbook_id)
-        self._execute(
-            "DELETE FROM user_playbooks WHERE user_playbook_id = ?", (user_playbook_id,)
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type="user_playbook",
+                entity_id=str(user_playbook_id),
+                op="hard_delete",
+                prov="wasInvalidatedBy",
+                source_ids=[],
+                actor="api",
+                request_id=batch_request_id,
+                reason="erasure",
+            )
+            self._fts_delete("user_playbooks_fts", user_playbook_id)
+            self._vec_delete("user_playbooks_vec", user_playbook_id)
+            self.conn.execute(
+                "DELETE FROM user_playbooks WHERE user_playbook_id = ?",
+                (user_playbook_id,),
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_user_playbooks_by_playbook_name(
@@ -305,20 +339,31 @@ class PlaybookMixin:
             sql += " AND agent_version = ?"
             params.append(agent_version)
         ids = [r["user_playbook_id"] for r in self._fetchall(sql, params)]
-        if ids:
-            ph = ",".join("?" for _ in ids)
-            with self._lock:
-                self.conn.execute(
-                    f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})", ids
+        if not ids:
+            return
+        ph = ",".join("?" for _ in ids)
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            for upid in ids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="user_playbook",
+                    entity_id=str(upid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
                 )
-                self.conn.commit()
-
-        del_sql = "DELETE FROM user_playbooks WHERE playbook_name = ?"
-        del_params: list[Any] = [playbook_name]
-        if agent_version is not None:
-            del_sql += " AND agent_version = ?"
-            del_params.append(agent_version)
-        self._execute(del_sql, del_params)
+            self.conn.execute(
+                f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})", ids
+            )
+            self.conn.execute(
+                f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})", ids
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbooks_by_ids(
@@ -749,19 +794,52 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_playbooks(self) -> None:
+        ids = [
+            r["agent_playbook_id"]
+            for r in self._fetchall("SELECT agent_playbook_id FROM agent_playbooks")
+        ]
+        batch_request_id = uuid.uuid4().hex
         with self._lock:
+            for apid in ids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(apid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
+                )
             self.conn.execute("DELETE FROM agent_playbooks_fts")
             self.conn.execute("DELETE FROM agent_playbooks")
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbook(self, agent_playbook_id: int) -> None:
-        self._fts_delete("agent_playbooks_fts", agent_playbook_id)
-        self._vec_delete("agent_playbooks_vec", agent_playbook_id)
-        self._execute(
-            "DELETE FROM agent_playbooks WHERE agent_playbook_id = ?",
-            (agent_playbook_id,),
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type="agent_playbook",
+                entity_id=str(agent_playbook_id),
+                op="hard_delete",
+                prov="wasInvalidatedBy",
+                source_ids=[],
+                actor="api",
+                request_id=batch_request_id,
+                reason="erasure",
+            )
+            self._fts_delete("agent_playbooks_fts", agent_playbook_id)
+            self._vec_delete("agent_playbooks_vec", agent_playbook_id)
+            self.conn.execute(
+                "DELETE FROM agent_playbooks WHERE agent_playbook_id = ?",
+                (agent_playbook_id,),
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_playbooks_by_playbook_name(
@@ -773,20 +851,31 @@ class PlaybookMixin:
             sql += " AND agent_version = ?"
             params.append(agent_version)
         ids = [r["agent_playbook_id"] for r in self._fetchall(sql, params)]
-        if ids:
-            ph = ",".join("?" for _ in ids)
-            with self._lock:
-                self.conn.execute(
-                    f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
+        if not ids:
+            return
+        ph = ",".join("?" for _ in ids)
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            for apid in ids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(apid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
                 )
-                self.conn.commit()
-
-        del_sql = "DELETE FROM agent_playbooks WHERE playbook_name = ?"
-        del_params: list[Any] = [playbook_name]
-        if agent_version is not None:
-            del_sql += " AND agent_version = ?"
-            del_params.append(agent_version)
-        self._execute(del_sql, del_params)
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
+            )
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbooks_by_ids(
@@ -1283,27 +1372,37 @@ class PlaybookMixin:
     def delete_archived_agent_playbooks_by_playbook_name(
         self, playbook_name: str, agent_version: str | None = None
     ) -> None:
-        # Get IDs for FTS cleanup
         sql = "SELECT agent_playbook_id FROM agent_playbooks WHERE playbook_name = ? AND status = 'archived'"
         params: list[Any] = [playbook_name]
         if agent_version is not None:
             sql += " AND agent_version = ?"
             params.append(agent_version)
         ids = [r["agent_playbook_id"] for r in self._fetchall(sql, params)]
-        if ids:
-            ph = ",".join("?" for _ in ids)
-            with self._lock:
-                self.conn.execute(
-                    f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
+        if not ids:
+            return
+        ph = ",".join("?" for _ in ids)
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            for apid in ids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(apid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
                 )
-                self.conn.commit()
-
-        del_sql = "DELETE FROM agent_playbooks WHERE playbook_name = ? AND status = 'archived'"
-        del_params: list[Any] = [playbook_name]
-        if agent_version is not None:
-            del_sql += " AND agent_version = ?"
-            del_params.append(agent_version)
-        self._execute(del_sql, del_params)
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})", ids
+            )
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def search_agent_playbooks(  # noqa: C901

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -414,26 +414,54 @@ class PlaybookMixin:
         playbook_name: str | None = None,
     ) -> int:
         new_val = new_status.value if new_status else None
-        params: list[Any] = [new_val]
+        old_val_str = old_status.value if old_status else "None"
+        new_val_str = new_status.value if new_status else "None"
+        reason = f"{old_val_str}->{new_val_str}"
 
         if old_status is None or (
             hasattr(old_status, "value") and old_status.value is None
         ):
             where = "status IS NULL"
+            select_params: list[Any] = []
         else:
             where = "status = ?"
-            params.append(old_status.value)
+            select_params = [old_status.value]
 
+        extra_params: list[Any] = []
         if agent_version is not None:
             where += " AND agent_version = ?"
-            params.append(agent_version)
+            extra_params.append(agent_version)
         if playbook_name is not None:
             where += " AND playbook_name = ?"
-            params.append(playbook_name)
+            extra_params.append(playbook_name)
 
-        cur = self._execute(
-            f"UPDATE user_playbooks SET status = ? WHERE {where}", params
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            affected = [
+                r["user_playbook_id"]
+                for r in self.conn.execute(
+                    f"SELECT user_playbook_id FROM user_playbooks WHERE {where}",
+                    select_params + extra_params,
+                ).fetchall()
+            ]
+            cur = self.conn.execute(
+                f"UPDATE user_playbooks SET status = ? WHERE {where}",
+                [new_val] + select_params + extra_params,
+            )
+            for upid in affected:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="user_playbook",
+                    entity_id=str(upid),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason=reason,
+                )
+            self.conn.commit()
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
@@ -1063,22 +1091,69 @@ class PlaybookMixin:
     def archive_agent_playbooks_by_playbook_name(
         self, playbook_name: str, agent_version: str | None = None
     ) -> None:
-        sql = "UPDATE agent_playbooks SET status = 'archived' WHERE playbook_name = ? AND playbook_status != ?"
+        select_sql = "SELECT agent_playbook_id FROM agent_playbooks WHERE playbook_name = ? AND playbook_status != ?"
+        update_sql = "UPDATE agent_playbooks SET status = 'archived' WHERE playbook_name = ? AND playbook_status != ?"
         params: list[Any] = [playbook_name, PlaybookStatus.APPROVED.value]
         if agent_version is not None:
-            sql += " AND agent_version = ?"
+            select_sql += " AND agent_version = ?"
+            update_sql += " AND agent_version = ?"
             params.append(agent_version)
-        self._execute(sql, params)
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            affected = [
+                r["agent_playbook_id"]
+                for r in self.conn.execute(select_sql, params).fetchall()
+            ]
+            self.conn.execute(update_sql, params)
+            for apid in affected:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(apid),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="None->archived",
+                )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def archive_agent_playbooks_by_ids(self, agent_playbook_ids: list[int]) -> None:
         if not agent_playbook_ids:
             return
         ph = ",".join("?" for _ in agent_playbook_ids)
-        self._execute(
-            f"UPDATE agent_playbooks SET status = 'archived' WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
-            [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            affected = [
+                r["agent_playbook_id"]
+                for r in self.conn.execute(
+                    f"SELECT agent_playbook_id FROM agent_playbooks"
+                    f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
+                    [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
+                ).fetchall()
+            ]
+            self.conn.execute(
+                f"UPDATE agent_playbooks SET status = 'archived'"
+                f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
+                [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
+            )
+            for apid in affected:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(apid),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="None->archived",
+                )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def restore_archived_agent_playbooks_by_playbook_name(

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1091,32 +1091,34 @@ class PlaybookMixin:
     def archive_agent_playbooks_by_playbook_name(
         self, playbook_name: str, agent_version: str | None = None
     ) -> None:
-        select_sql = "SELECT agent_playbook_id FROM agent_playbooks WHERE playbook_name = ? AND playbook_status != ?"
-        update_sql = "UPDATE agent_playbooks SET status = 'archived' WHERE playbook_name = ? AND playbook_status != ?"
+        where = "playbook_name = ? AND playbook_status != ?"
         params: list[Any] = [playbook_name, PlaybookStatus.APPROVED.value]
         if agent_version is not None:
-            select_sql += " AND agent_version = ?"
-            update_sql += " AND agent_version = ?"
+            where += " AND agent_version = ?"
             params.append(agent_version)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            affected = [
-                r["agent_playbook_id"]
-                for r in self.conn.execute(select_sql, params).fetchall()
-            ]
-            self.conn.execute(update_sql, params)
-            for apid in affected:
+            affected = self.conn.execute(
+                f"SELECT agent_playbook_id, status FROM agent_playbooks WHERE {where}",
+                params,
+            ).fetchall()
+            self.conn.execute(
+                f"UPDATE agent_playbooks SET status = 'archived' WHERE {where}",
+                params,
+            )
+            for row in affected:
+                prior = row["status"] or "None"
                 _append_event_stmt(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="agent_playbook",
-                    entity_id=str(apid),
+                    entity_id=str(row["agent_playbook_id"]),
                     op="status_change",
                     prov="wasInvalidatedBy",
                     source_ids=[],
                     actor="api",
                     request_id=batch_request_id,
-                    reason="None->archived",
+                    reason=f"{prior}->archived",
                 )
             self.conn.commit()
 
@@ -1127,31 +1129,29 @@ class PlaybookMixin:
         ph = ",".join("?" for _ in agent_playbook_ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            affected = [
-                r["agent_playbook_id"]
-                for r in self.conn.execute(
-                    f"SELECT agent_playbook_id FROM agent_playbooks"
-                    f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
-                    [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
-                ).fetchall()
-            ]
+            affected = self.conn.execute(
+                f"SELECT agent_playbook_id, status FROM agent_playbooks"
+                f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
+                [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
+            ).fetchall()
             self.conn.execute(
                 f"UPDATE agent_playbooks SET status = 'archived'"
                 f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?",
                 [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
             )
-            for apid in affected:
+            for row in affected:
+                prior = row["status"] or "None"
                 _append_event_stmt(
                     self.conn,
                     org_id=self.org_id,
                     entity_type="agent_playbook",
-                    entity_id=str(apid),
+                    entity_id=str(row["agent_playbook_id"]),
                     op="status_change",
                     prov="wasInvalidatedBy",
                     source_ids=[],
                     actor="api",
                     request_id=batch_request_id,
-                    reason="None->archived",
+                    reason=f"{prior}->archived",
                 )
             self.conn.commit()
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -50,6 +50,7 @@ def _emit_hard_delete_playbook(
     entity_type: str,
     entity_id: str,
     request_id: str,
+    actor: str = "api",
 ) -> None:
     """Emit a single hard_delete lineage event for a playbook entity."""
     _append_event_stmt(
@@ -60,7 +61,7 @@ def _emit_hard_delete_playbook(
         op="hard_delete",
         prov="wasInvalidatedBy",
         source_ids=[],
-        actor="api",
+        actor=actor,
         request_id=request_id,
         reason="erasure",
     )
@@ -328,19 +329,20 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbook(self, user_playbook_id: int) -> None:
         with self._lock:
-            _emit_hard_delete_playbook(
-                self.conn,
-                org_id=self.org_id,
-                entity_type="user_playbook",
-                entity_id=str(user_playbook_id),
-                request_id=uuid.uuid4().hex,
-            )
             self._fts_delete("user_playbooks_fts", user_playbook_id)
             self._vec_delete("user_playbooks_vec", user_playbook_id)
-            self.conn.execute(
+            cur = self.conn.execute(
                 "DELETE FROM user_playbooks WHERE user_playbook_id = ?",
                 (user_playbook_id,),
             )
+            if cur.rowcount > 0:
+                _emit_hard_delete_playbook(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="user_playbook",
+                    entity_id=str(user_playbook_id),
+                    request_id=uuid.uuid4().hex,
+                )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -393,6 +395,7 @@ class PlaybookMixin:
                         entity_type="user_playbook",
                         entity_id=str(upid),
                         request_id=batch_request_id,
+                        actor="system",
                     )
             self.conn.execute(
                 f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
@@ -471,6 +474,11 @@ class PlaybookMixin:
         agent_version: str | None = None,
         playbook_name: str | None = None,
     ) -> int:
+        if status != Status.PENDING:
+            raise ValueError(
+                f"delete_all_user_playbooks_by_status only accepts Status.PENDING "
+                f"(got {status!r}); use archive or hard-delete methods for other statuses"
+            )
         where = "status = ?"
         params: list[Any] = [status.value]
         if agent_version is not None:
@@ -852,19 +860,20 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbook(self, agent_playbook_id: int) -> None:
         with self._lock:
-            _emit_hard_delete_playbook(
-                self.conn,
-                org_id=self.org_id,
-                entity_type="agent_playbook",
-                entity_id=str(agent_playbook_id),
-                request_id=uuid.uuid4().hex,
-            )
             self._fts_delete("agent_playbooks_fts", agent_playbook_id)
             self._vec_delete("agent_playbooks_vec", agent_playbook_id)
-            self.conn.execute(
+            cur = self.conn.execute(
                 "DELETE FROM agent_playbooks WHERE agent_playbook_id = ?",
                 (agent_playbook_id,),
             )
+            if cur.rowcount > 0:
+                _emit_hard_delete_playbook(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(agent_playbook_id),
+                    request_id=uuid.uuid4().hex,
+                )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -918,6 +927,7 @@ class PlaybookMixin:
                         entity_type="agent_playbook",
                         entity_id=str(apid),
                         request_id=batch_request_id,
+                        actor="system",
                     )
             self.conn.execute(
                 f"DELETE FROM agent_playbooks_fts WHERE rowid IN ({ph})",
@@ -938,29 +948,33 @@ class PlaybookMixin:
         Each call generates a fresh request_id so every status change is recorded as
         a distinct audit event (not collapsed by the idempotency key).
         """
-        row = self._fetchone(
-            "SELECT agent_playbook_id FROM agent_playbooks WHERE agent_playbook_id = ?",
-            (agent_playbook_id,),
-        )
-        if not row:
-            raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
         with self._lock:
-            self.conn.execute(
+            row = self.conn.execute(
+                "SELECT playbook_status FROM agent_playbooks WHERE agent_playbook_id = ?",
+                (agent_playbook_id,),
+            ).fetchone()
+            if not row:
+                raise ValueError(
+                    f"Agent playbook with ID {agent_playbook_id} not found"
+                )
+            old_status = row["playbook_status"] or "None"
+            cur = self.conn.execute(
                 "UPDATE agent_playbooks SET playbook_status = ? WHERE agent_playbook_id = ?",
                 (playbook_status.value, agent_playbook_id),
             )
-            _append_event_stmt(
-                self.conn,
-                org_id=self.org_id,
-                entity_type="agent_playbook",
-                entity_id=str(agent_playbook_id),
-                op="status_change",
-                prov="wasInvalidatedBy",
-                source_ids=[],
-                actor="api",
-                request_id=uuid.uuid4().hex,
-                reason="in-place update",
-            )
+            if cur.rowcount > 0:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="agent_playbook",
+                    entity_id=str(agent_playbook_id),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=uuid.uuid4().hex,
+                    reason=f"{old_status}->{playbook_status.value}",
+                )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -25,8 +25,8 @@ from reflexio.server.llm.providers.embedding_service_provider import (
 )
 
 from ._base import (
-    SQLiteStorageBase,
     _TOMBSTONE_STATUS_VALUES,
+    SQLiteStorageBase,
     _build_status_sql,
     _effective_search_mode,
     _epoch_now,
@@ -237,7 +237,9 @@ class ProfileMixin:
             self.conn.commit()
             fts_parts = [new_profile.content or ""]
             if new_profile.custom_features:
-                fts_parts.extend(str(v) for v in new_profile.custom_features.values() if v)
+                fts_parts.extend(
+                    str(v) for v in new_profile.custom_features.values() if v
+                )
             if new_profile.expanded_terms:
                 fts_parts.append(new_profile.expanded_terms)
             self._fts_upsert_profile(profile_id, " ".join(fts_parts))
@@ -262,13 +264,28 @@ class ProfileMixin:
             "SELECT rowid FROM profiles WHERE profile_id = ?",
             (request.profile_id,),
         )
-        self._fts_delete_profile(request.profile_id)
-        if rowid_row:
-            self._vec_delete("profiles_vec", rowid_row["rowid"])
-        self._execute(
-            "DELETE FROM profiles WHERE user_id = ? AND profile_id = ?",
-            (request.user_id, request.profile_id),
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type="profile",
+                entity_id=str(request.profile_id),
+                op="hard_delete",
+                prov="wasInvalidatedBy",
+                source_ids=[],
+                actor="api",
+                request_id=batch_request_id,
+                reason="erasure",
+            )
+            self._fts_delete_profile(request.profile_id)
+            if rowid_row:
+                self._vec_delete("profiles_vec", rowid_row["rowid"])
+            self.conn.execute(
+                "DELETE FROM profiles WHERE user_id = ? AND profile_id = ?",
+                (request.user_id, request.profile_id),
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles_for_user(self, user_id: str) -> None:
@@ -278,13 +295,47 @@ class ProfileMixin:
                 "SELECT profile_id FROM profiles WHERE user_id = ?", (user_id,)
             )
         ]
-        for pid in pids:
-            self._fts_delete_profile(pid)
-        self._execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
+        if not pids:
+            return
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            for pid in pids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(pid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
+                )
+                self._fts_delete_profile(pid)
+            self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles(self) -> None:
+        pids = [
+            r["profile_id"] for r in self._fetchall("SELECT profile_id FROM profiles")
+        ]
+        batch_request_id = uuid.uuid4().hex
         with self._lock:
+            for pid in pids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(pid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
+                )
             self.conn.execute("DELETE FROM profiles_fts")
             self.conn.execute("DELETE FROM profiles")
             self.conn.commit()
@@ -379,16 +430,35 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles_by_status(self, status: Status) -> int:
-        # Clean up FTS for profiles being deleted
         pids = [
             r["profile_id"]
             for r in self._fetchall(
                 "SELECT profile_id FROM profiles WHERE status = ?", (status.value,)
             )
         ]
-        for pid in pids:
-            self._fts_delete_profile(pid)
-        cur = self._execute("DELETE FROM profiles WHERE status = ?", (status.value,))
+        if not pids:
+            return 0
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            for pid in pids:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(pid),
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason="erasure",
+                )
+                self._fts_delete_profile(pid)
+            ph = ",".join("?" for _ in pids)
+            cur = self.conn.execute(
+                f"DELETE FROM profiles WHERE profile_id IN ({ph})", pids
+            )
+            self.conn.commit()
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
@@ -405,15 +475,34 @@ class ProfileMixin:
         return [r["user_id"] for r in rows]
 
     @SQLiteStorageBase.handle_exceptions
-    def delete_profiles_by_ids(self, profile_ids: list[str]) -> int:
+    def delete_profiles_by_ids(
+        self, profile_ids: list[str], *, emit_hard_delete: bool = True
+    ) -> int:
         if not profile_ids:
             return 0
-        for pid in profile_ids:
-            self._fts_delete_profile(pid)
         ph = ",".join("?" for _ in profile_ids)
-        cur = self._execute(
-            f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            if emit_hard_delete:
+                for pid in profile_ids:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="profile",
+                        entity_id=str(pid),
+                        op="hard_delete",
+                        prov="wasInvalidatedBy",
+                        source_ids=[],
+                        actor="api",
+                        request_id=batch_request_id,
+                        reason="erasure",
+                    )
+            for pid in profile_ids:
+                self._fts_delete_profile(pid)
+            cur = self.conn.execute(
+                f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
+            )
+            self.conn.commit()
         return cur.rowcount
 
     # ------------------------------------------------------------------

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -94,6 +94,7 @@ class ProfileMixin:
     _fts_delete_profile: Any
     _vec_upsert: Any
     _vec_delete: Any
+    _delete_profile_search_rows: Any
     _has_sqlite_vec: bool
     llm_client: Any
     embedding_model_name: str
@@ -220,7 +221,7 @@ class ProfileMixin:
         )
         new_profile.embedding = embedding
         with self._lock:
-            self.conn.execute(
+            cur = self.conn.execute(
                 """UPDATE profiles SET content=?, last_modified_timestamp=?,
                    generated_from_request_id=?, profile_time_to_live=?,
                    expiration_timestamp=?, custom_features=?, embedding=?,
@@ -246,18 +247,19 @@ class ProfileMixin:
                     profile_id,
                 ),
             )
-            _append_event_stmt(
-                self.conn,
-                org_id=self.org_id,
-                entity_type="profile",
-                entity_id=str(profile_id),
-                op="revise",
-                prov="wasRevisionOf",
-                source_ids=[],
-                actor="api",
-                request_id=uuid.uuid4().hex,
-                reason="in-place update",
-            )
+            if cur.rowcount > 0:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(profile_id),
+                    op="revise",
+                    prov="wasRevisionOf",
+                    source_ids=[],
+                    actor="api",
+                    request_id=uuid.uuid4().hex,
+                    reason="in-place update",
+                )
             self.conn.commit()
             fts_parts = [new_profile.content or ""]
             if new_profile.custom_features:
@@ -317,8 +319,7 @@ class ProfileMixin:
             ]
             if not pids:
                 return
-            for pid in pids:
-                self._fts_delete_profile(pid)
+            self._delete_profile_search_rows(pids)
             self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
             for pid in pids:
                 _emit_hard_delete_profile(
@@ -490,8 +491,7 @@ class ProfileMixin:
             ]
             if not pids:
                 return 0
-            for pid in pids:
-                self._fts_delete_profile(pid)
+            self._delete_profile_search_rows(pids)
             ph = ",".join("?" for _ in pids)
             cur = self.conn.execute(
                 f"DELETE FROM profiles WHERE profile_id IN ({ph})", pids
@@ -528,13 +528,21 @@ class ProfileMixin:
         ph = ",".join("?" for _ in profile_ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            for pid in profile_ids:
-                self._fts_delete_profile(pid)
+            existing = [
+                r["profile_id"]
+                for r in self.conn.execute(
+                    f"SELECT profile_id FROM profiles WHERE profile_id IN ({ph})",
+                    profile_ids,
+                ).fetchall()
+            ]
+            if not existing:
+                return 0
+            self._delete_profile_search_rows(existing)
             cur = self.conn.execute(
                 f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
             )
             if emit_hard_delete:
-                for pid in profile_ids:
+                for pid in existing:
                     _emit_hard_delete_profile(
                         self.conn,
                         org_id=self.org_id,

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -2,6 +2,7 @@
 
 import logging
 import sqlite3
+import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -38,6 +39,7 @@ from ._base import (
     _true_rrf_merge,
     _vector_rank_rows,
 )
+from ._lineage import _append_event_stmt
 
 
 def _build_tags_sql(alias: str, tags: list[str] | None) -> tuple[str, list[Any]]:
@@ -173,58 +175,77 @@ class ProfileMixin:
     def update_user_profile_by_id(
         self, user_id: str, profile_id: str, new_profile: UserProfile
     ) -> None:
+        """Replace a profile's content in-place and emit a revise lineage event.
+
+        Each call generates a fresh request_id so every edit is a distinct audit
+        event (not collapsed by the idempotency key).  The UPDATE, lineage event,
+        FTS sync, and vec sync are all executed inside a single lock acquisition;
+        self._lock is an RLock so the inner _fts_upsert_profile/_vec_upsert calls
+        that re-acquire it are safe.
+        """
         current_ts = _epoch_now()
         row = self._fetchone(
             "SELECT profile_id FROM profiles WHERE user_id = ? AND profile_id = ? AND expiration_timestamp >= ?",
             (user_id, profile_id, current_ts),
         )
         if not row:
-            import logging
-
-            logger = logging.getLogger(__name__)
             logger.warning("User profile not found for user id: %s", user_id)
             return
         embedding = self._get_embedding(
             "\n".join([new_profile.content, str(new_profile.custom_features)])
         )
         new_profile.embedding = embedding
-        self._execute(
-            """UPDATE profiles SET content=?, last_modified_timestamp=?,
-               generated_from_request_id=?, profile_time_to_live=?,
-               expiration_timestamp=?, custom_features=?, embedding=?,
-               source=?, status=?, extractor_names=?, expanded_terms=?,
-               source_span=?, notes=?, reader_angle=?, tags=?
-               WHERE profile_id=?""",
-            (
-                new_profile.content,
-                new_profile.last_modified_timestamp,
-                new_profile.generated_from_request_id,
-                new_profile.profile_time_to_live.value,
-                new_profile.expiration_timestamp,
-                _json_dumps(new_profile.custom_features),
-                _json_dumps(new_profile.embedding),
-                new_profile.source,
-                new_profile.status.value if new_profile.status else None,
-                _json_dumps(new_profile.extractor_names),
-                new_profile.expanded_terms,
-                new_profile.source_span,
-                new_profile.notes,
-                new_profile.reader_angle,
-                _json_dumps(new_profile.tags),
-                profile_id,
-            ),
-        )
-        fts_parts = [new_profile.content or ""]
-        if new_profile.custom_features:
-            fts_parts.extend(str(v) for v in new_profile.custom_features.values() if v)
-        if new_profile.expanded_terms:
-            fts_parts.append(new_profile.expanded_terms)
-        self._fts_upsert_profile(profile_id, " ".join(fts_parts))
-        rowid_row = self._fetchone(
-            "SELECT rowid FROM profiles WHERE profile_id = ?", (profile_id,)
-        )
-        if rowid_row and embedding:
-            self._vec_upsert("profiles_vec", rowid_row["rowid"], embedding)
+        with self._lock:
+            self.conn.execute(
+                """UPDATE profiles SET content=?, last_modified_timestamp=?,
+                   generated_from_request_id=?, profile_time_to_live=?,
+                   expiration_timestamp=?, custom_features=?, embedding=?,
+                   source=?, status=?, extractor_names=?, expanded_terms=?,
+                   source_span=?, notes=?, reader_angle=?, tags=?
+                   WHERE profile_id=?""",
+                (
+                    new_profile.content,
+                    new_profile.last_modified_timestamp,
+                    new_profile.generated_from_request_id,
+                    new_profile.profile_time_to_live.value,
+                    new_profile.expiration_timestamp,
+                    _json_dumps(new_profile.custom_features),
+                    _json_dumps(new_profile.embedding),
+                    new_profile.source,
+                    new_profile.status.value if new_profile.status else None,
+                    _json_dumps(new_profile.extractor_names),
+                    new_profile.expanded_terms,
+                    new_profile.source_span,
+                    new_profile.notes,
+                    new_profile.reader_angle,
+                    _json_dumps(new_profile.tags),
+                    profile_id,
+                ),
+            )
+            _append_event_stmt(
+                self.conn,
+                org_id=self.org_id,
+                entity_type="profile",
+                entity_id=str(profile_id),
+                op="revise",
+                prov="wasRevisionOf",
+                source_ids=[],
+                actor="api",
+                request_id=uuid.uuid4().hex,
+                reason="in-place update",
+            )
+            self.conn.commit()
+            fts_parts = [new_profile.content or ""]
+            if new_profile.custom_features:
+                fts_parts.extend(str(v) for v in new_profile.custom_features.values() if v)
+            if new_profile.expanded_terms:
+                fts_parts.append(new_profile.expanded_terms)
+            self._fts_upsert_profile(profile_id, " ".join(fts_parts))
+            rowid_row = self._fetchone(
+                "SELECT rowid FROM profiles WHERE profile_id = ?", (profile_id,)
+            )
+            if rowid_row and embedding:
+                self._vec_upsert("profiles_vec", rowid_row["rowid"], embedding)
 
     @SQLiteStorageBase.handle_exceptions
     def update_user_profile_tags(

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -42,6 +42,28 @@ from ._base import (
 from ._lineage import _append_event_stmt
 
 
+def _emit_hard_delete_profile(
+    conn: sqlite3.Connection,
+    *,
+    org_id: str,
+    entity_id: str,
+    request_id: str,
+) -> None:
+    """Emit a single hard_delete lineage event for a profile entity."""
+    _append_event_stmt(
+        conn,
+        org_id=org_id,
+        entity_type="profile",
+        entity_id=entity_id,
+        op="hard_delete",
+        prov="wasInvalidatedBy",
+        source_ids=[],
+        actor="api",
+        request_id=request_id,
+        reason="erasure",
+    )
+
+
 def _build_tags_sql(alias: str, tags: list[str] | None) -> tuple[str, list[Any]]:
     if not tags:
         return "", []
@@ -58,6 +80,7 @@ class ProfileMixin:
     # Type hints for instance attributes/methods provided by SQLiteStorageBase via MRO
     _lock: Any
     conn: sqlite3.Connection
+    org_id: str
     _execute: Any
     _fetchone: Any
     _fetchall: Any
@@ -264,19 +287,12 @@ class ProfileMixin:
             "SELECT rowid FROM profiles WHERE profile_id = ?",
             (request.profile_id,),
         )
-        batch_request_id = uuid.uuid4().hex
         with self._lock:
-            _append_event_stmt(
+            _emit_hard_delete_profile(
                 self.conn,
                 org_id=self.org_id,
-                entity_type="profile",
                 entity_id=str(request.profile_id),
-                op="hard_delete",
-                prov="wasInvalidatedBy",
-                source_ids=[],
-                actor="api",
-                request_id=batch_request_id,
-                reason="erasure",
+                request_id=uuid.uuid4().hex,
             )
             self._fts_delete_profile(request.profile_id)
             if rowid_row:
@@ -289,28 +305,22 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles_for_user(self, user_id: str) -> None:
-        pids = [
-            r["profile_id"]
-            for r in self._fetchall(
-                "SELECT profile_id FROM profiles WHERE user_id = ?", (user_id,)
-            )
-        ]
-        if not pids:
-            return
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            pids = [
+                r["profile_id"]
+                for r in self.conn.execute(
+                    "SELECT profile_id FROM profiles WHERE user_id = ?", (user_id,)
+                ).fetchall()
+            ]
+            if not pids:
+                return
             for pid in pids:
-                _append_event_stmt(
+                _emit_hard_delete_profile(
                     self.conn,
                     org_id=self.org_id,
-                    entity_type="profile",
                     entity_id=str(pid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
                 self._fts_delete_profile(pid)
             self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
@@ -318,23 +328,18 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles(self) -> None:
-        pids = [
-            r["profile_id"] for r in self._fetchall("SELECT profile_id FROM profiles")
-        ]
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            pids = [
+                r["profile_id"]
+                for r in self.conn.execute("SELECT profile_id FROM profiles").fetchall()
+            ]
             for pid in pids:
-                _append_event_stmt(
+                _emit_hard_delete_profile(
                     self.conn,
                     org_id=self.org_id,
-                    entity_type="profile",
                     entity_id=str(pid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
             self.conn.execute("DELETE FROM profiles_fts")
             self.conn.execute("DELETE FROM profiles")
@@ -430,28 +435,22 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles_by_status(self, status: Status) -> int:
-        pids = [
-            r["profile_id"]
-            for r in self._fetchall(
-                "SELECT profile_id FROM profiles WHERE status = ?", (status.value,)
-            )
-        ]
-        if not pids:
-            return 0
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            pids = [
+                r["profile_id"]
+                for r in self.conn.execute(
+                    "SELECT profile_id FROM profiles WHERE status = ?", (status.value,)
+                ).fetchall()
+            ]
+            if not pids:
+                return 0
             for pid in pids:
-                _append_event_stmt(
+                _emit_hard_delete_profile(
                     self.conn,
                     org_id=self.org_id,
-                    entity_type="profile",
                     entity_id=str(pid),
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="api",
                     request_id=batch_request_id,
-                    reason="erasure",
                 )
                 self._fts_delete_profile(pid)
             ph = ",".join("?" for _ in pids)
@@ -485,17 +484,11 @@ class ProfileMixin:
         with self._lock:
             if emit_hard_delete:
                 for pid in profile_ids:
-                    _append_event_stmt(
+                    _emit_hard_delete_profile(
                         self.conn,
                         org_id=self.org_id,
-                        entity_type="profile",
                         entity_id=str(pid),
-                        op="hard_delete",
-                        prov="wasInvalidatedBy",
-                        source_ids=[],
-                        actor="api",
                         request_id=batch_request_id,
-                        reason="erasure",
                     )
             for pid in profile_ids:
                 self._fts_delete_profile(pid)

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -48,6 +48,7 @@ def _emit_hard_delete_profile(
     org_id: str,
     entity_id: str,
     request_id: str,
+    actor: str = "api",
 ) -> None:
     """Emit a single hard_delete lineage event for a profile entity."""
     _append_event_stmt(
@@ -58,7 +59,7 @@ def _emit_hard_delete_profile(
         op="hard_delete",
         prov="wasInvalidatedBy",
         source_ids=[],
-        actor="api",
+        actor=actor,
         request_id=request_id,
         reason="erasure",
     )
@@ -283,24 +284,25 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_profile(self, request: DeleteUserProfileRequest) -> None:
-        rowid_row = self._fetchone(
-            "SELECT rowid FROM profiles WHERE profile_id = ?",
-            (request.profile_id,),
-        )
         with self._lock:
-            _emit_hard_delete_profile(
-                self.conn,
-                org_id=self.org_id,
-                entity_id=str(request.profile_id),
-                request_id=uuid.uuid4().hex,
-            )
+            rowid_row = self.conn.execute(
+                "SELECT rowid FROM profiles WHERE user_id = ? AND profile_id = ?",
+                (request.user_id, request.profile_id),
+            ).fetchone()
             self._fts_delete_profile(request.profile_id)
             if rowid_row:
                 self._vec_delete("profiles_vec", rowid_row["rowid"])
-            self.conn.execute(
+            cur = self.conn.execute(
                 "DELETE FROM profiles WHERE user_id = ? AND profile_id = ?",
                 (request.user_id, request.profile_id),
             )
+            if cur.rowcount > 0:
+                _emit_hard_delete_profile(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_id=str(request.profile_id),
+                    request_id=uuid.uuid4().hex,
+                )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -316,14 +318,15 @@ class ProfileMixin:
             if not pids:
                 return
             for pid in pids:
+                self._fts_delete_profile(pid)
+            self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
+            for pid in pids:
                 _emit_hard_delete_profile(
                     self.conn,
                     org_id=self.org_id,
                     entity_id=str(pid),
                     request_id=batch_request_id,
                 )
-                self._fts_delete_profile(pid)
-            self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -472,7 +475,7 @@ class ProfileMixin:
                     request_id=uuid.uuid4().hex,
                     reason="None->archived",
                 )
-                self.conn.commit()
+            self.conn.commit()
         return cur.rowcount > 0
 
     @SQLiteStorageBase.handle_exceptions
@@ -488,17 +491,18 @@ class ProfileMixin:
             if not pids:
                 return 0
             for pid in pids:
+                self._fts_delete_profile(pid)
+            ph = ",".join("?" for _ in pids)
+            cur = self.conn.execute(
+                f"DELETE FROM profiles WHERE profile_id IN ({ph})", pids
+            )
+            for pid in pids:
                 _emit_hard_delete_profile(
                     self.conn,
                     org_id=self.org_id,
                     entity_id=str(pid),
                     request_id=batch_request_id,
                 )
-                self._fts_delete_profile(pid)
-            ph = ",".join("?" for _ in pids)
-            cur = self.conn.execute(
-                f"DELETE FROM profiles WHERE profile_id IN ({ph})", pids
-            )
             self.conn.commit()
         return cur.rowcount
 
@@ -524,6 +528,11 @@ class ProfileMixin:
         ph = ",".join("?" for _ in profile_ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            for pid in profile_ids:
+                self._fts_delete_profile(pid)
+            cur = self.conn.execute(
+                f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
+            )
             if emit_hard_delete:
                 for pid in profile_ids:
                     _emit_hard_delete_profile(
@@ -531,12 +540,8 @@ class ProfileMixin:
                         org_id=self.org_id,
                         entity_id=str(pid),
                         request_id=batch_request_id,
+                        actor="system",
                     )
-            for pid in profile_ids:
-                self._fts_delete_profile(pid)
-            cur = self.conn.execute(
-                f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
-            )
             self.conn.commit()
         return cur.rowcount
 

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -472,7 +472,7 @@ class ProfileMixin:
                     request_id=uuid.uuid4().hex,
                     reason="None->archived",
                 )
-            self.conn.commit()
+                self.conn.commit()
         return cur.rowcount > 0
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -359,25 +359,52 @@ class ProfileMixin:
     ) -> int:
         new_val = new_status.value if new_status else None
         now_ts = _epoch_now()
-        params: list[Any] = [new_val, now_ts]
+        old_val_str = old_status.value if old_status else "None"
+        new_val_str = new_status.value if new_status else "None"
+        reason = f"{old_val_str}->{new_val_str}"
 
         if old_status is None or (
             hasattr(old_status, "value") and old_status.value is None
         ):
             where = "status IS NULL"
+            select_params: list[Any] = []
         else:
             where = "status = ?"
-            params.append(old_status.value)
+            select_params = [old_status.value]
 
+        extra_params: list[Any] = []
         if user_ids is not None:
             placeholders = ",".join("?" for _ in user_ids)
             where += f" AND user_id IN ({placeholders})"
-            params.extend(user_ids)
+            extra_params.extend(user_ids)
 
-        cur = self._execute(
-            f"UPDATE profiles SET status = ?, last_modified_timestamp = ? WHERE {where}",
-            params,
-        )
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            affected = [
+                r["profile_id"]
+                for r in self.conn.execute(
+                    f"SELECT profile_id FROM profiles WHERE {where}",
+                    select_params + extra_params,
+                ).fetchall()
+            ]
+            cur = self.conn.execute(
+                f"UPDATE profiles SET status = ?, last_modified_timestamp = ? WHERE {where}",
+                [new_val, now_ts] + select_params + extra_params,
+            )
+            for pid in affected:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(pid),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=batch_request_id,
+                    reason=reason,
+                )
+            self.conn.commit()
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
@@ -426,11 +453,26 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def archive_profile_by_id(self, user_id: str, profile_id: str) -> bool:
-        cur = self._execute(
-            "UPDATE profiles SET status = ?, last_modified_timestamp = ? "
-            "WHERE profile_id = ? AND user_id = ? AND status IS NULL",
-            (Status.ARCHIVED.value, _epoch_now(), profile_id, user_id),
-        )
+        with self._lock:
+            cur = self.conn.execute(
+                "UPDATE profiles SET status = ?, last_modified_timestamp = ? "
+                "WHERE profile_id = ? AND user_id = ? AND status IS NULL",
+                (Status.ARCHIVED.value, _epoch_now(), profile_id, user_id),
+            )
+            if cur.rowcount > 0:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(profile_id),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="api",
+                    request_id=uuid.uuid4().hex,
+                    reason="None->archived",
+                )
+            self.conn.commit()
         return cur.rowcount > 0
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -395,6 +395,8 @@ class ProfileMixin:
                 f"UPDATE profiles SET status = ?, last_modified_timestamp = ? WHERE {where}",
                 [new_val, now_ts] + select_params + extra_params,
             )
+            from_val = old_status.value if old_status else None
+            to_val = new_status.value if new_status else None
             for pid in affected:
                 _append_event_stmt(
                     self.conn,
@@ -407,6 +409,9 @@ class ProfileMixin:
                     actor="api",
                     request_id=batch_request_id,
                     reason=reason,
+                    from_status=from_val,
+                    to_status=to_val,
+                    status_namespace="lifecycle_status",
                 )
             self.conn.commit()
         return cur.rowcount
@@ -475,6 +480,9 @@ class ProfileMixin:
                     actor="api",
                     request_id=uuid.uuid4().hex,
                     reason="None->archived",
+                    from_status=None,
+                    to_status="archived",
+                    status_namespace="lifecycle_status",
                 )
             self.conn.commit()
         return cur.rowcount > 0

--- a/reflexio/server/services/storage/storage_base/_profiles.py
+++ b/reflexio/server/services/storage/storage_base/_profiles.py
@@ -244,11 +244,17 @@ class ProfileMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def delete_profiles_by_ids(self, profile_ids: list[str]) -> int:
+    def delete_profiles_by_ids(
+        self, profile_ids: list[str], *, emit_hard_delete: bool = True
+    ) -> int:
         """Delete profiles by their IDs.
 
         Args:
             profile_ids (list[str]): List of profile IDs to delete
+            emit_hard_delete (bool): When True (default), emit a ``hard_delete``
+                lineage event for each id before removing the row.  Pass ``False``
+                from rollback callers that cleaned up a never-CURRENT successor to
+                avoid poisoning the audit log with phantom erasures.
 
         Returns:
             int: Number of profiles deleted

--- a/tests/server/services/playbook/test_aggregation_lineage_integration.py
+++ b/tests/server/services/playbook/test_aggregation_lineage_integration.py
@@ -1,0 +1,190 @@
+"""Integration test: aggregation emits op=aggregate set-level lineage events.
+
+Drives one aggregation run (mock the LLM cluster/consolidation decision) that
+rolls user playbooks UP-a and UP-b into a new agent playbook AP.
+
+Asserts:
+- a lineage event with op="aggregate" and entity_type="agent_playbook" exists,
+- entity_id matches the saved agent playbook id (AP),
+- prov_relation="wasDerivedFrom",
+- source_ids contains str(UP-a.user_playbook_id) and str(UP-b.user_playbook_id).
+
+Mirrors the real-SQLite + mocked-cluster fixture style of
+``test_consolidation_lineage_integration.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    PlaybookStatus,
+    UserPlaybook,
+)
+from reflexio.models.config_schema import PlaybookAggregatorConfig, PlaybookConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.playbook.playbook_aggregator import PlaybookAggregator
+from reflexio.server.services.playbook.playbook_service_utils import (
+    PlaybookAggregatorRequest,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_storage_dir():
+    """Per-test temp directory for SQLite isolation."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield temp_dir
+
+
+@pytest.fixture
+def sqlite_storage(temp_storage_dir, worker_id):
+    """Real SQLite storage in a per-test temp dir + per-worker org id."""
+    return SQLiteStorage(
+        org_id=f"test-agg-lineage-{worker_id}",
+        db_path=os.path.join(temp_storage_dir, "agg_lineage.db"),
+    )
+
+
+@pytest.fixture
+def request_context(sqlite_storage, temp_storage_dir, worker_id):
+    """RequestContext wired to real SQLite storage + mocked configurator."""
+    context = RequestContext(
+        org_id=f"test-agg-lineage-{worker_id}",
+        storage_base_dir=temp_storage_dir,
+    )
+    context.storage = sqlite_storage
+    context.prompt_manager = MagicMock()
+    context.configurator = MagicMock()
+    # Wire a minimal PlaybookConfig so the aggregator doesn't skip early.
+    agg_config = PlaybookAggregatorConfig(
+        min_cluster_size=2,
+        reaggregation_trigger_count=2,
+    )
+    context.configurator.get_config.return_value.user_playbook_extractor_config = (
+        PlaybookConfig(
+            extractor_name="default",
+            extraction_definition_prompt="stub",
+            aggregation_config=agg_config,
+        )
+    )
+    return context
+
+
+@pytest.fixture
+def aggregator(request_context):
+    """PlaybookAggregator wired to the real SQLite storage via request_context."""
+    return PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=request_context,
+        agent_version="v0",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_user_playbook(storage: SQLiteStorage, uid: int, org_id: str) -> UserPlaybook:
+    """Save a minimal user playbook and return the persisted row."""
+    pb = UserPlaybook(
+        user_playbook_id=0,
+        user_id="u1",
+        agent_version="v0",
+        request_id=f"req-{uid}",
+        playbook_name="default",
+        content=f"Do thing {uid}.",
+        trigger=f"when cond {uid}",
+        rationale="r",
+        status=None,
+        source="chat",
+        source_interaction_ids=[],
+    )
+    storage.save_user_playbooks([pb])
+    saved = storage.get_user_playbooks(user_id="u1")
+    # Return the most recently saved one (highest id).
+    return max(saved, key=lambda p: p.user_playbook_id)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_aggregation_emits_aggregate_lineage_event(
+    sqlite_storage: SQLiteStorage,
+    request_context: RequestContext,
+    aggregator: PlaybookAggregator,
+    worker_id: str,
+):
+    """One aggregation run rolling UP-a, UP-b -> AP emits op=aggregate event.
+
+    The cluster logic and LLM generation are mocked so the test is deterministic.
+    The storage and lineage append are real (SQLite).
+    """
+    org_id = request_context.org_id
+
+    # Seed two user playbooks that will form the cluster.
+    up_a = _seed_user_playbook(sqlite_storage, uid=1, org_id=org_id)
+    up_b = _seed_user_playbook(sqlite_storage, uid=2, org_id=org_id)
+
+    cluster_playbooks = [up_a, up_b]
+
+    # The agent playbook the LLM would produce (id=0 before save; storage assigns a real id).
+    unsaved_ap = AgentPlaybook(
+        agent_playbook_id=0,
+        playbook_name="default",
+        agent_version="v0",
+        content="Aggregated AP.",
+        playbook_status=PlaybookStatus.PENDING,
+    )
+
+    with (
+        patch.object(
+            PlaybookAggregator,
+            "get_clusters",
+            return_value={0: cluster_playbooks},
+        ),
+        patch.object(
+            PlaybookAggregator,
+            "_generate_playbooks_with_source_clusters",
+            return_value=[(unsaved_ap, cluster_playbooks)],
+        ),
+    ):
+        aggregator.run(PlaybookAggregatorRequest(agent_version="v0", rerun=True))
+
+    # Retrieve the saved agent playbook to get its real id.
+    saved_aps = sqlite_storage.get_agent_playbooks()
+    assert saved_aps, "Expected at least one agent playbook to be saved"
+    ap = saved_aps[0]
+    ap_id = str(ap.agent_playbook_id)
+
+    # Assert the aggregate lineage event was emitted.
+    events = sqlite_storage.get_lineage_events(
+        entity_type="agent_playbook",
+        entity_id=ap_id,
+    )
+    aggregate_events = [e for e in events if e.op == "aggregate"]
+    assert len(aggregate_events) == 1, f"Expected 1 aggregate event, got: {events}"
+
+    evt = aggregate_events[0]
+    assert evt.entity_type == "agent_playbook"
+    assert evt.prov_relation == "wasDerivedFrom"
+    assert str(up_a.user_playbook_id) in evt.source_ids, evt.source_ids
+    assert str(up_b.user_playbook_id) in evt.source_ids, evt.source_ids
+    assert evt.actor == "aggregator"
+    assert evt.org_id == org_id
+    assert evt.request_id != "", "request_id must be non-empty"

--- a/tests/server/services/playbook/test_aggregation_lineage_integration.py
+++ b/tests/server/services/playbook/test_aggregation_lineage_integration.py
@@ -9,6 +9,10 @@ Asserts:
 - prov_relation="wasDerivedFrom",
 - source_ids contains str(UP-a.user_playbook_id) and str(UP-b.user_playbook_id).
 
+Also includes a PB-7 best-effort regression test verifying that a transient
+``append_lineage_event`` failure does NOT abort the aggregation run and that
+``capture_anomaly`` is called with "lineage.aggregate.append_failed".
+
 Mirrors the real-SQLite + mocked-cluster fixture style of
 ``test_consolidation_lineage_integration.py``.
 """
@@ -188,3 +192,71 @@ def test_aggregation_emits_aggregate_lineage_event(
     assert evt.actor == "aggregator"
     assert evt.org_id == org_id
     assert evt.request_id != "", "request_id must be non-empty"
+
+
+def test_aggregate_lineage_append_failure_is_best_effort(
+    sqlite_storage: SQLiteStorage,
+    request_context: RequestContext,
+    aggregator: PlaybookAggregator,
+    worker_id: str,
+):
+    """PB-7: a transient append_lineage_event failure must NOT abort aggregation.
+
+    Pins the safety property: the try/except around ``storage.append_lineage_event``
+    swallows the exception, saves the agent playbook(s) anyway, and calls
+    ``capture_anomaly("lineage.aggregate.append_failed", ...)``.
+    """
+    org_id = request_context.org_id
+
+    up_a = _seed_user_playbook(sqlite_storage, uid=10, org_id=org_id)
+    up_b = _seed_user_playbook(sqlite_storage, uid=11, org_id=org_id)
+    cluster_playbooks = [up_a, up_b]
+
+    unsaved_ap = AgentPlaybook(
+        agent_playbook_id=0,
+        playbook_name="default",
+        agent_version="v0",
+        content="Best-effort AP.",
+        playbook_status=PlaybookStatus.PENDING,
+    )
+
+    def _raise_on_append(event):  # noqa: ANN001
+        raise RuntimeError("transient lineage failure")
+
+    with (
+        patch.object(
+            PlaybookAggregator,
+            "get_clusters",
+            return_value={0: cluster_playbooks},
+        ),
+        patch.object(
+            PlaybookAggregator,
+            "_generate_playbooks_with_source_clusters",
+            return_value=[(unsaved_ap, cluster_playbooks)],
+        ),
+        patch.object(
+            sqlite_storage, "append_lineage_event", side_effect=_raise_on_append
+        ),
+        patch(
+            "reflexio.server.services.playbook.playbook_aggregator.capture_anomaly"
+        ) as mock_capture,
+    ):
+        # (a) run must complete without raising
+        result = aggregator.run(
+            PlaybookAggregatorRequest(agent_version="v0", rerun=True)
+        )
+
+    # (a) no exception propagated — result is the stats dict
+    assert isinstance(result, dict), f"Expected dict, got: {result!r}"
+    assert "playbooks_generated" in result
+
+    # (b) the agent playbook was still saved despite the lineage failure
+    saved_aps = sqlite_storage.get_agent_playbooks()
+    assert saved_aps, "Agent playbook must be saved even when lineage append fails"
+
+    # (c) capture_anomaly was called with the correct anomaly key
+    assert mock_capture.called, (
+        "capture_anomaly must be called on lineage append failure"
+    )
+    anomaly_keys = [c.args[0] for c in mock_capture.call_args_list]
+    assert "lineage.aggregate.append_failed" in anomaly_keys, anomaly_keys

--- a/tests/server/services/reflection/test_reflection_profile_supersede_integration.py
+++ b/tests/server/services/reflection/test_reflection_profile_supersede_integration.py
@@ -131,9 +131,7 @@ class TestReflectionProfileSupersede:
 
     @pytest.fixture
     def service(self, request_context, llm_client):
-        return ReflectionService(
-            request_context=request_context, llm_client=llm_client
-        )
+        return ReflectionService(request_context=request_context, llm_client=llm_client)
 
     def test_cited_profile_becomes_superseded_with_pointer_and_revise_event(
         self, request_context, service, llm_client
@@ -169,7 +167,9 @@ class TestReflectionProfileSupersede:
             ]
         )
 
-        result = service.run(ReflectionServiceRequest(user_id="u1"))
+        result = service.run(
+            ReflectionServiceRequest(user_id="u1", request_id="req-reflect-1")
+        )
         assert result.ran is True
         assert result.revised_count == 1
 
@@ -196,6 +196,9 @@ class TestReflectionProfileSupersede:
         revise_evt = revise_events[0]
         assert revise_evt.actor == "reflection"
         assert "p1" in revise_evt.source_ids
+        # Pin that the reflection pass's request_id flows end-to-end into the revise event
+        # (relied on by B3's request-id reconstruction).
+        assert revise_evt.request_id == "req-reflect-1"
 
         # Old profile must NOT appear as ARCHIVED (no bleed from old code path).
         archived = storage.get_user_profile("u1", status_filter=[Status.ARCHIVED])

--- a/tests/server/services/reflection/test_reflection_profile_supersede_integration.py
+++ b/tests/server/services/reflection/test_reflection_profile_supersede_integration.py
@@ -242,3 +242,92 @@ class TestReflectionProfileSupersede:
         assert current[0].profile_id == "p1"
         events = storage.get_lineage_events(entity_type="profile", entity_id="p1")
         assert events == []
+
+    def test_two_passes_no_explicit_request_id_produce_distinct_revise_events(
+        self, request_context, llm_client
+    ):
+        """Two reflection passes with no explicit request_id produce two distinct revise events.
+
+        Before F006 fix: request_id defaulted to "", so both passes produced the same
+        5-col idempotency key (org, profile, "revise", "") and the second event was
+        silently dropped by INSERT OR IGNORE.  After the fix: each ReflectionServiceRequest
+        constructed without a request_id gets a fresh uuid4().hex, so both events persist.
+        """
+        # Use post_horizon_size=0 to disable the horizon filter so both passes can
+        # proceed regardless of how many follow-up interactions exist.
+        _set_config(request_context, reflection_config={"post_horizon_size": 0})
+        storage = request_context.storage
+
+        # --- Pass 1: revise p1 → successor p2 ---
+        _seed_profile(storage, "u1", "p1", content="original content")
+        cite1 = Citation(kind="profile", real_id="p1")
+        _seed_request_with_interactions(
+            storage,
+            "u1",
+            "r1",
+            [
+                _make_interaction("u1", "r1", "User", "hi"),
+                _make_interaction("u1", "r1", "Assistant", "hello", citations=[cite1]),
+            ],
+        )
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="profile",
+                    target_id="p1",
+                    new_content="revised content pass-1",
+                    reason="pass 1 revision",
+                )
+            ]
+        )
+        svc1 = ReflectionService(request_context=request_context, llm_client=llm_client)
+        result1 = svc1.run(ReflectionServiceRequest(user_id="u1"))
+        assert result1.revised_count == 1
+
+        # Fetch the successor profile written by pass 1.
+        current_after_1 = storage.get_user_profile("u1", status_filter=[None])
+        assert len(current_after_1) == 1
+        p2_id = current_after_1[0].profile_id
+        assert p2_id != "p1"
+
+        # --- Pass 2: revise p2 → successor p3 (stride gate reset by new interactions) ---
+        cite2 = Citation(kind="profile", real_id=p2_id)
+        _seed_request_with_interactions(
+            storage,
+            "u1",
+            "r2",
+            [
+                _make_interaction("u1", "r2", "User", "more input"),
+                _make_interaction("u1", "r2", "Assistant", "got it", citations=[cite2]),
+            ],
+        )
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="profile",
+                    target_id=p2_id,
+                    new_content="revised content pass-2",
+                    reason="pass 2 revision",
+                )
+            ]
+        )
+        svc2 = ReflectionService(request_context=request_context, llm_client=llm_client)
+        result2 = svc2.run(ReflectionServiceRequest(user_id="u1"))
+        assert result2.revised_count == 1
+
+        current_after_2 = storage.get_user_profile("u1", status_filter=[None])
+        assert len(current_after_2) == 1
+        p3_id = current_after_2[0].profile_id
+        assert p3_id != p2_id
+
+        # Both successors must have exactly one revise event and the two
+        # request_ids must be distinct (no collapsed idempotency key).
+        events_p2 = storage.get_lineage_events(entity_type="profile", entity_id=p2_id)
+        events_p3 = storage.get_lineage_events(entity_type="profile", entity_id=p3_id)
+        revise_p2 = [e for e in events_p2 if e.op == "revise"]
+        revise_p3 = [e for e in events_p3 if e.op == "revise"]
+        assert len(revise_p2) == 1, "pass-1 revise event must be present"
+        assert len(revise_p3) == 1, "pass-2 revise event must be present"
+        assert revise_p2[0].request_id != revise_p3[0].request_id, (
+            "two passes with no explicit request_id must produce distinct lineage request_ids"
+        )

--- a/tests/server/services/reflection/test_reflection_profile_supersede_integration.py
+++ b/tests/server/services/reflection/test_reflection_profile_supersede_integration.py
@@ -1,0 +1,241 @@
+"""Integration tests: reflection profile edit routes through supersede_record.
+
+After a reflection pass that revises a cited profile, the cited (old) profile
+must become status=SUPERSEDED with a ``superseded_by`` pointer, and a ``revise``
+lineage event must exist for the successor.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import Citation, UserProfile
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.reflection.reflection_service import ReflectionService
+from reflexio.server.services.reflection.reflection_service_utils import (
+    ReflectionDecision,
+    ReflectionOutput,
+    ReflectionServiceRequest,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — reused from test_reflection_service.py pattern
+# ---------------------------------------------------------------------------
+
+
+def _seed_profile(
+    storage, user_id: str, profile_id: str, content: str = "old content"
+) -> UserProfile:
+    p = UserProfile(
+        profile_id=profile_id,
+        user_id=user_id,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id="seed_req",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        custom_features={"k": "v"},
+        source="seed",
+    )
+    storage.add_user_profile(user_id, [p])
+    return p
+
+
+def _make_interaction(
+    user_id: str,
+    request_id: str,
+    role: str,
+    content: str,
+    citations: list | None = None,
+):
+    from reflexio.models.api_schema.domain.entities import Interaction
+
+    return Interaction(
+        user_id=user_id,
+        request_id=request_id,
+        role=role,
+        content=content,
+        created_at=int(datetime.now(UTC).timestamp()),
+        citations=citations or [],
+    )
+
+
+def _seed_request_with_interactions(storage, user_id, request_id, interactions):
+    from reflexio.models.api_schema.domain.entities import Request
+
+    storage.add_request(
+        Request(
+            request_id=request_id,
+            user_id=user_id,
+            session_id="test_session",
+            source="cli",
+            agent_version="v1",
+        )
+    )
+    storage.add_user_interactions_bulk(user_id=user_id, interactions=interactions)
+
+
+def _set_config(request_context, **overrides):
+    from reflexio.models.config_schema import Config, ReflectionConfig
+
+    cfg = Config.model_validate(
+        {
+            "storage_config": {"db_path": None},
+            "window_size": 5,
+            "stride_size": 2,
+            "reflection_config": ReflectionConfig().model_dump(),
+            **overrides,
+        }
+    )
+    request_context.configurator = MagicMock()
+    request_context.configurator.get_config.return_value = cfg
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestReflectionProfileSupersede:
+    """Reflection profile replacement uses supersede_record, not archive."""
+
+    @pytest.fixture
+    def request_context(self, tmp_path):
+        from reflexio.server.llm.litellm_client import LiteLLMClient
+        from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+        with (
+            patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
+            patch.object(
+                LiteLLMClient,
+                "get_embeddings",
+                side_effect=lambda texts, *_args, **_kwargs: [
+                    [0.0] * 512 for _ in texts
+                ],
+            ),
+        ):
+            ctx = RequestContext(org_id="test_org", storage_base_dir=str(tmp_path))
+            yield ctx
+
+    @pytest.fixture
+    def llm_client(self):
+        client = MagicMock()
+        client.generate_chat_response.return_value = ReflectionOutput(decisions=[])
+        return client
+
+    @pytest.fixture
+    def service(self, request_context, llm_client):
+        return ReflectionService(
+            request_context=request_context, llm_client=llm_client
+        )
+
+    def test_cited_profile_becomes_superseded_with_pointer_and_revise_event(
+        self, request_context, service, llm_client
+    ):
+        """After reflection revises a profile:
+        (a) cited profile is SUPERSEDED with superseded_by == new profile id
+        (b) a 'revise' lineage event exists for the successor profile
+        """
+        _set_config(request_context)
+        storage = request_context.storage
+
+        _seed_profile(storage, "u1", "p1", content="old content")
+
+        cite = Citation(kind="profile", real_id="p1")
+        _seed_request_with_interactions(
+            storage,
+            "u1",
+            "r1",
+            [
+                _make_interaction("u1", "r1", "User", "hi"),
+                _make_interaction("u1", "r1", "Assistant", "hello", citations=[cite]),
+            ],
+        )
+
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="profile",
+                    target_id="p1",
+                    new_content="new content",
+                    reason="user contradicted earlier preference",
+                )
+            ]
+        )
+
+        result = service.run(ReflectionServiceRequest(user_id="u1"))
+        assert result.ran is True
+        assert result.revised_count == 1
+
+        # (a) The old profile must be SUPERSEDED — not ARCHIVED — with a pointer.
+        superseded = storage.get_user_profile("u1", status_filter=[Status.SUPERSEDED])
+        assert len(superseded) == 1
+        old = superseded[0]
+        assert old.profile_id == "p1"
+        assert old.status == Status.SUPERSEDED
+
+        current = storage.get_user_profile("u1", status_filter=[None])
+        assert len(current) == 1
+        new_id = current[0].profile_id
+        assert new_id != "p1"
+        assert current[0].content == "new content"
+
+        # superseded_by pointer references the new current profile.
+        assert old.superseded_by == new_id
+
+        # (b) A 'revise' lineage event must exist for the successor.
+        events = storage.get_lineage_events(entity_type="profile", entity_id=new_id)
+        revise_events = [e for e in events if e.op == "revise"]
+        assert len(revise_events) >= 1
+        revise_evt = revise_events[0]
+        assert revise_evt.actor == "reflection"
+        assert "p1" in revise_evt.source_ids
+
+        # Old profile must NOT appear as ARCHIVED (no bleed from old code path).
+        archived = storage.get_user_profile("u1", status_filter=[Status.ARCHIVED])
+        assert archived == []
+
+    def test_no_supersede_when_no_change(self, request_context, service, llm_client):
+        """When LLM returns no_change, no supersede event is written."""
+        _set_config(request_context)
+        storage = request_context.storage
+
+        _seed_profile(storage, "u1", "p1")
+
+        cite = Citation(kind="profile", real_id="p1")
+        _seed_request_with_interactions(
+            storage,
+            "u1",
+            "r1",
+            [
+                _make_interaction("u1", "r1", "User", "hi"),
+                _make_interaction("u1", "r1", "Assistant", "hello", citations=[cite]),
+            ],
+        )
+
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="profile",
+                    target_id="p1",
+                    reason="still correct",
+                )
+            ]
+        )
+
+        result = service.run(ReflectionServiceRequest(user_id="u1"))
+        assert result.no_change_count == 1
+        assert result.revised_count == 0
+
+        # p1 remains CURRENT, no lineage events for it.
+        current = storage.get_user_profile("u1", status_filter=[None])
+        assert len(current) == 1
+        assert current[0].profile_id == "p1"
+        events = storage.get_lineage_events(entity_type="profile", entity_id="p1")
+        assert events == []

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -281,7 +281,7 @@ class TestCitedRowsAlreadyArchived:
 
 
 class TestReplaceProfile:
-    def test_replace_archives_cited_and_inserts_new_current(
+    def test_replace_supersedes_cited_and_inserts_new_current(
         self, request_context, service, llm_client
     ):
         _set_config(request_context)
@@ -317,9 +317,9 @@ class TestReplaceProfile:
         assert result.no_change_count == 0
 
         current = storage.get_user_profile("u1", status_filter=[None])
-        archived = storage.get_user_profile("u1", status_filter=[Status.ARCHIVED])
+        superseded = storage.get_user_profile("u1", status_filter=[Status.SUPERSEDED])
         assert len(current) == 1
-        assert len(archived) == 1
+        assert len(superseded) == 1
         assert current[0].profile_id != "p1"
         assert current[0].content == "new content"
         assert current[0].profile_time_to_live == ProfileTimeToLive.ONE_QUARTER
@@ -327,7 +327,9 @@ class TestReplaceProfile:
         assert current[0].user_id == "u1"
         assert current[0].custom_features == {"k": "v"}
         assert current[0].source == "seed"
-        assert archived[0].profile_id == "p1"
+        assert superseded[0].profile_id == "p1"
+        # superseded_by pointer must reference the new current profile.
+        assert superseded[0].superseded_by == current[0].profile_id
 
 
 class TestReplacePlaybook:
@@ -536,11 +538,11 @@ class TestPerDecisionMalformed:
         assert result.ran is True
         assert result.revised_count == 1
         assert result.failed_count >= 1
-        # Profile updated, playbook untouched.
-        archived_profiles = storage.get_user_profile(
-            "u1", status_filter=[Status.ARCHIVED]
+        # Profile superseded (not archived), playbook untouched.
+        superseded_profiles = storage.get_user_profile(
+            "u1", status_filter=[Status.SUPERSEDED]
         )
-        assert len(archived_profiles) == 1
+        assert len(superseded_profiles) == 1
         archived_playbooks = storage.get_user_playbooks(
             user_id="u1", status_filter=[Status.ARCHIVED]
         )
@@ -548,15 +550,16 @@ class TestPerDecisionMalformed:
 
 
 class TestArchiveAfterInsertFailure:
-    """Post-insert archive failures must keep the new row and log at ERROR.
+    """Post-insert supersede failures must keep the new row and log at ERROR.
 
     The reflection service explicitly accepts a transient duplicate
     (cited row stays current, new row inserted) over silently dropping
-    user data when the archive step fails. These tests pin that
-    behavior down.
+    user data when the supersede step raises. When supersede_record
+    returns False (CAS race lost), the successor is deleted cleanly.
+    These tests pin that behavior down.
     """
 
-    def test_replace_profile_archive_raises_keeps_new_row(
+    def test_replace_profile_supersede_raises_keeps_new_row(
         self, request_context, service, llm_client, caplog
     ):
         _set_config(request_context)
@@ -588,7 +591,7 @@ class TestArchiveAfterInsertFailure:
         with (
             patch.object(
                 storage,
-                "archive_profile_by_id",
+                "supersede_record",
                 side_effect=RuntimeError("disk full"),
             ),
             caplog.at_level(
@@ -611,7 +614,7 @@ class TestArchiveAfterInsertFailure:
         assert "kind=profile" in caplog.text
         assert "cited_id=p1" in caplog.text
 
-    def test_replace_profile_archive_returns_false_logs_noop(
+    def test_replace_profile_supersede_returns_false_drops_successor_and_logs_noop(
         self, request_context, service, llm_client, caplog
     ):
         _set_config(request_context)
@@ -640,10 +643,10 @@ class TestArchiveAfterInsertFailure:
             ]
         )
 
-        # archive_profile_by_id returns False (e.g. row was already
-        # archived between resolve and apply by a concurrent writer).
+        # supersede_record returns False (CAS race lost — incumbent was no
+        # longer CURRENT between resolve and apply by a concurrent writer).
         with (
-            patch.object(storage, "archive_profile_by_id", return_value=False),
+            patch.object(storage, "supersede_record", return_value=False),
             caplog.at_level(
                 "ERROR", logger="reflexio.server.services.reflection.reflection_service"
             ),
@@ -652,6 +655,10 @@ class TestArchiveAfterInsertFailure:
 
         assert result.revised_count == 1
         assert "reflection_archive_after_insert_noop" in caplog.text
+        # The successor was deleted (CAS lost → rollback); only p1 remains current.
+        current = storage.get_user_profile("u1", status_filter=[None])
+        assert len(current) == 1
+        assert current[0].profile_id == "p1"
 
     def test_replace_playbook_archive_raises_keeps_new_row(
         self, request_context, service, llm_client, caplog

--- a/tests/server/services/reflection/test_reflection_service_utils.py
+++ b/tests/server/services/reflection/test_reflection_service_utils.py
@@ -53,3 +53,23 @@ def test_reflection_result_no_replaced_count_field():
     # The old replaced_count field was renamed/folded into revised_count.
     fields = ReflectionResult.model_fields
     assert "replaced_count" not in fields
+
+
+def test_reflection_service_request_default_request_id_is_unique():
+    """Two requests constructed without an explicit request_id must differ.
+
+    The 5-col idempotency key for lineage events is (org, profile, op, request_id,
+    ...). A fixed empty-string default meant two reflection passes on the same
+    profile with no explicit request_id produced the SAME key, silently dropping
+    the second revise event via INSERT OR IGNORE. The default_factory ensures each
+    construction yields a distinct hex string.
+    """
+    from reflexio.server.services.reflection.reflection_service_utils import (
+        ReflectionServiceRequest,
+    )
+
+    r1 = ReflectionServiceRequest(user_id="u1")
+    r2 = ReflectionServiceRequest(user_id="u1")
+    assert r1.request_id != ""
+    assert r2.request_id != ""
+    assert r1.request_id != r2.request_id

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -1,0 +1,255 @@
+"""Integration tests: hard_delete lineage events on all remaining physical-delete methods.
+
+Phase A already covered delete_user_playbooks_by_ids / delete_agent_playbooks_by_ids.
+This file covers the net-new methods added in Phase B1 / Task 2:
+  - Single-row: delete_user_playbook, delete_agent_playbook, delete_user_profile
+  - Bulk by-ids: delete_profiles_by_ids (+ emit_hard_delete=False skip)
+  - Bulk GDPR/org-wipe: delete_all_profiles_for_user, delete_all_profiles,
+      delete_all_user_playbooks, delete_all_agent_playbooks,
+      delete_all_user_playbooks_by_playbook_name, delete_all_agent_playbooks_by_playbook_name,
+      delete_archived_agent_playbooks_by_playbook_name, delete_all_profiles_by_status
+  - Carve-out: delete_all_user_playbooks_by_status(PENDING) emits NO events
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
+from reflexio.models.api_schema.service_schemas import DeleteUserProfileRequest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _store(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    return s
+
+
+def _make_profile(
+    user_id: str = "u1", profile_id: str = "p1", content: str = "c"
+) -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_agent_playbook(
+    playbook_name: str = "pb", agent_version: str = "v1"
+) -> AgentPlaybook:
+    return AgentPlaybook(
+        playbook_name=playbook_name, agent_version=agent_version, content="c"
+    )
+
+
+# --------------------------------------------------------------------------
+# Single-row deletes
+# --------------------------------------------------------------------------
+
+
+def test_delete_user_playbook_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.delete_user_playbook(pb.user_playbook_id)
+    assert (
+        s.get_user_playbook_by_id(pb.user_playbook_id, include_tombstones=True) is None
+    )
+    assert any(
+        e.op == "hard_delete"
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    )
+
+
+def test_delete_agent_playbook_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.delete_agent_playbook(apid)
+    assert s.get_agent_playbook_by_id(apid, include_tombstones=True) is None
+    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id=str(apid)))
+
+
+def test_delete_user_profile_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="pr1")
+    s.add_user_profile("u1", [profile])
+    s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="pr1"))
+    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id="pr1"))
+
+
+# --------------------------------------------------------------------------
+# Bulk by-ids: delete_profiles_by_ids
+# --------------------------------------------------------------------------
+
+
+def test_delete_profiles_by_ids_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="pr2")
+    s.add_user_profile("u1", [profile])
+    s.delete_profiles_by_ids(["pr2"])
+    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id="pr2"))
+
+
+def test_delete_profiles_by_ids_multiple_emits_one_event_per_id(tmp_path):
+    s = _store(tmp_path)
+    p1 = _make_profile(user_id="u1", profile_id="pa")
+    p2 = _make_profile(user_id="u1", profile_id="pb")
+    s.add_user_profile("u1", [p1, p2])
+    s.delete_profiles_by_ids(["pa", "pb"])
+    events_a = [
+        e for e in s.get_lineage_events(entity_id="pa") if e.op == "hard_delete"
+    ]
+    events_b = [
+        e for e in s.get_lineage_events(entity_id="pb") if e.op == "hard_delete"
+    ]
+    assert len(events_a) == 1
+    assert len(events_b) == 1
+
+
+def test_delete_profiles_by_ids_emit_false_skips_event(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="pr3")
+    s.add_user_profile("u1", [profile])
+    s.delete_profiles_by_ids(["pr3"], emit_hard_delete=False)
+    assert not any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id="pr3"))
+
+
+# --------------------------------------------------------------------------
+# Bulk GDPR/org-wipe paths
+# --------------------------------------------------------------------------
+
+
+def test_delete_all_profiles_for_user_emits_hard_delete_per_id(tmp_path):
+    s = _store(tmp_path)
+    p1 = _make_profile(user_id="u2", profile_id="u2p1")
+    p2 = _make_profile(user_id="u2", profile_id="u2p2")
+    s.add_user_profile("u2", [p1, p2])
+    s.delete_all_profiles_for_user("u2")
+    for pid in ["u2p1", "u2p2"]:
+        assert any(
+            e.op == "hard_delete" for e in s.get_lineage_events(entity_id=pid)
+        ), f"no hard_delete for {pid}"
+
+
+def test_delete_all_profiles_emits_hard_delete_per_id(tmp_path):
+    s = _store(tmp_path)
+    p1 = _make_profile(user_id="u1", profile_id="all1")
+    p2 = _make_profile(user_id="u2", profile_id="all2")
+    s.add_user_profile("u1", [p1])
+    s.add_user_profile("u2", [p2])
+    s.delete_all_profiles()
+    for pid in ["all1", "all2"]:
+        assert any(
+            e.op == "hard_delete" for e in s.get_lineage_events(entity_id=pid)
+        ), f"no hard_delete for {pid}"
+
+
+def test_delete_all_profiles_by_status_emits_hard_delete_per_id(tmp_path):
+    s = _store(tmp_path)
+    p1 = _make_profile(user_id="u1", profile_id="arc1")
+    p1.status = Status.ARCHIVED
+    s.add_user_profile("u1", [p1])
+    s.delete_all_profiles_by_status(Status.ARCHIVED)
+    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id="arc1"))
+
+
+def test_delete_all_user_playbooks_emits_hard_delete_per_id(tmp_path):
+    s = _store(tmp_path)
+    pb1 = UserPlaybook(user_id="u", agent_version="v", request_id="r1", content="c")
+    pb2 = UserPlaybook(user_id="u", agent_version="v", request_id="r2", content="d")
+    s.save_user_playbooks([pb1, pb2])
+    s.delete_all_user_playbooks()
+    for pbid in [pb1.user_playbook_id, pb2.user_playbook_id]:
+        assert any(
+            e.op == "hard_delete" for e in s.get_lineage_events(entity_id=str(pbid))
+        ), f"no hard_delete for {pbid}"
+
+
+def test_delete_all_agent_playbooks_emits_hard_delete_per_id(tmp_path):
+    s = _store(tmp_path)
+    ap1 = _make_agent_playbook(playbook_name="ap1")
+    ap2 = _make_agent_playbook(playbook_name="ap2")
+    saved1 = s.save_agent_playbooks([ap1])
+    saved2 = s.save_agent_playbooks([ap2])
+    apid1 = saved1[0].agent_playbook_id
+    apid2 = saved2[0].agent_playbook_id
+    s.delete_all_agent_playbooks()
+    for apid in [apid1, apid2]:
+        assert any(
+            e.op == "hard_delete" for e in s.get_lineage_events(entity_id=str(apid))
+        ), f"no hard_delete for {apid}"
+
+
+def test_delete_all_user_playbooks_by_playbook_name_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        playbook_name="mybook",
+    )
+    s.save_user_playbooks([pb])
+    s.delete_all_user_playbooks_by_playbook_name("mybook")
+    assert any(
+        e.op == "hard_delete"
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    )
+
+
+def test_delete_all_agent_playbooks_by_playbook_name_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    ap = _make_agent_playbook(playbook_name="agentbook")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.delete_all_agent_playbooks_by_playbook_name("agentbook")
+    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id=str(apid)))
+
+
+def test_delete_archived_agent_playbooks_by_playbook_name_emits_hard_delete(tmp_path):
+    s = _store(tmp_path)
+    ap = AgentPlaybook(
+        playbook_name="archbook",
+        agent_version="v1",
+        content="c",
+        status=Status.ARCHIVED,
+    )
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.delete_archived_agent_playbooks_by_playbook_name("archbook")
+    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id=str(apid)))
+
+
+# --------------------------------------------------------------------------
+# Carve-out: PENDING purge emits NO events
+# --------------------------------------------------------------------------
+
+
+def test_delete_all_user_playbooks_by_status_pending_no_events(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        status=Status.PENDING,
+    )
+    s.save_user_playbooks([pb])
+    s.delete_all_user_playbooks_by_status(Status.PENDING)
+    # PENDING purge must NOT emit hard_delete events (ephemeral scratch carve-out)
+    events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert not any(e.op == "hard_delete" for e in events)

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -22,6 +22,7 @@ from reflexio.models.api_schema.domain.entities import (
 )
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import DeleteUserProfileRequest
+from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -262,3 +263,101 @@ def test_delete_all_user_playbooks_by_status_pending_no_events(tmp_path):
     # PENDING purge must NOT emit hard_delete events (ephemeral scratch carve-out)
     events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
     assert not any(e.op == "hard_delete" for e in events)
+
+
+# --------------------------------------------------------------------------
+# F002 negative: deleting nonexistent id emits NO hard_delete event
+# --------------------------------------------------------------------------
+
+
+def test_delete_user_playbook_nonexistent_no_event(tmp_path):
+    s = _store(tmp_path)
+    s.delete_user_playbook(99999)
+    events = s.get_lineage_events(entity_id="99999")
+    assert not any(e.op == "hard_delete" for e in events)
+
+
+def test_delete_agent_playbook_nonexistent_no_event(tmp_path):
+    s = _store(tmp_path)
+    s.delete_agent_playbook(99999)
+    events = s.get_lineage_events(entity_id="99999")
+    assert not any(e.op == "hard_delete" for e in events)
+
+
+def test_delete_user_profile_cross_user_no_event_and_no_delete(tmp_path):
+    """delete_user_profile for a profile_id owned by a DIFFERENT user emits NO event."""
+    s = _store(tmp_path)
+    # Insert profile owned by user "owner"
+    profile = _make_profile(user_id="owner", profile_id="cross-pr1")
+    s.add_user_profile("owner", [profile])
+    # Attempt delete as a different user
+    s.delete_user_profile(
+        DeleteUserProfileRequest(user_id="attacker", profile_id="cross-pr1")
+    )
+    # Profile must still exist
+    assert s.get_profile_by_id("cross-pr1") is not None
+    # No hard_delete event must have been emitted
+    assert not any(
+        e.op == "hard_delete" for e in s.get_lineage_events(entity_id="cross-pr1")
+    )
+
+
+# --------------------------------------------------------------------------
+# F008: delete_all_user_playbooks_by_status raises on non-PENDING status
+# --------------------------------------------------------------------------
+
+
+def test_delete_all_user_playbooks_by_status_archived_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(StorageError, match="PENDING"):
+        s.delete_all_user_playbooks_by_status(Status.ARCHIVED)
+
+
+def test_delete_all_user_playbooks_by_status_merged_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(StorageError, match="PENDING"):
+        s.delete_all_user_playbooks_by_status(Status.MERGED)
+
+
+# --------------------------------------------------------------------------
+# F012: by-ids delete methods emit actor="system"
+# --------------------------------------------------------------------------
+
+
+def test_delete_user_playbooks_by_ids_actor_is_system(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.delete_user_playbooks_by_ids([pb.user_playbook_id])
+    events = [
+        e
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+        if e.op == "hard_delete"
+    ]
+    assert len(events) == 1
+    assert events[0].actor == "system"
+
+
+def test_delete_agent_playbooks_by_ids_actor_is_system(tmp_path):
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.delete_agent_playbooks_by_ids([apid])
+    events = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "hard_delete"
+    ]
+    assert len(events) == 1
+    assert events[0].actor == "system"
+
+
+def test_delete_profiles_by_ids_actor_is_system(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="sys-pr1")
+    s.add_user_profile("u1", [profile])
+    s.delete_profiles_by_ids(["sys-pr1"])
+    events = [
+        e for e in s.get_lineage_events(entity_id="sys-pr1") if e.op == "hard_delete"
+    ]
+    assert len(events) == 1
+    assert events[0].actor == "system"

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -161,10 +161,19 @@ def test_delete_all_profiles_emits_hard_delete_per_id(tmp_path):
 def test_delete_all_profiles_by_status_emits_hard_delete_per_id(tmp_path):
     s = _store(tmp_path)
     p1 = _make_profile(user_id="u1", profile_id="arc1")
+    p2 = _make_profile(user_id="u1", profile_id="arc2")
     p1.status = Status.ARCHIVED
-    s.add_user_profile("u1", [p1])
+    p2.status = Status.ARCHIVED
+    s.add_user_profile("u1", [p1, p2])
     s.delete_all_profiles_by_status(Status.ARCHIVED)
-    assert any(e.op == "hard_delete" for e in s.get_lineage_events(entity_id="arc1"))
+    events_1 = [
+        e for e in s.get_lineage_events(entity_id="arc1") if e.op == "hard_delete"
+    ]
+    events_2 = [
+        e for e in s.get_lineage_events(entity_id="arc2") if e.op == "hard_delete"
+    ]
+    assert len(events_1) == 1
+    assert len(events_2) == 1
 
 
 def test_delete_all_user_playbooks_emits_hard_delete_per_id(tmp_path):

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -361,3 +361,89 @@ def test_delete_profiles_by_ids_actor_is_system(tmp_path):
     ]
     assert len(events) == 1
     assert events[0].actor == "system"
+
+
+# --------------------------------------------------------------------------
+# Nonexistent-id bulk deletes emit NO event (filter-to-existing guard)
+# --------------------------------------------------------------------------
+
+
+def test_delete_profiles_by_ids_nonexistent_no_event_and_returns_zero(tmp_path):
+    s = _store(tmp_path)
+    deleted = s.delete_profiles_by_ids(["ghost-1", "ghost-2"])
+    assert deleted == 0
+    assert not any(
+        e.op == "hard_delete" for e in s.get_lineage_events(entity_id="ghost-1")
+    )
+    assert not any(
+        e.op == "hard_delete" for e in s.get_lineage_events(entity_id="ghost-2")
+    )
+
+
+def test_delete_profiles_by_ids_partial_only_emits_for_existing(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="real-1")
+    s.add_user_profile("u1", [profile])
+    deleted = s.delete_profiles_by_ids(["real-1", "ghost-3"])
+    assert deleted == 1
+    real_events = [
+        e for e in s.get_lineage_events(entity_id="real-1") if e.op == "hard_delete"
+    ]
+    assert len(real_events) == 1
+    assert not any(
+        e.op == "hard_delete" for e in s.get_lineage_events(entity_id="ghost-3")
+    )
+
+
+# --------------------------------------------------------------------------
+# Bulk deletes clean up the vec table (when sqlite-vec is loaded)
+# --------------------------------------------------------------------------
+
+
+def _vec_rowids(s, table: str) -> set[int]:
+    return {
+        row["rowid"]
+        for row in s.conn.execute(f"SELECT rowid FROM {table}").fetchall()  # noqa: S608
+    }
+
+
+def test_delete_profiles_by_ids_cleans_vec(tmp_path):
+    s = _store(tmp_path)
+    if not s._has_sqlite_vec:
+        pytest.skip("sqlite-vec extension not loaded")
+    profile = _make_profile(user_id="u1", profile_id="vec-pr1")
+    s.add_user_profile("u1", [profile])
+    rowid_row = s.conn.execute(
+        "SELECT rowid FROM profiles WHERE profile_id = ?", ("vec-pr1",)
+    ).fetchone()
+    # Seed a vec row keyed on the profile's implicit sqlite rowid.
+    s._vec_upsert("profiles_vec", rowid_row["rowid"], [0.1] * s.embedding_dimensions)
+    assert rowid_row["rowid"] in _vec_rowids(s, "profiles_vec")
+    s.delete_profiles_by_ids(["vec-pr1"])
+    assert rowid_row["rowid"] not in _vec_rowids(s, "profiles_vec")
+
+
+def test_delete_all_user_playbooks_cleans_vec(tmp_path):
+    s = _store(tmp_path)
+    if not s._has_sqlite_vec:
+        pytest.skip("sqlite-vec extension not loaded")
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s._vec_upsert(
+        "user_playbooks_vec", pb.user_playbook_id, [0.2] * s.embedding_dimensions
+    )
+    assert pb.user_playbook_id in _vec_rowids(s, "user_playbooks_vec")
+    s.delete_all_user_playbooks()
+    assert pb.user_playbook_id not in _vec_rowids(s, "user_playbooks_vec")
+
+
+def test_delete_agent_playbooks_by_ids_cleans_vec(tmp_path):
+    s = _store(tmp_path)
+    if not s._has_sqlite_vec:
+        pytest.skip("sqlite-vec extension not loaded")
+    saved = s.save_agent_playbooks([_make_agent_playbook()])
+    apid = saved[0].agent_playbook_id
+    s._vec_upsert("agent_playbooks_vec", apid, [0.3] * s.embedding_dimensions)
+    assert apid in _vec_rowids(s, "agent_playbooks_vec")
+    s.delete_agent_playbooks_by_ids([apid])
+    assert apid not in _vec_rowids(s, "agent_playbooks_vec")

--- a/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
@@ -448,3 +448,148 @@ def test_update_agent_playbook_status_reason_is_transition(tmp_path):
     # Should be something like "pending->approved" or "None->approved"
     assert "approved" in evts[0].reason.lower()
     assert "->" in evts[0].reason
+
+
+# --------------------------------------------------------------------------
+# Structured status fields: from_status / to_status / status_namespace
+# --------------------------------------------------------------------------
+
+
+def test_archive_agent_playbooks_by_ids_structured_fields_null_prior(tmp_path):
+    """NULL-status agent_playbook archive yields from_status=None, to_status='archived', ns='lifecycle_status'."""
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_ids([apid])
+    evts = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status is None
+    assert evts[0].to_status == "archived"
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_archive_agent_playbooks_by_ids_structured_fields_pending_prior(tmp_path):
+    """PENDING-status agent_playbook archive yields from_status='pending', to_status='archived'."""
+    s = _store(tmp_path)
+    ap = AgentPlaybook(
+        playbook_name="pb_pending",
+        agent_version="v1",
+        content="c",
+        status=Status.PENDING,
+    )
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_ids([apid])
+    evts = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status == "pending"
+    assert evts[0].to_status == "archived"
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_archive_agent_playbooks_by_playbook_name_structured_fields(tmp_path):
+    """archive_agent_playbooks_by_playbook_name carries structured status fields."""
+    s = _store(tmp_path)
+    ap = _make_agent_playbook(playbook_name="struct_book")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_playbook_name("struct_book")
+    evts = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status is None
+    assert evts[0].to_status == "archived"
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_update_all_user_playbooks_status_structured_fields(tmp_path):
+    """update_all_user_playbooks_status carries from_status/to_status/status_namespace."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        status=Status.PENDING,
+    )
+    s.save_user_playbooks([pb])
+    s.update_all_user_playbooks_status(old_status=Status.PENDING, new_status=None)
+    evts = [
+        e
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+        if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status == "pending"
+    assert evts[0].to_status is None
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_update_all_user_playbooks_status_null_prior_structured_fields(tmp_path):
+    """update_all_user_playbooks_status with NULL->ARCHIVED carries from_status=None."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.update_all_user_playbooks_status(old_status=None, new_status=Status.ARCHIVED)
+    evts = [
+        e
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+        if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status is None
+    assert evts[0].to_status == "archived"
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_update_all_profiles_status_structured_fields(tmp_path):
+    """update_all_profiles_status carries from_status/to_status/status_namespace."""
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="struct_p1")
+    s.add_user_profile("u1", [profile])
+    s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED)
+    evts = [
+        e for e in s.get_lineage_events(entity_id="struct_p1") if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status is None
+    assert evts[0].to_status == "archived"
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_archive_profile_by_id_structured_fields(tmp_path):
+    """archive_profile_by_id always has NULL prior (guard is status IS NULL)."""
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="struct_p2")
+    s.add_user_profile("u1", [profile])
+    s.archive_profile_by_id("u1", "struct_p2")
+    evts = [
+        e for e in s.get_lineage_events(entity_id="struct_p2") if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status is None
+    assert evts[0].to_status == "archived"
+    assert evts[0].status_namespace == "lifecycle_status"
+
+
+def test_update_agent_playbook_status_structured_fields_pending_to_approved(tmp_path):
+    """update_agent_playbook_status: pending->approved yields structured fields with playbook_status ns."""
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    # Default playbook_status is 'pending'
+    s.update_agent_playbook_status(apid, PlaybookStatus.APPROVED)
+    evts = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(evts) == 1
+    assert evts[0].from_status == "pending"
+    assert evts[0].to_status == "approved"
+    assert evts[0].status_namespace == "playbook_status"

--- a/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
@@ -1,0 +1,282 @@
+"""Integration tests: status_change lineage events on archive + bulk status-flip methods.
+
+Phase B1 / Task 3: emit op=status_change per affected id, atomically with the UPDATE,
+for the following methods:
+  - archive_agent_playbooks_by_ids
+  - archive_agent_playbooks_by_playbook_name
+  - update_all_user_playbooks_status
+  - update_all_profiles_status
+  - archive_profile_by_id
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import AgentPlaybook, UserPlaybook, UserProfile
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
+from reflexio.models.api_schema.service_schemas import PlaybookStatus
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _store(tmp_path):
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    return s
+
+
+def _make_profile(user_id: str = "u1", profile_id: str = "p1", content: str = "c") -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_agent_playbook(
+    playbook_name: str = "pb", agent_version: str = "v1"
+) -> AgentPlaybook:
+    return AgentPlaybook(
+        playbook_name=playbook_name, agent_version=agent_version, content="c"
+    )
+
+
+# --------------------------------------------------------------------------
+# archive_agent_playbooks_by_ids
+# --------------------------------------------------------------------------
+
+
+def test_archive_agent_playbooks_by_ids_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_ids([apid])
+    events = s.get_lineage_events(entity_id=str(apid))
+    assert any(e.op == "status_change" for e in events)
+
+
+def test_archive_agent_playbooks_by_ids_emits_one_event_per_id(tmp_path):
+    s = _store(tmp_path)
+    ap1 = _make_agent_playbook(playbook_name="pb1")
+    ap2 = _make_agent_playbook(playbook_name="pb2")
+    saved1 = s.save_agent_playbooks([ap1])
+    saved2 = s.save_agent_playbooks([ap2])
+    id1 = saved1[0].agent_playbook_id
+    id2 = saved2[0].agent_playbook_id
+    s.archive_agent_playbooks_by_ids([id1, id2])
+    for apid in [id1, id2]:
+        events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
+        assert len(events) == 1, f"expected 1 status_change for {apid}, got {len(events)}"
+
+
+def test_archive_agent_playbooks_by_ids_skips_approved(tmp_path):
+    """APPROVED playbooks must not be archived (existing guard) — no status_change event emitted."""
+    s = _store(tmp_path)
+    ap = AgentPlaybook(
+        playbook_name="approved_pb",
+        agent_version="v1",
+        content="c",
+        playbook_status=PlaybookStatus.APPROVED,
+    )
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_ids([apid])
+    events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
+    assert len(events) == 0, "APPROVED playbooks must not emit status_change on archive"
+
+
+def test_archive_agent_playbooks_by_ids_reason_contains_transition(tmp_path):
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_ids([apid])
+    events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
+    assert events, "expected a status_change event"
+    assert "archived" in events[0].reason
+
+
+# --------------------------------------------------------------------------
+# archive_agent_playbooks_by_playbook_name
+# --------------------------------------------------------------------------
+
+
+def test_archive_agent_playbooks_by_playbook_name_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    ap = _make_agent_playbook(playbook_name="mybook")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_playbook_name("mybook")
+    events = s.get_lineage_events(entity_id=str(apid))
+    assert any(e.op == "status_change" for e in events)
+
+
+def test_archive_agent_playbooks_by_playbook_name_emits_one_event_per_id(tmp_path):
+    s = _store(tmp_path)
+    ap1 = _make_agent_playbook(playbook_name="shared_name", agent_version="v1")
+    ap2 = _make_agent_playbook(playbook_name="shared_name", agent_version="v2")
+    saved1 = s.save_agent_playbooks([ap1])
+    saved2 = s.save_agent_playbooks([ap2])
+    id1 = saved1[0].agent_playbook_id
+    id2 = saved2[0].agent_playbook_id
+    s.archive_agent_playbooks_by_playbook_name("shared_name")
+    for apid in [id1, id2]:
+        events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
+        assert len(events) == 1, f"expected 1 status_change for {apid}, got {len(events)}"
+
+
+# --------------------------------------------------------------------------
+# update_all_user_playbooks_status
+# --------------------------------------------------------------------------
+
+
+def test_update_all_user_playbooks_status_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        status=Status.PENDING,
+    )
+    s.save_user_playbooks([pb])
+    s.update_all_user_playbooks_status(old_status=Status.PENDING, new_status=None)
+    events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert any(e.op == "status_change" for e in events)
+
+
+def test_update_all_user_playbooks_status_emits_one_per_id(tmp_path):
+    s = _store(tmp_path)
+    pb1 = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r1",
+        content="c",
+        status=Status.PENDING,
+    )
+    pb2 = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r2",
+        content="d",
+        status=Status.PENDING,
+    )
+    s.save_user_playbooks([pb1, pb2])
+    s.update_all_user_playbooks_status(old_status=Status.PENDING, new_status=None)
+    for pb in [pb1, pb2]:
+        evts = [
+            e
+            for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+            if e.op == "status_change"
+        ]
+        assert len(evts) == 1, f"expected 1 status_change for {pb.user_playbook_id}, got {len(evts)}"
+
+
+def test_update_all_user_playbooks_status_reason_contains_transition(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        status=Status.PENDING,
+    )
+    s.save_user_playbooks([pb])
+    s.update_all_user_playbooks_status(old_status=Status.PENDING, new_status=None)
+    evts = [
+        e
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+        if e.op == "status_change"
+    ]
+    assert evts, "expected a status_change event"
+    assert "pending" in evts[0].reason.lower() or "None" in evts[0].reason
+
+
+def test_update_all_user_playbooks_status_no_match_no_event(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    # playbook status is None (current), but we ask to flip PENDING -> None
+    s.update_all_user_playbooks_status(old_status=Status.PENDING, new_status=None)
+    events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert not any(e.op == "status_change" for e in events)
+
+
+# --------------------------------------------------------------------------
+# update_all_profiles_status
+# --------------------------------------------------------------------------
+
+
+def test_update_all_profiles_status_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="psc1")
+    s.add_user_profile("u1", [profile])
+    s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED)
+    events = s.get_lineage_events(entity_id="psc1")
+    assert any(e.op == "status_change" for e in events)
+
+
+def test_update_all_profiles_status_emits_one_per_id(tmp_path):
+    s = _store(tmp_path)
+    p1 = _make_profile(user_id="u1", profile_id="psc2")
+    p2 = _make_profile(user_id="u1", profile_id="psc3")
+    s.add_user_profile("u1", [p1, p2])
+    s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED)
+    for pid in ["psc2", "psc3"]:
+        evts = [e for e in s.get_lineage_events(entity_id=pid) if e.op == "status_change"]
+        assert len(evts) == 1, f"expected 1 status_change for {pid}, got {len(evts)}"
+
+
+def test_update_all_profiles_status_with_user_id_filter(tmp_path):
+    s = _store(tmp_path)
+    p_u1 = _make_profile(user_id="ua", profile_id="pua")
+    p_u2 = _make_profile(user_id="ub", profile_id="pub")
+    s.add_user_profile("ua", [p_u1])
+    s.add_user_profile("ub", [p_u2])
+    s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED, user_ids=["ua"])
+    assert any(e.op == "status_change" for e in s.get_lineage_events(entity_id="pua"))
+    assert not any(e.op == "status_change" for e in s.get_lineage_events(entity_id="pub"))
+
+
+# --------------------------------------------------------------------------
+# archive_profile_by_id
+# --------------------------------------------------------------------------
+
+
+def test_archive_profile_by_id_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="arc_p1")
+    s.add_user_profile("u1", [profile])
+    result = s.archive_profile_by_id("u1", "arc_p1")
+    assert result is True
+    events = s.get_lineage_events(entity_id="arc_p1")
+    assert any(e.op == "status_change" for e in events)
+
+
+def test_archive_profile_by_id_already_archived_no_event(tmp_path):
+    """Already-archived (status != NULL) profiles must not emit a second event."""
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="arc_p2")
+    profile.status = Status.ARCHIVED
+    s.add_user_profile("u1", [profile])
+    # Guard in method: status IS NULL required — so this returns False and emits nothing.
+    result = s.archive_profile_by_id("u1", "arc_p2")
+    assert result is False
+    events = [e for e in s.get_lineage_events(entity_id="arc_p2") if e.op == "status_change"]
+    assert len(events) == 0
+
+
+def test_archive_profile_by_id_reason_contains_transition(tmp_path):
+    s = _store(tmp_path)
+    profile = _make_profile(user_id="u1", profile_id="arc_p3")
+    s.add_user_profile("u1", [profile])
+    s.archive_profile_by_id("u1", "arc_p3")
+    evts = [e for e in s.get_lineage_events(entity_id="arc_p3") if e.op == "status_change"]
+    assert evts
+    assert "archived" in evts[0].reason.lower()

--- a/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
@@ -13,7 +13,11 @@ from datetime import UTC, datetime
 
 import pytest
 
-from reflexio.models.api_schema.domain.entities import AgentPlaybook, UserPlaybook, UserProfile
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import PlaybookStatus
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
@@ -27,7 +31,9 @@ def _store(tmp_path):
     return s
 
 
-def _make_profile(user_id: str = "u1", profile_id: str = "p1", content: str = "c") -> UserProfile:
+def _make_profile(
+    user_id: str = "u1", profile_id: str = "p1", content: str = "c"
+) -> UserProfile:
     return UserProfile(
         user_id=user_id,
         profile_id=profile_id,
@@ -57,8 +63,10 @@ def test_archive_agent_playbooks_by_ids_emits_status_change(tmp_path):
     saved = s.save_agent_playbooks([ap])
     apid = saved[0].agent_playbook_id
     s.archive_agent_playbooks_by_ids([apid])
-    events = s.get_lineage_events(entity_id=str(apid))
-    assert any(e.op == "status_change" for e in events)
+    events = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(events) == 1
 
 
 def test_archive_agent_playbooks_by_ids_emits_one_event_per_id(tmp_path):
@@ -71,8 +79,14 @@ def test_archive_agent_playbooks_by_ids_emits_one_event_per_id(tmp_path):
     id2 = saved2[0].agent_playbook_id
     s.archive_agent_playbooks_by_ids([id1, id2])
     for apid in [id1, id2]:
-        events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
-        assert len(events) == 1, f"expected 1 status_change for {apid}, got {len(events)}"
+        events = [
+            e
+            for e in s.get_lineage_events(entity_id=str(apid))
+            if e.op == "status_change"
+        ]
+        assert len(events) == 1, (
+            f"expected 1 status_change for {apid}, got {len(events)}"
+        )
 
 
 def test_archive_agent_playbooks_by_ids_skips_approved(tmp_path):
@@ -87,7 +101,9 @@ def test_archive_agent_playbooks_by_ids_skips_approved(tmp_path):
     saved = s.save_agent_playbooks([ap])
     apid = saved[0].agent_playbook_id
     s.archive_agent_playbooks_by_ids([apid])
-    events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
+    events = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
     assert len(events) == 0, "APPROVED playbooks must not emit status_change on archive"
 
 
@@ -97,9 +113,48 @@ def test_archive_agent_playbooks_by_ids_reason_contains_transition(tmp_path):
     saved = s.save_agent_playbooks([ap])
     apid = saved[0].agent_playbook_id
     s.archive_agent_playbooks_by_ids([apid])
-    events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
+    events = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
     assert events, "expected a status_change event"
     assert "archived" in events[0].reason
+
+
+def test_archive_agent_playbooks_by_ids_per_row_reason(tmp_path):
+    """Reason must reflect actual prior status: pending->archived or None->archived."""
+    s = _store(tmp_path)
+    # NULL-status playbook
+    ap_null = _make_agent_playbook(playbook_name="null_pb")
+    saved_null = s.save_agent_playbooks([ap_null])
+    id_null = saved_null[0].agent_playbook_id
+
+    # pending-status playbook (status column, not playbook_status)
+    ap_pending = AgentPlaybook(
+        playbook_name="pending_pb",
+        agent_version="v1",
+        content="c",
+        status=Status.PENDING,
+    )
+    saved_pending = s.save_agent_playbooks([ap_pending])
+    id_pending = saved_pending[0].agent_playbook_id
+
+    s.archive_agent_playbooks_by_ids([id_null, id_pending])
+
+    evts_null = [
+        e
+        for e in s.get_lineage_events(entity_id=str(id_null))
+        if e.op == "status_change"
+    ]
+    assert len(evts_null) == 1
+    assert evts_null[0].reason == "None->archived"
+
+    evts_pending = [
+        e
+        for e in s.get_lineage_events(entity_id=str(id_pending))
+        if e.op == "status_change"
+    ]
+    assert len(evts_pending) == 1
+    assert evts_pending[0].reason == "pending->archived"
 
 
 # --------------------------------------------------------------------------
@@ -113,8 +168,10 @@ def test_archive_agent_playbooks_by_playbook_name_emits_status_change(tmp_path):
     saved = s.save_agent_playbooks([ap])
     apid = saved[0].agent_playbook_id
     s.archive_agent_playbooks_by_playbook_name("mybook")
-    events = s.get_lineage_events(entity_id=str(apid))
-    assert any(e.op == "status_change" for e in events)
+    events = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(events) == 1
 
 
 def test_archive_agent_playbooks_by_playbook_name_emits_one_event_per_id(tmp_path):
@@ -127,8 +184,67 @@ def test_archive_agent_playbooks_by_playbook_name_emits_one_event_per_id(tmp_pat
     id2 = saved2[0].agent_playbook_id
     s.archive_agent_playbooks_by_playbook_name("shared_name")
     for apid in [id1, id2]:
-        events = [e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"]
-        assert len(events) == 1, f"expected 1 status_change for {apid}, got {len(events)}"
+        events = [
+            e
+            for e in s.get_lineage_events(entity_id=str(apid))
+            if e.op == "status_change"
+        ]
+        assert len(events) == 1, (
+            f"expected 1 status_change for {apid}, got {len(events)}"
+        )
+
+
+def test_archive_agent_playbooks_by_playbook_name_skips_approved(tmp_path):
+    """APPROVED playbooks must not be archived via by-name method — zero status_change events."""
+    s = _store(tmp_path)
+    ap = AgentPlaybook(
+        playbook_name="approved_pb",
+        agent_version="v1",
+        content="c",
+        playbook_status=PlaybookStatus.APPROVED,
+    )
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_playbook_name("approved_pb")
+    events = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert len(events) == 0, "APPROVED playbooks must not emit status_change on archive"
+
+
+def test_archive_agent_playbooks_by_playbook_name_per_row_reason(tmp_path):
+    """Reason must reflect actual prior status per row."""
+    s = _store(tmp_path)
+    ap_null = _make_agent_playbook(playbook_name="reason_book")
+    saved_null = s.save_agent_playbooks([ap_null])
+    id_null = saved_null[0].agent_playbook_id
+
+    ap_pending = AgentPlaybook(
+        playbook_name="reason_book",
+        agent_version="v2",
+        content="c",
+        status=Status.PENDING,
+    )
+    saved_pending = s.save_agent_playbooks([ap_pending])
+    id_pending = saved_pending[0].agent_playbook_id
+
+    s.archive_agent_playbooks_by_playbook_name("reason_book")
+
+    evts_null = [
+        e
+        for e in s.get_lineage_events(entity_id=str(id_null))
+        if e.op == "status_change"
+    ]
+    assert len(evts_null) == 1
+    assert evts_null[0].reason == "None->archived"
+
+    evts_pending = [
+        e
+        for e in s.get_lineage_events(entity_id=str(id_pending))
+        if e.op == "status_change"
+    ]
+    assert len(evts_pending) == 1
+    assert evts_pending[0].reason == "pending->archived"
 
 
 # --------------------------------------------------------------------------
@@ -147,8 +263,12 @@ def test_update_all_user_playbooks_status_emits_status_change(tmp_path):
     )
     s.save_user_playbooks([pb])
     s.update_all_user_playbooks_status(old_status=Status.PENDING, new_status=None)
-    events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
-    assert any(e.op == "status_change" for e in events)
+    events = [
+        e
+        for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+        if e.op == "status_change"
+    ]
+    assert len(events) == 1
 
 
 def test_update_all_user_playbooks_status_emits_one_per_id(tmp_path):
@@ -175,7 +295,9 @@ def test_update_all_user_playbooks_status_emits_one_per_id(tmp_path):
             for e in s.get_lineage_events(entity_id=str(pb.user_playbook_id))
             if e.op == "status_change"
         ]
-        assert len(evts) == 1, f"expected 1 status_change for {pb.user_playbook_id}, got {len(evts)}"
+        assert len(evts) == 1, (
+            f"expected 1 status_change for {pb.user_playbook_id}, got {len(evts)}"
+        )
 
 
 def test_update_all_user_playbooks_status_reason_contains_transition(tmp_path):
@@ -229,7 +351,9 @@ def test_update_all_profiles_status_emits_one_per_id(tmp_path):
     s.add_user_profile("u1", [p1, p2])
     s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED)
     for pid in ["psc2", "psc3"]:
-        evts = [e for e in s.get_lineage_events(entity_id=pid) if e.op == "status_change"]
+        evts = [
+            e for e in s.get_lineage_events(entity_id=pid) if e.op == "status_change"
+        ]
         assert len(evts) == 1, f"expected 1 status_change for {pid}, got {len(evts)}"
 
 
@@ -239,9 +363,13 @@ def test_update_all_profiles_status_with_user_id_filter(tmp_path):
     p_u2 = _make_profile(user_id="ub", profile_id="pub")
     s.add_user_profile("ua", [p_u1])
     s.add_user_profile("ub", [p_u2])
-    s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED, user_ids=["ua"])
+    s.update_all_profiles_status(
+        old_status=None, new_status=Status.ARCHIVED, user_ids=["ua"]
+    )
     assert any(e.op == "status_change" for e in s.get_lineage_events(entity_id="pua"))
-    assert not any(e.op == "status_change" for e in s.get_lineage_events(entity_id="pub"))
+    assert not any(
+        e.op == "status_change" for e in s.get_lineage_events(entity_id="pub")
+    )
 
 
 # --------------------------------------------------------------------------
@@ -268,7 +396,9 @@ def test_archive_profile_by_id_already_archived_no_event(tmp_path):
     # Guard in method: status IS NULL required — so this returns False and emits nothing.
     result = s.archive_profile_by_id("u1", "arc_p2")
     assert result is False
-    events = [e for e in s.get_lineage_events(entity_id="arc_p2") if e.op == "status_change"]
+    events = [
+        e for e in s.get_lineage_events(entity_id="arc_p2") if e.op == "status_change"
+    ]
     assert len(events) == 0
 
 
@@ -277,6 +407,8 @@ def test_archive_profile_by_id_reason_contains_transition(tmp_path):
     profile = _make_profile(user_id="u1", profile_id="arc_p3")
     s.add_user_profile("u1", [profile])
     s.archive_profile_by_id("u1", "arc_p3")
-    evts = [e for e in s.get_lineage_events(entity_id="arc_p3") if e.op == "status_change"]
+    evts = [
+        e for e in s.get_lineage_events(entity_id="arc_p3") if e.op == "status_change"
+    ]
     assert evts
     assert "archived" in evts[0].reason.lower()

--- a/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
@@ -20,6 +20,7 @@ from reflexio.models.api_schema.domain.entities import (
 )
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import PlaybookStatus
+from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -412,3 +413,38 @@ def test_archive_profile_by_id_reason_contains_transition(tmp_path):
     ]
     assert evts
     assert "archived" in evts[0].reason.lower()
+
+
+# --------------------------------------------------------------------------
+# F003 negative: update_agent_playbook_status on nonexistent id emits NO event
+# --------------------------------------------------------------------------
+
+
+def test_update_agent_playbook_status_nonexistent_raises_no_event(tmp_path):
+    """A nonexistent agent_playbook_id must raise ValueError and emit no status_change."""
+    s = _store(tmp_path)
+    with pytest.raises(StorageError):
+        s.update_agent_playbook_status(99999, PlaybookStatus.APPROVED)
+    events = s.get_lineage_events(entity_id="99999")
+    assert not any(e.op == "status_change" for e in events)
+
+
+# --------------------------------------------------------------------------
+# F017: update_agent_playbook_status reason records actual transition
+# --------------------------------------------------------------------------
+
+
+def test_update_agent_playbook_status_reason_is_transition(tmp_path):
+    """reason field must record old->new playbook_status, not a generic string."""
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.update_agent_playbook_status(apid, PlaybookStatus.APPROVED)
+    evts = [
+        e for e in s.get_lineage_events(entity_id=str(apid)) if e.op == "status_change"
+    ]
+    assert evts
+    # Should be something like "pending->approved" or "None->approved"
+    assert "approved" in evts[0].reason.lower()
+    assert "->" in evts[0].reason

--- a/tests/server/services/storage/test_lineage_b1_update_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_update_integration.py
@@ -5,9 +5,14 @@ lineage event (op=revise when content changes, op=status_change otherwise).
 """
 
 import pytest
-from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
-from reflexio.models.api_schema.domain.entities import AgentPlaybook, UserPlaybook, UserProfile
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
 from reflexio.models.api_schema.domain.enums import PlaybookStatus
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
 
@@ -63,7 +68,9 @@ def test_update_agent_playbook_content_emits_revise(tmp_path):
     ap = AgentPlaybook(agent_version="v", content="old")
     saved = s.save_agent_playbooks([ap])
     s.update_agent_playbook(saved[0].agent_playbook_id, content="new")
-    ev = s.get_lineage_events(entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook")
+    ev = s.get_lineage_events(
+        entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook"
+    )
     assert [e.op for e in ev] == ["revise"]
 
 
@@ -72,7 +79,9 @@ def test_update_agent_playbook_metadata_only_emits_status_change(tmp_path):
     ap = AgentPlaybook(agent_version="v", content="c")
     saved = s.save_agent_playbooks([ap])
     s.update_agent_playbook(saved[0].agent_playbook_id, playbook_name="renamed")
-    ev = s.get_lineage_events(entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook")
+    ev = s.get_lineage_events(
+        entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook"
+    )
     assert [e.op for e in ev] == ["status_change"]
 
 
@@ -86,7 +95,9 @@ def test_update_agent_playbook_status_always_emits_status_change(tmp_path):
     ap = AgentPlaybook(agent_version="v", content="c")
     saved = s.save_agent_playbooks([ap])
     s.update_agent_playbook_status(saved[0].agent_playbook_id, PlaybookStatus.APPROVED)
-    ev = s.get_lineage_events(entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook")
+    ev = s.get_lineage_events(
+        entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook"
+    )
     assert [e.op for e in ev] == ["status_change"]
 
 

--- a/tests/server/services/storage/test_lineage_b1_update_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_update_integration.py
@@ -1,0 +1,114 @@
+"""Integration tests: in-place update_* methods emit lineage events atomically.
+
+Phase B1 — Task 1: verifies that each update_* method emits exactly one
+lineage event (op=revise when content changes, op=status_change otherwise).
+"""
+
+import pytest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.models.api_schema.domain.entities import AgentPlaybook, UserPlaybook, UserProfile
+from reflexio.models.api_schema.domain.enums import PlaybookStatus
+
+pytestmark = pytest.mark.integration
+
+
+def _store(tmp_path: pytest.TempPathFactory) -> SQLiteStorage:
+    s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    return s
+
+
+# ---------------------------------------------------------------------------
+# update_user_playbook
+# ---------------------------------------------------------------------------
+
+
+def test_update_user_playbook_content_emits_revise(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="old")
+    s.save_user_playbooks([pb])
+    s.update_user_playbook(pb.user_playbook_id, content="new guidance")
+    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert [e.op for e in ev] == ["revise"]
+    assert s.get_user_playbook_by_id(pb.user_playbook_id).content == "new guidance"
+
+
+def test_update_user_playbook_metadata_only_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.update_user_playbook(pb.user_playbook_id, playbook_name="renamed")  # no content
+    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert [e.op for e in ev] == ["status_change"]
+
+
+def test_update_user_playbook_multiple_edits_each_produce_event(tmp_path):
+    """Each call should produce a distinct event (not collapsed by idempotency key)."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.update_user_playbook(pb.user_playbook_id, content="v2")
+    s.update_user_playbook(pb.user_playbook_id, content="v3")
+    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert [e.op for e in ev] == ["revise", "revise"]
+
+
+# ---------------------------------------------------------------------------
+# update_agent_playbook
+# ---------------------------------------------------------------------------
+
+
+def test_update_agent_playbook_content_emits_revise(tmp_path):
+    s = _store(tmp_path)
+    ap = AgentPlaybook(agent_version="v", content="old")
+    saved = s.save_agent_playbooks([ap])
+    s.update_agent_playbook(saved[0].agent_playbook_id, content="new")
+    ev = s.get_lineage_events(entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook")
+    assert [e.op for e in ev] == ["revise"]
+
+
+def test_update_agent_playbook_metadata_only_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    ap = AgentPlaybook(agent_version="v", content="c")
+    saved = s.save_agent_playbooks([ap])
+    s.update_agent_playbook(saved[0].agent_playbook_id, playbook_name="renamed")
+    ev = s.get_lineage_events(entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook")
+    assert [e.op for e in ev] == ["status_change"]
+
+
+# ---------------------------------------------------------------------------
+# update_agent_playbook_status
+# ---------------------------------------------------------------------------
+
+
+def test_update_agent_playbook_status_always_emits_status_change(tmp_path):
+    s = _store(tmp_path)
+    ap = AgentPlaybook(agent_version="v", content="c")
+    saved = s.save_agent_playbooks([ap])
+    s.update_agent_playbook_status(saved[0].agent_playbook_id, PlaybookStatus.APPROVED)
+    ev = s.get_lineage_events(entity_id=str(saved[0].agent_playbook_id), entity_type="agent_playbook")
+    assert [e.op for e in ev] == ["status_change"]
+
+
+# ---------------------------------------------------------------------------
+# update_user_profile_by_id
+# ---------------------------------------------------------------------------
+
+
+def test_update_user_profile_emits_revise(tmp_path):
+    s = _store(tmp_path)
+    profile = UserProfile(
+        profile_id="prof-1",
+        user_id="u",
+        content="original content",
+        last_modified_timestamp=0,
+        generated_from_request_id="r",
+    )
+    s.add_user_profile("u", [profile])
+    updated = profile.model_copy(update={"content": "updated content"})
+    s.update_user_profile_by_id("u", str(profile.profile_id), updated)
+    ev = s.get_lineage_events(entity_id=str(profile.profile_id), entity_type="profile")
+    assert [e.op for e in ev] == ["revise"]
+    fetched = s.get_profile_by_id(str(profile.profile_id))
+    assert fetched is not None
+    assert fetched.content == "updated content"

--- a/tests/server/services/storage/test_lineage_b1_update_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_update_integration.py
@@ -4,6 +4,8 @@ Phase B1 — Task 1: verifies that each update_* method emits exactly one
 lineage event (op=revise when content changes, op=status_change otherwise).
 """
 
+from pathlib import Path
+
 import pytest
 
 from reflexio.models.api_schema.domain.entities import (
@@ -17,7 +19,7 @@ from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 pytestmark = pytest.mark.integration
 
 
-def _store(tmp_path: pytest.TempPathFactory) -> SQLiteStorage:
+def _store(tmp_path: Path) -> SQLiteStorage:
     s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
     s.migrate()
     return s
@@ -123,3 +125,52 @@ def test_update_user_profile_emits_revise(tmp_path):
     fetched = s.get_profile_by_id(str(profile.profile_id))
     assert fetched is not None
     assert fetched.content == "updated content"
+
+
+def test_update_user_profile_nonexistent_emits_no_event(tmp_path):
+    """Updating a profile that no longer exists must emit no revise event."""
+    s = _store(tmp_path)
+    ghost = UserProfile(
+        profile_id="ghost-prof",
+        user_id="u",
+        content="content",
+        last_modified_timestamp=0,
+        generated_from_request_id="r",
+    )
+    # Never persisted — the pre-check returns early, but assert the contract.
+    s.update_user_profile_by_id("u", "ghost-prof", ghost)
+    ev = s.get_lineage_events(entity_id="ghost-prof", entity_type="profile")
+    assert not any(e.op == "revise" for e in ev)
+
+
+# ---------------------------------------------------------------------------
+# archive_agent_playbooks_* — re-archiving an archived row emits no event
+# ---------------------------------------------------------------------------
+
+
+def test_archive_agent_playbooks_by_ids_already_archived_no_event(tmp_path):
+    s = _store(tmp_path)
+    ap = AgentPlaybook(agent_version="v", content="c")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    # First archive emits one status_change event.
+    s.archive_agent_playbooks_by_ids([apid])
+    first = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
+    assert [e.op for e in first] == ["status_change"]
+    # Re-archiving the already-archived row must emit no further event.
+    s.archive_agent_playbooks_by_ids([apid])
+    second = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
+    assert [e.op for e in second] == ["status_change"]
+
+
+def test_archive_agent_playbooks_by_playbook_name_already_archived_no_event(tmp_path):
+    s = _store(tmp_path)
+    ap = AgentPlaybook(playbook_name="arch-pb", agent_version="v", content="c")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.archive_agent_playbooks_by_playbook_name("arch-pb")
+    first = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
+    assert [e.op for e in first] == ["status_change"]
+    s.archive_agent_playbooks_by_playbook_name("arch-pb")
+    second = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
+    assert [e.op for e in second] == ["status_change"]

--- a/tests/server/services/storage/test_lineage_b1_update_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_update_integration.py
@@ -2,6 +2,8 @@
 
 Phase B1 — Task 1: verifies that each update_* method emits exactly one
 lineage event (op=revise when content changes, op=status_change otherwise).
+
+Also covers Task 9 (structured status fields on in-place update_* status_change path).
 """
 
 from pathlib import Path
@@ -13,7 +15,7 @@ from reflexio.models.api_schema.domain.entities import (
     UserPlaybook,
     UserProfile,
 )
-from reflexio.models.api_schema.domain.enums import PlaybookStatus
+from reflexio.models.api_schema.domain.enums import PlaybookStatus, Status
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -174,3 +176,92 @@ def test_archive_agent_playbooks_by_playbook_name_already_archived_no_event(tmp_
     s.archive_agent_playbooks_by_playbook_name("arch-pb")
     second = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
     assert [e.op for e in second] == ["status_change"]
+
+
+# ---------------------------------------------------------------------------
+# Structured status fields: update_agent_playbook playbook_status path
+# ---------------------------------------------------------------------------
+
+
+def test_update_agent_playbook_playbook_status_populates_structured_fields(tmp_path):
+    """update_agent_playbook(playbook_status=X) emits status_change with structured fields populated."""
+    s = _store(tmp_path)
+    # Default playbook_status on save is 'pending'
+    ap = AgentPlaybook(agent_version="v", content="c")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.update_agent_playbook(apid, playbook_status=PlaybookStatus.APPROVED)
+    ev = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
+    sc = [e for e in ev if e.op == "status_change"]
+    assert len(sc) == 1
+    assert sc[0].to_status == "approved"
+    assert sc[0].from_status == "pending"
+    assert sc[0].status_namespace == "playbook_status"
+
+
+def test_update_agent_playbook_metadata_only_leaves_structured_fields_null(tmp_path):
+    """update_agent_playbook(playbook_name=...) (no status, no content) emits status_change with all 3 fields NULL."""
+    s = _store(tmp_path)
+    ap = AgentPlaybook(agent_version="v", content="c")
+    saved = s.save_agent_playbooks([ap])
+    apid = saved[0].agent_playbook_id
+    s.update_agent_playbook(apid, playbook_name="renamed")
+    ev = s.get_lineage_events(entity_id=str(apid), entity_type="agent_playbook")
+    sc = [e for e in ev if e.op == "status_change"]
+    assert len(sc) == 1
+    assert sc[0].from_status is None
+    assert sc[0].to_status is None
+    assert sc[0].status_namespace is None
+
+
+# ---------------------------------------------------------------------------
+# Structured status fields: update_user_playbook lifecycle status path
+# ---------------------------------------------------------------------------
+
+
+def test_update_user_playbook_status_populates_structured_fields(tmp_path):
+    """update_user_playbook(status=X) emits status_change with structured fields populated."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.update_user_playbook(pb.user_playbook_id, status=Status.ARCHIVED)
+    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    sc = [e for e in ev if e.op == "status_change"]
+    assert len(sc) == 1
+    assert sc[0].to_status == "archived"
+    assert sc[0].from_status is None  # prior status was NULL
+    assert sc[0].status_namespace == "lifecycle_status"
+
+
+def test_update_user_playbook_status_with_prior_pending_populates_from_status(tmp_path):
+    """update_user_playbook(status=X) with a prior non-NULL status records the real from_status."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        status=Status.PENDING,
+    )
+    s.save_user_playbooks([pb])
+    s.update_user_playbook(pb.user_playbook_id, status=Status.ARCHIVED)
+    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    sc = [e for e in ev if e.op == "status_change"]
+    assert len(sc) == 1
+    assert sc[0].from_status == "pending"
+    assert sc[0].to_status == "archived"
+    assert sc[0].status_namespace == "lifecycle_status"
+
+
+def test_update_user_playbook_metadata_only_leaves_structured_fields_null(tmp_path):
+    """update_user_playbook(playbook_name=...) (no status, no content) emits status_change with all 3 fields NULL."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    s.update_user_playbook(pb.user_playbook_id, playbook_name="renamed")
+    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    sc = [e for e in ev if e.op == "status_change"]
+    assert len(sc) == 1
+    assert sc[0].from_status is None
+    assert sc[0].to_status is None
+    assert sc[0].status_namespace is None

--- a/tests/server/services/storage/test_lineage_b1_update_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_update_integration.py
@@ -15,7 +15,7 @@ from reflexio.models.api_schema.domain.entities import (
     UserPlaybook,
     UserProfile,
 )
-from reflexio.models.api_schema.domain.enums import PlaybookStatus, Status
+from reflexio.models.api_schema.domain.enums import PlaybookStatus
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -212,45 +212,6 @@ def test_update_agent_playbook_metadata_only_leaves_structured_fields_null(tmp_p
     assert sc[0].from_status is None
     assert sc[0].to_status is None
     assert sc[0].status_namespace is None
-
-
-# ---------------------------------------------------------------------------
-# Structured status fields: update_user_playbook lifecycle status path
-# ---------------------------------------------------------------------------
-
-
-def test_update_user_playbook_status_populates_structured_fields(tmp_path):
-    """update_user_playbook(status=X) emits status_change with structured fields populated."""
-    s = _store(tmp_path)
-    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
-    s.save_user_playbooks([pb])
-    s.update_user_playbook(pb.user_playbook_id, status=Status.ARCHIVED)
-    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
-    sc = [e for e in ev if e.op == "status_change"]
-    assert len(sc) == 1
-    assert sc[0].to_status == "archived"
-    assert sc[0].from_status is None  # prior status was NULL
-    assert sc[0].status_namespace == "lifecycle_status"
-
-
-def test_update_user_playbook_status_with_prior_pending_populates_from_status(tmp_path):
-    """update_user_playbook(status=X) with a prior non-NULL status records the real from_status."""
-    s = _store(tmp_path)
-    pb = UserPlaybook(
-        user_id="u",
-        agent_version="v",
-        request_id="r",
-        content="c",
-        status=Status.PENDING,
-    )
-    s.save_user_playbooks([pb])
-    s.update_user_playbook(pb.user_playbook_id, status=Status.ARCHIVED)
-    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
-    sc = [e for e in ev if e.op == "status_change"]
-    assert len(sc) == 1
-    assert sc[0].from_status == "pending"
-    assert sc[0].to_status == "archived"
-    assert sc[0].status_namespace == "lifecycle_status"
 
 
 def test_update_user_playbook_metadata_only_leaves_structured_fields_null(tmp_path):

--- a/tests/server/services/storage/test_lineage_contract.py
+++ b/tests/server/services/storage/test_lineage_contract.py
@@ -8,9 +8,11 @@ are added in Task 12 when their gated suite is built.
 import pytest
 
 from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
     LineageContext,
     LineageEvent,
     UserPlaybook,
+    UserProfile,
 )
 from reflexio.models.api_schema.domain.enums import Status
 
@@ -133,3 +135,104 @@ def test_merge_multi_source_skips_already_tombstoned(storage) -> None:
     events = storage.get_lineage_events(entity_id=str(survivor.user_playbook_id))
     merge_events = [e for e in events if e.op == "merge"]
     assert len(merge_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# B1 contract cases: update / hard_delete / archive / idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_update_content_emits_revise(storage) -> None:
+    """In-place update with content change emits exactly one op='revise' event."""
+    pb = UserPlaybook(agent_version="v", request_id="r-update-revise", content="old")
+    storage.save_user_playbooks([pb])
+
+    storage.update_user_playbook(pb.user_playbook_id, content="new")
+
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(pb.user_playbook_id)
+    )
+    revise_events = [e for e in events if e.op == "revise"]
+    assert len(revise_events) == 1
+
+
+def test_update_metadata_only_emits_status_change(storage) -> None:
+    """In-place update without content (metadata-only) emits exactly one op='status_change' event."""
+    pb = UserPlaybook(agent_version="v", request_id="r-update-meta", content="c")
+    storage.save_user_playbooks([pb])
+
+    storage.update_user_playbook(pb.user_playbook_id, playbook_name="new-name")
+
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(pb.user_playbook_id)
+    )
+    status_change_events = [e for e in events if e.op == "status_change"]
+    assert len(status_change_events) == 1
+    # Must not emit a revise event for a metadata-only update.
+    assert not any(e.op == "revise" for e in events)
+
+
+def test_delete_user_playbook_emits_hard_delete(storage) -> None:
+    """Physical delete of a user_playbook emits op='hard_delete' before deletion."""
+    pb = UserPlaybook(agent_version="v", request_id="r-delete-up", content="c")
+    storage.save_user_playbooks([pb])
+    entity_id = str(pb.user_playbook_id)
+
+    storage.delete_user_playbook(pb.user_playbook_id)
+
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=entity_id
+    )
+    assert any(e.op == "hard_delete" for e in events)
+
+
+def test_delete_profiles_by_ids_emits_hard_delete(storage) -> None:
+    """Physical delete of a profile via delete_profiles_by_ids emits op='hard_delete'."""
+    profile = UserProfile(
+        profile_id="prof-hd-1",
+        user_id="u",
+        content="some content",
+        last_modified_timestamp=1,
+        generated_from_request_id="r-prof-delete",
+    )
+    storage.add_user_profile("u", [profile])
+
+    storage.delete_profiles_by_ids([profile.profile_id])
+
+    events = storage.get_lineage_events(
+        entity_type="profile", entity_id=profile.profile_id
+    )
+    assert any(e.op == "hard_delete" for e in events)
+
+
+def test_archive_agent_playbooks_by_ids_emits_status_change(storage) -> None:
+    """archive_agent_playbooks_by_ids emits op='status_change' for each archived playbook."""
+    ap = AgentPlaybook(agent_version="v", content="some content")
+    storage.save_agent_playbooks([ap])
+    entity_id = str(ap.agent_playbook_id)
+
+    storage.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+
+    events = storage.get_lineage_events(
+        entity_type="agent_playbook", entity_id=entity_id
+    )
+    assert any(e.op == "status_change" for e in events)
+
+
+def test_append_lineage_event_idempotent_exact_key(storage) -> None:
+    """Duplicate append_lineage_event calls with the same 5-col key yield exactly one row."""
+    event = LineageEvent(
+        org_id=storage.org_id,
+        entity_type="user_playbook",
+        entity_id="idem-2",
+        op="revise",
+        request_id="r-idem-exact",
+    )
+    first = storage.append_lineage_event(event)
+    second = storage.append_lineage_event(event)
+
+    assert first == second
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id="idem-2"
+    )
+    assert len(events) == 1

--- a/tests/server/services/storage/test_lineage_contract.py
+++ b/tests/server/services/storage/test_lineage_contract.py
@@ -236,3 +236,52 @@ def test_append_lineage_event_idempotent_exact_key(storage) -> None:
         entity_type="user_playbook", entity_id="idem-2"
     )
     assert len(events) == 1
+
+
+def test_status_change_event_carries_structured_fields(storage) -> None:
+    """status_change via archive_agent_playbooks_by_ids carries from_status/to_status/status_namespace."""
+    ap = AgentPlaybook(agent_version="v", content="c for structured")
+    storage.save_agent_playbooks([ap])
+    entity_id = str(ap.agent_playbook_id)
+
+    storage.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+
+    events = storage.get_lineage_events(
+        entity_type="agent_playbook", entity_id=entity_id
+    )
+    sc_events = [e for e in events if e.op == "status_change"]
+    assert len(sc_events) == 1
+    evt = sc_events[0]
+    assert evt.from_status is None
+    assert evt.to_status == "archived"
+    assert evt.status_namespace == "lifecycle_status"
+
+
+def test_status_change_null_prior_stores_real_null(storage) -> None:
+    """from_status must be real NULL (None), not the string 'None', when prior status is absent."""
+    ap = AgentPlaybook(agent_version="v", content="c for null-prior")
+    storage.save_agent_playbooks([ap])
+    storage.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+
+    events = storage.get_lineage_events(
+        entity_type="agent_playbook", entity_id=str(ap.agent_playbook_id)
+    )
+    sc = next(e for e in events if e.op == "status_change")
+    # Must be Python None, not the string "None"
+    assert sc.from_status is None
+    assert sc.from_status != "None"
+
+
+def test_non_status_change_events_have_null_structured_fields(storage) -> None:
+    """merge/revise/hard_delete events must NOT carry status namespace fields."""
+    pb = UserPlaybook(agent_version="v", request_id="r-non-sc", content="c")
+    storage.save_user_playbooks([pb])
+    storage.delete_user_playbook(pb.user_playbook_id)
+
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(pb.user_playbook_id)
+    )
+    hd = next(e for e in events if e.op == "hard_delete")
+    assert hd.from_status is None
+    assert hd.to_status is None
+    assert hd.status_namespace is None


### PR DESCRIPTION
## Summary

Lineage **Phase B1 (OSS / SQLite)** — completes the content-free lineage instrumentation begun in Phase A so `lineage_event` becomes the complete, single audit source for every state-changing write to playbooks/profiles. Each mutation emits its event atomically (one `with self._lock:` + one commit), keyed on the 5-column idempotency key `(org_id, entity_type, entity_id, op, request_id)`.

## Changes

- **In-place `update_*`** (`update_user_playbook`, `update_agent_playbook`, `update_agent_playbook_status`, `update_user_profile_by_id`) → emit `op=revise` (content changed) or `op=status_change`, per-call UUID `request_id`.
- **`hard_delete` completeness** — `delete_profiles_by_ids` (+ `emit_hard_delete` param), single-row deletes, and the **bulk / GDPR org-wipe** paths (`delete_all_*`, `delete_all_profiles_for_user`, `delete_*_by_playbook_name`) now emit a per-id `hard_delete` before the physical delete (SELECT-inside-lock for atomicity). PENDING-rerun purge stays a no-event carve-out.
- **`status_change`** on archive + bulk status-flip paths, with accurate per-row `reason` (`{prior}->archived`).
- **Reflection** profile edit routed through `supersede_record` (old profile → SUPERSEDED tombstone + `superseded_by` + `revise` event; lost-CAS rollback uses `emit_hard_delete=False`). Closes a Phase A gap.
- **`op=aggregate`** set-level events on user→agent aggregation (W3C PROV `wasDerivedFrom`, M:N), best-effort (`capture_anomaly`, never aborts aggregation).
- **`resolve_current`** emits a Sentry `capture_anomaly` on cycle / max-hops (previously a silent `None`).
- Idempotency key extended to include `entity_type` (prevents cross-entity-type collisions) and `org_id`.
- Storage **contract cases** for the B1 ops (inherited by enterprise backends).

## Test Plan

- New integration tests per task (update/hard_delete/status_change/reflection-supersede/aggregate) + contract cases; ~187 storage integration tests pass, 0 regressions.
- Best-effort aggregate path has a regression test (failing append doesn't abort the run, `capture_anomaly` fires).
- Reflection `request_id` pinned end-to-end on the `revise` event.

Built via subagent-driven-development (per-task TDD + review + fix loop); final whole-branch review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer lineage events with optional status transition fields (from/to/status namespace).
  * Expanded audit/lineage emission across playbook and profile lifecycle operations, including per-entity hard deletes, per-row status changes, in-place revise tracking, and improved playbook aggregation lineage (best-effort).
  * Updated profile supersede/reflection flow to consistently attach and propagate request ids.
* **Bug Fixes**
  * Lineage events now better match actual successful mutations; aggregation lineage append failures no longer break the run.
* **Documentation**
  * Added guidance on SQLite lineage/FTS/vector atomic write behavior.
* **Tests**
  * Added/expanded integration and unit tests covering lineage contracts, aggregation/reflection behavior, and request-id uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->