### PR TITLE
chore(lineage): address CodeRabbit findings from B1/B2/B3-pre (#187/#188/#191)

### DIFF
--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -9,7 +9,7 @@ DONE
 - MOD: `reflexio/server/api.py` (lifespan wiring)
 
 ## Deviations from spec
-- `_discover_org_ids` uses `storage.list_org_ids()` (a generic cross-org sweep), falling back to bootstrap-only on `NotImplementedError`/`AttributeError`. The resume scheduler uses `list_resumable_work_org_ids` which is work-filtered. For GC, an unfiltered list is correct because we want to sweep all orgs regardless of whether they have pending work.
+- `_discover_org_ids` uses `storage.list_org_ids()` (a generic cross-org sweep), falling back to bootstrap-only on `NotImplementedError`. The resume scheduler uses `list_resumable_work_org_ids` which is work-filtered. For GC, an unfiltered list is correct because we want to sweep all orgs regardless of whether they have pending work.
 - Added `if ctx.storage is None: continue` guard in `_gc_tick` — pyright requires it because `create_storage()` returns `BaseStorage | None`. This is a correct, minimal guard.
 
 ## Tests

--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -575,7 +575,7 @@ def reconstruct_profile_change_log(
 
     Groups are formed over the union of request_ids from both signals.
     Request_id ``""`` is skipped — it would merge unrelated runs.
-    A row is emitted only when ``added ∪ removed`` is non-empty (matching
+    A row is emitted only when ``added or removed`` is non-empty (matching
     legacy semantics: ``add_profile_change_log`` was called only when
     ``all_new_profiles or superseded_profiles``).
 
@@ -595,7 +595,7 @@ def reconstruct_profile_change_log(
             ordered most-recent first (by max event ``created_at`` in each
             request_id group), capped at ``limit``.
     """
-    if limit == 0:
+    if limit <= 0:
         return ProfileChangeLogResponse(success=True, profile_change_logs=[])
 
     all_events = storage.get_lineage_events(

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -681,8 +681,8 @@ class LineageGCConfig(BaseModel):
     """
 
     enabled: bool = False
-    tombstone_grace_window_days: int = 90
-    poll_interval_seconds: int = 86400
+    tombstone_grace_window_days: int = Field(default=90, gt=0)
+    poll_interval_seconds: int = Field(default=86400, gt=0)
 
 
 @dataclass(frozen=True)

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -20,6 +20,7 @@ from reflexio.server.tracing import capture_anomaly
 logger = logging.getLogger(__name__)
 
 _DEFAULT_POLL_INTERVAL_SECONDS = 86400
+_MIN_POLL_SECONDS = 1
 
 # Window-misconfiguration tripwire: if a single tick deletes more than this
 # many tombstones for one org, something is likely wrong with the grace window.
@@ -138,7 +139,7 @@ class LineageGCScheduler:
                 self._gc_tick(org_ids)
             except Exception:
                 logger.exception("event=lineage_gc_scheduler_tick_failed")
-            self._stop_event.wait(poll_interval)
+            self._stop_event.wait(max(poll_interval, _MIN_POLL_SECONDS))
 
 
 def maybe_start_lineage_gc(

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -363,6 +363,8 @@ class SQLiteLineageMixin:
         Raises:
             ValueError: If ``entity_type`` is not a recognised entity type.
         """
+        if limit <= 0:
+            return 0
         meta = _GC_ENTITY_META.get(entity_type)
         if meta is None:
             raise ValueError(f"unknown entity_type: {entity_type!r}")
@@ -413,59 +415,63 @@ class SQLiteLineageMixin:
             batch_request_id = uuid.uuid4().hex
             ph = ",".join("?" * len(ids_to_delete))
 
-            # Emit hard_delete events BEFORE the DELETE, in the same transaction.
-            for eid in ids_to_delete:
-                _append_event_stmt(
-                    self.conn,
-                    org_id=self.org_id,
-                    entity_type=entity_type,
-                    entity_id=eid,
-                    op="hard_delete",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="system",
-                    request_id=batch_request_id,
-                    reason="ttl-gc",
-                )
+            try:
+                # Emit hard_delete events BEFORE the DELETE, in the same transaction.
+                for eid in ids_to_delete:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type=entity_type,
+                        entity_id=eid,
+                        op="hard_delete",
+                        prov="wasInvalidatedBy",
+                        source_ids=[],
+                        actor="system",
+                        request_id=batch_request_id,
+                        reason="ttl-gc",
+                    )
 
-            # Inline FTS/vec cleanup — raw DELETE to preserve atomicity.
-            # Do NOT call self._fts_delete/_vec_delete: they self-commit.
-            if entity_type in ("user_playbook", "agent_playbook"):
-                kind = "user" if entity_type == "user_playbook" else "agent"
-                int_ids = [int(eid) for eid in ids_to_delete]
-                int_ph = ",".join("?" * len(int_ids))
-                self.conn.execute(
-                    f"DELETE FROM {kind}_playbooks_fts WHERE rowid IN ({int_ph})",
-                    int_ids,
-                )
-                if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                # Inline FTS/vec cleanup — raw DELETE to preserve atomicity.
+                # Do NOT call self._fts_delete/_vec_delete: they self-commit.
+                if entity_type in ("user_playbook", "agent_playbook"):
+                    kind = "user" if entity_type == "user_playbook" else "agent"
+                    int_ids = [int(eid) for eid in ids_to_delete]
+                    int_ph = ",".join("?" * len(int_ids))
                     self.conn.execute(
-                        f"DELETE FROM {kind}_playbooks_vec WHERE rowid IN ({int_ph})",
+                        f"DELETE FROM {kind}_playbooks_fts WHERE rowid IN ({int_ph})",
                         int_ids,
                     )
-            else:
-                # profiles: FTS keyed on TEXT profile_id; vec keyed on implicit rowid.
-                self.conn.execute(
-                    f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",
+                    if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                        self.conn.execute(
+                            f"DELETE FROM {kind}_playbooks_vec WHERE rowid IN ({int_ph})",
+                            int_ids,
+                        )
+                else:
+                    # profiles: FTS keyed on TEXT profile_id; vec keyed on implicit rowid.
+                    self.conn.execute(
+                        f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",
+                        ids_to_delete,
+                    )
+                    if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                        rowid_rows = self.conn.execute(
+                            f"SELECT rowid FROM profiles WHERE profile_id IN ({ph})",  # noqa: S608
+                            ids_to_delete,
+                        ).fetchall()
+                        if rowid_rows:
+                            rowids = [r[0] for r in rowid_rows]
+                            rowid_ph = ",".join("?" * len(rowids))
+                            self.conn.execute(
+                                f"DELETE FROM profiles_vec WHERE rowid IN ({rowid_ph})",
+                                rowids,
+                            )
+
+                cur = self.conn.execute(
+                    f"DELETE FROM {table} WHERE {pk} IN ({ph})",  # noqa: S608
                     ids_to_delete,
                 )
-                if self._has_sqlite_vec:  # type: ignore[attr-defined]
-                    rowid_rows = self.conn.execute(
-                        f"SELECT rowid FROM profiles WHERE profile_id IN ({ph})",  # noqa: S608
-                        ids_to_delete,
-                    ).fetchall()
-                    if rowid_rows:
-                        rowids = [r[0] for r in rowid_rows]
-                        rowid_ph = ",".join("?" * len(rowids))
-                        self.conn.execute(
-                            f"DELETE FROM profiles_vec WHERE rowid IN ({rowid_ph})",
-                            rowids,
-                        )
-
-            cur = self.conn.execute(
-                f"DELETE FROM {table} WHERE {pk} IN ({ph})",  # noqa: S608
-                ids_to_delete,
-            )
-            self.conn.commit()
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
         return cur.rowcount

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -316,6 +316,8 @@ class PlaybookMixin:
                     "SELECT user_playbook_id FROM user_playbooks"
                 ).fetchall()
             ]
+            self._delete_playbook_search_rows("user", ids)
+            self.conn.execute("DELETE FROM user_playbooks")
             for upid in ids:
                 _emit_hard_delete_playbook(
                     self.conn,
@@ -324,8 +326,6 @@ class PlaybookMixin:
                     entity_id=str(upid),
                     request_id=batch_request_id,
                 )
-            self._delete_playbook_search_rows("user", ids)
-            self.conn.execute("DELETE FROM user_playbooks")
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -364,6 +364,10 @@ class PlaybookMixin:
             if not ids:
                 return
             ph = ",".join("?" for _ in ids)
+            self._delete_playbook_search_rows("user", ids)
+            self.conn.execute(
+                f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})", ids
+            )
             for upid in ids:
                 _emit_hard_delete_playbook(
                     self.conn,
@@ -372,10 +376,6 @@ class PlaybookMixin:
                     entity_id=str(upid),
                     request_id=batch_request_id,
                 )
-            self._delete_playbook_search_rows("user", ids)
-            self.conn.execute(
-                f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})", ids
-            )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -387,8 +387,20 @@ class PlaybookMixin:
         ph = ",".join("?" for _ in user_playbook_ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            existing = [
+                r["user_playbook_id"]
+                for r in self.conn.execute(
+                    f"SELECT user_playbook_id FROM user_playbooks WHERE user_playbook_id IN ({ph})",
+                    user_playbook_ids,
+                ).fetchall()
+            ]
+            self._delete_playbook_search_rows("user", user_playbook_ids)
+            cur = self.conn.execute(
+                f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",
+                user_playbook_ids,
+            )
             if emit_hard_delete:
-                for upid in user_playbook_ids:
+                for upid in existing:
                     _emit_hard_delete_playbook(
                         self.conn,
                         org_id=self.org_id,
@@ -397,11 +409,6 @@ class PlaybookMixin:
                         request_id=batch_request_id,
                         actor="system",
                     )
-            self._delete_playbook_search_rows("user", user_playbook_ids)
-            cur = self.conn.execute(
-                f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",
-                user_playbook_ids,
-            )
             self.conn.commit()
         return cur.rowcount
 
@@ -893,6 +900,10 @@ class PlaybookMixin:
             if not ids:
                 return
             ph = ",".join("?" for _ in ids)
+            self._delete_playbook_search_rows("agent", ids)
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
+            )
             for apid in ids:
                 _emit_hard_delete_playbook(
                     self.conn,
@@ -901,10 +912,6 @@ class PlaybookMixin:
                     entity_id=str(apid),
                     request_id=batch_request_id,
                 )
-            self._delete_playbook_search_rows("agent", ids)
-            self.conn.execute(
-                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
-            )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -916,8 +923,20 @@ class PlaybookMixin:
         ph = ",".join("?" for _ in agent_playbook_ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
+            existing = [
+                r["agent_playbook_id"]
+                for r in self.conn.execute(
+                    f"SELECT agent_playbook_id FROM agent_playbooks WHERE agent_playbook_id IN ({ph})",
+                    agent_playbook_ids,
+                ).fetchall()
+            ]
+            self._delete_playbook_search_rows("agent", agent_playbook_ids)
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})",
+                agent_playbook_ids,
+            )
             if emit_hard_delete:
-                for apid in agent_playbook_ids:
+                for apid in existing:
                     _emit_hard_delete_playbook(
                         self.conn,
                         org_id=self.org_id,
@@ -926,11 +945,6 @@ class PlaybookMixin:
                         request_id=batch_request_id,
                         actor="system",
                     )
-            self._delete_playbook_search_rows("agent", agent_playbook_ids)
-            self.conn.execute(
-                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})",
-                agent_playbook_ids,
-            )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -316,7 +316,6 @@ class PlaybookMixin:
                     "SELECT user_playbook_id FROM user_playbooks"
                 ).fetchall()
             ]
-            self._delete_playbook_search_rows("user", ids)
             self.conn.execute("DELETE FROM user_playbooks")
             for upid in ids:
                 _emit_hard_delete_playbook(
@@ -327,6 +326,7 @@ class PlaybookMixin:
                     request_id=batch_request_id,
                 )
             self.conn.commit()
+        self._delete_playbook_search_rows("user", ids)
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbook(self, user_playbook_id: int) -> None:
@@ -364,7 +364,6 @@ class PlaybookMixin:
             if not ids:
                 return
             ph = ",".join("?" for _ in ids)
-            self._delete_playbook_search_rows("user", ids)
             self.conn.execute(
                 f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})", ids
             )
@@ -377,6 +376,7 @@ class PlaybookMixin:
                     request_id=batch_request_id,
                 )
             self.conn.commit()
+        self._delete_playbook_search_rows("user", ids)
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbooks_by_ids(
@@ -394,7 +394,6 @@ class PlaybookMixin:
                     user_playbook_ids,
                 ).fetchall()
             ]
-            self._delete_playbook_search_rows("user", user_playbook_ids)
             cur = self.conn.execute(
                 f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",
                 user_playbook_ids,
@@ -410,6 +409,7 @@ class PlaybookMixin:
                         actor="system",
                     )
             self.conn.commit()
+        self._delete_playbook_search_rows("user", user_playbook_ids)
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
@@ -851,6 +851,7 @@ class PlaybookMixin:
                     "SELECT agent_playbook_id FROM agent_playbooks"
                 ).fetchall()
             ]
+            self.conn.execute("DELETE FROM agent_playbooks")
             for apid in ids:
                 _emit_hard_delete_playbook(
                     self.conn,
@@ -859,9 +860,8 @@ class PlaybookMixin:
                     entity_id=str(apid),
                     request_id=batch_request_id,
                 )
-            self._delete_playbook_search_rows("agent", ids)
-            self.conn.execute("DELETE FROM agent_playbooks")
             self.conn.commit()
+        self._delete_playbook_search_rows("agent", ids)
 
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbook(self, agent_playbook_id: int) -> None:
@@ -900,7 +900,6 @@ class PlaybookMixin:
             if not ids:
                 return
             ph = ",".join("?" for _ in ids)
-            self._delete_playbook_search_rows("agent", ids)
             self.conn.execute(
                 f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
             )
@@ -913,6 +912,7 @@ class PlaybookMixin:
                     request_id=batch_request_id,
                 )
             self.conn.commit()
+        self._delete_playbook_search_rows("agent", ids)
 
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbooks_by_ids(
@@ -930,7 +930,6 @@ class PlaybookMixin:
                     agent_playbook_ids,
                 ).fetchall()
             ]
-            self._delete_playbook_search_rows("agent", agent_playbook_ids)
             self.conn.execute(
                 f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})",
                 agent_playbook_ids,
@@ -946,6 +945,7 @@ class PlaybookMixin:
                         actor="system",
                     )
             self.conn.commit()
+        self._delete_playbook_search_rows("agent", agent_playbook_ids)
 
     @SQLiteStorageBase.handle_exceptions
     def update_agent_playbook_status(
@@ -1531,6 +1531,9 @@ class PlaybookMixin:
             if not ids:
                 return
             ph = ",".join("?" for _ in ids)
+            self.conn.execute(
+                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
+            )
             for apid in ids:
                 _emit_hard_delete_playbook(
                     self.conn,
@@ -1539,11 +1542,8 @@ class PlaybookMixin:
                     entity_id=str(apid),
                     request_id=batch_request_id,
                 )
-            self._delete_playbook_search_rows("agent", ids)
-            self.conn.execute(
-                f"DELETE FROM agent_playbooks WHERE agent_playbook_id IN ({ph})", ids
-            )
             self.conn.commit()
+        self._delete_playbook_search_rows("agent", ids)
 
     @SQLiteStorageBase.handle_exceptions
     def search_agent_playbooks(  # noqa: C901

--- a/reflexio/server/site_var/feature_flags.py
+++ b/reflexio/server/site_var/feature_flags.py
@@ -55,7 +55,7 @@ def is_feature_enabled(org_id: str, feature_name: str) -> bool:
     if feature_config.get("enabled", False):
         return True
 
-    enabled_org_ids = feature_config.get("enabled_org_ids", [])
+    enabled_org_ids = feature_config.get("enabled_org_ids", []) or []
     return org_id in enabled_org_ids
 
 
@@ -136,7 +136,7 @@ def is_dedup_soft_delete_enabled(org_id: str) -> bool:
     if feature_config.get("enabled", False):
         return True
 
-    enabled_org_ids = feature_config.get("enabled_org_ids", [])
+    enabled_org_ids = feature_config.get("enabled_org_ids", []) or []
     return org_id in enabled_org_ids
 
 

--- a/scripts/lineage_b3_parity_check.py
+++ b/scripts/lineage_b3_parity_check.py
@@ -92,13 +92,24 @@ def classify_parity(
             MATCH, RECON-MISSING, or LEGACY-MISSING.
     """
     legacy_by_req: dict[str, ProfileChangeLog] = {}
+    legacy_dupes: list[str] = []
     for row in legacy_rows:
-        # Last-write wins on duplicate request_ids (should not happen in production).
+        if row.request_id in legacy_by_req:
+            legacy_dupes.append(row.request_id)
         legacy_by_req[row.request_id] = row
 
     recon_by_req: dict[str, ProfileChangeLog] = {}
+    recon_dupes: list[str] = []
     for row in recon_rows:
+        if row.request_id in recon_by_req:
+            recon_dupes.append(row.request_id)
         recon_by_req[row.request_id] = row
+
+    if legacy_dupes or recon_dupes:
+        raise ValueError(
+            f"Duplicate request_ids detected — parity comparison is ambiguous. "
+            f"Legacy dupes: {legacy_dupes!r}. Recon dupes: {recon_dupes!r}."
+        )
 
     all_req_ids = set(legacy_by_req) | set(recon_by_req)
     results: list[ParityResult] = []
@@ -142,6 +153,9 @@ def classify_parity(
     return results
 
 
+_READ_CAP = 10_000
+
+
 def run_parity_check(storage: BaseStorage) -> list[ParityResult]:
     """Run both paths against storage and classify each request_id.
 
@@ -151,9 +165,32 @@ def run_parity_check(storage: BaseStorage) -> list[ParityResult]:
 
     Returns:
         list[ParityResult]: Classified results, one per distinct request_id.
+
+    Raises:
+        SystemExit: If either side returns exactly ``_READ_CAP`` rows, the
+            comparison may be based on truncated data and cannot be trusted.
+            The run is treated as INCONCLUSIVE and exits non-zero.
     """
-    legacy_rows = storage.get_profile_change_logs(limit=10_000)
-    recon_resp = reconstruct_profile_change_log(storage, limit=10_000)
+    legacy_rows = storage.get_profile_change_logs(limit=_READ_CAP)
+    recon_resp = reconstruct_profile_change_log(storage, limit=_READ_CAP)
+
+    truncated: list[str] = []
+    if len(legacy_rows) >= _READ_CAP:
+        truncated.append(f"legacy ({len(legacy_rows)} rows == cap)")
+    if len(recon_resp.profile_change_logs) >= _READ_CAP:
+        truncated.append(
+            f"reconstruction ({len(recon_resp.profile_change_logs)} rows == cap)"
+        )
+
+    if truncated:
+        print(
+            f"\nINCONCLUSIVE: data may be truncated at the {_READ_CAP}-row cap — "
+            f"{', '.join(truncated)}. "
+            "Re-run after raising the cap or filtering the dataset.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     return classify_parity(legacy_rows, recon_resp.profile_change_logs)
 
 

--- a/tests/models/test_lineage_gc_config.py
+++ b/tests/models/test_lineage_gc_config.py
@@ -1,5 +1,8 @@
 """Tests for ``LineageGCConfig`` (tombstone garbage-collection gate)."""
 
+import pytest
+from pydantic import ValidationError
+
 from reflexio.models.config_schema import (
     Config,
     LineageGCConfig,
@@ -39,3 +42,26 @@ def test_lineage_gc_null_falls_back_to_default():
     payload["lineage_gc"] = None
     cfg = Config.model_validate(payload)
     assert cfg.lineage_gc == LineageGCConfig()
+
+
+# ---------------------------------------------------------------------------
+# Bounds validation: negative/zero values must be rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("days", [0, -1, -90])
+def test_lineage_gc_rejects_non_positive_grace_window(days: int):
+    with pytest.raises(ValidationError):
+        LineageGCConfig(tombstone_grace_window_days=days)
+
+
+@pytest.mark.parametrize("interval", [0, -1, -86400])
+def test_lineage_gc_rejects_non_positive_poll_interval(interval: int):
+    with pytest.raises(ValidationError):
+        LineageGCConfig(poll_interval_seconds=interval)
+
+
+def test_lineage_gc_accepts_minimum_valid_values():
+    cfg = LineageGCConfig(tombstone_grace_window_days=1, poll_interval_seconds=1)
+    assert cfg.tombstone_grace_window_days == 1
+    assert cfg.poll_interval_seconds == 1

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -14,6 +14,7 @@ from reflexio.server.services.lineage import gc_scheduler
 from reflexio.server.services.lineage.gc_scheduler import (
     _ENTITY_TYPES,
     _HIGH_VOLUME_THRESHOLD,
+    _MIN_POLL_SECONDS,
     LineageGCScheduler,
     maybe_start_lineage_gc,
 )
@@ -272,3 +273,53 @@ def test_gc_tick_stops_mid_tick_when_stop_event_set():
 
     # With the stop event already set, the very first iteration should break.
     assert calls == [], f"Expected no orgs processed after stop, got {calls}"
+
+
+# ---------------------------------------------------------------------------
+# Poll interval clamp — non-positive values are floored to _MIN_POLL_SECONDS
+# ---------------------------------------------------------------------------
+
+
+def test_run_loop_clamps_non_positive_poll_interval():
+    """_run_loop must pass at least _MIN_POLL_SECONDS to _stop_event.wait.
+
+    Even though config validation now rejects non-positive values, the scheduler
+    defends itself at runtime: if a zero or negative interval somehow reaches
+    _run_loop, it is clamped to _MIN_POLL_SECONDS to prevent a hot-loop.
+    """
+    wait_calls: list[float] = []
+
+    # Patch _stop_event.wait to capture the timeout and then immediately stop
+    # the loop on the first call.
+    sched = _scheduler()
+
+    original_wait = sched._stop_event.wait
+
+    def capturing_wait(timeout: float) -> bool:
+        wait_calls.append(timeout)
+        sched._stop_event.set()  # stop after one iteration
+        return original_wait(0)  # return immediately
+
+    sched._stop_event.wait = capturing_wait  # type: ignore[method-assign]
+
+    # Directly monkey-patch _run_loop's poll_interval by making the config
+    # return 0 for poll_interval_seconds.
+    zero_cfg = SimpleNamespace(
+        lineage_gc=SimpleNamespace(
+            poll_interval_seconds=0,
+            tombstone_grace_window_days=90,
+        )
+    )
+    zero_ctx = SimpleNamespace(
+        org_id="org_bootstrap",
+        storage=MagicMock(),
+        configurator=SimpleNamespace(get_config=MagicMock(return_value=zero_cfg)),
+    )
+    sched.request_context_factory = lambda _: zero_ctx
+
+    sched._run_loop()
+
+    assert wait_calls, "wait was never called"
+    assert all(t >= _MIN_POLL_SECONDS for t in wait_calls), (
+        f"Non-positive poll interval was not clamped: got {wait_calls}"
+    )

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -395,6 +395,68 @@ def test_delete_profiles_by_ids_partial_only_emits_for_existing(tmp_path):
     )
 
 
+def test_delete_user_playbooks_by_ids_nonexistent_no_event(tmp_path):
+    """Calling delete_user_playbooks_by_ids with a non-existent id must not emit hard_delete."""
+    s = _store(tmp_path)
+    s.delete_user_playbooks_by_ids([99999])
+    assert not any(
+        e.op == "hard_delete"
+        for e in s.get_lineage_events(entity_id="99999", entity_type="user_playbook")
+    )
+
+
+def test_delete_user_playbooks_by_ids_partial_only_emits_for_existing(tmp_path):
+    """delete_user_playbooks_by_ids emits hard_delete only for ids that actually existed."""
+    s = _store(tmp_path)
+    pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
+    s.save_user_playbooks([pb])
+    real_id = pb.user_playbook_id
+    s.delete_user_playbooks_by_ids([real_id, 99999])
+    real_events = [
+        e
+        for e in s.get_lineage_events(
+            entity_id=str(real_id), entity_type="user_playbook"
+        )
+        if e.op == "hard_delete"
+    ]
+    assert len(real_events) == 1
+    assert not any(
+        e.op == "hard_delete"
+        for e in s.get_lineage_events(entity_id="99999", entity_type="user_playbook")
+    )
+
+
+def test_delete_agent_playbooks_by_ids_nonexistent_no_event(tmp_path):
+    """Calling delete_agent_playbooks_by_ids with a non-existent id must not emit hard_delete."""
+    s = _store(tmp_path)
+    s.delete_agent_playbooks_by_ids([99999])
+    assert not any(
+        e.op == "hard_delete"
+        for e in s.get_lineage_events(entity_id="99999", entity_type="agent_playbook")
+    )
+
+
+def test_delete_agent_playbooks_by_ids_partial_only_emits_for_existing(tmp_path):
+    """delete_agent_playbooks_by_ids emits hard_delete only for ids that actually existed."""
+    s = _store(tmp_path)
+    ap = _make_agent_playbook()
+    saved = s.save_agent_playbooks([ap])
+    real_id = saved[0].agent_playbook_id
+    s.delete_agent_playbooks_by_ids([real_id, 99999])
+    real_events = [
+        e
+        for e in s.get_lineage_events(
+            entity_id=str(real_id), entity_type="agent_playbook"
+        )
+        if e.op == "hard_delete"
+    ]
+    assert len(real_events) == 1
+    assert not any(
+        e.op == "hard_delete"
+        for e in s.get_lineage_events(entity_id="99999", entity_type="agent_playbook")
+    )
+
+
 # --------------------------------------------------------------------------
 # Bulk deletes clean up the vec table (when sqlite-vec is loaded)
 # --------------------------------------------------------------------------

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -509,3 +509,53 @@ def test_delete_agent_playbooks_by_ids_cleans_vec(tmp_path):
     assert apid in _vec_rowids(s, "agent_playbooks_vec")
     s.delete_agent_playbooks_by_ids([apid])
     assert apid not in _vec_rowids(s, "agent_playbooks_vec")
+
+
+# --------------------------------------------------------------------------
+# No-phantom-event: delete_all_agent_playbooks
+# Regression test for Finding 1: emit must happen AFTER DELETE (same commit),
+# not before. We verify that:
+#   - events emitted == rows that actually existed
+#   - calling on an empty table emits zero events
+#   - rows are gone after the call
+# --------------------------------------------------------------------------
+
+
+def test_delete_all_agent_playbooks_no_phantom_events_empty_table(tmp_path):
+    """delete_all_agent_playbooks on empty table emits zero hard_delete events."""
+    s = _store(tmp_path)
+    s.delete_all_agent_playbooks()
+    # No rows existed; no events should have been written.
+    all_events = s.get_lineage_events()
+    hard_deletes = [e for e in all_events if e.op == "hard_delete"]
+    assert hard_deletes == []
+
+
+def test_delete_all_agent_playbooks_emits_exactly_for_existing_rows(tmp_path):
+    """delete_all_agent_playbooks emits one hard_delete per existing row, no more."""
+    s = _store(tmp_path)
+    ap1 = _make_agent_playbook(playbook_name="x")
+    ap2 = _make_agent_playbook(playbook_name="y")
+    saved1 = s.save_agent_playbooks([ap1])
+    saved2 = s.save_agent_playbooks([ap2])
+    apid1 = saved1[0].agent_playbook_id
+    apid2 = saved2[0].agent_playbook_id
+
+    s.delete_all_agent_playbooks()
+
+    # Rows are gone.
+    assert s.get_agent_playbook_by_id(apid1, include_tombstones=True) is None
+    assert s.get_agent_playbook_by_id(apid2, include_tombstones=True) is None
+
+    # Exactly one hard_delete event per id — no phantom events for extra ids.
+    for apid in [apid1, apid2]:
+        events = [
+            e
+            for e in s.get_lineage_events(entity_id=str(apid))
+            if e.op == "hard_delete"
+        ]
+        assert len(events) == 1, f"expected 1 hard_delete for {apid}, got {len(events)}"
+
+    # Total hard_delete count matches exactly the two rows that existed.
+    all_hard_deletes = [e for e in s.get_lineage_events() if e.op == "hard_delete"]
+    assert len(all_hard_deletes) == 2

--- a/tests/server/services/storage/test_lineage_b1_update_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_update_integration.py
@@ -37,7 +37,9 @@ def test_update_user_playbook_content_emits_revise(tmp_path):
     pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="old")
     s.save_user_playbooks([pb])
     s.update_user_playbook(pb.user_playbook_id, content="new guidance")
-    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    ev = s.get_lineage_events(
+        entity_id=str(pb.user_playbook_id), entity_type="user_playbook"
+    )
     assert [e.op for e in ev] == ["revise"]
     assert s.get_user_playbook_by_id(pb.user_playbook_id).content == "new guidance"
 
@@ -47,7 +49,9 @@ def test_update_user_playbook_metadata_only_emits_status_change(tmp_path):
     pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
     s.save_user_playbooks([pb])
     s.update_user_playbook(pb.user_playbook_id, playbook_name="renamed")  # no content
-    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    ev = s.get_lineage_events(
+        entity_id=str(pb.user_playbook_id), entity_type="user_playbook"
+    )
     assert [e.op for e in ev] == ["status_change"]
 
 
@@ -58,7 +62,9 @@ def test_update_user_playbook_multiple_edits_each_produce_event(tmp_path):
     s.save_user_playbooks([pb])
     s.update_user_playbook(pb.user_playbook_id, content="v2")
     s.update_user_playbook(pb.user_playbook_id, content="v3")
-    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    ev = s.get_lineage_events(
+        entity_id=str(pb.user_playbook_id), entity_type="user_playbook"
+    )
     assert [e.op for e in ev] == ["revise", "revise"]
 
 
@@ -220,7 +226,9 @@ def test_update_user_playbook_metadata_only_leaves_structured_fields_null(tmp_pa
     pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
     s.save_user_playbooks([pb])
     s.update_user_playbook(pb.user_playbook_id, playbook_name="renamed")
-    ev = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    ev = s.get_lineage_events(
+        entity_id=str(pb.user_playbook_id), entity_type="user_playbook"
+    )
     sc = [e for e in ev if e.op == "status_change"]
     assert len(sc) == 1
     assert sc[0].from_status is None

--- a/tests/server/services/storage/test_lineage_b2_gc_integration.py
+++ b/tests/server/services/storage/test_lineage_b2_gc_integration.py
@@ -533,3 +533,116 @@ def test_gc_boundary_profile_at_cutoff_not_deleted(tmp_path):
         ).fetchone()
         is None
     ), "Profile one second before cutoff must be deleted"
+
+
+# ---------------------------------------------------------------------------
+# (g) limit guard: non-positive limit returns 0 without touching the DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_limit", [0, -1, -100])
+def test_gc_non_positive_limit_returns_zero(tmp_path, bad_limit: int):
+    s = _store(tmp_path)
+    pb = _make_user_playbook()
+    s.save_user_playbooks([pb])
+    pid = pb.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
+    )
+    _set_playbook_created_at(
+        s,
+        "user_playbooks",
+        "user_playbook_id",
+        pid,
+        _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
+    )
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    result = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff, limit=bad_limit
+    )
+
+    assert result == 0
+    # Row must NOT have been deleted
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid,)
+        ).fetchone()
+        is not None
+    ), "Row must survive when limit <= 0"
+
+
+# ---------------------------------------------------------------------------
+# (h) Atomic rollback: mid-operation failure leaves no partial state
+# ---------------------------------------------------------------------------
+
+
+def test_gc_rollback_on_mid_operation_failure(tmp_path):
+    """A failure after emitting the hard_delete event but before DELETE must
+    roll back — no orphan event, no partial deletion.
+
+    We patch the module-level ``_append_event_stmt`` so it writes the first
+    event then raises, simulating a failure partway through the write block.
+    The ``except`` branch in ``gc_expired_tombstones`` must rollback so neither
+    the partial event nor the row deletion persists.
+    """
+    from unittest.mock import patch
+
+    import reflexio.server.services.storage.sqlite_storage._lineage as _lineage_mod
+
+    s = _store(tmp_path)
+
+    # Seed two tombstone rows so the loop calls _append_event_stmt twice.
+    pb1 = _make_user_playbook(content="one")
+    pb2 = _make_user_playbook(content="two")
+    s.save_user_playbooks([pb1, pb2])
+    for pb in (pb1, pb2):
+        _set_playbook_status(
+            s,
+            "user_playbooks",
+            "user_playbook_id",
+            pb.user_playbook_id,
+            Status.MERGED.value,
+        )
+        _set_playbook_created_at(
+            s,
+            "user_playbooks",
+            "user_playbook_id",
+            pb.user_playbook_id,
+            _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
+        )
+
+    real_append = _lineage_mod._append_event_stmt
+    call_count = 0
+
+    def failing_append(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise RuntimeError("simulated mid-loop failure")
+        return real_append(*args, **kwargs)
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    with (
+        patch.object(_lineage_mod, "_append_event_stmt", side_effect=failing_append),
+        pytest.raises(RuntimeError, match="simulated mid-loop failure"),
+    ):
+        s.gc_expired_tombstones(entity_type="user_playbook", older_than_epoch=cutoff)
+
+    # Both rows must still exist — rollback prevented any partial deletion
+    for pb in (pb1, pb2):
+        assert (
+            s.conn.execute(
+                "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?",
+                (pb.user_playbook_id,),
+            ).fetchone()
+            is not None
+        ), f"Row {pb.user_playbook_id} must survive after rolled-back GC failure"
+
+    # No hard_delete events should have persisted (rolled back with the transaction)
+    for pb in (pb1, pb2):
+        events = _hard_delete_events(s, str(pb.user_playbook_id))
+        assert len(events) == 0, (
+            f"Expected 0 hard_delete events after rollback for {pb.user_playbook_id}, "
+            f"got {len(events)}"
+        )

--- a/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
@@ -184,6 +184,7 @@ def test_run_parity_check_all_match(tmp_path):
 
     results = run_parity_check(s)
     match_results = [r for r in results if r.request_id.startswith("req-full-")]
+    assert match_results, "expected at least one req-full-* result (non-vacuous guard)"
     assert all(r.classification == ParityClass.MATCH for r in match_results), (
         f"expected all MATCH but got: {[(r.request_id, r.classification) for r in match_results]}"
     )

--- a/tests/server/services/storage/test_lineage_b3_parity_gate_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_parity_gate_integration.py
@@ -9,9 +9,9 @@ Three cases are documented (matching the B3 spec):
    profile content and profile_id).  Seeds via the REAL dedup path:
    - adds via generated_from_request_id (immutable column)
    - removes via supersede_profiles_by_ids (emits status_change+superseded)
