### PR TITLE
fix(lineage): enforce non-empty operation request_id (optimizer run-correlation + fail-loud lineage writes)

### DIFF
--- a/reflexio/server/services/playbook/playbook_edit_apply.py
+++ b/reflexio/server/services/playbook/playbook_edit_apply.py
@@ -18,6 +18,7 @@ def apply_playbook_edit(
     incumbent_id: int,
     new_playbook: UserPlaybook,
     source: str,
+    request_id: str,
 ) -> int:
     """Insert a replacement playbook then atomically supersede the incumbent.
 
@@ -38,18 +39,27 @@ def apply_playbook_edit(
             ``status=None``).
         source: Provenance label stored on the new playbook row and in the
             lineage event actor field.
+        request_id: Operation-run correlation id for the lineage event. Must be
+            non-empty; use the reflection run id (``ReflectionServiceRequest.request_id``)
+            or another operation-scoped id. Raises ``ValueError`` immediately
+            (before any storage write) when empty, preventing orphaned successor rows.
 
     Returns:
         The ``user_playbook_id`` of the newly inserted playbook, or ``-1`` if
         the incumbent was not CURRENT (no mutation; no orphan left behind).
+
+    Raises:
+        ValueError: If ``request_id`` is empty or None.
     """
+    if not request_id:
+        raise ValueError(
+            "apply_playbook_edit: request_id must be non-empty (operation-run correlation id)"
+        )
     new_playbook.source = source
     storage.save_user_playbooks([new_playbook])
     new_id: int = new_playbook.user_playbook_id
 
