### PR TITLE
fix: scope evaluation results by user identity

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -381,6 +381,7 @@ class AgentPlaybookSourceWindow(BaseModel):
 
 class AgentSuccessEvaluationResult(BaseModel):
     result_id: int = 0
+    user_id: str = ""
     agent_version: str
     session_id: str
     is_success: bool

--- a/reflexio/models/api_schema/internal_schema.py
+++ b/reflexio/models/api_schema/internal_schema.py
@@ -38,8 +38,9 @@ class SessionFirstRequest(NamedTuple):
 
 
 class SessionCitation(NamedTuple):
-    """One cited rule/profile occurrence, keyed by session."""
+    """One cited rule/profile occurrence, keyed by user/session."""
 
+    user_id: str
     session_id: str
     kind: str
     real_id: str

--- a/reflexio/models/api_schema/ui/converters.py
+++ b/reflexio/models/api_schema/ui/converters.py
@@ -146,6 +146,7 @@ def to_evaluation_result_view(
     """
     return EvaluationResultView(
         result_id=result.result_id,
+        user_id=result.user_id,
         agent_version=result.agent_version,
         session_id=result.session_id,
         is_success=result.is_success,

--- a/reflexio/models/api_schema/ui/entities.py
+++ b/reflexio/models/api_schema/ui/entities.py
@@ -107,6 +107,7 @@ class EvaluationResultView(BaseModel):
     """User-facing AgentSuccessEvaluationResult — excludes embedding."""
 
     result_id: int = 0
+    user_id: str = ""
     agent_version: str
     session_id: str
     is_success: bool

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -392,7 +392,7 @@ Key files:
 
 **Flow**: Interactions → (deferred 10 min) → GroupEvaluationScheduler → run_group_evaluation → AgentSuccessEvaluator → AgentSuccessEvaluationResult → Storage
 
-**Session-Level Evaluation**: Evaluator treats all `request_interaction_data_models` in a session as a single conversation. Sampling rate checked once per session (not per-request). Result keyed by `session_id` (not `request_id`).
+**Session-Level Evaluation**: Evaluator treats one user's `request_interaction_data_models` in a session as a single conversation. Sampling rate checked once per session (not per-request). Results are keyed by `(user_id, session_id, evaluation_name)` so reused session IDs across users do not clobber each other.
 
 **Tool Context**: Reads `tool_can_use` from root `Config` level (shared with playbook extraction).
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -2310,6 +2310,7 @@ def _resolve_session_user_id(storage: Any, session_id: str) -> str | None:
 def _find_fresh_result_id(
     storage: Any,
     *,
+    user_id: str,
     session_id: str,
     agent_version: str,
     evaluation_name: str,
@@ -2322,6 +2323,7 @@ def _find_fresh_result_id(
 
     Args:
         storage: The request's storage backend.
+        user_id (str): The user whose session slice was graded.
         session_id (str): The graded session.
         agent_version (str): The version dimension.
         evaluation_name (str): Evaluator/result namespace to isolate readback.
@@ -2332,6 +2334,7 @@ def _find_fresh_result_id(
         runner wrote nothing.
     """
     result_ids = storage.get_agent_success_evaluation_result_ids(
+        user_id=user_id,
         session_id=session_id,
         evaluation_name=evaluation_name,
         agent_version=agent_version,
@@ -2412,6 +2415,7 @@ def grade_on_demand(
 
     previous_result_ids = set(
         storage.get_agent_success_evaluation_result_ids(
+            user_id=user_id,
             session_id=payload.session_id,
             evaluation_name=evaluation_name,
             agent_version=payload.agent_version,
@@ -2441,6 +2445,7 @@ def grade_on_demand(
 
     result_id = _find_fresh_result_id(
         storage,
+        user_id=user_id,
         session_id=payload.session_id,
         agent_version=payload.agent_version,
         evaluation_name=evaluation_name,

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_service.py
@@ -14,6 +14,10 @@ from reflexio.server.services.agent_success_evaluation.agent_success_evaluator i
     AgentSuccessEvaluator,
 )
 from reflexio.server.services.base_generation_service import BaseGenerationService
+from reflexio.server.services.extractor_interaction_utils import (
+    filter_interactions_by_source,
+    get_effective_source_filter,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +27,14 @@ class AgentSuccessGenerationServiceConfig:
     """Runtime configuration for agent success evaluation service shared across all extractors.
 
     Attributes:
+        user_id: The user whose session slice is being evaluated
         session_id: The session being evaluated
         agent_version: The agent version
         request_interaction_data_models: The interactions to evaluate
         source: Source of the interactions
     """
 
+    user_id: str
     session_id: str
     agent_version: str
     request_interaction_data_models: list[RequestInteractionDataModel]
@@ -76,6 +82,7 @@ class AgentSuccessEvaluationService(
             AgentSuccessGenerationServiceConfig object
         """
         return AgentSuccessGenerationServiceConfig(
+            user_id=request.user_id,
             session_id=request.session_id,
             agent_version=request.agent_version,
             request_interaction_data_models=request.request_interaction_data_models,
@@ -114,6 +121,34 @@ class AgentSuccessEvaluationService(
             service_config=service_config,
             agent_context=self.configurator.get_agent_context(),
         )
+
+    def _collect_scoped_interactions_for_precheck(
+        self, extractor_config: AgentSuccessConfig
+    ) -> tuple[list[RequestInteractionDataModel], AgentSuccessConfig]:
+        """Use the session slice already loaded by the group runner.
+
+        The generic pre-check queries storage for learnable interaction windows,
+        which intentionally excludes evaluation-only requests. Agent-success
+        evaluation is allowed to run on evaluation-only sessions, so its
+        pre-check must inspect the request models passed to this service.
+        """
+        service_config = self.service_config
+        if service_config is None:
+            raise RuntimeError("Agent success pre-check requires service_config")
+        session_data_models = service_config.request_interaction_data_models
+        should_skip, source_filter = get_effective_source_filter(
+            extractor_config, service_config.source
+        )
+        if should_skip:
+            self._last_precheck_sessions = []
+            return [], extractor_config
+
+        scoped_models = filter_interactions_by_source(
+            session_data_models,
+            source_filter,
+        )
+        self._last_precheck_sessions = scoped_models
+        return scoped_models, extractor_config
 
     def _process_results(self, results: list) -> None:
         """

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
@@ -19,6 +19,7 @@ from reflexio.server.services.service_utils import (
 class AgentSuccessEvaluationRequest(BaseModel):
     """Request schema for agent success evaluation"""
 
+    user_id: str = ""
     session_id: str
     agent_version: str
     request_interaction_data_models: list[RequestInteractionDataModel]

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluator.py
@@ -274,6 +274,7 @@ class AgentSuccessEvaluator:
             request_interaction_data_models
         )
         return AgentSuccessEvaluationResult(
+            user_id=self.service_config.user_id,
             session_id=self.service_config.session_id,
             agent_version=self.service_config.agent_version,
             evaluation_name=get_extractor_name(self.config),

--- a/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
+++ b/reflexio/server/services/agent_success_evaluation/group_evaluation_runner.py
@@ -169,6 +169,7 @@ def run_group_evaluation(
     if force_regenerate:
         config = request_context.configurator.get_config()
         old_result_ids = storage.get_agent_success_evaluation_result_ids(  # type: ignore[reportOptionalMemberAccess]
+            user_id=user_id,
             session_id=session_id,
             evaluation_name=get_extractor_name(config),
             agent_version=agent_version,
@@ -185,6 +186,7 @@ def run_group_evaluation(
     )
 
     evaluation_request = AgentSuccessEvaluationRequest(
+        user_id=user_id,
         session_id=session_id,
         agent_version=agent_version,
         source=source,

--- a/reflexio/server/services/agent_success_evaluation/regen_jobs.py
+++ b/reflexio/server/services/agent_success_evaluation/regen_jobs.py
@@ -190,9 +190,9 @@ def _build_sample_candidates(
         list[SampleCandidate]: One candidate per descriptor, ready for the
         pure ``sample_candidates`` function.
     """
-    session_ids = sorted({sd.session_id for sd in descriptors})
+    pairs = sorted({(sd.user_id, sd.session_id) for sd in descriptors})
     try:
-        first_requests = storage.get_first_requests_by_session_ids(session_ids)
+        first_requests = storage.get_first_requests_by_user_session_pairs(pairs)
     except Exception as e:  # noqa: BLE001 — discovery should not abort the whole job
         logger.warning(
             "Failed to bulk fetch first requests during F3 sampler candidate "
@@ -203,7 +203,7 @@ def _build_sample_candidates(
 
     candidates: list[SampleCandidate] = []
     for sd in descriptors:
-        first = first_requests.get(sd.session_id)
+        first = first_requests.get((sd.user_id, sd.session_id))
         if first is None:
             logger.warning(
                 "Session %s has no first request in storage despite being returned by "

--- a/reflexio/server/services/evaluation_overview/rule_attribution.py
+++ b/reflexio/server/services/evaluation_overview/rule_attribution.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 
 CitationKey = tuple[str, str]  # (kind, real_id) — matches PlaybookApplicationStat
+SessionIdentity = tuple[str, str]  # (user_id, session_id)
 
 
 @dataclass(frozen=True)
@@ -36,19 +37,19 @@ class RuleAttribution:
 
 def compute_net_sessions(
     *,
-    citations_by_session: Mapping[str, list[CitationKey]],
-    is_success_by_session: Mapping[str, bool],
+    citations_by_session: Mapping[SessionIdentity, list[CitationKey]],
+    is_success_by_session: Mapping[SessionIdentity, bool],
     rule_titles: Mapping[CitationKey, str],
     top_n: int,
 ) -> list[RuleAttribution]:
     """Aggregate net sessions per rule and return the top N by net_sessions.
 
     Args:
-        citations_by_session (Mapping[str, list[CitationKey]]): For each
-            session in the window, the list of `(kind, real_id)` citations
+        citations_by_session (Mapping[SessionIdentity, list[CitationKey]]): For
+            each user/session slice in the window, the list of `(kind, real_id)` citations
             harvested from its interactions.
-        is_success_by_session (Mapping[str, bool]): The session's evaluated
-            outcome. Sessions not in this map are skipped on both sides.
+        is_success_by_session (Mapping[SessionIdentity, bool]): The evaluated
+            outcome. User/session slices not in this map are skipped on both sides.
         rule_titles (Mapping[CitationKey, str]): Pre-loaded display titles
             for each rule (empty string when the underlying row is gone).
         top_n (int): How many rows to return at most. Ordering: net_sessions
@@ -65,8 +66,8 @@ def compute_net_sessions(
     # Ordering preserves caller-provided iteration order; the frontend sorts
     # the detail band by created_at when displaying.
     sessions_by_rule: dict[CitationKey, list[str]] = {}
-    for session_id, citations in citations_by_session.items():
-        outcome = is_success_by_session.get(session_id)
+    for session_key, citations in citations_by_session.items():
+        outcome = is_success_by_session.get(session_key)
         if outcome is None:
             continue
         # A rule cited multiple times in the same session counts once.
@@ -76,7 +77,7 @@ def compute_net_sessions(
                 successes[key] = successes.get(key, 0) + 1
             else:
                 failures[key] = failures.get(key, 0) + 1
-            sessions_by_rule.setdefault(key, []).append(session_id)
+            sessions_by_rule.setdefault(key, []).append(session_key[1])
 
     all_keys = set(successes) | set(failures)
     rows = [

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 
 from reflexio.models.api_schema.braintrust_schema import ImportedScore
 from reflexio.models.api_schema.domain.entities import (
@@ -56,6 +57,7 @@ _DAY_SECONDS = 24 * 60 * 60
 _WEEK_SECONDS = 7 * 24 * 60 * 60
 _TOP_N_RULES = 5
 _LOGGER = logging.getLogger(__name__)
+ResultKey = tuple[str, str]
 
 
 @dataclass
@@ -67,7 +69,7 @@ class EvaluationOverviewService:
     Stateless across calls — safe to reuse the instance across requests.
     """
 
-    storage: object
+    storage: Any
     config: Config
 
     def run(
@@ -114,34 +116,34 @@ class EvaluationOverviewService:
         ]
 
         earliest_eval_ts = min((r.created_at for r in all_results), default=None)
-        result_session_ids = list(
-            dict.fromkeys(r.session_id for r in results if r.session_id)
+        result_keys = list(
+            dict.fromkeys((r.user_id, r.session_id) for r in results if r.session_id)
         )
         if request.source_sets:
-            source_session_ids = list(
+            source_keys = list(
                 dict.fromkeys(
-                    r.session_id
+                    (r.user_id, r.session_id)
                     for r in (*results, *results_current_7d, *results_prev_7d)
                     if r.session_id
                 )
             )
         else:
-            source_session_ids = result_session_ids
+            source_keys = result_keys
         start = time.perf_counter()
-        session_sources = self._build_first_request_sources(source_session_ids)
+        session_sources = self._build_first_request_sources(source_keys)
         self._log_phase(
             "session_sources",
             start,
-            sessions=len(set(source_session_ids)),
+            sessions=len(set(source_keys)),
             rows=len(session_sources),
         )
 
         start = time.perf_counter()
-        citations_by_session, rule_titles = self._load_citations(result_session_ids)
+        citations_by_session, rule_titles = self._load_citations(result_keys)
         self._log_phase(
             "citations",
             start,
-            sessions=len(set(result_session_ids)),
+            sessions=len(set(result_keys)),
             rows=sum(len(v) for v in citations_by_session.values()),
         )
 
@@ -262,10 +264,12 @@ class EvaluationOverviewService:
     def _build_attribution(
         self,
         results: list[AgentSuccessEvaluationResult],
-        citations_by_session: dict[str, list[tuple[str, str]]],
+        citations_by_session: dict[ResultKey, list[tuple[str, str]]],
         rule_titles: dict[tuple[str, str], str],
     ) -> list[RuleAttributionRow]:
-        is_success_by_session = {r.session_id: r.is_success for r in results}
+        is_success_by_session = {
+            (r.user_id, r.session_id): r.is_success for r in results
+        }
         rows = compute_net_sessions(
             citations_by_session=citations_by_session,
             is_success_by_session=is_success_by_session,
@@ -286,19 +290,24 @@ class EvaluationOverviewService:
         ]
 
     def _load_citations(
-        self, session_ids: list[str]
-    ) -> tuple[dict[str, list[tuple[str, str]]], dict[tuple[str, str], str]]:
-        """Pull `Interaction.citations` keyed by session, with title lookup.
+        self, result_keys: list[ResultKey]
+    ) -> tuple[dict[ResultKey, list[tuple[str, str]]], dict[tuple[str, str], str]]:
+        """Pull `Interaction.citations` keyed by user/session, with title lookup.
 
         Falls back to empty data when the underlying storage method returns
         no interactions (default behavior on backends that haven't yet
         implemented `get_interactions_by_session`).
         """
-        citations_by_session: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        wanted = set(result_keys)
+        session_ids = sorted({session_id for _, session_id in result_keys})
+        citations_by_session: dict[ResultKey, list[tuple[str, str]]] = defaultdict(list)
         rule_titles: dict[tuple[str, str], str] = {}
         for citation in self.storage.get_citations_by_session_ids(session_ids):  # type: ignore[attr-defined]
+            result_key = (citation.user_id, citation.session_id)
+            if result_key not in wanted:
+                continue
             key = (citation.kind, citation.real_id)
-            citations_by_session[citation.session_id].append(key)
+            citations_by_session[result_key].append(key)
             if citation.title and key not in rule_titles:
                 rule_titles[key] = citation.title
         return citations_by_session, rule_titles
@@ -358,16 +367,16 @@ class EvaluationOverviewService:
         results: list[AgentSuccessEvaluationResult],
         current: list[AgentSuccessEvaluationResult],
         previous: list[AgentSuccessEvaluationResult],
-        session_sources: dict[str, str],
+        session_sources: dict[ResultKey, str],
         bucket: BucketLiteral,
-        citations_by_session: dict[str, list[tuple[str, str]]],
+        citations_by_session: dict[ResultKey, list[tuple[str, str]]],
         rule_titles: dict[tuple[str, str], str],
         current_scores: list[ImportedScore],
         prior_scores: list[ImportedScore],
     ) -> SourceSetComparison:
         """Build request-source cohort metrics for the evaluation page."""
         available_sources = sorted(
-            {session_sources.get(r.session_id or "", "") for r in results}
+            {session_sources.get((r.user_id, r.session_id), "") for r in results}
         )
         if not source_sets:
             return SourceSetComparison(available_sources=available_sources)
@@ -376,7 +385,8 @@ class EvaluationOverviewService:
         unmatched = sum(
             1
             for r in results
-            if session_sources.get(r.session_id or "", "") not in requested_sources
+            if session_sources.get((r.user_id, r.session_id), "")
+            not in requested_sources
         )
         rows: list[SourceSetEvaluationMetrics] = []
         for source_set in source_sets:
@@ -384,17 +394,17 @@ class EvaluationOverviewService:
             set_results = [
                 r
                 for r in results
-                if session_sources.get(r.session_id or "", "") in source_values
+                if session_sources.get((r.user_id, r.session_id), "") in source_values
             ]
             set_current = [
                 r
                 for r in current
-                if session_sources.get(r.session_id or "", "") in source_values
+                if session_sources.get((r.user_id, r.session_id), "") in source_values
             ]
             set_previous = [
                 r
                 for r in previous
-                if session_sources.get(r.session_id or "", "") in source_values
+                if session_sources.get((r.user_id, r.session_id), "") in source_values
             ]
             session_ids = {r.session_id for r in set_results if r.session_id}
             rows.append(
@@ -468,10 +478,14 @@ class EvaluationOverviewService:
             verdicts, judge_prompt_version=pinned_version
         )
 
-    def _build_first_request_sources(self, session_ids: list[str]) -> dict[str, str]:
-        """Map each session to its earliest request's source."""
-        first_requests = self.storage.get_first_requests_by_session_ids(session_ids)  # type: ignore[attr-defined]
-        return {sid: row.source or "" for sid, row in first_requests.items()}
+    def _build_first_request_sources(
+        self, result_keys: list[ResultKey]
+    ) -> dict[ResultKey, str]:
+        """Map each user/session slice to its earliest request's source."""
+        first_requests = self.storage.get_first_requests_by_user_session_pairs(
+            result_keys
+        )  # type: ignore[attr-defined]
+        return {key: row.source or "" for key, row in first_requests.items()}
 
     def _build_distribution(
         self,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -517,6 +517,7 @@ def _row_to_eval_result(row: sqlite3.Row) -> AgentSuccessEvaluationResult:
     d = dict(row)
     return AgentSuccessEvaluationResult(
         result_id=d["result_id"],
+        user_id=d.get("user_id") or "",
         session_id=d["session_id"],
         agent_version=d["agent_version"],
         evaluation_name=d.get("evaluation_name"),
@@ -695,6 +696,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_agent_playbook_source_windows()
         self._migrate_request_evaluation_only()
         self._migrate_request_session_id_required()
+        self._migrate_eval_result_user_id()
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
         self._migrate_lineage()
@@ -1467,6 +1469,30 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self.conn.commit()
         logger.info("Migrated requests.session_id to required non-empty values")
 
+    def _migrate_eval_result_user_id(self) -> None:
+        """Add user_id to session evaluation results for per-user identity."""
+        cols = {
+            row["name"]
+            for row in self.conn.execute(
+                "PRAGMA table_info(agent_success_evaluation_result)"
+            ).fetchall()
+        }
+        if not cols:
+            return
+        if "user_id" not in cols:
+            self.conn.execute(
+                "ALTER TABLE agent_success_evaluation_result "
+                "ADD COLUMN user_id TEXT NOT NULL DEFAULT ''"
+            )
+            logger.info("Added user_id column to agent_success_evaluation_result")
+        self.conn.execute("DROP INDEX IF EXISTS idx_eval_identity_created_at_desc")
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_eval_identity_created_at_desc "
+            "ON agent_success_evaluation_result"
+            "(user_id, session_id, evaluation_name, agent_version, created_at DESC)"
+        )
+        self.conn.commit()
+
     def _migrate_shadow_comparison_verdicts(self) -> None:
         """F1: create the shadow_comparison_verdicts table if missing.
 
@@ -1928,6 +1954,7 @@ CREATE INDEX IF NOT EXISTS idx_agent_playbooks_created_at ON agent_playbooks(cre
 
 CREATE TABLE IF NOT EXISTS agent_success_evaluation_result (
     result_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL DEFAULT '',
     session_id TEXT NOT NULL,
     agent_version TEXT NOT NULL DEFAULT '',
     evaluation_name TEXT,
@@ -1948,7 +1975,7 @@ CREATE INDEX IF NOT EXISTS idx_eval_created_at_desc
 CREATE INDEX IF NOT EXISTS idx_eval_agent_version_created_at_desc
     ON agent_success_evaluation_result(agent_version, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_eval_identity_created_at_desc
-    ON agent_success_evaluation_result(session_id, evaluation_name, agent_version, created_at DESC);
+    ON agent_success_evaluation_result(user_id, session_id, evaluation_name, agent_version, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS profile_change_logs (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -502,7 +502,7 @@ class ExtrasMixin:
             chunk = ids[i : i + chunk_size]
             ph = ",".join("?" for _ in chunk)
             rows = self._fetchall(
-                f"""SELECT r.session_id, i.citations
+                f"""SELECT r.user_id, r.session_id, i.citations
                     FROM requests r
                     JOIN interactions i ON i.request_id = r.request_id
                     WHERE r.session_id IN ({ph})
@@ -524,6 +524,7 @@ class ExtrasMixin:
                     if kind and real_id:
                         out.append(
                             SessionCitation(
+                                user_id=row["user_id"],
                                 session_id=row["session_id"],
                                 kind=str(kind),
                                 real_id=str(real_id),

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1847,12 +1847,13 @@ class PlaybookMixin:
             created_at_iso = _epoch_to_iso(result.created_at)
             self._execute(
                 """INSERT INTO agent_success_evaluation_result
-                   (session_id, agent_version, evaluation_name, is_success,
+                   (user_id, session_id, agent_version, evaluation_name, is_success,
                     failure_type, failure_reason, regular_vs_shadow,
                     number_of_correction_per_session, user_turns_to_resolution,
                     is_escalated, embedding, created_at)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?)""",
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
+                    result.user_id,
                     result.session_id,
                     result.agent_version,
                     result.evaluation_name,
@@ -1908,17 +1909,19 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def get_agent_success_evaluation_result_ids(
         self,
+        user_id: str,
         session_id: str,
         evaluation_name: str,
         agent_version: str,
     ) -> list[int]:
         rows = self._fetchall(
             """SELECT result_id FROM agent_success_evaluation_result
-               WHERE session_id = ?
+               WHERE user_id = ?
+                 AND session_id = ?
                  AND evaluation_name = ?
                  AND agent_version = ?
                ORDER BY created_at DESC""",
-            (session_id, evaluation_name, agent_version),
+            (user_id, session_id, evaluation_name, agent_version),
         )
         return [int(r["result_id"]) for r in rows]
 
@@ -1929,13 +1932,15 @@ class PlaybookMixin:
     @SQLiteStorageBase.handle_exceptions
     def delete_agent_success_evaluation_results_for_session(
         self,
+        user_id: str,
         session_id: str,
         evaluation_name: str,
         agent_version: str,
     ) -> int:
-        """Delete results scoped to (session_id, evaluation_name, agent_version).
+        """Delete results scoped to (user_id, session_id, evaluation_name, agent_version).
 
         Args:
+            user_id (str): User whose session results to clear.
             session_id (str): Session whose results to clear.
             evaluation_name (str): Which evaluator's results to clear.
             agent_version (str): Agent version scope.
@@ -1945,8 +1950,11 @@ class PlaybookMixin:
         """
         cur = self._execute(
             """DELETE FROM agent_success_evaluation_result
-               WHERE session_id = ? AND evaluation_name = ? AND agent_version = ?""",
-            (session_id, evaluation_name, agent_version),
+               WHERE user_id = ?
+                 AND session_id = ?
+                 AND evaluation_name = ?
+                 AND agent_version = ?""",
+            (user_id, session_id, evaluation_name, agent_version),
         )
         return cur.rowcount
 

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -298,3 +298,40 @@ class RequestMixin:
                     created_at=_iso_to_epoch(row["created_at"]),
                 )
         return out
+
+    @SQLiteStorageBase.handle_exceptions
+    def get_first_requests_by_user_session_pairs(
+        self, pairs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], SessionFirstRequest]:
+        if not pairs:
+            return {}
+        out: dict[tuple[str, str], SessionFirstRequest] = {}
+        pair_list = sorted(set(pairs))
+        chunk_size = 300
+        for i in range(0, len(pair_list), chunk_size):
+            chunk = pair_list[i : i + chunk_size]
+            values = ",".join("(?, ?)" for _ in chunk)
+            params = [value for pair in chunk for value in pair]
+            rows = self._fetchall(
+                f"""SELECT session_id, user_id, source, created_at
+                    FROM (
+                        SELECT session_id, user_id, source, created_at,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY user_id, session_id
+                                   ORDER BY created_at ASC, request_id ASC
+                               ) AS rn
+                        FROM requests
+                        WHERE (user_id, session_id) IN ({values})
+                    )
+                    WHERE rn = 1""",  # noqa: S608
+                params,
+            )
+            for row in rows:
+                key = (row["user_id"], row["session_id"])
+                out[key] = SessionFirstRequest(
+                    session_id=row["session_id"],
+                    user_id=row["user_id"],
+                    source=row["source"] or "",
+                    created_at=_iso_to_epoch(row["created_at"]),
+                )
+        return out

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -197,6 +197,7 @@ class ExtrasMixin:
                     if kind and real_id:
                         out.append(
                             SessionCitation(
+                                user_id="",
                                 session_id=session_id,
                                 kind=str(kind),
                                 real_id=str(real_id),

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -746,6 +746,7 @@ class PlaybookMixin:
 
     def get_agent_success_evaluation_result_ids(
         self,
+        user_id: str,
         session_id: str,
         evaluation_name: str,
         agent_version: str,
@@ -758,7 +759,9 @@ class PlaybookMixin:
         return [
             r.result_id
             for r in rows
-            if r.session_id == session_id and r.evaluation_name == evaluation_name
+            if r.user_id == user_id
+            and r.session_id == session_id
+            and r.evaluation_name == evaluation_name
         ]
 
     @abstractmethod
@@ -769,13 +772,15 @@ class PlaybookMixin:
     @abstractmethod
     def delete_agent_success_evaluation_results_for_session(
         self,
+        user_id: str,
         session_id: str,
         evaluation_name: str,
         agent_version: str,
     ) -> int:
-        """Delete stored results for (session_id, evaluation_name, agent_version).
+        """Delete stored results for (user_id, session_id, evaluation_name, agent_version).
 
         Args:
+            user_id (str): User whose session results to clear.
             session_id (str): Session whose results to clear.
             evaluation_name (str): Which evaluator's results to clear.
             agent_version (str): Agent version scope.

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -189,3 +189,26 @@ class RequestMixin:
                 created_at=first.created_at,
             )
         return out
+
+    def get_first_requests_by_user_session_pairs(
+        self, pairs: list[tuple[str, str]]
+    ) -> dict[tuple[str, str], SessionFirstRequest]:
+        """Return earliest-request metadata for each requested (user_id, session_id).
+
+        Default implementation preserves backend compatibility by calling the
+        existing user-scoped request lookup per distinct pair. SQL backends
+        override with set-based queries.
+        """
+        out: dict[tuple[str, str], SessionFirstRequest] = {}
+        for user_id, session_id in set(pairs):
+            requests = self.get_requests_by_session(user_id, session_id)
+            if not requests:
+                continue
+            first = min(requests, key=lambda r: r.created_at)
+            out[(user_id, session_id)] = SessionFirstRequest(
+                session_id=session_id,
+                user_id=user_id,
+                source=first.source or "",
+                created_at=first.created_at,
+            )
+        return out

--- a/tests/server/api_endpoints/test_grade_on_demand_integration.py
+++ b/tests/server/api_endpoints/test_grade_on_demand_integration.py
@@ -90,11 +90,12 @@ def _fake_runner_factory(storage, *, agent_version: str, evaluation_name: str):
     finds a fresh row to report as ``result_id``.
     """
 
-    def _fake(*, session_id: str, **_kwargs: object) -> None:
+    def _fake(*, user_id: str, session_id: str, **_kwargs: object) -> None:
         storage.save_agent_success_evaluation_results(
             [
                 AgentSuccessEvaluationResult(
                     result_id=0,
+                    user_id=user_id,
                     session_id=session_id,
                     agent_version=agent_version,
                     evaluation_name=evaluation_name,

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
@@ -12,10 +12,12 @@ import contextlib
 import datetime
 import tempfile
 from datetime import UTC
+from typing import cast
 from unittest.mock import patch
 
 import pytest
 
+from reflexio.models.api_schema.domain.enums import UserActionType
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
@@ -92,6 +94,7 @@ def test_loads_singular_agent_success_config():
         )
         service.configurator.set_config_by_name("agent_success_config", success_config)
         service.service_config = AgentSuccessGenerationServiceConfig(
+            user_id="test_user_id",
             session_id="test_group",
             agent_version="1.0",
             request_interaction_data_models=[],
@@ -106,12 +109,48 @@ def test_loads_no_agent_success_config_when_disabled():
         service = _make_agent_success_service(temp_dir)
         service.configurator.set_config_by_name("agent_success_config", None)
         service.service_config = AgentSuccessGenerationServiceConfig(
+            user_id="test_user_id",
             session_id="test_group",
             agent_version="1.0",
             request_interaction_data_models=[],
         )
 
         assert service._load_extractor_config() is None
+
+
+def test_precheck_uses_provided_session_models_for_evaluation_only():
+    """Agent success pre-check should not re-query learnable storage windows."""
+    user_id = "eval_only_user"
+    interaction = Interaction(
+        interaction_id=1,
+        user_id=user_id,
+        request_id="eval_only_request_id",
+        content="Please confirm this launch checklist answer is clear and useful.",
+        role="user",
+        created_at=int(datetime.datetime.now(UTC).timestamp()),
+    )
+    request_interaction = create_request_interaction_data_model(
+        request_id="eval_only_request_id",
+        user_id=user_id,
+        interactions=[interaction],
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        service = _make_agent_success_service(temp_dir)
+        success_config = AgentSuccessConfig(
+            evaluation_name="test_agent_success",
+            success_definition_prompt="Evaluate if the answer was clear and useful",
+        )
+        service.configurator.set_config_by_name("agent_success_config", success_config)
+        service.service_config = AgentSuccessGenerationServiceConfig(
+            user_id=user_id,
+            session_id="eval_only_session",
+            agent_version="1.0",
+            request_interaction_data_models=[request_interaction],
+            source="test",
+        )
+
+        assert service._should_run_before_extraction(success_config) is True
 
 
 def test_evaluate_agent_success(mock_chat_completion):
@@ -446,7 +485,7 @@ def test_none_request():
         )
 
         # Run with None request
-        agent_success_service.run(None)
+        agent_success_service.run(cast(AgentSuccessEvaluationRequest, None))
 
         # Verify no evaluation was generated
         assert True
@@ -474,7 +513,7 @@ def test_agent_success_message_construction_with_interactions():
             content="I used the search tool",
             role="assistant",
             created_at=int(datetime.datetime.now(UTC).timestamp()),
-            user_action="click",
+            user_action=UserActionType.CLICK,
             user_action_description="search button",
         ),
     ]

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
@@ -68,6 +68,7 @@ def _make_prior_result(
     session_id: str,
     evaluation_name: str,
     agent_version: str = "1.0.0",
+    user_id: str = "user_a",
 ) -> AgentSuccessEvaluationResult:
     """Construct an AgentSuccessEvaluationResult representing a prior-run row.
 
@@ -82,6 +83,7 @@ def _make_prior_result(
     """
     return AgentSuccessEvaluationResult(
         result_id=result_id,
+        user_id=user_id,
         session_id=session_id,
         agent_version=agent_version,
         evaluation_name=evaluation_name,
@@ -132,16 +134,17 @@ def _make_storage(
 
     # The runner captures prior result ids via the targeted, indexed lookup
     # get_agent_success_evaluation_result_ids (added in the evaluation-overview
-    # read optimization). Mirror the storage layer's own (session_id,
+    # read optimization). Mirror the storage layer's own (user_id, session_id,
     # evaluation_name, agent_version) filtering instead of a static return — so
     # the test fails if the runner wires the WRONG identity tuple, not merely if
     # it forgets to call the method.
     def _result_ids_for(
-        session_id: str, evaluation_name: str, agent_version: str
+        user_id: str, session_id: str, evaluation_name: str, agent_version: str
     ) -> list[int]:
         """Return seeded result_ids matching one eval identity tuple (mirrors storage).
 
         Args:
+            user_id (str): Owning user to match.
             session_id (str): Owning session to match.
             evaluation_name (str): Evaluator identifier to match.
             agent_version (str): Agent version scope to match.
@@ -153,7 +156,8 @@ def _make_storage(
         return [
             r.result_id
             for r in (prior_results or [])
-            if r.session_id == session_id
+            if r.user_id == user_id
+            and r.session_id == session_id
             and r.evaluation_name == evaluation_name
             and r.agent_version == agent_version
         ]
@@ -276,7 +280,7 @@ def test_force_regenerate_deletes_prior_results() -> None:
         )
 
     # By-id delete called once with the captured prior result_ids — proving the
-    # runner passed the matching (session_a, overall_success, 1.0.0) identity to
+    # runner passed the matching (user_a, session_a, overall_success, 1.0.0) identity to
     # get_agent_success_evaluation_result_ids (the mock now filters on it).
     storage.delete_agent_success_evaluation_results_by_ids.assert_called_once_with([42])
     # The old triple-scoped delete must NOT be called by the new flow.
@@ -426,6 +430,7 @@ def test_regenerate_happy_path_with_real_sqlite_storage(tmp_path) -> None:
         # failure_type="old_value" lets us distinguish it from the new row.
         old_row = AgentSuccessEvaluationResult(
             result_id=0,
+            user_id="user_a",
             session_id="session_a",
             agent_version="1.0.0",
             evaluation_name="overall_success",
@@ -550,6 +555,7 @@ def test_regenerate_failure_preserves_old_rows_with_real_sqlite_storage(
 
         old_row = AgentSuccessEvaluationResult(
             result_id=0,
+            user_id="user_a",
             session_id="session_a",
             agent_version="1.0.0",
             evaluation_name="overall_success",

--- a/tests/server/services/evaluation_overview/test_rule_attribution.py
+++ b/tests/server/services/evaluation_overview/test_rule_attribution.py
@@ -9,11 +9,15 @@ from reflexio.server.services.evaluation_overview.rule_attribution import (
 def test_basic_join_one_rule_two_successes_one_failure() -> None:
     """Net = successes_with_rule_fired - failures_with_rule_fired."""
     citations_by_session = {
-        "sess_a": [("playbook", "rule_42")],
-        "sess_b": [("playbook", "rule_42")],
-        "sess_c": [("playbook", "rule_42")],
+        ("u1", "sess_a"): [("playbook", "rule_42")],
+        ("u1", "sess_b"): [("playbook", "rule_42")],
+        ("u1", "sess_c"): [("playbook", "rule_42")],
     }
-    is_success_by_session = {"sess_a": True, "sess_b": True, "sess_c": False}
+    is_success_by_session = {
+        ("u1", "sess_a"): True,
+        ("u1", "sess_b"): True,
+        ("u1", "sess_c"): False,
+    }
     rule_titles = {("playbook", "rule_42"): "Confirm address before checkout"}
 
     attribs = compute_net_sessions(
@@ -36,20 +40,20 @@ def test_basic_join_one_rule_two_successes_one_failure() -> None:
 def test_ranks_by_net_sessions_descending_and_caps_at_top_n() -> None:
     """Top-N ordering by net_sessions desc; ties broken by total fires desc."""
     citations_by_session = {
-        "s1": [("playbook", "good")],
-        "s2": [("playbook", "good")],
-        "s3": [("playbook", "good")],
-        "s4": [("playbook", "ugly")],
-        "s5": [("playbook", "ugly")],
-        "s6": [("playbook", "meh")],
+        ("u1", "s1"): [("playbook", "good")],
+        ("u1", "s2"): [("playbook", "good")],
+        ("u1", "s3"): [("playbook", "good")],
+        ("u1", "s4"): [("playbook", "ugly")],
+        ("u1", "s5"): [("playbook", "ugly")],
+        ("u1", "s6"): [("playbook", "meh")],
     }
     is_success_by_session = {
-        "s1": True,
-        "s2": True,
-        "s3": True,
-        "s4": False,
-        "s5": False,
-        "s6": True,
+        ("u1", "s1"): True,
+        ("u1", "s2"): True,
+        ("u1", "s3"): True,
+        ("u1", "s4"): False,
+        ("u1", "s5"): False,
+        ("u1", "s6"): True,
     }
     rule_titles = {
         ("playbook", "good"): "good",
@@ -75,10 +79,10 @@ def test_session_missing_from_success_map_is_skipped() -> None:
     for, treat it as unknown and don't count it on either side."""
     _ = RuleAttribution  # imported for export sanity; no-op
     citations_by_session = {
-        "sess_known": [("playbook", "r1")],
-        "sess_orphan": [("playbook", "r1")],
+        ("u1", "sess_known"): [("playbook", "r1")],
+        ("u1", "sess_orphan"): [("playbook", "r1")],
     }
-    is_success_by_session = {"sess_known": True}
+    is_success_by_session = {("u1", "sess_known"): True}
     rule_titles = {("playbook", "r1"): "r1"}
 
     attribs = compute_net_sessions(
@@ -97,11 +101,15 @@ def test_session_missing_from_success_map_is_skipped() -> None:
 def test_cited_session_ids_populated_for_each_rule() -> None:
     """Each RuleAttribution row carries the session ids that cited the rule."""
     citations_by_session = {
-        "sess_alpha": [("playbook", "rule_a"), ("playbook", "rule_b")],
-        "sess_beta": [("playbook", "rule_a")],
-        "sess_gamma": [("playbook", "rule_b")],
+        ("u1", "sess_alpha"): [("playbook", "rule_a"), ("playbook", "rule_b")],
+        ("u1", "sess_beta"): [("playbook", "rule_a")],
+        ("u1", "sess_gamma"): [("playbook", "rule_b")],
     }
-    is_success_by_session = {"sess_alpha": True, "sess_beta": False, "sess_gamma": True}
+    is_success_by_session = {
+        ("u1", "sess_alpha"): True,
+        ("u1", "sess_beta"): False,
+        ("u1", "sess_gamma"): True,
+    }
     rule_titles = {("playbook", "rule_a"): "A", ("playbook", "rule_b"): "B"}
 
     rows = compute_net_sessions(
@@ -121,10 +129,10 @@ def test_cited_session_ids_populated_for_each_rule() -> None:
 def test_cited_session_ids_excludes_sessions_with_no_outcome() -> None:
     """Sessions absent from is_success_by_session are skipped on both sides."""
     citations_by_session = {
-        "graded": [("playbook", "rule_x")],
-        "ungraded": [("playbook", "rule_x")],
+        ("u1", "graded"): [("playbook", "rule_x")],
+        ("u1", "ungraded"): [("playbook", "rule_x")],
     }
-    is_success_by_session = {"graded": True}  # 'ungraded' not present
+    is_success_by_session = {("u1", "graded"): True}  # 'ungraded' not present
 
     rows = compute_net_sessions(
         citations_by_session=citations_by_session,
@@ -140,13 +148,13 @@ def test_cited_session_ids_excludes_sessions_with_no_outcome() -> None:
 def test_cited_session_ids_dedupes_within_same_session() -> None:
     """A rule cited multiple times in the same session yields a single session entry."""
     citations_by_session = {
-        "sess_a": [
+        ("u1", "sess_a"): [
             ("playbook", "rule_x"),
             ("playbook", "rule_x"),
             ("playbook", "rule_x"),
         ],
     }
-    is_success_by_session = {"sess_a": True}
+    is_success_by_session = {("u1", "sess_a"): True}
 
     rows = compute_net_sessions(
         citations_by_session=citations_by_session,

--- a/tests/server/services/evaluation_overview/test_service_grouping_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_grouping_integration.py
@@ -69,6 +69,7 @@ def _seed_session(
     storage.save_agent_success_evaluation_results(
         [
             AgentSuccessEvaluationResult(
+                user_id=user_id,
                 agent_version="v1",
                 session_id=session_id,
                 is_success=is_success,

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -25,11 +25,13 @@ def _eval_result(
     result_id: int,
     session_id: str,
     is_success: bool,
+    user_id: str = "u1",
     corrections: int = 0,
     created_at: int = 1700000000,
 ) -> AgentSuccessEvaluationResult:
     return AgentSuccessEvaluationResult(
         result_id=result_id,
+        user_id=user_id,
         agent_version="v_e2e",
         session_id=session_id,
         is_success=is_success,
@@ -45,10 +47,10 @@ def _storage_with_results(
     storage = MagicMock()
     storage.org_id = ""
     storage.get_agent_success_evaluation_results_in_window.return_value = results
-    storage.get_first_requests_by_session_ids.return_value = {
-        r.session_id: SessionFirstRequest(
+    storage.get_first_requests_by_user_session_pairs.return_value = {
+        (r.user_id, r.session_id): SessionFirstRequest(
             session_id=r.session_id,
-            user_id="u1",
+            user_id=r.user_id,
             source="api",
             created_at=r.created_at,
         )
@@ -202,6 +204,7 @@ def test_service_uses_bulk_storage_methods_without_per_session_reads() -> None:
     )
     storage.get_citations_by_session_ids.return_value = [
         SessionCitation(
+            user_id="u1",
             session_id="s1",
             kind="playbook",
             real_id="42",
@@ -218,7 +221,7 @@ def test_service_uses_bulk_storage_methods_without_per_session_reads() -> None:
     storage.get_sessions.assert_not_called()
     storage.get_interactions_by_session.assert_not_called()
     storage.get_playbook_application_stats.assert_not_called()
-    storage.get_first_requests_by_session_ids.assert_called_once()
+    storage.get_first_requests_by_user_session_pairs.assert_called_once()
     storage.get_citations_by_session_ids.assert_called_once()
 
 
@@ -241,14 +244,14 @@ def test_service_limits_source_lookup_to_window_when_no_source_sets() -> None:
             ),
         ]
     )
-    storage.get_first_requests_by_session_ids.return_value = {
-        "current": SessionFirstRequest(
+    storage.get_first_requests_by_user_session_pairs.return_value = {
+        ("u1", "current"): SessionFirstRequest(
             session_id="current",
             user_id="u1",
             source="current-source",
             created_at=now,
         ),
-        "previous": SessionFirstRequest(
+        ("u1", "previous"): SessionFirstRequest(
             session_id="previous",
             user_id="u1",
             source="previous-source",
@@ -267,7 +270,9 @@ def test_service_limits_source_lookup_to_window_when_no_source_sets() -> None:
     )
 
     assert response.source_set_comparison.available_sources == ["current-source"]
-    storage.get_first_requests_by_session_ids.assert_called_once_with(["current"])
+    storage.get_first_requests_by_user_session_pairs.assert_called_once_with(
+        [("u1", "current")]
+    )
 
 
 def test_service_loads_baseline_sources_when_source_sets_requested() -> None:
@@ -289,14 +294,14 @@ def test_service_loads_baseline_sources_when_source_sets_requested() -> None:
             ),
         ]
     )
-    storage.get_first_requests_by_session_ids.return_value = {
-        "current": SessionFirstRequest(
+    storage.get_first_requests_by_user_session_pairs.return_value = {
+        ("u1", "current"): SessionFirstRequest(
             session_id="current",
             user_id="u1",
             source="candidate",
             created_at=now,
         ),
-        "previous": SessionFirstRequest(
+        ("u1", "previous"): SessionFirstRequest(
             session_id="previous",
             user_id="u1",
             source="candidate",
@@ -320,8 +325,8 @@ def test_service_loads_baseline_sources_when_source_sets_requested() -> None:
     assert (
         response.source_set_comparison.sets[0].context_tiles.success.delta_pp == 100.0
     )
-    storage.get_first_requests_by_session_ids.assert_called_once_with(
-        ["current", "previous"]
+    storage.get_first_requests_by_user_session_pairs.assert_called_once_with(
+        [("u1", "current"), ("u1", "previous")]
     )
 
 
@@ -370,7 +375,7 @@ def test_service_handles_5k_sessions_with_bulk_call_shape() -> None:
 
     assert response.hero.regular_success_rate_pp == 50.0
     storage.get_agent_success_evaluation_results_in_window.assert_called_once()
-    storage.get_first_requests_by_session_ids.assert_called_once()
+    storage.get_first_requests_by_user_session_pairs.assert_called_once()
     storage.get_citations_by_session_ids.assert_called_once()
     storage.get_sessions.assert_not_called()
     storage.get_interactions_by_session.assert_not_called()

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -204,11 +204,13 @@ def _seed_eval_result(
     storage: BaseStorage,
     session_id: str,
     evaluation_name: str,
+    user_id: str = "u1",
     agent_version: str = "v1",
     created_at: int = 1000,
 ) -> None:
     """Save one ``AgentSuccessEvaluationResult`` row with minimal fields set."""
     result = AgentSuccessEvaluationResult(
+        user_id=user_id,
         session_id=session_id,
         agent_version=agent_version,
         evaluation_name=evaluation_name,
@@ -344,6 +346,7 @@ def test_targeted_eval_result_id_lookup(
     _seed_eval_result(storage, "s2", "overall_success", agent_version="v1")
 
     ids = storage.get_agent_success_evaluation_result_ids(
+        user_id="u1",
         session_id="s1",
         evaluation_name="overall_success",
         agent_version="v1",
@@ -366,7 +369,10 @@ def test_delete_scoped_to_session_and_name(storage: BaseStorage) -> None:
     _seed_eval_result(storage, "s2", "overall_success")
 
     n = storage.delete_agent_success_evaluation_results_for_session(
-        session_id="s1", evaluation_name="overall_success", agent_version="v1"
+        user_id="u1",
+        session_id="s1",
+        evaluation_name="overall_success",
+        agent_version="v1",
     )
 
     assert n == 1
@@ -377,6 +383,7 @@ def test_delete_scoped_to_session_and_name(storage: BaseStorage) -> None:
 
 def test_delete_unknown_session_returns_zero(storage: BaseStorage) -> None:
     n = storage.delete_agent_success_evaluation_results_for_session(
+        user_id="u1",
         session_id="does_not_exist",
         evaluation_name="overall_success",
         agent_version="v1",
@@ -388,12 +395,37 @@ def test_delete_respects_agent_version_scope(storage: BaseStorage) -> None:
     _seed_eval_result(storage, "s1", "overall_success", agent_version="v1")
     _seed_eval_result(storage, "s1", "overall_success", agent_version="v2")
     n = storage.delete_agent_success_evaluation_results_for_session(
-        session_id="s1", evaluation_name="overall_success", agent_version="v1"
+        user_id="u1",
+        session_id="s1",
+        evaluation_name="overall_success",
+        agent_version="v1",
     )
     assert n == 1
     remaining = storage.get_agent_success_evaluation_results(limit=100)
     versions = {r.agent_version for r in remaining if r.session_id == "s1"}
     assert versions == {"v2"}
+
+
+def test_eval_result_identity_is_user_scoped(storage: BaseStorage) -> None:
+    _seed_eval_result(storage, "shared", "overall_success", user_id="u1")
+    _seed_eval_result(storage, "shared", "overall_success", user_id="u2")
+
+    u1_ids = storage.get_agent_success_evaluation_result_ids(
+        user_id="u1",
+        session_id="shared",
+        evaluation_name="overall_success",
+        agent_version="v1",
+    )
+    u2_ids = storage.get_agent_success_evaluation_result_ids(
+        user_id="u2",
+        session_id="shared",
+        evaluation_name="overall_success",
+        agent_version="v1",
+    )
+
+    assert len(u1_ids) == 1
+    assert len(u2_ids) == 1
+    assert u1_ids != u2_ids
 
 
 def test_delete_by_ids_empty_list_is_noop(storage: BaseStorage) -> None:


### PR DESCRIPTION
## Summary
- Add user_id to agent success evaluation result identity and retrieval paths.
- Prevent cross-user collisions when users share session or request identifiers.
- Keep evaluation-only interaction models available to agent-success prechecks.

## Changes
- Thread user identity through agent success evaluation result schemas, storage lookups, and overview grouping.
- Update SQLite storage behavior and tests for user-scoped result identity.
- Add regression coverage for evaluation-only session prechecks.
- Refresh server docs for the result identity contract.

## Test Plan
- `uv run ruff check` on staged Python files
- `uv run ruff format` on staged Python files
- `uv run pyright` on staged Python files
- `uv run pytest tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py -q --no-cov`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation results are now scoped per user, allowing sessions to be safely reused across different users without ID collisions.
  * The system now uniquely identifies evaluation data using user and session pairs instead of session IDs alone, improving multi-user support and data isolation.

* **Database**
  * Added schema migration to support user-scoped evaluation result storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->