### PR TITLE
feat(lineage): dual-read divergence shim (Phase B3 parity gate)

### DIFF
--- a/reflexio/lib/_lineage_parity.py
+++ b/reflexio/lib/_lineage_parity.py
@@ -1,0 +1,228 @@
+"""Shared parity predicate for the lineage dual-read divergence shim.
+
+Compares the legacy ``ProfileChangeLog`` table against
+``reconstruct_profile_change_log`` output.  This module is the single source
+of truth for classification logic — used by the one-shot parity script and,
+later, by the online dual-read shim.
+
+All public functions are pure (no I/O, no storage access) except
+``profile_reconstructible_request_ids``, which reads from storage but makes
+no mutations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from reflexio.models.api_schema.domain.entities import ProfileChangeLog, UserProfile
+
+
+class ParityClass(StrEnum):
+    """Classification of a per-request_id parity comparison."""
+
+    MATCH = "MATCH"
+    RECON_MISSING = "RECON-MISSING"
+    LEGACY_MISSING = "LEGACY-MISSING"
+    CONTENT_MISMATCH = "CONTENT-MISMATCH"
+    INCONCLUSIVE = "INCONCLUSIVE"
+
+
+@dataclass
+class ParityResult:
+    """One row in the parity report.
+
+    Attributes:
+        request_id (str): The request_id being classified.
+        classification (ParityClass): The outcome classification.
+        detail (str): Optional human-readable description of why this
+            classification was chosen.
+    """
+
+    request_id: str
+    classification: ParityClass
+    detail: str = field(default="")
+
+
+def _profile_content_set(profiles: list[UserProfile]) -> set[tuple[str, str]]:
+    """Extract a (profile_id, content) set from a list of UserProfile.
+
+    Args:
+        profiles (list[UserProfile]): Profiles to extract from.
+
+    Returns:
+        set[tuple[str, str]]: Set of (profile_id, content) tuples.
+    """
+    return {(p.profile_id, p.content) for p in profiles}
+
+
+def _rows_match(legacy: ProfileChangeLog, recon: ProfileChangeLog) -> bool:
+    """Return True when legacy and recon agree on added/removed by content.
+
+    Deliberately ignores ``updated_profiles`` — the updated delta is tolerated
+    as a non-material difference between the two paths.
+
+    Args:
+        legacy (ProfileChangeLog): Row from the legacy table.
+        recon (ProfileChangeLog): Row from reconstruction.
+
+    Returns:
+        bool: True when added and removed sets match by (profile_id, content).
+    """
+    return _profile_content_set(legacy.added_profiles) == _profile_content_set(
+        recon.added_profiles
+    ) and _profile_content_set(legacy.removed_profiles) == _profile_content_set(
+        recon.removed_profiles
+    )
+
+
+def classify_change_log_parity(
+    legacy_rows: list[ProfileChangeLog],
+    recon_rows: list[ProfileChangeLog],
+    *,
+    reconstructible_request_ids: set[str],
+    read_cap_hit: bool,
+) -> list[ParityResult]:
+    """Compare legacy and reconstructed rows per request_id; return classified results.
+
+    This is a pure function — it performs no I/O or storage access.
+
+    Classification rules:
+    - ``read_cap_hit=True``: return a single INCONCLUSIVE result immediately.
+    - Any request_id appearing more than once on either side → INCONCLUSIVE
+      (detail="duplicate request_id"); that id is excluded from all other
+      classification. Never raises.
+    - In both sides, rows match → MATCH.
+    - In both sides, rows differ → CONTENT_MISMATCH.
+    - Legacy-only, id in ``reconstructible_request_ids`` → RECON_MISSING
+      (dangerous: signals exist but reconstruction dropped the run).
+    - Legacy-only, id NOT in ``reconstructible_request_ids`` → LEGACY_MISSING
+      (tolerated: no reconstructible signal; predates soft-delete or purged).
+    - Recon-only → CONTENT_MISMATCH (reconstruction produced a run absent
+      from legacy).
+
+    Args:
+        legacy_rows (list[ProfileChangeLog]): Rows from ``get_profile_change_logs``.
+        recon_rows (list[ProfileChangeLog]): Rows from ``reconstruct_profile_change_log``.
+        reconstructible_request_ids (set[str]): Request ids with reconstructible
+            signals, computed independently of reconstruction via
+            ``profile_reconstructible_request_ids``.
+        read_cap_hit (bool): True when either side hit the read cap, making the
+            comparison unreliable.
+
+    Returns:
+        list[ParityResult]: One entry per distinct request_id, classified.
+    """
+    if read_cap_hit:
+        return [
+            ParityResult(
+                request_id="*",
+                classification=ParityClass.INCONCLUSIVE,
+                detail="read cap hit; comparison truncated",
+            )
+        ]
+
+    # Build per-side dicts; track duplicates.
+    legacy_by_req: dict[str, ProfileChangeLog] = {}
+    legacy_dupes: set[str] = set()
+    for row in legacy_rows:
+        if row.request_id in legacy_by_req:
+            legacy_dupes.add(row.request_id)
+        legacy_by_req[row.request_id] = row
+
+    recon_by_req: dict[str, ProfileChangeLog] = {}
+    recon_dupes: set[str] = set()
+    for row in recon_rows:
+        if row.request_id in recon_by_req:
+            recon_dupes.add(row.request_id)
+        recon_by_req[row.request_id] = row
+
+    all_dupes = legacy_dupes | recon_dupes
+    results: list[ParityResult] = []
+
+    # Emit one INCONCLUSIVE per duplicate id; skip duplicates in all other logic.
+    results = [
+        ParityResult(
+            request_id=req_id,
+            classification=ParityClass.INCONCLUSIVE,
+            detail="duplicate request_id",
+        )
+        for req_id in sorted(all_dupes)
+    ]
+
+    all_req_ids = (set(legacy_by_req) | set(recon_by_req)) - all_dupes
+    for req_id in sorted(all_req_ids):
+        in_legacy = req_id in legacy_by_req
+        in_recon = req_id in recon_by_req
+
+        if in_legacy and in_recon:
+            if _rows_match(legacy_by_req[req_id], recon_by_req[req_id]):
+                results.append(
+                    ParityResult(request_id=req_id, classification=ParityClass.MATCH)
+                )
+            else:
+                results.append(
+                    ParityResult(
+                        request_id=req_id,
+                        classification=ParityClass.CONTENT_MISMATCH,
+                        detail="added/removed sets differ",
+                    )
+                )
+        elif in_legacy:
+            if req_id in reconstructible_request_ids:
+                results.append(
+                    ParityResult(
+                        request_id=req_id,
+                        classification=ParityClass.RECON_MISSING,
+                        detail="reconstructible signals exist but reconstruction dropped the run",
+                    )
+                )
+            else:
+                results.append(
+                    ParityResult(
+                        request_id=req_id,
+                        classification=ParityClass.LEGACY_MISSING,
+                        detail="no reconstructible signal; run predates soft-delete / purged — tolerated",
+                    )
+                )
+        else:
+            # recon-only: reconstruction produced a run that legacy lacks
+            results.append(
+                ParityResult(
+                    request_id=req_id,
+                    classification=ParityClass.CONTENT_MISMATCH,
+                    detail="reconstruction produced a run absent from legacy",
+                )
+            )
+
+    return results
+
+
+def profile_reconstructible_request_ids(storage: object) -> set[str]:
+    """Compute the set of request_ids that have reconstructible signals.
+
+    These are request_ids where reconstruction *could* produce a row:
+    either a profile was stamped with ``generated_from_request_id``, or a
+    ``status_change`` / ``superseded`` lineage event was recorded.  Used to
+    distinguish RECON_MISSING (a real gap) from LEGACY_MISSING (tolerated).
+
+    Args:
+        storage: Any ``BaseStorage`` instance that implements
+            ``get_distinct_generated_from_request_ids`` and
+            ``get_lineage_events``.
+
+    Returns:
+        set[str]: Request ids with at least one reconstructible signal.
+    """
+    ids: set[str] = set(storage.get_distinct_generated_from_request_ids())  # type: ignore[union-attr]
+    for evt in storage.get_lineage_events(  # type: ignore[union-attr]
+        entity_type="profile",
+        org_id=storage.org_id,  # type: ignore[union-attr]
+    ):
+        if (
+            evt.op == "status_change"
+            and evt.to_status == "superseded"
+            and evt.request_id
+        ):
+            ids.add(evt.request_id)
+    return ids

--- a/reflexio/lib/_lineage_parity.py
+++ b/reflexio/lib/_lineage_parity.py
@@ -14,8 +14,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from reflexio.models.api_schema.domain.entities import ProfileChangeLog, UserProfile
+
+if TYPE_CHECKING:
+    from reflexio.server.services.storage.storage_base import BaseStorage
 
 
 class ParityClass(StrEnum):
@@ -197,7 +201,7 @@ def classify_change_log_parity(
     return results
 
 
-def profile_reconstructible_request_ids(storage: object) -> set[str]:
+def profile_reconstructible_request_ids(storage: BaseStorage) -> set[str]:
     """Compute the set of request_ids that have reconstructible signals.
 
     These are request_ids where reconstruction *could* produce a row:
@@ -206,17 +210,17 @@ def profile_reconstructible_request_ids(storage: object) -> set[str]:
     distinguish RECON_MISSING (a real gap) from LEGACY_MISSING (tolerated).
 
     Args:
