### PR TITLE
feat(llm): provider-safe schema for discriminated-union outputs (Option C)

### DIFF
--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -4,7 +4,9 @@ import os
 from copy import deepcopy
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
 
 
 def positive_int_env(name: str, default: int, logger: logging.Logger) -> int:
@@ -52,6 +54,54 @@ _STRICT_SCHEMA_UNSUPPORTED_KEYWORDS = frozenset(
         "uniqueItems",
     }
 )
+
+
+def _fold_oneof_to_anyof(node: Any) -> None:
+    """Rewrite ``oneOf`` to ``anyOf`` and drop ``discriminator`` in place (recursive).
+
+    Pydantic emits ``oneOf`` + ``discriminator`` for a discriminated union, which
+    strict structured-output endpoints (OpenAI, minimax) reject. Folding into
+    ``anyOf`` keeps the identical variant set so generation stays constrained;
+    Pydantic still enforces the discriminator after parse, so semantics are
+    preserved.
+
+    Args:
+        node (Any): A JSON-schema fragment (dict, list, or scalar); mutated in place.
+    """
+    if isinstance(node, dict):
+        one_of = node.pop("oneOf", None)
+        node.pop("discriminator", None)
+        if isinstance(one_of, list):
+            node["anyOf"] = node.get("anyOf", []) + one_of
+        for value in node.values():
+            _fold_oneof_to_anyof(value)
+    elif isinstance(node, list):
+        for item in node:
+            _fold_oneof_to_anyof(item)
+
+
+class ProviderSafeUnionMixin:
+    """Make a model emit a provider-safe JSON schema by construction.
+
+    A model containing a Pydantic discriminated union serializes to JSON Schema
+    with ``oneOf`` + ``discriminator``, which strict structured-output endpoints
+    reject (the Sentry ``PYTHON-FASTAPI-9J`` incident). Mixing this in folds
+    ``oneOf`` into ``anyOf`` (and drops ``discriminator``) at the model boundary,
+    so every caller of ``model_json_schema()`` — litellm, instructor, our own
+    path — gets a provider-safe schema **unconditionally**, without depending on
+    a provider-detection gate (e.g. ``litellm.supports_response_schema``, which
+    under-reports some providers). Only the JSON (wire) schema is rewritten; the
+    core validation schema keeps the discriminator, so keyed dispatch and precise
+    per-variant errors are preserved.
+    """
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        schema = handler(core_schema)
+        _fold_oneof_to_anyof(schema)
+        return schema
 
 
 def is_pydantic_model(response_format: Any) -> bool:

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import os
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
@@ -65,6 +65,15 @@ def _fold_oneof_to_anyof(node: Any) -> None:
     Pydantic still enforces the discriminator after parse, so semantics are
     preserved.
 
+    This is a BLIND walk: it treats any dict key named ``oneOf``/``discriminator``
+    as a schema keyword, so it must NOT be used where a model field could be
+    literally named ``oneOf``/``discriminator`` (it would strip the property).
+    That is fine for ``ProviderSafeUnionMixin``'s use on real output models;
+    ``make_strict_json_schema`` instead folds inline within a structure-aware
+    traversal precisely to avoid this. Precondition: ``node`` is a finite acyclic
+    tree, as produced by ``model_json_schema()`` (which expresses recursion via
+    ``$ref``/``$defs`` strings, never in-memory cycles) — there is no cycle guard.
+
     Args:
         node (Any): A JSON-schema fragment (dict, list, or scalar); mutated in place.
     """
@@ -80,7 +89,14 @@ def _fold_oneof_to_anyof(node: Any) -> None:
             _fold_oneof_to_anyof(item)
 
 
-class ProviderSafeUnionMixin:
+# Statically the mixin must appear to derive from ``BaseModel`` so the ``super()``
+# call below type-checks; at runtime it is a bare mixin (``object`` base), and
+# ``super()`` resolves to ``BaseModel.__get_pydantic_json_schema__`` via the MRO
+# of the concrete model (e.g. ``class X(ProviderSafeUnionMixin, BaseModel)``).
+_ProviderSafeUnionBase = BaseModel if TYPE_CHECKING else object
+
+
+class ProviderSafeUnionMixin(_ProviderSafeUnionBase):
     """Make a model emit a provider-safe JSON schema by construction.
 
     A model containing a Pydantic discriminated union serializes to JSON Schema
