### PR TITLE
Lineage Phase B2 — TTL GC (tombstone garbage collection), OSS/SQLite

### DIFF
--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,0 +1,16 @@
+# Task 3 Report — LineageGCScheduler + Lifespan Wiring
+
+## Status
+DONE
+
+## Files changed
+- NEW: `reflexio/server/services/lineage/gc_scheduler.py`
+- NEW: `tests/server/services/lineage/test_gc_scheduler.py`
+- MOD: `reflexio/server/api.py` (lifespan wiring)
+
+## Deviations from spec
+- `_discover_org_ids` uses `storage.list_org_ids()` (a generic cross-org sweep), falling back to bootstrap-only on `NotImplementedError`/`AttributeError`. The resume scheduler uses `list_resumable_work_org_ids` which is work-filtered. For GC, an unfiltered list is correct because we want to sweep all orgs regardless of whether they have pending work.
+- Added `if ctx.storage is None: continue` guard in `_gc_tick` — pyright requires it because `create_storage()` returns `BaseStorage | None`. This is a correct, minimal guard.
+
+## Tests
+8 unit tests, all green. No threads used in tests — `_gc_tick` tested directly.

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -664,6 +664,27 @@ class PlaybookOptimizerConfig(BaseModel):
         return self
 
 
+class LineageGCConfig(BaseModel):
+    """Configuration for the tombstone garbage-collection job (off by default).
+
+    The GC hard-deletes lineage tombstone rows whose ``deleted_at`` timestamp
+    is older than ``tombstone_grace_window_days``.  It is opt-in and MUST NOT
+    be enabled until:
+
+    - The offline-tuner retention window is pinned (PB-9) so the GC cannot
+      delete tombstones that the tuner still needs for replay.
+    - The B2↔B3 timing contract is satisfied (PB-5) so the grace window is a
+      verified safe value, not the provisional default.
+
+    ``tombstone_grace_window_days`` is a provisional default — do not treat 90
+    days as a vetted value until PB-5 and PB-9 are closed.
+    """
+
+    enabled: bool = False
+    tombstone_grace_window_days: int = 90
+    poll_interval_seconds: int = 86400
+
+
 @dataclass(frozen=True)
 class EffectivePendingToolCallConfig:
     """Resolved pending-tool-call settings after applying tool overrides."""
@@ -801,6 +822,8 @@ class Config(BaseModel):
     playbook_optimizer_config: PlaybookOptimizerConfig = Field(
         default_factory=PlaybookOptimizerConfig
     )
