### PR TITLE
Lineage B3d/B3e/B3f (OSS) — delete-path atomicity + #195/#196 CodeRabbit follow-ups

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -832,22 +832,35 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._delete_in_chunks("interactions", "request_id", request_ids)
 
     def _delete_interaction_search_rows(self, interaction_ids: list[int]) -> None:
+        """Remove fts + vec index rows for the given interaction IDs.
+
+        Non-committing: participates in the caller's transaction.  Only called
+        from inside the retention atomic block (_retention_perform_delete).
+        """
         if not interaction_ids:
             return
         self._delete_in_chunks("interactions_fts", "rowid", interaction_ids)
-        for interaction_id in interaction_ids:
-            self._vec_delete("interactions_vec", interaction_id)
+        if self._has_sqlite_vec:
+            self._delete_in_chunks("interactions_vec", "rowid", interaction_ids)
 
     def _delete_profile_search_rows(self, profile_ids: list[str]) -> None:
+        """Remove fts + vec index rows for the given profile IDs.
+
+        Non-committing: participates in the caller's transaction.  Only called
+        from inside the retention atomic block (_retention_perform_delete).
+        profiles_fts is keyed by profile_id (TEXT); profiles_vec by rowid (INT).
+        """
         if not profile_ids:
             return
-        rows = self._select_in_chunks(
-            "SELECT rowid, profile_id FROM profiles WHERE profile_id IN ({placeholders})",
-            profile_ids,
-        )
-        for row in rows:
-            self._fts_delete_profile(row["profile_id"])
-            self._vec_delete("profiles_vec", row["rowid"])
+        self._delete_in_chunks("profiles_fts", "profile_id", profile_ids)
+        if self._has_sqlite_vec:
+            rows = self._select_in_chunks(
+                "SELECT rowid FROM profiles WHERE profile_id IN ({placeholders})",
+                profile_ids,
+            )
+            rowids = [row["rowid"] for row in rows]
+            if rowids:
+                self._delete_in_chunks("profiles_vec", "rowid", rowids)
 
     def _delete_playbook_search_rows(self, kind: str, ids: list[int]) -> None:
         if not ids:

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -810,6 +810,11 @@ class ProfileMixin:
                 "DELETE FROM interactions_fts WHERE rowid = ?",
                 (request.interaction_id,),
             )
+            if self._has_sqlite_vec:
+                self.conn.execute(
+                    "DELETE FROM interactions_vec WHERE rowid = ?",
+                    (request.interaction_id,),
+                )
             self.conn.execute(
                 "DELETE FROM interactions WHERE user_id = ? AND interaction_id = ?",
                 (request.user_id, request.interaction_id),
@@ -831,6 +836,10 @@ class ProfileMixin:
             self.conn.execute(
                 f"DELETE FROM interactions_fts WHERE rowid IN ({placeholders})", ids
             )
+            if self._has_sqlite_vec:
+                self.conn.execute(
+                    f"DELETE FROM interactions_vec WHERE rowid IN ({placeholders})", ids
+                )
             self.conn.execute("DELETE FROM interactions WHERE user_id = ?", (user_id,))
             self.conn.commit()
 
@@ -838,6 +847,8 @@ class ProfileMixin:
     def delete_all_interactions(self) -> None:
         with self._lock:
             self.conn.execute("DELETE FROM interactions_fts")
+            if self._has_sqlite_vec:
+                self.conn.execute("DELETE FROM interactions_vec")
             self.conn.execute("DELETE FROM interactions")
             self.conn.commit()
 
@@ -862,6 +873,10 @@ class ProfileMixin:
             self.conn.execute(
                 f"DELETE FROM interactions_fts WHERE rowid IN ({placeholders})", ids
             )
+            if self._has_sqlite_vec:
+                self.conn.execute(
+                    f"DELETE FROM interactions_vec WHERE rowid IN ({placeholders})", ids
+                )
             self.conn.execute(
                 f"DELETE FROM interactions WHERE interaction_id IN ({placeholders})",
                 ids,

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -95,6 +95,7 @@ class ProfileMixin:
     _vec_upsert: Any
     _vec_delete: Any
     _delete_profile_search_rows: Any
+    _delete_in_chunks: Any
     _has_sqlite_vec: bool
     llm_client: Any
     embedding_model_name: str
@@ -295,6 +296,8 @@ class ProfileMixin:
                 "SELECT rowid FROM profiles WHERE user_id = ? AND profile_id = ?",
                 (request.user_id, request.profile_id),
             ).fetchone()
+            if rowid_row is None:
+                return
             self.conn.execute(
                 "DELETE FROM profiles_fts WHERE profile_id = ?",
                 (request.profile_id,),
@@ -330,15 +333,9 @@ class ProfileMixin:
                 return
             pids = [r["profile_id"] for r in rows]
             rowids = [r["rowid"] for r in rows]
-            ph = ",".join("?" for _ in pids)
-            self.conn.execute(
-                f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})", pids
-            )
+            self._delete_in_chunks("profiles_fts", "profile_id", pids)
             if self._has_sqlite_vec and rowids:
-                rph = ",".join("?" for _ in rowids)
-                self.conn.execute(
-                    f"DELETE FROM profiles_vec WHERE rowid IN ({rph})", rowids
-                )
+                self._delete_in_chunks("profiles_vec", "rowid", rowids)
             self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
             for pid in pids:
                 _emit_hard_delete_profile(
@@ -633,17 +630,13 @@ class ProfileMixin:
                 return 0
             pids = [r["profile_id"] for r in rows]
             rowids = [r["rowid"] for r in rows]
-            ph = ",".join("?" for _ in pids)
-            self.conn.execute(
-                f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})", pids
-            )
+            self._delete_in_chunks("profiles_fts", "profile_id", pids)
             if self._has_sqlite_vec and rowids:
-                rph = ",".join("?" for _ in rowids)
-                self.conn.execute(
-                    f"DELETE FROM profiles_vec WHERE rowid IN ({rph})", rowids
-                )
+                self._delete_in_chunks("profiles_vec", "rowid", rowids)
+            ph = ",".join("?" for _ in pids)
             cur = self.conn.execute(
-                f"DELETE FROM profiles WHERE profile_id IN ({ph})", pids
+                f"DELETE FROM profiles WHERE profile_id IN ({ph})",
+                pids,  # noqa: S608
             )
             for pid in pids:
                 _emit_hard_delete_profile(
@@ -687,17 +680,12 @@ class ProfileMixin:
                 return 0
             existing = [r["profile_id"] for r in pre_rows]
             rowids = [r["rowid"] for r in pre_rows]
-            eph = ",".join("?" for _ in existing)
-            self.conn.execute(
-                f"DELETE FROM profiles_fts WHERE profile_id IN ({eph})", existing
-            )
+            self._delete_in_chunks("profiles_fts", "profile_id", existing)
             if self._has_sqlite_vec and rowids:
-                rph = ",".join("?" for _ in rowids)
-                self.conn.execute(
-                    f"DELETE FROM profiles_vec WHERE rowid IN ({rph})", rowids
-                )
+                self._delete_in_chunks("profiles_vec", "rowid", rowids)
             cur = self.conn.execute(
-                f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
+                f"DELETE FROM profiles WHERE profile_id IN ({ph})",
+                profile_ids,  # noqa: S608
             )
             if emit_hard_delete:
                 for pid in existing:
@@ -834,6 +822,12 @@ class ProfileMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:
         with self._lock:
+            row = self.conn.execute(
+                "SELECT interaction_id FROM interactions WHERE user_id = ? AND interaction_id = ?",
+                (request.user_id, request.interaction_id),
+            ).fetchone()
+            if row is None:
+                return
             self.conn.execute(
                 "DELETE FROM interactions_fts WHERE rowid = ?",
                 (request.interaction_id,),
@@ -851,23 +845,16 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_interactions_for_user(self, user_id: str) -> None:
-        ids = [
-            r["interaction_id"]
-            for r in self._fetchall(
-                "SELECT interaction_id FROM interactions WHERE user_id = ?", (user_id,)
-            )
-        ]
-        if not ids:
-            return
-        placeholders = ",".join("?" for _ in ids)
         with self._lock:
-            self.conn.execute(
-                f"DELETE FROM interactions_fts WHERE rowid IN ({placeholders})", ids
-            )
+            rows = self.conn.execute(
+                "SELECT interaction_id FROM interactions WHERE user_id = ?", (user_id,)
+            ).fetchall()
+            if not rows:
+                return
+            ids = [r["interaction_id"] for r in rows]
+            self._delete_in_chunks("interactions_fts", "rowid", ids)
             if self._has_sqlite_vec:
-                self.conn.execute(
-                    f"DELETE FROM interactions_vec WHERE rowid IN ({placeholders})", ids
-                )
+                self._delete_in_chunks("interactions_vec", "rowid", ids)
             self.conn.execute("DELETE FROM interactions WHERE user_id = ?", (user_id,))
             self.conn.commit()
 
@@ -889,26 +876,18 @@ class ProfileMixin:
     def delete_oldest_interactions(self, count: int) -> int:
         if count <= 0:
             return 0
-        rows = self._fetchall(
-            "SELECT interaction_id FROM interactions ORDER BY created_at ASC LIMIT ?",
-            (count,),
-        )
-        if not rows:
-            return 0
-        ids = [r["interaction_id"] for r in rows]
-        placeholders = ",".join("?" for _ in ids)
         with self._lock:
-            self.conn.execute(
-                f"DELETE FROM interactions_fts WHERE rowid IN ({placeholders})", ids
-            )
+            rows = self.conn.execute(
+                "SELECT interaction_id FROM interactions ORDER BY created_at ASC LIMIT ?",
+                (count,),
+            ).fetchall()
+            if not rows:
+                return 0
+            ids = [r["interaction_id"] for r in rows]
+            self._delete_in_chunks("interactions_fts", "rowid", ids)
             if self._has_sqlite_vec:
-                self.conn.execute(
-                    f"DELETE FROM interactions_vec WHERE rowid IN ({placeholders})", ids
-                )
-            self.conn.execute(
-                f"DELETE FROM interactions WHERE interaction_id IN ({placeholders})",
-                ids,
-            )
+                self._delete_in_chunks("interactions_vec", "rowid", ids)
+            self._delete_in_chunks("interactions", "interaction_id", ids)
             self.conn.commit()
         return len(ids)
 

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -286,12 +286,24 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_profile(self, request: DeleteUserProfileRequest) -> None:
-        # Capture rowid before DELETE (needed for vec cleanup after commit).
+        # Atomic: fts + vec + row + lineage in ONE lock/commit to prevent rowid reuse
+        # race. profiles uses implicit (reusable) rowid keyed by TEXT PK — a cleanup
+        # running after commit could race with a concurrent INSERT reusing the freed
+        # rowid and delete the NEW profile's vec row. (#196)
         with self._lock:
             rowid_row = self.conn.execute(
                 "SELECT rowid FROM profiles WHERE user_id = ? AND profile_id = ?",
                 (request.user_id, request.profile_id),
             ).fetchone()
+            self.conn.execute(
+                "DELETE FROM profiles_fts WHERE profile_id = ?",
+                (request.profile_id,),
+            )
+            if self._has_sqlite_vec and rowid_row:
+                self.conn.execute(
+                    "DELETE FROM profiles_vec WHERE rowid = ?",
+                    (rowid_row["rowid"],),
+                )
             cur = self.conn.execute(
                 "DELETE FROM profiles WHERE user_id = ? AND profile_id = ?",
                 (request.user_id, request.profile_id),
@@ -304,23 +316,29 @@ class ProfileMixin:
                     request_id=uuid.uuid4().hex,
                 )
             self.conn.commit()
-        # Search cleanup runs after commit — index maintenance, not the audited fact.
-        self._fts_delete_profile(request.profile_id)
-        if rowid_row:
-            self._vec_delete("profiles_vec", rowid_row["rowid"])
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles_for_user(self, user_id: str) -> None:
+        # Atomic: fts + vec + row + lineage in ONE lock/commit — rowid reuse race
+        # prevention (see delete_user_profile comment, #196).
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            # Capture rowids before DELETE (vec cleanup needs them after commit).
             rows = self.conn.execute(
                 "SELECT rowid, profile_id FROM profiles WHERE user_id = ?", (user_id,)
             ).fetchall()
             if not rows:
                 return
             pids = [r["profile_id"] for r in rows]
-            rowids = {r["profile_id"]: r["rowid"] for r in rows}
+            rowids = [r["rowid"] for r in rows]
+            ph = ",".join("?" for _ in pids)
+            self.conn.execute(
+                f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})", pids
+            )
+            if self._has_sqlite_vec and rowids:
+                rph = ",".join("?" for _ in rowids)
+                self.conn.execute(
+                    f"DELETE FROM profiles_vec WHERE rowid IN ({rph})", rowids
+                )
             self.conn.execute("DELETE FROM profiles WHERE user_id = ?", (user_id,))
             for pid in pids:
                 _emit_hard_delete_profile(
@@ -330,13 +348,10 @@ class ProfileMixin:
                     request_id=batch_request_id,
                 )
             self.conn.commit()
-        # Search cleanup runs after commit — index maintenance, not the audited fact.
-        for pid in pids:
-            self._fts_delete_profile(pid)
-            self._vec_delete("profiles_vec", rowids[pid])
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles(self) -> None:
+        # Also wipe profiles_vec (full-wipe variant of the rowid-race fix, #196).
         batch_request_id = uuid.uuid4().hex
         with self._lock:
             pids = [
@@ -351,6 +366,8 @@ class ProfileMixin:
                     request_id=batch_request_id,
                 )
             self.conn.execute("DELETE FROM profiles_fts")
+            if self._has_sqlite_vec:
+                self.conn.execute("DELETE FROM profiles_vec")
             self.conn.execute("DELETE FROM profiles")
             self.conn.commit()
 