-2. LEGACY-MISSING — a legacy row has no corresponding lineage event.  The
-   reconstruction simply returns no row; the discrepancy is *tolerated*
-   (best-effort drop), not a failure.
+2. RECON-MISSING — a legacy row has no corresponding lineage event.  The
+   reconstruction simply returns no row; the discrepancy means the gate
+   classifier flags it as a real gap (RECON-MISSING, exits non-zero).
 3. PURGED TOMBSTONE — the removed tombstone was GC'd after the legacy row was
    written.  Reconstruction yields an empty removed_profiles list rather than
    crashing; the legacy row retains the original content.  Both outcomes are
@@ -198,6 +198,21 @@ def test_reconstruction_parity_gate_multi_dedup(tmp_path):
         for row in reconstruct_profile_change_log(s).profile_change_logs
     }
 
+    # Exact request_id set check: legacy must contain exactly the seeded req_ids,
+    # and every seeded req_id must appear in reconstruction.
+    # (Reconstruction may additionally surface "seed" profiles added before any
+    # dedup run — those have no legacy counterpart and are expected extra output;
+    # they don't invalidate the gate.)
+    seeded_req_ids = {req_id for _, _, _, req_id, _, _ in pairs}
+    assert set(legacy_by_req) == seeded_req_ids, (
+        f"legacy request_ids must exactly match seeded set: "
+        f"legacy={set(legacy_by_req)!r} seeded={seeded_req_ids!r}"
+    )
+    assert seeded_req_ids <= set(recon_by_req), (
+        f"seeded request_ids missing from reconstruction: "
+        f"{seeded_req_ids - set(recon_by_req)}"
+    )
+
     for req_id, legacy in legacy_by_req.items():
         assert req_id in recon_by_req, f"reconstruction missing req_id={req_id}"
         recon_row = recon_by_req[req_id]