-        storage: Any ``BaseStorage`` instance that implements
+        storage (BaseStorage): Any ``BaseStorage`` instance that implements
             ``get_distinct_generated_from_request_ids`` and
             ``get_lineage_events``.
 
     Returns:
         set[str]: Request ids with at least one reconstructible signal.
     """
-    ids: set[str] = set(storage.get_distinct_generated_from_request_ids())  # type: ignore[union-attr]
-    for evt in storage.get_lineage_events(  # type: ignore[union-attr]
+    ids: set[str] = set(storage.get_distinct_generated_from_request_ids())
+    for evt in storage.get_lineage_events(
         entity_type="profile",
-        org_id=storage.org_id,  # type: ignore[union-attr]
+        org_id=storage.org_id,
     ):
         if (
             evt.op == "status_change"

--- a/reflexio/lib/_lineage_parity.py
+++ b/reflexio/lib/_lineage_parity.py
@@ -138,10 +138,9 @@ def classify_change_log_parity(
         recon_by_req[row.request_id] = row
 
     all_dupes = legacy_dupes | recon_dupes
-    results: list[ParityResult] = []
 
     # Emit one INCONCLUSIVE per duplicate id; skip duplicates in all other logic.
-    results = [
+    results: list[ParityResult] = [
         ParityResult(
             request_id=req_id,
             classification=ParityClass.INCONCLUSIVE,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -176,6 +176,7 @@ from reflexio.server.cache.reflexio_cache import (
     invalidate_reflexio_cache,
 )
 from reflexio.server.correlation import correlation_id_var, generate_correlation_id
+from reflexio.server.lineage_parity_shim import dual_read_diff
 from reflexio.server.operation_limiter import (
     OperationName,
     limiter_http_exception,
@@ -1041,13 +1042,16 @@ def unified_search_endpoint(
 
 @core_router.get("/api/profile_change_log", response_model=ProfileChangeLogViewResponse)
 def get_profile_change_log(
+    background_tasks: BackgroundTasks,
     org_id: str = Depends(default_get_org_id),
 ) -> ProfileChangeLogViewResponse:
-    from reflexio.server.lineage_parity_shim import dual_read_diff
-
+    # get_reflexio returns a TTL-cached Reflexio instance (1-hour TTL, module-level
+    # cache in server/cache/reflexio_cache.py).  Its request_context.storage is set
+    # at construction time and remains valid well beyond any single request lifecycle,
+    # so running the shim as a background task is safe.
     rfx = get_reflexio(org_id=org_id)
     response = rfx.get_profile_change_logs()
-    dual_read_diff(rfx, org_id)
+    background_tasks.add_task(dual_read_diff, rfx, org_id)
     return ProfileChangeLogViewResponse(
         success=response.success,
         profile_change_logs=[

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1043,7 +1043,11 @@ def unified_search_endpoint(
 def get_profile_change_log(
     org_id: str = Depends(default_get_org_id),
 ) -> ProfileChangeLogViewResponse:
-    response = get_reflexio(org_id=org_id).get_profile_change_logs()
+    from reflexio.server.lineage_parity_shim import dual_read_diff
+
+    rfx = get_reflexio(org_id=org_id)
+    response = rfx.get_profile_change_logs()
+    dual_read_diff(rfx, org_id)
     return ProfileChangeLogViewResponse(
         success=response.success,
         profile_change_logs=[

--- a/reflexio/server/lineage_parity_shim.py
+++ b/reflexio/server/lineage_parity_shim.py
@@ -1,0 +1,123 @@
+"""Read-time dual-read divergence shim for the profile-change-log route.
+
+Compares the legacy ``get_profile_change_logs`` path against
+``reconstruct_profile_change_log`` and emits metric/anomaly events for any
+divergence found.  Runs for SIDE EFFECTS ONLY — the served response is never
+altered.  The function MUST NEVER raise; all exceptions are swallowed and
+reported as anomalies.
+"""
+
+from __future__ import annotations
+
+from reflexio.lib._lineage_parity import (
+    ParityClass,
+    classify_change_log_parity,
+    profile_reconstructible_request_ids,
+)
+from reflexio.lib._profiles import reconstruct_profile_change_log
+from reflexio.server.site_var.feature_flags import is_lineage_dual_read_diff_enabled
+from reflexio.server.tracing import capture_anomaly
+from reflexio.server.usage_metrics import record_usage_event
+
+_PARITY_READ_CAP = 10_000
+
+
+def dual_read_diff(reflexio: object, org_id: str) -> None:
+    """Compare legacy and reconstructed profile-change-log paths; emit divergence metrics.
+
+    Runs for SIDE EFFECTS ONLY.  The function never raises — all exceptions are
+    caught and forwarded to ``capture_anomaly``.  The caller's served response is
+    never modified.
+
+    Args:
+        reflexio: A ``Reflexio`` instance (typed as ``object`` to avoid a circular
+            import; duck-typed to ``reflexio.request_context.storage``).
+        org_id (str): Organization ID for flag-gating and metric tagging.
+
+    Returns:
+        None
+    """
+    try:
+        if not is_lineage_dual_read_diff_enabled(org_id):
+            return
+
+        storage = reflexio.request_context.storage  # type: ignore[union-attr]
+
+        legacy_cmp = storage.get_profile_change_logs(limit=_PARITY_READ_CAP)
+        recon_cmp = reconstruct_profile_change_log(
+            storage, limit=_PARITY_READ_CAP
+        ).profile_change_logs
+        read_cap_hit = (
+            len(legacy_cmp) >= _PARITY_READ_CAP or len(recon_cmp) >= _PARITY_READ_CAP
+        )
+        reconstructible = profile_reconstructible_request_ids(storage)
+        results = classify_change_log_parity(
+            legacy_cmp,
+            recon_cmp,
+            reconstructible_request_ids=reconstructible,
+            read_cap_hit=read_cap_hit,
+        )
+
+        _emit_metrics(org_id=org_id, results=results, legacy_cmp=legacy_cmp)
+
+    except Exception as e:  # noqa: BLE001
+        capture_anomaly(
+            "lineage.reconstruct.error",
+            level="warning",
+            org_id=org_id,
+            error=type(e).__name__,
+        )
+
+
+def _emit_metrics(*, org_id: str, results: list, legacy_cmp: list) -> None:
+    """Emit divergence anomalies and a coverage usage event.
+
+    Args:
+        org_id (str): Organization ID for tagging.
+        results (list): Classified ``ParityResult`` list from ``classify_change_log_parity``.
+        legacy_cmp (list): Legacy ``ProfileChangeLog`` rows used to compute add-only
+            vs remove-bearing breakdown for matched runs.
+    """
+    divergent_classes = (ParityClass.RECON_MISSING, ParityClass.CONTENT_MISMATCH)
+
+    # Emit one anomaly per divergent result.
+    for r in results:
+        if r.classification in divergent_classes:
+            capture_anomaly(
+                "lineage.reconstruct.divergence",
+                level="warning",
+                org_id=org_id,
+                kind=r.classification.value,
+                run_request_id=r.request_id,
+            )
+
+    # Build a lookup from request_id -> legacy row for coverage dimension.
+    legacy_by_req = {row.request_id: row for row in legacy_cmp}
+
+    matches = [r for r in results if r.classification == ParityClass.MATCH]
+    divergences = [r for r in results if r.classification in divergent_classes]
+    inconclusive = [r for r in results if r.classification == ParityClass.INCONCLUSIVE]
+
+    add_only_runs = 0
+    remove_bearing_runs = 0
+    for r in matches:
+        row = legacy_by_req.get(r.request_id)
+        if row is not None and row.removed_profiles:
+            remove_bearing_runs += 1
+        else:
+            add_only_runs += 1
+
+    record_usage_event(
+        org_id=org_id,
+        event_name="lineage.reconstruct.coverage",
+        event_category="lineage",
+        count_value=len(matches),
+        outcome="diverged" if divergences else "match",
+        metadata={
+            "add_only_runs": add_only_runs,
+            "remove_bearing_runs": remove_bearing_runs,
+            "matches": len(matches),
+            "divergences": len(divergences),
+            "inconclusive": len(inconclusive),
+        },
+    )

--- a/reflexio/server/lineage_parity_shim.py
+++ b/reflexio/server/lineage_parity_shim.py
@@ -136,7 +136,9 @@ def _emit_metrics(
         event_name="lineage.reconstruct.coverage",
         event_category="lineage",
         count_value=len(matches),
-        outcome="diverged" if divergences else "match",
+        outcome=(
+            "diverged" if divergences else "inconclusive" if inconclusive else "match"
+        ),
         metadata={
             "add_only_runs": add_only_runs,
             "remove_bearing_runs": remove_bearing_runs,

--- a/reflexio/server/lineage_parity_shim.py
+++ b/reflexio/server/lineage_parity_shim.py
@@ -11,15 +11,25 @@ from __future__ import annotations
 
 from reflexio.lib._lineage_parity import (
     ParityClass,
+    ParityResult,
     classify_change_log_parity,
     profile_reconstructible_request_ids,
 )
 from reflexio.lib._profiles import reconstruct_profile_change_log
+from reflexio.models.api_schema.domain.entities import ProfileChangeLog
 from reflexio.server.site_var.feature_flags import is_lineage_dual_read_diff_enabled
 from reflexio.server.tracing import capture_anomaly
 from reflexio.server.usage_metrics import record_usage_event
 
+# The shim compares the whole-org change-log at a 10k read-cap (not the served
+# limit=100), so the served-response window (100) and parity window (10k)
+# intentionally differ.  The coverage metric measures parity coverage across the
+# full org history, not just the currently-served slice.
 _PARITY_READ_CAP = 10_000
+
+# Max per-run divergence anomalies emitted before collapsing into an aggregate.
+# Prevents Sentry quota exhaustion / high-cardinality explosion on first enablement.
+_MAX_DIVERGENCE_ANOMALIES = 20
 
 
 def dual_read_diff(reflexio: object, org_id: str) -> None:
@@ -60,7 +70,7 @@ def dual_read_diff(reflexio: object, org_id: str) -> None:
 
         _emit_metrics(org_id=org_id, results=results, legacy_cmp=legacy_cmp)
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:  # noqa: BLE001 — intentionally broad; BaseException (signals) still propagates
         capture_anomaly(
             "lineage.reconstruct.error",
             level="warning",
@@ -69,33 +79,47 @@ def dual_read_diff(reflexio: object, org_id: str) -> None:
         )
 
 
-def _emit_metrics(*, org_id: str, results: list, legacy_cmp: list) -> None:
+def _emit_metrics(
+    *,
+    org_id: str,
+    results: list[ParityResult],
+    legacy_cmp: list[ProfileChangeLog],
+) -> None:
     """Emit divergence anomalies and a coverage usage event.
 
     Args:
         org_id (str): Organization ID for tagging.
-        results (list): Classified ``ParityResult`` list from ``classify_change_log_parity``.
-        legacy_cmp (list): Legacy ``ProfileChangeLog`` rows used to compute add-only
+        results (list[ParityResult]): Classified results from ``classify_change_log_parity``.
+        legacy_cmp (list[ProfileChangeLog]): Legacy rows used to compute add-only
             vs remove-bearing breakdown for matched runs.
     """
     divergent_classes = (ParityClass.RECON_MISSING, ParityClass.CONTENT_MISMATCH)
 
-    # Emit one anomaly per divergent result.
-    for r in results:
-        if r.classification in divergent_classes:
-            capture_anomaly(
-                "lineage.reconstruct.divergence",
-                level="warning",
-                org_id=org_id,
-                kind=r.classification.value,
-                run_request_id=r.request_id,
-            )
+    divergences = [r for r in results if r.classification in divergent_classes]
+
+    # Emit per-run anomalies, capped at _MAX_DIVERGENCE_ANOMALIES to prevent
+    # Sentry quota exhaustion on first enablement (could be ~10k divergences).
+    for r in divergences[:_MAX_DIVERGENCE_ANOMALIES]:
+        capture_anomaly(
+            "lineage.reconstruct.divergence",
+            level="warning",
+            org_id=org_id,
+            kind=r.classification.value,
+            run_request_id=r.request_id,
+        )
+    if len(divergences) > _MAX_DIVERGENCE_ANOMALIES:
+        capture_anomaly(
+            "lineage.reconstruct.divergence_truncated",
+            level="warning",
+            org_id=org_id,
+            total_divergences=len(divergences),
+            emitted=_MAX_DIVERGENCE_ANOMALIES,
+        )
 
     # Build a lookup from request_id -> legacy row for coverage dimension.
     legacy_by_req = {row.request_id: row for row in legacy_cmp}
 
     matches = [r for r in results if r.classification == ParityClass.MATCH]
-    divergences = [r for r in results if r.classification in divergent_classes]
     inconclusive = [r for r in results if r.classification == ParityClass.INCONCLUSIVE]
 
     add_only_runs = 0

--- a/reflexio/server/site_var/feature_flags.py
+++ b/reflexio/server/site_var/feature_flags.py
@@ -264,3 +264,25 @@ def is_resumable_extraction_agent_enabled(org_id: str) -> bool:
         bool: True if the resumable extraction agent is enabled
     """
     return is_feature_enabled(org_id, "resumable_extraction_agent")
+
+
+def is_lineage_dual_read_diff_enabled(org_id: str) -> bool:
+    """
+    Check if the lineage dual-read diff path is enabled for a given organization.
+
+    Defaults to DISABLED when the key is absent from config (default-CLOSED). This
+    flag gates an experimental read path that compares new and old lineage query
+    results side-by-side; it must never activate accidentally on unconfigured
+    deployments.
+
+    A feature is enabled only if:
+    - The feature's "enabled" field is True (globally enabled), OR
+    - The org_id is in the feature's "enabled_org_ids" list.
+
+    Args:
+        org_id (str): The organization ID to check
+
+    Returns:
+        bool: True only if the feature is explicitly enabled for this org
+    """
+    return _is_fail_closed_flag_enabled(org_id, "lineage_dual_read_diff")

