### PR TITLE
feat: generalize PII in playbook aggregation prompt

### DIFF
--- a/reflexio/server/prompt/prompt_bank/playbook_aggregation/v2.3.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_aggregation/v2.3.0.prompt.md
@@ -182,7 +182,7 @@ Apply these rules to all source fields shown to you, including triggers, rationa
 - Do not turn one user's personal preference into an organization-wide rule
   unless the cluster supports it as shared behavior.
 - If removing or generalizing identifiers leaves no useful reusable agent
-  behavior, Return {{{{"playbook": null}}}}.
+  behavior, Return {{"playbook": null}}.
 
 ## What a Valid Canonical Policy Must Be
 
@@ -208,7 +208,7 @@ Before returning JSON:
 - Verify the rule remains grounded in the clustered source playbooks and reusable
   across users in the organization.
 - If either check fails and cannot be fixed by generalization, Return
-  {{{{"playbook": null}}}}.
+  {{"playbook": null}}.
 
 ## Output Format (Strict JSON)
 

--- a/reflexio/server/prompt/prompt_bank/playbook_aggregation/v2.3.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_aggregation/v2.3.0.prompt.md
@@ -158,6 +158,32 @@ on semantic similarity. Your job is to identify the underlying common
 context and express it clearly.
 
 ━━━━━━━━━━━━━━━━━━━━━━
+## Privacy and Identifier Generalization
+
+Agent playbooks are shared organization-wide rules. They must capture reusable
+agent behavior, not source-user identity or private source context.
+
+Apply these rules to all source fields shown to you, including triggers, rationales, and any freeform content or observations in the clustered input:
+
+- Never carry user-specific or source-specific direct identifiers into
+  `trigger`, `content`, or `rationale`.
+- Direct identifiers include person names; emails; phone numbers; addresses;
+  usernames or handles; government, employee, customer, account, ticket, and
+  similar exact identifiers; URLs or strings containing values tied to a person,
+  account, session, or secret; and named private customers, users, or
+  organization-specific people when the exact name is unnecessary for reusable
+  behavior.
+- Preserve the reusable procedure whenever possible by replacing direct
+  identifiers with generalized functional roles, resource types, or
+  relationships inferred from the clustered source playbooks.
+- Secrets and credentials must not be copied or generalized as values. Remove
+  secret values entirely, keeping only the non-secret procedural lesson if one
+  remains.
+- Do not turn one user's personal preference into an organization-wide rule
+  unless the cluster supports it as shared behavior.
+- If removing or generalizing identifiers leaves no useful reusable agent
+  behavior, Return {{{{"playbook": null}}}}.
+
 ## What a Valid Canonical Policy Must Be
 
 It MUST:
@@ -174,6 +200,16 @@ It MUST NOT:
 - Add conversational language
 
 ━━━━━━━━━━━━━━━━━━━━━━
+## Final Privacy Self-Check
+
+Before returning JSON:
+
+- Verify `trigger`, `content`, and `rationale` contain no direct identifiers, secrets, raw contact details, or exact IDs.
+- Verify the rule remains grounded in the clustered source playbooks and reusable
+  across users in the organization.
+- If either check fails and cannot be fixed by generalization, Return
+  {{{{"playbook": null}}}}.
+
 ## Output Format (Strict JSON)
 
 Return a JSON object with the following structure:

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1210,7 +1210,7 @@ def test_playbook_aggregation_prompt_generalizes_direct_identifiers():
     assert "triggers, rationales, and any freeform content" in out
     assert "Never carry user-specific or source-specific direct identifiers" in out
     assert "Secrets and credentials must not be copied" in out
-    assert "Return {{\"playbook\": null}}" in out
+    assert "Return {\"playbook\": null}" in out
 
 
 def test_playbook_aggregation_prompt_has_privacy_self_check_before_output():

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1210,7 +1210,7 @@ def test_playbook_aggregation_prompt_generalizes_direct_identifiers():
     assert "triggers, rationales, and any freeform content" in out
     assert "Never carry user-specific or source-specific direct identifiers" in out
     assert "Secrets and credentials must not be copied" in out
-    assert "Return {\"playbook\": null}" in out
+    assert 'Return {"playbook": null}' in out
 
 
 def test_playbook_aggregation_prompt_has_privacy_self_check_before_output():
