### PR TITLE
feat(lineage): purge_content — content-only erasure that keeps lineage chains

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -468,7 +468,16 @@ class LineageContext(BaseModel):
 
 
 class RecordRef(BaseModel):
-    """Result of resolve_current — the live survivor's id and whether its body was purged."""
+    """Result of resolve_current — the live survivor's id and whether its body was purged.
+
+    Attributes:
+        id: Primary key of the live survivor record.
+        is_purged: True when the survivor's content body has been blanked by
+            ``purge_content`` (GDPR/erasure).  Any consumer that dereferences the
+            resolved record's content MUST treat ``is_purged=True`` as "erased —
+            skip or treat as absent."  Reading blank content as if it were valid
+            is a silent data-quality bug.
+    """
 
     id: str
     is_purged: bool = False

--- a/reflexio/server/services/lineage/resolve.py
+++ b/reflexio/server/services/lineage/resolve.py
@@ -24,6 +24,12 @@ def resolve_current(
 ) -> RecordRef | None:
     """Follow merged_into/superseded_by pointers to the live survivor.
 
+    **Consumer contract:** if the returned ``RecordRef.is_purged`` is ``True``,
+    the survivor's content body has been blanked by ``purge_content`` (GDPR/erasure).
+    Any consumer that dereferences the resolved record's content MUST skip or treat
+    the record as absent when ``is_purged=True`` — reading blank content as if it
+    were valid data is a silent bug.
+
     Args:
         storage: Any storage backend exposing get_*_by_id with include_tombstones.
         entity_type: One of "user_playbook", "agent_playbook", "profile".

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1742,28 +1742,107 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     # ------------------------------------------------------------------
 
     def clear_user_data(self, user_id: str) -> dict[str, int]:
-        """Atomic per-``user_id`` row deletion across all user-scoped tables.
+        """Per-``user_id`` row deletion across all user-scoped tables.
 
-        Overrides the BaseStorage default with a single-transaction SQL
-        implementation. Removes interactions, user playbooks, profiles,
-        and requests scoped to the user. Intentionally does NOT touch
-        ``agent_playbooks`` — they are the cross-project rollup of
-        skills and have no ``user_id`` column.
+        Overrides the BaseStorage default with an optimised SQL implementation.
+        Removes interactions, user playbooks, profiles, and requests scoped to
+        the user. Intentionally does NOT touch ``agent_playbooks`` — they are
+        the cross-project rollup of skills and have no ``user_id`` column.
 
         Also cleans up FTS and vector sidecars for the user's rows so
         subsequent searches don't surface deleted data.
+
+        **Lineage-aware erasure for profiles and user_playbooks:**
+        Rows that are tombstones (``merged_into`` or ``superseded_by`` is set)
+        *or* are pointed-to by another row (``has_inbound_lineage_refs`` returns
+        True) are **content-purged** (skeleton kept, body blanked) rather than
+        hard-deleted. This preserves chain resolution across user erasures.
+        Standalone rows with no lineage involvement are hard-deleted as before.
+
+        **Commit ordering (atomicity invariant):**
+        The hard-deletes for interactions, requests, and the delete-sets of
+        profiles/user_playbooks are committed in one transaction first. Then
+        ``purge_content`` is called for each purge-eligible row — each call
+        commits atomically on its own. This two-phase approach is required
+        because ``purge_content`` issues its own ``conn.commit()``, and nesting
+        it inside the outer transaction would prematurely flush the still-pending
+        hard-DELETEs.
 
         Args:
             user_id (str): The user id whose rows should be deleted.
 
         Returns:
-            dict[str, int]: Per-entity deletion counts with keys
-                ``interactions``, ``user_playbooks``, ``profiles``, and
-                ``requests``.
+            dict[str, int]: Per-entity counts with keys ``interactions``,
+                ``user_playbooks``, ``profiles``, ``requests``,
+                ``purged_profiles``, and ``purged_user_playbooks``.
+                ``profiles`` and ``user_playbooks`` reflect hard-deleted counts;
+                purged rows are counted separately.
         """
+
+        def _split_profiles(
+            rows: list[object],
+        ) -> tuple[list[str], list[int], list[str], list[int]]:
+            """Partition profile rows into purge vs delete sets.
+
+            Returns:
+                Tuple of (purge_ids, purge_rowids, delete_ids, delete_rowids).
+            """
+            purge_ids: list[str] = []
+            purge_rowids: list[int] = []
+            delete_ids: list[str] = []
+            delete_rowids: list[int] = []
+            for r in rows:
+                pid = r["profile_id"]  # type: ignore[index]
+                rowid = r["rowid"]  # type: ignore[index]
+                is_tombstone = (
+                    self.conn.execute(
+                        "SELECT 1 FROM profiles WHERE profile_id = ?"
+                        " AND (merged_into IS NOT NULL OR superseded_by IS NOT NULL)",
+                        (pid,),
+                    ).fetchone()
+                    is not None
+                )
+                if is_tombstone or self.has_inbound_lineage_refs(
+                    entity_type="profile", entity_id=str(pid)
+                ):
+                    purge_ids.append(pid)
+                    purge_rowids.append(rowid)
+                else:
+                    delete_ids.append(pid)
+                    delete_rowids.append(rowid)
+            return purge_ids, purge_rowids, delete_ids, delete_rowids
+
+        def _split_user_playbooks(
+            ids: list[int],
+        ) -> tuple[list[int], list[int]]:
+            """Partition user_playbook ids into purge vs delete sets.
+
+            Returns:
+                Tuple of (purge_ids, delete_ids).
+            """
+            purge_ids: list[int] = []
+            delete_ids: list[int] = []
+            for upid in ids:
+                is_tombstone = (
+                    self.conn.execute(
+                        "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?"
+                        " AND (merged_into IS NOT NULL OR superseded_by IS NOT NULL)",
+                        (upid,),
+                    ).fetchone()
+                    is not None
+                )
+                if is_tombstone or self.has_inbound_lineage_refs(
+                    entity_type="user_playbook", entity_id=str(upid)
+                ):
+                    purge_ids.append(upid)
+                else:
+                    delete_ids.append(upid)
+            return purge_ids, delete_ids
+
         with self._lock:
-            # Snapshot rowids/ids that need FTS or vector cleanup before
-            # the DELETE removes them from the main tables.
+            # ------------------------------------------------------------------
+            # Phase 1: snapshot all user-scoped ids before any mutations.
+            # ------------------------------------------------------------------
             interaction_ids = [
                 r["interaction_id"]
                 for r in self.conn.execute(
@@ -1771,7 +1850,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     (user_id,),
                 ).fetchall()
             ]
