### PR TITLE
fix(lineage): parity shim error-level + false-clean guard (read-perm hardening, OSS)

### DIFF
--- a/reflexio/server/lineage_parity_shim.py
+++ b/reflexio/server/lineage_parity_shim.py
@@ -160,6 +160,13 @@ def _emit_metrics(
     # only flag the case where legacy HAS reconstructible-worthy rows (it is
     # non-empty AND carries removals) but reconstruction produced nothing usable
     # (no matches AND an empty reconstructed change log).
+    #
+    # KNOWN residual (intentionally NOT covered, to preserve the precision above):
+    # a *physically-purged add-only* run — legacy add-only rows whose profiles were
+    # hard-deleted/GDPR-purged so reconstruction is empty — has no remove-bearing
+    # legacy row, so it is NOT flagged degraded and still collapses to "match".
+    # This is the tolerated LEGACY_MISSING class ("predates soft-delete / purged");
+    # widening the guard to add-only would mislabel every legitimately-purged org.
     legacy_has_remove_bearing = any(row.removed_profiles for row in legacy_cmp)
     degenerate = (
         bool(legacy_cmp) and legacy_has_remove_bearing and not matches and not recon_cmp

--- a/reflexio/server/lineage_parity_shim.py
+++ b/reflexio/server/lineage_parity_shim.py
@@ -68,12 +68,24 @@ def dual_read_diff(reflexio: object, org_id: str) -> None:
             read_cap_hit=read_cap_hit,
         )
 
-        _emit_metrics(org_id=org_id, results=results, legacy_cmp=legacy_cmp)
+        _emit_metrics(
+            org_id=org_id,
+            results=results,
+            legacy_cmp=legacy_cmp,
+            recon_cmp=recon_cmp,
+        )
 
     except Exception as e:  # noqa: BLE001 — intentionally broad; BaseException (signals) still propagates
+        # error-level so a genuine shim failure reaches the Discord
+        # (environment:production AND level:error) rule.  A real prod failure
+        # (the 42501) hid as 17 escalating warnings for hours because this was
+        # level="warning".  Fires once per failed page-view — acceptable for a
+        # "the shim is broken" signal.  (Per-run *divergence* anomalies stay at
+        # level="warning" on purpose — during the parity window divergences are
+        # expected findings and would flood Discord.)
         capture_anomaly(
             "lineage.reconstruct.error",
-            level="warning",
+            level="error",
             org_id=org_id,
             error=type(e).__name__,
         )
@@ -84,6 +96,7 @@ def _emit_metrics(
     org_id: str,
     results: list[ParityResult],
     legacy_cmp: list[ProfileChangeLog],
+    recon_cmp: list[ProfileChangeLog],
 ) -> None:
     """Emit divergence anomalies and a coverage usage event.
 
@@ -91,7 +104,10 @@ def _emit_metrics(
         org_id (str): Organization ID for tagging.
         results (list[ParityResult]): Classified results from ``classify_change_log_parity``.
         legacy_cmp (list[ProfileChangeLog]): Legacy rows used to compute add-only
-            vs remove-bearing breakdown for matched runs.
+            vs remove-bearing breakdown for matched runs, and to detect the
+            false-clean (degenerate) case.
+        recon_cmp (list[ProfileChangeLog]): Reconstructed rows, used to detect a
+            degenerate reconstruction (empty recon while legacy is non-empty).
     """
     divergent_classes = (ParityClass.RECON_MISSING, ParityClass.CONTENT_MISMATCH)
 
@@ -131,19 +147,57 @@ def _emit_metrics(
         else:
             add_only_runs += 1
 
+    # False-clean guard: a run that could NOT actually reconstruct anything must
+    # NOT be reported as "match"/clean.  The failure mode: reconstruction reads
+    # succeed but yield an EMPTY signal set (e.g. get_lineage_events returns [] —
+    # or, pre-B1-fix, partially fails) while the LEGACY change log still has rows
+    # (especially remove-bearing ones).  Then classify_change_log_parity tags
+    # every legacy row LEGACY_MISSING (tolerated) → zero divergences → a FALSE
+    # "match" that would wrongly satisfy the parity gate on incomplete data.
+    #
+    # Be precise: a legitimately add-only org with genuinely no removals (no
+    # remove-bearing legacy rows) must still be able to reach a true "match".  We
+    # only flag the case where legacy HAS reconstructible-worthy rows (it is
+    # non-empty AND carries removals) but reconstruction produced nothing usable
+    # (no matches AND an empty reconstructed change log).
+    legacy_has_remove_bearing = any(row.removed_profiles for row in legacy_cmp)
+    degenerate = (
+        bool(legacy_cmp) and legacy_has_remove_bearing and not matches and not recon_cmp
+    )
+
+    if degenerate:
+        outcome = "degraded"
+    elif divergences:
+        outcome = "diverged"
+    elif inconclusive:
+        outcome = "inconclusive"
+    else:
+        outcome = "match"
+
+    if degenerate:
+        # "We think it's clean but reconstruction saw nothing."  error-level so
+        # an all-degenerate run is visible on the Discord production rule — this
+        # is the alarm that the false-clean guard fired.
+        capture_anomaly(
+            "lineage.reconstruct.degraded",
+            level="error",
+            org_id=org_id,
+            legacy_rows=len(legacy_cmp),
+            recon_rows=len(recon_cmp),
+        )
+
     record_usage_event(
         org_id=org_id,
         event_name="lineage.reconstruct.coverage",
         event_category="lineage",
         count_value=len(matches),
-        outcome=(
-            "diverged" if divergences else "inconclusive" if inconclusive else "match"
-        ),
+        outcome=outcome,
         metadata={
             "add_only_runs": add_only_runs,
             "remove_bearing_runs": remove_bearing_runs,
             "matches": len(matches),
             "divergences": len(divergences),
             "inconclusive": len(inconclusive),
+            "degraded": degenerate,
         },
     )

--- a/reflexio/server/lineage_parity_shim.py
+++ b/reflexio/server/lineage_parity_shim.py
@@ -162,26 +162,24 @@ def _emit_metrics(
     # (no matches AND an empty reconstructed change log).
     #
     # KNOWN residual (intentionally NOT covered, to preserve the precision above):
-    # a *physically-purged add-only* run — legacy add-only rows whose profiles were
-    # hard-deleted/GDPR-purged so reconstruction is empty — has no remove-bearing
-    # legacy row, so it is NOT flagged degraded and still collapses to "match".
-    # This is the tolerated LEGACY_MISSING class ("predates soft-delete / purged");
-    # widening the guard to add-only would mislabel every legitimately-purged org.
-    legacy_has_remove_bearing = any(row.removed_profiles for row in legacy_cmp)
+    # the guard fires ONLY when legacy carries removals.  Any *add-only* degeneracy —
+    # a physically-purged add-only run (profiles hard-deleted/GDPR-purged so
+    # reconstruction is empty), OR an add-only org whose reads genuinely returned [] —
+    # has no remove-bearing legacy row, so it is NOT flagged degraded and still
+    # collapses to "match" (the tolerated LEGACY_MISSING class).  Accepted because:
+    # widening the guard to add-only would mislabel every legitimately-purged org, and
+    # post-B1 a broken (anon-keyed) ref fails LOUD at storage construction rather than
+    # silently returning [], so the add-only-empty-read path is largely unreachable.
+    legacy_has_any_remove_bearing = any(row.removed_profiles for row in legacy_cmp)
     degenerate = (
-        bool(legacy_cmp) and legacy_has_remove_bearing and not matches and not recon_cmp
+        bool(legacy_cmp)
+        and legacy_has_any_remove_bearing
+        and not matches
+        and not recon_cmp
     )
 
     if degenerate:
         outcome = "degraded"
-    elif divergences:
-        outcome = "diverged"
-    elif inconclusive:
-        outcome = "inconclusive"
-    else:
-        outcome = "match"
-
-    if degenerate:
         # "We think it's clean but reconstruction saw nothing."  error-level so
         # an all-degenerate run is visible on the Discord production rule — this
         # is the alarm that the false-clean guard fired.
@@ -192,6 +190,12 @@ def _emit_metrics(
             legacy_rows=len(legacy_cmp),
             recon_rows=len(recon_cmp),
         )
+    elif divergences:
+        outcome = "diverged"
+    elif inconclusive:
+        outcome = "inconclusive"
+    else:
+        outcome = "match"
 
     record_usage_event(
         org_id=org_id,

--- a/tests/server/test_lineage_dual_read_false_clean_integration.py
+++ b/tests/server/test_lineage_dual_read_false_clean_integration.py
@@ -1,0 +1,329 @@
+"""Integration tests for the lineage dual-read shim's observability hardening.
+
+Covers two slices of the read-permission hardening work:
+
+  B2 — the shim's exception path emits ``capture_anomaly(..., level="error")``
+       (not ``"warning"``) so a genuine "the shim is broken" failure reaches the
+       Discord ``environment:production AND level:error`` rule.
+
+  B4 — the false-clean guard: a run that could NOT actually reconstruct anything
+       (empty reconstructed change log + empty reconstructible signal set) while
+       the legacy change log is non-empty AND has remove-bearing rows must NOT be
+       reported as ``outcome="match"``.  It is reported as ``"degraded"`` and a
+       distinct ``lineage.reconstruct.degraded`` (level="error") anomaly fires.
+       Control: a legitimately add-only org with genuinely no removals still
+       reaches a true ``"match"`` (no false ``degraded``).
+
+All tests use real SQLite storage in isolated temp dirs (mocked LLM via the
+project-level conftest).  Patterns mirror
+``tests/server/test_lineage_dual_read_shim_integration.py``.
+"""
+
+from __future__ import annotations
+
+import types
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import (
+    ProfileChangeLog,
+    ProfileChangeLogResponse,
+    UserProfile,
+)
+from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
+from reflexio.server.lineage_parity_shim import dual_read_diff
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.usage_metrics import (
+    UsageEvent,
+    configure_usage_event_recorder,
+)
+
+pytestmark = pytest.mark.integration
+
+_FLAG_ENABLED_CONFIG: dict[str, Any] = {
+    "lineage_dual_read_diff": {"enabled": True, "enabled_org_ids": []},
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_storage(tmp_path, worker_id: str) -> SQLiteStorage:
+    s = SQLiteStorage(
+        org_id=f"false-clean-{worker_id}-{tmp_path.name}",
+        db_path=str(tmp_path / "test.db"),
+    )
+    s.migrate()
+    return s
+
+
+def _make_profile(
+    user_id: str = "u1",
+    profile_id: str = "p1",
+    content: str = "c",
+    request_id: str = "",
+) -> UserProfile:
+    return UserProfile(
+        user_id=user_id,
+        profile_id=profile_id,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id=request_id or f"gen_{profile_id}",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_change_log(
+    user_id: str,
+    request_id: str,
+    added: list[UserProfile],
+    removed: list[UserProfile],
+) -> ProfileChangeLog:
+    return ProfileChangeLog(
+        id=0,
+        user_id=user_id,
+        request_id=request_id,
+        created_at=int(datetime.now(UTC).timestamp()),
+        added_profiles=added,
+        removed_profiles=removed,
+        mentioned_profiles=[],
+    )
+
+
+def _make_reflexio_stub(storage: SQLiteStorage) -> object:
+    request_context = types.SimpleNamespace(storage=storage)
+    return types.SimpleNamespace(request_context=request_context)
+
+
+class _CapturingRecorder:
+    def __init__(self) -> None:
+        self.events: list[UsageEvent] = []
+
+    def __call__(self, event: UsageEvent) -> None:
+        self.events.append(event)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage(tmp_path, worker_id):
+    return _make_storage(tmp_path, worker_id)
+
+
+@pytest.fixture
+def reflexio_stub(storage):
+    return _make_reflexio_stub(storage)
+
+
+@pytest.fixture
+def capturing_recorder():
+    recorder = _CapturingRecorder()
+    configure_usage_event_recorder(recorder)
+    yield recorder
+    configure_usage_event_recorder(None)
+
+
+# ---------------------------------------------------------------------------
+# B2 — exception path emits level="error"
+# ---------------------------------------------------------------------------
+
+
+def test_error_path_emits_error_level(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """B2: a failed reconstruction emits lineage.reconstruct.error at level='error'.
+
+    Forces the storage read inside the shim to raise, then asserts the swallowed
+    anomaly is emitted with ``level="error"`` (so it reaches the Discord
+    production rule), not the old ``level="warning"``.
+    """
+    org_id = storage.org_id
+
+    anomalies: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture(message: str, **kwargs: Any) -> None:
+        anomalies.append((message, kwargs))
+
+    def _exploding_reconstruct(*_args: Any, **_kwargs: Any) -> Any:
+        raise ValueError("simulated reconstruction failure")
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+            return_value=_FLAG_ENABLED_CONFIG,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.reconstruct_profile_change_log",
+            side_effect=_exploding_reconstruct,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.capture_anomaly",
+            side_effect=_capture,
+        ),
+    ):
+        result = dual_read_diff(reflexio_stub, org_id)
+
+    assert result is None
+
+    error_calls = [
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.error"
+    ]
+    assert error_calls, "expected a lineage.reconstruct.error anomaly"
+    assert all(kw.get("level") == "error" for _, kw in error_calls), (
+        f"expected level='error' on every error anomaly; got: {error_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# B4 — false-clean guard: degenerate reconstruction is NOT reported as match
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_reconstruction_reports_degraded_not_match(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """B4: empty reconstruction + remove-bearing legacy → outcome='degraded'.
+
+    Simulates the production failure mode: reconstruction reads succeed but
+    return an EMPTY signal set (e.g. ``get_lineage_events`` returns [] on an
+    anon-keyed ref) while the legacy change log retains remove-bearing rows.
+    Without the guard, every legacy row classifies as LEGACY_MISSING (tolerated)
+    → zero divergences → a FALSE ``outcome="match"``.
+
+    Asserts the coverage event reports ``outcome="degraded"`` (NOT ``"match"``)
+    and a distinct ``lineage.reconstruct.degraded`` (level="error") anomaly fires.
+    """
+    org_id = storage.org_id
+
+    # Seed a real, remove-bearing legacy change log row.
+    old_p = _make_profile("u1", "p-removed", "removed-content", request_id="req-rm")
+    new_p = _make_profile("u1", "p-kept", "kept-content", request_id="req-rm")
+    storage.add_user_profile("u1", [old_p, new_p])
+    storage.add_profile_change_log(_make_change_log("u1", "req-rm", [new_p], [old_p]))
+
+    anomalies: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture(message: str, **kwargs: Any) -> None:
+        anomalies.append((message, kwargs))
+
+    # Reconstruction reads succeed but yield NOTHING (the degenerate case): both
+    # the reconstructed change log and the reconstructible signal set are empty.
+    def _empty_reconstruct(*_args: Any, **_kwargs: Any) -> ProfileChangeLogResponse:
+        return ProfileChangeLogResponse(success=True, profile_change_logs=[])
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+            return_value=_FLAG_ENABLED_CONFIG,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.reconstruct_profile_change_log",
+            side_effect=_empty_reconstruct,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.profile_reconstructible_request_ids",
+            return_value=set(),
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.capture_anomaly",
+            side_effect=_capture,
+        ),
+    ):
+        dual_read_diff(reflexio_stub, org_id)
+
+    coverage_events = [
+        e
+        for e in capturing_recorder.events
+        if e.event_name == "lineage.reconstruct.coverage"
+    ]
+    assert len(coverage_events) == 1, (
+        f"expected exactly one coverage event; got {len(coverage_events)}"
+    )
+    evt = coverage_events[0]
+    assert evt.outcome == "degraded", (
+        f"expected outcome='degraded' for degenerate reconstruction; got {evt.outcome!r}"
+    )
+    assert evt.outcome != "match", "a degenerate run must NOT report a false 'match'"
+    assert evt.metadata.get("degraded") is True
+
+    degraded_calls = [
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.degraded"
+    ]
+    assert degraded_calls, "expected a lineage.reconstruct.degraded anomaly"
+    assert all(kw.get("level") == "error" for _, kw in degraded_calls), (
+        f"expected level='error' on degraded anomaly; got: {degraded_calls}"
+    )
+
+
+def test_add_only_org_reaches_true_match_no_false_degraded(
+    storage: SQLiteStorage,
+    reflexio_stub: object,
+    capturing_recorder: _CapturingRecorder,
+    worker_id: str,
+) -> None:
+    """B4 control: a genuinely add-only org with no removals still reports 'match'.
+
+    A legitimately add-only org has no remove-bearing legacy rows, so the
+    false-clean guard must NOT fire — even though reconstruction produces no
+    removals.  Asserts ``outcome="match"`` and that NO degraded anomaly is emitted.
+    """
+    org_id = storage.org_id
+
+    # Add-only run: a new profile, legacy row with no removals, reconstructs MATCH.
+    new_add = _make_profile("u1", "p-add", "add-content", request_id="req-add")
+    storage.add_user_profile("u1", [new_add])
+    storage.add_profile_change_log(_make_change_log("u1", "req-add", [new_add], []))
+
+    anomalies: list[tuple[str, dict[str, Any]]] = []
+
+    def _capture(message: str, **kwargs: Any) -> None:
+        anomalies.append((message, kwargs))
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags._get_feature_flags_config",
+            return_value=_FLAG_ENABLED_CONFIG,
+        ),
+        patch(
+            "reflexio.server.lineage_parity_shim.capture_anomaly",
+            side_effect=_capture,
+        ),
+    ):
+        dual_read_diff(reflexio_stub, org_id)
+
+    coverage_events = [
+        e
+        for e in capturing_recorder.events
+        if e.event_name == "lineage.reconstruct.coverage"
+    ]
+    assert len(coverage_events) == 1, (
+        f"expected exactly one coverage event; got {len(coverage_events)}"
+    )
+    evt = coverage_events[0]
+    assert evt.outcome == "match", (
+        f"expected a true 'match' for an add-only org; got {evt.outcome!r}"
+    )
+    assert evt.metadata.get("degraded") is False
+    assert evt.metadata["add_only_runs"] >= 1
+    assert evt.metadata["remove_bearing_runs"] == 0
+
+    degraded_calls = [
+        (msg, kw) for msg, kw in anomalies if msg == "lineage.reconstruct.degraded"
+    ]
+    assert not degraded_calls, (
+        f"add-only org must NOT trigger a degraded anomaly; got: {degraded_calls}"
+    )

--- a/tests/server/test_lineage_dual_read_false_clean_integration.py
+++ b/tests/server/test_lineage_dual_read_false_clean_integration.py
@@ -34,6 +34,7 @@ from reflexio.models.api_schema.domain.entities import (
     UserProfile,
 )
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
+from reflexio.server import usage_metrics as usage_metrics_module
 from reflexio.server.lineage_parity_shim import dual_read_diff
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.usage_metrics import (
@@ -125,10 +126,14 @@ def reflexio_stub(storage):
 
 @pytest.fixture
 def capturing_recorder():
+    # Save/restore the process-global recorder rather than resetting to None, so
+    # this fixture can't clobber a recorder configured by another test/fixture
+    # (order-dependent failures otherwise).
+    previous_recorder = usage_metrics_module._recorder
     recorder = _CapturingRecorder()
     configure_usage_event_recorder(recorder)
     yield recorder
-    configure_usage_event_recorder(None)
+    configure_usage_event_recorder(previous_recorder)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

OSS half of the lineage read-permission hardening (companion to reflexio-enterprise PR). The dual-read parity shim was failing in managed prod because a per-org data ref was silently keyed with an `anon` key (root cause + the config/validation fix are in the enterprise PR). This PR hardens the **shim's observability + false-clean detection** so such a failure is loud and can't masquerade as a clean parity result.

## Changes (`reflexio/server/lineage_parity_shim.py`)
- **B2 — error-level signal:** the shim's exception path now emits `capture_anomaly("lineage.reconstruct.error", level="error")` (was `warning`) so a real reconstruction failure hits the Discord `level:error` production rule. Per-run `divergence` anomalies intentionally stay `warning` (expected during the parity window).
- **B4 — false-clean guard:** when the legacy change log has remove-bearing rows but reconstruction produced no matches and an empty reconstructed log (the degenerate case — e.g. reads returned `[]`), the coverage event reports `outcome="degraded"` (not `"match"`) + fires a distinct `lineage.reconstruct.degraded` (`level="error"`) alarm. Without this, all-`LEGACY_MISSING` runs collapsed to a false `"match"` that would wrongly satisfy the parity gate. The guard is precise (a legitimately add-only org still reaches a true `match`); the add-only-degeneracy residual is documented (and largely unreachable post the enterprise B1 fail-loud fix).

## Tests
New `tests/server/test_lineage_dual_read_false_clean_integration.py`: error-level path, degenerate→degraded (real remove-bearing legacy + empty reconstruction), and an add-only control proving no false-degraded.

## Review
4-lens design review (which corrected a false SECURITY-DEFINER premise and dropped an RPC approach) → per-task review → whole-branch (opus) review → a 6-agent `/review-loop` (0 functional defects; only clarity folds applied here).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability for lineage dual-read reconstruction failures by escalating unexpected shim issues to error-level alerts while still safely handling exceptions.
  * Added clearer detection of “degenerate/false-clean” reconstruction outcomes and now reports them as degraded (with corresponding degraded anomaly reporting).

* **Tests**
  * Added new SQLite-backed integration coverage for reconstruction failure, degraded outcome classification, and add-only control scenarios to confirm correct anomaly emission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->