### PR TITLE
fix(search): suppress source user playbooks

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -3,6 +3,7 @@
 import json
 import sqlite3
 import uuid
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -1241,6 +1242,32 @@ class PlaybookMixin:
             window.user_playbook_id
             for window in self.get_source_windows_for_agent_playbook(agent_playbook_id)
         ]
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_source_user_playbook_ids_for_agent_playbooks(
+        self, agent_playbook_ids: Sequence[int]
+    ) -> dict[int, list[int]]:
+        if not agent_playbook_ids:
+            return {}
+        unique_ids = list(dict.fromkeys(int(apid) for apid in agent_playbook_ids))
+        ph = ",".join("?" for _ in unique_ids)
+        rows = self._fetchall(
+            f"""SELECT agent_playbook_id, user_playbook_id
+                FROM agent_playbook_source_user_playbooks
+                WHERE agent_playbook_id IN ({ph})
+                ORDER BY agent_playbook_id ASC, user_playbook_id ASC""",
+            unique_ids,
+        )
+        by_agent_id: dict[int, list[int]] = {apid: [] for apid in unique_ids}
+        seen_by_agent_id: dict[int, set[int]] = {apid: set() for apid in unique_ids}
+        for row in rows:
+            agent_playbook_id = int(row["agent_playbook_id"])
+            user_playbook_id = int(row["user_playbook_id"])
+            seen = seen_by_agent_id.setdefault(agent_playbook_id, set())
+            if user_playbook_id not in seen:
+                by_agent_id.setdefault(agent_playbook_id, []).append(user_playbook_id)
+                seen.add(user_playbook_id)
+        return by_agent_id
 
     @SQLiteStorageBase.handle_exceptions
     def set_source_windows_for_agent_playbook(

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from collections.abc import Sequence
 
 from reflexio.models.api_schema.common import BlockingIssue
 from reflexio.models.api_schema.domain import (
@@ -495,6 +496,13 @@ class PlaybookMixin:
         self, agent_playbook_id: int
     ) -> list[int]:
         """Return source user playbook ids for an agent playbook."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_source_user_playbook_ids_for_agent_playbooks(
+        self, agent_playbook_ids: Sequence[int]
+    ) -> dict[int, list[int]]:
+        """Return source user playbook ids keyed by agent playbook id."""
         raise NotImplementedError
 
     @abstractmethod

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -17,7 +17,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from reflexio.models.api_schema.retriever_schema import (
     ConversationTurn,
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _DEFAULT_ENTITY_TYPES = frozenset({"profiles", "agent_playbooks", "user_playbooks"})
+_SOURCE_USER_PLAYBOOK_IDS_KEY = "_source_user_playbook_ids"
 # Statuses returned for agent_playbooks when the caller does not pass an
 # explicit ``agent_playbook_status_filter``. Excludes REJECTED so that a
 # rejection in the dashboard immediately suppresses the playbook from search
@@ -152,6 +153,12 @@ def run_unified_search(
             top_k=top_k,
             cfg=floor_cfg,
         )
+
+    user_playbooks = _suppress_source_user_playbooks(
+        storage=storage,
+        agent_playbooks=agent_playbooks or [],
+        user_playbooks=user_playbooks or [],
+    )
 
     return UnifiedSearchResponse(
         success=True,
@@ -474,6 +481,67 @@ def _apply_floors(
         top_k,
     )
     return floored_profiles, floored_agent, floored_user
+
+
+def _suppress_source_user_playbooks(
+    *,
+    storage: BaseStorage,
+    agent_playbooks: list[AgentPlaybook],
+    user_playbooks: list[UserPlaybook],
+) -> list[UserPlaybook]:
+    """Drop user playbooks already represented by returned agent playbooks."""
+    if not agent_playbooks or not user_playbooks:
+        return user_playbooks
+
+    source_user_playbook_ids: set[int] = set()
+    agent_ids_needing_lookup: list[int] = []
+    for playbook in agent_playbooks:
+        source_ids = getattr(playbook, _SOURCE_USER_PLAYBOOK_IDS_KEY, None)
+        if source_ids is None:
+            agent_playbook_id = int(getattr(playbook, "agent_playbook_id", 0) or 0)
+            if agent_playbook_id:
+                agent_ids_needing_lookup.append(agent_playbook_id)
+            continue
+        source_user_playbook_ids.update(int(source_id) for source_id in source_ids)
+
+    if agent_ids_needing_lookup:
+        lookup = getattr(
+            storage, "get_source_user_playbook_ids_for_agent_playbooks", None
+        )
+        if callable(lookup):
+            try:
+                source_ids_by_agent = cast(
+                    dict[int, list[int]], lookup(agent_ids_needing_lookup)
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to resolve source user playbooks for unified search suppression",
+                    exc_info=True,
+                )
+            else:
+                for source_ids in source_ids_by_agent.values():
+                    source_user_playbook_ids.update(
+                        int(source_id) for source_id in source_ids
+                    )
+
+    if not source_user_playbook_ids:
+        return user_playbooks
+
+    filtered = [
+        playbook
+        for playbook in user_playbooks
+        if int(getattr(playbook, "user_playbook_id", 0) or 0)
+        not in source_user_playbook_ids
+    ]
+    suppressed_count = len(user_playbooks) - len(filtered)
+    if suppressed_count:
+        with profile_step(
+            "search.suppress_source_user_playbooks",
+            suppressed_count=suppressed_count,
+            source_user_playbook_count=len(source_user_playbook_ids),
+        ):
+            pass
+    return filtered
 
 
 def _get_cached_query_embedding(

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -302,6 +302,39 @@ class TestAgentPlaybookSourceWindows:
             )
         ]
 
+    def test_batch_source_user_playbook_ids_round_trip(self, storage):
+        storage.set_source_windows_for_agent_playbook(
+            10,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=2, source_interaction_ids=[20]
+                ),
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=3, source_interaction_ids=[30]
+                ),
+            ],
+        )
+        storage.set_source_windows_for_agent_playbook(
+            11,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=3, source_interaction_ids=[31]
+                )
+            ],
+        )
+
+        # Duplicate ids in the request are deduped; an agent playbook with no
+        # source rows still appears with an empty list so callers get a
+        # complete map.
+        result = storage.get_source_user_playbook_ids_for_agent_playbooks(
+            [10, 11, 10, 12]
+        )
+
+        assert result == {10: [2, 3], 11: [3], 12: []}
+
+    def test_batch_source_user_playbook_ids_empty_input(self, storage):
+        assert storage.get_source_user_playbook_ids_for_agent_playbooks([]) == {}
+
 
 # ---------------------------------------------------------------------------
 # TestAgentPlaybookCRUD


### PR DESCRIPTION
## Summary
- Suppress user playbook search results when they are already represented by returned agent playbooks.
- Preserve the managed hot path by allowing callers to use transient source-id metadata when available.
- Add a batch lineage lookup for fallback/local search paths.

## Changes
- Adds a storage contract method for batch source user playbook lookup by agent playbook IDs.
- Implements the batch lookup for SQLite storage.
- Filters unified-search user playbooks after relevance floors, with graceful fallback on lookup errors.
- Adds storage contract tests for batch source lookup.

## Test Plan
- `uv run ruff check reflexio/server/services/unified_search_service.py reflexio/server/services/storage/storage_base/_playbook.py reflexio/server/services/storage/sqlite_storage/_playbook.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run pyright reflexio/server/services/unified_search_service.py reflexio/server/services/storage/storage_base/_playbook.py reflexio/server/services/storage/sqlite_storage/_playbook.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run pytest --no-cov tests/server/services/storage/test_storage_contract_playbook.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now intelligently deduplicate playbooks, preventing redundant display when user-created playbooks are already represented within agent-generated results.

* **Tests**
  * Added contract tests for the new playbook deduplication functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->