### PR TITLE
feat(lineage): enable dual-read parity shim globally (start prod parity gate)

### DIFF
--- a/reflexio/server/site_var/site_var_sources/feature_flags.json
+++ b/reflexio/server/site_var/site_var_sources/feature_flags.json
@@ -9,5 +9,9 @@
     "resumable_extraction_agent": {
         "enabled": true,
         "enabled_org_ids": []
+    },
+    "lineage_dual_read_diff": {
+        "enabled": true,
+        "enabled_org_ids": []
     }
 }


### PR DESCRIPTION
## Summary

Enables the **lineage dual-read parity shim** globally by adding a `lineage_dual_read_diff` entry (`enabled: true`) to the `feature_flags` site var.

The shim (`server/lineage_parity_shim.py`, wired at `server/api.py:1054`) runs on `GET /api/profile_change_log` as a **`BackgroundTasks` job off the request thread** — it shadow-compares the legacy `ProfileChangeLog` against `reconstruct_profile_change_log()` and **serves the legacy result unchanged**. The flag is **fail-closed** (absent key ⇒ off); this is the explicit global enable now that soft-delete is live in production.

## Why now

Soft-delete is active in prod (the `service_role` grant gap is fixed and the `retired_at` / GC migrations are applied), and the profile dedup soft-delete path emits `status_change`/`to_status=superseded` events carrying the dedup run's `request_id` — exactly the signature `reconstruct_profile_change_log()` keys its removed-side on. So reconstruction can now be exercised against real traffic.

## What it produces

Per org, the shim emits:
- `lineage.reconstruct.divergence` / `lineage.reconstruct.error` (anomaly signals)
- `lineage.reconstruct.coverage` (usage event; add-only vs remove-bearing variety; outcome match/diverged/inconclusive)

## Gate to retire the legacy log

Per-org **divergence == 0 + error == 0 + coverage ≥ N across add-only AND remove-bearing runs**.

## Risk

Minimal: off-thread, serves legacy unchanged, fail-closed. No schema or API change — config-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A new feature flag for lineage dual read functionality has been added and is enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->