+    # Tombstone GC job gate (opt-in, off by default — see LineageGCConfig)
+    lineage_gc: LineageGCConfig = Field(default_factory=LineageGCConfig)
     # Optional non-blocking async information tools for classic extraction.
     pending_tool_call_config: PendingToolCallConfig = Field(
         default_factory=PendingToolCallConfig
@@ -858,6 +881,7 @@ class Config(BaseModel):
                 "stride_size",
                 "reflection_config",
                 "playbook_optimizer_config",
+                "lineage_gc",
                 "pending_tool_call_config",
                 "retrieval_floor",
             ):

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -2943,6 +2943,9 @@ def create_app(
     from reflexio.server.services.extraction.resume_scheduler import (
         maybe_start_resume_scheduler,
     )
+    from reflexio.server.services.lineage.gc_scheduler import (
+        maybe_start_lineage_gc,
+    )
 
     def _lifespan_org_id() -> str:
         if get_org_id is None:
@@ -2962,6 +2965,7 @@ def create_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         scheduler = None
+        gc_scheduler = None
         if mount_data_plane:
             validate_llm_availability()
             from reflexio.server.llm.rerank import prewarm as _prewarm_cross_encoder
@@ -2975,11 +2979,17 @@ def create_app(
                 lambda org_id: RequestContext(org_id=org_id),
                 bootstrap_org_id=_lifespan_org_id(),
             )
+            gc_scheduler = maybe_start_lineage_gc(
+                lambda org_id: RequestContext(org_id=org_id),
+                bootstrap_org_id=_lifespan_org_id(),
+            )
         try:
             yield
         finally:
             if scheduler is not None:
                 scheduler.stop()
+            if gc_scheduler is not None:
+                gc_scheduler.stop()
 
     app = FastAPI(docs_url="/docs", lifespan=lifespan)
 

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -70,7 +70,13 @@ class LineageGCScheduler:
         if storage is not None:
             try:
                 org_ids = storage.list_org_ids()
-            except (NotImplementedError, AttributeError):
+            except NotImplementedError:
+                logger.warning(
+                    "event=lineage_gc_list_org_ids_not_implemented "
+                    "backend=%s bootstrap_org_id=%s — GC will only process bootstrap org",
+                    type(storage).__name__,
+                    bootstrap_ctx.org_id,
+                )
                 org_ids = []
         if bootstrap_ctx.org_id not in org_ids:
             org_ids = [bootstrap_ctx.org_id, *org_ids]
@@ -85,6 +91,8 @@ class LineageGCScheduler:
             org_ids (list[str]): Org IDs to process in this tick.
         """
         for org_id in org_ids:
+            if self._stop_event.is_set():
+                break
             try:
                 ctx = self.request_context_factory(org_id)
                 cfg = ctx.configurator.get_config()

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -1,0 +1,171 @@
+"""Process-local scheduler for lineage tombstone garbage collection.
+
+The scheduler is per-org and config-gated: each tick it discovers every org,
+reads that org's ``lineage_gc`` config, and — if enabled — hard-deletes
+tombstone rows older than the configured grace window.  One org's failure
+never stalls the loop; errors are captured as Sentry anomalies and the
+scheduler continues to the next org.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.tracing import capture_anomaly
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POLL_INTERVAL_SECONDS = 86400
+
+# Window-misconfiguration tripwire: if a single tick deletes more than this
+# many tombstones for one org, something is likely wrong with the grace window.
+_HIGH_VOLUME_THRESHOLD = 1000
+
+_ENTITY_TYPES = ("user_playbook", "agent_playbook", "profile")
+
+
+class LineageGCScheduler:
+    """Polling daemon that garbage-collects expired lineage tombstones per org."""
+
+    def __init__(
+        self,
+        *,
+        request_context_factory: Callable[[str], RequestContext],
+        bootstrap_org_id: str,
+    ) -> None:
+        self.request_context_factory = request_context_factory
+        self.bootstrap_org_id = bootstrap_org_id
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start the daemon thread (idempotent if already running)."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name="reflexio-lineage-gc-scheduler",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("event=lineage_gc_scheduler_started")
+
+    def stop(self, *, timeout_seconds: float = 5.0) -> None:
+        """Signal the daemon to stop and wait for it to finish."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout_seconds)
+        self._thread = None
+        logger.info("event=lineage_gc_scheduler_stopped")
+
+    def _discover_org_ids(self, bootstrap_ctx: RequestContext) -> list[str]:
+        """Return every known org, always including the bootstrap org."""
+        storage = getattr(bootstrap_ctx, "storage", None)
+        org_ids: list[str] = []
+        if storage is not None:
+            try:
+                org_ids = storage.list_org_ids()
+            except (NotImplementedError, AttributeError):
+                org_ids = []
+        if bootstrap_ctx.org_id not in org_ids:
+            org_ids = [bootstrap_ctx.org_id, *org_ids]
+        return org_ids
+
+    def _gc_tick(self, org_ids: list[str]) -> None:
+        """Run one GC pass across the given org IDs.
+
+        Factored out of ``_run_loop`` so tests can exercise it without threads.
+
+        Args:
+            org_ids (list[str]): Org IDs to process in this tick.
+        """
+        for org_id in org_ids:
+            try:
+                ctx = self.request_context_factory(org_id)
+                cfg = ctx.configurator.get_config()
+                if not cfg.lineage_gc.enabled:
+                    continue
+                if ctx.storage is None:
+                    continue
+                older_than_epoch = (
+                    int(time.time())
+                    - cfg.lineage_gc.tombstone_grace_window_days * 86400
+                )
+                total_deleted = 0
+                for entity_type in _ENTITY_TYPES:
+                    count = ctx.storage.gc_expired_tombstones(
+                        entity_type=entity_type,
+                        older_than_epoch=older_than_epoch,
+                    )
+                    total_deleted += count
+                if total_deleted:
+                    logger.info(
+                        "event=lineage_gc_tick org_id=%s deleted=%d",
+                        org_id,
+                        total_deleted,
+                    )
+                if total_deleted > _HIGH_VOLUME_THRESHOLD:
+                    capture_anomaly(
+                        "lineage.gc.high_volume",
+                        org_id=org_id,
+                        count=total_deleted,
+                    )
+            except Exception:
+                capture_anomaly("lineage.gc.run_failed", org_id=org_id)
+                logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
+            try:
+                bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
+                cfg = bootstrap_ctx.configurator.get_config()
+                poll_interval = cfg.lineage_gc.poll_interval_seconds
+                org_ids = self._discover_org_ids(bootstrap_ctx)
+                self._gc_tick(org_ids)
+            except Exception:
+                logger.exception("event=lineage_gc_scheduler_tick_failed")
+            self._stop_event.wait(poll_interval)
+
+
+def maybe_start_lineage_gc(
+    request_context_factory: Callable[[str], RequestContext],
+    *,
+    bootstrap_org_id: str,
+) -> LineageGCScheduler | None:
+    """Start the GC scheduler only when the bootstrap-org config enables it.
+
+    Off by default — GC must not be enabled until the tuner retention window
+    (PB-9) and B2↔B3 timing contract (PB-5) are closed.
+
+    Args:
+        request_context_factory: Builds an org-scoped :class:`RequestContext`.
+        bootstrap_org_id: Org used to read config and seed cross-org discovery.
+
+    Returns:
+        LineageGCScheduler: The started scheduler, or ``None`` if not enabled.
+    """
+    try:
+        ctx = request_context_factory(bootstrap_org_id)
+        cfg = ctx.configurator.get_config()
+        if not cfg.lineage_gc.enabled:
+            return None
+    except Exception as exc:
+        logger.warning(
+            "event=lineage_gc_scheduler_start_skipped error_type=%s error=%s",
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+    scheduler = LineageGCScheduler(
+        request_context_factory=request_context_factory,
+        bootstrap_org_id=bootstrap_org_id,
+    )
+    scheduler.start()
+    return scheduler

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -2,21 +2,39 @@ import json
 import sqlite3
 import threading
 import time
+import uuid
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from reflexio.models.api_schema.domain.entities import LineageContext, LineageEvent
 from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.tracing import capture_anomaly
 
 EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
 # Tombstone statuses — rows with these statuses are skipped by merge_records guard.
 _TOMBSTONE = (Status.MERGED.value, Status.SUPERSEDED.value)
 
+# GC-eligible statuses — rows with these statuses may be hard-deleted by TTL GC.
+# Deliberately broader than _TOMBSTONE: includes ARCHIVED. Do NOT reuse _TOMBSTONE.
+_GC_ELIGIBLE_STATUSES: frozenset[str] = frozenset(
+    {Status.MERGED.value, Status.SUPERSEDED.value, Status.ARCHIVED.value}
+)
+
 # Mapping from entity_type string to (table_name, primary_key_column).
 _TABLE: dict[str, tuple[str, str]] = {
     "user_playbook": ("user_playbooks", "user_playbook_id"),
     "agent_playbook": ("agent_playbooks", "agent_playbook_id"),
     "profile": ("profiles", "profile_id"),
+}
+
+# Per-entity GC metadata: (table, pk_col, age_col, age_is_text).
+# age_is_text=True  → TEXT ISO-8601 column; compare cutoff as ISO string.
+# age_is_text=False → INTEGER epoch column; compare cutoff as int directly.
+_GC_ENTITY_META: dict[str, tuple[str, str, str, bool]] = {
+    "user_playbook": ("user_playbooks", "user_playbook_id", "created_at", True),
+    "agent_playbook": ("agent_playbooks", "agent_playbook_id", "created_at", True),
+    "profile": ("profiles", "profile_id", "last_modified_timestamp", False),
 }
 
 
@@ -290,3 +308,153 @@ class SQLiteLineageMixin:
             )
             self.conn.commit()
             return True
+
+    def _is_on_legal_hold(
+        self,
+        org_id: str,  # noqa: ARG002
+        entity_type: str,  # noqa: ARG002
+        entity_id: str,  # noqa: ARG002
+    ) -> bool:
+        """Return True if this entity is under a legal hold and must not be GC'd.
+
+        Deferred seam — always returns False until a hold store exists.
+
+        Args:
+            org_id (str): The organisation that owns the entity.
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            entity_id (str): The entity's primary key as a string.
+
+        Returns:
+            bool: False (no hold store implemented yet).
+        """
+        return False
+
+    def gc_expired_tombstones(
+        self, *, entity_type: str, older_than_epoch: int, limit: int = 1000
+    ) -> int:
+        """Hard-delete tombstone rows that are older than the given epoch cutoff.
+
+        Emits one ``hard_delete`` lineage event per deleted row, atomically, before
+        the DELETE commits. Rows on legal hold are skipped without emitting an event.
+
+        Args:
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            older_than_epoch (int): Unix timestamp cutoff (exclusive). Rows whose
+                age column is strictly less than this value are eligible.
+            limit (int): Maximum rows to delete per call. Defaults to 1000.
+
+        Returns:
+            int: The number of rows physically deleted.
+
+        Raises:
+            ValueError: If ``entity_type`` is not a recognised entity type.
+        """
+        meta = _GC_ENTITY_META.get(entity_type)
+        if meta is None:
+            raise ValueError(f"unknown entity_type: {entity_type!r}")
+        table, pk, age_col, age_is_text = meta
+
+        eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
+        eligible_vals = list(_GC_ELIGIBLE_STATUSES)
+
+        if age_is_text:
+            # Convert int epoch to the same ISO-8601 format stored in the column
+            # so the lexicographic comparison is chronologically correct.
+            cutoff_iso = datetime.fromtimestamp(older_than_epoch, tz=UTC).strftime(
+                "%Y-%m-%dT%H:%M:%S.000Z"
+            )
+            select_sql = (
+                f"SELECT {pk} FROM {table} "  # noqa: S608
+                f"WHERE status IN ({eligible_ph}) AND {age_col} < ? LIMIT ?"
+            )
+            select_params: list[Any] = [*eligible_vals, cutoff_iso, limit]
+        else:
+            select_sql = (
+                f"SELECT {pk} FROM {table} "  # noqa: S608
+                f"WHERE status IN ({eligible_ph}) AND {age_col} < ? LIMIT ?"
+            )
+            select_params = [*eligible_vals, older_than_epoch, limit]
+
+        with self._lock:
+            rows = self.conn.execute(select_sql, select_params).fetchall()
+            if not rows:
+                return 0
+
+            candidate_ids: list[str] = [str(r[0]) for r in rows]
+            ids_to_delete: list[str] = []
+            for eid in candidate_ids:
+                if self._is_on_legal_hold(self.org_id, entity_type, eid):
+                    capture_anomaly(
+                        "lineage.gc.legal_hold_skip",
+                        level="info",
+                        org_id=self.org_id,
+                        entity_type=entity_type,
+                        entity_id=eid,
+                    )
+                    continue
+                ids_to_delete.append(eid)
+
+            if not ids_to_delete:
+                return 0
+
+            batch_request_id = uuid.uuid4().hex
+            ph = ",".join("?" * len(ids_to_delete))
+
+            # Emit hard_delete events BEFORE the DELETE, in the same transaction.
+            for eid in ids_to_delete:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type=entity_type,
+                    entity_id=eid,
+                    op="hard_delete",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="system",
+                    request_id=batch_request_id,
+                    reason="ttl-gc",
+                )
+
+            # Inline FTS/vec cleanup — raw DELETE to preserve atomicity.
+            # Do NOT call self._fts_delete/_vec_delete: they self-commit.
+            if entity_type in ("user_playbook", "agent_playbook"):
+                kind = "user" if entity_type == "user_playbook" else "agent"
+                int_ids = [int(eid) for eid in ids_to_delete]
+                int_ph = ",".join("?" * len(int_ids))
+                self.conn.execute(
+                    f"DELETE FROM {kind}_playbooks_fts WHERE rowid IN ({int_ph})",
+                    int_ids,
+                )
+                if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                    self.conn.execute(
+                        f"DELETE FROM {kind}_playbooks_vec WHERE rowid IN ({int_ph})",
+                        int_ids,
+                    )
+            else:
+                # profiles: FTS keyed on TEXT profile_id; vec keyed on implicit rowid.
+                self.conn.execute(
+                    f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",
+                    ids_to_delete,
+                )
+                if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                    rowid_rows = self.conn.execute(
+                        f"SELECT rowid FROM profiles WHERE profile_id IN ({ph})",  # noqa: S608
+                        ids_to_delete,
+                    ).fetchall()
+                    if rowid_rows:
+                        rowids = [r[0] for r in rowid_rows]
+                        rowid_ph = ",".join("?" * len(rowids))
+                        self.conn.execute(
+                            f"DELETE FROM profiles_vec WHERE rowid IN ({rowid_ph})",
+                            rowids,
+                        )
+
+            cur = self.conn.execute(
+                f"DELETE FROM {table} WHERE {pk} IN ({ph})",  # noqa: S608
+                ids_to_delete,
+            )
+            self.conn.commit()
+
+        return cur.rowcount

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -3,12 +3,13 @@ import sqlite3
 import threading
 import time
 import uuid
-from datetime import UTC, datetime
 from typing import Any, Literal
 
 from reflexio.models.api_schema.domain.entities import LineageContext, LineageEvent
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.tracing import capture_anomaly
+
+from ._base import _epoch_to_iso
 
 EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
@@ -360,11 +361,10 @@ class SQLiteLineageMixin:
         eligible_vals = list(_GC_ELIGIBLE_STATUSES)
 
         if age_is_text:
-            # Convert int epoch to the same ISO-8601 format stored in the column
-            # so the lexicographic comparison is chronologically correct.
-            cutoff_iso = datetime.fromtimestamp(older_than_epoch, tz=UTC).strftime(
-                "%Y-%m-%dT%H:%M:%S.000Z"
-            )
+            # Use the same helper the writer uses so the cutoff string is
+            # byte-for-byte format-consistent with stored values.  This keeps
+            # the ``<`` comparison truly exclusive (strict) at the boundary.
+            cutoff_iso = _epoch_to_iso(older_than_epoch)
             select_sql = (
                 f"SELECT {pk} FROM {table} "  # noqa: S608
                 f"WHERE status IN ({eligible_ph}) AND {age_col} < ? LIMIT ?"

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -331,6 +331,17 @@ class SQLiteLineageMixin:
         """
         return False
 
+    def list_org_ids(self) -> list[str]:
+        """Return the single org_id for this SQLite storage instance.
+
+        SQLite storage is single-tenant: each instance is scoped to exactly one
+        org. Returns ``[self.org_id]``.
+
+        Returns:
+            list[str]: A one-element list containing this instance's org_id.
+        """
+        return [self.org_id]
+
     def gc_expired_tombstones(
         self, *, entity_type: str, older_than_epoch: int, limit: int = 1000
     ) -> int:

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -126,3 +126,20 @@ class LineageEventMixin:
             ValueError: If ``entity_type`` is not a recognized entity type.
         """
         raise NotImplementedError
+
+    def list_org_ids(self) -> list[str]:
+        """Return every distinct org_id known to this storage instance.
+
+        Used by :class:`LineageGCScheduler` to enumerate all tenants so GC
+        runs for every org, not just the bootstrap org.
+
+        Returns:
+            list[str]: Distinct org ids, order unspecified.
+
+        Raises:
+            NotImplementedError: If the backend has not yet implemented this
+                method (enterprise backends owe this in B2 Task 6).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement list_org_ids"
+        )

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -101,3 +101,28 @@ class LineageEventMixin:
                 ``False`` if the incumbent was not CURRENT and no mutation occurred.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def gc_expired_tombstones(
+        self, *, entity_type: str, older_than_epoch: int, limit: int = 1000
+    ) -> int:
+        """Hard-delete tombstone rows that are older than the given epoch cutoff.
+
+        Emits one ``hard_delete`` lineage event per deleted row before deleting it,
+        all within a single atomic transaction. Rows on legal hold are skipped.
+
+        Args:
+            entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            older_than_epoch (int): Unix timestamp. Rows whose age column value
+                is strictly less than this cutoff are eligible.
+            limit (int): Maximum number of rows to delete in one call. Defaults
+                to 1000.
+
+        Returns:
+            int: The number of rows physically deleted.
+
+        Raises:
+            ValueError: If ``entity_type`` is not a recognized entity type.
+        """
+        raise NotImplementedError