@@ -604,9 +621,10 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_profiles_by_status(self, status: Status) -> int:
+        # Atomic: fts + vec + row + lineage in ONE lock/commit — rowid reuse race
+        # prevention (see delete_user_profile comment, #196).
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            # Capture rowids before DELETE (vec cleanup needs them after commit).
             rows = self.conn.execute(
                 "SELECT rowid, profile_id FROM profiles WHERE status = ?",
                 (status.value,),
@@ -614,8 +632,16 @@ class ProfileMixin:
             if not rows:
                 return 0
             pids = [r["profile_id"] for r in rows]
-            rowids = {r["profile_id"]: r["rowid"] for r in rows}
+            rowids = [r["rowid"] for r in rows]
             ph = ",".join("?" for _ in pids)
+            self.conn.execute(
+                f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})", pids
+            )
+            if self._has_sqlite_vec and rowids:
+                rph = ",".join("?" for _ in rowids)
+                self.conn.execute(
+                    f"DELETE FROM profiles_vec WHERE rowid IN ({rph})", rowids
+                )
             cur = self.conn.execute(
                 f"DELETE FROM profiles WHERE profile_id IN ({ph})", pids
             )
@@ -627,10 +653,6 @@ class ProfileMixin:
                     request_id=batch_request_id,
                 )
             self.conn.commit()
-        # Search cleanup runs after commit — index maintenance, not the audited fact.
-        for pid in pids:
-            self._fts_delete_profile(pid)
-            self._vec_delete("profiles_vec", rowids[pid])
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
@@ -652,10 +674,11 @@ class ProfileMixin:
     ) -> int:
         if not profile_ids:
             return 0
+        # Atomic: fts + vec + row + lineage in ONE lock/commit — rowid reuse race
+        # prevention (see delete_user_profile comment, #196).
         ph = ",".join("?" for _ in profile_ids)
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            # Capture rowids before DELETE (vec cleanup needs them after commit).
             pre_rows = self.conn.execute(
                 f"SELECT rowid, profile_id FROM profiles WHERE profile_id IN ({ph})",
                 profile_ids,
@@ -663,7 +686,16 @@ class ProfileMixin:
             if not pre_rows:
                 return 0
             existing = [r["profile_id"] for r in pre_rows]
-            rowids = {r["profile_id"]: r["rowid"] for r in pre_rows}
+            rowids = [r["rowid"] for r in pre_rows]
+            eph = ",".join("?" for _ in existing)
+            self.conn.execute(
+                f"DELETE FROM profiles_fts WHERE profile_id IN ({eph})", existing
+            )
+            if self._has_sqlite_vec and rowids:
+                rph = ",".join("?" for _ in rowids)
+                self.conn.execute(
+                    f"DELETE FROM profiles_vec WHERE rowid IN ({rph})", rowids
+                )
             cur = self.conn.execute(
                 f"DELETE FROM profiles WHERE profile_id IN ({ph})", profile_ids
             )
@@ -677,10 +709,6 @@ class ProfileMixin:
                         actor="system",
                     )
             self.conn.commit()
-        # Search cleanup runs after commit — index maintenance, not the audited fact.
-        for pid in existing:
-            self._fts_delete_profile(pid)
-            self._vec_delete("profiles_vec", rowids[pid])
         return cur.rowcount
 
     # ------------------------------------------------------------------

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -805,29 +805,34 @@ class ProfileMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:
-        self._fts_delete("interactions_fts", request.interaction_id)
-        self._execute(
-            "DELETE FROM interactions WHERE user_id = ? AND interaction_id = ?",
-            (request.user_id, request.interaction_id),
-        )
+        with self._lock:
+            self.conn.execute(
+                "DELETE FROM interactions_fts WHERE rowid = ?",
+                (request.interaction_id,),
+            )
+            self.conn.execute(
+                "DELETE FROM interactions WHERE user_id = ? AND interaction_id = ?",
+                (request.user_id, request.interaction_id),
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_interactions_for_user(self, user_id: str) -> None:
-        # Delete FTS entries for this user's interactions
         ids = [
             r["interaction_id"]
             for r in self._fetchall(
                 "SELECT interaction_id FROM interactions WHERE user_id = ?", (user_id,)
             )
         ]
-        if ids:
-            placeholders = ",".join("?" for _ in ids)
-            with self._lock:
-                self.conn.execute(
-                    f"DELETE FROM interactions_fts WHERE rowid IN ({placeholders})", ids
-                )
-                self.conn.commit()
-        self._execute("DELETE FROM interactions WHERE user_id = ?", (user_id,))
+        if not ids:
+            return
+        placeholders = ",".join("?" for _ in ids)
+        with self._lock:
+            self.conn.execute(
+                f"DELETE FROM interactions_fts WHERE rowid IN ({placeholders})", ids
+            )
+            self.conn.execute("DELETE FROM interactions WHERE user_id = ?", (user_id,))
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_interactions(self) -> None:

--- a/reflexio/server/site_var/feature_flags.py
+++ b/reflexio/server/site_var/feature_flags.py
@@ -138,11 +138,16 @@ def _is_fail_closed_flag_enabled(org_id: str, feature_key: str) -> bool:
         )
         return False
 
-    if feature_config.get("enabled", False):
+    # Strict bool identity — truthy strings like "false" must not enable (#195).
+    enabled = feature_config.get("enabled", False)
+    if enabled is True:
         return True
 
-    enabled_org_ids = feature_config.get("enabled_org_ids", []) or []
-    return org_id in enabled_org_ids
+    # Reject non-list values — a string does substring `in` match, not membership (#195).
+    org_ids = feature_config.get("enabled_org_ids", [])
+    if not isinstance(org_ids, list):
+        return False
+    return org_id in org_ids
 
 
 def is_dedup_soft_delete_enabled(org_id: str) -> bool:

--- a/tests/server/services/storage/test_lineage_b3d_interactions_integration.py
+++ b/tests/server/services/storage/test_lineage_b3d_interactions_integration.py
@@ -1,0 +1,169 @@
+"""Integration tests for B3d: interaction delete fts+row atomicity (SQLite only).
+
+Both delete_user_interaction and delete_all_interactions_for_user previously called
+the self-committing _fts_delete helper BEFORE the interactions-row DELETE, leaving a
+crash window where the FTS entry was durably gone but the interaction row still existed.
+
+The fix rewrites both methods to do the FTS DELETE and the row DELETE inside a single
+`with self._lock:` block with one `conn.commit()`, mirroring the already-correct
+delete_all_interactions and delete_oldest_interactions siblings.
+
+These tests assert that after each method: the interaction row is gone AND its
+interactions_fts entry is also gone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    DeleteUserInteractionRequest,
+    Interaction,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path) -> SQLiteStorage:
+    s = SQLiteStorage(org_id="b3d-org", db_path=str(tmp_path / "b3d.db"))
+    s.migrate()
+    return s
+
+
+def _make_interaction(
+    user_id: str = "u1",
+    interaction_id: int = 1,
+    content: str = "content",
+    request_id: str = "req1",
+) -> Interaction:
+    import time
+
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id=user_id,
+        request_id=request_id,
+        content=content,
+        created_at=int(time.time()),
+    )
+
+
+def _fts_count(s: SQLiteStorage, interaction_id: int) -> int:
+    """Return the number of interactions_fts rows for a given interaction rowid."""
+    row = s.conn.execute(
+        "SELECT COUNT(*) AS cnt FROM interactions_fts WHERE rowid = ?",
+        (interaction_id,),
+    ).fetchone()
+    return row["cnt"] if row else 0
+
+
+def _interaction_row_count(s: SQLiteStorage, interaction_id: int) -> int:
+    """Return 1 if the interactions row exists, 0 otherwise."""
+    row = s.conn.execute(
+        "SELECT COUNT(*) AS cnt FROM interactions WHERE interaction_id = ?",
+        (interaction_id,),
+    ).fetchone()
+    return row["cnt"] if row else 0
+
+
+# ---------------------------------------------------------------------------
+# delete_user_interaction: row + FTS both cleaned atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserInteractionAtomicity:
+    def test_interaction_row_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 1, "click", "req1"))
+
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=1)
+        )
+
+        assert _interaction_row_count(s, 1) == 0
+
+    def test_fts_entry_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 2, "click", "req2"))
+        assert _fts_count(s, 2) == 1
+
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=2)
+        )
+
+        assert _fts_count(s, 2) == 0
+
+    def test_other_user_interaction_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 10, "a", "r10"))
+        s.add_user_interaction("u2", _make_interaction("u2", 11, "b", "r11"))
+
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=10)
+        )
+
+        assert _interaction_row_count(s, 10) == 0
+        assert _interaction_row_count(s, 11) == 1
+        assert _fts_count(s, 10) == 0
+        assert _fts_count(s, 11) == 1
+
+    def test_delete_nonexistent_interaction_is_noop(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        # Should not raise
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=999)
+        )
+        assert _interaction_row_count(s, 999) == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_all_interactions_for_user: rows + FTS both cleaned atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllInteractionsForUserAtomicity:
+    def test_interaction_rows_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 20, "a", "r20"))
+        s.add_user_interaction("u1", _make_interaction("u1", 21, "b", "r21"))
+
+        s.delete_all_interactions_for_user("u1")
+
+        assert _interaction_row_count(s, 20) == 0
+        assert _interaction_row_count(s, 21) == 0
+
+    def test_fts_entries_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 30, "a", "r30"))
+        s.add_user_interaction("u1", _make_interaction("u1", 31, "b", "r31"))
+        assert _fts_count(s, 30) == 1
+        assert _fts_count(s, 31) == 1
+
+        s.delete_all_interactions_for_user("u1")
+
+        assert _fts_count(s, 30) == 0
+        assert _fts_count(s, 31) == 0
+
+    def test_other_user_interactions_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 40, "a", "r40"))
+        s.add_user_interaction("u2", _make_interaction("u2", 41, "b", "r41"))
+
+        s.delete_all_interactions_for_user("u1")
+
+        assert _interaction_row_count(s, 40) == 0
+        assert _fts_count(s, 40) == 0
+        assert _interaction_row_count(s, 41) == 1
+        assert _fts_count(s, 41) == 1
+
+    def test_delete_all_interactions_for_user_no_interactions_is_noop(
+        self, tmp_path
+    ) -> None:
+        s = _store(tmp_path)
+        # Should not raise for a user with no interactions
+        s.delete_all_interactions_for_user("u_empty")

--- a/tests/server/services/storage/test_lineage_b3d_interactions_integration.py
+++ b/tests/server/services/storage/test_lineage_b3d_interactions_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for B3d: interaction delete fts+row atomicity (SQLite only).
+"""Integration tests for B3d: interaction delete fts+row+vec atomicity (SQLite only).
 
 Both delete_user_interaction and delete_all_interactions_for_user previously called
 the self-committing _fts_delete helper BEFORE the interactions-row DELETE, leaving a
@@ -8,8 +8,12 @@ The fix rewrites both methods to do the FTS DELETE and the row DELETE inside a s
 `with self._lock:` block with one `conn.commit()`, mirroring the already-correct
 delete_all_interactions and delete_oldest_interactions siblings.
 
+A follow-on fix (B3d vec) also adds interactions_vec cleanup to all four delete methods
+inside the same atomic block, closing the orphaned-vector leak.
+
 These tests assert that after each method: the interaction row is gone AND its