@@ -212,16 +227,17 @@ def test_reconstruction_parity_gate_multi_dedup(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Case 2 — LEGACY-MISSING: legacy row with no lineage event (tolerated)
+# Case 2 — RECON-MISSING: legacy row with no lineage event (real gap)
 # ---------------------------------------------------------------------------
 
 
-def test_reconstruction_parity_gate_legacy_missing(tmp_path):
-    """A legacy row with no lineage event reconstructs as nothing — TOLERATED.
+def test_reconstruction_parity_gate_recon_missing(tmp_path):
+    """A legacy row with no lineage event reconstructs as nothing — RECON-MISSING.
 
     This happens if a legacy row was written by old code that did not
     yet emit lineage events.  The parity checker classifies this as
-    LEGACY-MISSING and tolerates it (not a failure).
+    RECON-MISSING (legacy has a row, reconstruction does not) — a real gap
+    that triggers a non-zero exit in the gate script.
     """
     s = _store(tmp_path)
 

--- a/tests/server/services/storage/test_lineage_b3_request_id_invariant_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_request_id_invariant_integration.py
@@ -132,6 +132,10 @@ def test_empty_request_id_group_is_skipped(tmp_path):
 
     This replaces the old "collapse" documentation: the new behavior is a
     hard skip, enforced in reconstruct_profile_change_log.
+
+    Seeds rows with TRULY empty generated_from_request_id (bypassing the
+    _make_profile helper's ``or`` fallback by constructing directly) to ensure
+    the skip is exercised, not vacuously passing on an empty DB.
     """
     s = _store(tmp_path)
     # Add profiles with TRULY empty generated_from_request_id (bypass the
@@ -153,11 +157,20 @@ def test_empty_request_id_group_is_skipped(tmp_path):
         profile_time_to_live=ProfileTimeToLive.INFINITY,
     )
     s.add_user_profile("u1", [p1, p2])