--- a/tests/models/test_lineage_gc_config.py
+++ b/tests/models/test_lineage_gc_config.py
@@ -1,0 +1,41 @@
+"""Tests for ``LineageGCConfig`` (tombstone garbage-collection gate)."""
+
+from reflexio.models.config_schema import (
+    Config,
+    LineageGCConfig,
+    StorageConfigSQLite,
+)
+
+
+def test_lineage_gc_config_defaults():
+    cfg = LineageGCConfig()
+    assert cfg.enabled is False
+    assert cfg.tombstone_grace_window_days == 90
+    assert cfg.poll_interval_seconds == 86400
+
+
+def test_config_has_lineage_gc_default():
+    cfg = Config(storage_config=StorageConfigSQLite())
+    assert isinstance(cfg.lineage_gc, LineageGCConfig)
+    assert cfg.lineage_gc.enabled is False
+
+
+def test_lineage_gc_enabled_can_be_set():
+    cfg = LineageGCConfig(enabled=True)
+    assert cfg.enabled is True
+
+
+def test_lineage_gc_fields_can_be_overridden():
+    cfg = LineageGCConfig(tombstone_grace_window_days=30, poll_interval_seconds=3600)
+    assert cfg.tombstone_grace_window_days == 30
+    assert cfg.poll_interval_seconds == 3600
+
+
+def test_lineage_gc_null_falls_back_to_default():
+    # A stored config row with an explicit null must fall back to the default
+    # rather than failing validation — same pattern as retrieval_floor.
+    base = Config(storage_config=StorageConfigSQLite())
+    payload = base.model_dump()
+    payload["lineage_gc"] = None
+    cfg = Config.model_validate(payload)
+    assert cfg.lineage_gc == LineageGCConfig()

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -1,0 +1,193 @@
+"""Unit tests for LineageGCScheduler._gc_tick (no real threads needed)."""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from reflexio.models.config_schema import LineageGCConfig
+from reflexio.server.services.lineage import gc_scheduler
+from reflexio.server.services.lineage.gc_scheduler import (
+    _ENTITY_TYPES,
+    _HIGH_VOLUME_THRESHOLD,
+    LineageGCScheduler,
+    maybe_start_lineage_gc,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(*, gc_return: int = 0) -> MagicMock:
+    """Return a mock storage whose gc_expired_tombstones returns ``gc_return``."""
+    storage = MagicMock()
+    storage.gc_expired_tombstones.return_value = gc_return
+    return storage
+
+
+def _make_ctx(org_id: str, *, lineage_gc: LineageGCConfig, storage=None):
+    """Build a minimal request-context stand-in."""
+    if storage is None:
+        storage = _make_storage()
+    config = SimpleNamespace(lineage_gc=lineage_gc)
+    return SimpleNamespace(
+        org_id=org_id,
+        storage=storage,
+        configurator=SimpleNamespace(get_config=MagicMock(return_value=config)),
+    )
+
+
+def _scheduler(*, bootstrap_org_id: str = "org_bootstrap", factory=None):
+    """Return a LineageGCScheduler backed by ``factory`` (not started)."""
+    if factory is None:
+        factory = lambda org_id: _make_ctx(
+            org_id, lineage_gc=LineageGCConfig(enabled=True)
+        )  # noqa: E731
+    return LineageGCScheduler(
+        request_context_factory=factory,
+        bootstrap_org_id=bootstrap_org_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Enabled org — all three entity types get a gc call with correct cutoff
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_calls_all_entity_types_with_correct_cutoff():
+    grace_days = 30
+    cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=grace_days)
+    storage = _make_storage(gc_return=0)
+    ctx = _make_ctx("org_1", lineage_gc=cfg, storage=storage)
+
+    sched = _scheduler(factory=lambda _: ctx)
+
+    before = int(time.time())
+    sched._gc_tick(["org_1"])
+    after = int(time.time())
+
+    assert storage.gc_expired_tombstones.call_count == len(_ENTITY_TYPES)
+    for et in _ENTITY_TYPES:
+        # Find the call for this entity type
+        matching = [
+            c
+            for c in storage.gc_expired_tombstones.call_args_list
+            if c.kwargs.get("entity_type") == et
+        ]
+        assert len(matching) == 1, f"Expected one call for {et}"
+        epoch = matching[0].kwargs["older_than_epoch"]
+        expected_low = before - grace_days * 86400
+        expected_high = after - grace_days * 86400
+        assert expected_low <= epoch <= expected_high, (
+            f"older_than_epoch={epoch} not in [{expected_low}, {expected_high}]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (b) Disabled org — no gc calls
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_skips_disabled_org():
+    cfg = LineageGCConfig(enabled=False)
+    storage = _make_storage()
+    ctx = _make_ctx("org_disabled", lineage_gc=cfg, storage=storage)
+
+    sched = _scheduler(factory=lambda _: ctx)
+    sched._gc_tick(["org_disabled"])
+
+    storage.gc_expired_tombstones.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# (c) Resilience — one org failure triggers capture_anomaly, next org proceeds
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_continues_after_org_failure():
+    good_storage = _make_storage(gc_return=1)
+    good_cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=10)
+
+    def factory(org_id: str):
+        if org_id == "org_bad":
+            raise RuntimeError("simulated storage failure")
+        return _make_ctx(org_id, lineage_gc=good_cfg, storage=good_storage)
+
+    sched = _scheduler(factory=factory)
+
+    with patch.object(gc_scheduler, "capture_anomaly") as mock_anomaly:
+        sched._gc_tick(["org_bad", "org_good"])
+
+    # anomaly fired for the failing org
+    mock_anomaly.assert_called_once_with("lineage.gc.run_failed", org_id="org_bad")
+    # good org was still processed
+    assert good_storage.gc_expired_tombstones.call_count == len(_ENTITY_TYPES)
+
+
+# ---------------------------------------------------------------------------
+# (d) High-volume tripwire — capture_anomaly fires when count exceeds threshold
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_fires_high_volume_anomaly():
+    # Each of the 3 entity types returns enough to exceed the threshold in total
+    per_entity = (_HIGH_VOLUME_THRESHOLD // len(_ENTITY_TYPES)) + 1
+    cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=10)
+    storage = _make_storage(gc_return=per_entity)
+    ctx = _make_ctx("org_bigdel", lineage_gc=cfg, storage=storage)
+
+    sched = _scheduler(factory=lambda _: ctx)
+
+    with patch.object(gc_scheduler, "capture_anomaly") as mock_anomaly:
+        sched._gc_tick(["org_bigdel"])
+
+    total = per_entity * len(_ENTITY_TYPES)
+    assert total > _HIGH_VOLUME_THRESHOLD
+    mock_anomaly.assert_called_once_with(
+        "lineage.gc.high_volume", org_id="org_bigdel", count=total
+    )
+
+
+def test_gc_tick_no_high_volume_anomaly_below_threshold():
+    # Exactly at threshold — should NOT fire
+    per_entity = _HIGH_VOLUME_THRESHOLD // len(_ENTITY_TYPES)
+    cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=10)
+    storage = _make_storage(gc_return=per_entity)
+    ctx = _make_ctx("org_small", lineage_gc=cfg, storage=storage)
+
+    sched = _scheduler(factory=lambda _: ctx)
+
+    with patch.object(gc_scheduler, "capture_anomaly") as mock_anomaly:
+        sched._gc_tick(["org_small"])
+
+    mock_anomaly.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# maybe_start_lineage_gc — off-by-default factory
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_start_lineage_gc_returns_none_when_disabled():
+    cfg = LineageGCConfig(enabled=False)
+    ctx = _make_ctx("org_1", lineage_gc=cfg)
+    result = maybe_start_lineage_gc(lambda _: ctx, bootstrap_org_id="org_1")
+    assert result is None
+
+
+def test_maybe_start_lineage_gc_returns_scheduler_when_enabled():
+    cfg = LineageGCConfig(enabled=True)
+    ctx = _make_ctx("org_1", lineage_gc=cfg)
+    sched = maybe_start_lineage_gc(lambda _: ctx, bootstrap_org_id="org_1")
+    assert sched is not None
+    sched.stop(timeout_seconds=1.0)
+
+
+def test_maybe_start_lineage_gc_returns_none_on_factory_error():
+    def bad_factory(org_id: str):
+        raise RuntimeError("can't build context")
+
+    result = maybe_start_lineage_gc(bad_factory, bootstrap_org_id="org_1")
+    assert result is None

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from reflexio.models.config_schema import LineageGCConfig
 from reflexio.server.services.lineage import gc_scheduler