@@ -1229,12 +1229,14 @@ def test_playbook_aggregation_prompt_has_privacy_self_check_before_output():
     output_index = out.index("## Output")
     assert checklist_index < output_index
     assert "`trigger`, `content`, and `rationale`" in out[checklist_index:output_index]
-    assert "direct identifiers, secrets, raw contact details, or exact IDs" in out[
-        checklist_index:output_index
-    ]
-    assert "grounded in the clustered source playbooks" in out[
-        checklist_index:output_index
-    ]
+    assert (
+        "direct identifiers, secrets, raw contact details, or exact IDs"
+        in out[checklist_index:output_index]
+    )
+    assert (
+        "grounded in the clustered source playbooks"
+        in out[checklist_index:output_index]
+    )
 
 
 def test_playbook_aggregation_prompt_preserves_distinct_orientations():

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1192,6 +1192,51 @@ def test_playbook_aggregation_prompt_specifies_structured_format():
     assert "one sentence" in out.lower()
 
 
+def test_playbook_aggregation_prompt_generalizes_direct_identifiers():
+    """Aggregation prompt should generalize direct identifiers for shared playbooks."""
+    from reflexio.server.prompt.prompt_manager import PromptManager
+
+    out = PromptManager().render_prompt(
+        "playbook_aggregation",
+        {
+            "existing_approved_playbooks": "[]",
+            "user_playbooks": "TRIGGER conditions (to be consolidated):\n- when approving a deployment\nRATIONALE summaries:\n- direct approval details appeared in the source",
+        },
+    )
+
+    assert "Privacy and Identifier Generalization" in out
+    assert "shared organization-wide rules" in out
+    assert "all source fields shown to you" in out
+    assert "triggers, rationales, and any freeform content" in out
+    assert "Never carry user-specific or source-specific direct identifiers" in out
+    assert "Secrets and credentials must not be copied" in out
+    assert "Return {{\"playbook\": null}}" in out
+
+
+def test_playbook_aggregation_prompt_has_privacy_self_check_before_output():
+    """Privacy checklist should run after source sections and before final JSON output."""
+    from reflexio.server.prompt.prompt_manager import PromptManager
+
+    out = PromptManager().render_prompt(
+        "playbook_aggregation",
+        {
+            "existing_approved_playbooks": "[]",
+            "user_playbooks": "TRIGGER conditions (to be consolidated):\n- when handling account access",
+        },
+    )
+
+    checklist_index = out.index("Before returning JSON")
+    output_index = out.index("## Output")
+    assert checklist_index < output_index
+    assert "`trigger`, `content`, and `rationale`" in out[checklist_index:output_index]
+    assert "direct identifiers, secrets, raw contact details, or exact IDs" in out[
+        checklist_index:output_index
+    ]
+    assert "grounded in the clustered source playbooks" in out[
+        checklist_index:output_index
+    ]
+
+
 def test_playbook_aggregation_prompt_preserves_distinct_orientations():
     """v2.2.0: the aggregation prompt must carry the preserve-distinct-rules
     instruction that replaced the retired mechanical polarity-bucketing gate.


### PR DESCRIPTION
## Summary
- Add prompt-only privacy guidance so org-wide agent playbook aggregation generalizes source-user direct identifiers instead of copying them from user playbooks.
- Keep the mitigation lightweight and best-effort: no runtime validators, schema changes, extra LLM calls, or save-time guards.
- Cover all rendered source fields used by aggregation, including triggers, rationales, and freeform content/observations.

## Changes
- Updated the `playbook_aggregation` prompt with direct-identifier generalization rules, secret removal guidance, and a final privacy self-check.
- Added prompt rendering tests that lock the privacy guidance, no-example constraint, and escaped JSON rendering behavior.

## Test Plan
- `uv run pytest open_source/reflexio/tests/server/services/playbook/test_playbook_aggregator.py -v -o 'addopts='`
- `uv run pytest open_source/reflexio/tests/server/services/prompt/test_prompt_manager.py open_source/reflexio/tests/server/services/test_prompt_model_mapping.py -v -o 'addopts='`
- `uv run ruff check open_source/reflexio/tests/server/services/playbook/test_playbook_aggregator.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger privacy safeguards when generating playbooks, including automatic removal or generalization of direct identifiers and sensitive details.
  * If no reusable behavior remains after privacy cleanup, the system now returns no playbook output.

* **Tests**
  * Added coverage to verify privacy-focused wording appears in the generated prompt and that the final validation step is checked before output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->