--- a/scripts/lineage_b3_parity_check.py
+++ b/scripts/lineage_b3_parity_check.py
@@ -20,7 +20,10 @@ The reconstruction uses the time-travel-stable model:
                  (the dedup soft-delete signature; NOT reflection revise events).
 
 Prints a summary with counts per class.  Exits 0 when there are no RECON-MISSING
-gaps; exits 1 when at least one RECON-MISSING gap is found.
+or CONTENT-MISMATCH gaps; exits 1 when at least one such gap is found.  Note:
+recon-only runs (reconstruction produced a run absent from legacy) are classified
+as CONTENT_MISMATCH and therefore count as a gap → exit 1.  The old offline
+analysis tolerated recon-only as exit 0; this script does not.
 
 Usage (SQLite):
     uv run python scripts/lineage_b3_parity_check.py --db-path path/to/db --org-id myorg

--- a/scripts/lineage_b3_parity_check.py
+++ b/scripts/lineage_b3_parity_check.py
@@ -32,8 +32,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-from dataclasses import dataclass
-from enum import StrEnum
 from pathlib import Path
 
 _THIS_DIR = Path(__file__).resolve().parent  # scripts/
@@ -41,117 +39,14 @@ _PROJECT_ROOT = _THIS_DIR.parent  # repo root
 
 sys.path.insert(0, str(_PROJECT_ROOT))
 
+from reflexio.lib._lineage_parity import (
+    ParityClass,
+    ParityResult,
+    classify_change_log_parity,
+    profile_reconstructible_request_ids,
+)
 from reflexio.lib._profiles import reconstruct_profile_change_log
-from reflexio.models.api_schema.domain.entities import ProfileChangeLog, UserProfile
 from reflexio.server.services.storage.storage_base import BaseStorage
-
-
-class ParityClass(StrEnum):
-    """Classification of a per-request_id parity comparison."""
-
-    MATCH = "MATCH"
-    RECON_MISSING = "RECON-MISSING"
-    LEGACY_MISSING = "LEGACY-MISSING"
-
-
-@dataclass
-class ParityResult:
-    """One row in the parity report."""
-
-    request_id: str
-    classification: ParityClass
-    detail: str = ""
-
-
-def _profile_content_set(profiles: list[UserProfile]) -> set[tuple[str, str]]:
-    """Extract a (profile_id, content) set from a list of UserProfile."""
-    return {(p.profile_id, p.content) for p in profiles}
-
-
-def _rows_match(legacy: ProfileChangeLog, recon: ProfileChangeLog) -> bool:
-    """Return True when legacy and recon agree on added/removed by content."""
-    return _profile_content_set(legacy.added_profiles) == _profile_content_set(
-        recon.added_profiles
-    ) and _profile_content_set(legacy.removed_profiles) == _profile_content_set(
-        recon.removed_profiles
-    )
-
-
-def classify_parity(
-    legacy_rows: list[ProfileChangeLog],
-    recon_rows: list[ProfileChangeLog],
-) -> list[ParityResult]:
-    """Compare legacy and reconstructed rows per request_id; return classified results.
-
-    Args:
-        legacy_rows: Rows from ``get_profile_change_logs`` (legacy table).
-        recon_rows: Rows from ``reconstruct_profile_change_log``.
-
-    Returns:
-        list[ParityResult]: One entry per distinct request_id, classified as
-            MATCH, RECON-MISSING, or LEGACY-MISSING.
-    """
-    legacy_by_req: dict[str, ProfileChangeLog] = {}
-    legacy_dupes: list[str] = []
-    for row in legacy_rows:
-        if row.request_id in legacy_by_req:
-            legacy_dupes.append(row.request_id)
-        legacy_by_req[row.request_id] = row
-
-    recon_by_req: dict[str, ProfileChangeLog] = {}
-    recon_dupes: list[str] = []
-    for row in recon_rows:
-        if row.request_id in recon_by_req:
-            recon_dupes.append(row.request_id)
-        recon_by_req[row.request_id] = row
-
-    if legacy_dupes or recon_dupes:
-        raise ValueError(
-            f"Duplicate request_ids detected — parity comparison is ambiguous. "
-            f"Legacy dupes: {legacy_dupes!r}. Recon dupes: {recon_dupes!r}."
-        )
-
-    all_req_ids = set(legacy_by_req) | set(recon_by_req)
-    results: list[ParityResult] = []
-
-    for req_id in sorted(all_req_ids):
-        in_legacy = req_id in legacy_by_req
-        in_recon = req_id in recon_by_req
-
-        if in_legacy and in_recon:
-            if _rows_match(legacy_by_req[req_id], recon_by_req[req_id]):
-                results.append(
-                    ParityResult(request_id=req_id, classification=ParityClass.MATCH)
-                )
-            else:
-                # Content differs — treat as a real gap (reconstruction wrong).
-                results.append(
-                    ParityResult(
-                        request_id=req_id,
-                        classification=ParityClass.RECON_MISSING,
-                        detail="content mismatch between legacy and reconstruction",
-                    )
-                )
-        elif in_legacy and not in_recon:
-            results.append(
-                ParityResult(
-                    request_id=req_id,
-                    classification=ParityClass.RECON_MISSING,
-                    detail="legacy row exists but no lineage event found",
-                )
-            )
-        else:
-            # in_recon and not in_legacy
-            results.append(
-                ParityResult(
-                    request_id=req_id,
-                    classification=ParityClass.LEGACY_MISSING,
-                    detail="lineage event exists but legacy row absent",
-                )
-            )
-
-    return results
-
 
 _READ_CAP = 10_000
 
@@ -160,7 +55,7 @@ def run_parity_check(storage: BaseStorage) -> list[ParityResult]:
     """Run both paths against storage and classify each request_id.
 
     Args:
-        storage: Any ``BaseStorage`` instance that implements both
+        storage (BaseStorage): Any ``BaseStorage`` instance that implements both
             ``get_profile_change_logs`` and ``get_lineage_events``.
 
     Returns:
@@ -174,15 +69,19 @@ def run_parity_check(storage: BaseStorage) -> list[ParityResult]:
     legacy_rows = storage.get_profile_change_logs(limit=_READ_CAP)
     recon_resp = reconstruct_profile_change_log(storage, limit=_READ_CAP)
 
-    truncated: list[str] = []
-    if len(legacy_rows) >= _READ_CAP:
-        truncated.append(f"legacy ({len(legacy_rows)} rows == cap)")
-    if len(recon_resp.profile_change_logs) >= _READ_CAP:
-        truncated.append(
-            f"reconstruction ({len(recon_resp.profile_change_logs)} rows == cap)"
-        )
+    read_cap_hit = (
+        len(legacy_rows) >= _READ_CAP
+        or len(recon_resp.profile_change_logs) >= _READ_CAP
+    )
 
-    if truncated:
+    if read_cap_hit:
+        truncated: list[str] = []
+        if len(legacy_rows) >= _READ_CAP:
+            truncated.append(f"legacy ({len(legacy_rows)} rows == cap)")
+        if len(recon_resp.profile_change_logs) >= _READ_CAP:
+            truncated.append(
+                f"reconstruction ({len(recon_resp.profile_change_logs)} rows == cap)"
+            )
         print(
             f"\nINCONCLUSIVE: data may be truncated at the {_READ_CAP}-row cap — "
             f"{', '.join(truncated)}. "
@@ -191,14 +90,20 @@ def run_parity_check(storage: BaseStorage) -> list[ParityResult]:
         )
         sys.exit(2)
 
-    return classify_parity(legacy_rows, recon_resp.profile_change_logs)
+    reconstructible = profile_reconstructible_request_ids(storage)
+    return classify_change_log_parity(
+        legacy_rows,
+        recon_resp.profile_change_logs,
+        reconstructible_request_ids=reconstructible,
+        read_cap_hit=False,
+    )
 
 
 def print_summary(results: list[ParityResult]) -> None:
     """Print a human-readable summary of parity check results.
 
     Args:
-        results: Classified parity results.
+        results (list[ParityResult]): Classified parity results.
     """
     counts: dict[ParityClass, int] = dict.fromkeys(ParityClass, 0)
     for r in results:
@@ -208,20 +113,36 @@ def print_summary(results: list[ParityResult]) -> None:
     print(f"\n{'=' * 60}")
     print(f"B3 Parity Check — {total} request_ids checked")
     print(f"{'=' * 60}")
-    print(f"  MATCH          : {counts[ParityClass.MATCH]}")
-    print(f"  RECON-MISSING  : {counts[ParityClass.RECON_MISSING]}  (REAL GAPs)")
-    print(f"  LEGACY-MISSING : {counts[ParityClass.LEGACY_MISSING]}  (tolerated)")
+    print(f"  MATCH             : {counts[ParityClass.MATCH]}")
+    print(
+        f"  RECON-MISSING     : {counts[ParityClass.RECON_MISSING]}  (REAL GAPs — legacy-only, reconstructible)"
+    )
+    print(
+        f"  LEGACY-MISSING    : {counts[ParityClass.LEGACY_MISSING]}  (tolerated — no reconstructible signal)"
+    )
+    print(f"  CONTENT-MISMATCH  : {counts[ParityClass.CONTENT_MISMATCH]}  (divergence)")
+    print(
+        f"  INCONCLUSIVE      : {counts[ParityClass.INCONCLUSIVE]}  (duplicate ids or cap hit)"
+    )
     print(f"{'=' * 60}")
 
-    gaps = [r for r in results if r.classification == ParityClass.RECON_MISSING]
+    gaps = [
+        r
+        for r in results
+        if r.classification in (ParityClass.RECON_MISSING, ParityClass.CONTENT_MISMATCH)
+    ]
     if gaps:
-        print("\nREAL GAPs (reconstruction missing/wrong):")
+        print("\nREAL GAPs (reconstruction missing/wrong or content divergence):")
         for g in gaps[:20]:  # cap output for large dbs
-            print(f"  request_id={g.request_id!r}  detail={g.detail!r}")
+            print(
+                f"  request_id={g.request_id!r}  class={g.classification}  detail={g.detail!r}"
+            )
         if len(gaps) > 20:
             print(f"  ... and {len(gaps) - 20} more")
     else:
-        print("\nNo RECON-MISSING gaps found — safe to drop legacy table.")
+        print(
+            "\nNo RECON-MISSING or CONTENT-MISMATCH gaps found — safe to drop legacy table."
+        )
 
 
 def main() -> None:
@@ -238,7 +159,11 @@ def main() -> None:
     results = run_parity_check(storage)
     print_summary(results)
 
-    gaps = [r for r in results if r.classification == ParityClass.RECON_MISSING]
+    gaps = [
+        r
+        for r in results
+        if r.classification in (ParityClass.RECON_MISSING, ParityClass.CONTENT_MISMATCH)
+    ]
     sys.exit(1 if gaps else 0)
 
 

--- a/tests/lib/test_lineage_parity.py
+++ b/tests/lib/test_lineage_parity.py
@@ -1,0 +1,337 @@
+"""Unit tests for reflexio.lib._lineage_parity.
+
+Covers:
+- MATCH: both sides agree on added/removed.
+- CONTENT_MISMATCH (in-both): rows exist on both sides but differ.
+- CONTENT_MISMATCH (recon-only): reconstruction produced a run absent from legacy.
+- RECON_MISSING: legacy-only and request_id IS in reconstructible_request_ids.
+- LEGACY_MISSING: legacy-only and request_id NOT in reconstructible_request_ids.
+- Tolerated updated delta: added/removed equal but updated_profiles differ → MATCH.
+- Duplicate request_id on either side → INCONCLUSIVE (not raised).
+- read_cap_hit=True → single INCONCLUSIVE result.
+- Import identity: script uses the lib function, not a local redefinition.
+"""
+
+from __future__ import annotations
+
+from reflexio.lib._lineage_parity import (
+    ParityClass,
+    ParityResult,
+    classify_change_log_parity,
+)
+from reflexio.models.api_schema.domain.entities import ProfileChangeLog, UserProfile
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _profile(profile_id: str, content: str, user_id: str = "u1") -> UserProfile:
+    """Build a minimal UserProfile with only the fields used by the predicate."""
+    return UserProfile(
+        profile_id=profile_id,
+        user_id=user_id,
+        content=content,
+        last_modified_timestamp=0,
+        generated_from_request_id="",
+    )
+
+
+def _log(
+    request_id: str,
+    added: list[UserProfile] | None = None,
+    removed: list[UserProfile] | None = None,
+    updated: list[UserProfile] | None = None,
+) -> ProfileChangeLog:
+    """Build a minimal ProfileChangeLog row."""
+    return ProfileChangeLog(
+        id=0,
+        user_id="u1",
+        request_id=request_id,
+        added_profiles=added or [],
+        removed_profiles=removed or [],
+        mentioned_profiles=updated or [],
+    )
+
+
+def _classify(
+    legacy: list[ProfileChangeLog],
+    recon: list[ProfileChangeLog],
+    *,
+    reconstructible: set[str] | None = None,
+    read_cap_hit: bool = False,
+) -> list[ParityResult]:
+    """Convenience wrapper with a safe default for reconstructible_request_ids."""
+    return classify_change_log_parity(
+        legacy,
+        recon,
+        reconstructible_request_ids=reconstructible or set(),
+        read_cap_hit=read_cap_hit,
+    )
+
+
+# ---------------------------------------------------------------------------
+# MATCH
+# ---------------------------------------------------------------------------
+
+
+def test_match_identical_added_removed() -> None:
+    p1 = _profile("p1", "hello")
+    legacy = [_log("req1", added=[p1])]
+    recon = [_log("req1", added=[p1])]
+
+    results = _classify(legacy, recon)
+
+    assert len(results) == 1
+    assert results[0].classification == ParityClass.MATCH
+    assert results[0].request_id == "req1"
+
+
+def test_match_empty_rows() -> None:
+    """Both sides have the same empty added/removed → MATCH."""
+    legacy = [_log("req1")]
+    recon = [_log("req1")]
+
+    results = _classify(legacy, recon)
+
+    assert len(results) == 1
+    assert results[0].classification == ParityClass.MATCH
+
+
+def test_match_tolerated_updated_delta() -> None:
+    """added/removed equal but mentioned_profiles differ → still MATCH.
+
+    ProfileChangeLog.mentioned_profiles is used as the updated field in
+    legacy; _rows_match deliberately ignores it.
+    """
+    p1 = _profile("p1", "content-a")
+    p2 = _profile("p2", "content-b")
+
+    legacy = [_log("req1", added=[p1], removed=[], updated=[p2])]
+    recon = [_log("req1", added=[p1], removed=[], updated=[])]
+
+    results = _classify(legacy, recon)
+
+    assert len(results) == 1
+    assert results[0].classification == ParityClass.MATCH
+
+
+# ---------------------------------------------------------------------------
+# CONTENT_MISMATCH (both sides have the request_id but content differs)
+# ---------------------------------------------------------------------------
+
+
+def test_content_mismatch_different_added() -> None:
+    legacy = [_log("req1", added=[_profile("p1", "old")])]
+    recon = [_log("req1", added=[_profile("p1", "new")])]
+
+    results = _classify(legacy, recon)
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.classification == ParityClass.CONTENT_MISMATCH
+    assert r.request_id == "req1"
+    assert "differ" in r.detail
+
+
+def test_content_mismatch_different_removed() -> None:
+    p1 = _profile("p1", "same-added")
+    legacy = [_log("req1", added=[p1], removed=[_profile("r1", "old-removed")])]
+    recon = [_log("req1", added=[p1], removed=[_profile("r1", "new-removed")])]
+
+    results = _classify(legacy, recon)
+
+    assert len(results) == 1
+    assert results[0].classification == ParityClass.CONTENT_MISMATCH
+
+
+# ---------------------------------------------------------------------------
+# CONTENT_MISMATCH (recon-only)
+# ---------------------------------------------------------------------------
+
+
+def test_content_mismatch_recon_only() -> None:
+    """A run that exists only in reconstruction → CONTENT_MISMATCH."""
+    recon = [_log("req-recon-only", added=[_profile("p1", "extra")])]
+
+    results = _classify([], recon)
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.classification == ParityClass.CONTENT_MISMATCH
+    assert r.request_id == "req-recon-only"
+    assert "absent from legacy" in r.detail
+
+
+# ---------------------------------------------------------------------------
+# RECON_MISSING (legacy-only, id IN reconstructible)
+# ---------------------------------------------------------------------------
+
+
+def test_recon_missing_when_reconstructible_signal_exists() -> None:
+    legacy = [_log("req-gap", added=[_profile("p1", "content")])]
+
+    results = _classify(legacy, [], reconstructible={"req-gap"})
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.classification == ParityClass.RECON_MISSING
+    assert r.request_id == "req-gap"
+    assert "reconstructible" in r.detail
+
+
+# ---------------------------------------------------------------------------
+# LEGACY_MISSING (legacy-only, id NOT in reconstructible — tolerated)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_missing_when_no_reconstructible_signal() -> None:
+    legacy = [_log("req-old", added=[_profile("p1", "content")])]
+
+    # reconstructible is empty — no signal for this id
+    results = _classify(legacy, [], reconstructible=set())
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.classification == ParityClass.LEGACY_MISSING
+    assert r.request_id == "req-old"
+    assert "tolerated" in r.detail
+
+
+# ---------------------------------------------------------------------------
+# Duplicate request_id → INCONCLUSIVE (must NOT raise)
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_legacy_request_id_inconclusive_no_raise() -> None:
+    p1 = _profile("p1", "c1")
+    p2 = _profile("p2", "c2")
+    legacy = [_log("req-dup", added=[p1]), _log("req-dup", added=[p2])]
+
+    results = _classify(legacy, [])
+
+    dup_results = [r for r in results if r.request_id == "req-dup"]
+    assert len(dup_results) == 1
+    assert dup_results[0].classification == ParityClass.INCONCLUSIVE
+    assert "duplicate" in dup_results[0].detail
+
+
+def test_duplicate_recon_request_id_inconclusive_no_raise() -> None:
+    p1 = _profile("p1", "c1")
+    p2 = _profile("p2", "c2")
+    recon = [_log("req-dup", added=[p1]), _log("req-dup", added=[p2])]
+
+    results = _classify([], recon)
+
+    dup_results = [r for r in results if r.request_id == "req-dup"]
+    assert len(dup_results) == 1
+    assert dup_results[0].classification == ParityClass.INCONCLUSIVE
+
+
+def test_duplicate_excluded_from_other_classification() -> None:
+    """Duplicate ids must not also appear as MATCH/RECON_MISSING/etc."""
+    p1 = _profile("p1", "c1")
+    legacy = [
+        _log("req-dup", added=[p1]),
+        _log("req-dup", added=[p1]),  # duplicate
+        _log("req-ok", added=[p1]),
+    ]
+    recon = [_log("req-ok", added=[p1])]
+
+    results = _classify(legacy, recon, reconstructible={"req-dup"})
+
+    classes = {r.request_id: r.classification for r in results}
+    assert classes["req-dup"] == ParityClass.INCONCLUSIVE
+    assert classes["req-ok"] == ParityClass.MATCH
+    # req-dup must not also appear as RECON_MISSING
+    assert sum(1 for r in results if r.request_id == "req-dup") == 1
+
+
+# ---------------------------------------------------------------------------
+# read_cap_hit → single INCONCLUSIVE
+# ---------------------------------------------------------------------------
+
+
+def test_read_cap_hit_returns_single_inconclusive() -> None:
+    legacy = [_log("req1", added=[_profile("p1", "c")])]
+    recon = [_log("req2", added=[_profile("p2", "c")])]
+
+    results = _classify(legacy, recon, read_cap_hit=True)
+
+    assert len(results) == 1
+    r = results[0]
+    assert r.classification == ParityClass.INCONCLUSIVE
+    assert r.request_id == "*"
+    assert "cap" in r.detail
+
+
+def test_read_cap_hit_ignores_data() -> None:
+    """Even with matching data, read_cap_hit=True → INCONCLUSIVE only."""
+    p1 = _profile("p1", "c")
+    legacy = [_log("req1", added=[p1])]
+    recon = [_log("req1", added=[p1])]
+
+    results = _classify(legacy, recon, read_cap_hit=True)
+
+    assert len(results) == 1
+    assert results[0].classification == ParityClass.INCONCLUSIVE
+
+
+# ---------------------------------------------------------------------------
+# Multiple request_ids sorted deterministically
+# ---------------------------------------------------------------------------
+
+
+def test_multiple_request_ids_sorted() -> None:
+    p1 = _profile("p1", "c")
+    legacy = [
+        _log("req-b", added=[p1]),
+        _log("req-a", added=[p1]),
+    ]
+    recon = [
+        _log("req-b", added=[p1]),
+        _log("req-a", added=[p1]),
+    ]
+
+    results = _classify(legacy, recon)
+
+    assert [r.request_id for r in results] == ["req-a", "req-b"]
+    assert all(r.classification == ParityClass.MATCH for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Import-identity test: script delegates to the lib function
+# ---------------------------------------------------------------------------
+
+
+def test_script_uses_lib_classify_change_log_parity() -> None:
+    """Verify the parity script re-exports classify_change_log_parity from the lib.
+
+    Importing the script module must expose the same function object as the lib,
+    confirming there is no local redefinition.
+    """
+
+    # The script does sys.path.insert at import time; that's fine for this check.
+    # We use importlib to load it as a module without executing __main__.
+    import importlib.util
+    from pathlib import Path
+
+    script_path = (
+        Path(__file__).resolve().parents[2] / "scripts" / "lineage_b3_parity_check.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "lineage_b3_parity_check", script_path
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+
+    # The script must import classify_change_log_parity from the lib — same object.
+    assert hasattr(module, "classify_change_log_parity"), (
+        "Script does not expose classify_change_log_parity"
+    )
+    assert module.classify_change_log_parity is classify_change_log_parity, (
+        "Script's classify_change_log_parity is not the lib's function — "
+        "a local redefinition was found"
+    )

--- a/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
@@ -269,14 +269,14 @@ def test_run_parity_check_detects_recon_missing(tmp_path) -> None:
     assert any(r.request_id == "req-gap-only" for r in gaps)
 
 
-def test_run_parity_check_tolerates_legacy_missing(tmp_path) -> None:
-    """run_parity_check does not fail for LEGACY-MISSING rows.
+def test_run_parity_check_recon_only_is_content_mismatch(tmp_path) -> None:
+    """run_parity_check classifies a recon-only run as CONTENT_MISMATCH (not RECON-MISSING).
 
     Seeds a real dedup run (status_change+superseded event + profile with
     generated_from_request_id) WITHOUT writing a legacy row — this represents
     a run that used the new path but didn't dual-write to the legacy table.
     The reconstruction produces a row; the legacy table has none → CONTENT_MISMATCH
-    (recon-only).
+    (recon-only). This is a gap (exit 1) but distinct from a RECON-MISSING gap.
     """
     s = _store(tmp_path)
 