@@ -39,12 +42,14 @@ def _make_ctx(org_id: str, *, lineage_gc: LineageGCConfig, storage=None):
     )
 
 
+def _default_factory(org_id: str):
+    return _make_ctx(org_id, lineage_gc=LineageGCConfig(enabled=True))
+
+
 def _scheduler(*, bootstrap_org_id: str = "org_bootstrap", factory=None):
     """Return a LineageGCScheduler backed by ``factory`` (not started)."""
     if factory is None:
-        factory = lambda org_id: _make_ctx(
-            org_id, lineage_gc=LineageGCConfig(enabled=True)
-        )  # noqa: E731
+        factory = _default_factory
     return LineageGCScheduler(
         request_context_factory=factory,
         bootstrap_org_id=bootstrap_org_id,
@@ -153,6 +158,14 @@ def test_gc_tick_fires_high_volume_anomaly():
 def test_gc_tick_no_high_volume_anomaly_below_threshold():
     # Exactly at threshold — should NOT fire
     per_entity = _HIGH_VOLUME_THRESHOLD // len(_ENTITY_TYPES)
+    # Precondition: total must genuinely be below the threshold for this test
+    # to be meaningful. Integer-division truncation could silently trip this.
+    total = per_entity * len(_ENTITY_TYPES)
+    assert total < _HIGH_VOLUME_THRESHOLD, (
+        f"Test setup error: per_entity={per_entity} yields total={total} "
+        f">= _HIGH_VOLUME_THRESHOLD={_HIGH_VOLUME_THRESHOLD}; adjust the calculation"
+    )
+
     cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=10)
     storage = _make_storage(gc_return=per_entity)
     ctx = _make_ctx("org_small", lineage_gc=cfg, storage=storage)
