### PR TITLE
Lineage B2-GC: retired_at age-basis + vetted retention window (PB-5/PB-8b/PB-9) — OSS

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -682,9 +682,19 @@ class LineageGCConfig(BaseModel):
 
     Grace window
     ------------
-    90 days is a defensible engineering default — cf. common 90-day soft-delete
-    retention policies and GDPR Art. 5(1)(e) storage-limitation.  The value is a
-    per-deployment policy knob; ratify with your DPO before enabling in production.
+    90 days is the vetted default — cf. common 90-day soft-delete retention policies
+    and GDPR Art. 5(1)(e) storage-limitation.  The value is a per-deployment policy
+    knob; ratify with your DPO before enabling in production.
+
+    Enablement gate
+    ---------------
+    Enable per-org only after ALL of the following hold:
+
+    * ``tombstone_grace_window_days`` ≥ the B3 reconstruction read-back horizon, OR
+      B3 changelog replay is fully shipped and the horizon is confirmed.  Enabling
+      before this point risks GC'ing tombstones that B3 replay still needs.
+    * DPO/product sign-off on the PII-lifetime and audit-depth implications for the
+      specific deployment.
 
     Tuner floor
     -----------

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -667,17 +667,30 @@ class PlaybookOptimizerConfig(BaseModel):
 class LineageGCConfig(BaseModel):
     """Configuration for the tombstone garbage-collection job (off by default).
 
-    The GC hard-deletes lineage tombstone rows whose ``deleted_at`` timestamp
-    is older than ``tombstone_grace_window_days``.  It is opt-in and MUST NOT
-    be enabled until:
+    Purpose
+    -------
+    Retains tombstone content for ``tombstone_grace_window_days`` days after the
+    row's *retirement instant* (``retired_at``) to support audit, replay of dedup
+    and aggregation runs, and rollback.  After the window expires the row is
+    hard-deleted and a ``hard_delete`` lineage event is recorded.
 
-    - The offline-tuner retention window is pinned (PB-9) so the GC cannot
-      delete tombstones that the tuner still needs for replay.
-    - The B2↔B3 timing contract is satisfied (PB-5) so the grace window is a
-      verified safe value, not the provisional default.
+    Age basis
+    ---------
+    The GC ages on ``retired_at`` — the INTEGER epoch set when a row is tombstoned
+    (merged, superseded, or archived).  Rows with ``retired_at = NULL`` (created
+    before the column was added) are never eligible; they have no retirement clock.
 
-    ``tombstone_grace_window_days`` is a provisional default — do not treat 90
-    days as a vetted value until PB-5 and PB-9 are closed.
+    Grace window
+    ------------
+    90 days is a defensible engineering default — cf. common 90-day soft-delete
+    retention policies and GDPR Art. 5(1)(e) storage-limitation.  The value is a
+    per-deployment policy knob; ratify with your DPO before enabling in production.
+
+    Tuner floor
+    -----------
+    When the offline tuner ships, raise the effective floor to
+    ``max(window, tuner.window_days + rollback_horizon)`` so the GC cannot delete
+    tombstones the tuner still needs for replay.
     """
 
     enabled: bool = False

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -149,8 +149,14 @@ def maybe_start_lineage_gc(
 ) -> LineageGCScheduler | None:
     """Start the GC scheduler only when the bootstrap-org config enables it.
 
-    Off by default — GC must not be enabled until the tuner retention window
-    (PB-9) and B2↔B3 timing contract (PB-5) are closed.
+    Off by default. The mechanism is resolved: GC ages tombstones by
+    ``retired_at`` (the retirement instant, PB-8b) and the window default is a
+    vetted 90 days (PB-9) — see
+    ``docs/superpowers/specs/2026-06-21-lineage-pb9-gc-retention-resolution.md``.
+    Per-org enablement is an explicit ops action, and remains gated on the
+    B2↔B3 timing contract (PB-5: window ≥ the reconstruction read-back horizon,
+    or B3 shipped) PLUS DPO/product sign-off on the PII-lifetime and
+    audit-depth implications flagged in that spec.
 
     Args:
         request_context_factory: Builds an org-scoped :class:`RequestContext`.

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -149,14 +149,21 @@ def maybe_start_lineage_gc(
 ) -> LineageGCScheduler | None:
     """Start the GC scheduler only when the bootstrap-org config enables it.
 
-    Off by default. The mechanism is resolved: GC ages tombstones by
-    ``retired_at`` (the retirement instant, PB-8b) and the window default is a
-    vetted 90 days (PB-9) — see
-    ``docs/superpowers/specs/2026-06-21-lineage-pb9-gc-retention-resolution.md``.
-    Per-org enablement is an explicit ops action, and remains gated on the
-    B2↔B3 timing contract (PB-5: window ≥ the reconstruction read-back horizon,
-    or B3 shipped) PLUS DPO/product sign-off on the PII-lifetime and
-    audit-depth implications flagged in that spec.
+    Off by default. Enablement criteria (must ALL hold before enabling for a
+    production org):
+
+    1. **Mechanism**: GC ages tombstones by ``retired_at`` (the INTEGER epoch
+       written at every tombstone write-path).  Rows with ``retired_at = NULL``
+       (created before the column was added) are never eligible and are retained.
+    2. **Grace window**: 90 days is the vetted default (``tombstone_grace_window_days``).
+       This is a per-deployment policy knob — do not shorten without reviewing
+       PII-lifetime obligations (GDPR Art. 5(1)(e)) and audit-depth requirements.
+    3. **B2↔B3 timing gate**: enable per-org only once the grace window is ≥ the
+       reconstruction read-back horizon used by B3 changelog replay, OR once B3 is
+       fully shipped and the horizon is confirmed.  Enabling before this point risks
+       GC'ing tombstones the B3 replay still needs.
+    4. **DPO sign-off**: obtain sign-off on the PII-lifetime and audit-depth
+       implications before enabling in any deployment that processes personal data.
 
     Args:
         request_context_factory: Builds an org-scoped :class:`RequestContext`.

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -698,6 +698,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
         self._migrate_lineage()
+        self._migrate_retired_at()
         self._migrate_lineage_event_table()
         init_stall_state_table(self.conn)
         return True
@@ -1284,6 +1285,31 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     logger.info("Added %s column to %s", col, table)
         self.conn.commit()
 
+    def _migrate_retired_at(self) -> None:
+        """Add nullable ``retired_at INTEGER`` GC column to tombstone-bearing tables.
+
+        Backfill-safe: column is nullable with no default. Existing tombstones
+        will have ``retired_at = NULL`` (conservative — GC T2 uses ``retired_at``
+        as the age signal, so old tombstones without it are simply not yet eligible
+        by the new clock; ops can backfill via T4 if needed).
+        Also creates the covering index for GC queries (idempotent).
+        """
+        for table in ("profiles", "user_playbooks", "agent_playbooks"):
+            cols = {
+                row["name"]
+                for row in self.conn.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            if "retired_at" not in cols:
+                self.conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN retired_at INTEGER"  # noqa: S608
+                )
+                logger.info("Added retired_at column to %s", table)
+            self.conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{table}_retired_at "  # noqa: S608
+                f"ON {table}(status, retired_at)"
+            )
+        self.conn.commit()
+
     def _migrate_lineage_event_table(self) -> None:
         """Create the lineage_event table + index for existing databases (idempotent)."""
         with self._lock:
