### PR TITLE
fix(env): treat blank `KEY=` as unset; add env_str; configurable group-eval delay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,9 @@ LOCAL_STORAGE_PATH=
 # elided. (optional; default 512; set <= 0 to disable slicing and pass full
 # content)
 REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS=512
+# Inactivity delay in seconds before a quiet session is evaluated by agent-success
+# evaluation. (optional; default 600 = 10 minutes)
+GROUP_EVALUATION_DELAY_SECONDS=600
 
 # =============================================================================
 # 5. TESTING & LOGGING

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
+import os
 import re
 import secrets
 import sys
@@ -15,7 +16,7 @@ from pathlib import Path
 
 _logger = logging.getLogger(__name__)
 
-from dotenv import load_dotenv
+from dotenv import dotenv_values, load_dotenv
 
 from .paths import reflexio_home
 
@@ -93,6 +94,37 @@ _ENV_SEARCH_PATHS = [
 ]
 
 
+def _load_dotenv_pruned(path: Path, *, override: bool = False) -> None:
+    """Load a .env file, treating blank assignments (``KEY=``) as unset.
+
+    python-dotenv exports a blank ``KEY=`` line as ``os.environ["KEY"] = ""``
+    rather than leaving the key unset. That empty string silently defeats every
+    ``os.getenv("KEY", default)`` fallback — the root cause of the HF_HOME
+    cache-in-repo-root bug, and of any ``int()``/``float()`` parse that crashes
+    on ``""``. This wrapper normalizes "set to blank" to "unset" so callers that
+    rely on a default behave correctly.
+
+    After loading, it drops any key the FILE assigned a blank/whitespace value,
+    but only when the resulting environment value is still blank — so a real
+    process-env value (task definition, shell ``export``) or an earlier-loaded
+    file value is never removed.
+
+    Args:
+        path: Path to the .env file to load.
+        override: Forwarded to ``load_dotenv``. When False (default) the existing
+            process environment wins over the file's values.
+    """
+    file_vals = dotenv_values(path)
+    load_dotenv(dotenv_path=path, override=override)
+    for key, value in file_vals.items():
+        if (
+            value is not None
+            and not value.strip()
+            and not os.environ.get(key, "").strip()
+        ):
+            os.environ.pop(key, None)
+
+
 def load_reflexio_env(
     *,
     package_data_module: str = "reflexio.data",
@@ -118,7 +150,7 @@ def load_reflexio_env(
     global _loaded_env_path
     for env_path in _ENV_SEARCH_PATHS:
         if env_path.exists():
-            load_dotenv(dotenv_path=env_path)
+            _load_dotenv_pruned(env_path)
             resolved = env_path.resolve()
             _logger.debug("Loaded env from: %s", resolved)
             _loaded_env_path = resolved
@@ -157,8 +189,6 @@ def resolve_mode(cli_mode: str | None = None) -> str | None:
     Raises:
         ValueError: If the selected mode is not a safe slug.
     """
-    import os
-
     raw_mode = cli_mode if cli_mode is not None else os.environ.get("DEPLOYMENT_MODE")
     if raw_mode is None:
         return None
@@ -211,12 +241,12 @@ def load_reflexio_env_for_mode(
     # process env both still win where they define the same keys.
     home_secrets = _USER_ENV_DIR / f".env.{mode}"
     if home_secrets.exists():
-        load_dotenv(dotenv_path=home_secrets, override=False)
+        _load_dotenv_pruned(home_secrets, override=False)
 
     loaded: Path | None = None
     for env_path in (Path(f".env.{mode}"), home_secrets):
         if env_path.exists():
-            load_dotenv(dotenv_path=env_path, override=False)
+            _load_dotenv_pruned(env_path, override=False)
             _loaded_env_path = env_path.resolve()
             _logger.debug("Loaded mode env from: %s (mode=%s)", _loaded_env_path, mode)
             loaded = env_path
@@ -253,7 +283,7 @@ def _create_default_env_for_mode(mode: str, package_data_module: str) -> Path | 
     target = _USER_ENV_DIR / f".env.{mode}"
     target.write_text(content)
     target.chmod(0o600)
-    load_dotenv(dotenv_path=target, override=False)
+    _load_dotenv_pruned(target, override=False)
     _loaded_env_path = target.resolve()
     return target
 
@@ -322,7 +352,7 @@ def ensure_user_env_for_setup(
     """
     global _loaded_env_path
     if _USER_ENV_FILE.exists():
-        load_dotenv(dotenv_path=_USER_ENV_FILE)
+        _load_dotenv_pruned(_USER_ENV_FILE)
         resolved = _USER_ENV_FILE.resolve()
         _logger.debug("Loaded user env from: %s", resolved)
         _loaded_env_path = resolved
@@ -345,8 +375,6 @@ def _backfill_missing_keys(env_path: Path, keys: list[str]) -> None:
         env_path: Path to the existing .env file.
         keys: Env var names to check/generate.
     """
-    import os
-
     generated: list[str] = []
     for key in keys:
         if os.environ.get(key):
@@ -435,7 +463,7 @@ def _create_default_env(
 
     _USER_ENV_FILE.write_text(content)
     _USER_ENV_FILE.chmod(0o600)
-    load_dotenv(dotenv_path=_USER_ENV_FILE)
+    _load_dotenv_pruned(_USER_ENV_FILE)
 
     sys.stdout.write(f"Created env file: {_USER_ENV_FILE}\n")
     if auto_generate_keys:

--- a/reflexio/server/env_utils.py
+++ b/reflexio/server/env_utils.py
@@ -2,12 +2,40 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 
 
 def env_get(env: Mapping[str, str], name: str) -> str:
     """Return a stripped environment value or an empty string."""
     return str(env.get(name, "")).strip()
+
+
+def env_str(
+    name: str,
+    default: str = "",
+    *,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Return an environment value, treating unset OR blank as the default.
+
+    Unlike ``os.getenv(name, default)``, an empty / whitespace-only value
+    resolves to ``default`` rather than passing the empty string through. This
+    closes the "set to blank behaves differently from unset" gap: a ``KEY=``
+    line (which python-dotenv exports as ``""``) and an absent key both yield
+    the default, so callers never silently receive ``""`` where they expected a
+    real fallback (e.g. an ``int()``/``float()`` parse that would crash on ``""``).
+
+    Args:
+        name: Environment variable name.
+        default: Value returned when the variable is unset or blank.
+        env: Mapping to read from; defaults to ``os.environ``.
+
+    Returns:
+        The stripped environment value, or ``default`` when unset/blank.
+    """
+    raw = (env if env is not None else os.environ).get(name)
+    return raw.strip() if raw and raw.strip() else default
 
 
 def env_required(env: Mapping[str, str], name: str) -> str:

--- a/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/delayed_group_evaluator.py
@@ -18,8 +18,14 @@ from reflexio.server.services.agent_success_evaluation import _eval_health
 
 logger = logging.getLogger(__name__)
 
-# Delay in seconds before evaluating a group after the last request
-GROUP_EVALUATION_DELAY_SECONDS = 600  # 10 minutes
+# Default delay in seconds before evaluating a group after the last request.
+_DEFAULT_DELAY_SECONDS = 600  # 10 minutes
+
+# Inactivity delay before a session is evaluated. Override the default via the
+# GROUP_EVALUATION_DELAY_SECONDS environment variable (in seconds).
+GROUP_EVALUATION_DELAY_SECONDS = int(
+    os.environ.get("GROUP_EVALUATION_DELAY_SECONDS", str(_DEFAULT_DELAY_SECONDS))
+)
 
 # Kept as a patch point for tests. Production should use the full inactivity
 # delay unless a test deliberately lowers this constant.

--- a/tests/cli/test_env_loader_mode.py
+++ b/tests/cli/test_env_loader_mode.py
@@ -53,6 +53,33 @@ def test_override_false_process_env_wins(tmp_path, monkeypatch):
     assert os.environ["BACKEND_PORT"] == "9999"
 
 
+def test_load_drops_blank_assignments(tmp_path, monkeypatch):
+    # A blank ``KEY=`` line must behave as unset, not as ``""`` — otherwise it
+    # silently defeats every ``os.getenv(KEY, default)`` fallback (the HF_HOME
+    # cache-in-repo-root bug class).
+    env_file = tmp_path / ".env"
+    env_file.write_text("BLANK=\nWS=   \nREAL=value\n")
+    monkeypatch.setattr(env_loader, "_ENV_SEARCH_PATHS", [env_file])
+    monkeypatch.delenv("BLANK", raising=False)
+    monkeypatch.delenv("WS", raising=False)
+    monkeypatch.delenv("REAL", raising=False)
+    env_loader.load_reflexio_env()
+    assert os.getenv("BLANK") is None
+    assert os.getenv("WS") is None
+    assert os.environ["REAL"] == "value"
+
+
+def test_blank_assignment_does_not_clobber_process_env(tmp_path, monkeypatch):
+    # A real value already in the process environment must survive a later blank
+    # file assignment of the same key.
+    env_file = tmp_path / ".env"
+    env_file.write_text("KEEP=\n")
+    monkeypatch.setattr(env_loader, "_ENV_SEARCH_PATHS", [env_file])
+    monkeypatch.setenv("KEEP", "real")
+    env_loader.load_reflexio_env()
+    assert os.environ["KEEP"] == "real"
+
+
 def test_autogen_writes_home_not_committed(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     (tmp_path / ".env.platform").write_text("DEPLOYMENT_MODE=platform\n")

--- a/tests/server/services/agent_success_evaluation/test_delay_env_override.py
+++ b/tests/server/services/agent_success_evaluation/test_delay_env_override.py
@@ -1,0 +1,43 @@
+"""Tests that GROUP_EVALUATION_DELAY_SECONDS is configurable via the environment.
+
+The delay is resolved at import time, so these tests monkeypatch the environment
+and `importlib.reload` the module to re-evaluate the module-level globals.
+"""
+
+import importlib
+
+import pytest
+
+from reflexio.server.services.agent_success_evaluation import delayed_group_evaluator
+
+
+@pytest.fixture(autouse=True)
+def restore_module():
+    """Reload the module after each test so import-time globals match the real env."""
+    yield
+    importlib.reload(delayed_group_evaluator)
+
+
+def test_default_when_env_unset(monkeypatch):
+    """Unset env var -> default 600s."""
+    monkeypatch.delenv("GROUP_EVALUATION_DELAY_SECONDS", raising=False)
+    importlib.reload(delayed_group_evaluator)
+    assert delayed_group_evaluator.GROUP_EVALUATION_DELAY_SECONDS == 600
+
+
+def test_env_override_applies(monkeypatch):
+    """Explicit env var overrides the default and flows to the effective delay."""
+    monkeypatch.delenv("IS_TEST_ENV", raising=False)
+    monkeypatch.setenv("GROUP_EVALUATION_DELAY_SECONDS", "120")
+    importlib.reload(delayed_group_evaluator)
+    assert delayed_group_evaluator.GROUP_EVALUATION_DELAY_SECONDS == 120
+    assert delayed_group_evaluator._EFFECTIVE_DELAY_SECONDS == 120
+
+
+def test_test_env_wins_over_override(monkeypatch):
+    """IS_TEST_ENV=true forces the 30s effective delay regardless of the override."""
+    monkeypatch.setenv("IS_TEST_ENV", "true")
+    monkeypatch.setenv("GROUP_EVALUATION_DELAY_SECONDS", "120")
+    importlib.reload(delayed_group_evaluator)
+    assert delayed_group_evaluator.GROUP_EVALUATION_DELAY_SECONDS == 120
+    assert delayed_group_evaluator._EFFECTIVE_DELAY_SECONDS == 30

--- a/tests/server/test_env_utils.py
+++ b/tests/server/test_env_utils.py
@@ -6,6 +6,7 @@ from reflexio.server.env_utils import (
     env_get,
     env_required,
     env_required_literal,
+    env_str,
     env_truthy,
 )
 
@@ -13,6 +14,29 @@ from reflexio.server.env_utils import (
 def test_env_get_strips_values() -> None:
     assert env_get({"KEY": "  value  "}, "KEY") == "value"
     assert env_get({}, "KEY") == ""
+
+
+def test_env_str_treats_unset_and_blank_as_default() -> None:
+    # Unset -> default.
+    assert env_str("KEY", "fallback", env={}) == "fallback"
+    # Blank / whitespace-only -> default (the empty-equals-unset invariant).
+    assert env_str("KEY", "fallback", env={"KEY": ""}) == "fallback"
+    assert env_str("KEY", "fallback", env={"KEY": "   "}) == "fallback"
+    # Real value -> stripped value, never the default.
+    assert env_str("KEY", "fallback", env={"KEY": "  real  "}) == "real"
+
+
+def test_env_str_default_is_empty_string() -> None:
+    assert env_str("KEY", env={}) == ""
+
+
+def test_env_str_reads_os_environ_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REFLEXIO_TEST_ENV_STR", "  from-os  ")
+    assert env_str("REFLEXIO_TEST_ENV_STR", "fallback") == "from-os"
+    monkeypatch.setenv("REFLEXIO_TEST_ENV_STR", "")
+    assert env_str("REFLEXIO_TEST_ENV_STR", "fallback") == "fallback"
 
 
 def test_env_required_raises_for_missing_value() -> None:


### PR DESCRIPTION
## Summary

Closes the "set to blank behaves differently from unset" gap in env handling, plus makes the agent-success evaluation delay configurable.

A blank `KEY=` line is exported by python-dotenv as `os.environ["KEY"] = ""`. That empty string silently defeats every `os.getenv("KEY", default)` fallback (the root cause of the HF_HOME cache-in-repo-root bug class) and crashes any `int()`/`float()` parse that doesn't expect `""`.

## Changes

- **`cli/env_loader.py` — `_load_dotenv_pruned`**: wraps every dotenv load so a file's blank/whitespace-only `KEY=` is normalized to *unset*. It only drops the key when the resulting env value is still blank, so a real process-env value (task definition, shell `export`) or an earlier-loaded file value is never removed.
- **`server/env_utils.py` — `env_str(name, default)`**: an `os.getenv`-style reader that resolves unset **or** blank/whitespace-only to `default`, returning the stripped value otherwise. The intended replacement for `os.getenv(name, default)` where a real fallback matters.
- **`server/services/agent_success_evaluation/delayed_group_evaluator.py`**: `GROUP_EVALUATION_DELAY_SECONDS` is now read from the environment (default `600`s). `IS_TEST_ENV=true` still forces the 30s effective delay.
- **`.env.example`**: documents `GROUP_EVALUATION_DELAY_SECONDS`.

## Tests

- `tests/cli/test_env_loader_mode.py`: blank/whitespace `KEY=` is dropped; a real process-env value of the same key survives a later blank file assignment.
- `tests/server/test_env_utils.py`: `env_str` unset/blank → default, real value → stripped, default reads `os.environ`.
- `tests/server/services/agent_success_evaluation/test_delay_env_override.py`: default when unset, env override applies, `IS_TEST_ENV` wins over the override.

All 27 targeted tests pass; ruff + pyright clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable inactivity delay for group evaluation via `GROUP_EVALUATION_DELAY_SECONDS` environment variable (default: 600 seconds).

* **Bug Fixes**
  * Improved environment variable handling to prevent blank assignments from overriding default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->