### PR TITLE
fix(lineage): keep added-then-superseded playbooks in aggregation reconstruction

### DIFF
--- a/reflexio/lib/_agent_playbook.py
+++ b/reflexio/lib/_agent_playbook.py
@@ -382,9 +382,12 @@ def reconstruct_playbook_aggregation_change_log(
     ``updated_agent_playbooks = []`` (Decision 3 — tolerated delta; updates
     are folded into added/removed in the B3b reconstruction model).
 
-    Known limitation (Bucket-4 follow-up): added-side resolve omits
-    include_tombstones → an added-then-superseded playbook drops from its
-    run's history.
+    An agent_playbook *added* in run R is included in R's
+    ``added_agent_playbooks`` even if a later run superseded (tombstoned) it
+    (resolved with ``include_tombstones=True``) — so R is not dropped from the
+    change log, matching the legacy table and ``reconstruct_profile_change_log``.
+    As with the removed side, once a tombstone is physically purged (GC) the
+    snapshot resolves to ``None`` and is silently omitted.
 
     Version-semantics note (E1): for remove-only runs with mixed agent_version
     across the superseded set, ``agent_version`` is that of the first resolved
@@ -477,7 +480,10 @@ def reconstruct_playbook_aggregation_change_log(
         added = []
         for eid in added_by_req[req]:
             try:
-                pb = storage.get_agent_playbook_by_id(int(eid))
+                # include_tombstones: a playbook added in this run but later
+                # superseded must still appear in this run's added side (so the
+                # run is not dropped) — mirrors the removed-side resolve below.
+                pb = storage.get_agent_playbook_by_id(int(eid), include_tombstones=True)
             except (ValueError, TypeError):
                 logger.warning(
                     "reconstruct: malformed entity_id %r in added_by_req, skipping", eid

--- a/tests/server/services/playbook/test_aggregation_lineage_integration.py
+++ b/tests/server/services/playbook/test_aggregation_lineage_integration.py
@@ -471,10 +471,12 @@ def test_e2e_reconstruct_incremental_run_mode(
 
     assert result.success
     assert result.change_logs, "Expected at least one reconstructed entry"
-    # Most recent entry (index 0) is the incremental run (run 2 has a later timestamp).
-    # Run 1's ap was superseded by run 2, so it won't appear in run1's 'added' list
-    # (reconstruct skips tombstoned entries in the added slot). Run 2's ap is live and
-    # has the superseded ap1 in its 'removed' list — so run 2 IS the first entry.
+    # BOTH runs appear. Run 2 (later timestamp) is the most recent entry. Run 1's ap was
+    # superseded by run 2 but is still shown in run 1's 'added' list — reconstruct resolves
+    # the added side with include_tombstones, so run 1 is no longer dropped from history.
+    assert len(result.change_logs) == 2, (
+        f"Expected both runs reconstructed, got {len(result.change_logs)}"
+    )
     log_most_recent = result.change_logs[0]
     assert log_most_recent.run_mode == "incremental", (
         f"Expected run_mode='incremental' for the most recent run, got {log_most_recent.run_mode!r}"
@@ -484,4 +486,10 @@ def test_e2e_reconstruct_incremental_run_mode(
     )
     assert log_most_recent.removed_agent_playbooks, (
         "Expected removed playbooks in incremental run (ap1 superseded under run2 request_id)"
+    )
+    # Run 1 survives supersession: its (now-tombstoned) added playbook is still present.
+    log_run1 = result.change_logs[1]
+    run1_added_contents = {snap.content for snap in log_run1.added_agent_playbooks}
+    assert "Run 1 content." in run1_added_contents, (
+        f"Run 1's added playbook must survive supersession, got {run1_added_contents}"
     )

--- a/tests/server/services/storage/test_lineage_b3b_reconstruct_playbook_changelog_integration.py
+++ b/tests/server/services/storage/test_lineage_b3b_reconstruct_playbook_changelog_integration.py
@@ -320,6 +320,49 @@ def test_purged_tombstone_omitted_no_crash(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Test 7b: added-then-superseded playbook still appears in its run's added side
+# ---------------------------------------------------------------------------
+
+
+def test_added_then_superseded_still_in_added(tmp_path):
+    """A playbook added in run R1 and later superseded by R2 stays in R1's added side.
+
+    Inverse of test_purged_tombstone_omitted_no_crash: while the tombstone still exists
+    (not yet GC-purged), the added side is resolved with include_tombstones, so R1 is
+    NOT dropped from the change log. (Pre-fix, R1's only added playbook resolved to None
+    and R1 — having no removals — was dropped entirely.)
+    """
+    s = _store(tmp_path)
+
+    # Run 1 adds playbook X.
+    pb_x = _make_playbook(playbook_name="pb", agent_version="v1", content="X added in run1")
+    x_id = _add_playbook(s, pb_x)
+    _emit_aggregate_event(s, entity_id=str(x_id), request_id="run-1")
+
+    # Run 2 supersedes X (tombstones the row + emits the superseded event).
+    _set_superseded(s, x_id)
+    _emit_status_change_superseded(s, entity_id=str(x_id), request_id="run-2")
+
+    result = reconstruct_playbook_aggregation_change_log(s)
+    assert result.success
+
+    run1 = next(
+        (
+            log
+            for log in result.change_logs
+            if any(
+                snap.content == "X added in run1" for snap in log.added_agent_playbooks
+            )
+        ),
+        None,
+    )
+    assert run1 is not None, (
+        "Run 1 must remain in the change log with its added playbook, got "
+        f"{[(cl.added_agent_playbooks, cl.removed_agent_playbooks) for cl in result.change_logs]}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Test 8: get_lineage_events(request_id=...) filter
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Keep added-then-superseded playbooks in aggregation reconstruction

`reconstruct_playbook_aggregation_change_log` (the canonical aggregation change-log source after Track B retired the legacy table) resolved the **added** side via `get_agent_playbook_by_id(eid)` **without** `include_tombstones=True`, while the **removed** side correctly passed it. So an agent_playbook *added* in run R and later *superseded* (tombstoned) by run R2 resolved to `None` and silently dropped from R's `added_agent_playbooks` — and if it was R's only add (no removals), R was dropped from the change log entirely.

This is a parity regression vs the legacy table (which recorded each run's added set at write time). One-line fix: pass `include_tombstones=True` on the added-side resolve, mirroring the removed side.

**Profiles were never affected** — `reconstruct_profile_change_log` builds its added side from `get_all_generated_profiles()` ("All profiles, any status") and already documents the "added in R1 even if tombstoned in R2" semantics.

GC-purged-beyond-window stays a documented limitation (resolves to `None` → omitted), same as the removed side.

### Tests
- New `test_added_then_superseded_still_in_added` (inverse of the existing purged-tombstone test).
- Updated the e2e two-run test: both runs now appear (previously only run 2 was visible — that was this bug).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Playbook change logs now keep earlier “added” entries visible even if the playbook was later superseded.
  * When a deleted item has been fully removed, it is no longer shown in reconstructed history.

* **Tests**
  * Updated existing reconstruction coverage to expect both historical entries.
  * Added a new integration test for the add-then-supersede scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->