@@ -99,7 +115,10 @@ class ProviderSafeUnionMixin:
     def __get_pydantic_json_schema__(
         cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
-        schema = handler(core_schema)
+        # Chain via super() (not handler() directly) so a cooperative base that
+        # also customizes __get_pydantic_json_schema__ is not silently shadowed;
+        # BaseModel's default impl just invokes handler(core_schema).
+        schema = super().__get_pydantic_json_schema__(core_schema, handler)
         _fold_oneof_to_anyof(schema)
         return schema
 
@@ -139,10 +158,12 @@ def make_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
             node.pop(keyword, None)
 
         # Strict structured output (OpenAI) permits ``anyOf`` but rejects
-        # ``oneOf`` and ``discriminator``. Pydantic emits ``oneOf`` for
-        # discriminated unions; fold it into ``anyOf`` so generation is
-        # constrained to the same variants. Pydantic still enforces the
-        # discriminator after parse, so semantics are preserved.
+        # ``oneOf`` and ``discriminator``. Folded INLINE here (deliberately NOT
+        # via the shared ``_fold_oneof_to_anyof`` helper): this traversal is
+        # schema-structure-aware and only treats ``oneOf``/``discriminator`` as
+        # keywords at schema nodes, whereas the helper is a blind walk that would
+        # also strip a *property literally named* ``oneOf`` (see its docstring).
+        # Keep the two separate; they have different traversal contracts.
         one_of = node.pop("oneOf", None)
         node.pop("discriminator", None)
         if isinstance(one_of, list):

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -202,17 +202,18 @@ ConsolidationDecision = Annotated[
 ]
 
 
+# ``PlaybookConsolidationOutput`` mixes in ``ProviderSafeUnionMixin`` so the
+# emitted JSON schema is folded into the provider-accepted union shape while the
+# discriminator is kept for keyed validation at parse time (Sentry
+# PYTHON-FASTAPI-9J). This note is a comment, NOT part of the docstring, because
+# the docstring is serialized into the wire schema's ``description`` sent to the
+# model — keep implementation tokens out of it.
 class PlaybookConsolidationOutput(ProviderSafeUnionMixin, BaseModel):
-    """Output schema for playbook consolidation as a 4-kind discriminated union.
+    """Output schema for playbook consolidation as a 4-kind tagged union.
 
     Each decision is one of ``UnifyDecision``, ``RejectNewDecision``,
-    ``DifferentiateDecision``, or ``IndependentDecision``; the ``kind`` literal
+    ``DifferentiateDecision``, or ``IndependentDecision``; the ``kind`` field
     selects the concrete shape.
-
-    ``ProviderSafeUnionMixin`` folds the discriminated union's ``oneOf`` into
-    ``anyOf`` in the emitted JSON schema so strict structured-output providers
-    accept it, while keeping the discriminator's keyed validation at parse time
-    (see Sentry ``PYTHON-FASTAPI-9J``).
     """
 
     decisions: list[ConsolidationDecision] = Field(default_factory=list)

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -19,6 +19,7 @@ from reflexio.models.config_schema import (
 )
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.llm_utils import ProviderSafeUnionMixin
 from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
@@ -201,12 +202,17 @@ ConsolidationDecision = Annotated[
 ]
 
 
-class PlaybookConsolidationOutput(BaseModel):
+class PlaybookConsolidationOutput(ProviderSafeUnionMixin, BaseModel):
     """Output schema for playbook consolidation as a 4-kind discriminated union.
 
     Each decision is one of ``UnifyDecision``, ``RejectNewDecision``,
     ``DifferentiateDecision``, or ``IndependentDecision``; the ``kind`` literal
     selects the concrete shape.
+
+    ``ProviderSafeUnionMixin`` folds the discriminated union's ``oneOf`` into
+    ``anyOf`` in the emitted JSON schema so strict structured-output providers
+    accept it, while keeping the discriminator's keyed validation at parse time
+    (see Sentry ``PYTHON-FASTAPI-9J``).
     """
 
     decisions: list[ConsolidationDecision] = Field(default_factory=list)

--- a/tests/server/services/playbook/test_consolidation_output.py
+++ b/tests/server/services/playbook/test_consolidation_output.py
@@ -7,6 +7,8 @@ These tests pin down the shape of the consolidation LLM output schema after the
 longer parse — that structural guarantee is what the new schema buys.
 """
 
+import json
+
 import pytest
 from pydantic import ValidationError
 
@@ -18,6 +20,46 @@ from reflexio.server.services.playbook.playbook_consolidator import (
     RejectNewDecision,
     UnifyDecision,
 )
+
+
+def test_output_json_schema_is_provider_safe_by_construction():
+    """``model_json_schema()`` emits no ``oneOf``/``discriminator`` natively.
+
+    Option C (``ProviderSafeUnionMixin``): the discriminated union is folded to
+    ``anyOf`` at the model boundary, so the emitted JSON schema is accepted by
+    strict structured-output providers WITHOUT ``make_strict_json_schema`` and
+    WITHOUT any provider-detection gate (the gap that caused Sentry
+    ``PYTHON-FASTAPI-9J``). Asserting on the raw schema proves the property is
+    intrinsic to the model, not bolted on by a downstream normalizer.
+    """
+    raw = json.dumps(PlaybookConsolidationOutput.model_json_schema())
+    assert '"oneOf"' not in raw
+    assert '"discriminator"' not in raw
+    # The four variants survive as an ``anyOf`` branch (generation stays
+    # constrained to exactly those shapes).
+    assert '"anyOf"' in raw
+
+
+def test_provider_safe_schema_keeps_keyed_validation_errors():
+    """Folding the wire schema must NOT weaken validation.
+
+    The discriminator stays in the core (validation) schema, so a malformed
+    ``unify`` payload yields a single, pinpointed error at the ``unify``
+    variant's missing field — not the noisy multi-error spray a plain
+    (non-discriminated) union produces. This precise-error property is Option
+    C's advantage over flattening the union (Option B).
+    """
+    with pytest.raises(ValidationError) as exc_info:
+        PlaybookConsolidationOutput.model_validate(
+            {
+                "decisions": [{"kind": "unify", "new_id": "NEW-0"}]
+            }  # missing content/trigger/rationale
+        )
+    errors = exc_info.value.errors()
+    # Keyed dispatch routed validation to the ``unify`` variant only.
+    assert all("unify" in err["loc"] for err in errors)
+    # And the reported failure is the missing required field, not a union mismatch.
+    assert any(err["type"] == "missing" and "content" in err["loc"] for err in errors)
 
 
 def test_decision_kinds_are_discriminated_union():

--- a/tests/server/services/playbook/test_consolidation_output.py
+++ b/tests/server/services/playbook/test_consolidation_output.py
@@ -33,8 +33,11 @@ def test_output_json_schema_is_provider_safe_by_construction():
     intrinsic to the model, not bolted on by a downstream normalizer.
     """
     raw = json.dumps(PlaybookConsolidationOutput.model_json_schema())
-    assert '"oneOf"' not in raw
-    assert '"discriminator"' not in raw
+    # Bare-word (not just the ``"oneOf":`` JSON-key form) so a docstring/
+    # description leak of these tokens into the wire schema is also caught —
+    # the whole point is to keep them out of what ships to the provider.
+    assert "oneOf" not in raw
+    assert "discriminator" not in raw
     # The four variants survive as an ``anyOf`` branch (generation stays
     # constrained to exactly those shapes).
     assert '"anyOf"' in raw


### PR DESCRIPTION
## What

Make discriminated-union LLM output schemas **provider-safe by construction** — implements **Option C** from the design doc.

A Pydantic discriminated union (`Field(discriminator="kind")`) serializes to JSON Schema as `oneOf` + `discriminator`, which strict structured-output endpoints (OpenAI, minimax) reject with a 400. This is the root cause of Sentry **PYTHON-FASTAPI-9J**.

The shipped fix (#204) folds `oneOf` → `anyOf` inside `make_strict_json_schema`, **but only behind a provider gate** (`litellm.supports_response_schema` + an allowlist). That gate is exactly what failed in 9J (minimax under-reported `supports_response_schema=False`), and it leaves a standing dependency: the next under-reported provider re-breaks the same way.

## How

- `ProviderSafeUnionMixin` (in `server/llm/llm_utils.py`) overrides `__get_pydantic_json_schema__` to fold `oneOf` → `anyOf` and drop `discriminator` **at the model boundary**, via the shared `_fold_oneof_to_anyof` helper. Every caller of `model_json_schema()` — litellm, instructor, our own path — now gets a provider-safe schema **unconditionally**, with no dependency on provider detection.
- Applied to `PlaybookConsolidationOutput` (verified **internal-only** — not in the client, API schemas, or public docs).
- Only the **JSON (wire)** schema is rewritten; the **core (validation)** schema keeps the discriminator, so keyed dispatch and precise per-variant errors are preserved.

This is additive defense-in-depth — it does **not** remove #204's gate/normalizer (that path still handles strict-mode field stripping); it makes the oneOf-rejection class impossible at the source.

## Tests

`tests/server/services/playbook/test_consolidation_output.py`:
- `test_output_json_schema_is_provider_safe_by_construction` — `model_json_schema()` natively has no `oneOf`/`discriminator` (and keeps `anyOf`), with **no** `make_strict` and **no** provider gate.
- `test_provider_safe_schema_keeps_keyed_validation_errors` — a malformed `unify` payload still yields a single pinpointed error at the missing field (Option C's advantage over flattening the union).

Verified locally: ruff (lint+format) clean, pyright 0 errors, full consolidation-output suite (28) + mock-schema-compliance + litellm-unit (226 passed, 2 skipped) green.

## Design doc

`reflexio-enterprise` → `docs/superpowers/specs/2026-06-23-structured-output-provider-safe-schema-design.md` (PR #379), which covers Options A/B/C, the OpenAI `anyOf` first-key caveat, and the spike results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON schema compatibility with external API providers by adjusting union type representation.
  * Enhanced validation error messages to provide clearer feedback on union variant validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->