### PR TITLE
feat(cli): surface Supabase status and failure summary in dev banner

### DIFF
--- a/reflexio/cli/log_format.py
+++ b/reflexio/cli/log_format.py
@@ -187,15 +187,31 @@ def print_startup_banner(
     ports: dict[str, int],
     *,
     supabase_port: int | None = 54321,
+    supabase_status: str = "ready",
+    failures: list[str] | None = None,
     log_file: str = DEV_LOG_FILE,
     config_paths: dict[str, str] | None = None,
 ) -> None:
     """Print a consolidated startup summary banner with service URLs.
 
+    Services that were *requested* but failed to reach a ready state are
+    rendered with a red "not ready" status (instead of being silently
+    omitted), so operators can tell at a glance that startup did not
+    fully succeed.
+
     Args:
-        ports: Mapping of service name to port number.
-        supabase_port: Supabase port, or None if not running.
-        log_file: Path to the log file.
+        ports: Mapping of service name to port number for services that
+            were started (backend/frontend/docs).
+        supabase_port: Supabase port to display, or None to omit the
+            Supabase line entirely (e.g. when --no-supabase was passed).
+        supabase_status: ``"ready"`` (green) or anything else (rendered
+            as red "not ready"). Only consulted when ``supabase_port``
+            is not None.
+        failures: Optional list of human-readable failure summary
+            lines. Rendered as a red "Failures" section above the logs
+            so the cause is visible without scrolling back through the
+            scrollback.
+        log_file: Path to the dev-server log file.
         config_paths: Optional mapping of config-label → path string (e.g.
             ``{"env": "~/.reflexio/.env", "config": "~/.reflexio/configs/config_default.json"}``).
             Renders as a "Config" section above the "Logs" line so operators
@@ -219,7 +235,11 @@ def print_startup_banner(
     if supabase_port is not None:
         url = f"http://localhost:{supabase_port}"
         label = colorize("  Supabase   ", "36")
-        status = colorize("ready", "32")
+        status = (
+            colorize("ready", "32")
+            if supabase_status == "ready"
+            else colorize("not ready", "31", bold=True)
+        )
         lines.append(f"{label}{url:<26}{status}")
 
     home = str(Path.home())
@@ -233,6 +253,11 @@ def print_startup_banner(
         lines.append(f"{'-' * width}")
         for label, path in config_paths.items():
             lines.append(f"  {label:<11}{_collapse_home(str(path))}")
+
+    if failures:
+        lines.append(f"{'-' * width}")
+        lines.append(colorize("  Failures", "31", bold=True))
+        lines.extend(colorize(f"  - {msg}", "31") for msg in failures)
 
     lines.append(f"{'-' * width}")
     # Logs section — surface both the general dev log and the LLM I/O log.


### PR DESCRIPTION
## Summary

- `print_startup_banner` previously rendered Supabase as a single green "ready" and silently omitted the line when local Supabase failed to start. A partial failure (e.g. Docker not running → no Supabase) looked like a fully successful startup to the operator scanning the banner.
- Add two new keyword-only parameters: `supabase_status` ("ready" → green; anything else → bold red "not ready") and `failures` (list of human-readable summary lines rendered as a red "Failures" section above the logs).
- All new parameters are optional and backward-compatible — existing callers and any third-party consumers of the OSS CLI keep working unchanged.

## Changes

- `reflexio/cli/log_format.py:print_startup_banner` — new keyword-only params `supabase_status` and `failures`. The Supabase line is now always rendered when `supabase_port` is supplied (i.e. the user requested local Supabase); the status text reflects `supabase_status`. The `Failures` section is only emitted when `failures` is non-empty.

## Test Plan

- Manual: simulated both Docker-up and Docker-down startup banners; verified the "not ready" status appears in red bold on the Supabase line and the Failures section lists the cause.
- Verified ANSI codes are emitted only on real TTY (existing `colorize()` contract) — piped output stays parseable.
- Backward compatibility: the only production caller (reflexio-enterprise) was updated in lockstep; no other callers exist in this repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Startup banner now displays Supabase connection status (ready or not ready) when applicable
  * Added failures section to startup banner to highlight issues detected during startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->