### PR TITLE
fix(storage): allow delete_all_user_playbooks_by_status for non-PENDING (unblock playbook upgrade on SQLite)

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -483,11 +483,10 @@ class PlaybookMixin:
         agent_version: str | None = None,
         playbook_name: str | None = None,
     ) -> int:
-        if status != Status.PENDING:
-            raise ValueError(
-                f"delete_all_user_playbooks_by_status only accepts Status.PENDING "
-                f"(got {status!r}); use archive or hard-delete methods for other statuses"
-            )
+        # Bulk delete-by-status emits no hard_delete lineage events (parity with
+        # the Supabase backend, which routes this through _hard_delete_and_log with
+        # emit_hard_delete=False). Accepts any status: the upgrade flow legitimately
+        # deletes old ARCHIVED playbooks via _delete_items_by_status(Status.ARCHIVED).
         where = "status = ?"
         params: list[Any] = [status.value]
         if agent_version is not None:

--- a/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_harddelete_integration.py
@@ -22,7 +22,6 @@ from reflexio.models.api_schema.domain.entities import (
 )
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import DeleteUserProfileRequest
-from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -303,20 +302,31 @@ def test_delete_user_profile_cross_user_no_event_and_no_delete(tmp_path):
 
 
 # --------------------------------------------------------------------------
-# F008: delete_all_user_playbooks_by_status raises on non-PENDING status
+# F008: delete_all_user_playbooks_by_status deletes any status, emits NO events
+# (parity with Supabase backend; the upgrade flow deletes old ARCHIVED entries)
 # --------------------------------------------------------------------------
 
 
-def test_delete_all_user_playbooks_by_status_archived_raises(tmp_path):
+@pytest.mark.parametrize("status", [Status.ARCHIVED, Status.MERGED])
+def test_delete_all_user_playbooks_by_status_non_pending_deletes_no_events(
+    tmp_path, status
+):
     s = _store(tmp_path)
-    with pytest.raises(StorageError, match="PENDING"):
-        s.delete_all_user_playbooks_by_status(Status.ARCHIVED)
-
-
-def test_delete_all_user_playbooks_by_status_merged_raises(tmp_path):
-    s = _store(tmp_path)
-    with pytest.raises(StorageError, match="PENDING"):
-        s.delete_all_user_playbooks_by_status(Status.MERGED)
+    pb = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="c",
+        status=status,
+    )
+    s.save_user_playbooks([pb])
+    deleted = s.delete_all_user_playbooks_by_status(status)
+    # Row is physically deleted (the upgrade flow relies on this for old ARCHIVED).
+    assert deleted == 1
+    assert not s.get_user_playbooks(status_filter=[status])
+    # Bulk delete-by-status emits no hard_delete events (Supabase parity carve-out).
+    events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
+    assert not any(e.op == "hard_delete" for e in events)
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`/test-backend-pipeline` run found a **P1 regression** in the playbook upgrade flow on the SQLite backend.

Lineage Phase B1 (#187) added a `status != Status.PENDING` → `raise ValueError` guard to the SQLite `delete_all_user_playbooks_by_status`. But the shared upgrade flow (`base_generation_service._perform_upgrade`) calls `_delete_items_by_status(Status.ARCHIVED, request)` to purge old archived playbooks. As a result, `upgrade_all_user_playbooks` broke on SQLite — it returned `UpgradeUserPlaybooksResponse(success=False, ...)` with the guard error swallowed by `handle_exceptions`.

The **Supabase backend has no such guard**: it routes the same delete through `_hard_delete_and_log(..., emit_hard_delete=False)` and accepts any status. So this was a SQLite-only regression and a cross-backend divergence that the storage contract suite does not cover (`delete_all_user_playbooks_by_status` has no contract test).

## Root cause

| Backend | `delete_all_user_playbooks_by_status(ARCHIVED)` | Lineage |
|---|---|---|
| SQLite (pre-fix) | **raises ValueError** (B1 guard) | n/a |
| SQLite (post-fix) | deletes rows | none (matches Supabase) |
| Supabase | deletes rows | none (`emit_hard_delete=False`) |
| `delete_all_profiles_by_status` (both backends) | deletes rows | emits `hard_delete` |

## Fix

Remove the PENDING-only guard so SQLite matches the Supabase sibling: bulk delete-by-status accepts any status and (by design, matching Supabase) emits no `hard_delete` lineage events. The `PENDING` purge already emitted no events, so behavior for the original carve-out is unchanged.

Updated the two B1 integration tests that asserted the raise (`..._archived_raises`, `..._merged_raises`) into one parametrized test asserting the corrected behavior: the row is physically deleted and **no** `hard_delete` event is emitted.

## Verification

- `tests/server/services/storage/test_lineage_b1_harddelete_integration.py` — **34 passed**
- `tests/e2e_tests/test_playbook_workflows.py::test_upgrade_user_playbooks_end_to_end` — **passed** (was failing)
- `tests/e2e_tests/test_playbook_workflows.py` (full file) — **8 passed, 16 skipped** (was 1 failed)
- `ruff check` / `ruff format --check` / `pyright` — clean

## Follow-up (not in this PR)

The storage contract suite does not exercise `delete_all_user_playbooks_by_status`, which is why SQLite and Supabase diverged silently. A contract test covering this method (PENDING + a non-PENDING status, asserting deletion and the no-lineage carve-out) would prevent recurrence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue preventing deletion of archived and merged playbooks. The bulk delete function now successfully handles playbooks with any status, enabling users to perform comprehensive cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->