@@ -1803,7 +1829,8 @@ CREATE TABLE IF NOT EXISTS profiles (
     reader_angle TEXT,
     merged_into TEXT,
     superseded_by TEXT,
-    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    retired_at INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_profiles_user_id ON profiles(user_id);
 CREATE INDEX IF NOT EXISTS idx_profiles_status ON profiles(status);
@@ -1864,7 +1891,8 @@ CREATE TABLE IF NOT EXISTS user_playbooks (
     notes TEXT,
     reader_angle TEXT,
     merged_into INTEGER,
-    superseded_by INTEGER
+    superseded_by INTEGER,
+    retired_at INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_user_playbooks_playbook_name ON user_playbooks(playbook_name);
 CREATE INDEX IF NOT EXISTS idx_user_playbooks_agent_version ON user_playbooks(agent_version);
@@ -1887,7 +1915,8 @@ CREATE TABLE IF NOT EXISTS agent_playbooks (
     tags TEXT,
     status TEXT,
     merged_into INTEGER,
-    superseded_by INTEGER
+    superseded_by INTEGER,
+    retired_at INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_agent_playbooks_playbook_name ON agent_playbooks(playbook_name);
 CREATE INDEX IF NOT EXISTS idx_agent_playbooks_agent_version ON agent_playbooks(agent_version);

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1294,21 +1294,24 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         by the new clock; ops can backfill via T4 if needed).
         Also creates the covering index for GC queries (idempotent).
         """
-        for table in ("profiles", "user_playbooks", "agent_playbooks"):
-            cols = {
-                row["name"]
-                for row in self.conn.execute(f"PRAGMA table_info({table})").fetchall()
-            }
-            if "retired_at" not in cols:
+        with self._lock:
+            for table in ("profiles", "user_playbooks", "agent_playbooks"):
+                cols = {
+                    row["name"]
+                    for row in self.conn.execute(
+                        f"PRAGMA table_info({table})"  # noqa: S608
+                    ).fetchall()
+                }
+                if "retired_at" not in cols:
+                    self.conn.execute(
+                        f"ALTER TABLE {table} ADD COLUMN retired_at INTEGER"  # noqa: S608
+                    )
+                    logger.info("Added retired_at column to %s", table)
                 self.conn.execute(
-                    f"ALTER TABLE {table} ADD COLUMN retired_at INTEGER"  # noqa: S608
+                    f"CREATE INDEX IF NOT EXISTS idx_{table}_retired_at "  # noqa: S608
+                    f"ON {table}(status, retired_at)"
                 )
-                logger.info("Added retired_at column to %s", table)
-            self.conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_{table}_retired_at "  # noqa: S608
-                f"ON {table}(status, retired_at)"
-            )
-        self.conn.commit()
+            self.conn.commit()
 
     def _migrate_lineage_event_table(self) -> None:
         """Create the lineage_event table + index for existing databases (idempotent)."""

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -9,31 +9,19 @@ from reflexio.models.api_schema.domain.entities import LineageContext, LineageEv
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.tracing import capture_anomaly
 
-from ._base import _epoch_now as _now
+from ._base import _epoch_now
 
 EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
-# Tombstone statuses — rows with these statuses are skipped by merge_records guard.
-_TOMBSTONE = (Status.MERGED.value, Status.SUPERSEDED.value)
-
 # GC-eligible statuses — rows with these statuses may be hard-deleted by TTL GC.
-# Deliberately broader than _TOMBSTONE: includes ARCHIVED. Do NOT reuse _TOMBSTONE.
+# Also used as the merge guard: a source that already carries any of these
+# statuses is skipped (no re-tombstone, no clock reset).
 _GC_ELIGIBLE_STATUSES: frozenset[str] = frozenset(
     {Status.MERGED.value, Status.SUPERSEDED.value, Status.ARCHIVED.value}
 )
 
 # Mapping from entity_type string to (table_name, primary_key_column).
 _TABLE: dict[str, tuple[str, str]] = {
-    "user_playbook": ("user_playbooks", "user_playbook_id"),
-    "agent_playbook": ("agent_playbooks", "agent_playbook_id"),
-    "profile": ("profiles", "profile_id"),
-}
-
-# Per-entity GC metadata: (table, pk_col).
-# All entity types now age on the uniform INTEGER ``retired_at`` column (set by T1
-# at every tombstone write-path).  Pre-T1 rows have ``retired_at = NULL`` and are
-# never selected, which is correct — they have no retirement clock.
-_GC_ENTITY_META: dict[str, tuple[str, str]] = {
     "user_playbook": ("user_playbooks", "user_playbook_id"),
     "agent_playbook": ("agent_playbooks", "agent_playbook_id"),
     "profile": ("profiles", "profile_id"),
@@ -234,24 +222,29 @@ class SQLiteLineageMixin:
             ValueError: If ``entity_type`` is not a recognized entity type.
         """
         table, pk = _resolve_table(entity_type)
-        now = _now()
+        now = _epoch_now()
+        eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
+        eligible_vals = list(_GC_ELIGIBLE_STATUSES)
         with self._lock:
             for sid in source_ids:
                 if sid == survivor_id:
                     # Never tombstone the survivor itself, even if it is
                     # accidentally listed among the source ids.
                     continue
+                # Skip sources that already carry any eligible/tombstone status
+                # (MERGED, SUPERSEDED, or ARCHIVED) — avoids re-tombstoning an
+                # already-archived source and resetting its retired_at clock.
                 self.conn.execute(
                     f"UPDATE {table} SET status=?, merged_into=?, retired_at=? "  # noqa: S608
                     f"WHERE {pk}=? AND {pk}!=? "
-                    f"AND (status IS NULL OR status NOT IN (?, ?))",
+                    f"AND (status IS NULL OR status NOT IN ({eligible_ph}))",
                     (
                         Status.MERGED.value,
                         survivor_id,
                         now,
                         sid,
                         survivor_id,
-                        *_TOMBSTONE,
+                        *eligible_vals,
                     ),
                 )
             _append_event_stmt(
@@ -302,7 +295,7 @@ class SQLiteLineageMixin:
             cur = self.conn.execute(
                 f"UPDATE {table} SET status=?, superseded_by=?, retired_at=? "  # noqa: S608
                 f"WHERE {pk}=? AND status IS NULL",
-                (Status.SUPERSEDED.value, successor_id, _now(), incumbent_id),
+                (Status.SUPERSEDED.value, successor_id, _epoch_now(), incumbent_id),
             )
             if cur.rowcount == 0:
                 self.conn.commit()
@@ -381,20 +374,21 @@ class SQLiteLineageMixin:
         """
         if limit <= 0:
             return 0
-        meta = _GC_ENTITY_META.get(entity_type)
-        if meta is None:
-            raise ValueError(f"unknown entity_type: {entity_type!r}")
-        table, pk = meta
+        table, pk = _resolve_table(entity_type)
 
         eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
         eligible_vals = list(_GC_ELIGIBLE_STATUSES)
 
+        # ORDER BY retired_at ASC for deterministic forward progress.
+        # No SQL LIMIT here — the limit is applied after the legal-hold filter
+        # below so held rows at the front of the batch don't starve eligible rows.
         select_sql = (
             f"SELECT {pk} FROM {table} "  # noqa: S608
             f"WHERE status IN ({eligible_ph}) "
-            f"AND retired_at IS NOT NULL AND retired_at < ? LIMIT ?"
+            f"AND retired_at IS NOT NULL AND retired_at < ? "
+            f"ORDER BY retired_at ASC"
         )
-        select_params: list[Any] = [*eligible_vals, older_than_epoch, limit]
+        select_params: list[Any] = [*eligible_vals, older_than_epoch]
 
         with self._lock:
             rows = self.conn.execute(select_sql, select_params).fetchall()
@@ -405,6 +399,8 @@ class SQLiteLineageMixin:
             ids_to_delete: list[str] = []
             for eid in candidate_ids:
                 if self._is_on_legal_hold(self.org_id, entity_type, eid):
+                    # NOTE: any real hold-check implementation must run inside
+                    # the same transaction as the DELETE to remain atomic.
                     capture_anomaly(
                         "lineage.gc.legal_hold_skip",
                         level="info",
@@ -414,6 +410,8 @@ class SQLiteLineageMixin:
                     )
                     continue
                 ids_to_delete.append(eid)
+                if len(ids_to_delete) >= limit:
+                    break
 
             if not ids_to_delete:
                 return 0

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -10,7 +10,6 @@ from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.tracing import capture_anomaly
 
 from ._base import _epoch_now as _now
-from ._base import _epoch_to_iso
 
 EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 
@@ -30,13 +29,14 @@ _TABLE: dict[str, tuple[str, str]] = {
     "profile": ("profiles", "profile_id"),
 }
 
-# Per-entity GC metadata: (table, pk_col, age_col, age_is_text).
-# age_is_text=True  → TEXT ISO-8601 column; compare cutoff as ISO string.
-# age_is_text=False → INTEGER epoch column; compare cutoff as int directly.
-_GC_ENTITY_META: dict[str, tuple[str, str, str, bool]] = {
-    "user_playbook": ("user_playbooks", "user_playbook_id", "created_at", True),
-    "agent_playbook": ("agent_playbooks", "agent_playbook_id", "created_at", True),
-    "profile": ("profiles", "profile_id", "last_modified_timestamp", False),
+# Per-entity GC metadata: (table, pk_col).
+# All entity types now age on the uniform INTEGER ``retired_at`` column (set by T1
+# at every tombstone write-path).  Pre-T1 rows have ``retired_at = NULL`` and are
+# never selected, which is correct — they have no retirement clock.
+_GC_ENTITY_META: dict[str, tuple[str, str]] = {
+    "user_playbook": ("user_playbooks", "user_playbook_id"),
+    "agent_playbook": ("agent_playbooks", "agent_playbook_id"),
+    "profile": ("profiles", "profile_id"),
 }
 
 
@@ -357,7 +357,11 @@ class SQLiteLineageMixin:
     def gc_expired_tombstones(
         self, *, entity_type: str, older_than_epoch: int, limit: int = 1000
     ) -> int:
-        """Hard-delete tombstone rows that are older than the given epoch cutoff.
+        """Hard-delete tombstone rows whose retirement instant is older than the cutoff.
+
+        Ages on the uniform INTEGER ``retired_at`` column set at every tombstone
+        write-path (T1).  Rows with ``retired_at = NULL`` (pre-T1 tombstones) are
+        never selected — they have no retirement clock and must be retained.
 
         Emits one ``hard_delete`` lineage event per deleted row, atomically, before
         the DELETE commits. Rows on legal hold are skipped without emitting an event.
@@ -366,7 +370,7 @@ class SQLiteLineageMixin:
             entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
                 or ``"profile"``.
             older_than_epoch (int): Unix timestamp cutoff (exclusive). Rows whose
-                age column is strictly less than this value are eligible.
+                ``retired_at`` is strictly less than this value are eligible.
             limit (int): Maximum rows to delete per call. Defaults to 1000.
 
         Returns:
@@ -380,27 +384,17 @@ class SQLiteLineageMixin:
         meta = _GC_ENTITY_META.get(entity_type)
         if meta is None:
             raise ValueError(f"unknown entity_type: {entity_type!r}")
-        table, pk, age_col, age_is_text = meta
+        table, pk = meta
 
         eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
         eligible_vals = list(_GC_ELIGIBLE_STATUSES)
 
-        if age_is_text:
-            # Use the same helper the writer uses so the cutoff string is
-            # byte-for-byte format-consistent with stored values.  This keeps
-            # the ``<`` comparison truly exclusive (strict) at the boundary.
-            cutoff_iso = _epoch_to_iso(older_than_epoch)
-            select_sql = (
-                f"SELECT {pk} FROM {table} "  # noqa: S608
-                f"WHERE status IN ({eligible_ph}) AND {age_col} < ? LIMIT ?"
-            )
-            select_params: list[Any] = [*eligible_vals, cutoff_iso, limit]
-        else:
-            select_sql = (
-                f"SELECT {pk} FROM {table} "  # noqa: S608
-                f"WHERE status IN ({eligible_ph}) AND {age_col} < ? LIMIT ?"
-            )
-            select_params = [*eligible_vals, older_than_epoch, limit]
+        select_sql = (
+            f"SELECT {pk} FROM {table} "  # noqa: S608
+            f"WHERE status IN ({eligible_ph}) "
+            f"AND retired_at IS NOT NULL AND retired_at < ? LIMIT ?"
+        )
+        select_params: list[Any] = [*eligible_vals, older_than_epoch, limit]
 
         with self._lock:
             rows = self.conn.execute(select_sql, select_params).fetchall()

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -9,6 +9,7 @@ from reflexio.models.api_schema.domain.entities import LineageContext, LineageEv
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.tracing import capture_anomaly
 
+from ._base import _epoch_now as _now
 from ._base import _epoch_to_iso
 
 EntityType = Literal["user_playbook", "agent_playbook", "profile"]
@@ -233,6 +234,7 @@ class SQLiteLineageMixin:
             ValueError: If ``entity_type`` is not a recognized entity type.
         """
         table, pk = _resolve_table(entity_type)
+        now = _now()
         with self._lock:
             for sid in source_ids:
                 if sid == survivor_id:
@@ -240,10 +242,17 @@ class SQLiteLineageMixin:
                     # accidentally listed among the source ids.
                     continue
                 self.conn.execute(
-                    f"UPDATE {table} SET status=?, merged_into=? "  # noqa: S608
+                    f"UPDATE {table} SET status=?, merged_into=?, retired_at=? "  # noqa: S608
                     f"WHERE {pk}=? AND {pk}!=? "
                     f"AND (status IS NULL OR status NOT IN (?, ?))",
-                    (Status.MERGED.value, survivor_id, sid, survivor_id, *_TOMBSTONE),
+                    (
+                        Status.MERGED.value,
+                        survivor_id,
+                        now,
+                        sid,
+                        survivor_id,
+                        *_TOMBSTONE,
+                    ),
                 )
             _append_event_stmt(
                 self.conn,
@@ -291,9 +300,9 @@ class SQLiteLineageMixin:
         table, pk = _resolve_table(entity_type)
         with self._lock:
             cur = self.conn.execute(
-                f"UPDATE {table} SET status=?, superseded_by=? "  # noqa: S608
+                f"UPDATE {table} SET status=?, superseded_by=?, retired_at=? "  # noqa: S608
                 f"WHERE {pk}=? AND status IS NULL",
-                (Status.SUPERSEDED.value, successor_id, incumbent_id),
+                (Status.SUPERSEDED.value, successor_id, _now(), incumbent_id),
             )
             if cur.rowcount == 0:
                 self.conn.commit()

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -31,6 +31,7 @@ from ._base import (
     SQLiteStorageBase,
     _build_status_sql,
     _effective_search_mode,
+    _epoch_now,
     _epoch_to_iso,
     _json_dumps,
     _json_loads,
@@ -446,6 +447,7 @@ class PlaybookMixin:
         playbook_name: str | None = None,
     ) -> int:
         new_val = new_status.value if new_status else None
+        now_ts = _epoch_now()
         old_val_str = old_status.value if old_status else "None"
         new_val_str = new_status.value if new_status else "None"
         reason = f"{old_val_str}->{new_val_str}"
@@ -467,6 +469,14 @@ class PlaybookMixin:
             where += " AND playbook_name = ?"
             extra_params.append(playbook_name)
 
+        # Set retired_at = now when transitioning to a tombstone status; clear to NULL otherwise.
+        _tombstone_vals = {
+            Status.MERGED.value,
+            Status.SUPERSEDED.value,
+            Status.ARCHIVED.value,
+        }
+        retired_at_val = now_ts if new_val in _tombstone_vals else None
+
         batch_request_id = uuid.uuid4().hex
         with self._lock:
             affected = [
@@ -477,8 +487,8 @@ class PlaybookMixin:
                 ).fetchall()
             ]
             cur = self.conn.execute(
-                f"UPDATE user_playbooks SET status = ? WHERE {where}",
-                [new_val] + select_params + extra_params,
+                f"UPDATE user_playbooks SET status = ?, retired_at = ? WHERE {where}",
+                [new_val, retired_at_val] + select_params + extra_params,
             )
             from_val = old_status.value if old_status else None
             to_val = new_status.value if new_status else None
@@ -563,9 +573,9 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def archive_user_playbook_by_id(self, user_id: str, user_playbook_id: int) -> bool:
         cur = self._execute(
-            "UPDATE user_playbooks SET status = ? "
+            "UPDATE user_playbooks SET status = ?, retired_at = ? "
             "WHERE user_playbook_id = ? AND user_id = ? AND status IS NULL",
-            (Status.ARCHIVED.value, user_playbook_id, user_id),
+            (Status.ARCHIVED.value, _epoch_now(), user_playbook_id, user_id),
         )
         return cur.rowcount > 0
 
@@ -1169,6 +1179,7 @@ class PlaybookMixin:
         if agent_version is not None:
             where += " AND agent_version = ?"
             params.append(agent_version)
+        now_ts = _epoch_now()
         batch_request_id = uuid.uuid4().hex
         with self._lock:
             affected = self.conn.execute(
@@ -1176,8 +1187,8 @@ class PlaybookMixin:
                 params,
             ).fetchall()
             self.conn.execute(
-                f"UPDATE agent_playbooks SET status = 'archived' WHERE {where}",
-                params,
+                f"UPDATE agent_playbooks SET status = 'archived', retired_at = ? WHERE {where}",
+                [now_ts, *params],
             )
             for row in affected:
                 prior = row["status"] or "None"
@@ -1203,6 +1214,7 @@ class PlaybookMixin:
         if not agent_playbook_ids:
             return
         ph = ",".join("?" for _ in agent_playbook_ids)
+        now_ts = _epoch_now()
         batch_request_id = uuid.uuid4().hex
         with self._lock:
             affected = self.conn.execute(
@@ -1212,10 +1224,10 @@ class PlaybookMixin:
                 [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
             ).fetchall()
             self.conn.execute(
-                f"UPDATE agent_playbooks SET status = 'archived'"
+                f"UPDATE agent_playbooks SET status = 'archived', retired_at = ?"
                 f" WHERE agent_playbook_id IN ({ph}) AND playbook_status != ?"
                 f" AND (status IS NULL OR status != 'archived')",
-                [*agent_playbook_ids, PlaybookStatus.APPROVED.value],
+                [now_ts, *agent_playbook_ids, PlaybookStatus.APPROVED.value],
             )
             for row in affected:
                 prior = row["status"] or "None"
@@ -1276,11 +1288,12 @@ class PlaybookMixin:
                 # clause already excludes those rows atomically; the extra continue here
                 # would be a no-op and not worth the added complexity.
                 cur = self.conn.execute(
-                    "UPDATE agent_playbooks SET status = ?"
+                    "UPDATE agent_playbooks SET status = ?, retired_at = ?"
                     " WHERE agent_playbook_id = ? AND playbook_status != ?"
                     " AND (status IS NULL OR status NOT IN (?, ?))",
                     (
                         Status.SUPERSEDED.value,
+                        _epoch_now(),
                         apid,
                         PlaybookStatus.APPROVED.value,
                         *_TOMBSTONE_STATUS_VALUES,
@@ -1336,11 +1349,12 @@ class PlaybookMixin:
                 apid = row["agent_playbook_id"]
                 old_status = row["status"]
                 cur = self.conn.execute(
-                    "UPDATE agent_playbooks SET status = ?"
+                    "UPDATE agent_playbooks SET status = ?, retired_at = ?"
                     " WHERE agent_playbook_id = ? AND playbook_status != ?"
                     " AND status = 'archived'",
                     (
                         Status.SUPERSEDED.value,
+                        _epoch_now(),
                         apid,
                         PlaybookStatus.APPROVED.value,
                     ),
@@ -1361,7 +1375,7 @@ class PlaybookMixin:
     def restore_archived_agent_playbooks_by_playbook_name(
         self, playbook_name: str, agent_version: str | None = None
     ) -> None:
-        sql = "UPDATE agent_playbooks SET status = NULL WHERE playbook_name = ? AND status = 'archived'"
+        sql = "UPDATE agent_playbooks SET status = NULL, retired_at = NULL WHERE playbook_name = ? AND status = 'archived'"
         params: list[Any] = [playbook_name]
         if agent_version is not None:
             sql += " AND agent_version = ?"
@@ -1376,7 +1390,7 @@ class PlaybookMixin:
             return
         ph = ",".join("?" for _ in agent_playbook_ids)
         self._execute(
-            f"UPDATE agent_playbooks SET status = NULL WHERE agent_playbook_id IN ({ph}) AND status = 'archived'",
+            f"UPDATE agent_playbooks SET status = NULL, retired_at = NULL WHERE agent_playbook_id IN ({ph}) AND status = 'archived'",
             agent_playbook_ids,
         )
 

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -42,7 +42,7 @@ from ._base import (
     _true_rrf_merge,
     _vector_rank_rows,
 )
-from ._lineage import _append_event_stmt
+from ._lineage import _GC_ELIGIBLE_STATUSES, _append_event_stmt
 
 
 def _emit_hard_delete_playbook(
@@ -469,13 +469,8 @@ class PlaybookMixin:
             where += " AND playbook_name = ?"
             extra_params.append(playbook_name)
 
-        # Set retired_at = now when transitioning to a tombstone status; clear to NULL otherwise.
-        _tombstone_vals = {
-            Status.MERGED.value,
-            Status.SUPERSEDED.value,
-            Status.ARCHIVED.value,
-        }
-        retired_at_val = now_ts if new_val in _tombstone_vals else None
+        # Set retired_at = now when transitioning to a GC-eligible status; clear to NULL otherwise.
+        retired_at_val = now_ts if new_val in _GC_ELIGIBLE_STATUSES else None
 
         batch_request_id = uuid.uuid4().hex
         with self._lock:
@@ -1270,6 +1265,7 @@ class PlaybookMixin:
             return 0
         if not request_id:
             raise ValueError("request_id must be non-empty for supersede")
+        now_ts = _epoch_now()
         updated = 0
         with self._lock:
             for apid in agent_playbook_ids:
@@ -1293,7 +1289,7 @@ class PlaybookMixin:
                     " AND (status IS NULL OR status NOT IN (?, ?))",
                     (
                         Status.SUPERSEDED.value,
-                        _epoch_now(),
+                        now_ts,
                         apid,
                         PlaybookStatus.APPROVED.value,
                         *_TOMBSTONE_STATUS_VALUES,
@@ -1345,6 +1341,7 @@ class PlaybookMixin:
             rows = self.conn.execute(sql, params).fetchall()
             if not rows:
                 return 0
+            now_ts = _epoch_now()
             for row in rows:
                 apid = row["agent_playbook_id"]
                 old_status = row["status"]
@@ -1354,7 +1351,7 @@ class PlaybookMixin:
                     " AND status = 'archived'",
                     (
                         Status.SUPERSEDED.value,
-                        _epoch_now(),
+                        now_ts,
                         apid,
                         PlaybookStatus.APPROVED.value,
                     ),

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -401,6 +401,14 @@ class ProfileMixin:
             where += f" AND user_id IN ({placeholders})"
             extra_params.extend(user_ids)
 
+        # Set retired_at = now when transitioning to a tombstone status; clear to NULL otherwise.
+        _tombstone_vals = {
+            Status.MERGED.value,
+            Status.SUPERSEDED.value,
+            Status.ARCHIVED.value,
+        }
+        retired_at_val = now_ts if new_val in _tombstone_vals else None
+
         batch_request_id = uuid.uuid4().hex
         with self._lock:
             affected = [
@@ -411,8 +419,8 @@ class ProfileMixin:
                 ).fetchall()
             ]
             cur = self.conn.execute(
-                f"UPDATE profiles SET status = ?, last_modified_timestamp = ? WHERE {where}",
-                [new_val, now_ts] + select_params + extra_params,
+                f"UPDATE profiles SET status = ?, last_modified_timestamp = ?, retired_at = ? WHERE {where}",
+                [new_val, now_ts, retired_at_val] + select_params + extra_params,
             )
             from_val = old_status.value if old_status else None
             to_val = new_status.value if new_status else None
@@ -516,10 +524,11 @@ class ProfileMixin:
     @SQLiteStorageBase.handle_exceptions
     def archive_profile_by_id(self, user_id: str, profile_id: str) -> bool:
         with self._lock:
+            now_ts = _epoch_now()
             cur = self.conn.execute(
-                "UPDATE profiles SET status = ?, last_modified_timestamp = ? "
+                "UPDATE profiles SET status = ?, last_modified_timestamp = ?, retired_at = ? "
                 "WHERE profile_id = ? AND user_id = ? AND status IS NULL",
-                (Status.ARCHIVED.value, _epoch_now(), profile_id, user_id),
+                (Status.ARCHIVED.value, now_ts, now_ts, profile_id, user_id),
             )
             if cur.rowcount > 0:
                 _append_event_stmt(
@@ -585,11 +594,12 @@ class ProfileMixin:
                 if old_status_val not in eligible:
                     continue
                 cur = self.conn.execute(
-                    "UPDATE profiles SET status = ?, last_modified_timestamp = ? "
+                    "UPDATE profiles SET status = ?, last_modified_timestamp = ?, retired_at = ? "
                     "WHERE profile_id = ? AND user_id = ? "
                     "AND (status IS NULL OR status = ?)",
                     (
                         Status.SUPERSEDED.value,
+                        now_ts,
                         now_ts,
                         pid,
                         user_id,

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -39,7 +39,7 @@ from ._base import (
     _true_rrf_merge,
     _vector_rank_rows,
 )
-from ._lineage import _append_event_stmt
+from ._lineage import _GC_ELIGIBLE_STATUSES, _append_event_stmt
 
 
 def _emit_hard_delete_profile(
@@ -401,13 +401,8 @@ class ProfileMixin:
             where += f" AND user_id IN ({placeholders})"
             extra_params.extend(user_ids)
 
-        # Set retired_at = now when transitioning to a tombstone status; clear to NULL otherwise.
-        _tombstone_vals = {
-            Status.MERGED.value,
-            Status.SUPERSEDED.value,
-            Status.ARCHIVED.value,
-        }
-        retired_at_val = now_ts if new_val in _tombstone_vals else None
+        # Set retired_at = now when transitioning to a GC-eligible status; clear to NULL otherwise.
+        retired_at_val = now_ts if new_val in _GC_ELIGIBLE_STATUSES else None
 
         batch_request_id = uuid.uuid4().hex
         with self._lock:

--- a/tests/server/services/storage/test_lineage_b2_gc_integration.py
+++ b/tests/server/services/storage/test_lineage_b2_gc_integration.py
@@ -296,6 +296,13 @@ def test_gc_pb8b_old_created_at_recent_retired_at_not_gc_d(tmp_path):
     assert deleted_p == 0, (
         "Profile with recent retired_at must NOT be GC'd even when last_modified_timestamp is ancient"
     )
+    assert (
+        s.conn.execute(
+            "SELECT 1 FROM profiles WHERE profile_id = ?",
+            ("pb8b-profile",),
+        ).fetchone()
+        is not None
+    ), "PB-8b profile must still exist when retired_at is recent"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/storage/test_lineage_b2_gc_integration.py
+++ b/tests/server/services/storage/test_lineage_b2_gc_integration.py
@@ -1,24 +1,27 @@
 """Integration tests: gc_expired_tombstones + legal-hold stub (Lineage Phase B2).
 
 Tests cover:
-  (a) Aged tombstone (MERGED) past cutoff is GC'd: row deleted + hard_delete event.
-  (b) Fresh tombstone and CURRENT row are NOT deleted.
+  (a) Aged tombstone (MERGED) with retired_at past cutoff is GC'd: row deleted + hard_delete event.
+  (b) Fresh tombstone (recent retired_at) and CURRENT row are NOT deleted.
   (c) ARCHIVED aged tombstone IS GC'd (broader eligible set than _TOMBSTONE).
-  (d) PB-8 straddle: TEXT ISO created_at (playbooks) and INTEGER last_modified_timestamp
-      (profiles) both apply the cutoff correctly — only genuinely-older rows purged.
-  (e) Legal-hold: monkeypatched hold skips one row — no delete, no hard_delete event.
-  (f) Idempotent: second GC call on an already-empty set returns 0, adds no events.
+  (d) PB-8b regression: tombstone with OLD created_at but RECENT retired_at is NOT GC'd.
+      Proves the GC ages on retired_at, not created_at.
+  (e) retired_at = NULL tombstone (pre-T1 row) is NOT GC'd.
+  (f) Legal-hold: monkeypatched hold skips one row — no delete, no hard_delete event.
+  (g) Idempotent: second GC call on an already-empty set returns 0, adds no events.
+  (h) Atomic rollback: mid-operation failure leaves no partial state.
 """
 
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytest
 
+import reflexio.server.services.storage.sqlite_storage._lineage as _lineage_mod
 from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import AgentPlaybook, UserProfile
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
-from reflexio.server.services.storage.sqlite_storage._base import _epoch_to_iso
 
 pytestmark = pytest.mark.integration
 
@@ -87,21 +90,13 @@ def _set_profile_status(s: SQLiteStorage, profile_id: str, status: str) -> None:
     s.conn.commit()
 
 
-def _set_playbook_created_at(
-    s: SQLiteStorage, table: str, pk: str, pk_val: int, iso_ts: str
+def _set_retired_at(
+    s: SQLiteStorage, table: str, pk: str, pk_val: int | str, retired_at: int | None
 ) -> None:
-    """Force the created_at TEXT column on a playbook row for age comparisons."""
+    """Directly set retired_at on a row for test seeding."""
     s.conn.execute(
-        f"UPDATE {table} SET created_at = ? WHERE {pk} = ?",  # noqa: S608
-        (iso_ts, pk_val),
-    )
-    s.conn.commit()
-
-
-def _set_profile_last_modified(s: SQLiteStorage, profile_id: str, ts: int) -> None:
-    s.conn.execute(
-        "UPDATE profiles SET last_modified_timestamp = ? WHERE profile_id = ?",
-        (ts, profile_id),
+        f"UPDATE {table} SET retired_at = ? WHERE {pk} = ?",  # noqa: S608
+        (retired_at, pk_val),
     )
     s.conn.commit()
 
@@ -113,7 +108,7 @@ def _hard_delete_events(s: SQLiteStorage, entity_id: str) -> list:
 
 
 # ---------------------------------------------------------------------------
-# (a) Aged tombstone (MERGED) past cutoff is GC'd
+# (a) Aged tombstone (MERGED) with retired_at past cutoff is GC'd
 # ---------------------------------------------------------------------------
 
 
@@ -126,9 +121,9 @@ def test_gc_deletes_aged_merged_tombstone(tmp_path):
         s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
     )
 
-    # Age the row to well before the cutoff — use production format (+00:00, no fractional seconds)
-    old_iso = _epoch_to_iso(int(datetime(2020, 1, 1, tzinfo=UTC).timestamp()))
-    _set_playbook_created_at(s, "user_playbooks", "user_playbook_id", pid, old_iso)
+    # Set retired_at to well before the cutoff
+    old_retired_at = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
+    _set_retired_at(s, "user_playbooks", "user_playbook_id", pid, old_retired_at)
 
     cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
     deleted = s.gc_expired_tombstones(
@@ -149,32 +144,32 @@ def test_gc_deletes_aged_merged_tombstone(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# (b) Fresh tombstone and CURRENT row are NOT deleted
+# (b) Fresh tombstone (recent retired_at) and CURRENT row are NOT deleted
 # ---------------------------------------------------------------------------
 
 
 def test_gc_skips_fresh_tombstone_and_current(tmp_path):
     s = _store(tmp_path)
-    # Fresh merged tombstone — created_at is right now
+    # Fresh merged tombstone — retired_at is right now (after any historical cutoff)
     pb_fresh = _make_user_playbook(content="fresh")
     s.save_user_playbooks([pb_fresh])
     pid_fresh = pb_fresh.user_playbook_id
     _set_playbook_status(
         s, "user_playbooks", "user_playbook_id", pid_fresh, Status.MERGED.value
     )
-    # Note: created_at is already current, so it's after any historical cutoff
-
-    # CURRENT row (no status)
-    pb_current = _make_user_playbook(content="current")
-    s.save_user_playbooks([pb_current])
-    pid_current = pb_current.user_playbook_id
-    _set_playbook_created_at(
+    # retired_at is current — after the historical cutoff
+    _set_retired_at(
         s,
         "user_playbooks",
         "user_playbook_id",
-        pid_current,
-        _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
+        pid_fresh,
+        int(datetime(2025, 1, 1, tzinfo=UTC).timestamp()),
     )
+
+    # CURRENT row (no status, retired_at NULL)
+    pb_current = _make_user_playbook(content="current")
+    s.save_user_playbooks([pb_current])
+    pid_current = pb_current.user_playbook_id
     # status is NULL (CURRENT) — must NOT be deleted even if old
 
     cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
@@ -212,12 +207,12 @@ def test_gc_deletes_aged_archived_tombstone(tmp_path):
     _set_playbook_status(
         s, "agent_playbooks", "agent_playbook_id", apid, Status.ARCHIVED.value
     )
-    _set_playbook_created_at(
+    _set_retired_at(
         s,
         "agent_playbooks",
         "agent_playbook_id",
         apid,
-        _epoch_to_iso(int(datetime(2019, 6, 1, tzinfo=UTC).timestamp())),
+        int(datetime(2019, 6, 1, tzinfo=UTC).timestamp()),
     )
 
     cutoff = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
@@ -235,94 +230,113 @@ def test_gc_deletes_aged_archived_tombstone(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# (d) PB-8 straddle test: TEXT ISO vs INTEGER epoch type-correct comparison
+# (d) PB-8b regression: OLD created_at but RECENT retired_at → NOT GC'd
 # ---------------------------------------------------------------------------
 
 
-def test_gc_straddle_playbook_text_iso_and_profile_int_epoch(tmp_path):
+def test_gc_pb8b_old_created_at_recent_retired_at_not_gc_d(tmp_path):
+    """Tombstone with OLD created_at but RECENT retired_at must NOT be GC'd.
+
+    This is the PB-8b regression: proves the GC ages on retired_at (retirement
+    instant), not created_at or last_modified_timestamp.  Any row that was retired
+    recently must be preserved regardless of how old the underlying content is.
+    """
     s = _store(tmp_path)
 
-    # --- User playbooks: TEXT ISO created_at ---
-    pb_old = _make_user_playbook(content="old")
-    pb_new = _make_user_playbook(content="new")
-    s.save_user_playbooks([pb_old, pb_new])
-    old_id = pb_old.user_playbook_id
-    new_id = pb_new.user_playbook_id
-
+    # --- User playbook: OLD created_at, RECENT retired_at ---
+    pb = _make_user_playbook(content="old-content")
+    s.save_user_playbooks([pb])
+    pid = pb.user_playbook_id
     _set_playbook_status(
-        s, "user_playbooks", "user_playbook_id", old_id, Status.MERGED.value
-    )
-    _set_playbook_status(
-        s, "user_playbooks", "user_playbook_id", new_id, Status.MERGED.value
-    )
-    _set_playbook_created_at(
-        s,
-        "user_playbooks",
-        "user_playbook_id",
-        old_id,
-        _epoch_to_iso(int(datetime(2018, 1, 1, tzinfo=UTC).timestamp())),
-    )
-    _set_playbook_created_at(
-        s,
-        "user_playbooks",
-        "user_playbook_id",
-        new_id,
-        _epoch_to_iso(int(datetime(2025, 1, 1, tzinfo=UTC).timestamp())),
+        s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
     )
 
-    cutoff_pb = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
-    deleted_pb = s.gc_expired_tombstones(
-        entity_type="user_playbook", older_than_epoch=cutoff_pb
+    # Force created_at to 2018 (well before cutoff)
+    old_iso = "2018-01-01T00:00:00+00:00"
+    s.conn.execute(
+        "UPDATE user_playbooks SET created_at = ? WHERE user_playbook_id = ?",
+        (old_iso, pid),
     )
-    assert deleted_pb == 1
-    assert (
-        s.conn.execute(
-            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (old_id,)
-        ).fetchone()
-        is None
+    # But retired_at is recent (2025 — well after cutoff)
+    recent_retired_at = int(datetime(2025, 1, 1, tzinfo=UTC).timestamp())
+    _set_retired_at(s, "user_playbooks", "user_playbook_id", pid, recent_retired_at)
+    s.conn.commit()
+
+    cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
+    deleted = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+
+    assert deleted == 0, (
+        "Tombstone with recent retired_at must NOT be GC'd even when created_at is ancient"
     )
     assert (
         s.conn.execute(
-            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (new_id,)
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid,)
         ).fetchone()
         is not None
     )
 
-    # --- Profiles: INTEGER last_modified_timestamp ---
+    # --- Profile: OLD last_modified_timestamp, RECENT retired_at ---
     old_ts = int(datetime(2018, 6, 1, tzinfo=UTC).timestamp())
-    new_ts = int(datetime(2025, 6, 1, tzinfo=UTC).timestamp())
-
-    p_old = _make_profile(profile_id="prof-old", ts=old_ts)
-    p_new = _make_profile(profile_id="prof-new", ts=new_ts)
-    s.add_user_profile("u1", [p_old])
-    s.add_user_profile("u1", [p_new])
-    _set_profile_status(s, "prof-old", Status.SUPERSEDED.value)
-    _set_profile_status(s, "prof-new", Status.SUPERSEDED.value)
-    # Ensure last_modified_timestamp is set to our desired values
-    _set_profile_last_modified(s, "prof-old", old_ts)
-    _set_profile_last_modified(s, "prof-new", new_ts)
-
-    cutoff_pr = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
-    deleted_pr = s.gc_expired_tombstones(
-        entity_type="profile", older_than_epoch=cutoff_pr
+    p = _make_profile(profile_id="pb8b-profile", ts=old_ts)
+    s.add_user_profile("u1", [p])
+    _set_profile_status(s, "pb8b-profile", Status.SUPERSEDED.value)
+    # Ensure last_modified_timestamp is old
+    s.conn.execute(
+        "UPDATE profiles SET last_modified_timestamp = ? WHERE profile_id = ?",
+        (old_ts, "pb8b-profile"),
     )
-    assert deleted_pr == 1
+    # But retired_at is recent
+    _set_retired_at(s, "profiles", "profile_id", "pb8b-profile", recent_retired_at)
+    s.conn.commit()
+
+    deleted_p = s.gc_expired_tombstones(entity_type="profile", older_than_epoch=cutoff)
+
+    assert deleted_p == 0, (
+        "Profile with recent retired_at must NOT be GC'd even when last_modified_timestamp is ancient"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) retired_at = NULL tombstone (pre-T1 row) is NOT GC'd
+# ---------------------------------------------------------------------------
+
+
+def test_gc_null_retired_at_not_gc_d(tmp_path):
+    """A tombstone with retired_at = NULL (pre-T1 row) must never be GC'd.
+
+    NULL means no retirement clock; the GC must treat it as 'not yet eligible'.
+    """
+    s = _store(tmp_path)
+
+    pb = _make_user_playbook(content="pre-t1")
+    s.save_user_playbooks([pb])
+    pid = pb.user_playbook_id
+    _set_playbook_status(
+        s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
+    )
+
+    # Explicitly set retired_at = NULL (simulating a pre-T1 tombstone)
+    _set_retired_at(s, "user_playbooks", "user_playbook_id", pid, None)
+
+    # Use a far-future cutoff — would GC anything eligible
+    cutoff = int(datetime(2030, 1, 1, tzinfo=UTC).timestamp())
+    deleted = s.gc_expired_tombstones(
+        entity_type="user_playbook", older_than_epoch=cutoff
+    )
+
+    assert deleted == 0, "Pre-T1 tombstone (retired_at=NULL) must NOT be GC'd"
     assert (
         s.conn.execute(
-            "SELECT 1 FROM profiles WHERE profile_id = ?", ("prof-old",)
-        ).fetchone()
-        is None
-    )
-    assert (
-        s.conn.execute(
-            "SELECT 1 FROM profiles WHERE profile_id = ?", ("prof-new",)
+            "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?", (pid,)
         ).fetchone()
         is not None
     )
 
 
 # ---------------------------------------------------------------------------
-# (e) Legal-hold: held row skipped, no event, others still deleted
+# (f) Legal-hold: held row skipped, no event, others still deleted
 # ---------------------------------------------------------------------------
 
 
@@ -335,17 +349,12 @@ def test_gc_legal_hold_skips_held_row(tmp_path, monkeypatch):
     held_id = pb_held.user_playbook_id
     free_id = pb_free.user_playbook_id
 
+    old_retired_at = int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())
     for pid in (held_id, free_id):
         _set_playbook_status(
             s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
         )
-        _set_playbook_created_at(
-            s,
-            "user_playbooks",
-            "user_playbook_id",
-            pid,
-            _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
-        )
+        _set_retired_at(s, "user_playbooks", "user_playbook_id", pid, old_retired_at)
 
     # Monkeypatch: only held_id is on legal hold
     def mock_hold(org_id: str, entity_type: str, entity_id: str) -> bool:
@@ -380,7 +389,7 @@ def test_gc_legal_hold_skips_held_row(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# (f) Idempotent: second GC call returns 0 and adds no new events
+# (g) Idempotent: second GC call returns 0 and adds no new events
 # ---------------------------------------------------------------------------
 
 
@@ -392,12 +401,12 @@ def test_gc_idempotent(tmp_path):
     _set_playbook_status(
         s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
     )
-    _set_playbook_created_at(
+    _set_retired_at(
         s,
         "user_playbooks",
         "user_playbook_id",
         pid,
-        _epoch_to_iso(int(datetime(2018, 1, 1, tzinfo=UTC).timestamp())),
+        int(datetime(2018, 1, 1, tzinfo=UTC).timestamp()),
     )
 
     cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
@@ -445,12 +454,10 @@ def test_gc_empty_table_returns_zero(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_gc_boundary_playbook_at_cutoff_not_deleted(tmp_path):
-    """A playbook whose created_at == older_than_epoch must NOT be deleted.
+def test_gc_boundary_at_cutoff_not_deleted(tmp_path):
+    """A tombstone whose retired_at == older_than_epoch must NOT be deleted.
 
-    The contract is strictly-less-than.  The cutoff string is formatted by
-    _epoch_to_iso, matching the production write path exactly, so the
-    lexicographic ``<`` comparison is byte-for-byte consistent.
+    The contract is strictly-less-than.
     """
     s = _store(tmp_path)
     cutoff_epoch = int(datetime(2022, 6, 15, 12, 0, 0, tzinfo=UTC).timestamp())
@@ -462,9 +469,7 @@ def test_gc_boundary_playbook_at_cutoff_not_deleted(tmp_path):
     _set_playbook_status(
         s, "user_playbooks", "user_playbook_id", pid_at, Status.MERGED.value
     )
-    _set_playbook_created_at(
-        s, "user_playbooks", "user_playbook_id", pid_at, _epoch_to_iso(cutoff_epoch)
-    )
+    _set_retired_at(s, "user_playbooks", "user_playbook_id", pid_at, cutoff_epoch)
 
     # Row one second BEFORE the cutoff — must be deleted.
     pb_before = _make_user_playbook(content="before-boundary")
@@ -473,12 +478,8 @@ def test_gc_boundary_playbook_at_cutoff_not_deleted(tmp_path):
     _set_playbook_status(
         s, "user_playbooks", "user_playbook_id", pid_before, Status.MERGED.value
     )
-    _set_playbook_created_at(
-        s,
-        "user_playbooks",
-        "user_playbook_id",
-        pid_before,
-        _epoch_to_iso(cutoff_epoch - 1),
+    _set_retired_at(
+        s, "user_playbooks", "user_playbook_id", pid_before, cutoff_epoch - 1
     )
 
     deleted = s.gc_expired_tombstones(
@@ -503,18 +504,18 @@ def test_gc_boundary_playbook_at_cutoff_not_deleted(tmp_path):
 
 
 def test_gc_boundary_profile_at_cutoff_not_deleted(tmp_path):
-    """Profile (INTEGER age column) boundary: row at cutoff survives, row before doesn't."""
+    """Profile boundary: retired_at at cutoff survives, before doesn't."""
     s = _store(tmp_path)
     cutoff_epoch = int(datetime(2022, 6, 15, 12, 0, 0, tzinfo=UTC).timestamp())
 
-    p_at = _make_profile(profile_id="at-boundary", ts=cutoff_epoch)
-    p_before = _make_profile(profile_id="before-boundary", ts=cutoff_epoch - 1)
+    p_at = _make_profile(profile_id="at-boundary", ts=_now_epoch())
+    p_before = _make_profile(profile_id="before-boundary", ts=_now_epoch())
     s.add_user_profile("u1", [p_at])
     s.add_user_profile("u1", [p_before])
     _set_profile_status(s, "at-boundary", Status.MERGED.value)
     _set_profile_status(s, "before-boundary", Status.MERGED.value)
-    _set_profile_last_modified(s, "at-boundary", cutoff_epoch)
-    _set_profile_last_modified(s, "before-boundary", cutoff_epoch - 1)
+    _set_retired_at(s, "profiles", "profile_id", "at-boundary", cutoff_epoch)
+    _set_retired_at(s, "profiles", "profile_id", "before-boundary", cutoff_epoch - 1)
 
     deleted = s.gc_expired_tombstones(
         entity_type="profile", older_than_epoch=cutoff_epoch
@@ -549,12 +550,12 @@ def test_gc_non_positive_limit_returns_zero(tmp_path, bad_limit: int):
     _set_playbook_status(
         s, "user_playbooks", "user_playbook_id", pid, Status.MERGED.value
     )
-    _set_playbook_created_at(
+    _set_retired_at(
         s,
         "user_playbooks",
         "user_playbook_id",
         pid,
-        _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
+        int(datetime(2019, 1, 1, tzinfo=UTC).timestamp()),
     )
 
     cutoff = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
@@ -586,16 +587,13 @@ def test_gc_rollback_on_mid_operation_failure(tmp_path):
     The ``except`` branch in ``gc_expired_tombstones`` must rollback so neither
     the partial event nor the row deletion persists.
     """
-    from unittest.mock import patch
-
-    import reflexio.server.services.storage.sqlite_storage._lineage as _lineage_mod
-
     s = _store(tmp_path)
 
     # Seed two tombstone rows so the loop calls _append_event_stmt twice.
     pb1 = _make_user_playbook(content="one")
     pb2 = _make_user_playbook(content="two")
     s.save_user_playbooks([pb1, pb2])
+    old_retired_at = int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())
     for pb in (pb1, pb2):
         _set_playbook_status(
             s,
@@ -604,12 +602,8 @@ def test_gc_rollback_on_mid_operation_failure(tmp_path):
             pb.user_playbook_id,
             Status.MERGED.value,
         )
-        _set_playbook_created_at(
-            s,
-            "user_playbooks",
-            "user_playbook_id",
-            pb.user_playbook_id,
-            _epoch_to_iso(int(datetime(2019, 1, 1, tzinfo=UTC).timestamp())),
+        _set_retired_at(
+            s, "user_playbooks", "user_playbook_id", pb.user_playbook_id, old_retired_at
         )
 
     real_append = _lineage_mod._append_event_stmt

--- a/tests/server/services/storage/test_lineage_b2gc_retired_at_integration.py
+++ b/tests/server/services/storage/test_lineage_b2gc_retired_at_integration.py
@@ -1,0 +1,393 @@
+"""B2-GC T1 coverage contract: retired_at set/clear at every tombstone path.
+
+For each tombstone-creating operation, asserts that the row's ``retired_at``
+column is non-NULL (and approximately current epoch) after the operation.
+For each restore operation, asserts that ``retired_at`` is NULL.
+
+``retired_at`` is storage-internal — not on the domain model — so it is read
+via a direct ``SELECT retired_at FROM <table> WHERE <pk>=?``.
+"""
+
+import time
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    LineageContext,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FUZZ_SECONDS = 5  # retired_at must be within this many seconds of now
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _store(tmp_path, org_id: str) -> SQLiteStorage:
+    s = SQLiteStorage(org_id=org_id, db_path=str(tmp_path / f"{org_id}.db"))
+    s.migrate()
+    return s
+
+
+def _get_retired_at_profile(s: SQLiteStorage, profile_id: str) -> int | None:
+    row = s.conn.execute(
+        "SELECT retired_at FROM profiles WHERE profile_id = ?", (profile_id,)
+    ).fetchone()
+    assert row is not None, f"profile {profile_id!r} not found"
+    return row["retired_at"]
+
+
+def _get_retired_at_user_playbook(s: SQLiteStorage, upid: int) -> int | None:
+    row = s.conn.execute(
+        "SELECT retired_at FROM user_playbooks WHERE user_playbook_id = ?", (upid,)
+    ).fetchone()
+    assert row is not None, f"user_playbook {upid} not found"
+    return row["retired_at"]
+
+
+def _get_retired_at_agent_playbook(s: SQLiteStorage, apid: int) -> int | None:
+    row = s.conn.execute(
+        "SELECT retired_at FROM agent_playbooks WHERE agent_playbook_id = ?", (apid,)
+    ).fetchone()
+    assert row is not None, f"agent_playbook {apid} not found"
+    return row["retired_at"]
+
+
+def _assert_retired_now(retired_at: int | None) -> None:
+    """Assert retired_at is non-NULL and within _FUZZ_SECONDS of now."""
+    assert retired_at is not None, "retired_at must be non-NULL after tombstone op"
+    assert abs(_now() - retired_at) <= _FUZZ_SECONDS, (
+        f"retired_at {retired_at} not close to now {_now()}"
+    )
+
+
+def _assert_retired_null(retired_at: int | None) -> None:
+    assert retired_at is None, (
+        f"retired_at must be NULL after restore; got {retired_at!r}"
+    )
+
+
+def _make_profile(
+    profile_id: str = "p1",
+    user_id: str = "u1",
+) -> UserProfile:
+    return UserProfile(
+        profile_id=profile_id,
+        user_id=user_id,
+        content="content",
+        last_modified_timestamp=_now(),
+        generated_from_request_id=f"req_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_user_playbook(user_id: str = "u1") -> UserPlaybook:
+    return UserPlaybook(
+        user_id=user_id, agent_version="v1", request_id="r1", content="c"
+    )
+
+
+def _make_agent_playbook(playbook_name: str = "pb") -> AgentPlaybook:
+    return AgentPlaybook(playbook_name=playbook_name, agent_version="v1", content="c")
+
+
+# ---------------------------------------------------------------------------
+# merge_records — profiles, user_playbooks, agent_playbooks
+# ---------------------------------------------------------------------------
+
+
+def test_merge_records_profile_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-merge-profile")
+    source = _make_profile("src", "u1")
+    survivor = _make_profile("surv", "u1")
+    s.add_user_profile("u1", [source, survivor])
+
+    s.merge_records(
+        entity_type="profile",
+        survivor_id=survivor.profile_id,
+        source_ids=[source.profile_id],
+        context=LineageContext(op_kind="merge", actor="test", request_id="r-merge-p"),
+    )
+
+    _assert_retired_now(_get_retired_at_profile(s, source.profile_id))
+    # Survivor must not be retired
+    assert _get_retired_at_profile(s, survivor.profile_id) is None
+
+
+def test_merge_records_user_playbook_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-merge-up")
+    source = _make_user_playbook("u1")
+    survivor = _make_user_playbook("u1")
+    s.save_user_playbooks([source, survivor])
+
+    s.merge_records(
+        entity_type="user_playbook",
+        survivor_id=str(survivor.user_playbook_id),
+        source_ids=[str(source.user_playbook_id)],
+        context=LineageContext(op_kind="merge", actor="test", request_id="r-merge-up"),
+    )
+
+    _assert_retired_now(_get_retired_at_user_playbook(s, source.user_playbook_id))
+    assert _get_retired_at_user_playbook(s, survivor.user_playbook_id) is None
+
+
+def test_merge_records_agent_playbook_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-merge-ap")
+    source = _make_agent_playbook("pb")
+    survivor = _make_agent_playbook("pb2")
+    s.save_agent_playbooks([source, survivor])
+
+    s.merge_records(
+        entity_type="agent_playbook",
+        survivor_id=str(survivor.agent_playbook_id),
+        source_ids=[str(source.agent_playbook_id)],
+        context=LineageContext(op_kind="merge", actor="test", request_id="r-merge-ap"),
+    )
+
+    _assert_retired_now(_get_retired_at_agent_playbook(s, source.agent_playbook_id))
+    assert _get_retired_at_agent_playbook(s, survivor.agent_playbook_id) is None
+
+
+# ---------------------------------------------------------------------------
+# supersede_record
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_record_profile_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-super-record-p")
+    incumbent = _make_profile("inc", "u1")
+    successor = _make_profile("succ", "u1")
+    s.add_user_profile("u1", [incumbent, successor])
+
+    result = s.supersede_record(
+        entity_type="profile",
+        incumbent_id=incumbent.profile_id,
+        successor_id=successor.profile_id,
+        context=LineageContext(op_kind="revise", actor="test", request_id="r-super-p"),
+    )
+
+    assert result is True
+    _assert_retired_now(_get_retired_at_profile(s, incumbent.profile_id))
+    assert _get_retired_at_profile(s, successor.profile_id) is None
+
+
+def test_supersede_record_user_playbook_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-super-record-up")
+    incumbent = _make_user_playbook("u1")
+    successor = _make_user_playbook("u1")
+    s.save_user_playbooks([incumbent, successor])
+
+    result = s.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(incumbent.user_playbook_id),
+        successor_id=str(successor.user_playbook_id),
+        context=LineageContext(op_kind="revise", actor="test", request_id="r-super-up"),
+    )
+
+    assert result is True
+    _assert_retired_now(_get_retired_at_user_playbook(s, incumbent.user_playbook_id))
+    assert _get_retired_at_user_playbook(s, successor.user_playbook_id) is None
+
+
+# ---------------------------------------------------------------------------
+# supersede_profiles_by_ids
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_profiles_by_ids_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-super-profiles")
+    p1 = _make_profile("sp1", "u1")
+    p2 = _make_profile("sp2", "u1")
+    s.add_user_profile("u1", [p1, p2])
+
+    count = s.supersede_profiles_by_ids(
+        "u1", [p1.profile_id, p2.profile_id], "req-super"
+    )
+
+    assert count == 2
+    _assert_retired_now(_get_retired_at_profile(s, p1.profile_id))
+    _assert_retired_now(_get_retired_at_profile(s, p2.profile_id))
+
+
+# ---------------------------------------------------------------------------
+# archive_agent_playbooks_by_ids
+# ---------------------------------------------------------------------------
+
+
+def test_archive_agent_playbooks_by_ids_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-archive-ap-ids")
+    ap = _make_agent_playbook("pb")
+    s.save_agent_playbooks([ap])
+
+    s.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+
+    _assert_retired_now(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# archive_agent_playbooks_by_playbook_name
+# ---------------------------------------------------------------------------
+
+
+def test_archive_agent_playbooks_by_playbook_name_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-archive-ap-name")
+    ap = _make_agent_playbook("mybook")
+    s.save_agent_playbooks([ap])
+
+    s.archive_agent_playbooks_by_playbook_name("mybook")
+
+    _assert_retired_now(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# supersede_agent_playbooks_by_ids
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_agent_playbooks_by_ids_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-super-ap-ids")
+    ap = _make_agent_playbook("pb")
+    s.save_agent_playbooks([ap])
+
+    count = s.supersede_agent_playbooks_by_ids([ap.agent_playbook_id], "req-super-ap")
+
+    assert count == 1
+    _assert_retired_now(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# supersede_agent_playbooks_by_playbook_name
+# ---------------------------------------------------------------------------
+
+
+def test_supersede_agent_playbooks_by_playbook_name_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-super-ap-name")
+    ap = _make_agent_playbook("archbook")
+    s.save_agent_playbooks([ap])
+    # Must be archived first (supersede_by_name only targets archived rows)
+    s.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+
+    count = s.supersede_agent_playbooks_by_playbook_name(
+        "archbook", None, "req-super-apname"
+    )
+
+    assert count == 1
+    _assert_retired_now(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# update_all_profiles_status (tombstone → NULL restore)
+# ---------------------------------------------------------------------------
+
+
+def test_update_all_profiles_status_tombstone_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-upd-profiles-tomb")
+    p = _make_profile("up1", "u1")
+    s.add_user_profile("u1", [p])
+
+    count = s.update_all_profiles_status(None, Status.SUPERSEDED)
+
+    assert count >= 1
+    _assert_retired_now(_get_retired_at_profile(s, p.profile_id))
+
+
+def test_update_all_profiles_status_to_null_clears_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-upd-profiles-restore")
+    p = _make_profile("up2", "u1")
+    s.add_user_profile("u1", [p])
+    # First tombstone it
+    s.update_all_profiles_status(None, Status.SUPERSEDED)
+    _assert_retired_now(_get_retired_at_profile(s, p.profile_id))
+
+    # Now restore
+    s.update_all_profiles_status(Status.SUPERSEDED, None)
+
+    _assert_retired_null(_get_retired_at_profile(s, p.profile_id))
+
+
+# ---------------------------------------------------------------------------
+# update_all_user_playbooks_status (tombstone → NULL restore)
+# ---------------------------------------------------------------------------
+
+
+def test_update_all_user_playbooks_status_tombstone_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-upd-up-tomb")
+    up = _make_user_playbook("u1")
+    s.save_user_playbooks([up])
+
+    count = s.update_all_user_playbooks_status(None, Status.MERGED)
+
+    assert count >= 1
+    _assert_retired_now(_get_retired_at_user_playbook(s, up.user_playbook_id))
+
+
+def test_update_all_user_playbooks_status_to_null_clears_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-upd-up-restore")
+    up = _make_user_playbook("u1")
+    s.save_user_playbooks([up])
+    s.update_all_user_playbooks_status(None, Status.MERGED)
+    _assert_retired_now(_get_retired_at_user_playbook(s, up.user_playbook_id))
+
+    s.update_all_user_playbooks_status(Status.MERGED, None)
+
+    _assert_retired_null(_get_retired_at_user_playbook(s, up.user_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# restore_archived_agent_playbooks_by_playbook_name
+# ---------------------------------------------------------------------------
+
+
+def test_restore_archived_by_playbook_name_clears_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-restore-ap-name")
+    ap = _make_agent_playbook("restorebook")
+    s.save_agent_playbooks([ap])
+    s.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+    _assert_retired_now(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+    s.restore_archived_agent_playbooks_by_playbook_name("restorebook")
+
+    _assert_retired_null(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# restore_archived_agent_playbooks_by_ids
+# ---------------------------------------------------------------------------
+
+
+def test_restore_archived_by_ids_clears_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-restore-ap-ids")
+    ap = _make_agent_playbook("restorebook2")
+    s.save_agent_playbooks([ap])
+    s.archive_agent_playbooks_by_ids([ap.agent_playbook_id])
+    _assert_retired_now(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+    s.restore_archived_agent_playbooks_by_ids([ap.agent_playbook_id])
+
+    _assert_retired_null(_get_retired_at_agent_playbook(s, ap.agent_playbook_id))
+
+
+# ---------------------------------------------------------------------------
+# Schema guard: retired_at column exists on all three tables
+# ---------------------------------------------------------------------------
+
+
+def test_retired_at_column_exists_on_all_tombstone_tables(tmp_path) -> None:
+    s = _store(tmp_path, "org-schema-guard")
+    for table in ("profiles", "user_playbooks", "agent_playbooks"):
+        cols = {
+            row["name"]
+            for row in s.conn.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        assert "retired_at" in cols, f"retired_at column missing from {table}"

--- a/tests/server/services/storage/test_lineage_b2gc_retired_at_integration.py
+++ b/tests/server/services/storage/test_lineage_b2gc_retired_at_integration.py
@@ -379,6 +379,154 @@ def test_restore_archived_by_ids_clears_retired_at(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# F3 — missing contract cases: archive_user_playbook_by_id,
+#       archive_profile_by_id, supersede_record(agent_playbook)
+# ---------------------------------------------------------------------------
+
+
+def test_archive_user_playbook_by_id_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-archive-up-by-id")
+    up = _make_user_playbook()
+    s.save_user_playbooks([up])
+
+    result = s.archive_user_playbook_by_id("u1", up.user_playbook_id)
+
+    assert result is True
+    _assert_retired_now(_get_retired_at_user_playbook(s, up.user_playbook_id))
+
+
+def test_archive_profile_by_id_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-archive-profile-by-id")
+    p = _make_profile("ap1", "u1")
+    s.add_user_profile("u1", [p])
+
+    result = s.archive_profile_by_id("u1", p.profile_id)
+
+    assert result is True
+    _assert_retired_now(_get_retired_at_profile(s, p.profile_id))
+
+
+def test_supersede_record_agent_playbook_sets_retired_at(tmp_path) -> None:
+    s = _store(tmp_path, "org-super-record-ap")
+    incumbent = _make_agent_playbook("pb-inc")
+    successor = _make_agent_playbook("pb-succ")
+    s.save_agent_playbooks([incumbent, successor])
+
+    result = s.supersede_record(
+        entity_type="agent_playbook",
+        incumbent_id=str(incumbent.agent_playbook_id),
+        successor_id=str(successor.agent_playbook_id),
+        context=LineageContext(op_kind="revise", actor="test", request_id="r-super-ap"),
+    )
+
+    assert result is True
+    _assert_retired_now(_get_retired_at_agent_playbook(s, incumbent.agent_playbook_id))
+    assert _get_retired_at_agent_playbook(s, successor.agent_playbook_id) is None
+
+
+# ---------------------------------------------------------------------------
+# F4 — merge-on-archived: archived source must NOT be re-tombstoned to MERGED
+# ---------------------------------------------------------------------------
+
+
+def test_merge_does_not_re_tombstone_archived_source(tmp_path) -> None:
+    """Archived source must keep status=ARCHIVED and retired_at=T0 after merge."""
+    s = _store(tmp_path, "org-merge-archived-guard")
+    source = _make_profile("src-arch", "u1")
+    survivor = _make_profile("surv-arch", "u1")
+    s.add_user_profile("u1", [source, survivor])
+
+    # Archive the source first — records its retired_at=T0.
+    s.archive_profile_by_id("u1", source.profile_id)
+    retired_at_t0 = _get_retired_at_profile(s, source.profile_id)
+    assert retired_at_t0 is not None
+
+    # Now merge with the archived source among source_ids.
+    s.merge_records(
+        entity_type="profile",
+        survivor_id=survivor.profile_id,
+        source_ids=[source.profile_id],
+        context=LineageContext(
+            op_kind="merge", actor="test", request_id="r-merge-arch"
+        ),
+    )
+
+    # Status must remain ARCHIVED, not flipped to MERGED.
+    row = s.conn.execute(
+        "SELECT status, retired_at FROM profiles WHERE profile_id = ?",
+        (source.profile_id,),
+    ).fetchone()
+    assert row["status"] == "archived", (
+        f"Expected status=archived, got {row['status']!r}"
+    )
+    # retired_at must be unchanged — not re-set by the merge.
+    assert row["retired_at"] == retired_at_t0, (
+        f"retired_at changed from {retired_at_t0} to {row['retired_at']} after merge"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F5 — GC legal-hold forward-progress: a held oldest row must not starve
+#       eligible non-held rows in the same pass
+# ---------------------------------------------------------------------------
+
+
+def test_gc_legal_hold_does_not_starve_non_held_eligible_rows(tmp_path) -> None:
+    """Hold the oldest tombstone; assert the next eligible row is still GC'd."""
+    from unittest.mock import patch
+
+    s = _store(tmp_path, "org-gc-hold-progress")
+
+    # Seed two user_playbook tombstones: older_up (smaller retired_at) and newer_up.
+    older_up = _make_user_playbook()
+    newer_up = _make_user_playbook()
+    s.save_user_playbooks([older_up, newer_up])
+
+    old_epoch = _now() - 200  # 200 s ago — clearly past any cutoff
+    recent_eligible_epoch = _now() - 100  # 100 s ago
+
+    s.conn.execute(
+        "UPDATE user_playbooks SET status = 'merged', retired_at = ? "
+        "WHERE user_playbook_id = ?",
+        (old_epoch, older_up.user_playbook_id),
+    )
+    s.conn.execute(
+        "UPDATE user_playbooks SET status = 'merged', retired_at = ? "
+        "WHERE user_playbook_id = ?",
+        (recent_eligible_epoch, newer_up.user_playbook_id),
+    )
+    s.conn.commit()
+
+    cutoff = _now() - 50  # both tombstones are older than 50 s
+
+    held_id = str(older_up.user_playbook_id)
+
+    def _hold_oldest(org_id: str, entity_type: str, entity_id: str) -> bool:  # noqa: ARG001
+        return entity_id == held_id
+
+    with patch.object(s.__class__, "_is_on_legal_hold", side_effect=_hold_oldest):
+        deleted = s.gc_expired_tombstones(
+            entity_type="user_playbook",
+            older_than_epoch=cutoff,
+            limit=1,  # small limit: only 1 non-held row can be GC'd per pass
+        )
+
+    assert deleted == 1, f"Expected 1 deletion (the non-held row), got {deleted}"
+    # Held (older) row must still exist.
+    still_there = s.conn.execute(
+        "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?",
+        (older_up.user_playbook_id,),
+    ).fetchone()
+    assert still_there is not None, "Held row was incorrectly deleted"
+    # Non-held (newer) row must be gone.
+    gone = s.conn.execute(
+        "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?",
+        (newer_up.user_playbook_id,),
+    ).fetchone()
+    assert gone is None, "Non-held eligible row was NOT deleted"
+
+
+# ---------------------------------------------------------------------------
 # Schema guard: retired_at column exists on all three tables
 # ---------------------------------------------------------------------------
 

--- a/tests/server/services/storage/test_storage_contract_gc_tombstones.py
+++ b/tests/server/services/storage/test_storage_contract_gc_tombstones.py
@@ -151,6 +151,9 @@ def test_gc_does_not_delete_fresh_tombstone(storage) -> None:
     )
 
     assert deleted == 0
+    assert (
+        storage.get_profile_by_id("gc-fresh-src", include_tombstones=True) is not None
+    ), "Fresh tombstone must survive when retired_at is after cutoff"
 
     # The fresh tombstone must still be retrievable.
     events = storage.get_lineage_events(entity_type="profile", entity_id="gc-fresh-src")

--- a/tests/server/services/storage/test_storage_contract_gc_tombstones.py
+++ b/tests/server/services/storage/test_storage_contract_gc_tombstones.py
@@ -6,16 +6,13 @@ in Task 6; they will skip here without DATA_* env vars.
 
 Seeding note
 ------------
-Playbook tables store ``created_at`` as a TEXT column set by the database at
-insert time.  There is no public API to override it, so aged-playbook seeding
-requires raw SQL (handled in the SQLite-only integration test,
-``test_lineage_b2_gc_integration.py``).
+GC now ages on ``retired_at`` (INTEGER epoch, set at every tombstone write-path).
+After calling ``merge_records`` (which sets ``retired_at = now``), tests that need
+an "aged" tombstone must back-date ``retired_at`` via a raw SQL helper.  The
+SQLite-backed ``storage`` fixture exposes ``storage.conn`` for this purpose.
 
-Profile tables store ``last_modified_timestamp`` as an INTEGER set by the
-caller.  Passing an old epoch at construction time is backend-agnostic, so
-the "aged tombstone deleted + hard_delete event" case is covered here using
-profiles.  The corresponding playbook age-straddle detail lives in the SQLite
-integration test.
+Profile tables are used for contract cases because ``merge_records`` works on all
+entity types and the ``retired_at`` column exists on all tombstone-bearing tables.
 """
 
 from datetime import UTC, datetime
@@ -28,15 +25,18 @@ from reflexio.models.api_schema.service_schemas import UserProfile
 
 pytestmark = pytest.mark.integration
 
-# A fixed epoch well in the past, used to seed "aged" profiles.
+# A fixed epoch well in the past, used to seed "aged" retired_at values.
 _EPOCH_2020 = int(datetime(2020, 1, 1, tzinfo=UTC).timestamp())
-# A cutoff after the old epoch — any profile with ts < this is eligible.
+# A cutoff after the old epoch — any tombstone retired_at < this is eligible.
 _CUTOFF_2021 = int(datetime(2021, 1, 1, tzinfo=UTC).timestamp())
-# A future epoch for "fresh" profiles — after any historical cutoff.
+# A future epoch for "fresh" retired_at values — after any historical cutoff.
 _EPOCH_FUTURE = int(datetime(2035, 1, 1, tzinfo=UTC).timestamp())
 
 
-def _make_profile(profile_id: str, ts: int) -> UserProfile:
+def _make_profile(profile_id: str, ts: int | None = None) -> UserProfile:
+    from datetime import UTC, datetime
+
+    ts = ts or int(datetime.now(UTC).timestamp())
     return UserProfile(
         user_id="u1",
         profile_id=profile_id,
@@ -63,21 +63,36 @@ def _merge_into_survivor(
     )
 
 
+def _backdate_retired_at(storage, profile_id: str, retired_at: int) -> None:
+    """Back-date retired_at on a profile row for test seeding.
+
+    merge_records sets retired_at = now; tests that need an "aged" tombstone must
+    call this after the merge.
+    """
+    storage.conn.execute(
+        "UPDATE profiles SET retired_at = ? WHERE profile_id = ?",
+        (retired_at, profile_id),
+    )
+    storage.conn.commit()
+
+
 # ---------------------------------------------------------------------------
-# Case 1: Aged tombstone (MERGED, old last_modified_timestamp) is hard-deleted
+# Case 1: Aged tombstone (MERGED, old retired_at) is hard-deleted
 # and a hard_delete lineage event is emitted.
 # ---------------------------------------------------------------------------
 
 
 def test_gc_deletes_aged_merged_profile_and_emits_hard_delete(storage) -> None:
-    """Aged MERGED profile past the cutoff is deleted; a hard_delete event is recorded."""
-    old_profile = _make_profile("gc-aged-src", ts=_EPOCH_2020)
-    survivor_profile = _make_profile("gc-aged-survivor", ts=_EPOCH_2020)
+    """Aged MERGED profile (retired_at past cutoff) is deleted; a hard_delete event is recorded."""
+    old_profile = _make_profile("gc-aged-src")
+    survivor_profile = _make_profile("gc-aged-survivor")
     storage.add_user_profile("u1", [old_profile])
     storage.add_user_profile("u1", [survivor_profile])
 
-    # Tombstone old_profile (MERGED) via public API; last_modified_timestamp stays 2020.
+    # Tombstone old_profile (MERGED) via public API; retired_at is set to now.
     _merge_into_survivor(storage, "gc-aged-src", "gc-aged-survivor")
+    # Back-date retired_at so it falls before the cutoff.
+    _backdate_retired_at(storage, "gc-aged-src", _EPOCH_2020)
 
     deleted = storage.gc_expired_tombstones(
         entity_type="profile", older_than_epoch=_CUTOFF_2021
@@ -100,8 +115,8 @@ def test_gc_deletes_aged_merged_profile_and_emits_hard_delete(storage) -> None:
 
 
 def test_gc_does_not_delete_current_row(storage) -> None:
-    """A CURRENT profile (status None) must never be deleted by gc_expired_tombstones."""
-    current = _make_profile("gc-current", ts=_EPOCH_2020)
+    """A CURRENT profile (status None, retired_at NULL) must never be deleted by gc_expired_tombstones."""
+    current = _make_profile("gc-current")
     storage.add_user_profile("u1", [current])
 
     # Cutoff is far in the future — would delete any tombstone — but status is NULL.
@@ -115,31 +130,29 @@ def test_gc_does_not_delete_current_row(storage) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Case 3: A fresh tombstone (created just now) is NOT deleted by a historical
-# cutoff.
+# Case 3: A fresh tombstone (recent retired_at) is NOT deleted by a historical cutoff.
 # ---------------------------------------------------------------------------
 
 
 def test_gc_does_not_delete_fresh_tombstone(storage) -> None:
-    """A just-created tombstone whose age column is after the cutoff must survive GC."""
-    # Create the profiles with a current (future-like) timestamp so the profile's
-    # age column is well after the historical cutoff.
-    fresh_src = _make_profile("gc-fresh-src", ts=_EPOCH_FUTURE)
-    fresh_survivor = _make_profile("gc-fresh-survivor", ts=_EPOCH_FUTURE)
+    """A tombstone whose retired_at is after the cutoff must survive GC."""
+    fresh_src = _make_profile("gc-fresh-src")
+    fresh_survivor = _make_profile("gc-fresh-survivor")
     storage.add_user_profile("u1", [fresh_src])
     storage.add_user_profile("u1", [fresh_survivor])
 
-    # Tombstone the source — last_modified_timestamp stays at _EPOCH_FUTURE.
+    # Tombstone the source — retired_at is set to now by merge_records.
     _merge_into_survivor(storage, "gc-fresh-src", "gc-fresh-survivor")
+    # Leave retired_at as-is (current timestamp, well after _CUTOFF_2021).
 
-    # Cutoff is 2021 — the tombstone's ts (2035) is after the cutoff; must NOT be GC'd.
+    # Cutoff is 2021 — the tombstone's retired_at (now) is after the cutoff; must NOT be GC'd.
     deleted = storage.gc_expired_tombstones(
         entity_type="profile", older_than_epoch=_CUTOFF_2021
     )
 
     assert deleted == 0
 
-    # The fresh tombstone must still be retrievable (include_tombstones API).
+    # The fresh tombstone must still be retrievable.
     events = storage.get_lineage_events(entity_type="profile", entity_id="gc-fresh-src")
     hd_events = [e for e in events if e.op == "hard_delete"]
     assert len(hd_events) == 0
@@ -152,11 +165,12 @@ def test_gc_does_not_delete_fresh_tombstone(storage) -> None:
 
 def test_gc_idempotent_returns_zero_on_second_call(storage) -> None:
     """After GC deletes a tombstone, a second identical call returns 0 with no new events."""
-    old_profile = _make_profile("gc-idem-src", ts=_EPOCH_2020)
-    survivor = _make_profile("gc-idem-survivor", ts=_EPOCH_2020)
+    old_profile = _make_profile("gc-idem-src")
+    survivor = _make_profile("gc-idem-survivor")
     storage.add_user_profile("u1", [old_profile])
     storage.add_user_profile("u1", [survivor])
     _merge_into_survivor(storage, "gc-idem-src", "gc-idem-survivor")
+    _backdate_retired_at(storage, "gc-idem-src", _EPOCH_2020)
 
     first = storage.gc_expired_tombstones(
         entity_type="profile", older_than_epoch=_CUTOFF_2021


### PR DESCRIPTION
## Lineage B2-GC: `retired_at` age-basis + vetted retention window (resolves PB-5 / PB-8b / PB-9) — OSS

Makes the B2 tombstone garbage-collector age tombstones **correctly** so the soft-delete flags can eventually be enabled. Spec: `docs/superpowers/specs/2026-06-21-lineage-pb9-gc-retention-resolution.md` (revised after a 4-lens `/review-design-doc`, incl. a web-grounded tech-choice lens). GC stays **off-by-default** — this is the correctness fix, not enablement.

### The bug (PB-8b)
GC aged tombstones by the row's `created_at`/`last_modified_timestamp` = time-since-*write*, not time-since-*retirement* (supersede/merge/archive set `status` but never bumped those columns). So a row created long ago but retired today was **immediately GC-eligible** — and a row retired via `merge_records`/`supersede_record` had no per-row retirement event at all. (An earlier draft proposed an event-log subquery; the review proved it misses the merge/reflection-supersede paths → those tombstones would never GC. Pivoted to the industry-standard pattern.)

### The fix
- **`retired_at` epoch column** (storage-internal; not on any model/SDK) on `profiles`/`user_playbooks`/`agent_playbooks` + a `(status, retired_at)` index, added via DDL and an idempotent `_migrate_retired_at` for existing DBs.
- **Set `retired_at` at every tombstone path** (merge_records, supersede_record, supersede_*_by_ids/_by_playbook_name, archive_* incl. archive_profile_by_id/archive_user_playbook_by_id, bulk update_all_*_status) and **clear it on restore** — in the same atomic UPDATE as the status flip.
- **GC ages on `retired_at`**: `WHERE status IN (eligible) AND retired_at IS NOT NULL AND retired_at < cutoff` (uniform INTEGER epoch — also **dissolves PB-8**'s TEXT/INT heterogeneity; removed the dead `_GC_ENTITY_META` age columns). `retired_at IS NOT NULL` retains pre-existing tombstones.
- **Window:** `tombstone_grace_window_days` default **90** (vetted), docstring de-"provisional"-ized with the GDPR Art. 5(1)(e) rationale + tuner-floor note.

### Tests
A **coverage contract test** (the safety net) asserts `retired_at` is set after every tombstone op and cleared on restore; GC tests incl. the PB-8b regression (old `created_at` + recent `retired_at` → retained), NULL-retained, old-retired-purged + `hard_delete`, legal-hold-skip. 541 storage tests pass.

### Enablement gate (NOT in this PR)
GC stays `enabled=False`. Per-org enablement is an ops action gated on PB-5 (window ≥ reconstruction read-back horizon, or B3 shipped) **and DPO/product sign-off** on two flagged implications (the spec details them): the PII-lifetime extension (retirement-basis keeps content for the window *after* retirement; no content-only purge until Phase C) and the bounded audit-depth.

Paired with the enterprise PR (Supabase migration + PL/pgSQL mirror).
Minor follow-ups (non-blocking): unify `_GC_ENTITY_META` with `_TABLE`; document the tombstone→tombstone clock-reset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified tombstone GC retention/eligibility, including grace-window behavior, enablement conditions, and the tuner-floor rule.
  * Expanded GC scheduler documentation to reflect retirement-timestamp-based gating.
* **Bug Fixes**
  * Standardized tombstone aging on a single `retired_at` timestamp across profiles and playbooks; restores now clear it and GC uses strict cutoff rules.
  * Prevented re-tombstoning already archived sources during merge/supersede.
* **Chores**
  * Added SQLite migration and indexes for `retired_at` and updated table schemas accordingly.
* **Tests**
  * Updated and expanded GC integration/contract tests to seed/verify `retired_at`, legal-hold behavior, idempotency, limits, and rollback safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->