@@ -191,3 +204,71 @@ def test_maybe_start_lineage_gc_returns_none_on_factory_error():
 
     result = maybe_start_lineage_gc(bad_factory, bootstrap_org_id="org_1")
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# list_org_ids — degraded-mode fallback is visible (not silent)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_org_ids_not_implemented_warns_and_falls_back_to_bootstrap(
+    caplog,
+):
+    """When list_org_ids raises NotImplementedError the bootstrap org is still
+    processed and a warning is logged (degraded mode is VISIBLE)."""
+    storage = MagicMock()
+    storage.list_org_ids.side_effect = NotImplementedError("not impl")
+    cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=7)
+    bootstrap_ctx = _make_ctx("org_bootstrap", lineage_gc=cfg, storage=storage)
+
+    sched = _scheduler(bootstrap_org_id="org_bootstrap")
+
+    with caplog.at_level(
+        logging.WARNING, logger="reflexio.server.services.lineage.gc_scheduler"
+    ):
+        org_ids = sched._discover_org_ids(bootstrap_ctx)
+
+    assert org_ids == ["org_bootstrap"]
+    assert any(
+        "lineage_gc_list_org_ids_not_implemented" in record.message
+        for record in caplog.records
+    ), "Expected a warning with event=lineage_gc_list_org_ids_not_implemented"
+
+
+# ---------------------------------------------------------------------------
+# list_org_ids — SQLite single-tenant implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_sqlite_list_org_ids_returns_own_org(tmp_path):
+    """SQLiteStorage.list_org_ids() returns [self.org_id] for a fresh DB."""
+    from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+    db_path = str(tmp_path / "test.db")
+    storage = SQLiteStorage(org_id="test_org_abc", db_path=db_path)
+    assert storage.list_org_ids() == ["test_org_abc"]
+
+
+# ---------------------------------------------------------------------------
+# mid-tick stop check — _gc_tick honours _stop_event between orgs
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_stops_mid_tick_when_stop_event_set():
+    """_gc_tick must break out of the per-org loop when _stop_event fires."""
+    calls: list[str] = []
+    cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=7)
+
+    def factory(org_id: str):
+        calls.append(org_id)
+        return _make_ctx(org_id, lineage_gc=cfg)
+
+    sched = _scheduler(factory=factory)
+    # Set stop after the scheduler is created but before the tick runs.
+    sched._stop_event.set()
+
+    sched._gc_tick(["org_a", "org_b", "org_c"])
+
+    # With the stop event already set, the very first iteration should break.
+    assert calls == [], f"Expected no orgs processed after stop, got {calls}"