-    ctx = LineageContext(
-        op_kind="revise", actor=source, request_id=new_playbook.request_id
-    )
+    ctx = LineageContext(op_kind="revise", actor=source, request_id=request_id)
     superseded = storage.supersede_record(
         entity_type="user_playbook",
         incumbent_id=str(incumbent_id),

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -535,7 +535,14 @@ def _supersede_user_playbook(
     Returns:
         int | None: ``user_playbook_id`` of the successor, or ``None`` if the
             incumbent was not CURRENT.
+
+    Raises:
+        ValueError: If ``request_id`` is empty or None.
     """
+    if not request_id:
+        raise ValueError(
+            "_supersede_user_playbook: request_id must be non-empty (run-correlation id)"
+        )
     successor = incumbent.model_copy(
         update={"user_playbook_id": 0, "content": best_content, "status": None}
     )
@@ -587,7 +594,14 @@ def _supersede_agent_playbook(
     Returns:
         int | None: ``agent_playbook_id`` of the successor, or ``None`` if the
             incumbent was not CURRENT.
+
+    Raises:
+        ValueError: If ``request_id`` is empty or None.
     """
+    if not request_id:
+        raise ValueError(
+            "_supersede_agent_playbook: request_id must be non-empty (run-correlation id)"
+        )
     successor = incumbent.model_copy(
         update={
             "agent_playbook_id": 0,

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -129,6 +129,7 @@ class PlaybookOptimizer:
                 metadata_json=json.dumps(split_metadata, ensure_ascii=False),
             )
         )
+        run_request_id = f"optjob_{job.job_id}"
         logger.info(
             "event=playbook_optimization_start job_id=%d candidate_id=none "
             "target_kind=%s target_id=%d "
@@ -251,7 +252,9 @@ class PlaybookOptimizer:
             )
             return "completed"
 
-        successor_id = self._commit_if_allowed(target, incumbent, best_content, config)
+        successor_id = self._commit_if_allowed(
+            target, incumbent, best_content, config, run_request_id
+        )
         logger.info(
             "event=playbook_optimization_committed job_id=%d candidate_id=%d "
             "successor_target_id=%s best_score=%.3f",
@@ -425,6 +428,7 @@ class PlaybookOptimizer:
         incumbent: AgentPlaybook,
         best_content: str,
         config: PlaybookOptimizerConfig,
+        run_request_id: str,
     ) -> int | None:
         # The optimize() entrypoint already gates on _can_adopt_winner before
         # creating the job, but check again so this stays correct if called
@@ -451,6 +455,7 @@ class PlaybookOptimizer:
                 best_content,
                 "playbook_optimizer",
                 playbook_metadata=metadata,
+                request_id=run_request_id,
             )
             if successor_id is not None:
                 self.storage.set_source_windows_for_agent_playbook(
@@ -468,7 +473,11 @@ class PlaybookOptimizer:
         # is no derived polarity label or separate polarity field to keep in
         # sync.
         return _supersede_user_playbook(
-            self.storage, current_user, best_content, "playbook_optimizer"
+            self.storage,
+            current_user,
+            best_content,
+            "playbook_optimizer",
+            request_id=run_request_id,
         )
 
 
@@ -506,6 +515,8 @@ def _supersede_user_playbook(
     incumbent: UserPlaybook,
     best_content: str,
     source: str,
+    *,
+    request_id: str,
 ) -> int | None:
     """Insert a user-playbook successor then atomically supersede the incumbent.
 
@@ -518,6 +529,8 @@ def _supersede_user_playbook(
         incumbent: The current user playbook to replace.
         best_content: Content for the successor playbook.
         source: Provenance label written to the lineage event actor field.
+        request_id: Run-scoped correlation id for the lineage event. Must be
+            non-empty; use the job-derived id from the calling optimizer run.
 
     Returns:
         int | None: ``user_playbook_id`` of the successor, or ``None`` if the
@@ -530,7 +543,7 @@ def _supersede_user_playbook(
     ctx = LineageContext(
         op_kind="revise",
         actor=source,
-        request_id=incumbent.request_id,
+        request_id=request_id,
     )
     ok = storage.supersede_record(
         entity_type="user_playbook",
@@ -553,6 +566,8 @@ def _supersede_agent_playbook(
     best_content: str,
     source: str,
     playbook_metadata: str = "",
+    *,
+    request_id: str,
 ) -> int | None:
     """Insert an agent-playbook successor then atomically supersede the incumbent.
 
@@ -566,6 +581,8 @@ def _supersede_agent_playbook(
         best_content: Content for the successor playbook.
         source: Provenance label written to the lineage event actor field.
         playbook_metadata: Optional metadata string for the successor row.
+        request_id: Run-scoped correlation id for the lineage event. Must be
+            non-empty; use the job-derived id from the calling optimizer run.
 
     Returns:
         int | None: ``agent_playbook_id`` of the successor, or ``None`` if the
@@ -587,7 +604,7 @@ def _supersede_agent_playbook(
     ctx = LineageContext(
         op_kind="revise",
         actor=source,
-        request_id=None,
+        request_id=request_id,
     )
     ok = storage.supersede_record(
         entity_type="agent_playbook",

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -31,6 +31,22 @@ from .scenario_resolver import ScenarioResolver
 
 logger = logging.getLogger(__name__)
 
+# Prefix used when constructing the run-scoped lineage request_id from a job id.
+# Shared with tests so the format is defined in one place.
+_OPTIMIZER_RUN_ID_PREFIX = "optjob_"
+
+
+def optimizer_run_request_id(job_id: int) -> str:
+    """Return the lineage request_id for a playbook optimizer run.
+
+    Args:
+        job_id (int): The ``PlaybookOptimizationJob.job_id`` for this run.
+
+    Returns:
+        str: A non-empty, job-scoped request id of the form ``optjob_<job_id>``.
+    """
+    return f"{_OPTIMIZER_RUN_ID_PREFIX}{job_id}"
+
 
 class PlaybookOptimizationTarget(BaseModel):
     """A single playbook (agent or user) the optimizer should try to improve."""
@@ -129,7 +145,7 @@ class PlaybookOptimizer:
                 metadata_json=json.dumps(split_metadata, ensure_ascii=False),
             )
         )
-        run_request_id = f"optjob_{job.job_id}"
+        run_request_id = optimizer_run_request_id(job.job_id)
         logger.info(
             "event=playbook_optimization_start job_id=%d candidate_id=none "
             "target_kind=%s target_id=%d "

--- a/reflexio/server/services/reflection/reflection_service.py
+++ b/reflexio/server/services/reflection/reflection_service.py
@@ -604,6 +604,7 @@ class ReflectionService:
                 incumbent_id=cited.user_playbook_id,
                 new_playbook=new_playbook,
                 source=new_playbook.source or "reflection",
+                request_id=request.request_id,
             )
         except Exception as exc:  # noqa: BLE001
             with sentry_tags(

--- a/reflexio/server/services/reflection/reflection_service_utils.py
+++ b/reflexio/server/services/reflection/reflection_service_utils.py
@@ -17,6 +17,7 @@ from typing import Literal
 from pydantic import BaseModel, Field
 
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
+from reflexio.models.api_schema.validators import NonEmptyStr
 
 REFLECTION_OPERATION_NAME = "reflection"
 
@@ -30,11 +31,13 @@ class ReflectionServiceRequest(BaseModel):
 
     Args:
         user_id (str): User to scope the bookmark and window to.
-        request_id (str): The publish pass's own request id; used as the
+        request_id (NonEmptyStr): The publish pass's own request id; used as the
             lineage event ``request_id`` on revise events so B3
             reconstruction can link revisions back to the triggering pass.
             Defaults to a fresh UUID hex so two passes on the same profile
             with no explicit request_id produce distinct lineage events.
+            Empty strings and whitespace-only values are rejected at
+            construction (``ValidationError``), before any storage write.
         agent_version (str): Agent version of the current publish; copied
             into replacement playbooks.
         source (str | None): Optional source filter for the window.
@@ -43,7 +46,7 @@ class ReflectionServiceRequest(BaseModel):
     """
 
     user_id: str
-    request_id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    request_id: NonEmptyStr = Field(default_factory=lambda: uuid.uuid4().hex)
     agent_version: str = ""
     source: str | None = None
 

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -27,6 +27,9 @@ _TABLE: dict[str, tuple[str, str]] = {
     "profile": ("profiles", "profile_id"),
 }
 
+# Error message used by merge_records and supersede_record guards.
+# Shared here so tests can reference this exact string without hardcoding.
+_EMPTY_REQUEST_ID_MSG = "request_id must be non-empty"
 
 def _resolve_table(entity_type: str) -> tuple[str, str]:
     """Map an entity_type to its (table, primary_key), raising on bad input."""
@@ -220,9 +223,10 @@ class SQLiteLineageMixin:
 
         Raises:
             ValueError: If ``entity_type`` is not a recognized entity type.
+            ValueError: If ``context.request_id`` is empty or whitespace-only.
         """
-        if not context.request_id:
-            raise ValueError("lineage merge: request_id must be non-empty")
+        if not (context.request_id and context.request_id.strip()):
+            raise ValueError(f"lineage merge: {_EMPTY_REQUEST_ID_MSG}")
         table, pk = _resolve_table(entity_type)
         now = _epoch_now()
         eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
@@ -291,9 +295,10 @@ class SQLiteLineageMixin:
 
         Raises:
             ValueError: If ``entity_type`` is not a recognized entity type.
+            ValueError: If ``context.request_id`` is empty or whitespace-only.
         """
-        if not context.request_id:
-            raise ValueError("lineage supersede: request_id must be non-empty")
+        if not (context.request_id and context.request_id.strip()):
+            raise ValueError(f"lineage supersede: {_EMPTY_REQUEST_ID_MSG}")
         table, pk = _resolve_table(entity_type)
         with self._lock:
             cur = self.conn.execute(

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -221,6 +221,8 @@ class SQLiteLineageMixin:
         Raises:
             ValueError: If ``entity_type`` is not a recognized entity type.
         """
+        if not context.request_id:
+            raise ValueError("lineage merge: request_id must be non-empty")
         table, pk = _resolve_table(entity_type)
         now = _epoch_now()
         eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
@@ -256,7 +258,7 @@ class SQLiteLineageMixin:
                 prov="wasDerivedFrom",
                 source_ids=source_ids,
                 actor=context.actor,
-                request_id=context.request_id or "",
+                request_id=context.request_id,
                 reason=context.reason,
             )
             self.conn.commit()
@@ -290,6 +292,8 @@ class SQLiteLineageMixin:
         Raises:
             ValueError: If ``entity_type`` is not a recognized entity type.
         """
+        if not context.request_id:
+            raise ValueError("lineage supersede: request_id must be non-empty")
         table, pk = _resolve_table(entity_type)
         with self._lock:
             cur = self.conn.execute(
@@ -309,7 +313,7 @@ class SQLiteLineageMixin:
                 prov="wasRevisionOf",
                 source_ids=[incumbent_id],
                 actor=context.actor,
-                request_id=context.request_id or "",
+                request_id=context.request_id,
                 reason=context.reason,
             )
             self.conn.commit()

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -21,6 +21,14 @@ class LineageEventMixin:
 
         Returns:
             int: The assigned or existing ``event_id``.
+
+        Note:
+            This method deliberately does NOT enforce a non-empty ``request_id``.
+            System and GC events (e.g. ``hard_delete`` from TTL GC, ``status_change``
+            from internal transitions) legitimately use an auto-generated UUID that
+            need not be tied to a user-facing request id. Callers that require
+            request-scoped lineage (``merge_records``, ``supersede_record``) enforce
+            non-empty ``request_id`` themselves.
         """
         raise NotImplementedError
 
@@ -76,6 +84,9 @@ class LineageEventMixin:
             survivor_id (str): The id of the record that survives the merge.
             source_ids (list[str]): Ids of records to tombstone as merged.
             context (LineageContext): Caller-supplied intent (actor, reason, etc.).
+
+        Raises:
+            ValueError: If ``context.request_id`` is empty or whitespace-only.
         """
         raise NotImplementedError
 
@@ -106,6 +117,9 @@ class LineageEventMixin:
         Returns:
             bool: ``True`` if the incumbent was CURRENT and was superseded;
                 ``False`` if the incumbent was not CURRENT and no mutation occurred.
+
+        Raises:
+            ValueError: If ``context.request_id`` is empty or whitespace-only.
         """
         raise NotImplementedError
 

--- a/tests/server/services/playbook/test_apply_playbook_edit_integration.py
+++ b/tests/server/services/playbook/test_apply_playbook_edit_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for apply_playbook_edit() — atomic supersede path."""
 
 import pytest
+
 from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.services.playbook.playbook_edit_apply import apply_playbook_edit
@@ -15,7 +16,13 @@ def test_apply_supersedes_incumbent_and_links(tmp_path):
     inc = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v1")
     s.save_user_playbooks([inc])
     new = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v2")
-    new_id = apply_playbook_edit(s, incumbent_id=inc.user_playbook_id, new_playbook=new, source="offline_optimizer")
+    new_id = apply_playbook_edit(
+        s,
+        incumbent_id=inc.user_playbook_id,
+        new_playbook=new,
+        source="offline_optimizer",
+        request_id="run-test-1",
+    )
     assert new_id > 0
     tomb = s.get_user_playbook_by_id(inc.user_playbook_id, include_tombstones=True)
     assert tomb.status is Status.SUPERSEDED and tomb.superseded_by == new_id
@@ -24,11 +31,23 @@ def test_apply_supersedes_incumbent_and_links(tmp_path):
 def test_apply_no_orphan_when_incumbent_already_gone(tmp_path):
     s = SQLiteStorage(org_id="test_org", db_path=str(tmp_path / "t.db"))
     s.migrate()
-    inc = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v1", status=Status.ARCHIVED)
+    inc = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r",
+        content="v1",
+        status=Status.ARCHIVED,
+    )
     s.save_user_playbooks([inc])
     new = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="v2")
-    rc = apply_playbook_edit(s, incumbent_id=inc.user_playbook_id, new_playbook=new, source="offline_optimizer")
+    rc = apply_playbook_edit(
+        s,
+        incumbent_id=inc.user_playbook_id,
+        new_playbook=new,
+        source="offline_optimizer",
+        request_id="run-test-2",
+    )
     assert rc == -1
     # no orphan CURRENT row left behind
-    currents = [p for p in s.get_user_playbooks(user_id="u")]
+    currents = list(s.get_user_playbooks(user_id="u"))
     assert all(p.content != "v2" for p in currents)

--- a/tests/server/services/playbook/test_playbook_edit_apply.py
+++ b/tests/server/services/playbook/test_playbook_edit_apply.py
@@ -7,6 +7,9 @@ import pytest
 
 from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage._lineage import (
+    _EMPTY_REQUEST_ID_MSG,
+)
 
 
 def _storage(tmp: str) -> SQLiteStorage:
@@ -169,25 +172,49 @@ def test_apply_raises_on_empty_request_id_before_write():
             s.save_user_playbooks([old])
             old_id = old.user_playbook_id
 
-        with pytest.raises(ValueError, match="request_id must be non-empty"):
+        # Patch save_user_playbooks to confirm it is never reached on empty request_id.
+        with patch.object(s, "save_user_playbooks") as mock_save:
+            with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
+                apply_playbook_edit(
+                    s,
+                    incumbent_id=old_id,
+                    new_playbook=_playbook(content="new"),
+                    source="offline_optimizer",
+                    request_id="",
+                )
+            mock_save.assert_not_called()
+
+        # No orphan: no successor row was inserted (incumbent still CURRENT, count==1).
+        count = s.conn.execute(
+            "SELECT COUNT(*) FROM user_playbooks WHERE status IS NULL"
+        ).fetchone()[0]
+        assert count == 1, (
+            "no orphan successor row should be inserted on empty request_id"
+        )
+
+
+@pytest.mark.parametrize("bad_request_id", ["", None])
+def test_apply_raises_on_empty_or_none_request_id(bad_request_id):
+    """apply_playbook_edit raises ValueError for both empty string and None request_id."""
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+
+        with pytest.raises((ValueError, TypeError)):
             apply_playbook_edit(
                 s,
                 incumbent_id=old_id,
                 new_playbook=_playbook(content="new"),
                 source="offline_optimizer",
-                request_id="",
+                request_id=bad_request_id,  # type: ignore[arg-type]
             )
-
-        # No orphan: no successor row was inserted
-        count = s.conn.execute(
-            "SELECT COUNT(*) FROM user_playbooks WHERE status IS NULL"
-        ).fetchone()[0]
-        # The original old playbook was archived by archive_user_playbook_by_id;
-        # without that call here the incumbent is still CURRENT; count must be 1
-        # (only the original, no successor).
-        assert count == 1, (
-            "no orphan successor row should be inserted on empty request_id"
-        )
 
 
 def test_apply_lineage_event_carries_operation_run_id():

--- a/tests/server/services/playbook/test_playbook_edit_apply.py
+++ b/tests/server/services/playbook/test_playbook_edit_apply.py
@@ -3,6 +3,8 @@
 import tempfile
 from unittest.mock import patch
 
+import pytest
+
 from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
@@ -38,7 +40,11 @@ def test_apply_inserts_new_and_archives_incumbent():
 
             new = _playbook(content="new")
             new_id = apply_playbook_edit(
-                s, incumbent_id=old_id, new_playbook=new, source="offline_optimizer"
+                s,
+                incumbent_id=old_id,
+                new_playbook=new,
+                source="offline_optimizer",
+                request_id="run-abc",
             )
         assert new_id > 0
 
@@ -67,7 +73,11 @@ def test_apply_skips_archive_when_incumbent_not_current():
 
             new = _playbook(content="new")
             new_id = apply_playbook_edit(
-                s, incumbent_id=old_id, new_playbook=new, source="offline_optimizer"
+                s,
+                incumbent_id=old_id,
+                new_playbook=new,
+                source="offline_optimizer",
+                request_id="run-abc",
             )
         # Optimistic-concurrency: incumbent was already archived → skip and return -1
         assert new_id == -1
@@ -93,6 +103,7 @@ def test_apply_expect_current_false_archives():
                 incumbent_id=old_id,
                 new_playbook=new,
                 source="offline_optimizer",
+                request_id="run-abc",
             )
         assert new_id > 0
 
@@ -130,6 +141,7 @@ def test_apply_expect_current_false_returns_minus1_and_no_orphan():
                 incumbent_id=old_id,
                 new_playbook=new,
                 source="offline_optimizer",
+                request_id="run-abc",
             )
         # supersede_record returned False → -1, successor cleaned up (no orphan)
         assert new_id == -1
@@ -138,3 +150,81 @@ def test_apply_expect_current_false_returns_minus1_and_no_orphan():
         all_pbs = s.get_user_playbooks(user_id="u1")
         current_ids = {p.user_playbook_id for p in all_pbs if p.status is None}
         assert len(current_ids) == 0
+
+
+def test_apply_raises_on_empty_request_id_before_write():
+    """apply_playbook_edit raises ValueError on empty request_id before any storage write.
+
+    The I2 (orphan) guard: an empty request_id is rejected immediately so no
+    successor row is ever inserted when the caller forgets to supply a run id.
+    """
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+
+        with pytest.raises(ValueError, match="request_id must be non-empty"):
+            apply_playbook_edit(
+                s,
+                incumbent_id=old_id,
+                new_playbook=_playbook(content="new"),
+                source="offline_optimizer",
+                request_id="",
+            )
+
+        # No orphan: no successor row was inserted
+        count = s.conn.execute(
+            "SELECT COUNT(*) FROM user_playbooks WHERE status IS NULL"
+        ).fetchone()[0]
+        # The original old playbook was archived by archive_user_playbook_by_id;
+        # without that call here the incumbent is still CURRENT; count must be 1
+        # (only the original, no successor).
+        assert count == 1, (
+            "no orphan successor row should be inserted on empty request_id"
+        )
+
+
+def test_apply_lineage_event_carries_operation_run_id():
+    """apply_playbook_edit records the operation-run request_id on the revise event.
+
+    The lineage event must carry the operation request_id (the reflection run id),
+    NOT the incumbent's birth request_id.  This enables correct run-correlation.
+    """
+    from reflexio.server.services.playbook.playbook_edit_apply import (
+        apply_playbook_edit,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        s = _storage(tmp)
+        with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+            old = _playbook(content="old")
+            s.save_user_playbooks([old])
+            old_id = old.user_playbook_id
+            assert old_id > 0
+
+            operation_run_id = "reflection_run_xyz"
+            new = _playbook(content="new")
+            new_id = apply_playbook_edit(
+                s,
+                incumbent_id=old_id,
+                new_playbook=new,
+                source="reflection",
+                request_id=operation_run_id,
+            )
+        assert new_id > 0
+
+        events = s.get_lineage_events(
+            entity_type="user_playbook", entity_id=str(new_id)
+        )
+        assert len(events) == 1
+        assert events[0].op == "revise"
+        assert events[0].request_id == operation_run_id, (
+            f"lineage event must carry the operation run id {operation_run_id!r}, "
+            f"not the incumbent's birth request_id {old.request_id!r}"
+        )

--- a/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
+++ b/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
@@ -56,7 +56,11 @@ def test_supersede_user_playbook_sets_superseded_by_and_revise_event(tmp_path):
     incumbent_id = incumbent.user_playbook_id
 
     result = _supersede_user_playbook(
-        storage, incumbent, "new content", "playbook_optimizer"
+        storage,
+        incumbent,
+        "new content",
+        "playbook_optimizer",
+        request_id="optjob_1",
     )
 
     assert result is not None, "helper should return the successor id on success"
@@ -106,7 +110,11 @@ def test_supersede_user_playbook_returns_none_for_non_current_incumbent(tmp_path
     ).fetchone()["cnt"]
 
     result = _supersede_user_playbook(
-        storage, incumbent, "new content", "playbook_optimizer"
+        storage,
+        incumbent,
+        "new content",
+        "playbook_optimizer",
+        request_id="optjob_2",
     )
 
     assert result is None, "helper should return None when incumbent is not CURRENT"
@@ -143,7 +151,11 @@ def test_supersede_agent_playbook_sets_superseded_by_and_revise_event(tmp_path):
     incumbent_id = incumbent.agent_playbook_id
 
     result = _supersede_agent_playbook(
-        storage, incumbent, "new agent content", "playbook_optimizer"
+        storage,
+        incumbent,
+        "new agent content",
+        "playbook_optimizer",
+        request_id="optjob_99",
     )
 
     assert result is not None, "helper should return the successor id on success"
@@ -195,7 +207,11 @@ def test_supersede_agent_playbook_returns_none_for_non_current_incumbent(tmp_pat
     ).fetchone()["cnt"]
 
     result = _supersede_agent_playbook(
-        storage, incumbent, "new agent content", "playbook_optimizer"
+        storage,
+        incumbent,
+        "new agent content",
+        "playbook_optimizer",
+        request_id="job-x",
     )
 
     assert result is None, "helper should return None when incumbent is not CURRENT"
@@ -209,3 +225,84 @@ def test_supersede_agent_playbook_returns_none_for_non_current_incumbent(tmp_pat
 
     events = storage.get_lineage_events(entity_type="agent_playbook")
     assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: two optimizer passes on the same agent_playbook must produce
+# two distinct, non-colliding lineage events (not silently drop the second).
+# Bug: _supersede_agent_playbook passed request_id=None which coerced to ""
+# causing (org, "agent_playbook", id, "revise", "") to collide on the second
+# call — ON CONFLICT DO NOTHING silently discarded the second event.
+# ---------------------------------------------------------------------------
+
+
+def test_two_optimizer_passes_produce_distinct_revise_events(tmp_path):
+    """Regression: two optimizer supersede calls on the same incumbent emit two events.
+
+    Pre-fix: both calls used request_id="" (coerced from None) so the second
+    INSERT OR IGNORE hit the unique constraint and was silently dropped,
+    leaving only one event in the log.
+
+    Post-fix: each call receives a distinct job-derived request_id so both
+    events are stored and both are non-empty.
+    """
+    storage = _storage(tmp_path)
+    [incumbent] = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="original content",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+
+    # First optimizer pass — simulates job 101
+    result_1 = _supersede_agent_playbook(
+        storage,
+        incumbent,
+        "improved content v1",
+        "playbook_optimizer",
+        request_id="optjob_101",
+    )
+    assert result_1 is not None, "first supersede should succeed"
+
+    # Restore the incumbent to CURRENT so a second pass can supersede it again
+    # (simulates a separate optimizer run picking up the same original row
+    # before the first pass has committed, or replays on a fresh incumbent copy).
+    # In practice we re-insert the original incumbent and supersede it again.
+    [incumbent2] = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="original content",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+
+    # Second optimizer pass — simulates job 102 (different request_id)
+    result_2 = _supersede_agent_playbook(
+        storage,
+        incumbent2,
+        "improved content v2",
+        "playbook_optimizer",
+        request_id="optjob_102",
+    )
+    assert result_2 is not None, "second supersede should succeed"
+
+    # Both revise events must exist and carry distinct non-empty request_ids
+    events = storage.get_lineage_events(entity_type="agent_playbook")
+    revise_events = [e for e in events if e.op == "revise"]
+    assert len(revise_events) == 2, (
+        f"expected 2 distinct revise events, got {len(revise_events)}; "
+        "the second may have been silently dropped by ON CONFLICT DO NOTHING "
+        "(regression: request_id=None coerced to '' causing key collision)"
+    )
+    request_ids = {e.request_id for e in revise_events}
+    assert "" not in request_ids, "no revise event should have an empty request_id"
+    assert request_ids == {"optjob_101", "optjob_102"}, (
+        f"expected distinct job-derived request_ids, got {request_ids}"
+    )

--- a/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
+++ b/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
@@ -26,8 +26,12 @@ from reflexio.models.api_schema.domain.enums import Status
 from reflexio.server.services.playbook_optimizer.optimizer import (
     _supersede_agent_playbook,
     _supersede_user_playbook,
+    optimizer_run_request_id,
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage._lineage import (
+    _EMPTY_REQUEST_ID_MSG,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -65,7 +69,7 @@ def test_supersede_user_playbook_sets_superseded_by_and_revise_event(tmp_path):
         incumbent,
         "new content",
         "playbook_optimizer",
-        request_id="optjob_1",
+        request_id=optimizer_run_request_id(1),
     )
 
     assert result is not None, "helper should return the successor id on success"
@@ -119,7 +123,7 @@ def test_supersede_user_playbook_returns_none_for_non_current_incumbent(tmp_path
         incumbent,
         "new content",
         "playbook_optimizer",
-        request_id="optjob_2",
+        request_id=optimizer_run_request_id(2),
     )
 
     assert result is None, "helper should return None when incumbent is not CURRENT"
@@ -160,7 +164,7 @@ def test_supersede_agent_playbook_sets_superseded_by_and_revise_event(tmp_path):
         incumbent,
         "new agent content",
         "playbook_optimizer",
-        request_id="optjob_99",
+        request_id=optimizer_run_request_id(99),
     )
 
     assert result is not None, "helper should return the successor id on success"
@@ -255,7 +259,7 @@ def test_supersede_user_playbook_revise_event_carries_job_request_id(tmp_path):
     )
     storage.save_user_playbooks([incumbent])
 
-    run_id = "optjob_42"
+    run_id = optimizer_run_request_id(42)
     result = _supersede_user_playbook(
         storage,
         incumbent,
@@ -274,7 +278,6 @@ def test_supersede_user_playbook_revise_event_carries_job_request_id(tmp_path):
         f"revise event must carry the job-derived run id {run_id!r}, "
         f"got {events[0].request_id!r}"
     )
-    assert events[0].request_id != "", "revise event request_id must not be empty"
 
 
 def test_supersede_agent_playbook_revise_event_carries_job_request_id(tmp_path):
@@ -295,7 +298,7 @@ def test_supersede_agent_playbook_revise_event_carries_job_request_id(tmp_path):
         ]
     )
 
-    run_id = "optjob_99"
+    run_id = optimizer_run_request_id(99)
     result = _supersede_agent_playbook(
         storage,
         incumbent,
@@ -314,7 +317,6 @@ def test_supersede_agent_playbook_revise_event_carries_job_request_id(tmp_path):
         f"revise event must carry the job-derived run id {run_id!r}, "
         f"got {events[0].request_id!r}"
     )
-    assert events[0].request_id != "", "revise event request_id must not be empty"
 
 
 def test_supersede_user_playbook_raises_on_empty_request_id(tmp_path):
@@ -329,9 +331,7 @@ def test_supersede_user_playbook_raises_on_empty_request_id(tmp_path):
     )
     storage.save_user_playbooks([incumbent])
 
-    import pytest
-
-    with pytest.raises(ValueError, match="request_id must be non-empty"):
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
         _supersede_user_playbook(
             storage, incumbent, "new content", "playbook_optimizer", request_id=""
         )
@@ -355,9 +355,7 @@ def test_supersede_agent_playbook_raises_on_empty_request_id(tmp_path):
         ]
     )
 
-    import pytest
-
-    with pytest.raises(ValueError, match="request_id must be non-empty"):
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
         _supersede_agent_playbook(
             storage, incumbent, "new content", "playbook_optimizer", request_id=""
         )

--- a/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
+++ b/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
@@ -4,6 +4,11 @@ Tests the ``_supersede_user_playbook`` and ``_supersede_agent_playbook`` helpers
 that were extracted from ``PlaybookOptimizer._commit_if_allowed`` as part of the
 lineage Phase A work.  These helpers are unit-tested directly against a real
 SQLite storage so no full PlaybookOptimizer construction is needed.
+
+B3 request_id contract: each supersede call must stamp a non-empty, job-derived
+request_id on its revise lineage event, enabling correct run-correlation (tying
+optimizer/edit events to their originating job).  An empty request_id would coerce
+to "" and be silently rejected by the non-empty guard in ``supersede_record``.
 """
 
 from __future__ import annotations
@@ -228,23 +233,55 @@ def test_supersede_agent_playbook_returns_none_for_non_current_incumbent(tmp_pat
 
 
 # ---------------------------------------------------------------------------
-# Regression: two optimizer passes on the same agent_playbook must produce
-# two distinct, non-colliding lineage events (not silently drop the second).
-# Bug: _supersede_agent_playbook passed request_id=None which coerced to ""
-# causing (org, "agent_playbook", id, "revise", "") to collide on the second
-# call — ON CONFLICT DO NOTHING silently discarded the second event.
+# B3 contract: helpers stamp a non-empty, job-derived request_id on revise events
 # ---------------------------------------------------------------------------
 
 
-def test_two_optimizer_passes_produce_distinct_revise_events(tmp_path):
-    """Regression: two optimizer supersede calls on the same incumbent emit two events.
+def test_supersede_user_playbook_revise_event_carries_job_request_id(tmp_path):
+    """_supersede_user_playbook stamps the passed request_id on the revise event.
 
-    Pre-fix: both calls used request_id="" (coerced from None) so the second
-    INSERT OR IGNORE hit the unique constraint and was silently dropped,
-    leaving only one event in the log.
+    The value of the B3 request_id change is correct run-correlation: tying each
+    optimizer/edit event to its originating job id.  The revise event's request_id
+    must be non-empty and equal the run id passed in — not empty, not the incumbent's
+    birth request_id.
+    """
+    storage = _storage(tmp_path)
+    incumbent = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="birth-req-original",
+        playbook_name="support",
+        content="old content",
+    )
+    storage.save_user_playbooks([incumbent])
 
-    Post-fix: each call receives a distinct job-derived request_id so both
-    events are stored and both are non-empty.
+    run_id = "optjob_42"
+    result = _supersede_user_playbook(
+        storage,
+        incumbent,
+        "new content",
+        "playbook_optimizer",
+        request_id=run_id,
+    )
+
+    assert result is not None
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(result)
+    )
+    assert len(events) == 1
+    assert events[0].op == "revise"
+    assert events[0].request_id == run_id, (
+        f"revise event must carry the job-derived run id {run_id!r}, "
+        f"got {events[0].request_id!r}"
+    )
+    assert events[0].request_id != "", "revise event request_id must not be empty"
+
+
+def test_supersede_agent_playbook_revise_event_carries_job_request_id(tmp_path):
+    """_supersede_agent_playbook stamps the passed request_id on the revise event.
+
+    Same contract as the user-playbook helper: the lineage event's request_id
+    must equal the job-derived run id, enabling correct run-correlation.
     """
     storage = _storage(tmp_path)
     [incumbent] = storage.save_agent_playbooks(
@@ -252,57 +289,79 @@ def test_two_optimizer_passes_produce_distinct_revise_events(tmp_path):
             AgentPlaybook(
                 playbook_name="support",
                 agent_version="v1",
-                content="original content",
+                content="old agent content",
                 playbook_status=PlaybookStatus.PENDING,
             )
         ]
     )
 
-    # First optimizer pass — simulates job 101
-    result_1 = _supersede_agent_playbook(
+    run_id = "optjob_99"
+    result = _supersede_agent_playbook(
         storage,
         incumbent,
-        "improved content v1",
+        "new agent content",
         "playbook_optimizer",
-        request_id="optjob_101",
+        request_id=run_id,
     )
-    assert result_1 is not None, "first supersede should succeed"
 
-    # Restore the incumbent to CURRENT so a second pass can supersede it again
-    # (simulates a separate optimizer run picking up the same original row
-    # before the first pass has committed, or replays on a fresh incumbent copy).
-    # In practice we re-insert the original incumbent and supersede it again.
-    [incumbent2] = storage.save_agent_playbooks(
+    assert result is not None
+    events = storage.get_lineage_events(
+        entity_type="agent_playbook", entity_id=str(result)
+    )
+    assert len(events) == 1
+    assert events[0].op == "revise"
+    assert events[0].request_id == run_id, (
+        f"revise event must carry the job-derived run id {run_id!r}, "
+        f"got {events[0].request_id!r}"
+    )
+    assert events[0].request_id != "", "revise event request_id must not be empty"
+
+
+def test_supersede_user_playbook_raises_on_empty_request_id(tmp_path):
+    """_supersede_user_playbook raises ValueError on empty request_id before any write."""
+    storage = _storage(tmp_path)
+    incumbent = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="birth-req",
+        playbook_name="support",
+        content="old content",
+    )
+    storage.save_user_playbooks([incumbent])
+
+    import pytest
+
+    with pytest.raises(ValueError, match="request_id must be non-empty"):
+        _supersede_user_playbook(
+            storage, incumbent, "new content", "playbook_optimizer", request_id=""
+        )
+
+    # No orphan successor should have been inserted
+    count = storage.conn.execute("SELECT COUNT(*) FROM user_playbooks").fetchone()[0]
+    assert count == 1, "no orphan row should be inserted when request_id is empty"
+
+
+def test_supersede_agent_playbook_raises_on_empty_request_id(tmp_path):
+    """_supersede_agent_playbook raises ValueError on empty request_id before any write."""
+    storage = _storage(tmp_path)
+    [incumbent] = storage.save_agent_playbooks(
         [
             AgentPlaybook(
                 playbook_name="support",
                 agent_version="v1",
-                content="original content",
+                content="old content",
                 playbook_status=PlaybookStatus.PENDING,
             )
         ]
     )
 
-    # Second optimizer pass — simulates job 102 (different request_id)
-    result_2 = _supersede_agent_playbook(
-        storage,
-        incumbent2,
-        "improved content v2",
-        "playbook_optimizer",
-        request_id="optjob_102",
-    )
-    assert result_2 is not None, "second supersede should succeed"
+    import pytest
 
-    # Both revise events must exist and carry distinct non-empty request_ids
-    events = storage.get_lineage_events(entity_type="agent_playbook")
-    revise_events = [e for e in events if e.op == "revise"]
-    assert len(revise_events) == 2, (
-        f"expected 2 distinct revise events, got {len(revise_events)}; "
-        "the second may have been silently dropped by ON CONFLICT DO NOTHING "
-        "(regression: request_id=None coerced to '' causing key collision)"
-    )
-    request_ids = {e.request_id for e in revise_events}
-    assert "" not in request_ids, "no revise event should have an empty request_id"
-    assert request_ids == {"optjob_101", "optjob_102"}, (
-        f"expected distinct job-derived request_ids, got {request_ids}"
-    )
+    with pytest.raises(ValueError, match="request_id must be non-empty"):
+        _supersede_agent_playbook(
+            storage, incumbent, "new content", "playbook_optimizer", request_id=""
+        )
+
+    # No orphan successor should have been inserted
+    count = storage.conn.execute("SELECT COUNT(*) FROM agent_playbooks").fetchone()[0]
+    assert count == 1, "no orphan row should be inserted when request_id is empty"

--- a/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
+++ b/tests/server/services/playbook_optimizer/test_optimizer_supersede_integration.py
@@ -7,8 +7,8 @@ SQLite storage so no full PlaybookOptimizer construction is needed.
 
 B3 request_id contract: each supersede call must stamp a non-empty, job-derived
 request_id on its revise lineage event, enabling correct run-correlation (tying
-optimizer/edit events to their originating job).  An empty request_id would coerce
-to "" and be silently rejected by the non-empty guard in ``supersede_record``.
+optimizer/edit events to their originating job).  An empty request_id is rejected
+loudly (``ValueError``) by the guard at the top of each helper, before any write.
 """
 
 from __future__ import annotations

--- a/tests/server/services/reflection/test_reflection_service_utils.py
+++ b/tests/server/services/reflection/test_reflection_service_utils.py
@@ -1,8 +1,12 @@
 """Tests for ReflectionDecision and ReflectionResult schema shape."""
 
+import pytest
+from pydantic import ValidationError
+
 from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionDecision,
     ReflectionResult,
+    ReflectionServiceRequest,
 )
 
 
@@ -64,12 +68,30 @@ def test_reflection_service_request_default_request_id_is_unique():
     the second revise event via INSERT OR IGNORE. The default_factory ensures each
     construction yields a distinct hex string.
     """
-    from reflexio.server.services.reflection.reflection_service_utils import (
-        ReflectionServiceRequest,
-    )
-
     r1 = ReflectionServiceRequest(user_id="u1")
     r2 = ReflectionServiceRequest(user_id="u1")
     assert r1.request_id != ""
     assert r2.request_id != ""
     assert r1.request_id != r2.request_id
+
+
+@pytest.mark.parametrize("bad_id", ["", "   "])
+def test_reflection_service_request_rejects_empty_request_id(bad_id):
+    """ReflectionServiceRequest rejects empty and whitespace-only request_id at construction.
+
+    The NonEmptyStr type on request_id ensures an empty string is caught before
+    any storage write, closing the orphan-on-empty path (F001).
+    """
+    with pytest.raises(ValidationError):
+        ReflectionServiceRequest(user_id="u1", request_id=bad_id)
+
+
+def test_reflection_service_request_default_factory_yields_nonempty():
+    """Omitting request_id uses the default_factory and always yields a non-empty UUID hex.
+
+    The default_factory composes correctly with NonEmptyStr: uuid4().hex is never
+    empty, so construction without an explicit request_id always succeeds.
+    """
+    req = ReflectionServiceRequest(user_id="u1")
+    assert req.request_id  # truthy — not empty, not whitespace
+    assert len(req.request_id) == 32  # uuid4().hex is always 32 chars

--- a/tests/server/services/storage/test_lineage_b3_request_id_invariant_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_request_id_invariant_integration.py
@@ -8,9 +8,8 @@ Verifies that:
    unrelated runs under "".
 3. ReflectionServiceRequest.request_id has a non-empty default_factory so the
    production path always supplies a non-empty id.
-4. A guard assertion fires at the reflection→supersede boundary when an empty
-   request_id is passed (scoped to the profile reflection path via a helper
-   that is the single enforcement point).
+4. supersede_record and merge_records raise ValueError on empty/None
+   context.request_id (production raise, not a test-only helper).
 """
 
 from __future__ import annotations
@@ -21,7 +20,7 @@ from datetime import UTC, datetime
 import pytest
 
 from reflexio.lib._profiles import reconstruct_profile_change_log
-from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.api_schema.domain.entities import LineageContext, UserProfile
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
@@ -217,57 +216,59 @@ def test_reflection_service_request_explicit_request_id_preserved():
 
 
 # ---------------------------------------------------------------------------
-# Test 4 — Guard: assert_nonempty_request_id helper raises on empty
+# Test 4 — supersede_record and merge_records raise on empty request_id
+# (production guards in _lineage.py, not a test-only helper)
 # ---------------------------------------------------------------------------
 
 
-def assert_nonempty_request_id(
-    request_id: str, *, context: str = "profile supersede"
-) -> None:
-    """Guard: raise ValueError if request_id is empty.
-
-    Scoped to the reflection→profile-supersede boundary.  Call this before
-    ``supersede_record`` in the reflection service when entity_type='profile'.
-    Do NOT add this to supersede_record's shared signature — other callers
-    (merge etc.) have different invariants.
-
-    Args:
-        request_id (str): The request_id to validate.
-        context (str): Human-readable name of the call site for error messages.
-
-    Raises:
-        ValueError: If request_id is empty.
-    """
-    if not request_id:
-        raise ValueError(
-            f"Empty request_id at {context}: every profile supersede must carry "
-            "a non-empty request_id so reconstruct_profile_change_log groups "
-            "events correctly. Supply request.request_id from "
-            "ReflectionServiceRequest (has default_factory=uuid4().hex)."
+def test_supersede_record_raises_on_empty_request_id(tmp_path):
+    """supersede_record raises ValueError when context.request_id is empty."""
+    s = _store(tmp_path)
+    ctx = LineageContext(op_kind="revise", actor="test", request_id="")
+    with pytest.raises(ValueError, match="request_id must be non-empty"):
+        s.supersede_record(
+            entity_type="user_playbook",
+            incumbent_id="1",
+            successor_id="2",
+            context=ctx,
         )
 
 
-def test_guard_raises_on_empty_request_id():
-    """assert_nonempty_request_id raises ValueError for an empty string."""
-    with pytest.raises(ValueError, match="Empty request_id"):
-        assert_nonempty_request_id("", context="test")
+def test_supersede_record_raises_on_none_request_id(tmp_path):
+    """supersede_record raises ValueError when context.request_id is None."""
+    s = _store(tmp_path)
+    # LineageContext allows None for request_id field
+    ctx = LineageContext(op_kind="revise", actor="test", request_id=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="request_id must be non-empty"):
+        s.supersede_record(
+            entity_type="user_playbook",
+            incumbent_id="1",
+            successor_id="2",
+            context=ctx,
+        )
 
 
-def test_guard_passes_on_whitespace_request_id():
-    """assert_nonempty_request_id does NOT raise for whitespace — it is non-empty.
-
-    Whitespace-only strings are truthy (len > 0) in Python, so the guard does
-    not fire.  The production path uses ``uuid.uuid4().hex`` which never
-    produces whitespace, so this edge case cannot arise from normal callers.
-    """
-    assert_nonempty_request_id("   ")  # no exception — whitespace is truthy
-
-
-def test_guard_passes_on_nonempty_request_id():
-    """assert_nonempty_request_id is a no-op for a non-empty string."""
-    assert_nonempty_request_id("req-abc-123")  # no exception
+def test_merge_records_raises_on_empty_request_id(tmp_path):
+    """merge_records raises ValueError when context.request_id is empty."""
+    s = _store(tmp_path)
+    ctx = LineageContext(op_kind="merge", actor="test", request_id="")
+    with pytest.raises(ValueError, match="request_id must be non-empty"):
+        s.merge_records(
+            entity_type="user_playbook",
+            survivor_id="1",
+            source_ids=["2"],
+            context=ctx,
+        )
 
 
-def test_guard_passes_on_uuid_hex():
-    """assert_nonempty_request_id is a no-op for a UUID hex request_id."""
-    assert_nonempty_request_id(uuid.uuid4().hex)
+def test_merge_records_raises_on_none_request_id(tmp_path):
+    """merge_records raises ValueError when context.request_id is None."""
+    s = _store(tmp_path)
+    ctx = LineageContext(op_kind="merge", actor="test", request_id=None)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="request_id must be non-empty"):
+        s.merge_records(
+            entity_type="user_playbook",
+            survivor_id="1",
+            source_ids=["2"],
+            context=ctx,
+        )

--- a/tests/server/services/storage/test_lineage_b3_request_id_invariant_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_request_id_invariant_integration.py
@@ -23,6 +23,9 @@ from reflexio.lib._profiles import reconstruct_profile_change_log
 from reflexio.models.api_schema.domain.entities import LineageContext, UserProfile
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage._lineage import (
+    _EMPTY_REQUEST_ID_MSG,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -225,7 +228,7 @@ def test_supersede_record_raises_on_empty_request_id(tmp_path):
     """supersede_record raises ValueError when context.request_id is empty."""
     s = _store(tmp_path)
     ctx = LineageContext(op_kind="revise", actor="test", request_id="")
-    with pytest.raises(ValueError, match="request_id must be non-empty"):
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
         s.supersede_record(
             entity_type="user_playbook",
             incumbent_id="1",
@@ -238,8 +241,8 @@ def test_supersede_record_raises_on_none_request_id(tmp_path):
     """supersede_record raises ValueError when context.request_id is None."""
     s = _store(tmp_path)
     # LineageContext allows None for request_id field
-    ctx = LineageContext(op_kind="revise", actor="test", request_id=None)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="request_id must be non-empty"):
+    ctx = LineageContext(op_kind="revise", actor="test", request_id=None)
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
         s.supersede_record(
             entity_type="user_playbook",
             incumbent_id="1",
@@ -252,7 +255,7 @@ def test_merge_records_raises_on_empty_request_id(tmp_path):
     """merge_records raises ValueError when context.request_id is empty."""
     s = _store(tmp_path)
     ctx = LineageContext(op_kind="merge", actor="test", request_id="")
-    with pytest.raises(ValueError, match="request_id must be non-empty"):
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
         s.merge_records(
             entity_type="user_playbook",
             survivor_id="1",
@@ -264,8 +267,41 @@ def test_merge_records_raises_on_empty_request_id(tmp_path):
 def test_merge_records_raises_on_none_request_id(tmp_path):
     """merge_records raises ValueError when context.request_id is None."""
     s = _store(tmp_path)
-    ctx = LineageContext(op_kind="merge", actor="test", request_id=None)  # type: ignore[arg-type]
-    with pytest.raises(ValueError, match="request_id must be non-empty"):
+    ctx = LineageContext(op_kind="merge", actor="test", request_id=None)
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
+        s.merge_records(
+            entity_type="user_playbook",
+            survivor_id="1",
+            source_ids=["2"],
+            context=ctx,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — whitespace-only request_id is also rejected (F009)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("ws_id", ["   ", "\t", "\n"])
+def test_supersede_record_raises_on_whitespace_request_id(tmp_path, ws_id):
+    """supersede_record raises ValueError when context.request_id is whitespace-only."""
+    s = _store(tmp_path)
+    ctx = LineageContext(op_kind="revise", actor="test", request_id=ws_id)
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
+        s.supersede_record(
+            entity_type="user_playbook",
+            incumbent_id="1",
+            successor_id="2",
+            context=ctx,
+        )
+
+
+@pytest.mark.parametrize("ws_id", ["   ", "\t", "\n"])
+def test_merge_records_raises_on_whitespace_request_id(tmp_path, ws_id):
+    """merge_records raises ValueError when context.request_id is whitespace-only."""
+    s = _store(tmp_path)
+    ctx = LineageContext(op_kind="merge", actor="test", request_id=ws_id)
+    with pytest.raises(ValueError, match=_EMPTY_REQUEST_ID_MSG):
         s.merge_records(
             entity_type="user_playbook",
             survivor_id="1",

--- a/tests/server/services/storage/test_sqlite_lineage_event_integration.py
+++ b/tests/server/services/storage/test_sqlite_lineage_event_integration.py
@@ -38,3 +38,75 @@ def test_append_is_idempotent_on_unique_key(tmp_path):
     again = s.append_lineage_event(_evt())  # same (entity_id, op, request_id)
     assert first == again
     assert len(s.get_lineage_events(entity_id="UP-1")) == 1
+
+
+# ---------------------------------------------------------------------------
+# B3 idempotency-key hazard: empty request_id collapses distinct events
+# ---------------------------------------------------------------------------
+
+
+def test_empty_request_id_collapses_second_event(tmp_path):
+    """Two events with the same (org, entity_type, entity_id, op) and request_id=''
+    collapse to one row via ON CONFLICT DO NOTHING.
+
+    This is the storage-level mechanism that non-empty request_ids protect against.
+    When request_id is '' (empty string), the unique key
+    (org_id, entity_type, entity_id, op, request_id) treats all events for a
+    given entity+op as the same row — the second INSERT is silently dropped.
+
+    This test proves the hazard honestly: it is NOT that two optimizer passes on
+    the same incumbent collide (they cannot — each supersede_record uses a FRESH
+    successor_id as entity_id), but that any two events for the SAME entity_id
+    and op with request_id='' would collapse.  Non-empty, distinct request_ids
+    prevent this for run-correlation events.
+    """
+    s = SQLiteStorage(org_id="org-42", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+
+    # Two events for the same entity+op but both with request_id="" → only one persists
+    e1 = _evt(
+        entity_id="UP-hazard", op="revise", request_id="", prov_relation="wasRevisionOf"
+    )
+    e2 = _evt(
+        entity_id="UP-hazard", op="revise", request_id="", prov_relation="wasRevisionOf"
+    )
+    s.append_lineage_event(e1)
+    s.append_lineage_event(e2)
+
+    rows = s.get_lineage_events(entity_type="user_playbook", entity_id="UP-hazard")
+    assert len(rows) == 1, (
+        "both events share request_id='' → ON CONFLICT DO NOTHING silently drops the second"
+    )
+
+
+def test_distinct_nonempty_request_ids_both_persist(tmp_path):
+    """Two events for the same (entity_type, entity_id, op) with DISTINCT non-empty
+    request_ids both persist — the unique key discriminates on request_id.
+
+    This is the correct behaviour for run-correlation: each operation run stamps
+    its own non-empty id so independent events are recorded independently.
+    """
+    s = SQLiteStorage(org_id="org-42", db_path=str(tmp_path / "t.db"))
+    s.migrate()
+
+    e1 = _evt(
+        entity_id="UP-safe",
+        op="revise",
+        request_id="run-aaa",
+        prov_relation="wasRevisionOf",
+    )
+    e2 = _evt(
+        entity_id="UP-safe",
+        op="revise",
+        request_id="run-bbb",
+        prov_relation="wasRevisionOf",
+    )
+    s.append_lineage_event(e1)
+    s.append_lineage_event(e2)
+
+    rows = s.get_lineage_events(entity_type="user_playbook", entity_id="UP-safe")
+    assert len(rows) == 2, (
+        "distinct non-empty request_ids must produce two separate rows"
+    )
+    stored_request_ids = {r.request_id for r in rows}
+    assert stored_request_ids == {"run-aaa", "run-bbb"}


### PR DESCRIPTION
## Summary

Enforces the lineage invariant **`lineage_event.request_id` = the operation-run correlation id, never empty** — closing a provenance gap in the playbook optimizer and hardening the lineage write contract.

This is **contract-hardening + correct run-correlation**, not a fix for an active data-loss bug. (An earlier framing claimed two optimizer passes could collide on the idempotency key and silently drop the second revise event — that was **wrong**: `supersede_record` keys its event on a fresh `successor_id` each pass, so the key never collides regardless of `request_id`. The rationale and tests were corrected accordingly.)

## Changes

- **Optimizer run-correlation** — both supersede paths now stamp a job-derived run id (`optjob_<job_id>`) on their `revise` lineage event:
  - `_supersede_agent_playbook` previously passed `request_id=None` (→ silently coerced to `""`).
  - `_supersede_user_playbook` previously inherited the incumbent's *birth* `request_id` (semantically the wrong id for the operation).
- **Reflection edit-apply** — `apply_playbook_edit` takes an explicit operation `request_id` and the reflection service threads the **reflection run id** (`request.request_id`) into it, instead of the incumbent's birth id.
- **Fail loud** — `supersede_record` / `merge_records` now raise `ValueError` on an empty `request_id` instead of silently coercing with `or ""`. Guards are placed **before** the successor `save_*`, so a raise can never orphan a row.

## Test Plan

- New storage-level hazard tests that *honestly* demonstrate the idempotency mechanism: two events on the same `(org, entity_type, entity_id, op)` with `request_id=""` collapse to one row (ON CONFLICT DO NOTHING); with distinct non-empty ids both persist.
- Both optimizer paths assert a non-empty job-derived `request_id` on their lineage event.
- `apply_playbook_edit` / optimizer helpers raise on empty `request_id` **and** leave no orphan successor row.
- Storage primitives raise on empty/None `request_id`.
- Green: 28 changed lineage/playbook tests, 42 reflection, 314 playbook (3 skipped), 38 optimizer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced non-empty request identifiers for playbook edit/replace and optimizer supersede operations, ensuring lineage events always include a valid run correlation id.
  * Added earlier validation to prevent writes when `request_id` is empty/whitespace-only, avoiding orphan successor/current rows during supersede.
  * Improved request-id propagation so reflection and optimization runs consistently carry the correct lineage correlation id.
* **Tests**
  * Updated and expanded integration coverage to verify request-id propagation, rejection behavior, and lineage event idempotency for empty vs non-empty values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->