--- a/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
@@ -296,6 +296,7 @@ def test_run_parity_check_tolerates_legacy_missing(tmp_path) -> None:
     assert any(r.request_id == req_id for r in content_mismatch), (
         f"Expected CONTENT_MISMATCH for {req_id!r}; got {[(r.request_id, r.classification) for r in results]}"
     )
-    # No RECON-MISSING → exit code will correctly reflect any real gaps (none here).
+    # No RECON-MISSING → only CONTENT_MISMATCH (recon-only) which IS a gap and
+    # would cause exit 1, but not a RECON_MISSING gap.
     gaps = [r for r in results if r.classification == ParityClass.RECON_MISSING]
     assert not gaps, "recon-only run should not trigger RECON-MISSING"

--- a/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
+++ b/tests/server/services/storage/test_lineage_b3_parity_classifier_integration.py
@@ -1,14 +1,18 @@
-"""Integration tests: B3 parity classifier (lineage_b3_parity_check.py).
+"""Integration tests: B3 parity classifier.
 
-Verifies that ``classify_parity`` labels each class correctly on seeded data:
-  - MATCH: legacy and reconstruction agree on content
-  - RECON-MISSING: legacy row exists, no lineage event (real gap → exit non-zero)
-  - LEGACY-MISSING: lineage event exists, no legacy row (tolerated)
+Verifies that ``classify_change_log_parity`` labels each class correctly on
+seeded data:
+  - MATCH: legacy and reconstruction agree on content.
+  - RECON-MISSING: legacy row exists AND a reconstructible signal exists but
+    reconstruction dropped the run (real gap → exit non-zero).
+  - LEGACY-MISSING: legacy row exists but NO reconstructible signal (tolerated —
+    predates soft-delete or purged).
+  - CONTENT_MISMATCH: both sides exist but content differs, or recon-only.
 """
 
 from __future__ import annotations
 
-# Script under test lives outside the package; import via sys.path trick.
+# Import run_parity_check from the script (it calls storage, so still lives there).
 import importlib.util
 import sys
 from datetime import UTC, datetime
@@ -16,6 +20,10 @@ from pathlib import Path
 
 import pytest
 
+from reflexio.lib._lineage_parity import (
+    ParityClass,
+    classify_change_log_parity,
+)
 from reflexio.models.api_schema.domain.entities import (
     ProfileChangeLog,
     UserProfile,
@@ -30,8 +38,6 @@ _mod = importlib.util.module_from_spec(_spec)
 sys.modules.setdefault("lineage_b3_parity_check", _mod)
 _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
 
-classify_parity = _mod.classify_parity
-ParityClass = _mod.ParityClass
 run_parity_check = _mod.run_parity_check
 
 pytestmark = pytest.mark.integration
@@ -82,57 +88,92 @@ def _legacy_row(
 
 
 # ---------------------------------------------------------------------------
-# Unit-level: classify_parity labels correctly on hand-crafted inputs
+# Unit-level: classify_change_log_parity labels correctly on hand-crafted inputs
 # ---------------------------------------------------------------------------
 
 
-def test_classify_match():
+def test_classify_match() -> None:
     """MATCH when both sides have identical added/removed content."""
     p_old = _make_profile("u1", "p-old", "old c")
     p_new = _make_profile("u1", "p-new", "new c")
     legacy = [_legacy_row("u1", "req-1", [p_new], [p_old])]
     recon = [_legacy_row("u1", "req-1", [p_new], [p_old])]
-    results = classify_parity(legacy, recon)
+    results = classify_change_log_parity(
+        legacy, recon, reconstructible_request_ids=set(), read_cap_hit=False
+    )
     assert len(results) == 1
     assert results[0].classification == ParityClass.MATCH
 
 
-def test_classify_recon_missing_no_lineage_event():
-    """RECON-MISSING when legacy has a row but recon list is empty."""
+def test_classify_legacy_only_with_reconstructible_signal_is_recon_missing() -> None:
+    """RECON-MISSING when legacy row exists AND a reconstructible signal is present."""
     p_old = _make_profile("u1", "p-old", "old c")
     p_new = _make_profile("u1", "p-new", "new c")
     legacy = [_legacy_row("u1", "req-gap", [p_new], [p_old])]
     recon: list[ProfileChangeLog] = []
-    results = classify_parity(legacy, recon)
+    results = classify_change_log_parity(
+        legacy,
+        recon,
+        reconstructible_request_ids={"req-gap"},
+        read_cap_hit=False,
+    )
     assert len(results) == 1
     assert results[0].classification == ParityClass.RECON_MISSING
 
 
-def test_classify_recon_missing_content_mismatch():
-    """RECON-MISSING when both sides exist but content disagrees."""
+def test_classify_legacy_only_without_reconstructible_signal_is_legacy_missing() -> (
+    None
+):
+    """LEGACY-MISSING when legacy row exists but no reconstructible signal (tolerated)."""
+    p_old = _make_profile("u1", "p-old", "old c")
+    p_new = _make_profile("u1", "p-new", "new c")
+    legacy = [_legacy_row("u1", "req-old", [p_new], [p_old])]
+    recon: list[ProfileChangeLog] = []
+    results = classify_change_log_parity(
+        legacy,
+        recon,
+        reconstructible_request_ids=set(),
+        read_cap_hit=False,
+    )
+    assert len(results) == 1
+    assert results[0].classification == ParityClass.LEGACY_MISSING
+
+
+def test_classify_content_mismatch_both_exist() -> None:
+    """CONTENT_MISMATCH when both sides exist but content disagrees."""
     p_old = _make_profile("u1", "p-old", "old c")
     p_new_legacy = _make_profile("u1", "p-new", "correct content")
     p_new_recon = _make_profile("u1", "p-new", "WRONG content")
     legacy = [_legacy_row("u1", "req-mismatch", [p_new_legacy], [p_old])]
     recon = [_legacy_row("u1", "req-mismatch", [p_new_recon], [p_old])]
-    results = classify_parity(legacy, recon)
+    results = classify_change_log_parity(
+        legacy,
+        recon,
+        reconstructible_request_ids=set(),
+        read_cap_hit=False,
+    )
     assert len(results) == 1
-    assert results[0].classification == ParityClass.RECON_MISSING
+    assert results[0].classification == ParityClass.CONTENT_MISMATCH
 
 
-def test_classify_legacy_missing():
-    """LEGACY-MISSING when recon has a row but legacy list is empty."""
+def test_classify_recon_only_is_content_mismatch() -> None:
+    """CONTENT_MISMATCH when recon has a row but legacy list is empty."""
     p_old = _make_profile("u1", "p-old", "old c")
     p_new = _make_profile("u1", "p-new", "new c")
     legacy: list[ProfileChangeLog] = []
     recon = [_legacy_row("u1", "req-orphan", [p_new], [p_old])]
-    results = classify_parity(legacy, recon)
+    results = classify_change_log_parity(
+        legacy,
+        recon,
+        reconstructible_request_ids=set(),
+        read_cap_hit=False,
+    )
     assert len(results) == 1
-    assert results[0].classification == ParityClass.LEGACY_MISSING
+    assert results[0].classification == ParityClass.CONTENT_MISMATCH
 
 
-def test_classify_mixed():
-    """Mixed: one MATCH, one RECON-MISSING, one LEGACY-MISSING."""
+def test_classify_mixed() -> None:
+    """Mixed: one MATCH, one LEGACY_MISSING (no signal), one CONTENT_MISMATCH (recon-only)."""
     p = _make_profile
 
     # MATCH
@@ -143,18 +184,23 @@ def test_classify_mixed():
         "u1", "req-match", [p("u1", "pa", "ca")], [p("u1", "pb", "cb")]
     )
 
-    # RECON-MISSING (legacy only)
+    # LEGACY_MISSING (legacy only, no reconstructible signal)
     l_gap = _legacy_row("u1", "req-gap", [p("u1", "pc", "cc")], [])
 
-    # LEGACY-MISSING (recon only)
+    # CONTENT_MISMATCH (recon only)
     r_orphan = _legacy_row("u1", "req-orphan", [p("u1", "pd", "cd")], [])
 
-    results = classify_parity([l_match, l_gap], [r_match, r_orphan])
+    results = classify_change_log_parity(
+        [l_match, l_gap],
+        [r_match, r_orphan],
+        reconstructible_request_ids=set(),
+        read_cap_hit=False,
+    )
     by_req = {r.request_id: r.classification for r in results}
 
     assert by_req["req-match"] == ParityClass.MATCH
-    assert by_req["req-gap"] == ParityClass.RECON_MISSING
-    assert by_req["req-orphan"] == ParityClass.LEGACY_MISSING
+    assert by_req["req-gap"] == ParityClass.LEGACY_MISSING
+    assert by_req["req-orphan"] == ParityClass.CONTENT_MISMATCH
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +208,7 @@ def test_classify_mixed():
 # ---------------------------------------------------------------------------
 
 
-def test_run_parity_check_all_match(tmp_path):
+def test_run_parity_check_all_match(tmp_path) -> None:
     """run_parity_check returns all MATCH when both paths are seeded together.
 
     Uses the real dedup path:
@@ -190,15 +236,32 @@ def test_run_parity_check_all_match(tmp_path):
     )
 
 
-def test_run_parity_check_detects_recon_missing(tmp_path):
-    """run_parity_check flags RECON-MISSING when legacy-only row exists."""
+def test_run_parity_check_detects_recon_missing(tmp_path) -> None:
+    """run_parity_check flags RECON-MISSING when legacy-only row exists with a reconstructible signal.
+
+    To produce RECON_MISSING we need:
+      1. A status_change+superseded lineage event for "req-gap-only" (puts it
+         in the reconstructible set).
+      2. The superseded profile is physically deleted (reconstruction can't
+         fetch it → removed=[]).
+      3. No profile has generated_from_request_id="req-gap-only" → added=[].
+      4. Reconstruction skips the row (empty added+removed).
+      5. Legacy table has the row → RECON_MISSING.
+    """
     s = _store(tmp_path)
 
-    old_p = _make_profile("u1", "p-gap-old", "old")
-    new_p = _make_profile("u1", "p-gap-new", "new")
-    s.add_user_profile("u1", [old_p, new_p])
-    # Only legacy row — no lineage event.
-    s.add_profile_change_log(_legacy_row("u1", "req-gap-only", [new_p], [old_p]))
+    old_p = _make_profile("u1", "p-gap-old", "old", request_id="seed-old")
+    s.add_user_profile("u1", [old_p])
+    # Dedup soft-delete: emits status_change+superseded with request_id="req-gap-only".
+    s.supersede_profiles_by_ids("u1", ["p-gap-old"], "req-gap-only")
+    # Simulate GC hard-deleting the tombstone so reconstruction can't find the profile.
+    s.conn.execute("DELETE FROM profiles WHERE profile_id = ?", ("p-gap-old",))
+    s.conn.commit()
+
+    # Legacy row exists for "req-gap-only" — reconstruction produces nothing (empty add+remove).
+    s.add_profile_change_log(
+        _legacy_row("u1", "req-gap-only", [], [old_p])  # legacy retains the content
+    )
 
     results = run_parity_check(s)
     gaps = [r for r in results if r.classification == ParityClass.RECON_MISSING]
