### PR TITLE
Lineage Phase B3h (OSS) — retention + playbook-delete atomicity (final delete-path sweep)

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -737,9 +737,13 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         # Wrap dependency + target deletes in a single critical section so
         # concurrent writers see either both or neither.
         with self._lock:
-            self._retention_delete_dependencies(target, keys)
-            self._retention_delete_target_rows(target, keys)
-            self.conn.commit()
+            try:
+                self._retention_delete_dependencies(target, keys)
+                self._retention_delete_target_rows(target, keys)
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     def _retention_delete_dependencies(
         self, target: RetentionTarget, keys: list[tuple[Any, ...]]

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -879,6 +879,11 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 cleanup.  Pass ``commit=False`` from inside the retention atomic
                 block so the deletes participate in the single block-level commit
                 (``_retention_perform_delete``).
+
+        Note: callers may already hold ``self._lock`` when calling this (the
+        ``commit=False`` retention/atomic-delete call sites do). The internal
+        ``with self._lock:`` re-acquire is safe ONLY because ``self._lock`` is a
+        reentrant ``threading.RLock``; a non-reentrant lock would deadlock here.
         """
         if not ids:
             return

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -754,10 +754,14 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             self._delete_profile_search_rows([str(v) for v in ids])
         elif target_name == "user_playbooks":
             self._delete_source_windows_for_user_playbook_ids([int(v) for v in ids])
-            self._delete_playbook_search_rows("user", [int(v) for v in ids])
+            self._delete_playbook_search_rows(
+                "user", [int(v) for v in ids], commit=False
+            )
         elif target_name == "agent_playbooks":
             self._delete_source_windows_for_agent_playbook_ids([int(v) for v in ids])
-            self._delete_playbook_search_rows("agent", [int(v) for v in ids])
+            self._delete_playbook_search_rows(
+                "agent", [int(v) for v in ids], commit=False
+            )
         elif target_name == "playbook_optimization_jobs":
             self._delete_optimizer_rows_for_job_ids([int(v) for v in ids])
         elif target_name == "playbook_optimization_candidates":
@@ -862,12 +866,28 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             if rowids:
                 self._delete_in_chunks("profiles_vec", "rowid", rowids)
 
-    def _delete_playbook_search_rows(self, kind: str, ids: list[int]) -> None:
+    def _delete_playbook_search_rows(
+        self, kind: str, ids: list[int], *, commit: bool = True
+    ) -> None:
+        """Remove fts + vec index rows for the given playbook IDs.
+
+        Args:
+            kind: ``"user"`` or ``"agent"``.
+            ids: Playbook row IDs to remove from the search indexes.
+            commit: When ``True`` (default) commits after the deletes so the
+                after-commit callers in ``_playbook.py`` get a clean, durable
+                cleanup.  Pass ``commit=False`` from inside the retention atomic
+                block so the deletes participate in the single block-level commit
+                (``_retention_perform_delete``).
+        """
         if not ids:
             return
-        self._delete_in_chunks(f"{kind}_playbooks_fts", "rowid", ids)
-        for item_id in ids:
-            self._vec_delete(f"{kind}_playbooks_vec", item_id)
+        with self._lock:
+            self._delete_in_chunks(f"{kind}_playbooks_fts", "rowid", ids)
+            if self._has_sqlite_vec:
+                self._delete_in_chunks(f"{kind}_playbooks_vec", "rowid", ids)
+            if commit:
+                self.conn.commit()
 
     def _delete_source_windows_for_agent_playbook_ids(
         self, agent_playbook_ids: list[int]

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -525,12 +525,17 @@ class PlaybookMixin:
             ids = [
                 r["user_playbook_id"]
                 for r in self.conn.execute(
-                    f"SELECT user_playbook_id FROM user_playbooks WHERE {where}", params
+                    f"SELECT user_playbook_id FROM user_playbooks WHERE {where}",
+                    params,  # noqa: S608
                 ).fetchall()
             ]
             if not ids:
                 return 0
-            cur = self.conn.execute(f"DELETE FROM user_playbooks WHERE {where}", params)
+            ph = ",".join("?" for _ in ids)
+            cur = self.conn.execute(
+                f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",  # noqa: S608
+                ids,
+            )
             self._delete_playbook_search_rows("user", ids, commit=False)
             self.conn.commit()
         return cur.rowcount

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -357,8 +357,6 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_user_playbook(self, user_playbook_id: int) -> None:
         with self._lock:
-            self._fts_delete("user_playbooks_fts", user_playbook_id)
-            self._vec_delete("user_playbooks_vec", user_playbook_id)
             cur = self.conn.execute(
                 "DELETE FROM user_playbooks WHERE user_playbook_id = ?",
                 (user_playbook_id,),
@@ -371,6 +369,7 @@ class PlaybookMixin:
                     entity_id=str(user_playbook_id),
                     request_id=uuid.uuid4().hex,
                 )
+            self._delete_playbook_search_rows("user", [user_playbook_id], commit=False)
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
@@ -522,19 +521,18 @@ class PlaybookMixin:
             where += " AND playbook_name = ?"
             params.append(playbook_name)
 
-        # Clean up FTS + vec
-        ids = [
-            r["user_playbook_id"]
-            for r in self._fetchall(
-                f"SELECT user_playbook_id FROM user_playbooks WHERE {where}", params
-            )
-        ]
-        if ids:
-            with self._lock:
-                self._delete_playbook_search_rows("user", ids)
-                self.conn.commit()
-
-        cur = self._execute(f"DELETE FROM user_playbooks WHERE {where}", params)
+        with self._lock:
+            ids = [
+                r["user_playbook_id"]
+                for r in self.conn.execute(
+                    f"SELECT user_playbook_id FROM user_playbooks WHERE {where}", params
+                ).fetchall()
+            ]
+            if not ids:
+                return 0
+            cur = self.conn.execute(f"DELETE FROM user_playbooks WHERE {where}", params)
+            self._delete_playbook_search_rows("user", ids, commit=False)
+            self.conn.commit()
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
@@ -891,8 +889,6 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_playbook(self, agent_playbook_id: int) -> None:
         with self._lock:
-            self._fts_delete("agent_playbooks_fts", agent_playbook_id)
-            self._vec_delete("agent_playbooks_vec", agent_playbook_id)
             cur = self.conn.execute(
                 "DELETE FROM agent_playbooks WHERE agent_playbook_id = ?",
                 (agent_playbook_id,),
@@ -905,6 +901,9 @@ class PlaybookMixin:
                     entity_id=str(agent_playbook_id),
                     request_id=uuid.uuid4().hex,
                 )
+            self._delete_playbook_search_rows(
+                "agent", [agent_playbook_id], commit=False
+            )
             self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions

--- a/tests/server/services/storage/test_retention_rollback_integration.py
+++ b/tests/server/services/storage/test_retention_rollback_integration.py
@@ -1,0 +1,123 @@
+"""Integration test: _retention_perform_delete rolls back on failure.
+
+Verifies that if any step inside the retention critical section raises, the
+whole transaction is rolled back and no partial writes are committed.
+"""
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+from reflexio.server.services.storage.error import StorageError
+from reflexio.server.services.storage.retention import RETENTION_TARGETS_BY_NAME
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+_USER_PLAYBOOKS_TARGET = RETENTION_TARGETS_BY_NAME["user_playbooks"]
+
+
+def _store(tmp_path) -> SQLiteStorage:
+    s = SQLiteStorage(org_id="org-rollback", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+    return s
+
+
+def _make_user_playbook(uid: int) -> UserPlaybook:
+    return UserPlaybook(
+        user_playbook_id=uid,
+        user_id="u1",
+        playbook_name="pb",
+        agent_version="v1",
+        request_id=f"req-{uid}",
+        content=f"content-{uid}",
+        created_at=uid,
+        source="test",
+        source_interaction_ids=[],
+    )
+
+
+def test_retention_perform_delete_rolls_back_on_target_row_failure(
+    tmp_path, monkeypatch
+) -> None:
+    """If _retention_delete_target_rows raises, no dependency deletes are committed."""
+    s = _store(tmp_path)
+    s.save_user_playbooks([_make_user_playbook(1), _make_user_playbook(2)])
+
+    conn = s.conn
+    saved = conn.execute(
+        "SELECT user_playbook_id FROM user_playbooks ORDER BY user_playbook_id"
+    ).fetchall()
+    assert len(saved) == 2
+    saved_ids = [r["user_playbook_id"] for r in saved]
+
+    # Assign ordered created_at so deletion targets are deterministic.
+    for i, upid in enumerate(saved_ids, start=1):
+        conn.execute(
+            "UPDATE user_playbooks SET created_at = ? WHERE user_playbook_id = ?",
+            (i, upid),
+        )
+    conn.commit()
+
+    # Verify FTS rows exist before the attempted retention delete.
+    ph = ",".join("?" for _ in saved_ids)
+    fts_before = conn.execute(
+        f"SELECT rowid FROM user_playbooks_fts WHERE rowid IN ({ph})",  # noqa: S608
+        saved_ids,
+    ).fetchall()
+    assert len(fts_before) == 2
+
+    # Force the target-row delete to fail.
+    def _fail(*args, **kwargs):
+        raise RuntimeError("injected failure")
+
+    monkeypatch.setattr(s, "_retention_delete_target_rows", _fail)
+
+    keys = s._retention_select_oldest_keys(_USER_PLAYBOOKS_TARGET, 1)  # type: ignore[attr-defined]
+
+    with pytest.raises(StorageError, match="injected failure"):
+        s._retention_perform_delete(_USER_PLAYBOOKS_TARGET, keys)  # type: ignore[attr-defined]
+
+    # After the rollback, the user_playbooks rows must be untouched.
+    rows_after = conn.execute(
+        f"SELECT user_playbook_id FROM user_playbooks WHERE user_playbook_id IN ({ph})",  # noqa: S608
+        saved_ids,
+    ).fetchall()
+    assert len(rows_after) == 2, "rollback must leave all rows intact"
+
+    # FTS rows must also be intact (dependency deletes were rolled back).
+    fts_after = conn.execute(
+        f"SELECT rowid FROM user_playbooks_fts WHERE rowid IN ({ph})",  # noqa: S608
+        saved_ids,
+    ).fetchall()
+    assert len(fts_after) == 2, "rollback must leave all FTS rows intact"
+
+
+def test_retention_perform_delete_rolls_back_on_dependency_failure(
+    tmp_path, monkeypatch
+) -> None:
+    """If _retention_delete_dependencies raises, the target row delete is not committed."""
+    s = _store(tmp_path)
+    s.save_user_playbooks([_make_user_playbook(1)])
+
+    conn = s.conn
+    saved = conn.execute("SELECT user_playbook_id FROM user_playbooks").fetchall()
+    assert len(saved) == 1
+    upid = saved[0]["user_playbook_id"]
+
+    # Force the dependency delete to fail.
+    def _fail(*args, **kwargs):
+        raise RuntimeError("injected dep failure")
+
+    monkeypatch.setattr(s, "_retention_delete_dependencies", _fail)
+
+    keys = s._retention_select_oldest_keys(_USER_PLAYBOOKS_TARGET, 1)  # type: ignore[attr-defined]
+
+    with pytest.raises(StorageError, match="injected dep failure"):
+        s._retention_perform_delete(_USER_PLAYBOOKS_TARGET, keys)  # type: ignore[attr-defined]
+
+    # The user_playbooks row must still be present after rollback.
+    row_after = conn.execute(
+        "SELECT user_playbook_id FROM user_playbooks WHERE user_playbook_id = ?",
+        (upid,),
+    ).fetchone()
+    assert row_after is not None, "rollback must leave the target row intact"

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -320,3 +320,89 @@ def test_retention_agent_playbook_delete_cleans_fts(storage: BaseStorage) -> Non
         "SELECT rowid FROM agent_playbooks_fts WHERE rowid = ?", (kept_id,)
     ).fetchall()
     assert len(fts_kept) == 1, "fts row for surviving agent_playbook must remain"
+
+
+# ---------------------------------------------------------------------------
+# delete_all_user_playbooks_by_status — atomicity + FTS/vec cleanup (B3h Fix 1)
+# ---------------------------------------------------------------------------
+
+
+def test_delete_all_user_playbooks_by_status_cleans_search_rows(
+    storage: BaseStorage,
+) -> None:
+    """delete_all_user_playbooks_by_status must remove both the playbook rows and
+    their FTS (and vec when sqlite-vec is available) entries atomically.
+    A non-matching playbook's row and FTS entry must survive.
+    """
+    from reflexio.models.api_schema.service_schemas import Status
+
+    # Two ARCHIVED playbooks (to be deleted) + one active (no status) that must survive.
+    archived_pb = _make_user_playbook(1)
+    archived_pb2 = _make_user_playbook(2)
+    surviving_pb = _make_user_playbook(3)
+
+    storage.save_user_playbooks([archived_pb, archived_pb2, surviving_pb])
+
+    conn = storage.conn  # type: ignore[attr-defined]
+
+    # Retrieve auto-assigned IDs.
+    all_rows = conn.execute(
+        "SELECT user_playbook_id FROM user_playbooks ORDER BY user_playbook_id"
+    ).fetchall()
+    assert len(all_rows) == 3
+    saved_ids = [r["user_playbook_id"] for r in all_rows]
+    archived_id1, archived_id2, surviving_id = saved_ids
+
+    # Mark first two as ARCHIVED; leave the third with no status (active).
+    conn.execute(
+        "UPDATE user_playbooks SET status = ? WHERE user_playbook_id IN (?, ?)",
+        (Status.ARCHIVED.value, archived_id1, archived_id2),
+    )
+    conn.commit()
+
+    # Confirm FTS rows exist for all three before deletion.
+    ph3 = ",".join("?" for _ in saved_ids)
+    fts_before = conn.execute(
+        f"SELECT rowid FROM user_playbooks_fts WHERE rowid IN ({ph3})",  # noqa: S608
+        saved_ids,
+    ).fetchall()
+    assert len(fts_before) == 3, "all three fts rows must exist before delete"
+
+    deleted = storage.delete_all_user_playbooks_by_status(Status.ARCHIVED)
+
+    assert deleted == 2
+
+    # Playbook rows for deleted IDs must be gone.
+    rows_after = conn.execute("SELECT user_playbook_id FROM user_playbooks").fetchall()
+    remaining_ids = {r["user_playbook_id"] for r in rows_after}
+    assert archived_id1 not in remaining_ids
+    assert archived_id2 not in remaining_ids
+    assert surviving_id in remaining_ids
+
+    # FTS rows for deleted playbooks must be gone.
+    fts_deleted = conn.execute(
+        "SELECT rowid FROM user_playbooks_fts WHERE rowid IN (?, ?)",
+        (archived_id1, archived_id2),
+    ).fetchall()
+    assert fts_deleted == [], "fts rows for deleted playbooks must be gone"
+
+    # FTS row for the surviving playbook must remain.
+    fts_kept = conn.execute(
+        "SELECT rowid FROM user_playbooks_fts WHERE rowid = ?", (surviving_id,)
+    ).fetchall()
+    assert len(fts_kept) == 1, "fts row for surviving playbook must remain"
+
+    # Vec rows for deleted playbooks must be gone (when sqlite-vec is available).
+    has_vec = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='user_playbooks_vec'"
+    ).fetchone()
+    if has_vec:
+        vec_deleted = conn.execute(
+            "SELECT rowid FROM user_playbooks_vec WHERE rowid IN (?, ?)",
+            (archived_id1, archived_id2),
+        ).fetchall()
+        assert vec_deleted == [], "vec rows for deleted playbooks must be gone"
+        vec_kept = conn.execute(
+            "SELECT rowid FROM user_playbooks_vec WHERE rowid = ?", (surviving_id,)
+        ).fetchall()
+        assert len(vec_kept) == 1, "vec row for surviving playbook must remain"

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -5,10 +5,12 @@ from datetime import UTC, datetime
 import pytest
 
 from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
     Interaction,
     ProfileTimeToLive,
     Request,
     UserActionType,
+    UserPlaybook,
     UserProfile,
 )
 from reflexio.server.services.storage.storage_base import BaseStorage
@@ -189,3 +191,132 @@ def test_retention_request_cascade_cleans_interaction_fts(
         "SELECT rowid FROM interactions_fts WHERE rowid = 3"
     ).fetchall()
     assert len(fts_kept) == 1, "fts row for surviving interaction must remain"
+
+
+# ---------------------------------------------------------------------------
+# Playbook retention FTS + vec cleanup (B3h)
+# ---------------------------------------------------------------------------
+
+
+def _make_user_playbook(user_playbook_id: int) -> UserPlaybook:
+    return UserPlaybook(
+        user_playbook_id=user_playbook_id,
+        user_id="u1",
+        playbook_name="pb",
+        agent_version="v1",
+        request_id=f"req-{user_playbook_id}",
+        content=f"content-{user_playbook_id}",
+        created_at=user_playbook_id,
+        source="test",
+        source_interaction_ids=[],
+    )
+
+
+def _make_agent_playbook(agent_playbook_id: int) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=agent_playbook_id,
+        playbook_name="pb",
+        agent_version="v1",
+        content=f"content-{agent_playbook_id}",
+        created_at=agent_playbook_id,
+    )
+
+
+def test_retention_user_playbook_delete_cleans_fts(storage: BaseStorage) -> None:
+    """After retention-deleting user_playbooks, their fts rows must be gone."""
+    storage.save_user_playbooks(
+        [_make_user_playbook(1), _make_user_playbook(2), _make_user_playbook(3)]
+    )
+    conn = storage.conn  # type: ignore[attr-defined]
+
+    saved = conn.execute(
+        "SELECT user_playbook_id FROM user_playbooks ORDER BY user_playbook_id"
+    ).fetchall()
+    assert len(saved) == 3
+    saved_ids = [r["user_playbook_id"] for r in saved]
+
+    # Assign distinct created_at values so deletion order is deterministic.
+    for i, upid in enumerate(saved_ids, start=1):
+        conn.execute(
+            "UPDATE user_playbooks SET created_at = ? WHERE user_playbook_id = ?",
+            (i, upid),
+        )
+    conn.commit()
+
+    ph3 = ",".join("?" for _ in saved_ids)
+    fts_before = conn.execute(
+        f"SELECT rowid FROM user_playbooks_fts WHERE rowid IN ({ph3})",  # noqa: S608
+        saved_ids,
+    ).fetchall()
+    assert len(fts_before) == 3, "fts rows must exist before retention delete"
+
+    deleted = storage.delete_oldest_retention_target_rows("user_playbooks", 2)
+
+    assert deleted == 2
+
+    # The two oldest entries' fts rows must be gone.
+    oldest_ids = saved_ids[:2]
+    ph2 = ",".join("?" for _ in oldest_ids)
+    fts_after = conn.execute(
+        f"SELECT rowid FROM user_playbooks_fts WHERE rowid IN ({ph2})",  # noqa: S608
+        oldest_ids,
+    ).fetchall()
+    assert fts_after == [], "fts rows for retention-deleted user_playbooks must be gone"
+
+    # The surviving entry's fts row must remain.
+    kept_id = saved_ids[2]
+    fts_kept = conn.execute(
+        "SELECT rowid FROM user_playbooks_fts WHERE rowid = ?", (kept_id,)
+    ).fetchall()
+    assert len(fts_kept) == 1, "fts row for surviving user_playbook must remain"
+
+
+def test_retention_agent_playbook_delete_cleans_fts(storage: BaseStorage) -> None:
+    """After retention-deleting agent_playbooks, their fts rows must be gone."""
+    storage.save_agent_playbooks(
+        [_make_agent_playbook(1), _make_agent_playbook(2), _make_agent_playbook(3)]
+    )
+    conn = storage.conn  # type: ignore[attr-defined]
+
+    saved = conn.execute(
+        "SELECT agent_playbook_id FROM agent_playbooks ORDER BY agent_playbook_id"
+    ).fetchall()
+    assert len(saved) == 3
+    saved_ids = [r["agent_playbook_id"] for r in saved]
+
+    # Assign distinct created_at values so deletion order is deterministic.
+    for i, apid in enumerate(saved_ids, start=1):
+        conn.execute(
+            "UPDATE agent_playbooks SET created_at = ? WHERE agent_playbook_id = ?",
+            (i, apid),
+        )
+    conn.commit()
+
+    ph3 = ",".join("?" for _ in saved_ids)
+    fts_before = conn.execute(
+        f"SELECT rowid FROM agent_playbooks_fts WHERE rowid IN ({ph3})",  # noqa: S608
+        saved_ids,
+    ).fetchall()
+    assert len(fts_before) == 3, "fts rows must exist before retention delete"
+
+    deleted = storage.delete_oldest_retention_target_rows("agent_playbooks", 2)
+
+    assert deleted == 2
+
+    # The two oldest entries' fts rows must be gone.
+    oldest_ids = saved_ids[:2]
+    ph2 = ",".join("?" for _ in oldest_ids)
+    fts_after = conn.execute(
+        f"SELECT rowid FROM agent_playbooks_fts WHERE rowid IN ({ph2})",  # noqa: S608
+        oldest_ids,
+    ).fetchall()
+    assert fts_after == [], (
+        "fts rows for retention-deleted agent_playbooks must be gone"
+    )
+
+    # The surviving entry's fts row must remain.
+    kept_id = saved_ids[2]
+    fts_kept = conn.execute(
+        "SELECT rowid FROM agent_playbooks_fts WHERE rowid = ?", (kept_id,)
+    ).fetchall()
+    assert len(fts_kept) == 1, "fts row for surviving agent_playbook must remain"


### PR DESCRIPTION
## Lineage Phase B3h (OSS) — retention-cascade + playbook-delete atomicity (final delete-path sweep)

The last of the delete-path search-index-cleanup sweep started in B3d/B3e/B3f/B3g. OSS/SQLite-only (enterprise/Postgres deletes are transactional). Closes the remaining self-committing-helper-in-atomic-block and search-before-row-delete cases.

### Core fix — `_delete_playbook_search_rows` is the last self-committing dependency helper
It used a per-id self-committing `_vec_delete` loop, which broke the retention cascade's "one critical section" atomicity (`_retention_perform_delete`). Rewrote it as `(_kind, ids, *, commit=True)`:
- non-committing `_delete_in_chunks` for both fts and vec (vec guarded on `_has_sqlite_vec`),
- wrapped in `with self._lock:`,
- `if commit: conn.commit()`.
The 2 retention call sites pass `commit=False` (atomic with the block's single commit); the 8 playbook callers keep the default `commit=True` (also fixes a latent gap where, without sqlite-vec, the fts deletes were previously left uncommitted by this helper).

### Caller ordering bugs fixed (caught in review)
- **`delete_all_user_playbooks_by_status`** — deleted+committed the search rows BEFORE deleting the playbook rows (separate statement), and snapshotted ids via `_fetchall` outside the lock. Now: snapshot + row DELETE + `_delete_playbook_search_rows(commit=False)` in ONE `with self._lock:` + single commit; returns the real rowcount.
- **`delete_user_playbook` / `delete_agent_playbook`** (single-record) — same search-before-row ordering via self-committing `_fts_delete`/`_vec_delete`. Now atomic: row DELETE → rowcount-guarded hard_delete lineage emit → `_delete_playbook_search_rows(commit=False)` → one commit. Audit-only-on-commit preserved.

The other retention dependency helpers (`_delete_source_windows_*`, `_delete_optimizer_*`) were verified already non-committing — untouched.

### Tests
New retention tests (user/agent playbook fts+vec cleaned within the atomic block) + a guard test for `delete_all_user_playbooks_by_status` (matched rows+fts+vec gone; non-matching survivor intact). 45 storage/retention tests pass. Production file pyright-clean.

Completes the delete-path atomicity class across profiles (B3c/B3f), interactions (B3d), retention interaction/profile helpers (B3e), and now playbooks + the retention playbook helper (B3h). Independent OSS PR; enterprise OSS-pin lags this SQLite-only fix harmlessly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention and playbook deletion so associated search-index rows are consistently cleaned up when playbooks are removed (including vector index entries when available).
  * Ensured retention deletions are fully atomic: failures during dependent cleanup or target-row deletion now roll back to prevent partial data removal.

* **Tests**
  * Added/expanded integration coverage verifying search cleanup for individual deletions and bulk status-based deletions, and validating rollback behavior on retention delete failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->