### PR TITLE
fix(llm): send normalized strict schema to OpenAI-compatible providers litellm under-reports

### DIFF
--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -473,6 +473,15 @@ class LiteLLMClient:
         "xai/": "xai",
     }
 
+    # OpenAI-compatible providers that accept a ``json_schema`` response_format
+    # but that ``litellm.supports_response_schema`` reports as unsupported. For
+    # these, the gate below would fall back to handing LiteLLM the raw Pydantic
+    # model; LiteLLM then builds the ``json_schema`` itself and emits ``oneOf``
+    # for discriminated unions, which strict structured-output endpoints reject
+    # (Sentry PYTHON-FASTAPI-9J). Listing the provider here forces our own
+    # normalized strict schema (``oneOf`` folded into ``anyOf``) to be sent.
+    _JSON_SCHEMA_PROVIDER_ALLOWLIST: frozenset[str] = frozenset({"minimax"})
+
     # Models that only support temperature=1.0 (custom values cause errors or degraded performance)
     TEMPERATURE_RESTRICTED_MODELS = {
         "gpt-5",
@@ -1084,6 +1093,28 @@ class LiteLLMClient:
         except Exception:
             return False
 
+    @staticmethod
+    @lru_cache(maxsize=256)
+    def _provider_for_model(model: str) -> str | None:
+        try:
+            return litellm.get_llm_provider(model)[1]
+        except Exception:
+            return None
+
+    @classmethod
+    def _accepts_json_schema_response_format(cls, model: str) -> bool:
+        """Whether to send ``model`` an explicit strict ``json_schema`` schema.
+
+        True when LiteLLM reports native response-schema support, or when the
+        provider is a known OpenAI-compatible endpoint that LiteLLM
+        under-reports (see ``_JSON_SCHEMA_PROVIDER_ALLOWLIST``). In the latter
+        case LiteLLM would otherwise forward a ``json_schema`` it built itself,
+        emitting ``oneOf`` for discriminated unions that the endpoint rejects.
+        """
+        if cls._supports_response_schema(model):
+            return True
+        return cls._provider_for_model(model) in cls._JSON_SCHEMA_PROVIDER_ALLOWLIST
+
     def _provider_response_format(
         self,
         *,
@@ -1093,16 +1124,19 @@ class LiteLLMClient:
     ) -> Any:
         """Return the provider-facing response_format while preserving parser schema.
 
-        Callers pass a Pydantic model so local parsing stays type-safe. When
-        LiteLLM says the target model supports JSON Schema response formats, we
-        send an explicit strict schema to constrain generation. Unsupported
-        providers keep the existing Pydantic response_format behavior.
+        Callers pass a Pydantic model so local parsing stays type-safe. When the
+        target model accepts a JSON Schema response format — either LiteLLM
+        reports native support, or the provider is an OpenAI-compatible endpoint
+        LiteLLM under-reports (see ``_accepts_json_schema_response_format``) — we
+        send an explicit strict schema to constrain generation. Truly
+        unsupported providers keep the existing Pydantic response_format
+        behavior.
         """
 
         if (
             strict_response_format
             and is_pydantic_model(response_format)
-            and self._supports_response_schema(model)
+            and self._accepts_json_schema_response_format(model)
         ):
             return strict_response_format_for_model(response_format)
         return response_format

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -36,7 +36,7 @@ import json
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from reflexio.test_support.llm_model_registry import get_model_registry
@@ -93,13 +93,53 @@ def _extraction_finish_args(prompt_content: str) -> dict[str, Any]:
     same schema marker the content-mode path uses.
     """
     registry = get_model_registry()
+    # Both extraction entries carry dict ``minimal_valid`` payloads (the
+    # ``| str`` arm of the registry type only applies to raw-string entries).
     if '"playbooks"' in prompt_content:
-        return registry["playbook_extraction"].minimal_valid
-    return registry["profile_extraction"].minimal_valid
+        return cast(dict[str, Any], registry["playbook_extraction"].minimal_valid)
+    return cast(dict[str, Any], registry["profile_extraction"].minimal_valid)
+
+
+def _find_schema_key(node: Any, key: str) -> bool:
+    """Recursively report whether ``key`` appears anywhere in a JSON schema."""
+    if isinstance(node, dict):
+        if key in node:
+            return True
+        return any(_find_schema_key(v, key) for v in node.values())
+    if isinstance(node, list):
+        return any(_find_schema_key(v, key) for v in node)
+    return False
+
+
+def _assert_response_format_strict_compatible(kwargs: dict[str, Any]) -> None:
+    """Guard every structured-output call: a ``json_schema`` response_format sent
+    to the provider must be OpenAI strict-mode compatible (no ``oneOf`` /
+    ``discriminator``). Pydantic discriminated unions emit ``oneOf``, which strict
+    structured-output endpoints reject with a 400 (Sentry PYTHON-FASTAPI-9J) — a
+    failure the canned mock would otherwise hide. Raw Pydantic-class
+    response_format (the unsupported-provider passthrough) is skipped: that path
+    is handled by LiteLLM/the provider, not by an explicit strict schema.
+    """
+    response_format = kwargs.get("response_format")
+    if not isinstance(response_format, dict):
+        return
+    if response_format.get("type") != "json_schema":
+        return
+    schema = response_format.get("json_schema", {}).get("schema")
+    if not isinstance(schema, dict):
+        return
+    for banned in ("oneOf", "discriminator"):
+        if _find_schema_key(schema, banned):
+            raise AssertionError(
+                f"response_format json_schema contains '{banned}' — OpenAI strict "
+                "structured outputs reject it. Normalize via make_strict_json_schema "
+                "before sending (Sentry PYTHON-FASTAPI-9J)."
+            )
 
 
 def _mock_completion(*args: Any, **kwargs: Any) -> MagicMock:
     """Mock implementation for litellm.completion."""
+    _assert_response_format_strict_compatible(kwargs)
     messages = kwargs.get("messages", args[0] if args else [])
     prompt_content = ""
     for message in messages:

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -100,12 +100,29 @@ def _extraction_finish_args(prompt_content: str) -> dict[str, Any]:
     return cast(dict[str, Any], registry["profile_extraction"].minimal_valid)
 
 
+# Keys whose *values* are name→subschema maps: their entries are user-chosen
+# names (field names, $def names), not JSON-Schema keywords. We recurse into the
+# subschemas but must not treat the names themselves as keyword matches —
+# otherwise a model with a field literally named ``oneOf`` would false-positive.
+_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
+
+
 def _find_schema_key(node: Any, key: str) -> bool:
-    """Recursively report whether ``key`` appears anywhere in a JSON schema."""
+    """Report whether ``key`` appears as a JSON-Schema *keyword* anywhere in a schema.
+
+    Context-aware: occurrences of ``key`` as a property/``$defs`` *name* are not
+    matches — only occurrences in JSON-Schema keyword position count.
+    """
     if isinstance(node, dict):
         if key in node:
             return True
-        return any(_find_schema_key(v, key) for v in node.values())
+        for k, v in node.items():
+            if k in _SCHEMA_NAME_MAP_KEYS and isinstance(v, dict):
+                if any(_find_schema_key(sub, key) for sub in v.values()):
+                    return True
+            elif _find_schema_key(v, key):
+                return True
+        return False
     if isinstance(node, list):
         return any(_find_schema_key(v, key) for v in node)
     return False

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1030,14 +1030,26 @@ class TestMaybeParseStructuredOutput:
             )
 
 
+# Keys whose values are name→subschema maps; their entries are user-chosen names,
+# not JSON-Schema keywords (so a field named ``oneOf`` must not count as a match).
+_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
+
+
 def _find_schema_keys(node: Any, key: str) -> list[str]:
-    """Return JSON-pointer-ish paths to every occurrence of ``key`` in a schema."""
+    """Return paths to every occurrence of ``key`` in JSON-Schema *keyword* position.
+
+    Context-aware: a property/``$defs`` *name* equal to ``key`` is not a match.
+    """
     hits: list[str] = []
     if isinstance(node, dict):
         for k, v in node.items():
             if k == key:
                 hits.append(k)
-            hits.extend(f"{k}.{p}" for p in _find_schema_keys(v, key))
+            if k in _SCHEMA_NAME_MAP_KEYS and isinstance(v, dict):
+                for name, sub in v.items():
+                    hits.extend(f"{k}.{name}.{p}" for p in _find_schema_keys(sub, key))
+            else:
+                hits.extend(f"{k}.{p}" for p in _find_schema_keys(v, key))
     elif isinstance(node, list):
         for i, v in enumerate(node):
             hits.extend(f"[{i}].{p}" for p in _find_schema_keys(v, key))
@@ -1216,6 +1228,20 @@ class TestStrictStructuredOutputRequest:
             "model (Sentry PYTHON-FASTAPI-9J)"
         )
         schema = provider_format["json_schema"]["schema"]
+        assert _find_schema_keys(schema, "oneOf") == []
+        assert _find_schema_keys(schema, "discriminator") == []
+
+    def test_finder_ignores_property_named_like_a_keyword(self):
+        # A field literally named `oneOf`/`discriminator` is a property NAME, not a
+        # schema keyword, and must not trip the strict-schema guard (the finder is
+        # context-aware — CodeRabbit false-positive fix).
+        class _TrickyNames(BaseModel):
+            oneOf: str = ""  # noqa: N815  (deliberately a keyword-like field name)
+            discriminator: int = 0
+
+        schema = make_strict_json_schema(_TrickyNames.model_json_schema())
+        assert "oneOf" in schema["properties"]
+        assert "discriminator" in schema["properties"]
         assert _find_schema_keys(schema, "oneOf") == []
         assert _find_schema_keys(schema, "discriminator") == []
 

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1175,9 +1175,9 @@ class TestStrictStructuredOutputRequest:
         # (strict structured-output endpoints reject `oneOf`).
 
         # Sanity: the raw Pydantic schema really does emit the rejected keyword.
-        raw_items = _DiscriminatedOutput.model_json_schema()["properties"][
-            "decisions"
-        ]["items"]
+        raw_items = _DiscriminatedOutput.model_json_schema()["properties"]["decisions"][
+            "items"
+        ]
         assert "oneOf" in raw_items
 
         client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M3"))
@@ -1198,6 +1198,26 @@ class TestStrictStructuredOutputRequest:
         assert _find_schema_keys(sent_schema, "discriminator") == []
         # The variants are preserved as `anyOf` so generation stays constrained.
         assert "anyOf" in sent_schema["properties"]["decisions"]["items"]
+
+    def test_real_minimax_gate_normalizes_without_mocking_predicate(self):
+        # The bug slipped because every strict-schema test PATCHED
+        # _supports_response_schema. This one does NOT — it exercises the real
+        # litellm capability lookup + allowlist for the actual default prod model
+        # (minimax). With the discriminated-union output, the response_format
+        # actually built must be a normalized dict with no oneOf/discriminator.
+        client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M3"))
+        params, _, _, _, _ = client._build_completion_params(
+            [{"role": "user", "content": "test"}],
+            response_format=_DiscriminatedOutput,
+        )
+        provider_format = params["response_format"]
+        assert isinstance(provider_format, dict), (
+            "minimax must receive a normalized strict schema, not the raw Pydantic "
+            "model (Sentry PYTHON-FASTAPI-9J)"
+        )
+        schema = provider_format["json_schema"]["schema"]
+        assert _find_schema_keys(schema, "oneOf") == []
+        assert _find_schema_keys(schema, "discriminator") == []
 
     def test_strict_response_format_can_be_disabled_per_call(self):
         client = _build_client(LiteLLMConfig(model="gpt-4o-mini"))

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -14,7 +14,7 @@ import tempfile
 import time
 import zlib
 from pathlib import Path
-from typing import Any, cast
+from typing import Annotated, Any, Literal, cast
 from unittest.mock import MagicMock, patch
 
 import litellm
@@ -1030,6 +1030,42 @@ class TestMaybeParseStructuredOutput:
             )
 
 
+def _find_schema_keys(node: Any, key: str) -> list[str]:
+    """Return JSON-pointer-ish paths to every occurrence of ``key`` in a schema."""
+    hits: list[str] = []
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == key:
+                hits.append(k)
+            hits.extend(f"{k}.{p}" for p in _find_schema_keys(v, key))
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            hits.extend(f"[{i}].{p}" for p in _find_schema_keys(v, key))
+    return hits
+
+
+# A minimal discriminated-union output schema, the shape behind PYTHON-FASTAPI-9J.
+# Pydantic emits `oneOf` + `discriminator` at properties.decisions.items, which
+# strict structured-output endpoints reject.
+class _UnifyDecision(BaseModel):
+    kind: Literal["unify"] = "unify"
+    new_id: str
+
+
+class _RejectDecision(BaseModel):
+    kind: Literal["reject"] = "reject"
+    existing_id: int
+
+
+_ConsolidationDecision = Annotated[
+    _UnifyDecision | _RejectDecision, Field(discriminator="kind")
+]
+
+
+class _DiscriminatedOutput(BaseModel):
+    decisions: list[_ConsolidationDecision] = Field(default_factory=list)
+
+
 class TestStrictStructuredOutputRequest:
     """Provider-facing structured output request format."""
 
@@ -1088,7 +1124,10 @@ class TestStrictStructuredOutputRequest:
         assert parse_structured is True
 
     def test_unsupported_model_keeps_pydantic_response_format(self):
-        client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M2.7"))
+        # A provider that is neither natively response-schema-capable nor on the
+        # OpenAI-compatible allowlist keeps the raw Pydantic model so LiteLLM can
+        # apply its own provider-specific handling (e.g. tool-calling).
+        client = _build_client(LiteLLMConfig(model="ollama/llama3"))
 
         with patch.object(
             LiteLLMClient,
@@ -1102,6 +1141,63 @@ class TestStrictStructuredOutputRequest:
 
         assert params["response_format"] is SampleResponse
         assert parser_schema is SampleResponse
+
+    def test_openai_compatible_underreported_provider_uses_strict_schema(self):
+        # Regression for Sentry PYTHON-FASTAPI-9J: minimax reports
+        # supports_response_schema=False, but it is an OpenAI-compatible endpoint
+        # LiteLLM would still hand a self-built json_schema. We must send our own
+        # normalized strict schema instead of the raw Pydantic model.
+        client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M3"))
+
+        with patch.object(
+            LiteLLMClient,
+            "_supports_response_schema",
+            return_value=False,
+        ):
+            params, parser_schema, parse_structured, _, _ = (
+                client._build_completion_params(
+                    [{"role": "user", "content": "test"}],
+                    response_format=SampleResponse,
+                )
+            )
+
+        provider_format = params["response_format"]
+        assert provider_format["type"] == "json_schema"
+        assert provider_format["json_schema"]["strict"] is True
+        assert parser_schema is SampleResponse
+        assert parse_structured is True
+
+    def test_discriminated_union_strips_oneof_for_underreported_provider(self):
+        # The exact shape behind PYTHON-FASTAPI-9J: a discriminated-union output
+        # whose Pydantic schema carries `oneOf`/`discriminator` at
+        # properties.<field>.items. On an under-reported OpenAI-compatible
+        # provider (minimax), the schema actually sent must contain neither
+        # (strict structured-output endpoints reject `oneOf`).
+
+        # Sanity: the raw Pydantic schema really does emit the rejected keyword.
+        raw_items = _DiscriminatedOutput.model_json_schema()["properties"][
+            "decisions"
+        ]["items"]
+        assert "oneOf" in raw_items
+
+        client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M3"))
+        with patch.object(
+            LiteLLMClient,
+            "_supports_response_schema",
+            return_value=False,
+        ):
+            params, _, _, _, _ = client._build_completion_params(
+                [{"role": "user", "content": "test"}],
+                response_format=_DiscriminatedOutput,
+            )
+
+        provider_format = params["response_format"]
+        assert provider_format["type"] == "json_schema"
+        sent_schema = provider_format["json_schema"]["schema"]
+        assert _find_schema_keys(sent_schema, "oneOf") == []
+        assert _find_schema_keys(sent_schema, "discriminator") == []
+        # The variants are preserved as `anyOf` so generation stays constrained.
+        assert "anyOf" in sent_schema["properties"]["decisions"]["items"]
 
     def test_strict_response_format_can_be_disabled_per_call(self):
         client = _build_client(LiteLLMConfig(model="gpt-4o-mini"))

--- a/tests/server/services/test_llm_mock_schema_compliance.py
+++ b/tests/server/services/test_llm_mock_schema_compliance.py
@@ -109,6 +109,22 @@ class TestSchemaCompliance:
         result = entry.model_class.model_validate(entry.minimal_valid)
         assert isinstance(result, entry.model_class)
 
+    def test_guard_finder_ignores_property_named_like_a_keyword(self):
+        """The mock guard's finder must not flag a field NAMED oneOf/discriminator.
+
+        Those are property names, not schema keywords (CodeRabbit false-positive fix).
+        """
+        from pydantic import BaseModel
+
+        class _TrickyNames(BaseModel):
+            oneOf: str = ""  # noqa: N815  (deliberately a keyword-like field name)
+            discriminator: int = 0
+
+        schema = strict_response_format_for_model(_TrickyNames)["json_schema"]["schema"]
+        assert "oneOf" in schema["properties"]
+        assert not _find_schema_key(schema, "oneOf")
+        assert not _find_schema_key(schema, "discriminator")
+
     @pytest.mark.parametrize("entry_name", list(get_model_registry().keys()))
     def test_registry_models_emit_strict_compatible_schema(self, entry_name):
         """Every structured-output model must produce a provider-strict schema.

--- a/tests/server/services/test_llm_mock_schema_compliance.py
+++ b/tests/server/services/test_llm_mock_schema_compliance.py
@@ -17,8 +17,9 @@ import json
 import pytest
 from syrupy.extensions.json import JSONSnapshotExtension
 
+from reflexio.server.llm.llm_utils import strict_response_format_for_model
 from reflexio.test_support.llm_fixtures import load_llm_fixture_content
-from reflexio.test_support.llm_mock import _create_mock_completion
+from reflexio.test_support.llm_mock import _create_mock_completion, _find_schema_key
 from reflexio.test_support.llm_model_registry import get_model_registry
 
 # Mapping from fixture file names to their expected model registry keys.
@@ -107,6 +108,30 @@ class TestSchemaCompliance:
             pytest.skip("No model class for raw string responses")
         result = entry.model_class.model_validate(entry.minimal_valid)
         assert isinstance(result, entry.model_class)
+
+    @pytest.mark.parametrize("entry_name", list(get_model_registry().keys()))
+    def test_registry_models_emit_strict_compatible_schema(self, entry_name):
+        """Every structured-output model must produce a provider-strict schema.
+
+        The schema actually sent (``strict_response_format_for_model``) must
+        contain no ``oneOf``/``discriminator`` — OpenAI strict structured outputs
+        reject them, which is how a Pydantic discriminated union (e.g.
+        ``PlaybookConsolidationOutput``) 400'd in production (PYTHON-FASTAPI-9J).
+        This is the provider-agnostic invariant guard for the whole registry.
+        """
+        entry = get_model_registry()[entry_name]
+        if entry.model_class is None:
+            pytest.skip("No model class for raw string responses")
+        rf = strict_response_format_for_model(entry.model_class)
+        schema = rf["json_schema"]["schema"]
+        assert not _find_schema_key(schema, "oneOf"), (
+            f"{entry.model_class.__name__} emits 'oneOf' (discriminated union); "
+            "strict structured-output providers reject it."
+        )
+        assert not _find_schema_key(schema, "discriminator"), (
+            f"{entry.model_class.__name__} emits 'discriminator'; "
+            "strict structured-output providers reject it."
+        )
 
     @pytest.mark.parametrize("fixture_name,model_key", FIXTURE_TO_MODEL)
     def test_fixtures_validate_against_models(self, fixture_name, model_key):


### PR DESCRIPTION
## Problem (Sentry PYTHON-FASTAPI-9J)

Playbook consolidation fails in production with:

> `litellm.BadRequestError: OpenAIException - Invalid schema for response_format 'PlaybookConsolidationOutput': In context=('properties', 'decisions', 'items'), 'oneOf' is not permitted.`

`PlaybookConsolidationOutput.decisions` is a Pydantic **discriminated union**, which serializes to JSON Schema as `oneOf` + `discriminator`. OpenAI strict structured-outputs accept only `anyOf` and reject `oneOf` with a 400 — before any token is generated.

## Root cause

`_provider_response_format` only sends our `oneOf`→`anyOf`-normalized strict schema (`make_strict_json_schema`) when `litellm.supports_response_schema(model)` is True. For `minimax/MiniMax-M3` — the **default model for every LLM role** in prod — that returns **False**, so the raw Pydantic model is handed to litellm. litellm then builds the `json_schema` *itself* (emitting the un-normalized `oneOf`) and sends it to the OpenAI-compatible minimax endpoint → 400. The `gpt-5-mini` fallback reuses the same primary-built `response_format`, so it inherits the `oneOf` and 400s too.

Verified empirically: `litellm.supports_response_schema('minimax/MiniMax-M3') == False`; the raw schema carries `oneOf` at exactly `properties.decisions.items`; our normalizer already strips it correctly — the **gate** was the defect.

## Fix

Add an allowlist of OpenAI-compatible providers that litellm under-reports (`_JSON_SCHEMA_PROVIDER_ALLOWLIST = {"minimax"}`) and broaden the gate to `_accepts_json_schema_response_format(model)` = `supports_response_schema(model) OR provider ∈ allowlist`. These models now receive our normalized strict schema; the fallback inherits the same normalized schema. Genuinely-unsupported providers (ollama, etc.) are untouched and still pass the raw Pydantic model so litellm's provider-specific handling (e.g. tool-calling) is preserved.

## Invariant + tests

> The `response_format` handed to litellm for a JSON-schema-capable provider must never contain `oneOf`/`discriminator`.

- `test_openai_compatible_underreported_provider_uses_strict_schema` — minimax now gets a strict `json_schema` dict.
- `test_discriminated_union_strips_oneof_for_underreported_provider` — reproduces the PYTHON-FASTAPI-9J shape; asserts the sent schema has no `oneOf`/`discriminator` and keeps the variants under `anyOf`.
- `test_unsupported_model_keeps_pydantic_response_format` — repointed to `ollama/llama3` to keep guarding the raw-passthrough branch (it previously encoded the buggy minimax behavior).

All 193 tests in `test_litellm_client_unit.py` pass; ruff + pyright clean.

## Notes / scope

- Other OpenAI-compatible providers configured but unverified for structured output (e.g. `xai`) are intentionally **not** added — no evidence they're used on a discriminated-union path here; one-line to add if needed.
- Impact in prod is degraded-not-down: the exception is handled, the request returns 200, but consolidation/dedup is silently skipped. Shipping requires the enterprise submodule-pointer bump + ECS redeploy (the current prod image still has the bug).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed structured JSON output handling for OpenAI-compatible providers that under-report schema support, ensuring strict `json_schema` is used consistently.
  * Normalized structured-output schemas to match provider strict-mode expectations (e.g., removing unsupported schema shapes).

* **Tests**
  * Expanded unit and compliance test coverage for strict structured-output behavior, including schema-shape regression checks and stricter mock validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->