@@ -206,13 +269,14 @@ def test_run_parity_check_detects_recon_missing(tmp_path):
     assert any(r.request_id == "req-gap-only" for r in gaps)
 
 
-def test_run_parity_check_tolerates_legacy_missing(tmp_path):
+def test_run_parity_check_tolerates_legacy_missing(tmp_path) -> None:
     """run_parity_check does not fail for LEGACY-MISSING rows.
 
     Seeds a real dedup run (status_change+superseded event + profile with
     generated_from_request_id) WITHOUT writing a legacy row — this represents
     a run that used the new path but didn't dual-write to the legacy table.
-    The reconstruction produces a row; the legacy table has none → LEGACY-MISSING.
+    The reconstruction produces a row; the legacy table has none → CONTENT_MISMATCH
+    (recon-only).
     """
     s = _store(tmp_path)
 
@@ -225,11 +289,13 @@ def test_run_parity_check_tolerates_legacy_missing(tmp_path):
     s.supersede_profiles_by_ids("u1", ["p-orphan-old"], req_id)
 
     results = run_parity_check(s)
-    legacy_missing = [
-        r for r in results if r.classification == ParityClass.LEGACY_MISSING
+    # Recon-only → CONTENT_MISMATCH (reconstruction produced a run absent from legacy).
+    content_mismatch = [
+        r for r in results if r.classification == ParityClass.CONTENT_MISMATCH
     ]
-    assert legacy_missing, "expected at least one LEGACY-MISSING"
-    assert any(r.request_id == req_id for r in legacy_missing)
-    # No RECON-MISSING → exit code would be 0.
+    assert any(r.request_id == req_id for r in content_mismatch), (
+        f"Expected CONTENT_MISMATCH for {req_id!r}; got {[(r.request_id, r.classification) for r in results]}"
+    )
+    # No RECON-MISSING → exit code will correctly reflect any real gaps (none here).
     gaps = [r for r in results if r.classification == ParityClass.RECON_MISSING]
-    assert not gaps, "LEGACY-MISSING should not trigger a real gap"
+    assert not gaps, "recon-only run should not trigger RECON-MISSING"

--- a/tests/server/site_var/test_feature_flags.py
+++ b/tests/server/site_var/test_feature_flags.py
@@ -7,6 +7,7 @@ from reflexio.server.site_var.feature_flags import (
     is_dedup_soft_delete_enabled,
     is_deduplicator_enabled,
     is_feature_enabled,
+    is_lineage_dual_read_diff_enabled,
     is_resumable_extraction_agent_enabled,
 )
 
@@ -608,6 +609,110 @@ class TestSoftDeleteDefaultOn(unittest.TestCase):
         """Explicit per-org exclusion via enabled=False + list without org → False."""
         self.assertFalse(is_aggregation_soft_delete_enabled("org-not-exempt"))
         self.assertTrue(is_aggregation_soft_delete_enabled("org-exempt"))
+
+
+class TestLineageDualReadDiffFlag(unittest.TestCase):
+    """Tests for is_lineage_dual_read_diff_enabled — a DEFAULT-CLOSED flag.
+
+    The key is absent from config → False (fail-CLOSED). The flag must never
+    activate on unconfigured deployments. Explicit enable via enabled=True or
+    per-org enabled_org_ids still works. Malformed config (non-dict) → False
+    with a warning (safe fallback). Strict-bool identity guards prevent truthy
+    strings and non-bool ints from enabling the flag.
+    """
+
+    # Default-closed: the critical case — key absent → OFF
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={},
+    )
+    def test_absent_key_returns_false(self, _mock):
+        """DEFAULT-CLOSED: key absent from config → False (dual-read diff off by default)."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value=MOCK_CONFIG,  # MOCK_CONFIG has no lineage_dual_read_diff key
+    )
+    def test_key_missing_from_populated_config_returns_false(self, _mock):
+        """DEFAULT-CLOSED: key missing from a non-empty config still returns False."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-123"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "lineage_dual_read_diff": {"enabled": True, "enabled_org_ids": []},
+        },
+    )
+    def test_globally_enabled_returns_true(self, _mock):
+        """Globally enabled (enabled=True) → True for any org."""
+        self.assertTrue(is_lineage_dual_read_diff_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "lineage_dual_read_diff": {
+                "enabled": False,
+                "enabled_org_ids": ["org-pilot"],
+            },
+        },
+    )
+    def test_org_in_enabled_list_returns_true(self, _mock):
+        """Org in enabled_org_ids → True even when global enabled=False."""
+        self.assertTrue(is_lineage_dual_read_diff_enabled("org-pilot"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "lineage_dual_read_diff": {
+                "enabled": False,
+                "enabled_org_ids": ["org-pilot"],
+            },
+        },
+    )
+    def test_org_not_in_enabled_list_returns_false(self, _mock):
+        """Org NOT in enabled_org_ids with global disabled → False."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-other"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={"lineage_dual_read_diff": "yes"},
+    )
+    def test_malformed_scalar_value_returns_false(self, _mock):
+        """Non-dict config value (scalar) → False, no AttributeError."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "lineage_dual_read_diff": {"enabled": "true", "enabled_org_ids": []}
+        },
+    )
+    def test_string_true_enabled_returns_false(self, _mock):
+        """enabled='true' (string) is not bool True — strict identity must reject it."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={"lineage_dual_read_diff": {"enabled": 1, "enabled_org_ids": []}},
+    )
+    def test_int_one_enabled_returns_false(self, _mock):
+        """enabled=1 (int) is not bool True — strict identity must reject it."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-any"))
+
+    @patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value={
+            "lineage_dual_read_diff": {
+                "enabled": False,
+                "enabled_org_ids": "org-pilot",
+            }
+        },
+    )
+    def test_string_org_ids_returns_false(self, _mock):
+        """enabled_org_ids='org-pilot' (string) must not match via substring in (#195)."""
+        self.assertFalse(is_lineage_dual_read_diff_enabled("org-pilot"))
+        self.assertFalse(is_lineage_dual_read_diff_enabled("pilot"))
 
 
 if __name__ == "__main__":

--- a/tests/server/test_lineage_dual_read_shim_integration.py
+++ b/tests/server/test_lineage_dual_read_shim_integration.py
@@ -303,14 +303,14 @@ def test_coverage_usage_event_recorded(
 ) -> None:
     """(c) Exactly one lineage.reconstruct.coverage event is emitted.
 
-    Seeds two runs:
-      - One MATCH (add-only): new profile stamped with req-id, old superseded,
-        but no removed_profiles in the legacy row → add_only_runs should be 1.
-      - One MATCH (remove-bearing): legacy row has a non-empty removed_profiles
-        list → remove_bearing_runs should be 1.
+    Seeds three runs, all of which produce MATCH:
+      - "req-add-only": new profile (add-only), no removed_profiles in legacy row.
+      - "seed-rem": seed profile for the remove-bearing run; reconstruction
+        produces an add-only row for it; we add a matching legacy row.
+      - "req-remove-bearing": the actual dedup run; legacy row has removed_profiles.
 
-    Asserts: event_category="lineage", add_only_runs and remove_bearing_runs
-    are integers, and their values match expectations.
+    Asserts: event_category="lineage", add_only_runs=2, remove_bearing_runs=1,
+    outcome="match" (zero divergences).
     """
     org_id = storage.org_id
 
