### PR TITLE
chore(lint): cover openclaw plugin in ruff per-file-ignores + small cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,12 @@ ignore = [
 "reflexio/server/api.py" = ["B008", "ARG001", "ARG002"]
 "reflexio/server/api_endpoints/**" = ["B008", "ARG001", "ARG002"]
 "reflexio/integrations/**" = ["ARG002"]
+# The openclaw plugin is a nested package; its tests/scripts/cli are not reached
+# by the top-level "tests/**" / "reflexio/cli/**" globs above (those only match
+# at the tree root), so mirror the same standard test/cli ignores here.
+"reflexio/integrations/openclaw/plugin/tests/**" = ["S101", "ARG001", "ARG002", "ARG005", "PTH", "ANN", "S105", "S106", "S107", "S108", "S310", "N802", "N806"]
+"reflexio/integrations/openclaw/plugin/scripts/**" = ["S101", "G004", "ANN", "S603", "S607"]
+"reflexio/integrations/openclaw/plugin/src/openclaw_smart/cli.py" = ["S603", "S607"]
 "reflexio/server/services/configurator/test_config_storage.py" = ["S101", "ANN", "S108"]
 "demo/**" = ["S101", "PTH", "G004", "ANN"]
 "reflexio/server/services/storage/sqlite_storage/**" = ["S608"]

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/cli.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/cli.py
@@ -259,7 +259,9 @@ def _rebuild_dashboard() -> int:
         try:
             subprocess.run(install_cmd, cwd=_DASHBOARD_DIR, check=True)
         except subprocess.CalledProcessError as exc:
-            sys.stderr.write(f"error: dashboard install failed (exit {exc.returncode})\n")
+            sys.stderr.write(
+                f"error: dashboard install failed (exit {exc.returncode})\n"
+            )
             return exc.returncode or 1
     sys.stdout.write("Rebuilding dashboard…\n")
     try:
@@ -430,14 +432,14 @@ def _resolve_clear_all_targets() -> list[_ClearAllTarget]:
                 db_path = _resolve_absolute_path(
                     raw_db_path.strip(), source="configured SQLite db_path"
                 )
-                for suffix in ("", "-wal", "-shm", "-journal"):
-                    targets.append(
-                        _ClearAllTarget(
-                            Path(f"{db_path}{suffix}"),
-                            "file",
-                            "configured SQLite data",
-                        )
+                targets.extend(
+                    _ClearAllTarget(
+                        Path(f"{db_path}{suffix}"),
+                        "file",
+                        "configured SQLite data",
                     )
+                    for suffix in ("", "-wal", "-shm", "-journal")
+                )
         elif kind == "disk":
             raw_dir_path = storage_config.get("dir_path")
             if not isinstance(raw_dir_path, str) or not raw_dir_path.strip():

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/context_format.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/context_format.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from openclaw_smart import oc_cite
 

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/events/after_tool_call.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/events/after_tool_call.py
@@ -37,7 +37,7 @@ def _looks_like_secret(value: str) -> bool:
 def _mask_secrets(text: str) -> str:
     """Mask values that look like high-entropy secrets in ``KEY=value`` form."""
 
-    def sub(match: "re.Match[str]") -> str:
+    def sub(match: re.Match[str]) -> str:
         value = match.group("value")
         if not _looks_like_secret(value):
             return match.group(0)
@@ -59,8 +59,7 @@ def _redact_string(value: str) -> str:
 def _redact(tool_input: dict[str, Any]) -> dict[str, Any]:
     """Redact obvious secrets and truncate oversized string values."""
     return {
-        k: _redact_string(v) if isinstance(v, str) else v
-        for k, v in tool_input.items()
+        k: _redact_string(v) if isinstance(v, str) else v for k, v in tool_input.items()
     }
 
 
@@ -71,9 +70,10 @@ def _derive_status(tool_response: Any) -> str:
     ``result``; a structured failure may use ``is_error``/``error`` keys,
     while plain string results default to success.
     """
-    if isinstance(tool_response, dict):
-        if tool_response.get("is_error") or tool_response.get("error"):
-            return "error"
+    if isinstance(tool_response, dict) and (
+        tool_response.get("is_error") or tool_response.get("error")
+    ):
+        return "error"
     return "success"
 
 

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/events/agent_end.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/events/agent_end.py
@@ -112,9 +112,7 @@ def _extract_text_blocks(content: Any) -> list[str]:
     return out
 
 
-def _resolve_cited_items(
-    session_id: str, cited_ids: list[str]
-) -> list[dict[str, Any]]:
+def _resolve_cited_items(session_id: str, cited_ids: list[str]) -> list[dict[str, Any]]:
     """Map citation ids to ``{id, kind, title}`` entries via the session registry.
 
     Unknown ids (model hallucinations, or items injected in a newer session

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/events/session_start.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/events/session_start.py
@@ -16,6 +16,7 @@ stdout for the TS shim to relay back to openClaw. Otherwise emits nothing.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import sys
@@ -117,10 +118,9 @@ def handle(payload: dict[str, Any]) -> None:
     sys.stdout.write(json.dumps({"prependContext": banner}))
     sys.stdout.write("\n")
 
-    try:
+    # Telemetry must not break the session.
+    with contextlib.suppress(Exception):
         adapter.mark_stall_notified()
-    except Exception:  # noqa: BLE001 — telemetry must not break session.
-        pass
 
 
 def _optimizer_assistant_path() -> str:

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/hook.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/hook.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 import json
 import logging
 import sys
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from openclaw_smart import runtime
 from openclaw_smart.internal_call import is_internal_invocation

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/oc_cite.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/oc_cite.py
@@ -64,7 +64,7 @@ _FINGERPRINT_LEN = 4
 # may be comma- and/or whitespace-separated. Chained commands (&&, |, ;)
 # and extra trailing tokens remain rejected by the anchored `\s*$`
 # terminator so accidental mentions don't register as citations.
-_ID_TOKEN = r"(?i:oc:)?(?i:[ps])\d+(?:-(?i:[a-z0-9]){1,4})?"
+_ID_TOKEN = r"(?i:oc:)?(?i:[ps])\d+(?:-(?i:[a-z0-9]){1,4})?"  # noqa: S105 — regex pattern, not a secret.
 _ID_SEP = r"[,\s]+"
 CITATION_CMD_RE = re.compile(
     rf"^\s*(?:[^\s]*/)?oc-cite\s+({_ID_TOKEN}(?:{_ID_SEP}{_ID_TOKEN})*)\s*$"
@@ -157,11 +157,11 @@ def parse_text_citations(text: str) -> list[str]:
 
 
 def _parse_id_tokens(raw_ids: str) -> list[str]:
-    ids: list[str] = []
-    for tok in _SPLIT_RE.split(raw_ids.strip()):
-        if clean := _CLEAN_ID_RE.match(tok):
-            ids.append(clean.group(1).lower())
-    return ids
+    return [
+        clean.group(1).lower()
+        for tok in _SPLIT_RE.split(raw_ids.strip())
+        if (clean := _CLEAN_ID_RE.match(tok))
+    ]
 
 
 def ensure_installed() -> Path:

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/optimizer_assistant.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/optimizer_assistant.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import subprocess  # noqa: S404 — subprocess is the integration point.
 import sys
+from pathlib import Path
 from typing import Any
 
 _CLI_TIMEOUT_SECONDS = 300
@@ -170,7 +171,7 @@ def _render_transcript(messages: list[dict[str, str]]) -> str:
 def _resolve_cli_path() -> str | None:
     """Return the openclaw binary path, honoring ``OPENCLAW_BIN`` then PATH."""
     override = os.environ.get(ENV_CLI_PATH)
-    if override and os.path.isfile(override) and os.access(override, os.X_OK):
+    if override and Path(override).is_file() and os.access(override, os.X_OK):
         return override
     return shutil.which("openclaw")
 

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/query_compose.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/query_compose.py
@@ -10,8 +10,9 @@ meaning-dense strings give the most selective hybrid ranking.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 _MAX_SNIPPET_LEN = 400
 

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/reflexio_adapter.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/reflexio_adapter.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any
 
 from openclaw_smart import runtime
 

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/state.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/state.py
@@ -137,7 +137,9 @@ def append_injected(session_id: str, entries: Iterable[dict[str, Any]]) -> None:
         return
     path = injected_path(session_id)
     if path is None:
-        _LOGGER.warning("rejected unsafe session_id for append_injected: %r", session_id)
+        _LOGGER.warning(
+            "rejected unsafe session_id for append_injected: %r", session_id
+        )
         return
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:

--- a/reflexio/integrations/openclaw/plugin/tests/integration/test_e2e_session_loop.py
+++ b/reflexio/integrations/openclaw/plugin/tests/integration/test_e2e_session_loop.py
@@ -79,7 +79,12 @@ def test_full_session_loop_records_all_roles(
     project = "test-project"
 
     # session-start: pushes defaults + emits a stall banner (or empty stdout).
-    assert _drive(monkeypatch, "session-start", {"sessionKey": session, "agentId": project}) == 0
+    assert (
+        _drive(
+            monkeypatch, "session-start", {"sessionKey": session, "agentId": project}
+        )
+        == 0
+    )
     capsys.readouterr()  # drain
 
     # before-prompt-build: appends a "User" record.
@@ -149,7 +154,10 @@ def test_full_session_loop_records_all_roles(
     capsys.readouterr()
 
     # session-end: force-publish; should not crash.
-    assert _drive(monkeypatch, "session-end", {"sessionKey": session, "agentId": project}) == 0
+    assert (
+        _drive(monkeypatch, "session-end", {"sessionKey": session, "agentId": project})
+        == 0
+    )
     capsys.readouterr()
 
     records = state.read_all(session)

--- a/reflexio/integrations/openclaw/plugin/tests/test_cli.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_cli.py
@@ -17,8 +17,9 @@ def isolate_state_dir(monkeypatch, tmp_path):
 
 
 def test_cmd_show_fetches_all_entities(capsys):
-    with patch("openclaw_smart.cli.Adapter") as Ad, patch(
-        "openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"
+    with (
+        patch("openclaw_smart.cli.Adapter") as Ad,
+        patch("openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"),
     ):
         Ad.return_value.fetch_all.return_value = ([], [], [])
         rc = cli.cmd_show(Namespace(project=None))
@@ -28,8 +29,9 @@ def test_cmd_show_fetches_all_entities(capsys):
 
 
 def test_cmd_show_renders_markdown(capsys):
-    with patch("openclaw_smart.cli.Adapter") as Ad, patch(
-        "openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"
+    with (
+        patch("openclaw_smart.cli.Adapter") as Ad,
+        patch("openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"),
     ):
         Ad.return_value.fetch_all.return_value = (
             [{"user_playbook_id": "abc", "content": "Test rule"}],
@@ -43,8 +45,9 @@ def test_cmd_show_renders_markdown(capsys):
 
 
 def test_cmd_show_honors_project_override(capsys):
-    with patch("openclaw_smart.cli.Adapter") as Ad, patch(
-        "openclaw_smart.cli.ids.resolve_project_id", return_value="ignored"
+    with (
+        patch("openclaw_smart.cli.Adapter") as Ad,
+        patch("openclaw_smart.cli.ids.resolve_project_id", return_value="ignored"),
     ):
         Ad.return_value.fetch_all.return_value = ([], [], [])
         cli.cmd_show(Namespace(project="explicit-proj"))
@@ -63,8 +66,9 @@ def test_cmd_learn_force_extracts(isolate_state_dir):
     from openclaw_smart import state
 
     state.append("sess-1", {"role": "User", "content": "x"})
-    with patch("openclaw_smart.cli.publish") as pub, patch(
-        "openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"
+    with (
+        patch("openclaw_smart.cli.publish") as pub,
+        patch("openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"),
     ):
         pub.publish_unpublished.return_value = ("ok", 1)
         rc = cli.cmd_learn(Namespace(session=None, project=None, note=None))
@@ -78,8 +82,9 @@ def test_cmd_learn_appends_note(isolate_state_dir):
     from openclaw_smart import state
 
     state.append("sess-2", {"role": "User", "content": "earlier"})
-    with patch("openclaw_smart.cli.publish") as pub, patch(
-        "openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"
+    with (
+        patch("openclaw_smart.cli.publish") as pub,
+        patch("openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"),
     ):
         pub.publish_unpublished.return_value = ("ok", 2)
         cli.cmd_learn(Namespace(session="sess-2", project=None, note="key insight"))
@@ -92,8 +97,9 @@ def test_cmd_learn_handles_unreachable_backend(isolate_state_dir, capsys):
     from openclaw_smart import state
 
     state.append("sess-3", {"role": "User", "content": "x"})
-    with patch("openclaw_smart.cli.publish") as pub, patch(
-        "openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"
+    with (
+        patch("openclaw_smart.cli.publish") as pub,
+        patch("openclaw_smart.cli.ids.resolve_project_id", return_value="proj-x"),
     ):
         pub.publish_unpublished.return_value = ("failed", 0)
         rc = cli.cmd_learn(Namespace(session=None, project=None, note=None))
@@ -102,9 +108,7 @@ def test_cmd_learn_handles_unreachable_backend(isolate_state_dir, capsys):
 
 
 def test_cmd_clear_all_requires_yes(capsys):
-    with patch(
-        "openclaw_smart.cli._resolve_clear_all_targets", return_value=[]
-    ):
+    with patch("openclaw_smart.cli._resolve_clear_all_targets", return_value=[]):
         rc = cli.cmd_clear_all(Namespace(yes=False))
     assert rc != 0
     assert "--yes" in capsys.readouterr().out
@@ -116,10 +120,10 @@ def test_cmd_clear_all_with_yes_proceeds(monkeypatch, tmp_path):
     (sessions / "old.jsonl").write_text('{"role":"User"}\n')
     monkeypatch.setenv("OPENCLAW_SMART_STATE_DIR", str(sessions))
 
-    with patch(
-        "openclaw_smart.cli._resolve_clear_all_targets", return_value=[]
-    ), patch("openclaw_smart.cli._service_status", return_value="not running"), patch(
-        "openclaw_smart.cli._run_service", return_value=0
+    with (
+        patch("openclaw_smart.cli._resolve_clear_all_targets", return_value=[]),
+        patch("openclaw_smart.cli._service_status", return_value="not running"),
+        patch("openclaw_smart.cli._run_service", return_value=0),
     ):
         rc = cli.cmd_clear_all(Namespace(yes=True))
     assert rc == 0
@@ -138,13 +142,14 @@ def test_cmd_clear_all_restarts_backend_after_delete_failure(tmp_path):
         service_calls.append(command)
         return 0
 
-    with patch(
-        "openclaw_smart.cli._resolve_clear_all_targets", return_value=[target]
-    ), patch("openclaw_smart.cli._service_status", return_value="running on 8071"), patch(
-        "openclaw_smart.cli._remove_clear_all_target",
-        side_effect=cli._ClearAllError("boom"),
-    ), patch(
-        "openclaw_smart.cli._run_service", side_effect=fake_run_service
+    with (
+        patch("openclaw_smart.cli._resolve_clear_all_targets", return_value=[target]),
+        patch("openclaw_smart.cli._service_status", return_value="running on 8071"),
+        patch(
+            "openclaw_smart.cli._remove_clear_all_target",
+            side_effect=cli._ClearAllError("boom"),
+        ),
+        patch("openclaw_smart.cli._run_service", side_effect=fake_run_service),
     ):
         rc = cli.cmd_clear_all(Namespace(yes=True))
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_events_after_tool_call.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_events_after_tool_call.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 
 import pytest
-
 from openclaw_smart.events import after_tool_call as atc
 
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_events_agent_end.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_events_agent_end.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
 from openclaw_smart import state
 from openclaw_smart.events import agent_end
 
@@ -95,9 +94,12 @@ def test_handle_no_session_id_returns_silently(isolate_state_dir):
 
 
 def test_handle_appends_assistant_record(isolate_state_dir):
-    with patch("openclaw_smart.events.agent_end.publish") as pub, patch(
-        "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.agent_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         pub.publish_unpublished.return_value = ("ok", 1)
         agent_end.handle(
@@ -118,9 +120,12 @@ def test_handle_appends_assistant_record(isolate_state_dir):
 
 
 def test_handle_publishes_unpublished_slice(isolate_state_dir):
-    with patch("openclaw_smart.events.agent_end.publish") as pub, patch(
-        "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.agent_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         pub.publish_unpublished.return_value = ("ok", 1)
         agent_end.handle(
@@ -151,9 +156,12 @@ def test_handle_resolves_citations(isolate_state_dir, monkeypatch):
         ],
     )
 
-    with patch("openclaw_smart.events.agent_end.publish") as pub, patch(
-        "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.agent_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         pub.publish_unpublished.return_value = ("ok", 1)
         agent_end.handle(
@@ -181,9 +189,12 @@ def test_handle_resolves_citations(isolate_state_dir, monkeypatch):
 
 def test_handle_skips_unknown_citations(isolate_state_dir):
     """Citations for ids not in the registry are dropped, not raised."""
-    with patch("openclaw_smart.events.agent_end.publish") as pub, patch(
-        "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.agent_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         pub.publish_unpublished.return_value = ("ok", 1)
         agent_end.handle(
@@ -193,8 +204,7 @@ def test_handle_skips_unknown_citations(isolate_state_dir):
                     {
                         "role": "assistant",
                         "content": (
-                            "Done.\n"
-                            "✨ 1 openclaw-smart learning applied [oc:s9-9999]"
+                            "Done.\n✨ 1 openclaw-smart learning applied [oc:s9-9999]"
                         ),
                     }
                 ],
@@ -205,9 +215,12 @@ def test_handle_skips_unknown_citations(isolate_state_dir):
 
 
 def test_handle_falls_back_to_session_id(isolate_state_dir):
-    with patch("openclaw_smart.events.agent_end.publish") as pub, patch(
-        "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.agent_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.agent_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         pub.publish_unpublished.return_value = ("ok", 1)
         agent_end.handle(

--- a/reflexio/integrations/openclaw/plugin/tests/test_events_before_prompt_build.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_events_before_prompt_build.py
@@ -6,8 +6,6 @@ import json
 from unittest.mock import patch
 
 import pytest
-
-from openclaw_smart import state
 from openclaw_smart.events import before_prompt_build as bpb
 
 
@@ -19,11 +17,12 @@ def isolate_state_dir(monkeypatch, tmp_path):
 
 
 def test_handle_buffers_prompt(isolate_state_dir):
-    with patch(
-        "openclaw_smart.events.before_prompt_build.context_inject"
-    ) as ci, patch(
-        "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.before_prompt_build.context_inject") as ci,
+        patch(
+            "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         ci.emit_context.return_value = False
         bpb.handle(
@@ -45,11 +44,12 @@ def test_handle_buffers_prompt(isolate_state_dir):
 
 
 def test_handle_calls_emit_context_with_top_k():
-    with patch(
-        "openclaw_smart.events.before_prompt_build.context_inject"
-    ) as ci, patch(
-        "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.before_prompt_build.context_inject") as ci,
+        patch(
+            "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         bpb.handle(
             {
@@ -81,11 +81,12 @@ def test_handle_skips_when_no_prompt(isolate_state_dir):
 
 
 def test_handle_swallows_emit_exceptions(isolate_state_dir):
-    with patch(
-        "openclaw_smart.events.before_prompt_build.context_inject"
-    ) as ci, patch(
-        "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.before_prompt_build.context_inject") as ci,
+        patch(
+            "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         ci.emit_context.side_effect = ConnectionError("reflexio down")
         # Must not raise
@@ -103,11 +104,12 @@ def test_handle_swallows_emit_exceptions(isolate_state_dir):
 
 
 def test_handle_falls_back_to_session_id():
-    with patch(
-        "openclaw_smart.events.before_prompt_build.context_inject"
-    ) as ci, patch(
-        "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.before_prompt_build.context_inject") as ci,
+        patch(
+            "openclaw_smart.events.before_prompt_build.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         bpb.handle({"sessionId": "s2", "prompt": "hello", "agentId": "a"})
         ci.emit_context.assert_called_once()

--- a/reflexio/integrations/openclaw/plugin/tests/test_events_session_end.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_events_session_end.py
@@ -14,9 +14,12 @@ def test_handle_no_session_id_returns_silently():
 
 
 def test_handle_force_extracts():
-    with patch("openclaw_smart.events.session_end.publish") as pub, patch(
-        "openclaw_smart.events.session_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-x",
+    with (
+        patch("openclaw_smart.events.session_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.session_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-x",
+        ),
     ):
         session_end.handle({"sessionKey": "s1", "agentId": "a"})
         pub.publish_unpublished.assert_called_once()
@@ -28,9 +31,12 @@ def test_handle_force_extracts():
 
 
 def test_handle_falls_back_to_session_id_key():
-    with patch("openclaw_smart.events.session_end.publish") as pub, patch(
-        "openclaw_smart.events.session_end.ids.resolve_project_id_with_fallback",
-        return_value="proj-y",
+    with (
+        patch("openclaw_smart.events.session_end.publish") as pub,
+        patch(
+            "openclaw_smart.events.session_end.ids.resolve_project_id_with_fallback",
+            return_value="proj-y",
+        ),
     ):
         session_end.handle({"sessionId": "s2"})
         pub.publish_unpublished.assert_called_once()

--- a/reflexio/integrations/openclaw/plugin/tests/test_events_session_start.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_events_session_start.py
@@ -7,7 +7,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from openclaw_smart.events import session_start
 
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_hook_dispatch.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_hook_dispatch.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import io
 import json
-from unittest.mock import patch
 
 import pytest
-
 from openclaw_smart import hook
 
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_internal_call.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_internal_call.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from openclaw_smart import internal_call
 
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_publish.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_publish.py
@@ -46,4 +46,3 @@ def test_publish_unpublished_serializes_with_lock_and_stamps_watermark(
         for line in (isolate_state_dir / "s1.jsonl").read_text().splitlines()
     ]
     assert records[-1] == {"published_up_to": 1}
-

--- a/reflexio/integrations/openclaw/plugin/tests/test_query_compose.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_query_compose.py
@@ -24,9 +24,7 @@ def test_write_tool_uses_content_fallback():
 
 
 def test_bash_tool_query_uses_first_line():
-    q = query_compose.from_tool_call(
-        "Bash", {"command": "pytest tests/\nexit 0"}
-    )
+    q = query_compose.from_tool_call("Bash", {"command": "pytest tests/\nexit 0"})
     assert "pytest tests/" in q
     assert "exit 0" not in q
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_reflexio_adapter.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_reflexio_adapter.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from openclaw_smart.reflexio_adapter import Adapter
 
 
@@ -47,9 +45,7 @@ def test_get_client_returns_none_on_construction_failure():
 
 def test_publish_returns_true_for_empty_interactions():
     adapter = Adapter()
-    assert (
-        adapter.publish(session_id="s", project_id="p", interactions=[]) is True
-    )
+    assert adapter.publish(session_id="s", project_id="p", interactions=[]) is True
 
 
 def test_publish_returns_false_when_client_none():
@@ -161,9 +157,7 @@ def test_apply_extraction_defaults_skips_when_already_matching():
     fake_client.get_config.return_value = config
     adapter = Adapter()
     with patch.object(adapter, "_get_client", return_value=fake_client):
-        assert (
-            adapter.apply_extraction_defaults(window_size=10, stride_size=5) is True
-        )
+        assert adapter.apply_extraction_defaults(window_size=10, stride_size=5) is True
         fake_client.set_config.assert_not_called()
 
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_runtime.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_runtime.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from openclaw_smart import runtime
 
 

--- a/reflexio/integrations/openclaw/plugin/tests/test_state.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_state.py
@@ -164,7 +164,12 @@ def test_append_injected_writes_registry():
         "s4",
         [
             {"id": "s1-abcd", "kind": "skill", "title": "Test skill", "real_id": "abc"},
-            {"id": "p1-efgh", "kind": "preference", "title": "Test pref", "real_id": "def"},
+            {
+                "id": "p1-efgh",
+                "kind": "preference",
+                "title": "Test pref",
+                "real_id": "def",
+            },
         ],
     )
     registry = state.read_injected("s4")
@@ -196,9 +201,7 @@ def test_path_traversal_session_id_rejected(isolate_state_dir, tmp_path):
         "a" * 200,  # over 128 char cap
     ]
     for sid in escape_attempts:
-        assert state.session_path(sid) is None, (
-            f"unsafe session_path accepted: {sid!r}"
-        )
+        assert state.session_path(sid) is None, f"unsafe session_path accepted: {sid!r}"
         assert state.injected_path(sid) is None
         # Append + read must silently no-op rather than writing anywhere.
         state.append(sid, {"role": "User", "content": "x"})

--- a/reflexio/models/api_schema/domain/enums.py
+++ b/reflexio/models/api_schema/domain/enums.py
@@ -43,7 +43,9 @@ class Status(str, Enum):  # noqa: UP042 - CURRENT=None is not compatible with St
         "archive_in_progress"  # temporary status during downgrade operation
     )
     MERGED = "merged"  # tombstone: consolidated into a survivor (merged_into set)
-    SUPERSEDED = "superseded"  # tombstone: replaced by a new version (superseded_by set)
+    SUPERSEDED = (
+        "superseded"  # tombstone: replaced by a new version (superseded_by set)
+    )
 
 
 class OperationStatus(StrEnum):

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -31,6 +31,7 @@ _TABLE: dict[str, tuple[str, str]] = {
 # Shared here so tests can reference this exact string without hardcoding.
 _EMPTY_REQUEST_ID_MSG = "request_id must be non-empty"
 
+
 def _resolve_table(entity_type: str) -> tuple[str, str]:
     """Map an entity_type to its (table, primary_key), raising on bad input."""
     table = _TABLE.get(entity_type)


### PR DESCRIPTION
## Summary
Surfaced by running `/check-and-test`: `ruff check open_source/reflexio/reflexio/ ...` reported **566 errors, all confined to `reflexio/integrations/openclaw/plugin/`**.

Root cause: the plugin is a nested package, and the existing ruff `per-file-ignores` globs (`tests/**`, `reflexio/cli/**`) only match at the tree root, so they don't reach `reflexio/integrations/openclaw/plugin/tests/` or the plugin `cli.py`. ~555 of the findings were the standard test-only rules (S101/ANN/ARG/PTH/S310/N802/N806) and the cli's expected subprocess S603/S607.

## Changes
- **`pyproject.toml`**: add per-file-ignores mirroring the repo's standard test/cli ignores for the plugin subtree (tests, scripts, cli).
- **Genuine source cleanups** ruff surfaced in plugin `src/`:
  - `optimizer_assistant`: `os.path.isfile` → `Path.is_file` (PTH113)
  - `events/session_start`: `try/except/pass` → `contextlib.suppress` (SIM105/S110)
  - `events/after_tool_call`: collapse nested `if` (SIM102)
  - `oc_cite._parse_id_tokens` + cli clear-all targets: comprehension / `.extend` (PERF401)
  - `oc_cite`: `# noqa: S105` on the `_ID_TOKEN` regex (false-positive secret)
- ruff `format` auto-fixes across the plugin; two cosmetic re-wraps in `enums.py` / `sqlite_storage/_lineage.py`.

## Verification
- `ruff check` clean; `ruff format --check` clean.
- Full plugin test suite: **142 passed, 2 skipped** (behavior-preserving).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized type imports to use `collections.abc` for standard types.
  * Simplified code patterns, including conditional logic and list construction.
  * Improved exception handling using context managers.

* **Style**
  * Standardized code formatting across the codebase for consistency and readability.

* **Chores**
  * Updated build configuration with additional linting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->