-interactions_fts entry is also gone.
+interactions_fts entry is also gone. When sqlite-vec is available, also assert that
+the interactions_vec entry is gone.
 """
 
 from __future__ import annotations
@@ -71,8 +75,19 @@ def _interaction_row_count(s: SQLiteStorage, interaction_id: int) -> int:
     return row["cnt"] if row else 0
 
 
+def _vec_count(s: SQLiteStorage, interaction_id: int) -> int:
+    """Return number of interactions_vec rows for a given rowid (0 when sqlite-vec absent)."""
+    if not s._has_sqlite_vec:
+        return 0
+    row = s.conn.execute(
+        "SELECT COUNT(*) AS cnt FROM interactions_vec WHERE rowid = ?",
+        (interaction_id,),
+    ).fetchone()
+    return row["cnt"] if row else 0
+
+
 # ---------------------------------------------------------------------------
-# delete_user_interaction: row + FTS both cleaned atomically
+# delete_user_interaction: row + FTS + vec all cleaned atomically
 # ---------------------------------------------------------------------------
 
 
@@ -98,6 +113,19 @@ class TestDeleteUserInteractionAtomicity:
 
         assert _fts_count(s, 2) == 0
 
+    def test_vec_entry_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 3, "click", "req3"))
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not available")
+        assert _vec_count(s, 3) == 1
+
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=3)
+        )
+
+        assert _vec_count(s, 3) == 0
+
     def test_other_user_interaction_untouched(self, tmp_path) -> None:
         s = _store(tmp_path)
         s.add_user_interaction("u1", _make_interaction("u1", 10, "a", "r10"))
@@ -111,6 +139,9 @@ class TestDeleteUserInteractionAtomicity:
         assert _interaction_row_count(s, 11) == 1
         assert _fts_count(s, 10) == 0
         assert _fts_count(s, 11) == 1
+        if s._has_sqlite_vec:
+            assert _vec_count(s, 10) == 0
+            assert _vec_count(s, 11) == 1
 
     def test_delete_nonexistent_interaction_is_noop(self, tmp_path) -> None:
         s = _store(tmp_path)
@@ -122,7 +153,7 @@ class TestDeleteUserInteractionAtomicity:
 
 
 # ---------------------------------------------------------------------------
-# delete_all_interactions_for_user: rows + FTS both cleaned atomically
+# delete_all_interactions_for_user: rows + FTS + vec all cleaned atomically
 # ---------------------------------------------------------------------------
 
 
@@ -149,6 +180,20 @@ class TestDeleteAllInteractionsForUserAtomicity:
         assert _fts_count(s, 30) == 0
         assert _fts_count(s, 31) == 0
 
+    def test_vec_entries_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 32, "a", "r32"))
+        s.add_user_interaction("u1", _make_interaction("u1", 33, "b", "r33"))
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not available")
+        assert _vec_count(s, 32) == 1
+        assert _vec_count(s, 33) == 1
+
+        s.delete_all_interactions_for_user("u1")
+
+        assert _vec_count(s, 32) == 0
+        assert _vec_count(s, 33) == 0
+
     def test_other_user_interactions_untouched(self, tmp_path) -> None:
         s = _store(tmp_path)
         s.add_user_interaction("u1", _make_interaction("u1", 40, "a", "r40"))
@@ -160,6 +205,9 @@ class TestDeleteAllInteractionsForUserAtomicity:
         assert _fts_count(s, 40) == 0
         assert _interaction_row_count(s, 41) == 1
         assert _fts_count(s, 41) == 1
+        if s._has_sqlite_vec:
+            assert _vec_count(s, 40) == 0
+            assert _vec_count(s, 41) == 1
 
     def test_delete_all_interactions_for_user_no_interactions_is_noop(
         self, tmp_path
@@ -167,3 +215,84 @@ class TestDeleteAllInteractionsForUserAtomicity:
         s = _store(tmp_path)
         # Should not raise for a user with no interactions
         s.delete_all_interactions_for_user("u_empty")
+
+
+# ---------------------------------------------------------------------------
+# delete_all_interactions: rows + FTS + vec all cleaned atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllInteractionsAtomicity:
+    def test_rows_fts_vec_all_gone_after_delete(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 50, "a", "r50"))
+        s.add_user_interaction("u2", _make_interaction("u2", 51, "b", "r51"))
+
+        s.delete_all_interactions()
+
+        assert _interaction_row_count(s, 50) == 0
+        assert _interaction_row_count(s, 51) == 0
+        assert _fts_count(s, 50) == 0
+        assert _fts_count(s, 51) == 0
+        if s._has_sqlite_vec:
+            assert _vec_count(s, 50) == 0
+            assert _vec_count(s, 51) == 0
+
+    def test_delete_all_interactions_no_rows_is_noop(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        # Should not raise when table is empty
+        s.delete_all_interactions()
+
+
+# ---------------------------------------------------------------------------
+# delete_oldest_interactions: rows + FTS + vec all cleaned atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteOldestInteractionsAtomicity:
+    def test_oldest_rows_fts_vec_gone_after_delete(self, tmp_path) -> None:
+        import time
+
+        s = _store(tmp_path)
+        # Insert two interactions with different created_at so ordering is deterministic
+        old = Interaction(
+            interaction_id=60,
+            user_id="u1",
+            request_id="r60",
+            content="old",
+            created_at=int(time.time()) - 100,
+        )
+        new = Interaction(
+            interaction_id=61,
+            user_id="u1",
+            request_id="r61",
+            content="new",
+            created_at=int(time.time()),
+        )
+        s.add_user_interaction("u1", old)
+        s.add_user_interaction("u1", new)
+
+        deleted = s.delete_oldest_interactions(1)
+
+        assert deleted == 1
+        assert _interaction_row_count(s, 60) == 0
+        assert _fts_count(s, 60) == 0
+        if s._has_sqlite_vec:
+            assert _vec_count(s, 60) == 0
+        # Newer interaction untouched
+        assert _interaction_row_count(s, 61) == 1
+        assert _fts_count(s, 61) == 1
+        if s._has_sqlite_vec:
+            assert _vec_count(s, 61) == 1
+
+    def test_delete_oldest_interactions_count_zero_is_noop(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u1", _make_interaction("u1", 70, "x", "r70"))
+        deleted = s.delete_oldest_interactions(0)
+        assert deleted == 0
+        assert _interaction_row_count(s, 70) == 1
+
+    def test_delete_oldest_interactions_empty_table_is_noop(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        deleted = s.delete_oldest_interactions(5)
+        assert deleted == 0

--- a/tests/server/services/storage/test_lineage_b3d_interactions_integration.py
+++ b/tests/server/services/storage/test_lineage_b3d_interactions_integration.py
@@ -296,3 +296,41 @@ class TestDeleteOldestInteractionsAtomicity:
         s = _store(tmp_path)
         deleted = s.delete_oldest_interactions(5)
         assert deleted == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_user_interaction: cross-user sidecar protection (Fix A)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserInteractionCrossUser:
+    """Fix A: u1 deleting u2's interaction_id leaves u2's row+fts+vec intact."""
+
+    def test_cross_user_row_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u2", _make_interaction("u2", 80, "b", "r80"))
+        # u1 tries to delete u2's interaction_id
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=80)
+        )
+        assert _interaction_row_count(s, 80) == 1
+
+    def test_cross_user_fts_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u2", _make_interaction("u2", 81, "b", "r81"))
+        assert _fts_count(s, 81) == 1
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=81)
+        )
+        assert _fts_count(s, 81) == 1
+
+    def test_cross_user_vec_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_interaction("u2", _make_interaction("u2", 82, "b", "r82"))
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not available")
+        assert _vec_count(s, 82) == 1
+        s.delete_user_interaction(
+            DeleteUserInteractionRequest(user_id="u1", interaction_id=82)
+        )
+        assert _vec_count(s, 82) == 1

--- a/tests/server/services/storage/test_lineage_b3f_profile_atomic_integration.py
+++ b/tests/server/services/storage/test_lineage_b3f_profile_atomic_integration.py
@@ -1,0 +1,308 @@
+"""Integration tests for B3f: atomic profile deletes (close rowid-reuse race, #196).
+
+B3c moved search cleanup to AFTER commit (outside the lock). This left a rowid-reuse
+race for profiles: profiles.profile_id is a TEXT PK backed by SQLite's IMPLICIT
+(reusable) rowid. In the window between commit and cleanup re-acquiring the lock, a
+concurrent INSERT can reuse the freed rowid. The cleanup then deletes the NEW profile's
+profiles_vec row.
+
+B3f fixes all 4 profile-delete methods and delete_all_profiles to perform
+fts + vec + row + lineage in ONE `with self._lock:` / single `conn.commit()`.
+No cleanup runs outside the lock. This mirrors the B3d interaction pattern.
+
+Also verifies delete_all_profiles now cleans profiles_vec (it leaked before B3f).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
+from reflexio.models.api_schema.service_schemas import (
+    DeleteUserProfileRequest,
+    UserProfile,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path) -> SQLiteStorage:
+    s = SQLiteStorage(org_id="b3f-org", db_path=str(tmp_path / "b3f.db"))
+    s.migrate()
+    return s
+
+
+def _make_profile(
+    user_id: str = "u1",
+    profile_id: str = "p1",
+    content: str = "content",
+    status: Status | None = None,
+) -> UserProfile:
+    from datetime import UTC, datetime
+
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+        status=status,
+    )
+
+
+def _fts_count(s: SQLiteStorage, profile_id: str) -> int:
+    row = s.conn.execute(
+        "SELECT COUNT(*) AS cnt FROM profiles_fts WHERE profile_id = ?", (profile_id,)
+    ).fetchone()
+    return row["cnt"] if row else 0
+
+
+def _vec_rowids(s: SQLiteStorage) -> set[int]:
+    return {
+        r["rowid"] for r in s.conn.execute("SELECT rowid FROM profiles_vec").fetchall()
+    }
+
+
+# ---------------------------------------------------------------------------
+# delete_user_profile: row + fts + vec removed atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserProfileAtomic:
+    """Row, FTS, and vec removed in one atomic block (no post-commit cleanup)."""
+
+    def test_row_and_fts_removed(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "a1")])
+        assert _fts_count(s, "a1") == 1
+
+        s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="a1"))
+
+        assert s.get_profile_by_id("a1") is None
+        assert _fts_count(s, "a1") == 0
+
+    def test_vec_removed_atomically(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not loaded")
+        s.add_user_profile("u1", [_make_profile("u1", "a2")])
+        rowid_row = s.conn.execute(
+            "SELECT rowid FROM profiles WHERE profile_id = ?", ("a2",)
+        ).fetchone()
+        assert rowid_row is not None
+        rowid = rowid_row["rowid"]
+        s._vec_upsert("profiles_vec", rowid, [0.1] * s.embedding_dimensions)
+        assert rowid in _vec_rowids(s)
+
+        s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="a2"))
+
+        # vec removed inside the lock before commit — no post-commit cleanup race
+        assert rowid not in _vec_rowids(s)
+
+    def test_hard_delete_event_emitted(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "a3")])
+        s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="a3"))
+        events = s.get_lineage_events(entity_id="a3")
+        assert any(e.op == "hard_delete" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# delete_all_profiles_for_user: all rows + fts + vec removed atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllProfilesForUserAtomic:
+    """All profile rows, FTS, and vec removed atomically for a user."""
+
+    def test_rows_and_fts_removed(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u2", [_make_profile("u2", "b1"), _make_profile("u2", "b2")])
+        assert _fts_count(s, "b1") == 1
+        assert _fts_count(s, "b2") == 1
+
+        s.delete_all_profiles_for_user("u2")
+
+        assert s.get_user_profile("u2") == []
+        assert _fts_count(s, "b1") == 0
+        assert _fts_count(s, "b2") == 0
+
+    def test_vec_removed_atomically(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not loaded")
+        s.add_user_profile("u2", [_make_profile("u2", "b3")])
+        rowid_row = s.conn.execute(
+            "SELECT rowid FROM profiles WHERE profile_id = ?", ("b3",)
+        ).fetchone()
+        assert rowid_row is not None
+        rowid = rowid_row["rowid"]
+        s._vec_upsert("profiles_vec", rowid, [0.1] * s.embedding_dimensions)
+        assert rowid in _vec_rowids(s)
+
+        s.delete_all_profiles_for_user("u2")
+
+        assert rowid not in _vec_rowids(s)
+
+    def test_hard_delete_events_emitted(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u2", [_make_profile("u2", "b4"), _make_profile("u2", "b5")])
+        s.delete_all_profiles_for_user("u2")
+        for pid in ["b4", "b5"]:
+            events = s.get_lineage_events(entity_id=pid)
+            assert any(e.op == "hard_delete" for e in events), (
+                f"no hard_delete for {pid}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# delete_all_profiles_by_status: rows + fts + vec removed atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllProfilesByStatusAtomic:
+    """Profiles with the given status are removed along with fts and vec atomically."""
+
+    def test_rows_and_fts_removed(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile(
+            "u1",
+            [
+                _make_profile("u1", "c1", status=Status.ARCHIVED),
+                _make_profile("u1", "c2", status=Status.ARCHIVED),
+            ],
+        )
+        assert _fts_count(s, "c1") == 1
+        assert _fts_count(s, "c2") == 1
+
+        deleted = s.delete_all_profiles_by_status(Status.ARCHIVED)
+
+        assert deleted == 2
+        assert _fts_count(s, "c1") == 0
+        assert _fts_count(s, "c2") == 0
+
+    def test_vec_removed_atomically(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not loaded")
+        s.add_user_profile("u1", [_make_profile("u1", "c3", status=Status.ARCHIVED)])
+        rowid_row = s.conn.execute(
+            "SELECT rowid FROM profiles WHERE profile_id = ?", ("c3",)
+        ).fetchone()
+        assert rowid_row is not None
+        rowid = rowid_row["rowid"]
+        s._vec_upsert("profiles_vec", rowid, [0.1] * s.embedding_dimensions)
+        assert rowid in _vec_rowids(s)
+
+        s.delete_all_profiles_by_status(Status.ARCHIVED)
+
+        assert rowid not in _vec_rowids(s)
+
+    def test_hard_delete_events_emitted(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "c4", status=Status.ARCHIVED)])
+        s.delete_all_profiles_by_status(Status.ARCHIVED)
+        events = s.get_lineage_events(entity_id="c4")
+        assert any(e.op == "hard_delete" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# delete_profiles_by_ids: rows + fts + vec removed atomically
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProfilesByIdsAtomic:
+    """Profiles by ID are removed along with fts and vec atomically."""
+
+    def test_rows_and_fts_removed(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "d1"), _make_profile("u1", "d2")])
+        assert _fts_count(s, "d1") == 1
+        assert _fts_count(s, "d2") == 1
+
+        deleted = s.delete_profiles_by_ids(["d1", "d2"])
+
+        assert deleted == 2
+        assert _fts_count(s, "d1") == 0
+        assert _fts_count(s, "d2") == 0
+
+    def test_vec_removed_atomically(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not loaded")
+        s.add_user_profile("u1", [_make_profile("u1", "d3")])
+        rowid_row = s.conn.execute(
+            "SELECT rowid FROM profiles WHERE profile_id = ?", ("d3",)
+        ).fetchone()
+        assert rowid_row is not None
+        rowid = rowid_row["rowid"]
+        s._vec_upsert("profiles_vec", rowid, [0.1] * s.embedding_dimensions)
+        assert rowid in _vec_rowids(s)
+
+        s.delete_profiles_by_ids(["d3"])
+
+        assert rowid not in _vec_rowids(s)
+
+    def test_hard_delete_event_emitted_actor_system(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "d4")])
+        s.delete_profiles_by_ids(["d4"])
+        events = [
+            e for e in s.get_lineage_events(entity_id="d4") if e.op == "hard_delete"
+        ]
+        assert len(events) == 1
+        assert events[0].actor == "system"
+
+    def test_emit_false_suppresses_event_and_cleans_fts(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "d5")])
+        assert _fts_count(s, "d5") == 1
+
+        s.delete_profiles_by_ids(["d5"], emit_hard_delete=False)
+
+        assert _fts_count(s, "d5") == 0
+        events = s.get_lineage_events(entity_id="d5")
+        assert not any(e.op == "hard_delete" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# delete_all_profiles: vec is now also wiped (previously leaked, #196)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAllProfilesVecWipe:
+    """delete_all_profiles wipes profiles_vec (was a leak before B3f)."""
+
+    def test_vec_wiped_on_delete_all(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not loaded")
+        s.add_user_profile("u1", [_make_profile("u1", "e1"), _make_profile("u1", "e2")])
+        # Manually plant vec rows to ensure they are present before wipe.
+        for pid in ["e1", "e2"]:
+            rowid_row = s.conn.execute(
+                "SELECT rowid FROM profiles WHERE profile_id = ?", (pid,)
+            ).fetchone()
+            assert rowid_row is not None
+            s._vec_upsert(
+                "profiles_vec", rowid_row["rowid"], [0.1] * s.embedding_dimensions
+            )
+        assert len(_vec_rowids(s)) >= 2
+
+        s.delete_all_profiles()
+
+        assert len(_vec_rowids(s)) == 0
+
+    def test_fts_and_rows_still_wiped(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u1", [_make_profile("u1", "e3")])
+        s.delete_all_profiles()
+        assert s.count_all_profiles() == 0
+        assert _fts_count(s, "e3") == 0

--- a/tests/server/services/storage/test_lineage_b3f_profile_atomic_integration.py
+++ b/tests/server/services/storage/test_lineage_b3f_profile_atomic_integration.py
@@ -306,3 +306,41 @@ class TestDeleteAllProfilesVecWipe:
         s.delete_all_profiles()
         assert s.count_all_profiles() == 0
         assert _fts_count(s, "e3") == 0
+
+
+# ---------------------------------------------------------------------------
+# delete_user_profile: cross-user sidecar protection (Fix A)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUserProfileCrossUser:
+    """Fix A: u1 deleting u2's profile_id leaves u2's row+fts+vec intact."""
+
+    def test_cross_user_row_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u2", [_make_profile("u2", "x1")])
+        s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="x1"))
+        assert s.get_profile_by_id("x1") is not None
+
+    def test_cross_user_fts_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        s.add_user_profile("u2", [_make_profile("u2", "x2")])
+        assert _fts_count(s, "x2") == 1
+        s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="x2"))
+        assert _fts_count(s, "x2") == 1
+
+    def test_cross_user_vec_untouched(self, tmp_path) -> None:
+        s = _store(tmp_path)
+        if not s._has_sqlite_vec:
+            pytest.skip("sqlite-vec not loaded")
+        s.add_user_profile("u2", [_make_profile("u2", "x3")])
+        rowid_row = s.conn.execute(
+            "SELECT rowid FROM profiles WHERE profile_id = ?", ("x3",)
+        ).fetchone()
+        assert rowid_row is not None
+        rowid = rowid_row["rowid"]
+        # Verify vec row exists
+        assert rowid in _vec_rowids(s)
+        s.delete_user_profile(DeleteUserProfileRequest(user_id="u1", profile_id="x3"))
+        # u2's vec row must still be there
+        assert rowid in _vec_rowids(s)

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -102,3 +102,90 @@ def test_retention_deletes_requests_before_orphaning_interactions(
     assert storage.get_request("req3") is not None
     remaining = storage.get_all_interactions(limit=10)
     assert {interaction.request_id for interaction in remaining} == {"req3"}
+
+
+def test_retention_interaction_delete_cleans_fts(storage: BaseStorage) -> None:
+    """After retaining interactions, their fts rows must also be gone."""
+    now = int(datetime.now(UTC).timestamp())
+    for i in range(1, 4):
+        storage.add_user_interaction("u1", _make_interaction(i, f"req{i}", now + i))
+
+    conn = storage.conn  # type: ignore[attr-defined]
+
+    # Verify fts rows exist before deletion.
+    fts_before = conn.execute(
+        "SELECT rowid FROM interactions_fts WHERE rowid IN (1, 2, 3)"
+    ).fetchall()
+    assert len(fts_before) == 3
+
+    deleted = storage.delete_oldest_retention_target_rows("interactions", 2)
+
+    assert deleted == 2
+    fts_after = conn.execute(
+        "SELECT rowid FROM interactions_fts WHERE rowid IN (1, 2)"
+    ).fetchall()
+    assert fts_after == [], "fts rows for deleted interactions must be gone"
+    fts_kept = conn.execute(
+        "SELECT rowid FROM interactions_fts WHERE rowid = 3"
+    ).fetchall()
+    assert len(fts_kept) == 1, "fts row for retained interaction must remain"
+
+
+def test_retention_profile_delete_cleans_fts(storage: BaseStorage) -> None:
+    """After retaining profiles, their fts rows must also be gone."""
+    storage.add_user_profile("u1", [_make_profile("p1")])
+    storage.add_user_profile("u1", [_make_profile("p2")])
+    storage.add_user_profile("u1", [_make_profile("p3")])
+    conn = storage.conn  # type: ignore[attr-defined]
+    conn.execute("UPDATE profiles SET created_at = ? WHERE profile_id = ?", ("1", "p1"))
+    conn.execute("UPDATE profiles SET created_at = ? WHERE profile_id = ?", ("2", "p2"))
+    conn.execute("UPDATE profiles SET created_at = ? WHERE profile_id = ?", ("3", "p3"))
+    conn.commit()
+
+    # Verify fts rows exist before deletion.
+    fts_before = conn.execute(
+        "SELECT profile_id FROM profiles_fts WHERE profile_id IN ('p1', 'p2', 'p3')"
+    ).fetchall()
+    assert len(fts_before) == 3
+
+    deleted = storage.delete_oldest_retention_target_rows("profiles", 2)
+
+    assert deleted == 2
+    fts_after = conn.execute(
+        "SELECT profile_id FROM profiles_fts WHERE profile_id IN ('p1', 'p2')"
+    ).fetchall()
+    assert fts_after == [], "fts rows for deleted profiles must be gone"
+    fts_kept = conn.execute(
+        "SELECT profile_id FROM profiles_fts WHERE profile_id = 'p3'"
+    ).fetchall()
+    assert len(fts_kept) == 1, "fts row for retained profile must remain"
+
+
+def test_retention_request_cascade_cleans_interaction_fts(
+    storage: BaseStorage,
+) -> None:
+    """Request-cascade delete must also remove interaction fts rows."""
+    now = int(datetime.now(UTC).timestamp())
+    for i in range(1, 4):
+        request_id = f"req{i}"
+        storage.add_request(_make_request(request_id, now + i))
+        storage.add_user_interaction("u1", _make_interaction(i, request_id, now + i))
+
+    conn = storage.conn  # type: ignore[attr-defined]
+    fts_before = conn.execute(
+        "SELECT rowid FROM interactions_fts WHERE rowid IN (1, 2, 3)"
+    ).fetchall()
+    assert len(fts_before) == 3
+
+    deleted = storage.delete_oldest_retention_target_rows("requests", 2)
+
+    assert deleted == 2
+    # Interactions 1 and 2 were cascaded; their fts rows must be gone.
+    fts_after = conn.execute(
+        "SELECT rowid FROM interactions_fts WHERE rowid IN (1, 2)"
+    ).fetchall()
+    assert fts_after == [], "fts rows for cascaded interactions must be gone"
+    fts_kept = conn.execute(
+        "SELECT rowid FROM interactions_fts WHERE rowid = 3"
+    ).fetchall()
+    assert len(fts_kept) == 1, "fts row for surviving interaction must remain"

--- a/tests/server/site_var/test_feature_flags.py
+++ b/tests/server/site_var/test_feature_flags.py
@@ -439,5 +439,99 @@ class TestFailClosedFlagMalformedConfig(unittest.TestCase):
         self.assertFalse(is_aggregation_soft_delete_enabled("org-any"))
 
 
+class TestFailClosedFlagStrictBoolValidation(unittest.TestCase):
+    """#195: strict enabled is True — truthy strings and non-bool ints must not enable.
+
+    CodeRabbit finding: `if feature_config.get("enabled", False):` accepts any truthy
+    value including the string "false". Fix: `if enabled is True:` (strict identity).
+    """
+
+    # --- is_dedup_soft_delete_enabled ---
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={"dedup_soft_delete": {"enabled": "false", "enabled_org_ids": []}},
+    )
+    def test_dedup_string_false_returns_false(self, _mock):
+        """enabled='false' (string) must not enable — truthy string previously bypassed guard."""
+        self.assertFalse(is_dedup_soft_delete_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={"dedup_soft_delete": {"enabled": "true", "enabled_org_ids": []}},
+    )
+    def test_dedup_string_true_returns_false(self, _mock):
+        """enabled='true' (string) is not bool True — must return False."""
+        self.assertFalse(is_dedup_soft_delete_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={"dedup_soft_delete": {"enabled": 1, "enabled_org_ids": []}},
+    )
+    def test_dedup_int_one_returns_false(self, _mock):
+        """enabled=1 (int) is not bool True — strict identity check must reject it."""
+        self.assertFalse(is_dedup_soft_delete_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "dedup_soft_delete": {
+                "enabled": False,
+                "enabled_org_ids": "org-pilot",
+            }
+        },
+    )
+    def test_dedup_string_org_ids_substring_org_pilot_returns_false(self, _mock):
+        """enabled_org_ids='org-pilot' (string) must not match 'org-pilot' via in-string (#195)."""
+        self.assertFalse(is_dedup_soft_delete_enabled("org-pilot"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "dedup_soft_delete": {
+                "enabled": False,
+                "enabled_org_ids": "org-pilot",
+            }
+        },
+    )
+    def test_dedup_string_org_ids_substring_pilot_returns_false(self, _mock):
+        """enabled_org_ids='org-pilot' (string) must not match substring 'pilot' (#195)."""
+        self.assertFalse(is_dedup_soft_delete_enabled("pilot"))
+
+    # --- is_aggregation_soft_delete_enabled ---
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "aggregation_soft_delete": {"enabled": "false", "enabled_org_ids": []}
+        },
+    )
+    def test_aggregation_string_false_returns_false(self, _mock):
+        """enabled='false' (string) must not enable aggregation soft-delete."""
+        self.assertFalse(is_aggregation_soft_delete_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={"aggregation_soft_delete": {"enabled": 1, "enabled_org_ids": []}},
+    )
+    def test_aggregation_int_one_returns_false(self, _mock):
+        """enabled=1 (int) must not enable aggregation soft-delete."""
+        self.assertFalse(is_aggregation_soft_delete_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "aggregation_soft_delete": {
+                "enabled": False,
+                "enabled_org_ids": "org-pilot",
+            }
+        },
+    )
+    def test_aggregation_string_org_ids_returns_false(self, _mock):
+        """enabled_org_ids='org-pilot' (string) must not match 'org-pilot' or 'pilot'."""
+        self.assertFalse(is_aggregation_soft_delete_enabled("org-pilot"))
+        self.assertFalse(is_aggregation_soft_delete_enabled("pilot"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Lineage B3d/B3e/B3f (OSS) — delete-path atomicity + CodeRabbit follow-ups from #195/#196

OSS/SQLite hardening from the B3b review-loop. Interactions/profiles emit no audit events for the search-index parts; the lineage emit on profile hard-deletes is preserved (audit-only-on-commit). Enterprise/Postgres deletes are transactional and unaffected.

### B3d — interaction public deletes (`sqlite_storage/_profiles.py`)
The 4 interaction-delete methods now clean `interactions_fts` + `interactions_vec` + the row in one atomic `with self._lock:`/single commit (raw DELETEs, vec guarded on `_has_sqlite_vec`). Closes a crash-window search-index drift AND an `interactions_vec` orphaned-vector leak (vec was never cleaned on delete).

### B3e — retention cascade (`sqlite_storage/_base.py`)
`_delete_interaction_search_rows` and `_delete_profile_search_rows` no longer self-commit (raw non-committing `_delete_in_chunks`), so the retention critical section (`_retention_perform_delete`) is truly atomic. `_delete_playbook_search_rows` left untouched (dual-use; 8 after-commit callers rely on its self-commit) — tracked follow-up.

### B3f — CodeRabbit findings that merged unaddressed in #195/#196
- **#196 (Major) — rowid-reuse race:** B3c cleaned profiles_fts/vec AFTER commit/outside the lock; `profiles` uses an implicit reusable rowid, so a concurrent insert could reuse it and the cleanup would delete the new row's vec entry. The 4 profile delete methods are now atomic (fts+vec+row+emit in one lock+commit, raw deletes) — race closed. Added the missing `profiles_vec` wipe to `delete_all_profiles`. (Playbooks/interactions are AUTOINCREMENT → no reuse → not affected.)
- **#195 (Major) — fail-closed validation:** `_is_fail_closed_flag_enabled` now uses `enabled is True` (strict; `{"enabled":"false"}`/`{"enabled":1}` no longer enable) and `isinstance(enabled_org_ids, list)` (a string no longer substring-matches). The fail-OPEN `is_feature_enabled` is intentionally unchanged.

### Tests
B3d (15) + B3e retention (3) + B3f profile-atomic (16) + flag strict-validation (9) + existing suites — all green (495 storage + flag tests). Vec assertions skip when sqlite-vec is unavailable (CI-env limitation).

### Process note
#195/#196 were merged before fully triaging CodeRabbit; B3f closes the two valid Major comments that slipped. The dual-use `_delete_playbook_search_rows` retention atomicity is the one remaining tracked item.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleted profiles and interactions are now reliably removed from search indexes and embeddings, preventing deleted items from appearing in search results.
  * Improved cleanup of historical data during retention operations to prevent orphaned search index entries.

* **Tests**
  * Added comprehensive integration tests validating atomic deletion of profiles and interactions with search index cleanup.
  * Enhanced feature flag validation tests for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->