@@ -333,6 +333,10 @@ def test_coverage_usage_event_recorded(
     storage.add_profile_change_log(
         _make_change_log("u1", "req-remove-bearing", [new_rem], [old_rem])
     )
+    # Add legacy row for "seed-rem" so reconstruction (which produces an add-only
+    # row for old_rem's generated_from_request_id) finds a matching legacy entry
+    # → MATCH instead of CONTENT_MISMATCH.
+    storage.add_profile_change_log(_make_change_log("u1", "seed-rem", [old_rem], []))
 
     with patch(
         "reflexio.server.site_var.feature_flags._get_feature_flags_config",
@@ -358,11 +362,15 @@ def test_coverage_usage_event_recorded(
     assert isinstance(meta.get("remove_bearing_runs"), int), (
         f"remove_bearing_runs must be int; got {type(meta.get('remove_bearing_runs'))}"
     )
-    assert meta["add_only_runs"] == 1, (
-        f"expected add_only_runs=1; got {meta['add_only_runs']}"
+    # req-add-only and seed-rem both produce add-only MATCH rows (legacy removed=[]).
+    assert meta["add_only_runs"] == 2, (
+        f"expected add_only_runs=2; got {meta['add_only_runs']}"
     )
     assert meta["remove_bearing_runs"] == 1, (
         f"expected remove_bearing_runs=1; got {meta['remove_bearing_runs']}"
+    )
+    assert evt.outcome == "match", (
+        f"expected outcome='match' (zero divergences); got {evt.outcome!r}"
     )
 
 
@@ -403,11 +411,17 @@ def test_non_disruption_returns_none_and_does_not_mutate_legacy(
     legacy_after_on = storage.get_profile_change_logs()
 
     # With flag OFF.
+    capturing_recorder.events.clear()
     with patch(
         "reflexio.server.site_var.feature_flags._get_feature_flags_config",
         return_value=_FLAG_DISABLED_CONFIG,
     ):
         result_off = dual_read_diff(reflexio_stub, org_id)
+
+    # A disabled flag must emit ZERO usage events (no side-effects at all).
+    assert not capturing_recorder.events, (
+        f"expected no usage events when flag is OFF; got: {capturing_recorder.events}"
+    )
 
     legacy_after_off = storage.get_profile_change_logs()
 

--- a/tests/server/test_lineage_dual_read_shim_integration.py
+++ b/tests/server/test_lineage_dual_read_shim_integration.py
@@ -1,0 +1,489 @@
+"""Integration tests for the lineage dual-read divergence shim.
+
+Covers:
+  (a) divergence emitted on a real RECON-MISSING mismatch.
+  (b) no divergence on tolerated deltas (MATCH, LEGACY_MISSING).
+  (c) coverage usage event recorded with correct metadata.
+  (d) non-disruption — dual_read_diff returns None and does not alter the legacy read.
+  (e) error path — exception in reconstruct is swallowed; lineage.reconstruct.error emitted.
+
+All tests use real SQLite storage in isolated temp dirs (mocked LLM via the
+project-level conftest). The feature flag is enabled via the standard
+``_get_feature_flags_config`` patch mechanism (see
+``tests/server/site_var/test_feature_flags.py``).
+"""
+
+from __future__ import annotations
+
+import tempfile
+import types
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import ProfileChangeLog, UserProfile
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
+from reflexio.server.lineage_parity_shim import dual_read_diff
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.usage_metrics import (
+    UsageEvent,
+    configure_usage_event_recorder,
+)
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Feature-flag config that enables the dual-read diff for all orgs.
+# ---------------------------------------------------------------------------
+
+_FLAG_ENABLED_CONFIG: dict[str, Any] = {
+    "lineage_dual_read_diff": {"enabled": True, "enabled_org_ids": []},
+}
+
+_FLAG_DISABLED_CONFIG: dict[str, Any] = {}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(tmp_path, worker_id: str) -> SQLiteStorage:
+    """Create and migrate a fresh SQLiteStorage for one test."""
+    s = SQLiteStorage(
+        org_id=f"shim-test-{worker_id}-{tmp_path.name}",
+        db_path=str(tmp_path / "test.db"),
+    )
+    s.migrate()
+    return s
+
+
+def _make_profile(
+    user_id: str = "u1",
+    profile_id: str = "p1",
+    content: str = "c",
+    request_id: str = "",
+) -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=request_id or f"gen_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_change_log(
+    user_id: str,
+    request_id: str,
+    added: list[UserProfile],
+    removed: list[UserProfile],
+) -> ProfileChangeLog:
+    return ProfileChangeLog(
+        id=0,
+        user_id=user_id,
+        request_id=request_id,
+        created_at=int(datetime.now(UTC).timestamp()),
+        added_profiles=added,
+        removed_profiles=removed,
+        mentioned_profiles=[],
+    )
+
+
+def _make_reflexio_stub(storage: SQLiteStorage) -> object:
+    """Minimal stub that duck-types ``reflexio.request_context.storage``."""
+    request_context = types.SimpleNamespace(storage=storage)
+    return types.SimpleNamespace(request_context=request_context)
+
+
+class _CapturingRecorder:
+    """Simple list-accumulating usage event recorder."""
+
+    def __init__(self) -> None:
+        self.events: list[UsageEvent] = []
+
+    def __call__(self, event: UsageEvent) -> None:
+        self.events.append(event)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(tmp_path, worker_id):
+    """Real SQLite storage, isolated per test."""
+    return _make_storage(tmp_path, worker_id)
+
+
+@pytest.fixture
+def reflexio_stub(storage):
+    """Minimal object that exposes .request_context.storage."""
+    return _make_reflexio_stub(storage)
+
+
+@pytest.fixture
+def capturing_recorder():
+    """Install a capturing usage recorder; reset to None after the test."""
+    recorder = _CapturingRecorder()
+    configure_usage_event_recorder(recorder)
+    yield recorder
+    configure_usage_event_recorder(None)
+
+
+# ---------------------------------------------------------------------------
+# (a) Divergence emitted on a real RECON-MISSING mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_divergence_emitted_for_recon_missing(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """(a) A RECON-MISSING run produces a lineage.reconstruct.divergence anomaly.
+
+    Seeding strategy (mirrors test_run_parity_check_detects_recon_missing):
+      1. Add an old profile, then supersede it with request_id="req-missing".
+         This emits a status_change+superseded lineage event → puts the id in
+         the reconstructible set.
+      2. Hard-delete the tombstone row so reconstruction can't fetch it →
+         added=[], removed=[] → reconstruction drops the run entirely.
+      3. Write a legacy row for "req-missing" → RECON-MISSING.
+    """
+    org_id = storage.org_id
+
+    old_p = _make_profile("u1", "p-gap", "gap-content", request_id="seed")
+    storage.add_user_profile("u1", [old_p])
+    storage.supersede_profiles_by_ids("u1", ["p-gap"], "req-missing")
+    # Hard-delete the tombstone so reconstruction yields nothing.
+    storage.conn.execute("DELETE FROM profiles WHERE profile_id = ?", ("p-gap",))
+    storage.conn.commit()
+
+    # Legacy table retains the row.
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-missing", [], [old_p])
+    )
+
+    anomalies: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture(message: str, **kwargs: Any) -> None:
+        anomalies.append((message, kwargs))
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+            return_value=_FLAG_ENABLED_CONFIG,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.capture_anomaly",
+            side_effect=_capture,
+        ),
+    ):
+        dual_read_diff(reflexio_stub, org_id)
+
+    divergence_calls = [
+        (msg, kw)
+        for msg, kw in anomalies
+        if msg == "lineage.reconstruct.divergence"
+    ]
+    assert divergence_calls, "expected at least one lineage.reconstruct.divergence anomaly"
+    assert any(
+        kw.get("kind") == "RECON-MISSING" for _, kw in divergence_calls
+    ), f"expected kind=RECON-MISSING in divergence anomalies, got: {divergence_calls}"
+
+
+# ---------------------------------------------------------------------------
+# (b) No divergence on tolerated deltas
+# ---------------------------------------------------------------------------
+
+
+def test_no_divergence_on_matching_run(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """(b) A clean dedup run that reconstructs to MATCH emits zero divergences.
+
+    Also seeds a LEGACY_MISSING run (legacy row exists but has no reconstructible
+    signal — the legacy row's content never received a generated_from_request_id
+    stamp and no supersede event was recorded for that request_id) — also
+    tolerated: no divergence anomaly.
+
+    Seeding note: ``_make_profile`` sets ``generated_from_request_id`` to the
+    given ``request_id``.  The "seed" profile for the old-profile slot must use
+    the SAME request_id that also has a legacy row, otherwise reconstruction
+    sees a phantom run for "seed-*" with no matching legacy row → CONTENT_MISMATCH.
+    Here we use a single dedup run where both the old profile and the new profile
+    have their generated_from_request_id set to the same run's request_id (which
+    is fine because the supersede event is what puts the run in the reconstructible
+    set, and reconstruction uses generated_from_request_id for add and the
+    superseded event for remove).
+    """
+    org_id = storage.org_id
+
+    # --- MATCH run ---
+    # old_match uses generated_from_request_id="req-match-seed" — we also add a
+    # legacy row for "req-match-seed" so it doesn't become a phantom CONTENT_MISMATCH.
+    # The actual dedup run is "req-match".
+    old_match = _make_profile("u1", "p-match-old", "old-match", request_id="req-match-seed")
+    new_match = _make_profile("u1", "p-match-new", "new-match", request_id="req-match")
+    storage.add_user_profile("u1", [old_match])
+    storage.add_user_profile("u1", [new_match])
+    storage.supersede_profiles_by_ids("u1", ["p-match-old"], "req-match")
+    # Legacy row for the dedup run.
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-match", [new_match], [old_match])
+    )
+    # Legacy row for the seed profile's request_id (no-op: add-only, matches recon).
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-match-seed", [old_match], [])
+    )
+
+    # --- LEGACY_MISSING run (no reconstructible signal; tolerated) ---
+    # Write a legacy row for a request_id that has zero reconstructible signals
+    # (no profile with that generated_from_request_id, no supersede event for it).
+    legacy_only_p = _make_profile(
+        "u1", "p-legacy-only", "legacy-content", request_id="req-legacy-only-seed"
+    )
+    # Persist the profile so the legacy change log row is valid, then write the
+    # legacy row with a DIFFERENT request_id that has no reconstructible signal.
+    storage.add_user_profile("u1", [legacy_only_p])
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-no-signal", [legacy_only_p], [])
+    )
+    # Also add a legacy row for "req-legacy-only-seed" to cover the profile stamp.
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-legacy-only-seed", [legacy_only_p], [])
+    )
+    # Neither req-no-signal nor req-legacy-only-seed has a supersede event,
+    # but req-legacy-only-seed DOES have a profile stamp so reconstruction will
+    # produce it → we wrote the legacy row above for it.
+    # req-no-signal has no stamp and no supersede event → LEGACY_MISSING (tolerated).
+
+    anomalies: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture(message: str, **kwargs: Any) -> None:
+        anomalies.append((message, kwargs))
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+            return_value=_FLAG_ENABLED_CONFIG,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.capture_anomaly",
+            side_effect=_capture,
+        ),
+    ):
+        dual_read_diff(reflexio_stub, org_id)
+
+    divergence_calls = [
+        (msg, kw)
+        for msg, kw in anomalies
+        if msg == "lineage.reconstruct.divergence"
+    ]
+    assert not divergence_calls, (
+        f"expected zero divergence anomalies for MATCH+LEGACY_MISSING data; got: {divergence_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) Coverage usage event recorded
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_usage_event_recorded(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """(c) Exactly one lineage.reconstruct.coverage event is emitted.
+
+    Seeds two runs:
+      - One MATCH (add-only): new profile stamped with req-id, old superseded,
+        but no removed_profiles in the legacy row → add_only_runs should be 1.
+      - One MATCH (remove-bearing): legacy row has a non-empty removed_profiles
+        list → remove_bearing_runs should be 1.
+
+    Asserts: event_category="lineage", add_only_runs and remove_bearing_runs
+    are integers, and their values match expectations.
+    """
+    org_id = storage.org_id
+
+    # --- add-only MATCH run ---
+    new_add = _make_profile("u1", "p-add-new", "add-new", request_id="req-add-only")
+    storage.add_user_profile("u1", [new_add])
+    # No superseded profile → removed=[] in reconstruction.
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-add-only", [new_add], [])
+    )
+
+    # --- remove-bearing MATCH run ---
+    old_rem = _make_profile("u1", "p-rem-old", "old-rem", request_id="seed-rem")
+    new_rem = _make_profile("u1", "p-rem-new", "new-rem", request_id="req-remove-bearing")
+    storage.add_user_profile("u1", [old_rem])
+    storage.add_user_profile("u1", [new_rem])
+    storage.supersede_profiles_by_ids("u1", ["p-rem-old"], "req-remove-bearing")
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-remove-bearing", [new_rem], [old_rem])
+    )
+
+    with patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value=_FLAG_ENABLED_CONFIG,
+    ):
+        dual_read_diff(reflexio_stub, org_id)
+
+    coverage_events = [
+        e
+        for e in capturing_recorder.events
+        if e.event_name == "lineage.reconstruct.coverage"
+    ]
+    assert len(coverage_events) == 1, (
+        f"expected exactly one coverage event; got {len(coverage_events)}"
+    )
+    evt = coverage_events[0]
+    assert evt.event_category == "lineage"
+
+    meta = evt.metadata
+    assert isinstance(meta.get("add_only_runs"), int), (
+        f"add_only_runs must be int; got {type(meta.get('add_only_runs'))}"
+    )
+    assert isinstance(meta.get("remove_bearing_runs"), int), (
+        f"remove_bearing_runs must be int; got {type(meta.get('remove_bearing_runs'))}"
+    )
+    assert meta["add_only_runs"] == 1, f"expected add_only_runs=1; got {meta['add_only_runs']}"
+    assert meta["remove_bearing_runs"] == 1, (
+        f"expected remove_bearing_runs=1; got {meta['remove_bearing_runs']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) Non-disruption
+# ---------------------------------------------------------------------------
+
+
+def test_non_disruption_returns_none_and_does_not_mutate_legacy(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """(d) dual_read_diff returns None; legacy read is identical before and after.
+
+    Also asserts that calling with the flag OFF produces the same legacy result
+    (flag gate has zero side-effects).
+    """
+    org_id = storage.org_id
+
+    old_p = _make_profile("u1", "p-nd-old", "nd-old", request_id="seed-nd")
+    new_p = _make_profile("u1", "p-nd-new", "nd-new", request_id="req-nd")
+    storage.add_user_profile("u1", [old_p])
+    storage.add_user_profile("u1", [new_p])
+    storage.supersede_profiles_by_ids("u1", ["p-nd-old"], "req-nd")
+    storage.add_profile_change_log(
+        _make_change_log("u1", "req-nd", [new_p], [old_p])
+    )
+
+    legacy_before = storage.get_profile_change_logs()
+
+    # With flag ON.
+    with patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value=_FLAG_ENABLED_CONFIG,
+    ):
+        result_on = dual_read_diff(reflexio_stub, org_id)
+
+    legacy_after_on = storage.get_profile_change_logs()
+
+    # With flag OFF.
+    with patch(
+        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+        return_value=_FLAG_DISABLED_CONFIG,
+    ):
+        result_off = dual_read_diff(reflexio_stub, org_id)
+
+    legacy_after_off = storage.get_profile_change_logs()
+
+    assert result_on is None, f"expected None from dual_read_diff (flag ON); got {result_on!r}"
+    assert result_off is None, f"expected None from dual_read_diff (flag OFF); got {result_off!r}"
+
+    # Legacy read must be unchanged by the shim.
+    def _key(row: ProfileChangeLog) -> str:
+        return row.request_id
+
+    assert sorted(legacy_before, key=_key) == sorted(legacy_after_on, key=_key), (
+        "legacy rows changed after dual_read_diff (flag ON)"
+    )
+    assert sorted(legacy_before, key=_key) == sorted(legacy_after_off, key=_key), (
+        "legacy rows changed after dual_read_diff (flag OFF)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) Error path
+# ---------------------------------------------------------------------------
+
+
+def test_error_path_swallowed_and_emits_anomaly(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """(e) Exception inside reconstruct is swallowed; lineage.reconstruct.error emitted.
+
+    Monkeypatches reconstruct_profile_change_log in the shim's module namespace
+    to raise a ValueError. Asserts:
+      - dual_read_diff does not raise,
+      - a lineage.reconstruct.error anomaly is captured with error="ValueError",
+      - no lineage.reconstruct.divergence anomaly is emitted.
+    """
+    org_id = storage.org_id
+
+    anomalies: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture(message: str, **kwargs: Any) -> None:
+        anomalies.append((message, kwargs))
+
+    def _exploding_reconstruct(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("simulated reconstruction failure")
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+            return_value=_FLAG_ENABLED_CONFIG,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.reconstruct_profile_change_log",
+            side_effect=_exploding_reconstruct,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.capture_anomaly",
+            side_effect=_capture,
+        ),
+    ):
+        # Must not raise.
+        result = dual_read_diff(reflexio_stub, org_id)
+
+    assert result is None, f"expected None; got {result!r}"
+
+    error_calls = [(msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.error"]
+    assert error_calls, "expected at least one lineage.reconstruct.error anomaly"
+    assert any(
+        kw.get("error") == "ValueError" for _, kw in error_calls
+    ), f"expected error='ValueError' in anomaly kwargs; got: {error_calls}"
+
+    divergence_calls = [
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.divergence"
+    ]
+    assert not divergence_calls, (
+        f"no divergence anomaly expected on error path; got: {divergence_calls}"
+    )

--- a/tests/server/test_lineage_dual_read_shim_integration.py
+++ b/tests/server/test_lineage_dual_read_shim_integration.py
@@ -15,7 +15,6 @@ project-level conftest). The feature flag is enabled via the standard
 
 from __future__ import annotations
 
-import tempfile
 import types
 from datetime import UTC, datetime
 from typing import Any
@@ -165,9 +164,7 @@ def test_divergence_emitted_for_recon_missing(
     storage.conn.commit()
 
     # Legacy table retains the row.
-    storage.add_profile_change_log(
-        _make_change_log("u1", "req-missing", [], [old_p])
-    )
+    storage.add_profile_change_log(_make_change_log("u1", "req-missing", [], [old_p]))
 
     anomalies: list[tuple[str, dict[str, Any]]] = []
 
@@ -187,14 +184,14 @@ def test_divergence_emitted_for_recon_missing(
         dual_read_diff(reflexio_stub, org_id)
 
     divergence_calls = [
-        (msg, kw)
-        for msg, kw in anomalies
-        if msg == "lineage.reconstruct.divergence"
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.divergence"
     ]
-    assert divergence_calls, "expected at least one lineage.reconstruct.divergence anomaly"
-    assert any(
-        kw.get("kind") == "RECON-MISSING" for _, kw in divergence_calls
-    ), f"expected kind=RECON-MISSING in divergence anomalies, got: {divergence_calls}"
+    assert divergence_calls, (
+        "expected at least one lineage.reconstruct.divergence anomaly"
+    )
+    assert any(kw.get("kind") == "RECON-MISSING" for _, kw in divergence_calls), (
+        f"expected kind=RECON-MISSING in divergence anomalies, got: {divergence_calls}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +228,9 @@ def test_no_divergence_on_matching_run(
     # old_match uses generated_from_request_id="req-match-seed" — we also add a
     # legacy row for "req-match-seed" so it doesn't become a phantom CONTENT_MISMATCH.
     # The actual dedup run is "req-match".
-    old_match = _make_profile("u1", "p-match-old", "old-match", request_id="req-match-seed")
+    old_match = _make_profile(
+        "u1", "p-match-old", "old-match", request_id="req-match-seed"
+    )
     new_match = _make_profile("u1", "p-match-new", "new-match", request_id="req-match")
     storage.add_user_profile("u1", [old_match])
     storage.add_user_profile("u1", [new_match])
@@ -284,9 +283,7 @@ def test_no_divergence_on_matching_run(
         dual_read_diff(reflexio_stub, org_id)
 
     divergence_calls = [
-        (msg, kw)
-        for msg, kw in anomalies
-        if msg == "lineage.reconstruct.divergence"
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.divergence"
     ]
     assert not divergence_calls, (
         f"expected zero divergence anomalies for MATCH+LEGACY_MISSING data; got: {divergence_calls}"
@@ -327,7 +324,9 @@ def test_coverage_usage_event_recorded(
 
     # --- remove-bearing MATCH run ---
     old_rem = _make_profile("u1", "p-rem-old", "old-rem", request_id="seed-rem")
-    new_rem = _make_profile("u1", "p-rem-new", "new-rem", request_id="req-remove-bearing")
+    new_rem = _make_profile(
+        "u1", "p-rem-new", "new-rem", request_id="req-remove-bearing"
+    )
     storage.add_user_profile("u1", [old_rem])
     storage.add_user_profile("u1", [new_rem])
     storage.supersede_profiles_by_ids("u1", ["p-rem-old"], "req-remove-bearing")
@@ -359,7 +358,9 @@ def test_coverage_usage_event_recorded(
     assert isinstance(meta.get("remove_bearing_runs"), int), (
         f"remove_bearing_runs must be int; got {type(meta.get('remove_bearing_runs'))}"
     )
-    assert meta["add_only_runs"] == 1, f"expected add_only_runs=1; got {meta['add_only_runs']}"
+    assert meta["add_only_runs"] == 1, (
+        f"expected add_only_runs=1; got {meta['add_only_runs']}"
+    )
     assert meta["remove_bearing_runs"] == 1, (
         f"expected remove_bearing_runs=1; got {meta['remove_bearing_runs']}"
     )
@@ -388,9 +389,7 @@ def test_non_disruption_returns_none_and_does_not_mutate_legacy(
     storage.add_user_profile("u1", [old_p])
     storage.add_user_profile("u1", [new_p])
     storage.supersede_profiles_by_ids("u1", ["p-nd-old"], "req-nd")
-    storage.add_profile_change_log(
-        _make_change_log("u1", "req-nd", [new_p], [old_p])
-    )
+    storage.add_profile_change_log(_make_change_log("u1", "req-nd", [new_p], [old_p]))
 
     legacy_before = storage.get_profile_change_logs()
 
@@ -412,8 +411,12 @@ def test_non_disruption_returns_none_and_does_not_mutate_legacy(
 
     legacy_after_off = storage.get_profile_change_logs()
 
-    assert result_on is None, f"expected None from dual_read_diff (flag ON); got {result_on!r}"
-    assert result_off is None, f"expected None from dual_read_diff (flag OFF); got {result_off!r}"
+    assert result_on is None, (
+        f"expected None from dual_read_diff (flag ON); got {result_on!r}"
+    )
+    assert result_off is None, (
+        f"expected None from dual_read_diff (flag OFF); got {result_off!r}"
+    )
 
     # Legacy read must be unchanged by the shim.
     def _key(row: ProfileChangeLog) -> str:
@@ -475,11 +478,13 @@ def test_error_path_swallowed_and_emits_anomaly(
 
     assert result is None, f"expected None; got {result!r}"
 
-    error_calls = [(msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.error"]
+    error_calls = [
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.error"
+    ]
     assert error_calls, "expected at least one lineage.reconstruct.error anomaly"
-    assert any(
-        kw.get("error") == "ValueError" for _, kw in error_calls
-    ), f"expected error='ValueError' in anomaly kwargs; got: {error_calls}"
+    assert any(kw.get("error") == "ValueError" for _, kw in error_calls), (
+        f"expected error='ValueError' in anomaly kwargs; got: {error_calls}"
+    )
 
     divergence_calls = [
         (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.divergence"


### PR DESCRIPTION
## Summary

Builds the **dual-read divergence shim** (Phase B3 parity gate) per spec `2026-06-22-lineage-dual-read-divergence-shim.md` and plan `2026-06-22-lineage-dual-read-shim-build.md`. It replaces the passive "parity window" with an evidence gate: on `GET /api/profile_change_log`, when a **default-closed** per-org flag is enabled, it shadow-compares the legacy `ProfileChangeLog` against `reconstruct_profile_change_log`, **serves the legacy result unchanged**, and emits a divergence anomaly + a coverage usage-event. The Track-A retirement can then be gated on *measured* equivalence (divergence==0 over varied per-org traffic) instead of a calendar wait.

Track B stays offline (existing `scripts/lineage_b3_parity_check.py`) — no live shim, per its accept-loss/reversible disposition and the absence of a sound run-key.

## What's here

- **`lib/_lineage_parity.py`** — pure `classify_change_log_parity` (MATCH / RECON-MISSING / CONTENT-MISMATCH / LEGACY-MISSING / INCONCLUSIVE) + `profile_reconstructible_request_ids`. The RECON-MISSING-vs-LEGACY-MISSING split keys on an independently-computed reconstructible-signal set (the add-only false-negative guard), not a timestamp.
- **`server/lineage_parity_shim.py`** — `dual_read_diff`: never raises, never alters the served response; capped divergence-anomaly fan-out; coverage via `record_usage_event` (with add-only/remove-bearing variety), divergence/error via `capture_anomaly`.
- **`server/api.py`** — wires the shim into the route via `BackgroundTasks` (runs off the request thread).
- **`server/site_var/feature_flags.py`** — default-CLOSED `is_lineage_dual_read_diff_enabled` via `_is_fail_closed_flag_enabled`.
- **`scripts/lineage_b3_parity_check.py`** — migrated to call the shared predicate (single source of truth; import-identity tested).
- Tests: predicate unit tests + shim integration tests (real seeded SQLite, including the RECON-MISSING path and non-disruption).

No schema change, no new storage contract method.

## Review

Built via subagent-driven-development (per-task review each task), then a capable-model whole-branch review (core non-disruption invariant traced), then `/review-loop` (3 concern specialists + an adversarial pass). The adversarial pass caught two real issues now fixed: the shim ran synchronously on the request thread (→ `BackgroundTasks`) and an uncapped per-run `capture_anomaly` fan-out (→ capped at 20 + an aggregate). Deferred as documented follow-ups (off the request path once the shim is backgrounded): batching `reconstruct_profile_change_log`'s pre-existing N+1, de-duping the double event-read, a wall-clock timeout.

Default-closed → lands safe; produces signal only once soft-delete is active in prod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background divergence verification for the profile change log endpoint by comparing legacy results to reconstructed results.
  * Added a feature flag to enable dual-read divergence monitoring per organization.
* **Improvements**
  * Expanded parity classification and coverage tracking, including detection of content mismatches and improved anomaly reporting with caps to prevent excessive noise.
* **Tests**
  * Added comprehensive unit and integration tests covering parity classifications, truncation behavior, duplicate handling, and feature-flag gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->