--- a/tests/server/services/storage/test_lineage_b2_gc_integration.py
+++ b/tests/server/services/storage/test_lineage_b2_gc_integration.py
@@ -1,0 +1,415 @@
+"""Integration tests: gc_expired_tombstones + legal-hold stub (Lineage Phase B2).
+
+Tests cover:
+  (a) Aged tombstone (MERGED) past cutoff is GC'd: row deleted + hard_delete event.
+  (b) Fresh tombstone and CURRENT row are NOT deleted.
+  (c) ARCHIVED aged tombstone IS GC'd (broader eligible set than _TOMBSTONE).
+  (d) PB-8 straddle: TEXT ISO created_at (playbooks) and INTEGER last_modified_timestamp
+      (profiles) both apply the cutoff correctly — only genuinely-older rows purged.
+  (e) Legal-hold: monkeypatched hold skips one row — no delete, no hard_delete event.
+  (f) Idempotent: second GC call on an already-empty set returns 0, adds no events.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserPlaybook
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
+from reflexio.models.api_schema.service_schemas import AgentPlaybook, UserProfile
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path, org_id: str = "org-gc") -> SQLiteStorage:
+    s = SQLiteStorage(org_id=org_id, db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    return s
+
+
+def _now_epoch() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+def _make_profile(
+    user_id: str = "u1",
+    profile_id: str = "p1",
+    content: str = "c",
+    ts: int | None = None,
+) -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=content,
+        last_modified_timestamp=ts if ts is not None else _now_epoch(),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_user_playbook(user_id: str = "u1", content: str = "c") -> UserPlaybook:
+    return UserPlaybook(
+        user_id=user_id, agent_version="v1", request_id="r1", content=content
+    )
+
+
+def _make_agent_playbook(
+    playbook_name: str = "pb", content: str = "c"
+) -> AgentPlaybook:
+    return AgentPlaybook(
+        playbook_name=playbook_name, agent_version="v1", content=content
+    )
+
+
+def _set_playbook_status(
+    s: SQLiteStorage, table: str, pk: str, pk_val: int, status: str
+) -> None:
+    """Directly set the status of a playbook row for test seeding."""
+    s.conn.execute(
+        f"UPDATE {table} SET status = ? WHERE {pk} = ?",  # noqa: S608
+        (status, pk_val),
+    )
+    s.conn.commit()
+
+
+def _set_profile_status(s: SQLiteStorage, profile_id: str, status: str) -> None:
+    s.conn.execute(
+        "UPDATE profiles SET status = ? WHERE profile_id = ?",
+        (status, profile_id),
+    )
+    s.conn.commit()
+
+
+def _set_playbook_created_at(
+    s: SQLiteStorage, table: str, pk: str, pk_val: int, iso_ts: str
+) -> None:
+    """Force the created_at TEXT column on a playbook row for age comparisons."""
+    s.conn.execute(
+        f"UPDATE {table} SET created_at = ? WHERE {pk} = ?",  # noqa: S608
+        (iso_ts, pk_val),
+    )
+    s.conn.commit()
+
+
+def _set_profile_last_modified(s: SQLiteStorage, profile_id: str, ts: int) -> None:
+    s.conn.execute(
+        "UPDATE profiles SET last_modified_timestamp = ? WHERE profile_id = ?",
+        (ts, profile_id),
+    )
+    s.conn.commit()
+
+
+def _hard_delete_events(s: SQLiteStorage, entity_id: str) -> list:
+    return [
+        e for e in s.get_lineage_events(entity_id=entity_id) if e.op == "hard_delete"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# (a) Aged tombstone (MERGED) past cutoff is GC'd
+# ---------------------------------------------------------------------------
+
+
+def test_gc_deletes_aged_merged_tombstone(tmp_path):
+    s = _store(tmp_path)
+    pb = _make_user_playbook()
+    s.save_user_playbooks([pb])
+    pid = pb.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
+    )
+
+    # Age the row to well before the cutoff
+    old_iso = "2020-01-01T00:00:00.000Z"
+    _set_playbook_created_at(s, "user_playbooks", "user_playbook_id", pid, old_iso)
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    deleted = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+
+    assert deleted == 1
+    # Row is gone
+    row = s.conn.execute(
+        "SELECT * FROM user_playbooks WHERE user_playbook_id = ?", (pid,)
+    ).fetchone()
+    assert row is None
+    # hard_delete event emitted
+    events = _hard_delete_events(s, str(pid))
+    assert len(events) == 1
+    assert events[0].actor == "system"
+    assert events[0].reason == "ttl-gc"
+
+
+# ---------------------------------------------------------------------------
+# (b) Fresh tombstone and CURRENT row are NOT deleted
+# ---------------------------------------------------------------------------
+
+
+def test_gc_skips_fresh_tombstone_and_current(tmp_path):
+    s = _store(tmp_path)
+    # Fresh merged tombstone — created_at is right now
+    pb_fresh = _make_user_playbook(content="fresh")
+    s.save_user_playbooks([pb_fresh])
+    pid_fresh = pb_fresh.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid_fresh, Status.MERGED.value
+    )
+    # Note: created_at is already current, so it's after any historical cutoff
+
+    # CURRENT row (no status)
+    pb_current = _make_user_playbook(content="current")
+    s.save_user_playbooks([pb_current])
+    pid_current = pb_current.user_playbook_id
+    _set_playbook_created_at(
+        s, "user_playbooks", "user_playbook_id", pid_current, "2019-01-01T00:00:00.000Z"
+    )
+    # status is NULL (CURRENT) — must NOT be deleted even if old
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    deleted = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+
+    assert deleted == 0
+    # Both rows still exist
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid_fresh,)
+        ).fetchone()
+        is not None
+    )
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid_current,)
+        ).fetchone()
+        is not None
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) ARCHIVED aged tombstone IS GC'd
+# ---------------------------------------------------------------------------
+
+
+def test_gc_deletes_aged_archived_tombstone(tmp_path):
+    s = _store(tmp_path)
+    pb = _make_agent_playbook(playbook_name="archbook")
+    saved = s.save_agent_playbooks([pb])
+    apid = saved[0].agent_playbook_id
+
+    _set_playbook_status(
+        s, "agent_playbooks", "agent_playbook_id", apid, Status.ARCHIVED.value
+    )
+    _set_playbook_created_at(
+        s, "agent_playbooks", "agent_playbook_id", apid, "2019-06-01T00:00:00.000Z"
+    )
+
+    cutoff = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
+    deleted = s.gc_expired_tombstones(
+        entity_type="agent_playbook", older_than_epoch=cutoff
+    )
+
+    assert deleted == 1
+    row = s.conn.execute(
+        "SELECT * FROM agent_playbooks WHERE agent_playbook_id = ?", (apid,)
+    ).fetchone()
+    assert row is None
+    events = _hard_delete_events(s, str(apid))
+    assert len(events) == 1
+
+
+# ---------------------------------------------------------------------------
+# (d) PB-8 straddle test: TEXT ISO vs INTEGER epoch type-correct comparison
+# ---------------------------------------------------------------------------
+
+
+def test_gc_straddle_playbook_text_iso_and_profile_int_epoch(tmp_path):
+    s = _store(tmp_path)
+
+    # --- User playbooks: TEXT ISO created_at ---
+    pb_old = _make_user_playbook(content="old")
+    pb_new = _make_user_playbook(content="new")
+    s.save_user_playbooks([pb_old, pb_new])
+    old_id = pb_old.user_playbook_id
+    new_id = pb_new.user_playbook_id
+
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", old_id, Status.MERGED.value
+    )
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", new_id, Status.MERGED.value
+    )
+    _set_playbook_created_at(
+        s, "user_playbooks", "user_playbook_id", old_id, "2018-01-01T00:00:00.000Z"
+    )
+    _set_playbook_created_at(
+        s, "user_playbooks", "user_playbook_id", new_id, "2025-01-01T00:00:00.000Z"
+    )
+
+    cutoff_pb = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
+    deleted_pb = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff_pb
+    )
+    assert deleted_pb == 1
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (old_id,)
+        ).fetchone()
+        is None
+    )
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (new_id,)
+        ).fetchone()
+        is not None
+    )
+
+    # --- Profiles: INTEGER last_modified_timestamp ---
+    old_ts = int(datetime(2018, 6, 1, tzinfo=UTC).timestamp())
+    new_ts = int(datetime(2025, 6, 1, tzinfo=UTC).timestamp())
+
+    p_old = _make_profile(profile_id="prof-old", ts=old_ts)
+    p_new = _make_profile(profile_id="prof-new", ts=new_ts)
+    s.add_user_profile("u1", [p_old])
+    s.add_user_profile("u1", [p_new])
+    _set_profile_status(s, "prof-old", Status.SUPERSEDED.value)
+    _set_profile_status(s, "prof-new", Status.SUPERSEDED.value)
+    # Ensure last_modified_timestamp is set to our desired values
+    _set_profile_last_modified(s, "prof-old", old_ts)
+    _set_profile_last_modified(s, "prof-new", new_ts)
+
+    cutoff_pr = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
+    deleted_pr = s.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=cutoff_pr
+    )
+    assert deleted_pr == 1
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM profiles WHERE profile_id = ?", ("prof-old",)
+        ).fetchone()
+        is None
+    )
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM profiles WHERE profile_id = ?", ("prof-new",)
+        ).fetchone()
+        is not None
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) Legal-hold: held row skipped, no event, others still deleted
+# ---------------------------------------------------------------------------
+
+
+def test_gc_legal_hold_skips_held_row(tmp_path, monkeypatch):
+    s = _store(tmp_path)
+
+    pb_held = _make_user_playbook(content="held")
+    pb_free = _make_user_playbook(content="free")
+    s.save_user_playbooks([pb_held, pb_free])
+    held_id = pb_held.user_playbook_id
+    free_id = pb_free.user_playbook_id
+
+    for pid in (held_id, free_id):
+        _set_playbook_status(
+            s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
+        )
+        _set_playbook_created_at(
+            s, "user_playbooks", "user_playbook_id", pid, "2019-01-01T00:00:00.000Z"
+        )
+
+    # Monkeypatch: only held_id is on legal hold
+    def mock_hold(org_id: str, entity_type: str, entity_id: str) -> bool:
+        return entity_id == str(held_id)
+
+    monkeypatch.setattr(s, "_is_on_legal_hold", mock_hold)
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    deleted = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+
+    assert deleted == 1
+    # held row still exists
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (held_id,)
+        ).fetchone()
+        is not None
+    )
+    # free row deleted
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (free_id,)
+        ).fetchone()
+        is None
+    )
+    # No hard_delete event for held row
+    assert len(_hard_delete_events(s, str(held_id))) == 0
+    # hard_delete event for free row
+    assert len(_hard_delete_events(s, str(free_id))) == 1
+
+
+# ---------------------------------------------------------------------------
+# (f) Idempotent: second GC call returns 0 and adds no new events
+# ---------------------------------------------------------------------------
+
+
+def test_gc_idempotent(tmp_path):
+    s = _store(tmp_path)
+    pb = _make_user_playbook()
+    s.save_user_playbooks([pb])
+    pid = pb.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
+    )
+    _set_playbook_created_at(
+        s, "user_playbooks", "user_playbook_id", pid, "2018-01-01T00:00:00.000Z"
+    )
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    first = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+    assert first == 1
+
+    events_after_first = s.get_lineage_events(entity_id=str(pid))
+
+    second = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+    assert second == 0
+
+    events_after_second = s.get_lineage_events(entity_id=str(pid))
+    assert len(events_after_second) == len(events_after_first)
+
+
+# ---------------------------------------------------------------------------
+# Edge: unknown entity_type raises ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_gc_unknown_entity_type_raises(tmp_path):
+    s = _store(tmp_path)
+    with pytest.raises(ValueError, match="unknown entity_type"):
+        s.gc_expired_tombstones(entity_type="bogus_type", older_than_epoch=_now_epoch())
+
+
+# ---------------------------------------------------------------------------
+# Edge: empty table returns 0 without error
+# ---------------------------------------------------------------------------
+
+
+def test_gc_empty_table_returns_zero(tmp_path):
+    s = _store(tmp_path)
+    cutoff = int(datetime(2030, 1, 1, tzinfo=UTC).timestamp())
+    result = s.gc_expired_tombstones(entity_type="profile", older_than_epoch=cutoff)
+    assert result == 0

--- a/tests/server/services/storage/test_lineage_b2_gc_integration.py
+++ b/tests/server/services/storage/test_lineage_b2_gc_integration.py
@@ -18,6 +18,7 @@ from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import AgentPlaybook, UserProfile
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage._base import _epoch_to_iso
 
 pytestmark = pytest.mark.integration
 
@@ -125,8 +126,8 @@ def test_gc_deletes_aged_merged_tombstone(tmp_path):
         s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
     )
 
-    # Age the row to well before the cutoff
-    old_iso = "2020-01-01T00:00:00.000Z"
+    # Age the row to well before the cutoff — use production format (+00:00, no fractional seconds)
+    old_iso = _epoch_to_iso(int(datetime(2020, 1, 1, tzinfo=UTC).timestamp()))
     _set_playbook_created_at(s, "user_playbooks", "user_playbook_id", pid, old_iso)
 
     cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
@@ -168,7 +169,11 @@ def test_gc_skips_fresh_tombstone_and_current(tmp_path):
     s.save_user_playbooks([pb_current])
     pid_current = pb_current.user_playbook_id
     _set_playbook_created_at(
-        s, "user_playbooks", "user_playbook_id", pid_current, "2019-01-01T00:00:00.000Z"
+        s,
+        "user_playbooks",
+        "user_playbook_id",
+        pid_current,
+        _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
     )
     # status is NULL (CURRENT) — must NOT be deleted even if old
 
@@ -208,7 +213,11 @@ def test_gc_deletes_aged_archived_tombstone(tmp_path):
         s, "agent_playbooks", "agent_playbook_id", apid, Status.ARCHIVED.value
     )
     _set_playbook_created_at(
-        s, "agent_playbooks", "agent_playbook_id", apid, "2019-06-01T00:00:00.000Z"
+        s,
+        "agent_playbooks",
+        "agent_playbook_id",
+        apid,
+        _epoch_to_iso(int(datetime(2019, 6, 1, tzinfo=UTC).timestamp())),
     )
 
     cutoff = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
@@ -247,10 +256,18 @@ def test_gc_straddle_playbook_text_iso_and_profile_int_epoch(tmp_path):
         s, "user_playbooks", "user_playbook_id", new_id, Status.MERGED.value
     )
     _set_playbook_created_at(
-        s, "user_playbooks", "user_playbook_id", old_id, "2018-01-01T00:00:00.000Z"
+        s,
+        "user_playbooks",
+        "user_playbook_id",
+        old_id,
+        _epoch_to_iso(int(datetime(2018, 1, 1, tzinfo=UTC).timestamp())),
     )
     _set_playbook_created_at(
-        s, "user_playbooks", "user_playbook_id", new_id, "2025-01-01T00:00:00.000Z"
+        s,
+        "user_playbooks",
+        "user_playbook_id",
+        new_id,
+        _epoch_to_iso(int(datetime(2025, 1, 1, tzinfo=UTC).timestamp())),
     )
 
     cutoff_pb = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
@@ -323,7 +340,11 @@ def test_gc_legal_hold_skips_held_row(tmp_path, monkeypatch):
             s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
         )
         _set_playbook_created_at(
-            s, "user_playbooks", "user_playbook_id", pid, "2019-01-01T00:00:00.000Z"
+            s,
+            "user_playbooks",
+            "user_playbook_id",
+            pid,
+            _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
         )
 
     # Monkeypatch: only held_id is on legal hold
@@ -372,7 +393,11 @@ def test_gc_idempotent(tmp_path):
         s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
     )
     _set_playbook_created_at(
-        s, "user_playbooks", "user_playbook_id", pid, "2018-01-01T00:00:00.000Z"
+        s,
+        "user_playbooks",
+        "user_playbook_id",
+        pid,
+        _epoch_to_iso(int(datetime(2018, 1, 1, tzinfo=UTC).timestamp())),
     )
 
     cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
@@ -413,3 +438,98 @@ def test_gc_empty_table_returns_zero(tmp_path):
     cutoff = int(datetime(2030, 1, 1, tzinfo=UTC).timestamp())
     result = s.gc_expired_tombstones(entity_type="profile", older_than_epoch=cutoff)
     assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Boundary exclusivity: cutoff is EXCLUSIVE (strictly-less-than)
+# ---------------------------------------------------------------------------
+
+
+def test_gc_boundary_playbook_at_cutoff_not_deleted(tmp_path):
+    """A playbook whose created_at == older_than_epoch must NOT be deleted.
+
+    The contract is strictly-less-than.  The cutoff string is formatted by
+    _epoch_to_iso, matching the production write path exactly, so the
+    lexicographic ``<`` comparison is byte-for-byte consistent.
+    """
+    s = _store(tmp_path)
+    cutoff_epoch = int(datetime(2022, 6, 15, 12, 0, 0, tzinfo=UTC).timestamp())
+
+    # Row at EXACTLY the cutoff second — must survive GC.
+    pb_at = _make_user_playbook(content="at-boundary")
+    s.save_user_playbooks([pb_at])
+    pid_at = pb_at.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid_at, Status.MERGED.value
+    )
+    _set_playbook_created_at(
+        s, "user_playbooks", "user_playbook_id", pid_at, _epoch_to_iso(cutoff_epoch)
+    )
+
+    # Row one second BEFORE the cutoff — must be deleted.
+    pb_before = _make_user_playbook(content="before-boundary")
+    s.save_user_playbooks([pb_before])
+    pid_before = pb_before.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid_before, Status.MERGED.value
+    )
+    _set_playbook_created_at(
+        s,
+        "user_playbooks",
+        "user_playbook_id",
+        pid_before,
+        _epoch_to_iso(cutoff_epoch - 1),
+    )
+
+    deleted = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff_epoch
+    )
+
+    assert deleted == 1
+    # Row at boundary survives.
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid_at,)
+        ).fetchone()
+        is not None
+    ), "Row at exact cutoff epoch must NOT be deleted (exclusive boundary)"
+    # Row before boundary is gone.
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid_before,)
+        ).fetchone()
+        is None
+    ), "Row one second before cutoff must be deleted"
+
+
+def test_gc_boundary_profile_at_cutoff_not_deleted(tmp_path):
+    """Profile (INTEGER age column) boundary: row at cutoff survives, row before doesn't."""
+    s = _store(tmp_path)
+    cutoff_epoch = int(datetime(2022, 6, 15, 12, 0, 0, tzinfo=UTC).timestamp())
+
+    p_at = _make_profile(profile_id="at-boundary", ts=cutoff_epoch)
+    p_before = _make_profile(profile_id="before-boundary", ts=cutoff_epoch - 1)
+    s.add_user_profile("u1", [p_at])
+    s.add_user_profile("u1", [p_before])
+    _set_profile_status(s, "at-boundary", Status.MERGED.value)
+    _set_profile_status(s, "before-boundary", Status.MERGED.value)
+    _set_profile_last_modified(s, "at-boundary", cutoff_epoch)
+    _set_profile_last_modified(s, "before-boundary", cutoff_epoch - 1)
+
+    deleted = s.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=cutoff_epoch
+    )
+
+    assert deleted == 1
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM profiles WHERE profile_id = ?", ("at-boundary",)
+        ).fetchone()
+        is not None
+    ), "Profile at exact cutoff epoch must NOT be deleted (exclusive boundary)"
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM profiles WHERE profile_id = ?", ("before-boundary",)
+        ).fetchone()
+        is None
+    ), "Profile one second before cutoff must be deleted"

