### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -140,6 +140,7 @@ client (Python SDK)
   - `evaluation_overview/` - Evaluation-page aggregates and hero metrics
   - `playbook_optimizer/` - Scenario-based playbook optimization experiments
   - `braintrust/` - Braintrust eval export/sync support
+  - `lineage/` - Resolve current records and schedule tombstone garbage collection for superseded profile/playbook rows
   - `storage/` - Abstract layer (SQLite prod, LocalJSON test)
   - `pre_retrieval/` - Query rewriting and document expansion helpers
   - `configurator/` - YAML config loader

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -19,6 +19,7 @@ Description: FastAPI backend server that processes user interactions to generate
   - [Reflection and Async Extraction](#reflection-and-async-extraction)
   - [Shadow Comparison and Evaluation Overview](#shadow-comparison-and-evaluation-overview)
   - [Playbook Optimizer and Braintrust](#playbook-optimizer-and-braintrust)
+  - [Lineage](#lineage)
   - [Query Reformulator](#query-reformulator)
   - [Unified Search Service](#unified-search-service)
   - [Storage](#storage)
@@ -186,6 +187,7 @@ python -m reflexio.server.scripts.manage_invitation_codes list --show-used
 - **Async clarification**: `extraction/` and `reflection/` manage resumable agent runs, pending tool calls, prior-answer search, and long-horizon reflection updates.
 - **Search preparation**: `pre_retrieval/` and `unified_search_service.py` handle query reformulation, document expansion, embeddings, and cross-entity search orchestration.
 - **Optimization/integrations**: `playbook_optimizer/` and `braintrust/` run candidate playbook optimization, rollout support, and Braintrust export/sync.
+- **Lineage**: `lineage/` resolves active records across superseded chains and schedules tombstone garbage collection for profile/playbook storage.
 - **Persistence/config**: `storage/`, `configurator/`, and `operation_state_utils.py` provide storage abstractions, config loading, locks, bookmarks, progress, and cancellation.
 
 ### Orchestrator
@@ -435,6 +437,17 @@ Key files:
 
 **Pattern**: These are evaluation/optimization integrations around the core playbook pipeline. Keep production extraction changes in `services/playbook/`; use optimizer/Braintrust modules for experiments, rollouts, and external eval sync.
 
+### Lineage
+
+**Directory**: `services/lineage/`
+
+| File | Purpose |
+|------|---------|
+| `resolve.py` | Helpers for resolving current records across supersede chains and status transitions. |
+| `gc_scheduler.py` | Tombstone garbage-collection scheduler for lineage-aware storage cleanup. |
+
+**Pattern**: profile/playbook update paths preserve lineage metadata in storage; service code asks lineage helpers to find current records rather than walking superseded chains ad hoc.
+
 ### Query Reformulator
 
 **File**: `services/pre_retrieval/_query_reformulator.py` - `QueryReformulator`
@@ -464,8 +477,8 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 
 | File | Purpose |
 |------|---------|
-| `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
-| `sqlite_storage/` | SQLite-backed implementation split across the same domains |
+| `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_lineage.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
+| `sqlite_storage/` | SQLite-backed implementation split across the same domains, including lineage/tombstone support in `_lineage.py` |
 | `retention.py`, `retention_mixin.py` | Data retention and cleanup helpers |
 | `constants.py`, `error.py` | Storage constants and shared errors |
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -38,6 +38,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 | `evaluation_overview/` | Dashboard rollups: `service.py`, `hero_state.py`, `distribution.py`, `rule_attribution.py`, `shadow_aggregation.py`, `eval_sampler.py`. |
 | `playbook_optimizer/` | Scenario-based playbook optimization: `optimizer.py`, `scheduler.py`, `rollout.py`, `judge.py`, `scenario_resolver.py`, `gepa_adapter.py`, `assistant_webhook.py`. |
 | `braintrust/` | Braintrust export/sync: `service.py`, `client.py`, `_cron.py`, `_encryption.py`. |
+| `lineage/` | Current-record resolution and tombstone GC: `resolve.py`, `gc_scheduler.py`. |
 | `pre_retrieval/` | `QueryReformulator` (`_query_reformulator.py`) + `_document_expander.py` — query rewrite & doc expansion for recall. |
 | `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks. |
 | `retrieval/` | `relevance_floor.py` — result relevance thresholding. |
@@ -46,7 +47,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 
 | Path | Purpose |
 |------|---------|
-| `storage/` | `storage_base/` (`BaseStorage` split by domain) + `sqlite_storage/` + `retention*.py`. Access via `request_context.storage` only. |
+| `storage/` | `storage_base/` (`BaseStorage` split by domain, including `_lineage.py`) + `sqlite_storage/` (including lineage/tombstones) + `retention*.py`. Access via `request_context.storage` only. |
 | `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
 
 ## Key Rules


### PR DESCRIPTION
## Summary
- Updates code-map READMEs to include the new lineage service and lineage-aware storage surfaces.
- Documents current-record resolution, tombstone GC, and `_lineage.py` storage-base/SQLite split.
- Follows the parent repository's `how_to_write_readme.md` guidance for concise navigation-focused code maps.

## Repositories/submodules reviewed
- `ReflexioAI/reflexio` submodule (`open_source/reflexio`)
- Parent repository and other declared submodule were also reviewed in this scheduled run.

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- `git diff --check` passed inside the submodule.

## Notes/Risks
- Documentation-only change.
- The public user-facing `README.md` at the submodule root was not rewritten as a code map.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated multiple README files to document the new Lineage component and its role in record resolution and garbage collection scheduling across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->