### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -74,8 +74,9 @@ and `openclaw-smart repair`.
   `force_extraction=True` so the session's learnings are available before
   the next openClaw run.
 
-The full design lives in
-[`docs/superpowers/specs/2026-05-19-openclaw-smart-design.md`](../../../../docs/superpowers/specs/2026-05-19-openclaw-smart-design.md).
+For shipped behavior, use this README plus the plugin contract in
+[`plugin/README.md`](plugin/README.md); internal design notes are not packaged
+with the public repository.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Removes a broken relative link from `reflexio/integrations/openclaw/README.md` to an internal design spec that is not packaged in the public repository.
- Points readers to the shipped local plugin README/contract instead.
- Follows the code-map README guidance in the parent `how_to_write_readme.md`: concise, navigation-focused, and limited to a materially broken path.

## Repositories/submodules reviewed
- `ReflexioAI/reflexio` submodule repository

## README files updated
- `reflexio/integrations/openclaw/README.md`

## Validation
- `git diff --check`
- Local README link/path check for the changed README

## Notes/Risks
- This PR does not update the parent repository's submodule pointer; the parent docs fix is in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to clarify where to find plugin behavior documentation, directing users to the README and public plugin contract as the authoritative sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->