### PR TITLE
feat(llm): unified provider-safe base for all structured-output models

### DIFF
--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -12,6 +12,7 @@ from typing import Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from reflexio.models.api_schema.validators import NonEmptyStr
+from reflexio.models.structured_output import StrictStructuredOutput
 
 HeroStateLiteral = Literal["full", "early", "shadow_off", "empty"]
 BucketLiteral = Literal["day", "week"]
@@ -428,7 +429,7 @@ class GradeOnDemandResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class ShadowComparisonOutput(BaseModel):
+class ShadowComparisonOutput(StrictStructuredOutput):
     """LLM judge verdict for a per-turn Reflexio-vs-Shadow comparison (F1).
 
     Args:

--- a/reflexio/models/structured_output.py
+++ b/reflexio/models/structured_output.py
@@ -1,0 +1,109 @@
+"""Provider-safe base class for LLM structured-output Pydantic models.
+
+Every Pydantic model sent to an LLM as a structured-output schema (a
+``response_format`` or a tool's parameter schema) should inherit
+``StrictStructuredOutput``. It carries a ``__get_pydantic_json_schema__`` hook
+(via ``ProviderSafeUnionMixin``) that folds a discriminated union's ``oneOf`` into
+``anyOf`` and drops ``discriminator`` in the *emitted* JSON schema, so strict
+structured-output endpoints (OpenAI, minimax) accept it **by construction** — with
+no provider-detection gate and no post-processing. Only the wire schema is
+rewritten; the core (validation) schema keeps the discriminator, so keyed dispatch
+and precise per-variant errors are preserved.
+
+This module lives under ``models/`` (depending only on pydantic) so both
+``models/api_schema/`` schemas and ``server/services/*`` models can inherit the
+base without a layering inversion (a ``models/`` file importing from
+``server/llm/`` would invert the dependency direction).
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema
+
+
+def _fold_oneof_to_anyof(node: Any) -> None:
+    """Rewrite ``oneOf`` to ``anyOf`` and drop ``discriminator`` in place (recursive).
+
+    Pydantic emits ``oneOf`` + ``discriminator`` for a discriminated union, which
+    strict structured-output endpoints (OpenAI, minimax) reject. Folding into
+    ``anyOf`` keeps the identical variant set so generation stays constrained;
+    Pydantic still enforces the discriminator after parse, so semantics are
+    preserved.
+
+    This is a BLIND walk: it treats any dict key named ``oneOf``/``discriminator``
+    as a schema keyword, so it must NOT be used where a model field could be
+    literally named ``oneOf``/``discriminator`` (it would strip the property).
+    That is fine for ``ProviderSafeUnionMixin``'s use on real output models;
+    ``make_strict_json_schema`` instead folds inline within a structure-aware
+    traversal precisely to avoid this. Precondition: ``node`` is a finite acyclic
+    tree, as produced by ``model_json_schema()`` (which expresses recursion via
+    ``$ref``/``$defs`` strings, never in-memory cycles) — there is no cycle guard.
+
+    Args:
+        node (Any): A JSON-schema fragment (dict, list, or scalar); mutated in place.
+    """
+    if isinstance(node, dict):
+        one_of = node.pop("oneOf", None)
+        node.pop("discriminator", None)
+        if isinstance(one_of, list):
+            node["anyOf"] = node.get("anyOf", []) + one_of
+        for value in node.values():
+            _fold_oneof_to_anyof(value)
+    elif isinstance(node, list):
+        for item in node:
+            _fold_oneof_to_anyof(item)
+
+
+# Statically the mixin must appear to derive from ``BaseModel`` so the ``super()``
+# call below type-checks; at runtime it is a bare mixin (``object`` base), and
+# ``super()`` resolves to ``BaseModel.__get_pydantic_json_schema__`` via the MRO
+# of the concrete model (e.g. ``class X(ProviderSafeUnionMixin, BaseModel)``).
+_ProviderSafeUnionBase = BaseModel if TYPE_CHECKING else object
+
+
+class ProviderSafeUnionMixin(_ProviderSafeUnionBase):
+    """Make a model emit a provider-safe JSON schema by construction.
+
+    A model containing a Pydantic discriminated union serializes to JSON Schema
+    with ``oneOf`` + ``discriminator``, which strict structured-output endpoints
+    reject (the Sentry ``PYTHON-FASTAPI-9J`` incident). Mixing this in folds
+    ``oneOf`` into ``anyOf`` (and drops ``discriminator``) at the model boundary,
+    so every caller of ``model_json_schema()`` — litellm, instructor, our own
+    path — gets a provider-safe schema **unconditionally**, without depending on
+    a provider-detection gate (e.g. ``litellm.supports_response_schema``, which
+    under-reports some providers). Only the JSON (wire) schema is rewritten; the
+    core validation schema keeps the discriminator, so keyed dispatch and precise
+    per-variant errors are preserved.
+
+    Prefer inheriting ``StrictStructuredOutput`` (below) on output models rather
+    than mixing this in directly.
+    """
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        # Chain via super() (not handler() directly) so a cooperative base that
+        # also customizes __get_pydantic_json_schema__ is not silently shadowed;
+        # BaseModel's default impl just invokes handler(core_schema).
+        schema = super().__get_pydantic_json_schema__(core_schema, handler)
+        _fold_oneof_to_anyof(schema)
+        return schema
+
+
+class StrictStructuredOutput(ProviderSafeUnionMixin, BaseModel):
+    """Base for every Pydantic model sent to an LLM as a structured-output schema.
+
+    Inherits the provider-safe schema hook from ``ProviderSafeUnionMixin`` so the
+    emitted JSON schema folds any discriminated union (``oneOf``→``anyOf``, drop
+    ``discriminator``) by construction — accepted by strict structured-output
+    providers with no provider gate, including any *future* discriminated union.
+
+    Deliberately adds NO ``model_config``: each model keeps its own ``extra=`` and
+    ``json_schema_extra`` exactly as before. This base unifies the *provider-safety
+    guarantee*, not the per-model config (centralizing config is a separate change —
+    ``extra=`` is not uniform across models, so a blanket dedup would silently shift
+    validation/serialization behavior).
+    """

--- a/reflexio/models/structured_output.py
+++ b/reflexio/models/structured_output.py
@@ -107,3 +107,40 @@ class StrictStructuredOutput(ProviderSafeUnionMixin, BaseModel):
     ``extra=`` is not uniform across models, so a blanket dedup would silently shift
     validation/serialization behavior).
     """
+
+
+# Keys whose *values* are name→subschema maps: their entries are user-chosen names
+# (field names, $def names), not JSON-Schema keywords. We recurse into the
+# subschemas but must not treat the names themselves as keyword matches — otherwise
+# a model with a field literally named ``oneOf`` would false-positive.
+_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
+
+
+def find_schema_keyword(node: Any, keyword: str) -> bool:
+    """Report whether ``keyword`` appears as a JSON-Schema *keyword* anywhere in ``node``.
+
+    Structure-aware: an occurrence of ``keyword`` as a property/``$defs`` *name*
+    (e.g. a model field literally named ``oneOf``) is NOT a match — only an
+    occurrence in JSON-Schema keyword position counts. Use this (not a blind
+    ``in``-walk) to check a schema for provider-unsafe keywords.
+
+    Args:
+        node (Any): A JSON-schema fragment (dict, list, or scalar).
+        keyword (str): The JSON-Schema keyword to search for (e.g. ``"oneOf"``).
+
+    Returns:
+        bool: True if ``keyword`` appears in keyword position, else False.
+    """
+    if isinstance(node, dict):
+        if keyword in node:
+            return True
+        for key, value in node.items():
+            if key in _SCHEMA_NAME_MAP_KEYS and isinstance(value, dict):
+                if any(find_schema_keyword(sub, keyword) for sub in value.values()):
+                    return True
+            elif find_schema_keyword(value, keyword):
+                return True
+        return False
+    if isinstance(node, list):
+        return any(find_schema_keyword(item, keyword) for item in node)
+    return False

--- a/reflexio/models/structured_output.py
+++ b/reflexio/models/structured_output.py
@@ -22,6 +22,12 @@ from pydantic import BaseModel, GetJsonSchemaHandler
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
 
+# Keys whose *values* are name→subschema maps: their entries are user-chosen names
+# (field names, $def names), not JSON-Schema keywords. Traversals must recurse into
+# the subschemas but never treat the names themselves as keywords — otherwise a
+# model with a field literally named ``oneOf`` would be mishandled.
+_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
+
 
 def _fold_oneof_to_anyof(node: Any) -> None:
     """Rewrite ``oneOf`` to ``anyOf`` and drop ``discriminator`` in place (recursive).
@@ -32,14 +38,13 @@ def _fold_oneof_to_anyof(node: Any) -> None:
     Pydantic still enforces the discriminator after parse, so semantics are
     preserved.
 
-    This is a BLIND walk: it treats any dict key named ``oneOf``/``discriminator``
-    as a schema keyword, so it must NOT be used where a model field could be
-    literally named ``oneOf``/``discriminator`` (it would strip the property).
-    That is fine for ``ProviderSafeUnionMixin``'s use on real output models;
-    ``make_strict_json_schema`` instead folds inline within a structure-aware
-    traversal precisely to avoid this. Precondition: ``node`` is a finite acyclic
-    tree, as produced by ``model_json_schema()`` (which expresses recursion via
-    ``$ref``/``$defs`` strings, never in-memory cycles) — there is no cycle guard.
+    Structure-aware: under a name→subschema map (``properties``/``$defs``/…) it
+    recurses into the subschemas but does NOT treat a property/``$def`` *name* as a
+    keyword — so a model field literally named ``oneOf``/``discriminator`` is
+    preserved (only keyword-position occurrences are folded). Precondition:
+    ``node`` is a finite acyclic tree, as produced by ``model_json_schema()``
+    (which expresses recursion via ``$ref``/``$defs`` strings, never in-memory
+    cycles) — there is no cycle guard.
 
     Args:
         node (Any): A JSON-schema fragment (dict, list, or scalar); mutated in place.
@@ -49,8 +54,12 @@ def _fold_oneof_to_anyof(node: Any) -> None:
         node.pop("discriminator", None)
         if isinstance(one_of, list):
             node["anyOf"] = node.get("anyOf", []) + one_of
-        for value in node.values():
-            _fold_oneof_to_anyof(value)
+        for key, value in node.items():
+            if key in _SCHEMA_NAME_MAP_KEYS and isinstance(value, dict):
+                for sub in value.values():
+                    _fold_oneof_to_anyof(sub)
+            else:
+                _fold_oneof_to_anyof(value)
     elif isinstance(node, list):
         for item in node:
             _fold_oneof_to_anyof(item)
@@ -107,13 +116,6 @@ class StrictStructuredOutput(ProviderSafeUnionMixin, BaseModel):
     ``extra=`` is not uniform across models, so a blanket dedup would silently shift
     validation/serialization behavior).
     """
-
-
-# Keys whose *values* are name→subschema maps: their entries are user-chosen names
-# (field names, $def names), not JSON-Schema keywords. We recurse into the
-# subschemas but must not treat the names themselves as keyword matches — otherwise
-# a model with a field literally named ``oneOf`` would false-positive.
-_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
 
 
 def find_schema_keyword(node: Any, keyword: str) -> bool:

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -1134,21 +1134,19 @@ class LiteLLMClient:
         behavior.
         """
 
-        # Boundary guard: assert the model's native schema is provider-safe
-        # regardless of which path it takes below. Models inheriting
-        # StrictStructuredOutput are safe by construction; this catches a model
-        # that forgot the base (raises under tests, warns in prod).
-        if is_pydantic_model(response_format):
-            assert_provider_safe_schema(
-                response_format.model_json_schema(), name=response_format.__name__
-            )
+        if not is_pydantic_model(response_format):
+            return response_format
 
-        if (
-            strict_response_format
-            and is_pydantic_model(response_format)
-            and self._accepts_json_schema_response_format(model)
-        ):
-            return strict_response_format_for_model(response_format)
+        # Build the native schema once and reuse it for both the boundary guard and
+        # (when applicable) the strict normalizer, avoiding a second schema build.
+        # Boundary guard: models inheriting StrictStructuredOutput are safe by
+        # construction; this catches a model that forgot the base (raises under
+        # tests, warns in prod) regardless of which path is taken below.
+        schema = response_format.model_json_schema()
+        assert_provider_safe_schema(schema, name=response_format.__name__)
+
+        if strict_response_format and self._accepts_json_schema_response_format(model):
+            return strict_response_format_for_model(response_format, schema=schema)
         return response_format
 
     def _compute_cost_usd(self, response: Any, model: str | None) -> float | None:

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -31,6 +31,7 @@ from reflexio.server.llm.image_utils import (
     encode_image_to_base64 as _encode_image_to_base64,
 )
 from reflexio.server.llm.llm_utils import (
+    assert_provider_safe_schema,
     is_pydantic_model,
     strict_response_format_for_model,
 )
@@ -1132,6 +1133,15 @@ class LiteLLMClient:
         unsupported providers keep the existing Pydantic response_format
         behavior.
         """
+
+        # Boundary guard: assert the model's native schema is provider-safe
+        # regardless of which path it takes below. Models inheriting
+        # StrictStructuredOutput are safe by construction; this catches a model
+        # that forgot the base (raises under tests, warns in prod).
+        if is_pydantic_model(response_format):
+            assert_provider_safe_schema(
+                response_format.model_json_schema(), name=response_format.__name__
+            )
 
         if (
             strict_response_format

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import os
+import sys
 from copy import deepcopy
 from typing import Any
 
@@ -97,12 +98,12 @@ def make_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
             node.pop(keyword, None)
 
         # Strict structured output (OpenAI) permits ``anyOf`` but rejects
-        # ``oneOf`` and ``discriminator``. Folded INLINE here (deliberately NOT
-        # via the shared ``_fold_oneof_to_anyof`` helper): this traversal is
-        # schema-structure-aware and only treats ``oneOf``/``discriminator`` as
-        # keywords at schema nodes, whereas the helper is a blind walk that would
-        # also strip a *property literally named* ``oneOf`` (see its docstring).
-        # Keep the two separate; they have different traversal contracts.
+        # ``oneOf`` and ``discriminator``. Folded inline here, fused into this
+        # single structure-aware pass (the shared ``_fold_oneof_to_anyof`` helper
+        # does the same fold for the model-boundary hook; kept inline here to
+        # avoid a second full-tree walk). ``visit`` only ever recurses into
+        # property/$def *values*, never the name maps, so a field literally named
+        # ``oneOf`` is preserved — same contract as the helper.
         one_of = node.pop("oneOf", None)
         node.pop("discriminator", None)
         if isinstance(one_of, list):
@@ -147,9 +148,16 @@ def assert_provider_safe_schema(schema: dict[str, Any], *, name: str = "") -> No
     forgot the base, or a tool-argument / dynamically-built schema not covered by
     the registry contract test.
 
-    Under tests it RAISES so a regression fails CI loudly; otherwise it logs a
-    warning and returns, so a miss degrades to existing behavior rather than a
-    request failure (the strict path's ``make_strict_json_schema`` still folds it).
+    Enforcement: under pytest (``"pytest" in sys.modules``) it RAISES so a
+    regression fails CI loudly — including at import/collection time, which a
+    per-test signal like ``PYTEST_CURRENT_TEST`` would miss. In prod it logs a
+    warning (observability) and returns; it does NOT mutate what is sent. So a
+    forgot-the-base model is meant to be caught **pre-merge** (by this raise plus
+    the registry contract test), not auto-repaired at runtime: on the strict /
+    allowlisted path ``make_strict_json_schema`` independently folds the schema,
+    but on the raw passthrough path the warning is the only signal and an unfolded
+    ``oneOf`` would still reach the provider. Keep every output model on
+    ``StrictStructuredOutput``.
 
     Args:
         schema (dict[str, Any]): The emitted JSON schema to check.
@@ -166,19 +174,29 @@ def assert_provider_safe_schema(schema: dict[str, Any], *, name: str = "") -> No
         "StrictStructuredOutput so the schema folds oneOf->anyOf by construction "
         "(Sentry PYTHON-FASTAPI-9J)."
     )
-    if os.environ.get("PYTEST_CURRENT_TEST"):
+    if "pytest" in sys.modules:
         raise ValueError(msg)
     logger.warning(msg)
 
 
-def strict_response_format_for_model(model: type[BaseModel]) -> dict[str, Any]:
-    """Build a LiteLLM/OpenAI-compatible strict ``json_schema`` response format."""
+def strict_response_format_for_model(
+    model: type[BaseModel], schema: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Build a LiteLLM/OpenAI-compatible strict ``json_schema`` response format.
+
+    Args:
+        model: The Pydantic model (supplies the schema ``name``).
+        schema: Optional pre-built ``model.model_json_schema()`` to reuse, avoiding
+            a second schema build when the caller already has one.
+    """
 
     return {
         "type": "json_schema",
         "json_schema": {
             "name": model.__name__,
-            "schema": make_strict_json_schema(model.model_json_schema()),
+            "schema": make_strict_json_schema(
+                schema if schema is not None else model.model_json_schema()
+            ),
             "strict": True,
         },
     }

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -6,6 +6,14 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from reflexio.models.structured_output import find_schema_keyword
+
+logger = logging.getLogger(__name__)
+
+# JSON-Schema keywords that strict structured-output endpoints (OpenAI, minimax)
+# reject; see PYTHON-FASTAPI-9J.
+PROVIDER_UNSAFE_KEYWORDS = ("oneOf", "discriminator")
+
 
 def positive_int_env(name: str, default: int, logger: logging.Logger) -> int:
     """Resolve a strictly-positive int from environment variable ``name``.
@@ -127,6 +135,40 @@ def make_strict_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
 
     visit(strict_schema)
     return strict_schema
+
+
+def assert_provider_safe_schema(schema: dict[str, Any], *, name: str = "") -> None:
+    """Enforce that an emitted structured-output schema is provider-safe.
+
+    Strict structured-output endpoints (OpenAI, minimax) reject ``oneOf`` /
+    ``discriminator`` (Sentry PYTHON-FASTAPI-9J). Models that inherit
+    ``StrictStructuredOutput`` are safe by construction; this is the runtime net
+    at the call boundary for anything that bypasses that guarantee — a model that
+    forgot the base, or a tool-argument / dynamically-built schema not covered by
+    the registry contract test.
+
+    Under tests it RAISES so a regression fails CI loudly; otherwise it logs a
+    warning and returns, so a miss degrades to existing behavior rather than a
+    request failure (the strict path's ``make_strict_json_schema`` still folds it).
+
+    Args:
+        schema (dict[str, Any]): The emitted JSON schema to check.
+        name (str): Identifier for the schema's source, used in the message.
+    """
+    offenders = [
+        kw for kw in PROVIDER_UNSAFE_KEYWORDS if find_schema_keyword(schema, kw)
+    ]
+    if not offenders:
+        return
+    msg = (
+        f"Structured-output schema {name or '<unnamed>'!r} contains provider-unsafe "
+        f"keyword(s) {offenders}; strict providers reject these. Inherit "
+        "StrictStructuredOutput so the schema folds oneOf->anyOf by construction "
+        "(Sentry PYTHON-FASTAPI-9J)."
+    )
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        raise ValueError(msg)
+    logger.warning(msg)
 
 
 def strict_response_format_for_model(model: type[BaseModel]) -> dict[str, Any]:

--- a/reflexio/server/llm/llm_utils.py
+++ b/reflexio/server/llm/llm_utils.py
@@ -2,11 +2,9 @@ import inspect
 import logging
 import os
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-from pydantic import BaseModel, GetJsonSchemaHandler
-from pydantic.json_schema import JsonSchemaValue
-from pydantic_core import CoreSchema
+from pydantic import BaseModel
 
 
 def positive_int_env(name: str, default: int, logger: logging.Logger) -> int:
@@ -54,73 +52,6 @@ _STRICT_SCHEMA_UNSUPPORTED_KEYWORDS = frozenset(
         "uniqueItems",
     }
 )
-
-
-def _fold_oneof_to_anyof(node: Any) -> None:
-    """Rewrite ``oneOf`` to ``anyOf`` and drop ``discriminator`` in place (recursive).
-
-    Pydantic emits ``oneOf`` + ``discriminator`` for a discriminated union, which
-    strict structured-output endpoints (OpenAI, minimax) reject. Folding into
-    ``anyOf`` keeps the identical variant set so generation stays constrained;
-    Pydantic still enforces the discriminator after parse, so semantics are
-    preserved.
-
-    This is a BLIND walk: it treats any dict key named ``oneOf``/``discriminator``
-    as a schema keyword, so it must NOT be used where a model field could be
-    literally named ``oneOf``/``discriminator`` (it would strip the property).
-    That is fine for ``ProviderSafeUnionMixin``'s use on real output models;
-    ``make_strict_json_schema`` instead folds inline within a structure-aware
-    traversal precisely to avoid this. Precondition: ``node`` is a finite acyclic
-    tree, as produced by ``model_json_schema()`` (which expresses recursion via
-    ``$ref``/``$defs`` strings, never in-memory cycles) — there is no cycle guard.
-
-    Args:
-        node (Any): A JSON-schema fragment (dict, list, or scalar); mutated in place.
-    """
-    if isinstance(node, dict):
-        one_of = node.pop("oneOf", None)
-        node.pop("discriminator", None)
-        if isinstance(one_of, list):
-            node["anyOf"] = node.get("anyOf", []) + one_of
-        for value in node.values():
-            _fold_oneof_to_anyof(value)
-    elif isinstance(node, list):
-        for item in node:
-            _fold_oneof_to_anyof(item)
-
-
-# Statically the mixin must appear to derive from ``BaseModel`` so the ``super()``
-# call below type-checks; at runtime it is a bare mixin (``object`` base), and
-# ``super()`` resolves to ``BaseModel.__get_pydantic_json_schema__`` via the MRO
-# of the concrete model (e.g. ``class X(ProviderSafeUnionMixin, BaseModel)``).
-_ProviderSafeUnionBase = BaseModel if TYPE_CHECKING else object
-
-
-class ProviderSafeUnionMixin(_ProviderSafeUnionBase):
-    """Make a model emit a provider-safe JSON schema by construction.
-
-    A model containing a Pydantic discriminated union serializes to JSON Schema
-    with ``oneOf`` + ``discriminator``, which strict structured-output endpoints
-    reject (the Sentry ``PYTHON-FASTAPI-9J`` incident). Mixing this in folds
-    ``oneOf`` into ``anyOf`` (and drops ``discriminator``) at the model boundary,
-    so every caller of ``model_json_schema()`` — litellm, instructor, our own
-    path — gets a provider-safe schema **unconditionally**, without depending on
-    a provider-detection gate (e.g. ``litellm.supports_response_schema``, which
-    under-reports some providers). Only the JSON (wire) schema is rewritten; the
-    core validation schema keeps the discriminator, so keyed dispatch and precise
-    per-variant errors are preserved.
-    """
-
-    @classmethod
-    def __get_pydantic_json_schema__(
-        cls, core_schema: CoreSchema, handler: GetJsonSchemaHandler
-    ) -> JsonSchemaValue:
-        # Chain via super() (not handler() directly) so a cooperative base that
-        # also customizes __get_pydantic_json_schema__ is not silently shadowed;
-        # BaseModel's default impl just invokes handler(core_schema).
-        schema = super().__get_pydantic_json_schema__(core_schema, handler)
-        _fold_oneof_to_anyof(schema)
-        return schema
 
 
 def is_pydantic_model(response_format: Any) -> bool:

--- a/reflexio/server/llm/tools.py
+++ b/reflexio/server/llm/tools.py
@@ -13,7 +13,10 @@ logger = logging.getLogger(__name__)
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
-from reflexio.server.llm.llm_utils import make_strict_json_schema
+from reflexio.server.llm.llm_utils import (
+    assert_provider_safe_schema,
+    make_strict_json_schema,
+)
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 
 if TYPE_CHECKING:
@@ -72,6 +75,11 @@ class Tool(BaseModel):
 
     def openai_spec(self) -> dict:
         parameters = self.args_model.model_json_schema()
+        # Boundary guard: tool-arg schemas bypass the response_format path and the
+        # registry contract test, so enforce provider-safety here too (raises under
+        # tests, warns in prod). Checked on the native schema to catch a model that
+        # forgot StrictStructuredOutput even when ``strict`` would later fold it.
+        assert_provider_safe_schema(parameters, name=self.args_model.__name__)
         if self.strict:
             parameters = make_strict_json_schema(parameters)
         return {

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_constants.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_constants.py
@@ -3,7 +3,9 @@
 from dataclasses import dataclass
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from reflexio.models.structured_output import StrictStructuredOutput
 
 
 @dataclass(frozen=True)
@@ -14,7 +16,7 @@ class AgentSuccessEvaluationConstants:
     AGENT_SUCCESS_EVALUATION_PROMPT_ID = "agent_success_evaluation"
 
 
-class AgentSuccessEvaluationOutput(BaseModel):
+class AgentSuccessEvaluationOutput(StrictStructuredOutput):
     """
     Unified output schema for agent success evaluation.
 

--- a/reflexio/server/services/extraction/pending_tool_call_dispatch.py
+++ b/reflexio/server/services/extraction/pending_tool_call_dispatch.py
@@ -11,6 +11,7 @@ from typing import Annotated, Any
 from pydantic import BaseModel, Field, field_validator
 
 from reflexio.models.config_schema import PendingToolCallConfig
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.llm.tools import (
     AsyncAccepted,
     AsyncInfoTool,
@@ -31,7 +32,7 @@ from reflexio.server.usage_metrics import record_usage_event
 logger = logging.getLogger(__name__)
 
 
-class AskHumanArgs(BaseModel):
+class AskHumanArgs(StrictStructuredOutput):
     """Ask Agent Builder for missing extraction information and continue now."""
 
     question: Annotated[str, Field(min_length=1)]
@@ -46,7 +47,7 @@ class AskHumanArgs(BaseModel):
         return value
 
 
-class AttachPendingInfoRequestArgs(BaseModel):
+class AttachPendingInfoRequestArgs(StrictStructuredOutput):
     """Attach this run to a relevant pending Prior Knowledge request."""
 
     pending_tool_call_id: Annotated[str, Field(min_length=1)]

--- a/reflexio/server/services/playbook/playbook_consolidator.py
+++ b/reflexio/server/services/playbook/playbook_consolidator.py
@@ -17,9 +17,9 @@ from reflexio.models.config_schema import (
     DeduplicationConfig,
     SearchOptions,
 )
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
-from reflexio.server.llm.llm_utils import ProviderSafeUnionMixin
 from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
@@ -202,13 +202,13 @@ ConsolidationDecision = Annotated[
 ]
 
 
-# ``PlaybookConsolidationOutput`` mixes in ``ProviderSafeUnionMixin`` so the
+# ``PlaybookConsolidationOutput`` inherits ``StrictStructuredOutput`` so the
 # emitted JSON schema is folded into the provider-accepted union shape while the
 # discriminator is kept for keyed validation at parse time (Sentry
 # PYTHON-FASTAPI-9J). This note is a comment, NOT part of the docstring, because
 # the docstring is serialized into the wire schema's ``description`` sent to the
 # model — keep implementation tokens out of it.
-class PlaybookConsolidationOutput(ProviderSafeUnionMixin, BaseModel):
+class PlaybookConsolidationOutput(StrictStructuredOutput):
     """Output schema for playbook consolidation as a 4-kind tagged union.
 
     Each decision is one of ``UnifyDecision``, ``RejectNewDecision``,

--- a/reflexio/server/services/playbook/playbook_service_utils.py
+++ b/reflexio/server/services/playbook/playbook_service_utils.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from reflexio.models.api_schema.domain.entities import Interaction, UserPlaybook
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.playbook.playbook_service_constants import (
     PlaybookServiceConstants,
@@ -113,7 +114,7 @@ class StructuredPlaybookContent(BaseModel):
         return bool(self.content and self.content.strip())
 
 
-class StructuredPlaybookList(BaseModel):
+class StructuredPlaybookList(StrictStructuredOutput):
     """
     Wrapper schema for extracting zero or more playbook entries in a single LLM call.
 
@@ -134,7 +135,7 @@ class StructuredPlaybookList(BaseModel):
     )
 
 
-class PlaybookAggregationOutput(BaseModel):
+class PlaybookAggregationOutput(StrictStructuredOutput):
     """
     Output schema for the playbook_aggregation prompt.
 

--- a/reflexio/server/services/playbook_optimizer/models.py
+++ b/reflexio/server/services/playbook_optimizer/models.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from reflexio.models.api_schema.domain import Interaction
+from reflexio.models.structured_output import StrictStructuredOutput
 
 
 class ChatMessage(BaseModel):
@@ -58,7 +59,7 @@ class JudgeASI(BaseModel):
     recommended_mutation: str | list[str] = ""
 
 
-class JudgeOutput(BaseModel):
+class JudgeOutput(StrictStructuredOutput):
     verdict: Literal["candidate", "incumbent", "tie"]
     score: float = Field(ge=0.0, le=1.0)
     likert: int = Field(ge=1, le=5)

--- a/reflexio/server/services/profile/profile_deduplicator.py
+++ b/reflexio/server/services/profile/profile_deduplicator.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from reflexio.models.api_schema.retriever_schema import SearchUserProfileRequest
 from reflexio.models.api_schema.service_schemas import Status, UserProfile
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.deduplication_utils import (
@@ -130,7 +131,7 @@ class ProfileDeletionDirective(BaseModel):
     )
 
 
-class ProfileDeduplicationOutput(BaseModel):
+class ProfileDeduplicationOutput(StrictStructuredOutput):
     """
     Output schema for profile deduplication with NEW/EXISTING format.
 

--- a/reflexio/server/services/profile/profile_generation_service_utils.py
+++ b/reflexio/server/services/profile/profile_generation_service_utils.py
@@ -14,6 +14,7 @@ from reflexio.models.api_schema.service_schemas import (
     ProfileTimeToLive,
     UserProfile,
 )
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.service_utils import (
     MessageConstructionConfig,
@@ -102,7 +103,7 @@ class ProfileAddItem(BaseModel):
     )
 
 
-class ProfileUpdateOutput(BaseModel):
+class ProfileUpdateOutput(StrictStructuredOutput):
     """
     Legacy output schema for profile_update_main prompt (kept for backward compatibility).
     Represents the complete set of profile updates including additions, deletions, and mentions.
@@ -133,7 +134,7 @@ class ProfileUpdateOutput(BaseModel):
     )
 
 
-class StructuredProfilesOutput(BaseModel):
+class StructuredProfilesOutput(StrictStructuredOutput):
     """
     Output schema for extraction-only profile extraction.
     Only extracts profiles — no delete/mention operations.

--- a/reflexio/server/services/reflection/reflection_service_utils.py
+++ b/reflexio/server/services/reflection/reflection_service_utils.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive
 from reflexio.models.api_schema.validators import NonEmptyStr
+from reflexio.models.structured_output import StrictStructuredOutput
 
 REFLECTION_OPERATION_NAME = "reflection"
 
@@ -98,7 +99,7 @@ class ReflectionDecision(BaseModel):
     reason: str = ""
 
 
-class ReflectionOutput(BaseModel):
+class ReflectionOutput(StrictStructuredOutput):
     """Structured LLM output for one reflection pass."""
 
     decisions: list[ReflectionDecision] = Field(default_factory=list)

--- a/reflexio/server/services/tagging/tagging_service.py
+++ b/reflexio/server/services/tagging/tagging_service.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import logging
 import os
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
 
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     UserPlaybook,
     UserProfile,
 )
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
@@ -27,7 +28,7 @@ TAGGING_PROMPT_ID = "tagging"
 _TAGGING_FETCH_LIMIT = 1000
 
 
-class TagsOutput(BaseModel):
+class TagsOutput(StrictStructuredOutput):
     tags: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -39,6 +39,7 @@ from contextlib import contextmanager
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+from reflexio.models.structured_output import find_schema_keyword as _find_schema_key
 from reflexio.test_support.llm_model_registry import get_model_registry
 
 
@@ -98,34 +99,6 @@ def _extraction_finish_args(prompt_content: str) -> dict[str, Any]:
     if '"playbooks"' in prompt_content:
         return cast(dict[str, Any], registry["playbook_extraction"].minimal_valid)
     return cast(dict[str, Any], registry["profile_extraction"].minimal_valid)
-
-
-# Keys whose *values* are name→subschema maps: their entries are user-chosen
-# names (field names, $def names), not JSON-Schema keywords. We recurse into the
-# subschemas but must not treat the names themselves as keyword matches —
-# otherwise a model with a field literally named ``oneOf`` would false-positive.
-_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
-
-
-def _find_schema_key(node: Any, key: str) -> bool:
-    """Report whether ``key`` appears as a JSON-Schema *keyword* anywhere in a schema.
-
-    Context-aware: occurrences of ``key`` as a property/``$defs`` *name* are not
-    matches — only occurrences in JSON-Schema keyword position count.
-    """
-    if isinstance(node, dict):
-        if key in node:
-            return True
-        for k, v in node.items():
-            if k in _SCHEMA_NAME_MAP_KEYS and isinstance(v, dict):
-                if any(_find_schema_key(sub, key) for sub in v.values()):
-                    return True
-            elif _find_schema_key(v, key):
-                return True
-        return False
-    if isinstance(node, list):
-        return any(_find_schema_key(v, key) for v in node)
-    return False
 
 
 def _assert_response_format_strict_compatible(kwargs: dict[str, Any]) -> None:

--- a/reflexio/test_support/llm_model_registry.py
+++ b/reflexio/test_support/llm_model_registry.py
@@ -29,6 +29,7 @@ class ModelRegistryEntry:
 
 def _build_registry() -> dict[str, ModelRegistryEntry]:
     """Build the model registry with lazy imports to avoid circular dependencies."""
+    from reflexio.models.api_schema.eval_overview_schema import ShadowComparisonOutput
     from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_constants import (
         AgentSuccessEvaluationOutput,
     )
@@ -39,12 +40,16 @@ def _build_registry() -> dict[str, ModelRegistryEntry]:
         PlaybookAggregationOutput,
         StructuredPlaybookList,
     )
+    from reflexio.server.services.playbook_optimizer.models import JudgeOutput
     from reflexio.server.services.profile.profile_deduplicator import (
         ProfileDeduplicationOutput,
     )
     from reflexio.server.services.profile.profile_generation_service_utils import (
         ProfileUpdateOutput,
         StructuredProfilesOutput,
+    )
+    from reflexio.server.services.reflection.reflection_service_utils import (
+        ReflectionOutput,
     )
     from reflexio.server.services.tagging.tagging_service import TagsOutput
 
@@ -113,9 +118,36 @@ def _build_registry() -> dict[str, ModelRegistryEntry]:
             model_class=TagsOutput,
             minimal_valid={"tags": ["example_tag"]},
         ),
+        "reflection": ModelRegistryEntry(
+            model_class=ReflectionOutput,
+            minimal_valid={
+                "decisions": [
+                    {
+                        "target_kind": "profile",
+                        "target_id": "PROFILE-0",
+                        "reason": "no change",
+                    },
+                ],
+            },
+        ),
+        "playbook_optimizer_judge": ModelRegistryEntry(
+            model_class=JudgeOutput,
+            minimal_valid={
+                "verdict": "candidate",
+                "score": 0.5,
+                "likert": 3,
+            },
+        ),
+        "shadow_comparison": ModelRegistryEntry(
+            model_class=ShadowComparisonOutput,
+            minimal_valid={
+                "better_request": "1",
+                "is_significantly_better": True,
+            },
+        ),
         # F1 cleanup: ``agent_success_evaluation_comparison`` was removed along
-        # with the session-level shadow comparison branch. Per-turn shadow
-        # comparison registers its own registry entry alongside its prompt.
+        # with the session-level shadow comparison branch. The per-turn shadow
+        # comparison entry is registered above (``shadow_comparison``).
         "boolean_evaluation": ModelRegistryEntry(
             model_class=None,
             minimal_valid="true",

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -39,6 +39,7 @@ from reflexio.models.config_schema import (
 from reflexio.models.config_schema import (
     OpenAIConfig as CommonsOpenAIConfig,
 )
+from reflexio.models.structured_output import find_schema_keyword
 from reflexio.server.llm.litellm_client import (
     LiteLLMClient,
     LiteLLMClientError,
@@ -1030,30 +1031,9 @@ class TestMaybeParseStructuredOutput:
             )
 
 
-# Keys whose values are name→subschema maps; their entries are user-chosen names,
-# not JSON-Schema keywords (so a field named ``oneOf`` must not count as a match).
-_SCHEMA_NAME_MAP_KEYS = ("properties", "$defs", "definitions", "patternProperties")
-
-
-def _find_schema_keys(node: Any, key: str) -> list[str]:
-    """Return paths to every occurrence of ``key`` in JSON-Schema *keyword* position.
-
-    Context-aware: a property/``$defs`` *name* equal to ``key`` is not a match.
-    """
-    hits: list[str] = []
-    if isinstance(node, dict):
-        for k, v in node.items():
-            if k == key:
-                hits.append(k)
-            if k in _SCHEMA_NAME_MAP_KEYS and isinstance(v, dict):
-                for name, sub in v.items():
-                    hits.extend(f"{k}.{name}.{p}" for p in _find_schema_keys(sub, key))
-            else:
-                hits.extend(f"{k}.{p}" for p in _find_schema_keys(v, key))
-    elif isinstance(node, list):
-        for i, v in enumerate(node):
-            hits.extend(f"[{i}].{p}" for p in _find_schema_keys(v, key))
-    return hits
+# Schema-keyword presence is checked via the shared structure-aware
+# ``find_schema_keyword`` (reflexio.models.structured_output) — single source of
+# truth for the name-map special-casing.
 
 
 # A minimal discriminated-union output schema, the shape behind PYTHON-FASTAPI-9J.
@@ -1211,8 +1191,8 @@ class TestStrictStructuredOutputRequest:
         provider_format = params["response_format"]
         assert provider_format["type"] == "json_schema"
         sent_schema = provider_format["json_schema"]["schema"]
-        assert _find_schema_keys(sent_schema, "oneOf") == []
-        assert _find_schema_keys(sent_schema, "discriminator") == []
+        assert not find_schema_keyword(sent_schema, "oneOf")
+        assert not find_schema_keyword(sent_schema, "discriminator")
         # The variants are preserved as `anyOf` so generation stays constrained.
         assert "anyOf" in sent_schema["properties"]["decisions"]["items"]
 
@@ -1237,8 +1217,8 @@ class TestStrictStructuredOutputRequest:
             "model (Sentry PYTHON-FASTAPI-9J)"
         )
         schema = provider_format["json_schema"]["schema"]
-        assert _find_schema_keys(schema, "oneOf") == []
-        assert _find_schema_keys(schema, "discriminator") == []
+        assert not find_schema_keyword(schema, "oneOf")
+        assert not find_schema_keyword(schema, "discriminator")
 
     def test_finder_ignores_property_named_like_a_keyword(self):
         # A field literally named `oneOf`/`discriminator` is a property NAME, not a
@@ -1251,8 +1231,8 @@ class TestStrictStructuredOutputRequest:
         schema = make_strict_json_schema(_TrickyNames.model_json_schema())
         assert "oneOf" in schema["properties"]
         assert "discriminator" in schema["properties"]
-        assert _find_schema_keys(schema, "oneOf") == []
-        assert _find_schema_keys(schema, "discriminator") == []
+        assert not find_schema_keyword(schema, "oneOf")
+        assert not find_schema_keyword(schema, "discriminator")
 
     def test_strict_response_format_can_be_disabled_per_call(self):
         client = _build_client(LiteLLMConfig(model="gpt-4o-mini"))

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1193,10 +1193,15 @@ class TestStrictStructuredOutputRequest:
         assert "oneOf" in raw_items
 
         client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M3"))
-        with patch.object(
-            LiteLLMClient,
-            "_supports_response_schema",
-            return_value=False,
+        # ``_DiscriminatedOutput`` is intentionally a non-base double (emits oneOf)
+        # to exercise make_strict's prod backstop. The by-construction boundary
+        # guard would (correctly) raise on it under pytest, so patch it to a no-op
+        # here — this test asserts the make_strict fallback, not the guard.
+        with (
+            patch.object(
+                LiteLLMClient, "_supports_response_schema", return_value=False
+            ),
+            patch("reflexio.server.llm.litellm_client.assert_provider_safe_schema"),
         ):
             params, _, _, _, _ = client._build_completion_params(
                 [{"role": "user", "content": "test"}],
@@ -1218,10 +1223,14 @@ class TestStrictStructuredOutputRequest:
         # (minimax). With the discriminated-union output, the response_format
         # actually built must be a normalized dict with no oneOf/discriminator.
         client = _build_client(LiteLLMConfig(model="minimax/MiniMax-M3"))
-        params, _, _, _, _ = client._build_completion_params(
-            [{"role": "user", "content": "test"}],
-            response_format=_DiscriminatedOutput,
-        )
+        # Non-base double exercises the make_strict backstop; patch the
+        # by-construction guard (it would raise under pytest) — see the sibling
+        # test above for why.
+        with patch("reflexio.server.llm.litellm_client.assert_provider_safe_schema"):
+            params, _, _, _, _ = client._build_completion_params(
+                [{"role": "user", "content": "test"}],
+                response_format=_DiscriminatedOutput,
+            )
         provider_format = params["response_format"]
         assert isinstance(provider_format, dict), (
             "minimax must receive a normalized strict schema, not the raw Pydantic "

--- a/tests/server/llm/test_provider_safe_guard.py
+++ b/tests/server/llm/test_provider_safe_guard.py
@@ -59,12 +59,19 @@ def test_guard_passes_for_base_inheriting_model():
     )
 
 
-def test_guard_ignores_property_literally_named_oneof():
-    """A field literally named ``oneOf`` is a property name, not a keyword."""
+def test_structure_aware_fold_preserves_property_named_oneof():
+    """The base's fold must PRESERVE a field literally named ``oneOf`` in the
+    emitted schema (a blind fold would delete it from the wire schema, silently
+    hiding the field from the model), and ``find_schema_keyword`` must not treat
+    that property name as a keyword.
+    """
 
     class _Weird(StrictStructuredOutput):
         oneOf: str = "x"  # noqa: N815 — intentional pathological field name
 
     schema = _Weird.model_json_schema()
-    assert not find_schema_keyword(schema, "oneOf")  # structure-aware: no match
+    # Structure-aware fold preserves the property (this is the regression guard
+    # for the silent-strip footgun).
+    assert "oneOf" in schema["properties"]
+    assert not find_schema_keyword(schema, "oneOf")  # name position, not a keyword
     assert_provider_safe_schema(schema, name="_Weird")  # must not raise

--- a/tests/server/llm/test_provider_safe_guard.py
+++ b/tests/server/llm/test_provider_safe_guard.py
@@ -1,0 +1,70 @@
+"""Tests for the provider-safe schema boundary guard (assert_provider_safe_schema).
+
+The guard is the runtime net for structured-output schemas that bypass the
+``StrictStructuredOutput`` base / the registry contract test (e.g. a model that
+forgot the base, or a tool-argument schema). Under tests it must RAISE so a
+regression fails CI loudly.
+"""
+
+from typing import Annotated, Literal
+
+import pytest
+from pydantic import BaseModel, Field
+
+from reflexio.models.structured_output import (
+    StrictStructuredOutput,
+    find_schema_keyword,
+)
+from reflexio.server.llm.llm_utils import assert_provider_safe_schema
+
+
+class _VariantA(BaseModel):
+    kind: Literal["a"] = "a"
+    a: int
+
+
+class _VariantB(BaseModel):
+    kind: Literal["b"] = "b"
+    b: str
+
+
+_Union = Annotated[_VariantA | _VariantB, Field(discriminator="kind")]
+
+
+class _UnsafeUnionModel(BaseModel):
+    """Plain BaseModel with a discriminated union -> emits oneOf/discriminator."""
+
+    choice: _Union
+
+
+class _SafeUnionModel(StrictStructuredOutput):
+    """Same union, but provider-safe by construction via the base."""
+
+    choice: _Union
+
+
+def test_guard_raises_on_model_that_forgot_the_base():
+    """A discriminated-union model NOT inheriting the base trips the guard."""
+    with pytest.raises(ValueError, match="provider-unsafe"):
+        assert_provider_safe_schema(
+            _UnsafeUnionModel.model_json_schema(), name="_UnsafeUnionModel"
+        )
+
+
+def test_guard_passes_for_base_inheriting_model():
+    """The same union is accepted once the model inherits StrictStructuredOutput."""
+    # Must not raise.
+    assert_provider_safe_schema(
+        _SafeUnionModel.model_json_schema(), name="_SafeUnionModel"
+    )
+
+
+def test_guard_ignores_property_literally_named_oneof():
+    """A field literally named ``oneOf`` is a property name, not a keyword."""
+
+    class _Weird(StrictStructuredOutput):
+        oneOf: str = "x"  # noqa: N815 — intentional pathological field name
+
+    schema = _Weird.model_json_schema()
+    assert not find_schema_keyword(schema, "oneOf")  # structure-aware: no match
+    assert_provider_safe_schema(schema, name="_Weird")  # must not raise

--- a/tests/server/llm/test_tools.py
+++ b/tests/server/llm/test_tools.py
@@ -56,6 +56,56 @@ def test_tool_openai_spec_uses_docstring_and_schema():
     assert spec["function"]["parameters"]["properties"]["content"]["type"] == "string"
 
 
+def test_openai_spec_guard_raises_on_unsafe_tool_arg_union():
+    """Tool-arg schemas bypass the response_format path + the registry contract
+    test, so ``openai_spec()`` runs the boundary guard. A plain-BaseModel
+    discriminated-union args_model emits ``oneOf`` → the guard raises under pytest.
+    """
+    from typing import Annotated, Literal
+
+    from pydantic import Field
+
+    class _A(BaseModel):
+        kind: Literal["a"] = "a"
+        a: int
+
+    class _B(BaseModel):
+        kind: Literal["b"] = "b"
+        b: str
+
+    class _UnsafeArgs(BaseModel):
+        choice: Annotated[_A | _B, Field(discriminator="kind")]
+
+    t = Tool(name="unsafe", args_model=_UnsafeArgs, handler=lambda _a, _c: {})
+    with pytest.raises(ValueError, match="provider-unsafe"):
+        t.openai_spec()
+
+
+def test_openai_spec_passes_for_strict_structured_output_tool_arg():
+    """A tool-arg model inheriting StrictStructuredOutput is provider-safe by
+    construction — ``openai_spec()`` does not raise even with a union."""
+    from typing import Annotated, Literal
+
+    from pydantic import Field
+
+    from reflexio.models.structured_output import StrictStructuredOutput
+
+    class _A(BaseModel):
+        kind: Literal["a"] = "a"
+        a: int
+
+    class _B(BaseModel):
+        kind: Literal["b"] = "b"
+        b: str
+
+    class _SafeArgs(StrictStructuredOutput):
+        choice: Annotated[_A | _B, Field(discriminator="kind")]
+
+    t = Tool(name="safe", args_model=_SafeArgs, handler=lambda _a, _c: {})
+    spec = t.openai_spec()  # must not raise
+    assert spec["function"]["name"] == "safe"
+
+
 def test_registry_handle_parses_and_dispatches():
     ctx = Ctx()
     t = Tool(name="emit_profile", args_model=EmitProfileArgs, handler=ctx.emit)

--- a/tests/server/services/test_llm_mock_schema_compliance.py
+++ b/tests/server/services/test_llm_mock_schema_compliance.py
@@ -13,14 +13,71 @@ schema validation detects "it broke the contract" (precise).
 """
 
 import json
+from typing import Any
 
 import pytest
 from syrupy.extensions.json import JSONSnapshotExtension
 
+from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.llm.llm_utils import strict_response_format_for_model
 from reflexio.test_support.llm_fixtures import load_llm_fixture_content
 from reflexio.test_support.llm_mock import _create_mock_completion, _find_schema_key
 from reflexio.test_support.llm_model_registry import get_model_registry
+
+
+def _registry_model_keys() -> list[str]:
+    """Registry keys whose entries carry a Pydantic model class (skip raw/boolean)."""
+    return [
+        name
+        for name, entry in get_model_registry().items()
+        if entry.model_class is not None
+    ]
+
+
+def _walk(node: Any):
+    """Yield every dict node in a JSON-schema fragment (recursive)."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _walk(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _walk(item)
+
+
+def _resolve_ref(ref: str, defs: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a local ``#/$defs/Name`` reference against a ``$defs`` map."""
+    name = ref.rsplit("/", 1)[-1]
+    return defs.get(name, {})
+
+
+def _member_first_key(
+    member: dict[str, Any], defs: dict[str, Any]
+) -> tuple[Any, Any] | None:
+    """Return the ``(first-property-name, first-const-value)`` of an anyOf member.
+
+    Resolves a ``$ref`` member against ``$defs`` so the member's own
+    ``properties`` are inspected, mirroring how OpenAI evaluates anyOf
+    distinguishability. Returns ``None`` for a member that is not an object
+    schema (e.g. a bare ``{"type": "null"}`` / ``{"type": "array"}`` arm of an
+    *optional* field's nullable union) — that arm is not a discriminated-union
+    variant, so it does not participate in the first-key distinguishability rule
+    OpenAI applies to *object* members.
+    """
+    if "$ref" in member:
+        member = _resolve_ref(member["$ref"], defs)
+    properties = member.get("properties", {})
+    if not properties:
+        return None
+    first_name = next(iter(properties))
+    first_schema = properties[first_name]
+    const_value = first_schema.get("const")
+    if const_value is None:
+        enum_values = first_schema.get("enum")
+        if isinstance(enum_values, list) and len(enum_values) == 1:
+            const_value = enum_values[0]
+    return (first_name, const_value)
+
 
 # Mapping from fixture file names to their expected model registry keys.
 FIXTURE_TO_MODEL: list[tuple[str, str]] = [
@@ -148,6 +205,71 @@ class TestSchemaCompliance:
             f"{entry.model_class.__name__} emits 'discriminator'; "
             "strict structured-output providers reject it."
         )
+
+    @pytest.mark.parametrize("entry_name", _registry_model_keys())
+    def test_registry_models_native_schema_is_provider_safe(self, entry_name):
+        """Native ``model_json_schema()`` must be provider-safe by construction.
+
+        With no ``make_strict`` normalization and no provider gate, the raw
+        schema a model emits must already carry no ``oneOf`` and no
+        ``discriminator`` at any depth — the ``StrictStructuredOutput`` hook
+        folds any discriminated union into ``anyOf``. This proves the
+        by-construction safety the boundary guard relies on.
+        """
+        model_class = get_model_registry()[entry_name].model_class
+        assert model_class is not None
+        schema = model_class.model_json_schema()
+        for node in _walk(schema):
+            assert "oneOf" not in node, (
+                f"{model_class.__name__} emits native 'oneOf'; "
+                "StrictStructuredOutput must fold it to 'anyOf'."
+            )
+            assert "discriminator" not in node, (
+                f"{model_class.__name__} emits native 'discriminator'; "
+                "StrictStructuredOutput must drop it."
+            )
+
+    @pytest.mark.parametrize("entry_name", _registry_model_keys())
+    def test_registry_models_anyof_first_keys_distinguishable(self, entry_name):
+        """Every ``anyOf`` member set must have unique first ``(key, const)`` pairs.
+
+        OpenAI rejects ``anyOf`` members that share an identical first property
+        key unless disambiguated by a ``const`` — our folded discriminated-union
+        variants all lead with the discriminator field but carry distinct
+        ``Literal`` consts, so the pairs must be unique. Models with no
+        ``anyOf`` pass trivially.
+        """
+        model_class = get_model_registry()[entry_name].model_class
+        assert model_class is not None
+        schema = model_class.model_json_schema()
+        defs = schema.get("$defs", {})
+        for node in _walk(schema):
+            members = node.get("anyOf")
+            if not isinstance(members, list):
+                continue
+            # Only object members (discriminated-union variants) are subject to
+            # the first-key rule; nullable scalar arms return None and are
+            # ignored.
+            keys = [
+                key
+                for member in members
+                if (key := _member_first_key(member, defs)) is not None
+            ]
+            assert len(keys) == len(set(keys)), (
+                f"{model_class.__name__} has anyOf members sharing a "
+                f"(first-key, const) pair: {keys}; OpenAI rejects this."
+            )
+
+    @pytest.mark.parametrize("entry_name", _registry_model_keys())
+    def test_registry_models_are_strict_structured_output_subclasses(self, entry_name):
+        """Every registry model must inherit ``StrictStructuredOutput``.
+
+        A new structured-output model that forgets the base — and thus the
+        provider-safe schema hook — fails here.
+        """
+        model_class = get_model_registry()[entry_name].model_class
+        assert model_class is not None
+        assert issubclass(model_class, StrictStructuredOutput)
 
     @pytest.mark.parametrize("fixture_name,model_key", FIXTURE_TO_MODEL)
     def test_fixtures_validate_against_models(self, fixture_name, model_key):


### PR DESCRIPTION
## What

Unify the provider-safety guarantee for **all** LLM structured-output models behind one base class, so any model — including any *future* discriminated union — emits a strict-provider-safe JSON schema **by construction**, with a runtime guard as the enforcement net. Follow-up to #216 (Option C).

This is the **scoped** approach from the design review: unify the *safety guarantee* only; **no `model_config` is touched** on any model (centralizing config is where the risk is — `extra=` is not uniform — so it's deliberately out of scope). Every migration is a parent-class swap; zero validation/serialization/emitted-schema change.

## How

- **New base** `reflexio/models/structured_output.py::StrictStructuredOutput` — a low-layer base (pydantic-only deps, so both `models/` and `server/` can inherit without a layering inversion). It carries the `__get_pydantic_json_schema__` hook (relocated `ProviderSafeUnionMixin` + `_fold_oneof_to_anyof` from #216) and **adds no config**.
- **Migrated all 11 structured-output models + 2 tool-arg models** to inherit it (parent-class swap only): `PlaybookConsolidationOutput`, `StructuredPlaybookList`, `PlaybookAggregationOutput`, `StructuredProfilesOutput`, `ProfileUpdateOutput`, `ProfileDeduplicationOutput`, `AgentSuccessEvaluationOutput`, `TagsOutput`, `ReflectionOutput`, `JudgeOutput`, `ShadowComparisonOutput`, `AskHumanArgs`, `AttachPendingInfoRequestArgs`. `ShadowComparisonOutput` is publicly pinned (FastAPI `response_model` + website + docs) — verified the hook is a **no-op** on it (schema byte-identical, SHA-256 match) since it has no union.
- **Completed the test model registry** (+3: `reflection`, `playbook_optimizer_judge`, `shadow_comparison`) so it covers all 11 models.
- **Strengthened the contract test** (`test_llm_mock_schema_compliance.py`) over every registry model: (a) native `model_json_schema()` has no `oneOf`/`discriminator`; (b) `anyOf` members have unique `(first-key, first-const)` pairs — the real OpenAI strict rule that "no `oneOf`" alone doesn't cover; (c) every registry model is a `StrictStructuredOutput` subclass.
- **Boundary guard** `assert_provider_safe_schema` at both schema-emission points (`litellm_client._provider_response_format` + `tools.Tool.openai_spec`) so coverage doesn't depend on the registry being complete (catches tool-arg / dynamic / forgot-the-base schemas). **Raises under tests** (CI fails loudly); **warns in prod** and proceeds (the strict-path `make_strict` still folds), so a miss degrades gracefully, never a 500.

## What this deliberately does NOT do
- Does **not** touch any `model_config` (no `extra=` flips, no serialization drift).
- Keeps `make_strict_json_schema` (its strict-mode keyword-strip + `required` injection are mandatory and untouched) and the `{minimax}` allowlist.
- `make_strict` keeps its own *structure-aware* inline `oneOf` fold (deliberately not the blind shared helper, which would strip a property literally named `oneOf`).

## Tests
- Full unit sweep `tests/server`: **2010 passed, 2 skipped** (the 4 failed/6 errors are a pre-existing, unrelated `AgentSuccessGenerationServiceConfig` config-constructor drift on main — a Pydantic parent-class swap cannot cause it).
- ruff clean, pyright 0 errors on all changed non-test files.
- New `test_provider_safe_guard.py` covers the guard (raises on a non-base union; passes with the base; ignores a property literally named `oneOf`).

## Design
`reflexio-enterprise` → `docs/superpowers/specs/2026-06-23-structured-output-provider-safe-schema-design.md` (PR #379), "Unified architecture (scoped)" section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated structured-output response models to use a stricter validation base for more consistent LLM schema handling.

* **Bug Fixes**
  * Added schema compatibility checks to prevent submitting provider-unsafe structured outputs.
  * Improved strict response format generation to keep schema construction consistent across strict-mode paths.
  * Added earlier guardrails when generating tool argument specs.

* **Tests**
  * Expanded coverage for provider-safe schema boundaries, including discriminated-union scenarios and regression cases for property names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->