--- a/tests/server/services/storage/test_storage_contract_gc_tombstones.py
+++ b/tests/server/services/storage/test_storage_contract_gc_tombstones.py
@@ -1,0 +1,178 @@
+"""Storage contract tests for gc_expired_tombstones (Lineage Phase B2, Task 5).
+
+Parametrized over locally-testable backends via the shared ``storage`` fixture
+in conftest.py (currently SQLite only).  Enterprise backends add their params
+in Task 6; they will skip here without DATA_* env vars.
+
+Seeding note
+------------
+Playbook tables store ``created_at`` as a TEXT column set by the database at
+insert time.  There is no public API to override it, so aged-playbook seeding
+requires raw SQL (handled in the SQLite-only integration test,
+``test_lineage_b2_gc_integration.py``).
+
+Profile tables store ``last_modified_timestamp`` as an INTEGER set by the
+caller.  Passing an old epoch at construction time is backend-agnostic, so
+the "aged tombstone deleted + hard_delete event" case is covered here using
+profiles.  The corresponding playbook age-straddle detail lives in the SQLite
+integration test.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import LineageContext
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
+from reflexio.models.api_schema.service_schemas import UserProfile
+
+pytestmark = pytest.mark.integration
+
+# A fixed epoch well in the past, used to seed "aged" profiles.
+_EPOCH_2020 = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
+# A cutoff after the old epoch — any profile with ts < this is eligible.
+_CUTOFF_2021 = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+# A future epoch for "fresh" profiles — after any historical cutoff.
+_EPOCH_FUTURE = int(datetime(2035, 1, 1, tzinfo=UTC).timestamp())
+
+
+def _make_profile(profile_id: str, ts: int) -> UserProfile:
+    return UserProfile(
+        user_id="u1",
+        profile_id=profile_id,
+        content=f"content for {profile_id}",
+        last_modified_timestamp=ts,
+        generated_from_request_id=f"req-{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _merge_into_survivor(
+    storage, source_profile_id: str, survivor_profile_id: str
+) -> None:
+    """Tombstone the source into the survivor via the public merge_records API."""
+    storage.merge_records(
+        entity_type="profile",
+        survivor_id=survivor_profile_id,
+        source_ids=[source_profile_id],
+        context=LineageContext(
+            op_kind="merge",
+            actor="test",
+            request_id=f"req-merge-{source_profile_id}",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Case 1: Aged tombstone (MERGED, old last_modified_timestamp) is hard-deleted
+# and a hard_delete lineage event is emitted.
+# ---------------------------------------------------------------------------
+
+
+def test_gc_deletes_aged_merged_profile_and_emits_hard_delete(storage) -> None:
+    """Aged MERGED profile past the cutoff is deleted; a hard_delete event is recorded."""
+    old_profile = _make_profile("gc-aged-src", ts=_EPOCH_2020)
+    survivor_profile = _make_profile("gc-aged-survivor", ts=_EPOCH_2020)
+    storage.add_user_profile("u1", [old_profile])
+    storage.add_user_profile("u1", [survivor_profile])
+
+    # Tombstone old_profile (MERGED) via public API; last_modified_timestamp stays 2020.
+    _merge_into_survivor(storage, "gc-aged-src", "gc-aged-survivor")
+
+    deleted = storage.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=_CUTOFF_2021
+    )
+
+    assert deleted == 1
+
+    # The tombstoned row must be physically gone (even with include_tombstones=True).
+    assert storage.get_profile_by_id("gc-aged-src", include_tombstones=True) is None
+
+    # A hard_delete lineage event must have been emitted for the deleted row.
+    events = storage.get_lineage_events(entity_type="profile", entity_id="gc-aged-src")
+    hd_events = [e for e in events if e.op == "hard_delete"]
+    assert len(hd_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Case 2: CURRENT row (status None) is NOT deleted, even with a future cutoff.
+# ---------------------------------------------------------------------------
+
+
+def test_gc_does_not_delete_current_row(storage) -> None:
+    """A CURRENT profile (status None) must never be deleted by gc_expired_tombstones."""
+    current = _make_profile("gc-current", ts=_EPOCH_2020)
+    storage.add_user_profile("u1", [current])
+
+    # Cutoff is far in the future — would delete any tombstone — but status is NULL.
+    deleted = storage.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=_EPOCH_FUTURE
+    )
+
+    assert deleted == 0
+    # CURRENT profile must still exist.
+    assert storage.get_profile_by_id("gc-current", include_tombstones=True) is not None
+
+
+# ---------------------------------------------------------------------------
+# Case 3: A fresh tombstone (created just now) is NOT deleted by a historical
+# cutoff.
+# ---------------------------------------------------------------------------
+
+
+def test_gc_does_not_delete_fresh_tombstone(storage) -> None:
+    """A just-created tombstone whose age column is after the cutoff must survive GC."""
+    # Create the profiles with a current (future-like) timestamp so the profile's
+    # age column is well after the historical cutoff.
+    fresh_src = _make_profile("gc-fresh-src", ts=_EPOCH_FUTURE)
+    fresh_survivor = _make_profile("gc-fresh-survivor", ts=_EPOCH_FUTURE)
+    storage.add_user_profile("u1", [fresh_src])
+    storage.add_user_profile("u1", [fresh_survivor])
+
+    # Tombstone the source — last_modified_timestamp stays at _EPOCH_FUTURE.
+    _merge_into_survivor(storage, "gc-fresh-src", "gc-fresh-survivor")
+
+    # Cutoff is 2021 — the tombstone's ts (2035) is after the cutoff; must NOT be GC'd.
+    deleted = storage.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=_CUTOFF_2021
+    )
+
+    assert deleted == 0
+
+    # The fresh tombstone must still be retrievable (include_tombstones API).
+    events = storage.get_lineage_events(entity_type="profile", entity_id="gc-fresh-src")
+    hd_events = [e for e in events if e.op == "hard_delete"]
+    assert len(hd_events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Case 4: Idempotent — second gc call returns 0 and emits no new events.
+# ---------------------------------------------------------------------------
+
+
+def test_gc_idempotent_returns_zero_on_second_call(storage) -> None:
+    """After GC deletes a tombstone, a second identical call returns 0 with no new events."""
+    old_profile = _make_profile("gc-idem-src", ts=_EPOCH_2020)
+    survivor = _make_profile("gc-idem-survivor", ts=_EPOCH_2020)
+    storage.add_user_profile("u1", [old_profile])
+    storage.add_user_profile("u1", [survivor])
+    _merge_into_survivor(storage, "gc-idem-src", "gc-idem-survivor")
+
+    first = storage.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=_CUTOFF_2021
+    )
+    assert first == 1
+
+    events_after_first = storage.get_lineage_events(
+        entity_type="profile", entity_id="gc-idem-src"
+    )
+
+    second = storage.gc_expired_tombstones(
+        entity_type="profile", older_than_epoch=_CUTOFF_2021
+    )
+    assert second == 0
+
+    events_after_second = storage.get_lineage_events(
+        entity_type="profile", entity_id="gc-idem-src"
+    )
+    assert len(events_after_second) == len(events_after_first)


### PR DESCRIPTION
## What

Lineage Phase B2 — **TTL GC (tombstone garbage collection)**, OSS/SQLite half. Ships **OFF by default**.

The stage-2 of the soft-delete→hard-purge model: a scheduled, per-org, config-gated job that physically hard-deletes *aged* tombstones (status ∈ {merged, superseded, archived}, older than a retention window), emitting one content-free `hard_delete` lineage event per deleted row first — reusing the B1 emit-before-delete atomic pattern.

## Changes

- **`LineageGCConfig`** (`config_schema.py`) — `enabled=False`, `tombstone_grace_window_days=90`, `poll_interval_seconds=86400`. Off by default; attached to root `Config`.
- **`gc_expired_tombstones(*, entity_type, older_than_epoch, limit)`** (storage base + SQLite) — type-correct age comparison (TEXT-ISO `created_at` via `_epoch_to_iso` for playbooks, INTEGER `last_modified_timestamp` for profiles), exclusive cutoff, eligible-status set `{merged,superseded,archived}` (its own set, not `_TOMBSTONE`), emit-then-delete in one lock/one commit with raw inline FTS/vec cleanup (no self-committing helpers), real per-call batch `request_id`, idempotent. Plus a `_is_on_legal_hold` deferred seam.
- **`LineageGCScheduler`** + lifespan wiring (`gc_scheduler.py`, `api.py`) — daemon mirroring `resume_scheduler`; per-org config gate; `capture_anomaly` checkpoints (`lineage.gc.run_failed` / `high_volume` / `legal_hold_skip`); no bookmark (GC is idempotent); mid-tick stop. `list_org_ids` declared on the base (SQLite returns `[self.org_id]`); the scheduler degrades to bootstrap-org with a logged warning where unimplemented.
- **Tests** — GC integration (boundary-exclusive at the exact cutoff for both age-column types, ARCHIVED inclusion, legal-hold skip, idempotency, unknown-type raise) + a backend-agnostic contract test.

## Safety

GC is **triple-gated off** (config default, scheduler factory, per-org gate) and **cannot be enabled** until the documented pre-enable gates are resolved (tuner-window pinning PB-9, B2↔B3 timing PB-5, the age-basis decision PB-8b, a real legal-hold store, enterprise `list_org_ids`). This PR builds the mechanism only.

Built via subagent-driven-development: per-task implement → review → fix → re-review, plus a final whole-branch review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic garbage collection for expired lineage records with configurable retention windows and polling intervals.
  * Added configuration option to enable or disable garbage collection functionality per organization.
  * Automatic cleanup now permanently removes expired records based on configured grace periods.

* **Improvements**
  * Enhanced application lifespan management to properly initialize and terminate garbage collection services during startup and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->