-    # Even if a status_change event with request_id="" existed, it would be skipped.
+    # Verify the seed was actually persisted (non-vacuous guard): query the
+    # DB directly to confirm empty generated_from_request_id rows are present.
+    rows = s.conn.execute(
+        "SELECT profile_id FROM profiles WHERE generated_from_request_id = ''",
+    ).fetchall()
+    assert len(rows) == 2, (
+        "test setup failed: expected 2 profiles with empty generated_from_request_id "
+        f"in storage, got {len(rows)}"
+    )
 
     result = reconstruct_profile_change_log(s)
     assert result.success
-    # Empty request_id group is skipped entirely.
+    # Empty request_id group is skipped entirely — the seeded rows are in storage
+    # but the empty-string key is excluded before grouping.
     req_ids = {row.request_id for row in result.profile_change_logs}
     assert "" not in req_ids, "empty request_id must be skipped"
     assert result.profile_change_logs == [], "empty generated_from_request_id → no rows"

--- a/tests/server/site_var/test_feature_flags.py
+++ b/tests/server/site_var/test_feature_flags.py
@@ -257,6 +257,40 @@ class TestDedupSoftDeleteFlag(unittest.TestCase):
         self.assertTrue(is_feature_enabled("org-any", key))
         self.assertFalse(is_dedup_soft_delete_enabled("org-any"))
 
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "dedup_soft_delete": {"enabled": False, "enabled_org_ids": None},
+        },
+    )
+    def test_explicit_null_enabled_org_ids_returns_false(self, _mock):
+        """Explicit null enabled_org_ids must not raise TypeError.
+
+        When ``enabled_org_ids`` is explicitly null (None) in config, the
+        membership check must treat it as an empty list and return False,
+        not raise TypeError.
+        """
+        self.assertFalse(is_dedup_soft_delete_enabled("org-pilot"))
+
+
+class TestIsFeatureFlagsNullOrgIds(unittest.TestCase):
+    """Null-safety tests for is_feature_enabled with null enabled_org_ids."""
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "some_feature": {"enabled": False, "enabled_org_ids": None},
+        },
+    )
+    def test_explicit_null_enabled_org_ids_returns_false(self, _mock):
+        """Explicit null enabled_org_ids must not raise TypeError in is_feature_enabled.
+
+        When ``enabled_org_ids`` is explicitly null (None) in config, the
+        membership check must treat it as an empty list and return False,
+        not raise TypeError.
+        """
+        self.assertFalse(is_feature_enabled("org-any", "some_feature"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Addresses the CodeRabbit review findings left on the **merged** lineage PRs **#187 (B1)**, **#188 (B2)**, and **#191 (B3-pre)**. Pure remediation — no new features.

## Fixes by source PR

**#191 (B3-pre)** — `22d2540`: negative-`limit` guard (`<=0`) in reconstruction; `enabled_org_ids or []` defensiveness in feature flags; parity script **fail-closed on duplicate `request_id`** + **INCONCLUSIVE (exit 2) on at-cap/truncated reads**; test hygiene (vacuous-MATCH guard, RECON-vs-LEGACY label, exact request_id set-equality, empty-id seeding); ASCII `union` (RUF002).

**#188 (B2)** — `4204598`: `LineageGCConfig` bounds (`Field(gt=0)`); scheduler poll-interval clamp; `gc_expired_tombstones` `limit<=0` guard; **explicit rollback** to keep GC atomic on mid-write failure.

**#187 (B1)** — `a5f6558` + `f792ddb`: **phantom-audit guards on the bulk-delete paths** (emit `hard_delete` only for rows that exist, in the **same commit** as the base DELETE; FTS/vec cleanup moved **after** the commit per the SQLite self-commit rule) — fixing `delete_all_agent_playbooks` and `delete_archived_agent_playbooks_by_playbook_name`, which emitted *before* the mutation; `entity_type` filter in a lineage-lookup test.

## Deliberately NOT changed (with reasons)

- **SQLite `get_profiles_by_generated_from_request_id` "not org-scoped"** — SQLite `profiles` has **no `org_id` column** (tenant isolation is per-DB-file; enterprise is per-schema), and the reconstruction's event pool is already `org_id`-scoped via `get_lineage_events`. Adding a profiles-level org filter needs a schema migration — tracked as a separate follow-up, not a quick fix.
- **`_set_config(**kwargs)` `🔴 Critical`** — **confirmed false alarm**: `Config.model_validate({..., **overrides})` is valid Pydantic; the test passes and applies the right config.
- Several #187 items were **already addressed** by later phases (rowcount gates, already-archived exclusion, atomicity, existing-row filters, vec-sidecar cleanup, `request_id` non-optional, `StorageError` wrapping) — verified against current code and skipped.

All changes tested (reviewed via a final whole-branch pass that caught the bulk-delete ordering). No behavior change beyond the hardening above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for scheduler configuration values to ensure they meet minimum requirements.

* **Bug Fixes**
  * Improved transaction atomicity during garbage collection operations.
  * Fixed feature flag evaluation to safely handle missing or null org ID lists.
  * Enhanced duplicate detection in data parity validation.
  * Enforced minimum scheduler poll interval to improve reliability.

* **Tests**
  * Added comprehensive tests for configuration validation and garbage collection scenarios.
  * Strengthened parity checking and deletion operation test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->