-            user_playbook_ids = [
+            raw_upb_ids = [
                 r["user_playbook_id"]
                 for r in self.conn.execute(
                     "SELECT user_playbook_id FROM user_playbooks WHERE user_id = ?",
@@ -1782,67 +1861,103 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 "SELECT rowid, profile_id FROM profiles WHERE user_id = ?",
                 (user_id,),
             ).fetchall()
-            profile_rowids = [r["rowid"] for r in profile_rows]
-            profile_ids = [r["profile_id"] for r in profile_rows]
 
-            # FTS cleanup
+            # ------------------------------------------------------------------
+            # Phase 2: partition profiles and user_playbooks into purge vs delete.
+            # ------------------------------------------------------------------
+            (
+                purge_profile_ids,
+                purge_profile_rowids,
+                delete_profile_ids,
+                delete_profile_rowids,
+            ) = _split_profiles(profile_rows)
+            purge_upb_ids, delete_upb_ids = _split_user_playbooks(raw_upb_ids)
+
+            # ------------------------------------------------------------------
+            # Phase 3: FTS and vector cleanup — only for the delete-sets
+            # (purge_content handles its own index cleanup for purged rows).
+            # ------------------------------------------------------------------
             if interaction_ids:
                 ph = ",".join("?" for _ in interaction_ids)
                 self.conn.execute(
-                    f"DELETE FROM interactions_fts WHERE rowid IN ({ph})",
+                    f"DELETE FROM interactions_fts WHERE rowid IN ({ph})",  # noqa: S608
                     interaction_ids,
                 )
-            if user_playbook_ids:
-                ph = ",".join("?" for _ in user_playbook_ids)
+            if delete_upb_ids:
+                ph = ",".join("?" for _ in delete_upb_ids)
                 self.conn.execute(
-                    f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",
-                    user_playbook_ids,
+                    f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",  # noqa: S608
+                    delete_upb_ids,
                 )
-            if profile_ids:
-                ph = ",".join("?" for _ in profile_ids)
+            if delete_profile_ids:
+                ph = ",".join("?" for _ in delete_profile_ids)
                 self.conn.execute(
-                    f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",
-                    profile_ids,
+                    f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",  # noqa: S608
+                    delete_profile_ids,
                 )
 
-            # Vector index cleanup (best-effort: only if sqlite-vec loaded)
             if self._has_sqlite_vec:
-                vec_targets = (
+                vec_targets: list[tuple[str, list[int]]] = [
                     ("interactions_vec", interaction_ids),
-                    ("user_playbooks_vec", user_playbook_ids),
-                    ("profiles_vec", profile_rowids),
-                )
+                    ("user_playbooks_vec", delete_upb_ids),
+                    ("profiles_vec", delete_profile_rowids),
+                ]
                 for vec_table, rowids in vec_targets:
                     if rowids:
                         ph = ",".join("?" for _ in rowids)
                         self.conn.execute(
-                            f"DELETE FROM {vec_table} WHERE rowid IN ({ph})",
+                            f"DELETE FROM {vec_table} WHERE rowid IN ({ph})",  # noqa: S608
                             rowids,
                         )
 
-            # Main-table deletes. Order matters only for foreign key
-            # integrity; SQLite default has FK off for most tables here
-            # so order is chosen for readability.
+            # ------------------------------------------------------------------
+            # Phase 4: hard-delete the delete-sets and all interactions/requests.
+            # ------------------------------------------------------------------
             interactions_cur = self.conn.execute(
                 "DELETE FROM interactions WHERE user_id = ?", (user_id,)
-            )
-            user_playbooks_cur = self.conn.execute(
-                "DELETE FROM user_playbooks WHERE user_id = ?", (user_id,)
-            )
-            profiles_cur = self.conn.execute(
-                "DELETE FROM profiles WHERE user_id = ?", (user_id,)
             )
             requests_cur = self.conn.execute(
                 "DELETE FROM requests WHERE user_id = ?", (user_id,)
             )
+            upb_deleted_count = 0
+            if delete_upb_ids:
+                ph = ",".join("?" for _ in delete_upb_ids)
+                upb_cur = self.conn.execute(
+                    f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",  # noqa: S608
+                    delete_upb_ids,
+                )
+                upb_deleted_count = upb_cur.rowcount
+            profile_deleted_count = 0
+            if delete_profile_ids:
+                ph = ",".join("?" for _ in delete_profile_ids)
+                prof_cur = self.conn.execute(
+                    f"DELETE FROM profiles WHERE profile_id IN ({ph})",  # noqa: S608
+                    delete_profile_ids,
+                )
+                profile_deleted_count = prof_cur.rowcount
+
+            # Commit the hard-deletes before calling purge_content, because
+            # purge_content issues its own conn.commit() and nesting it here
+            # would prematurely flush the still-pending deletes.
             self.conn.commit()
 
-            return {
-                "interactions": interactions_cur.rowcount,
-                "user_playbooks": user_playbooks_cur.rowcount,
-                "profiles": profiles_cur.rowcount,
-                "requests": requests_cur.rowcount,
-            }
+        # ------------------------------------------------------------------
+        # Phase 5: content-purge the purge-sets (each call self-commits).
+        # Done outside the lock so purge_content can acquire it independently.
+        # ------------------------------------------------------------------
+        for pid in purge_profile_ids:
+            self.purge_content(entity_type="profile", entity_id=str(pid))
+        for upid in purge_upb_ids:
+            self.purge_content(entity_type="user_playbook", entity_id=str(upid))
+
+        return {
+            "interactions": interactions_cur.rowcount,
+            "user_playbooks": upb_deleted_count,
+            "profiles": profile_deleted_count,
+            "requests": requests_cur.rowcount,
+            "purged_profiles": len(purge_profile_ids),
+            "purged_user_playbooks": len(purge_upb_ids),
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1877,13 +1877,12 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             # would prematurely flush the still-pending deletes.
             self.conn.commit()
 
-        # ------------------------------------------------------------------
-        # Phase 5: content-purge the purge-sets (each call self-commits).
-        # self._lock is an RLock, so purge_content's internal ``with self._lock``
-        # re-acquires cleanly. The hard-delete commit above already closed the
-        # outer transaction, so no flush hazard exists.
-        # ------------------------------------------------------------------
-        with self._lock:
+            # Phase 5: content-purge the purge-sets WITHOUT releasing the lock,
+            # so erase-eligible rows are never observable by another thread with
+            # PII still intact between the hard-delete commit and the purge. Each
+            # purge_content call self-commits; self._lock is an RLock so its
+            # internal ``with self._lock`` re-acquires cleanly, and the commit
+            # above already closed the outer transaction (no flush hazard).
             for pid in purge_profile_ids:
                 self.purge_content(entity_type="profile", entity_id=str(pid))
             for upid in purge_upb_ids:

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1836,39 +1836,17 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             # ------------------------------------------------------------------
             # Phase 3: FTS and vector cleanup — only for the delete-sets
             # (purge_content handles its own index cleanup for purged rows).
+            # Use _delete_in_chunks to stay under SQLite's SQLITE_MAX_VARIABLE_NUMBER
+            # limit for large user datasets.
             # ------------------------------------------------------------------
-            if interaction_ids:
-                ph = ",".join("?" for _ in interaction_ids)
-                self.conn.execute(
-                    f"DELETE FROM interactions_fts WHERE rowid IN ({ph})",  # noqa: S608
-                    interaction_ids,
-                )
-            if delete_upb_ids:
-                ph = ",".join("?" for _ in delete_upb_ids)
-                self.conn.execute(
-                    f"DELETE FROM user_playbooks_fts WHERE rowid IN ({ph})",  # noqa: S608
-                    delete_upb_ids,
-                )
-            if delete_profile_ids:
-                ph = ",".join("?" for _ in delete_profile_ids)
-                self.conn.execute(
-                    f"DELETE FROM profiles_fts WHERE profile_id IN ({ph})",  # noqa: S608
-                    delete_profile_ids,
-                )
+            self._delete_in_chunks("interactions_fts", "rowid", interaction_ids)
+            self._delete_in_chunks("user_playbooks_fts", "rowid", delete_upb_ids)
+            self._delete_in_chunks("profiles_fts", "profile_id", delete_profile_ids)
 
             if self._has_sqlite_vec:
-                vec_targets: list[tuple[str, list[int]]] = [
-                    ("interactions_vec", interaction_ids),
-                    ("user_playbooks_vec", delete_upb_ids),
-                    ("profiles_vec", delete_profile_rowids),
-                ]
-                for vec_table, rowids in vec_targets:
-                    if rowids:
-                        ph = ",".join("?" for _ in rowids)
-                        self.conn.execute(
-                            f"DELETE FROM {vec_table} WHERE rowid IN ({ph})",  # noqa: S608
-                            rowids,
-                        )
+                self._delete_in_chunks("interactions_vec", "rowid", interaction_ids)
+                self._delete_in_chunks("user_playbooks_vec", "rowid", delete_upb_ids)
+                self._delete_in_chunks("profiles_vec", "rowid", delete_profile_rowids)
 
             # ------------------------------------------------------------------
             # Phase 4: hard-delete the delete-sets and all interactions/requests.
@@ -1881,20 +1859,18 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             )
             upb_deleted_count = 0
             if delete_upb_ids:
-                ph = ",".join("?" for _ in delete_upb_ids)
-                upb_cur = self.conn.execute(
-                    f"DELETE FROM user_playbooks WHERE user_playbook_id IN ({ph})",  # noqa: S608
-                    delete_upb_ids,
+                # Clean up source-window join rows before deleting the parent rows.
+                self._delete_source_windows_for_user_playbook_ids(delete_upb_ids)
+                self._delete_in_chunks(
+                    "user_playbooks", "user_playbook_id", delete_upb_ids
                 )
-                upb_deleted_count = upb_cur.rowcount
+                # rowcount not available from _delete_in_chunks; derive from list length
+                # (all ids came from a pre-snapshot so they exist at delete time).
+                upb_deleted_count = len(delete_upb_ids)
             profile_deleted_count = 0
             if delete_profile_ids:
-                ph = ",".join("?" for _ in delete_profile_ids)
-                prof_cur = self.conn.execute(
-                    f"DELETE FROM profiles WHERE profile_id IN ({ph})",  # noqa: S608
-                    delete_profile_ids,
-                )
-                profile_deleted_count = prof_cur.rowcount
+                self._delete_in_chunks("profiles", "profile_id", delete_profile_ids)
+                profile_deleted_count = len(delete_profile_ids)
 
             # Commit the hard-deletes before calling purge_content, because
             # purge_content issues its own conn.commit() and nesting it here
@@ -1903,12 +1879,15 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
 
         # ------------------------------------------------------------------
         # Phase 5: content-purge the purge-sets (each call self-commits).
-        # Done outside the lock so purge_content can acquire it independently.
+        # self._lock is an RLock, so purge_content's internal ``with self._lock``
+        # re-acquires cleanly. The hard-delete commit above already closed the
+        # outer transaction, so no flush hazard exists.
         # ------------------------------------------------------------------
-        for pid in purge_profile_ids:
-            self.purge_content(entity_type="profile", entity_id=str(pid))
-        for upid in purge_upb_ids:
-            self.purge_content(entity_type="user_playbook", entity_id=str(upid))
+        with self._lock:
+            for pid in purge_profile_ids:
+                self.purge_content(entity_type="profile", entity_id=str(pid))
+            for upid in purge_upb_ids:
+                self.purge_content(entity_type="user_playbook", entity_id=str(upid))
 
         return {
             "interactions": interactions_cur.rowcount,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1759,6 +1759,11 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         hard-deleted. This preserves chain resolution across user erasures.
         Standalone rows with no lineage involvement are hard-deleted as before.
 
+        The purge/delete decision delegates to
+        ``BaseStorage._partition_purge_vs_delete`` so the logic is defined once
+        and shared with the default ``clear_user_data`` implementation used by
+        Supabase/Postgres backends.
+
         **Commit ordering (atomicity invariant):**
         The hard-deletes for interactions, requests, and the delete-sets of
         profiles/user_playbooks are committed in one transaction first. Then
@@ -1778,67 +1783,6 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 ``profiles`` and ``user_playbooks`` reflect hard-deleted counts;
                 purged rows are counted separately.
         """
-
-        def _split_profiles(
-            rows: list[object],
-        ) -> tuple[list[str], list[int], list[str], list[int]]:
-            """Partition profile rows into purge vs delete sets.
-
-            Returns:
-                Tuple of (purge_ids, purge_rowids, delete_ids, delete_rowids).
-            """
-            purge_ids: list[str] = []
-            purge_rowids: list[int] = []
-            delete_ids: list[str] = []
-            delete_rowids: list[int] = []
-            for r in rows:
-                pid = r["profile_id"]  # type: ignore[index]
-                rowid = r["rowid"]  # type: ignore[index]
-                is_tombstone = (
-                    self.conn.execute(
-                        "SELECT 1 FROM profiles WHERE profile_id = ?"
-                        " AND (merged_into IS NOT NULL OR superseded_by IS NOT NULL)",
-                        (pid,),
-                    ).fetchone()
-                    is not None
-                )
-                if is_tombstone or self.has_inbound_lineage_refs(
-                    entity_type="profile", entity_id=str(pid)
-                ):
-                    purge_ids.append(pid)
-                    purge_rowids.append(rowid)
-                else:
-                    delete_ids.append(pid)
-                    delete_rowids.append(rowid)
-            return purge_ids, purge_rowids, delete_ids, delete_rowids
-
-        def _split_user_playbooks(
-            ids: list[int],
-        ) -> tuple[list[int], list[int]]:
-            """Partition user_playbook ids into purge vs delete sets.
-
-            Returns:
-                Tuple of (purge_ids, delete_ids).
-            """
-            purge_ids: list[int] = []
-            delete_ids: list[int] = []
-            for upid in ids:
-                is_tombstone = (
-                    self.conn.execute(
-                        "SELECT 1 FROM user_playbooks WHERE user_playbook_id = ?"
-                        " AND (merged_into IS NOT NULL OR superseded_by IS NOT NULL)",
-                        (upid,),
-                    ).fetchone()
-                    is not None
-                )
-                if is_tombstone or self.has_inbound_lineage_refs(
-                    entity_type="user_playbook", entity_id=str(upid)
-                ):
-                    purge_ids.append(upid)
-                else:
-                    delete_ids.append(upid)
-            return purge_ids, delete_ids
-
         with self._lock:
             # ------------------------------------------------------------------
             # Phase 1: snapshot all user-scoped ids before any mutations.
@@ -1862,16 +1806,32 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 (user_id,),
             ).fetchall()
 
+            # Build a rowid lookup for FTS/vec cleanup (SQLite-specific need).
+            profile_rowid_by_id: dict[str, int] = {
+                r["profile_id"]: r["rowid"] for r in profile_rows
+            }
+            all_profile_ids = list(profile_rowid_by_id.keys())
+
             # ------------------------------------------------------------------
             # Phase 2: partition profiles and user_playbooks into purge vs delete.
+            # Delegates to the shared BaseStorage helper so the decision logic
+            # is defined once and reused by all backends.
             # ------------------------------------------------------------------
-            (
-                purge_profile_ids,
-                purge_profile_rowids,
-                delete_profile_ids,
-                delete_profile_rowids,
-            ) = _split_profiles(profile_rows)
-            purge_upb_ids, delete_upb_ids = _split_user_playbooks(raw_upb_ids)
+            purge_profile_ids, delete_profile_ids = self._partition_purge_vs_delete(
+                "profile", all_profile_ids
+            )
+            purge_upb_str_ids, delete_upb_str_ids = self._partition_purge_vs_delete(
+                "user_playbook", [str(uid) for uid in raw_upb_ids]
+            )
+            purge_upb_ids = [int(s) for s in purge_upb_str_ids]
+            delete_upb_ids = [int(s) for s in delete_upb_str_ids]
+
+            # Rowids for the delete-set only (purge_content handles its own cleanup).
+            delete_profile_rowids = [
+                profile_rowid_by_id[pid]
+                for pid in delete_profile_ids
+                if pid in profile_rowid_by_id
+            ]
 
             # ------------------------------------------------------------------
             # Phase 3: FTS and vector cleanup — only for the delete-sets

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1744,7 +1744,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     def clear_user_data(self, user_id: str) -> dict[str, int]:
         """Per-``user_id`` row deletion across all user-scoped tables.
 
-        Overrides the BaseStorage default with an optimised SQL implementation.
+        Overrides the BaseStorage default with an optimized SQL implementation.
         Removes interactions, user playbooks, profiles, and requests scoped to
         the user. Intentionally does NOT touch ``agent_playbooks`` — they are
         the cross-project rollup of skills and have no ``user_id`` column.

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -386,15 +386,16 @@ class SQLiteLineageMixin:
         table, pk = _resolve_table(entity_type)
         with self._lock:
             row = self.conn.execute(
-                f"SELECT rowid FROM {table} WHERE {pk}=?",  # noqa: S608
+                f"SELECT rowid AS _rowid FROM {table} WHERE {pk}=?",  # noqa: S608
                 (entity_id,),
             ).fetchone()
             if row is None:
                 return False
-            rowid = row["rowid"]
+            rowid = row["_rowid"]
             cur = self.conn.execute(sql, (entity_id,))
             if cur.rowcount > 0:
-                # Body was actually blanked this call — record the audited fact.
+                # Row matched (rowcount==1 whenever it exists); attempt the event —
+                # INSERT OR IGNORE dedups on the deterministic request_id.
                 _append_event_stmt(
                     self.conn,
                     org_id=self.org_id,

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -85,6 +85,30 @@ def _append_event_stmt(
     )
 
 
+# Per-entity purge SQL: blank every PII/content column, guard on content != '' for
+# idempotency (re-running on an already-blank row skips the event emission).
+_PROFILE_PURGE_SQL = (
+    "UPDATE profiles SET "
+    "content='', user_id='', generated_from_request_id='', source='', "
+    "embedding=NULL, extractor_names=NULL, expanded_terms=NULL, tags=NULL, "
+    "custom_features=NULL, notes=NULL, source_span=NULL, reader_angle=NULL "
+    "WHERE profile_id=? AND content != ''"
+)
+_USER_PLAYBOOK_PURGE_SQL = (
+    "UPDATE user_playbooks SET "
+    "content='', user_id=NULL, source=NULL, "
+    "trigger=NULL, rationale=NULL, blocking_issue=NULL, "
+    "source_interaction_ids=NULL, embedding=NULL, expanded_terms=NULL, "
+    "tags=NULL, source_span=NULL, notes=NULL, reader_angle=NULL "
+    "WHERE user_playbook_id=? AND content != ''"
+)
+# agent_playbook purge not yet required; added when Task 3/4 needs it.
+_PURGE_SQL: dict[str, str] = {
+    "profile": _PROFILE_PURGE_SQL,
+    "user_playbook": _USER_PLAYBOOK_PURGE_SQL,
+}
+
+
 class SQLiteLineageMixin:
     """SQLite implementation of the append-only, content-free lineage event log."""
 
@@ -324,6 +348,81 @@ class SQLiteLineageMixin:
             )
             self.conn.commit()
             return True
+
+    def purge_content(self, *, entity_type: EntityType, entity_id: str) -> bool:
+        """Blank a record's PII body, keep its lineage skeleton, emit op=purge.
+
+        Blanks every non-skeleton column for the row identified by ``entity_id``,
+        emits one ``op=purge`` lineage event in the same commit, then runs FTS/vec
+        index cleanup after the commit. The ``request_id`` is deterministic
+        (``"purge_" + entity_id``) so re-runs on an already-blank row do not
+        produce a duplicate event (``INSERT OR IGNORE`` on the unique key).
+
+        Args:
+            entity_type (EntityType): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            entity_id (str): The entity's primary key as a string.
+
+        Returns:
+            bool: ``True`` if the row exists; ``False`` if the id had no matching row.
+
+        Raises:
+            ValueError: If ``entity_type`` is not a recognized entity type or
+                if ``entity_type`` is ``"agent_playbook"`` (not yet supported).
+        """
+        sql = _PURGE_SQL.get(entity_type)
+        if sql is None:
+            raise ValueError(f"purge_content: unsupported entity_type {entity_type!r}")
+        table, pk = _resolve_table(entity_type)
+        with self._lock:
+            row = self.conn.execute(
+                f"SELECT rowid FROM {table} WHERE {pk}=?",  # noqa: S608
+                (entity_id,),
+            ).fetchone()
+            if row is None:
+                return False
+            rowid = row["rowid"]
+            cur = self.conn.execute(sql, (entity_id,))
+            if cur.rowcount > 0:
+                # Body was actually blanked this call — record the audited fact.
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    op="purge",
+                    prov="wasPurged",
+                    source_ids=[],
+                    actor="erasure",  # no user identifier
+                    request_id=f"purge_{entity_id}",  # deterministic → idempotent
+                    reason="content_purge",
+                )
+            self.conn.commit()
+        # Post-commit index cleanup (self-committing helpers; idempotent/replayable).
+        self._purge_search_indexes(entity_type, entity_id, rowid)
+        return True
+
+    def _purge_search_indexes(
+        self, entity_type: EntityType, entity_id: str, rowid: int
+    ) -> None:
+        """Remove FTS and vec index entries for a purged entity.
+
+        Called after the blanking commit so index cleanup never interleaves with
+        the atomic mutation+event transaction.
+
+        Args:
+            entity_type (EntityType): One of ``"user_playbook"`` or ``"profile"``.
+            entity_id (str): The entity's primary key (used for profiles FTS).
+            rowid (int): The sqlite rowid (used for playbooks FTS and all vec tables).
+        """
+        if entity_type == "profile":
+            self._fts_delete_profile(entity_id)  # type: ignore[attr-defined]
+            if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                self._vec_delete("profiles_vec", rowid)  # type: ignore[attr-defined]
+        elif entity_type == "user_playbook":
+            self._fts_delete("user_playbooks_fts", rowid)  # type: ignore[attr-defined]
+            if self._has_sqlite_vec:  # type: ignore[attr-defined]
+                self._vec_delete("user_playbooks_vec", rowid)  # type: ignore[attr-defined]
 
     def has_inbound_lineage_refs(
         self, *, entity_type: EntityType, entity_id: str

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -85,14 +85,18 @@ def _append_event_stmt(
     )
 
 
-# Per-entity purge SQL: blank every PII/content column, guard on content != '' for
-# idempotency (re-running on an already-blank row skips the event emission).
+# Per-entity purge SQL: blank every PII/content column.
+# No ``content != ''`` guard — a row with content='' but other PII still populated
+# (user_id, embedding, tags, …) would be skipped by that guard, leaving its PII live.
+# Blanking already-blank columns is an idempotent no-op in SQLite (rowcount=1 either
+# way because the row matched); event idempotency is guaranteed by the deterministic
+# request_id + INSERT OR IGNORE on (org,entity_type,entity_id,op,request_id).
 _PROFILE_PURGE_SQL = (
     "UPDATE profiles SET "
     "content='', user_id='', generated_from_request_id='', source='', "
     "embedding=NULL, extractor_names=NULL, expanded_terms=NULL, tags=NULL, "
     "custom_features=NULL, notes=NULL, source_span=NULL, reader_angle=NULL "
-    "WHERE profile_id=? AND content != ''"
+    "WHERE profile_id=?"
 )
 _USER_PLAYBOOK_PURGE_SQL = (
     "UPDATE user_playbooks SET "
@@ -100,7 +104,7 @@ _USER_PLAYBOOK_PURGE_SQL = (
     "trigger=NULL, rationale=NULL, blocking_issue=NULL, "
     "source_interaction_ids=NULL, embedding=NULL, expanded_terms=NULL, "
     "tags=NULL, source_span=NULL, notes=NULL, reader_angle=NULL "
-    "WHERE user_playbook_id=? AND content != ''"
+    "WHERE user_playbook_id=?"
 )
 # agent_playbook purge not yet required; added when Task 3/4 needs it.
 _PURGE_SQL: dict[str, str] = {
@@ -358,9 +362,15 @@ class SQLiteLineageMixin:
         (``"purge_" + entity_id``) so re-runs on an already-blank row do not
         produce a duplicate event (``INSERT OR IGNORE`` on the unique key).
 
+        Re-running on a row whose content is already blank is safe: the UPDATE
+        still matches the row and sets the same values (harmless idempotent write),
+        while the INSERT OR IGNORE deduplicates the event on
+        ``(org_id, entity_type, entity_id, op, request_id)``.
+
         Args:
-            entity_type (EntityType): One of ``"user_playbook"``, ``"agent_playbook"``,
-                or ``"profile"``.
+            entity_type (EntityType): One of ``"user_playbook"`` or ``"profile"``.
+                ``"agent_playbook"`` raises ``ValueError`` — agent playbooks have no
+                ``user_id`` and are out of scope for content purge.
             entity_id (str): The entity's primary key as a string.
 
         Returns:
@@ -368,7 +378,7 @@ class SQLiteLineageMixin:
 
         Raises:
             ValueError: If ``entity_type`` is not a recognized entity type or
-                if ``entity_type`` is ``"agent_playbook"`` (not yet supported).
+                if ``entity_type`` is ``"agent_playbook"`` (not supported).
         """
         sql = _PURGE_SQL.get(entity_type)
         if sql is None:

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -325,6 +325,33 @@ class SQLiteLineageMixin:
             self.conn.commit()
             return True
 
+    def has_inbound_lineage_refs(
+        self, *, entity_type: EntityType, entity_id: str
+    ) -> bool:
+        """Return True if any row points at ``entity_id`` via merged_into/superseded_by.
+
+        Org-scoped but deliberately NOT user_id-scoped: a cross-user chain
+        (one user's tombstone pointing at another user's survivor) must be
+        detected so the survivor is purged, not hard-deleted, on erasure.
+
+        Args:
+            entity_type (EntityType): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            entity_id (str): The entity's primary key to check for inbound refs.
+
+        Returns:
+            bool: True if any row has ``merged_into == entity_id``
+                OR ``superseded_by == entity_id``; False otherwise.
+        """
+        table, _pk = _resolve_table(entity_type)
+        with self._lock:
+            row = self.conn.execute(
+                f"SELECT 1 FROM {table} "  # noqa: S608
+                f"WHERE merged_into = ? OR superseded_by = ? LIMIT 1",
+                (entity_id, entity_id),
+            ).fetchone()
+        return row is not None
+
     def _is_on_legal_hold(
         self,
         org_id: str,  # noqa: ARG002

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -143,6 +143,19 @@ class BaseStorage(
         """
         interaction_count = len(self.get_user_interaction(user_id))
 
+        # All statuses a user's row can have — including tombstones (SUPERSEDED,
+        # MERGED). Erasure MUST reach every row the user owns regardless of
+        # status; the old filter excluded tombstones, leaving them in the DB
+        # after clear_user_data (GDPR regression).
+        _all_statuses: list[Status | None] = [
+            None,  # CURRENT
+            Status.ARCHIVED,
+            Status.PENDING,
+            Status.ARCHIVE_IN_PROGRESS,
+            Status.SUPERSEDED,
+            Status.MERGED,
+        ]
+
         # Snapshot user_playbook ids for the user and partition into
         # purge vs delete sets.
         raw_upb_ids = [
@@ -150,7 +163,7 @@ class BaseStorage(
             for up in self.get_user_playbooks(
                 user_id=user_id,
                 limit=1_000_000,
-                status_filter=[None, Status.ARCHIVED, Status.PENDING],
+                status_filter=_all_statuses,
             )
             if up.user_playbook_id is not None
         ]
@@ -162,9 +175,7 @@ class BaseStorage(
         # purge vs delete sets.
         raw_profile_ids = [
             p.profile_id
-            for p in self.get_user_profile(
-                user_id, status_filter=[None, Status.ARCHIVED, Status.PENDING]
-            )
+            for p in self.get_user_profile(user_id, status_filter=_all_statuses)
             if p.profile_id is not None
         ]
         purge_profile_ids, delete_profile_ids = self._partition_purge_vs_delete(

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -23,7 +23,7 @@ from ._agent_run import (
 )
 from ._base import BaseStorageCore, matches_status_filter
 from ._extras import ExtrasMixin
-from ._lineage import LineageEventMixin
+from ._lineage import EntityType, LineageEventMixin
 from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
 from ._profiles import ProfileMixin
@@ -50,6 +50,65 @@ class BaseStorage(
 ):
     """Base class for storage."""
 
+    def _is_lineage_tombstone(self, entity_type: EntityType, entity_id: str) -> bool:
+        """Return True when the entity row is a tombstone (merged_into or superseded_by set).
+
+        Uses the portable ``include_tombstones=True`` getters so the check
+        works for every backend without backend-specific SQL.
+
+        Args:
+            entity_type (EntityType): ``"profile"`` or ``"user_playbook"``.
+            entity_id (str): The entity's primary key as a string.
+
+        Returns:
+            bool: True if the row has ``merged_into`` or ``superseded_by`` set.
+        """
+        if entity_type == "profile":
+            row = self.get_profile_by_id(entity_id, include_tombstones=True)
+            if row is None:
+                return False
+            return bool(row.merged_into or row.superseded_by)
+        if entity_type == "user_playbook":
+            row = self.get_user_playbook_by_id(int(entity_id), include_tombstones=True)
+            if row is None:
+                return False
+            return bool(row.merged_into or row.superseded_by)
+        return False
+
+    def _partition_purge_vs_delete(
+        self, entity_type: EntityType, ids: list[str]
+    ) -> tuple[list[str], list[str]]:
+        """Split entity ids into purge-eligible and hard-delete sets.
+
+        An entity is purge-eligible when it is a tombstone (``merged_into`` or
+        ``superseded_by`` is set) **or** is pointed to by another row
+        (``has_inbound_lineage_refs`` returns True). All other ids go to the
+        hard-delete set.
+
+        Uses only portable storage reads so this helper works for every
+        backend (SQLite, Supabase, Postgres). Callers that need
+        backend-specific efficiency may override ``clear_user_data`` instead.
+
+        Args:
+            entity_type (EntityType): ``"profile"`` or ``"user_playbook"``.
+            ids (list[str]): Entity primary keys as strings.
+
+        Returns:
+            tuple[list[str], list[str]]: ``(purge_ids, delete_ids)`` where
+                ``purge_ids`` are content-purge candidates and ``delete_ids``
+                are safe to hard-delete.
+        """
+        purge_ids: list[str] = []
+        delete_ids: list[str] = []
+        for eid in ids:
+            if self._is_lineage_tombstone(
+                entity_type, eid
+            ) or self.has_inbound_lineage_refs(entity_type=entity_type, entity_id=eid):
+                purge_ids.append(eid)
+            else:
+                delete_ids.append(eid)
+        return purge_ids, delete_ids
+
     def clear_user_data(self, user_id: str) -> dict[str, int]:
         """Delete all rows scoped to a single ``user_id``.
 
@@ -61,6 +120,12 @@ class BaseStorage(
         parallel tasks without one task's clear-all nuking another
         in-flight task's rows.
 
+        **Lineage-aware erasure:** rows that are tombstones (``merged_into``
+        or ``superseded_by`` is set) *or* are pointed to by another row
+        (``has_inbound_lineage_refs`` returns True) are content-purged
+        (skeleton kept, body blanked) rather than hard-deleted. Standalone
+        rows with no lineage involvement are hard-deleted.
+
         The default implementation composes existing per-user / by-ids
         primitives so any backend that implements those (sqlite, supabase,
         postgres, ...) gets correct behaviour for free.
@@ -70,18 +135,18 @@ class BaseStorage(
             user_id (str): The user id whose rows should be deleted.
 
         Returns:
-            dict[str, int]: Per-entity deletion counts with keys
-                ``interactions``, ``user_playbooks``, ``profiles``, and
-                ``requests``. Counts reflect pre-deletion totals for the
-                user (i.e. how many rows existed for that user).
+            dict[str, int]: Per-entity counts with keys ``interactions``,
+                ``user_playbooks``, ``profiles``, ``requests``,
+                ``purged_profiles``, and ``purged_user_playbooks``.
+                ``profiles`` and ``user_playbooks`` reflect hard-deleted
+                counts; purged rows are counted separately.
         """
         interaction_count = len(self.get_user_interaction(user_id))
 
-        # Snapshot user_playbook ids for the user so we can both count
-        # and delete via the existing bulk-by-ids primitive (no per-user
-        # playbook delete primitive exists at the mixin level).
-        user_playbook_ids = [
-            up.user_playbook_id
+        # Snapshot user_playbook ids for the user and partition into
+        # purge vs delete sets.
+        raw_upb_ids = [
+            str(up.user_playbook_id)
             for up in self.get_user_playbooks(
                 user_id=user_id,
                 limit=1_000_000,
@@ -89,10 +154,21 @@ class BaseStorage(
             )
             if up.user_playbook_id is not None
         ]
-        profile_count = len(
-            self.get_user_profile(
+        purge_upb_ids, delete_upb_ids = self._partition_purge_vs_delete(
+            "user_playbook", raw_upb_ids
+        )
+
+        # Snapshot profile ids for the user and partition into
+        # purge vs delete sets.
+        raw_profile_ids = [
+            p.profile_id
+            for p in self.get_user_profile(
                 user_id, status_filter=[None, Status.ARCHIVED, Status.PENDING]
             )
+            if p.profile_id is not None
+        ]
+        purge_profile_ids, delete_profile_ids = self._partition_purge_vs_delete(
+            "profile", raw_profile_ids
         )
 
         # Snapshot request ids for the user so we can both count and
@@ -107,30 +183,42 @@ class BaseStorage(
         ]
 
         # Delete in dependency-safe order: interactions first (they
-        # reference requests), then user playbooks (also reference
-        # requests), then profiles, then the requests themselves.
+        # reference requests), then user playbooks, then profiles, then
+        # requests. Only the delete-sets are hard-deleted; purge-sets are
+        # content-purged below.
         self.delete_all_interactions_for_user(user_id)
         deleted_user_playbooks = (
-            self.delete_user_playbooks_by_ids(user_playbook_ids)
-            if user_playbook_ids
+            self.delete_user_playbooks_by_ids([int(i) for i in delete_upb_ids])
+            if delete_upb_ids
             else 0
         )
-        self.delete_all_profiles_for_user(user_id)
+        deleted_profiles = (
+            self.delete_profiles_by_ids(delete_profile_ids) if delete_profile_ids else 0
+        )
         deleted_requests = (
             self.delete_requests_by_ids(request_ids) if request_ids else 0
         )
 
+        # Content-purge the purge-eligible rows after the hard-deletes.
+        for pid in purge_profile_ids:
+            self.purge_content(entity_type="profile", entity_id=pid)
+        for upid in purge_upb_ids:
+            self.purge_content(entity_type="user_playbook", entity_id=upid)
+
         return {
             "interactions": interaction_count,
             "user_playbooks": deleted_user_playbooks,
-            "profiles": profile_count,
+            "profiles": deleted_profiles,
             "requests": deleted_requests,
+            "purged_profiles": len(purge_profile_ids),
+            "purged_user_playbooks": len(purge_upb_ids),
         }
 
 
 __all__ = [
     "AgentBinding",
     "AgentRunMixin",
+    "EntityType",
     "LineageEventMixin",
     "AgentRunRecord",
     "AgentRunStatus",

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -131,6 +131,12 @@ class BaseStorage(
         postgres, ...) gets correct behaviour for free.
         Subclasses MAY override for atomic / transactional efficiency.
 
+        **Atomicity note (default path only):** this default implementation is
+        NOT wrapped in a single transaction. Each ``purge_content`` call commits
+        independently, so a crash mid-erasure may leave some purge-eligible rows
+        with PII intact until ``clear_user_data`` is re-invoked. The call is
+        idempotent — re-invoking it is safe and will finish the erasure.
+
         Args:
             user_id (str): The user id whose rows should be deleted.
 

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -157,15 +157,18 @@ class LineageEventMixin:
         Returns ``True`` if a row existed (whether or not new blanking was done).
 
         Args:
-            entity_type (EntityType): One of ``"user_playbook"``, ``"agent_playbook"``,
-                or ``"profile"``.
+            entity_type (EntityType): One of ``"user_playbook"`` or ``"profile"``.
+                ``"agent_playbook"`` is **not** supported (agent playbooks have no
+                ``user_id`` and are out of scope for content purge) — implementations
+                must raise ``ValueError`` for that value.
             entity_id (str): The entity's primary key as a string.
 
         Returns:
             bool: ``True`` if the row exists; ``False`` if the id had no matching row.
 
         Raises:
-            ValueError: If ``entity_type`` is not a recognized entity type.
+            ValueError: If ``entity_type`` is not a recognized entity type or is
+                ``"agent_playbook"``.
         """
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -142,7 +142,7 @@ class LineageEventMixin:
             bool: True if any row in the entity's table has ``merged_into == entity_id``
                 OR ``superseded_by == entity_id``; False otherwise.
         """
-        ...
+        raise NotImplementedError
 
     @abstractmethod
     def purge_content(self, *, entity_type: EntityType, entity_id: str) -> bool:

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -145,6 +145,31 @@ class LineageEventMixin:
         ...
 
     @abstractmethod
+    def purge_content(self, *, entity_type: EntityType, entity_id: str) -> bool:
+        """Blank a record's PII body, keep its lineage skeleton, emit op=purge.
+
+        Keeps only ``{pk, status, merged_into, superseded_by, retired_at}`` and
+        non-PII bookkeeping columns (timestamps, TTL); blanks every other column
+        (text → ``''``, nullable → ``NULL``; ``user_id`` → ``''``). Irreversible.
+        Emits a single ``op=purge`` lineage event with a deterministic
+        ``request_id="purge_{entity_id}"`` so repeated calls are idempotent —
+        an already-blank row re-runs without recording a duplicate event.
+        Returns ``True`` if a row existed (whether or not new blanking was done).
+
+        Args:
+            entity_type (EntityType): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            entity_id (str): The entity's primary key as a string.
+
+        Returns:
+            bool: ``True`` if the row exists; ``False`` if the id had no matching row.
+
+        Raises:
+            ValueError: If ``entity_type`` is not a recognized entity type.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def gc_expired_tombstones(
         self, *, entity_type: str, older_than_epoch: int, limit: int = 1000
     ) -> int:

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -124,6 +124,27 @@ class LineageEventMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def has_inbound_lineage_refs(
+        self, *, entity_type: EntityType, entity_id: str
+    ) -> bool:
+        """Return True if any row points at ``entity_id`` via merged_into/superseded_by.
+
+        Org-scoped but deliberately NOT user_id-scoped: a cross-user chain
+        (one user's tombstone pointing at another user's survivor) must be
+        detected so the survivor is purged, not hard-deleted, on erasure.
+
+        Args:
+            entity_type (EntityType): One of ``"user_playbook"``, ``"agent_playbook"``,
+                or ``"profile"``.
+            entity_id (str): The entity's primary key to check for inbound refs.
+
+        Returns:
+            bool: True if any row in the entity's table has ``merged_into == entity_id``
+                OR ``superseded_by == entity_id``; False otherwise.
+        """
+        ...
+
+    @abstractmethod
     def gc_expired_tombstones(
         self, *, entity_type: str, older_than_epoch: int, limit: int = 1000
     ) -> int:

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -87,6 +87,45 @@ def test_purge_returns_false_for_missing_entity(storage):
     )
 
 
+def test_resolve_current_returns_is_purged_for_purged_survivor(storage):
+    """Guard: resolve_current returns is_purged=True when the live survivor was purged.
+
+    Contract lock-in for Task 6 (purge_content companion).  No production consumer
+    currently dereferences the resolved record's content, so no skip-logic is needed
+    today.  This test ensures the signal any future consumer relies on is stable and
+    cannot regress silently.
+
+    Audit finding: as of 2026-06-23 there are ZERO call sites outside of
+    resolve_current itself and test code that call resolve_current and then read
+    the returned RecordRef's content — the function is only consumed by tests and
+    the clear_user_data path (which only uses the resolved id, not the content).
+    No skip-guard was added to any consumer because none read content.
+    """
+    from reflexio.server.services.lineage.resolve import resolve_current
+
+    # A→B (live survivor): purge B's content, then resolve from A.
+    storage.add_user_profile("alice", [_profile("A", "alice", "old body")])
+    storage.add_user_profile("alice", [_profile("B", "alice", "live body")])
+    storage.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
+    )
+
+    # Before purge: is_purged must be False.
+    ref_before = resolve_current(storage, "profile", "A")
+    assert ref_before is not None
+    assert ref_before.id == "B"
+    assert ref_before.is_purged is False
+
+    # Purge the live survivor's content.
+    storage.purge_content(entity_type="profile", entity_id="B")
+
+    # After purge: resolving from A must yield is_purged=True on the same id.
+    ref_after = resolve_current(storage, "profile", "A")
+    assert ref_after is not None
+    assert ref_after.id == "B"
+    assert ref_after.is_purged is True
+
+
 class _BoomOnCommit:
     """Thin proxy around sqlite3.Connection that raises on the first commit call.
 

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -227,6 +227,7 @@ def test_clear_user_data_cross_user_chain_purges_other_users_survivor(tmp_path):
     assert c_row is not None, (
         "C must not be hard-deleted — alice's chain still references it"
     )
+    assert c_row["content"] == "", "C's content must be blanked (purged), not merely kept"
     # Alice's A still resolves to C via the pointer.
     ref = resolve_current(s, "profile", "A")
     assert ref is not None and ref.id == "C"

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -1,0 +1,40 @@
+"""Task 1: has_inbound_lineage_refs query for purge-vs-hard-delete decision."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import LineageContext, UserProfile
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _ctx(rid: str = "r1") -> LineageContext:
+    return LineageContext(op_kind="revise", actor="test", reason="t", request_id=rid)
+
+
+def _profile(storage: SQLiteStorage, pid: str, uid: str, content: str) -> UserProfile:
+    return UserProfile(
+        profile_id=pid,
+        user_id=uid,
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id="req-1",
+    )
+
+
+def test_has_inbound_lineage_refs_true_when_pointed_to(tmp_path):
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+    # Two profiles; B supersedes A → A.superseded_by=B, so B has an inbound ref.
+    s.add_user_profile("alice", [_profile(s, "A", "alice", "old")])
+    s.add_user_profile("alice", [_profile(s, "B", "alice", "new")])
+    s.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
+    )
+    assert s.has_inbound_lineage_refs(entity_type="profile", entity_id="B") is True
+    assert s.has_inbound_lineage_refs(entity_type="profile", entity_id="A") is False

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 
 import pytest
 
-from reflexio.models.api_schema.domain.entities import LineageContext, UserProfile
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    AgentPlaybookSourceWindow,
+    LineageContext,
+    UserPlaybook,
+    UserProfile,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -381,4 +387,176 @@ def test_clear_user_data_cross_user_chain_purges_other_users_survivor(tmp_path):
     assert ref is not None and ref.id == "C"
     assert ref.is_purged is True, (
         "Resolved survivor C must be marked is_purged after content purge"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F1 — user_playbook purge path
+# ---------------------------------------------------------------------------
+
+
+def _user_playbook(user_id: str, content: str = "secret body") -> UserPlaybook:
+    return UserPlaybook(
+        user_id=user_id,
+        agent_version="v1",
+        request_id="req-upb",
+        content=content,
+    )
+
+
+def test_purge_user_playbook_blanks_body_user_id_null(storage):
+    """purge_content on a user_playbook tombstone blanks body and sets user_id=NULL.
+
+    user_playbooks.user_id is NULLABLE, so the purge SQL sets it to NULL
+    (unlike profiles where user_id is NOT NULL and is blanked to '').
+    The skeleton (status, pointers) must be kept intact and exactly one
+    op=purge lineage event must be recorded.
+    """
+    # Create incumbent and successor user_playbooks.
+    up_inc = _user_playbook("alice", "alice@secret.com")
+    up_suc = _user_playbook("alice", "replacement body")
+    storage.save_user_playbooks([up_inc])
+    storage.save_user_playbooks([up_suc])
+    inc_id = up_inc.user_playbook_id
+    suc_id = up_suc.user_playbook_id
+
+    # Supersede the incumbent — now it is a tombstone.
+    storage.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(inc_id),
+        successor_id=str(suc_id),
+        context=_ctx("r-upb"),
+    )
+
+    # Confirm the tombstone state.
+    row_before = storage.conn.execute(
+        "SELECT user_id, superseded_by, status FROM user_playbooks WHERE user_playbook_id=?",
+        (inc_id,),
+    ).fetchone()
+    assert row_before["user_id"] == "alice"
+    assert row_before["superseded_by"] == suc_id
+
+    # Purge the tombstone.
+    result = storage.purge_content(entity_type="user_playbook", entity_id=str(inc_id))
+    assert result is True
+
+    # Content and user_id must be blanked; user_id is NULLABLE → goes to NULL.
+    row = storage.conn.execute(
+        "SELECT content, user_id, status, superseded_by FROM user_playbooks WHERE user_playbook_id=?",
+        (inc_id,),
+    ).fetchone()
+    assert row["content"] == ""
+    assert row["user_id"] is None  # NULLABLE column → NULL, not ''
+    assert row["status"] == "superseded"  # skeleton kept
+    assert row["superseded_by"] == suc_id  # pointer kept
+
+    # Exactly one op=purge lineage event.
+    events = storage.get_lineage_events(
+        entity_type="user_playbook", entity_id=str(inc_id), org_id="0"
+    )
+    purges = [e for e in events if e.op == "purge"]
+    assert len(purges) == 1
+    assert purges[0].request_id == f"purge_{inc_id}"
+
+
+def test_purge_agent_playbook_raises_value_error(storage):
+    """purge_content with entity_type='agent_playbook' must raise ValueError."""
+    with pytest.raises(ValueError, match="agent_playbook"):
+        storage.purge_content(entity_type="agent_playbook", entity_id="x")
+
+
+# ---------------------------------------------------------------------------
+# F2 — chunk-boundary: clear_user_data handles more rows than chunk size
+# ---------------------------------------------------------------------------
+
+
+def test_clear_user_data_chunk_boundary(tmp_path, monkeypatch):
+    """clear_user_data deletes all rows even when the count exceeds the chunk size.
+
+    Monkeypatches the ``chunked`` helper used by ``_delete_in_chunks`` to force
+    a chunk size of 2, then seeds 5 profiles so the delete-set crosses the chunk
+    boundary. All rows must be deleted/purged without error.
+    """
+    import reflexio.server.services.storage.sqlite_storage._base as _base_mod
+    from reflexio.server.services.storage.retention_mixin import chunked as real_chunked
+
+    def chunked_size2(values, chunk_size=500):  # type: ignore[misc]
+        return real_chunked(values, chunk_size=2)
+
+    monkeypatch.setattr(_base_mod, "chunked", chunked_size2)
+
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+
+    # Seed 5 standalone profiles for "alice" — all go to the hard-delete set.
+    for i in range(5):
+        s.add_user_profile("alice", [_profile(f"P{i}", "alice", f"body {i}")])
+
+    counts = s.clear_user_data("alice")
+
+    # All 5 profiles hard-deleted (no lineage refs, no tombstone).
+    assert counts["profiles"] == 5, f"expected 5 hard-deleted, got {counts['profiles']}"
+    assert counts["purged_profiles"] == 0
+
+    # Confirm the table is empty for alice.
+    remaining = s.conn.execute(
+        "SELECT count(*) AS n FROM profiles WHERE user_id='alice'"
+    ).fetchone()["n"]
+    assert remaining == 0
+
+
+# ---------------------------------------------------------------------------
+# F3 — source-window orphan: clear_user_data cleans join rows for hard-deleted playbooks
+# ---------------------------------------------------------------------------
+
+
+def test_clear_user_data_no_orphan_source_window_rows(tmp_path):
+    """After clear_user_data, no orphan rows remain in agent_playbook_source_user_playbooks
+    for the erased user's hard-deleted playbooks.
+
+    Source-window cleanup applies only to the HARD-DELETE set; a purged playbook
+    keeps its skeleton and join rows. Here the user_playbook has no lineage refs,
+    so it is hard-deleted and its join rows must be gone.
+    """
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+
+    # Create a user_playbook for alice (standalone, no lineage → will be hard-deleted).
+    upb = _user_playbook("alice", "alice's playbook body")
+    s.save_user_playbooks([upb])
+    upb_id = upb.user_playbook_id
+
+    # Create an agent_playbook and link it to the user_playbook via a source window.
+    [ap] = s.save_agent_playbooks(
+        [AgentPlaybook(agent_version="v1", content="agent body")]
+    )
+    ap_id = ap.agent_playbook_id
+    s.set_source_windows_for_agent_playbook(
+        ap_id,
+        [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=upb_id, source_interaction_ids=[1]
+            )
+        ],
+    )
+
+    # Confirm the join row exists before erasure.
+    join_before = s.conn.execute(
+        "SELECT count(*) AS n FROM agent_playbook_source_user_playbooks WHERE user_playbook_id=?",
+        (upb_id,),
+    ).fetchone()["n"]
+    assert join_before == 1
+
+    # Erase alice — user_playbook is standalone → hard-deleted → join row must be removed.
+    counts = s.clear_user_data("alice")
+    assert counts["user_playbooks"] == 1  # hard-deleted, not purged
+    assert counts["purged_user_playbooks"] == 0
+
+    # No orphan join rows for the deleted user_playbook_id.
+    join_after = s.conn.execute(
+        "SELECT count(*) AS n FROM agent_playbook_source_user_playbooks WHERE user_playbook_id=?",
+        (upb_id,),
+    ).fetchone()["n"]
+    assert join_after == 0, (
+        f"Orphan source-window row survived for hard-deleted user_playbook_id={upb_id}"
     )

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -87,6 +87,63 @@ def test_purge_returns_false_for_missing_entity(storage):
     )
 
 
+def test_purge_with_empty_content_still_blanks_other_pii(storage):
+    """Row with content='' but other PII populated must be fully purged.
+
+    Guards against the former ``AND content != ''`` guard that would skip the
+    UPDATE entirely when content was already blank, leaving user_id / embedding /
+    tags / etc. intact.
+    """
+    # Insert a profile and then zero out content manually, leaving user_id set.
+    storage.add_user_profile("alice", [_profile("E", "alice", "initial body")])
+    # Blank only content so the row has content='' but user_id='alice' still live.
+    storage.conn.execute("UPDATE profiles SET content='' WHERE profile_id='E'")
+    storage.conn.commit()
+
+    # Sanity: user_id is still populated before the purge.
+    before = storage.conn.execute(
+        "SELECT content, user_id FROM profiles WHERE profile_id='E'"
+    ).fetchone()
+    assert before["content"] == ""
+    assert before["user_id"] == "alice"
+
+    # Purge must return True (row exists) and blank user_id even though content was ''.
+    assert storage.purge_content(entity_type="profile", entity_id="E") is True
+
+    after = storage.conn.execute(
+        "SELECT content, user_id FROM profiles WHERE profile_id='E'"
+    ).fetchone()
+    assert after["content"] == "", "content already blank — stays blank"
+    assert after["user_id"] == "", (
+        "user_id must be blanked even when content was already ''"
+    )
+
+    # Exactly one purge event recorded.
+    events = storage.get_lineage_events(
+        entity_type="profile", entity_id="E", org_id="0"
+    )
+    purges = [e for e in events if e.op == "purge"]
+    assert len(purges) == 1
+
+
+def test_purge_idempotent_on_already_purged_row(storage):
+    """Re-running purge on an already-purged row yields exactly one op=purge event.
+
+    The deterministic request_id ``"purge_{entity_id}"`` + INSERT OR IGNORE on the
+    unique key ensures no duplicate event is recorded.
+    """
+    storage.add_user_profile("bob", [_profile("F", "bob", "some content")])
+    storage.purge_content(entity_type="profile", entity_id="F")  # first purge
+    storage.purge_content(entity_type="profile", entity_id="F")  # re-run
+
+    events = storage.get_lineage_events(
+        entity_type="profile", entity_id="F", org_id="0"
+    )
+    purges = [e for e in events if e.op == "purge"]
+    assert len(purges) == 1, f"Expected 1 purge event, got {len(purges)}"
+    assert purges[0].request_id == "purge_F"
+
+
 def test_resolve_current_returns_is_purged_for_purged_survivor(storage):
     """Guard: resolve_current returns is_purged=True when the live survivor was purged.
 
@@ -273,24 +330,21 @@ def test_clear_user_data_tombstone_only_user(tmp_path):
     # Erase alice — her only profile is a tombstone; erasure must reach it.
     counts = s.clear_user_data("alice")
 
-    # A is tombstone and pointed-to by nothing itself (B points at A via
-    # superseded_by, so A has no inbound refs) — but A IS a tombstone so it
-    # is purge-eligible via _is_lineage_tombstone.
+    # A is a tombstone (superseded_by=B set) → _is_lineage_tombstone returns True
+    # → _partition_purge_vs_delete puts A in the purge set (not hard-delete).
+    # The row must still exist, content blanked, and count as purged.
     a_row = s.conn.execute(
         "SELECT content, user_id FROM profiles WHERE profile_id='A'"
     ).fetchone()
-    # Row must have been reached: either purged (content='') or hard-deleted.
-    # Both outcomes satisfy erasure; the key is the row is NOT intact.
-    if a_row is not None:
-        # Purged: content blanked.
-        assert a_row["content"] == "", (
-            "Tombstone profile A must be content-purged on erasure"
-        )
-    # If a_row is None it was hard-deleted — also acceptable (no inbound refs).
-    # Either way at least one profile was touched.
-    assert counts["purged_profiles"] + counts["profiles"] >= 1, (
-        "Erasure must report at least one profile touched "
-        f"(purged={counts['purged_profiles']}, deleted={counts['profiles']})"
+    assert a_row is not None, (
+        "Tombstone A must be content-purged (skeleton kept), not hard-deleted"
+    )
+    assert a_row["content"] == "", "Tombstone profile A must have its content blanked"
+    assert counts["purged_profiles"] == 1, (
+        f"Expected 1 purged profile, got {counts['purged_profiles']}"
+    )
+    assert counts["profiles"] == 0, (
+        f"Expected 0 hard-deleted profiles, got {counts['profiles']}"
     )
 
 
@@ -322,6 +376,9 @@ def test_clear_user_data_cross_user_chain_purges_other_users_survivor(tmp_path):
     assert c_row["content"] == "", (
         "C's content must be blanked (purged), not merely kept"
     )
-    # Alice's A still resolves to C via the pointer.
+    # Alice's A still resolves to C via the pointer, and C is marked purged.
     ref = resolve_current(s, "profile", "A")
     assert ref is not None and ref.id == "C"
+    assert ref.is_purged is True, (
+        "Resolved survivor C must be marked is_purged after content purge"
+    )

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -156,3 +156,77 @@ def test_has_inbound_lineage_refs_true_when_merged_into(storage):
     assert (
         storage.has_inbound_lineage_refs(entity_type="profile", entity_id="C") is False
     )
+
+
+def test_clear_user_data_purges_referenced_keeps_chain(tmp_path):
+    """Chain A→B→C(live) + standalone D; clear_user_data purges tombstones/referenced,
+    hard-deletes unreferenced standalone rows, and chain still resolves after erasure.
+
+    Ordering invariant: A and B are tombstones (superseded_by/merged_into set) so they
+    are purge-eligible. C is the live survivor but has inbound lineage refs (B points to
+    it), so it is also purged rather than hard-deleted. D is unreferenced → hard-deleted.
+    """
+    from reflexio.server.services.lineage.resolve import resolve_current
+
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+
+    # Build chain A→B→C with supersede then merge; D is standalone.
+    s.add_user_profile("alice", [_profile("A", "alice", "a")])
+    s.add_user_profile("alice", [_profile("B", "alice", "b")])
+    s.add_user_profile("alice", [_profile("C", "alice", "c")])
+    s.add_user_profile("alice", [_profile("D", "alice", "d")])
+    s.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx("r1")
+    )
+    s.merge_records(
+        entity_type="profile", source_ids=["B"], survivor_id="C", context=_ctx("r2")
+    )
+
+    counts = s.clear_user_data("alice")
+
+    # D must be hard-deleted (row gone).
+    assert (
+        s.conn.execute("SELECT 1 FROM profiles WHERE profile_id='D'").fetchone() is None
+    )
+    # C must be content-purged (skeleton kept, body blanked).
+    c_row = s.conn.execute(
+        "SELECT content FROM profiles WHERE profile_id='C'"
+    ).fetchone()
+    assert c_row is not None and c_row["content"] == ""
+    # Chain A→B→C still resolves via lineage pointers.
+    ref = resolve_current(s, "profile", "A")
+    assert ref is not None and ref.id == "C" and ref.is_purged is True
+    # Count checks: 3 purged (A, B, C), 1 hard-deleted (D).
+    assert counts["purged_profiles"] == 3
+    assert counts["profiles"] == 1
+
+
+def test_clear_user_data_cross_user_chain_purges_other_users_survivor(tmp_path):
+    """Cross-user: alice's tombstone A points to bob's live C.
+    Erasing bob must PURGE C (not hard-delete it), so alice's A still resolves.
+    Proves has_inbound_lineage_refs is not scoped to the user being erased.
+    """
+    from reflexio.server.services.lineage.resolve import resolve_current
+
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+
+    s.add_user_profile("alice", [_profile("A", "alice", "a")])
+    s.add_user_profile("bob", [_profile("C", "bob", "c")])  # survivor owned by bob
+    s.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="C", context=_ctx()
+    )
+
+    s.clear_user_data("bob")  # erase bob; alice's tombstone A still points at C
+
+    # C must be PURGED (skeleton kept), not hard-deleted.
+    c_row = s.conn.execute(
+        "SELECT content FROM profiles WHERE profile_id='C'"
+    ).fetchone()
+    assert c_row is not None, (
+        "C must not be hard-deleted — alice's chain still references it"
+    )
+    # Alice's A still resolves to C via the pointer.
+    ref = resolve_current(s, "profile", "A")
+    assert ref is not None and ref.id == "C"

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -17,7 +17,7 @@ def _ctx(rid: str = "r1") -> LineageContext:
     return LineageContext(op_kind="revise", actor="test", reason="t", request_id=rid)
 
 
-def _profile(storage: SQLiteStorage, pid: str, uid: str, content: str) -> UserProfile:
+def _profile(pid: str, uid: str, content: str) -> UserProfile:
     return UserProfile(
         profile_id=pid,
         user_id=uid,
@@ -27,14 +27,40 @@ def _profile(storage: SQLiteStorage, pid: str, uid: str, content: str) -> UserPr
     )
 
 
-def test_has_inbound_lineage_refs_true_when_pointed_to(tmp_path):
+@pytest.fixture
+def storage(tmp_path):
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
-        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+        yield SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+
+
+def test_has_inbound_lineage_refs_true_when_pointed_to(storage):
     # Two profiles; B supersedes A → A.superseded_by=B, so B has an inbound ref.
-    s.add_user_profile("alice", [_profile(s, "A", "alice", "old")])
-    s.add_user_profile("alice", [_profile(s, "B", "alice", "new")])
-    s.supersede_record(
+    storage.add_user_profile("alice", [_profile("A", "alice", "old")])
+    storage.add_user_profile("alice", [_profile("B", "alice", "new")])
+    storage.supersede_record(
         entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
     )
-    assert s.has_inbound_lineage_refs(entity_type="profile", entity_id="B") is True
-    assert s.has_inbound_lineage_refs(entity_type="profile", entity_id="A") is False
+    assert (
+        storage.has_inbound_lineage_refs(entity_type="profile", entity_id="B") is True
+    )
+    assert (
+        storage.has_inbound_lineage_refs(entity_type="profile", entity_id="A") is False
+    )
+
+
+def test_has_inbound_lineage_refs_true_when_merged_into(storage):
+    # Two profiles; A is merged into B → A.merged_into=B, so B has an inbound ref.
+    storage.add_user_profile("bob", [_profile("C", "bob", "old")])
+    storage.add_user_profile("bob", [_profile("D", "bob", "new")])
+    storage.merge_records(
+        entity_type="profile",
+        survivor_id="D",
+        source_ids=["C"],
+        context=_ctx(rid="r2"),
+    )
+    assert (
+        storage.has_inbound_lineage_refs(entity_type="profile", entity_id="D") is True
+    )
+    assert (
+        storage.has_inbound_lineage_refs(entity_type="profile", entity_id="C") is False
+    )

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -202,6 +202,59 @@ def test_clear_user_data_purges_referenced_keeps_chain(tmp_path):
     assert counts["profiles"] == 1
 
 
+def test_clear_user_data_tombstone_only_user(tmp_path):
+    """Erasure reaches users whose ONLY rows are tombstones.
+
+    Regression guard for the GDPR bug where ``clear_user_data`` enumerated
+    profiles/user_playbooks with ``status_filter=[None, ARCHIVED, PENDING]``,
+    which excluded SUPERSEDED and MERGED rows.  A user whose sole profile was
+    superseded by another user's profile would survive erasure entirely.
+
+    Scenario: alice's profile A is superseded by bob's profile B.
+    After supersede, A has ``status='superseded'`` and A.superseded_by=B.
+    Erasing alice must still reach A (her only row) and purge it.
+    """
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+
+    # alice has one profile that ends up superseded by bob's profile.
+    s.add_user_profile("alice", [_profile("A", "alice", "alice@secret.com")])
+    s.add_user_profile("bob", [_profile("B", "bob", "bob content")])
+    s.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
+    )
+
+    # Confirm A is now a tombstone with status='superseded'.
+    row = s.conn.execute(
+        "SELECT status, superseded_by FROM profiles WHERE profile_id='A'"
+    ).fetchone()
+    assert row["status"] == "superseded"
+    assert row["superseded_by"] == "B"
+
+    # Erase alice — her only profile is a tombstone; erasure must reach it.
+    counts = s.clear_user_data("alice")
+
+    # A is tombstone and pointed-to by nothing itself (B points at A via
+    # superseded_by, so A has no inbound refs) — but A IS a tombstone so it
+    # is purge-eligible via _is_lineage_tombstone.
+    a_row = s.conn.execute(
+        "SELECT content, user_id FROM profiles WHERE profile_id='A'"
+    ).fetchone()
+    # Row must have been reached: either purged (content='') or hard-deleted.
+    # Both outcomes satisfy erasure; the key is the row is NOT intact.
+    if a_row is not None:
+        # Purged: content blanked.
+        assert a_row["content"] == "", (
+            "Tombstone profile A must be content-purged on erasure"
+        )
+    # If a_row is None it was hard-deleted — also acceptable (no inbound refs).
+    # Either way at least one profile was touched.
+    assert counts["purged_profiles"] + counts["profiles"] >= 1, (
+        "Erasure must report at least one profile touched "
+        f"(purged={counts['purged_profiles']}, deleted={counts['profiles']})"
+    )
+
+
 def test_clear_user_data_cross_user_chain_purges_other_users_survivor(tmp_path):
     """Cross-user: alice's tombstone A points to bob's live C.
     Erasing bob must PURGE C (not hard-delete it), so alice's A still resolves.
@@ -227,7 +280,9 @@ def test_clear_user_data_cross_user_chain_purges_other_users_survivor(tmp_path):
     assert c_row is not None, (
         "C must not be hard-deleted — alice's chain still references it"
     )
-    assert c_row["content"] == "", "C's content must be blanked (purged), not merely kept"
+    assert c_row["content"] == "", (
+        "C's content must be blanked (purged), not merely kept"
+    )
     # Alice's A still resolves to C via the pointer.
     ref = resolve_current(s, "profile", "A")
     assert ref is not None and ref.id == "C"

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -48,6 +48,98 @@ def test_has_inbound_lineage_refs_true_when_pointed_to(storage):
     )
 
 
+def test_purge_blanks_body_keeps_skeleton(storage):
+    storage.add_user_profile("alice", [_profile("A", "alice", "alice@x.com secret")])
+    storage.add_user_profile("alice", [_profile("B", "alice", "new")])
+    storage.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
+    )
+    assert storage.purge_content(entity_type="profile", entity_id="A") is True
+    row = storage.conn.execute(
+        "SELECT content, user_id, status, superseded_by FROM profiles WHERE profile_id='A'"
+    ).fetchone()
+    assert row["content"] == ""  # body blanked
+    assert row["user_id"] == ""  # PII blanked to '' (NOT NULL)
+    assert row["status"] == "superseded"  # skeleton kept
+    assert row["superseded_by"] == "B"  # pointer kept
+
+
+def test_purge_emits_one_pii_free_event_idempotent(storage):
+    storage.add_user_profile("alice", [_profile("A", "alice", "x")])
+    storage.add_user_profile("alice", [_profile("B", "alice", "y")])
+    storage.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
+    )
+    storage.purge_content(entity_type="profile", entity_id="A")
+    storage.purge_content(entity_type="profile", entity_id="A")  # re-run
+    events = storage.get_lineage_events(
+        entity_type="profile", entity_id="A", org_id="0"
+    )
+    purges = [e for e in events if e.op == "purge"]
+    assert len(purges) == 1  # deterministic request_id → no duplicate
+    assert "alice" not in (purges[0].actor or "")  # event carries no user identifier
+    assert purges[0].request_id == "purge_A"
+
+
+def test_purge_returns_false_for_missing_entity(storage):
+    assert (
+        storage.purge_content(entity_type="profile", entity_id="nonexistent") is False
+    )
+
+
+class _BoomOnCommit:
+    """Thin proxy around sqlite3.Connection that raises on the first commit call.
+
+    sqlite3.Connection.commit is a C-level slot and cannot be monkeypatched
+    directly, so we wrap the real connection in a proxy and swap s.conn.
+    """
+
+    def __init__(self, real_conn: object) -> None:
+        self._real = real_conn
+        self._boom = True  # raise on next commit
+
+    def commit(self) -> None:
+        if self._boom:
+            raise RuntimeError("crash")
+        self._real.commit()  # type: ignore[attr-defined]
+
+    def rollback(self) -> None:
+        self._real.rollback()  # type: ignore[attr-defined]
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._real, name)
+
+
+def test_purge_atomic_no_phantom_event(tmp_path):
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))
+    s.add_user_profile("alice", [_profile("A", "alice", "x")])
+    s.add_user_profile("alice", [_profile("B", "alice", "y")])
+    s.supersede_record(
+        entity_type="profile", incumbent_id="A", successor_id="B", context=_ctx()
+    )
+    # Swap in a proxy that raises on the first commit (post-UPDATE, pre-durability).
+    real_conn = s.conn
+    proxy = _BoomOnCommit(real_conn)
+    s.conn = proxy  # type: ignore[assignment]
+    with pytest.raises(RuntimeError, match="crash"):
+        s.purge_content(entity_type="profile", entity_id="A")
+    # Restore real connection and roll back the aborted transaction.
+    s.conn = real_conn
+    real_conn.rollback()
+    # Neither the blank nor the event survived.
+    row = real_conn.execute(
+        "SELECT content FROM profiles WHERE profile_id='A'"
+    ).fetchone()
+    assert row["content"] != ""  # body intact
+    purges = [
+        e
+        for e in s.get_lineage_events(entity_type="profile", entity_id="A", org_id="0")
+        if e.op == "purge"
+    ]
+    assert purges == []
+
+
 def test_has_inbound_lineage_refs_true_when_merged_into(storage):
     # Two profiles; A is merged into B → A.merged_into=B, so B has an inbound ref.
     storage.add_user_profile("bob", [_profile("C", "bob", "old")])


### PR DESCRIPTION
Implements the `purge_content` primitive (specified but never built in the lineage design §5.1E/§14). Pairs with the enterprise PR that adds the Supabase/Postgres RPC + bumps this submodule pointer.

## What it does
GDPR erasure (`clear_user_data`) now **content-purges** a user's *referenced* lineage tombstones instead of hard-deleting them — blanks all PII (incl. `user_id`), keeps the `{id, status, merged_into, superseded_by, retired_at}` skeleton, emits an `op=purge` event — so `resolve_current` chains stay resolvable (`is_purged=True`) while the PII is gone. Standalone rows + interactions/requests hard-delete as before.

## Changes (TDD, per-task reviewed)
- **`has_inbound_lineage_refs`** (org-scoped, **not** user-scoped — cross-user chains).
- **`purge_content(entity_type, id)`** — blank = complement of the keep-allowlist; `profiles.user_id`→`''` (NOT NULL), `user_playbooks.user_id`→`NULL`; atomic blank+event in one commit (rowcount-guarded), FTS/vec cleanup after commit (the codebase's emit-before-commit hazard avoided); deterministic `request_id="purge_"+id` → idempotent (no duplicate event); PII-free event. Crash-window test proves no phantom event.
- **Both `clear_user_data` bodies** (SQLite override + BaseStorage default for Supabase/Postgres) gain the purge-vs-delete decision (tombstone OR pointed-to → purge; else hard-delete) via a shared `_partition_purge_vs_delete` helper. Erasure enumerates **all statuses incl. tombstones** (SUPERSEDED/MERGED).
- **`is_purged` contract** strengthened on `resolve_current`/`RecordRef` + a guard test. Audit found zero consumers dereference resolved content today (so live-pointed-to-survivor purge is safe now; the consumer-skip is a documented gated dependency for any future consumer).

## Verification
SQLite purge suite 10 passed; broader storage suite 527 passed; ruff + pyright clean. A final whole-branch review verified atomicity, blank-completeness parity with Supabase, tombstone-erasure completeness, and idempotency.

> **Governance:** the retained skeleton is "put beyond use" / Art. 18 restriction — **not** anonymisation. See the enterprise PR's DPO decision record.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated record reference documentation to clarify handling when content is erased for privacy.
  * Enhanced function contract documentation describing how purged records should be treated.

* **New Features**
  * Content erasure for user data deletion now intelligently preserves lineage relationships while blanking personal information.

* **Tests**
  * Added comprehensive integration tests validating content erasure behavior and privacy compliance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->