### PR TITLE
feat: log publish concurrency hardware capacity

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -179,6 +179,7 @@ from reflexio.server.correlation import correlation_id_var, generate_correlation
 from reflexio.server.operation_limiter import (
     OperationName,
     limiter_http_exception,
+    log_publish_hardware_capacity,
     run_with_operation_limit,
 )
 from reflexio.server.services.agent_success_evaluation.group_evaluation_runner import (
@@ -2975,6 +2976,7 @@ def create_app(
         scheduler = None
         gc_scheduler = None
         if mount_data_plane:
+            log_publish_hardware_capacity()
             validate_llm_availability()
             from reflexio.server.llm.rerank import prewarm as _prewarm_cross_encoder
 

--- a/reflexio/server/operation_limiter.py
+++ b/reflexio/server/operation_limiter.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import threading
 import time
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Literal
 
 from fastapi import HTTPException, status
@@ -16,6 +18,8 @@ from reflexio.server.tracing import profile_step
 from reflexio.server.usage_metrics import record_usage_event
 
 OperationName = Literal["search", "publish", "aggregation"]
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_LIMITS: dict[OperationName, int] = {
     "search": 8,
@@ -27,6 +31,12 @@ _DEFAULT_TIMEOUT_SECONDS: dict[OperationName, float] = {
     "publish": 5.0,
     "aggregation": 1.0,
 }
+_ESTIMATED_THREADS_PER_PUBLISH = 3
+_PUBLISH_WAIT_LOG_THRESHOLD_MS = 250
+_PUBLISH_PRESSURE_LOG_INTERVAL_SECONDS = 60.0
+_CGROUP_ROOT = Path("/sys/fs/cgroup")
+_PROC_SELF_CGROUP = Path("/proc/self/cgroup")
+_last_publish_pressure_log_by_org: dict[str, float] = {}
 
 
 @dataclass
@@ -34,6 +44,7 @@ class _LimiterState:
     semaphore: threading.BoundedSemaphore
     limit: int
     waiting: int = 0
+    active: int = 0
 
 
 _limiters: dict[tuple[str, OperationName], _LimiterState] = {}
@@ -61,6 +72,277 @@ def _timeout_for(operation: OperationName) -> float:
     return _DEFAULT_TIMEOUT_SECONDS[operation]
 
 
+def _resource_limit_nproc() -> int | str | None:
+    try:
+        import resource
+    except ImportError:  # pragma: no cover - platform-specific
+        return None
+    try:
+        soft, _hard = resource.getrlimit(resource.RLIMIT_NPROC)
+    except (OSError, ValueError, AttributeError):
+        return None
+    if soft == resource.RLIM_INFINITY:
+        return "unlimited"
+    return int(soft)
+
+
+def _linux_threads_max() -> int | None:
+    try:
+        with Path("/proc/sys/kernel/threads-max").open() as threads_max_file:
+            return int(threads_max_file.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _process_os_thread_count() -> int | None:
+    try:
+        with Path("/proc/self/status").open() as status_file:
+            for line in status_file:
+                if line.startswith("Threads:"):
+                    return int(line.split(":", maxsplit=1)[1].strip())
+    except (OSError, ValueError):
+        return None
+    return None
+
+
+def _available_memory_bytes() -> int | None:
+    try:
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        available_pages = os.sysconf("SC_AVPHYS_PAGES")
+    except (OSError, ValueError, AttributeError):
+        return None
+    if isinstance(page_size, int) and isinstance(available_pages, int):
+        return page_size * available_pages
+    return None
+
+
+def _read_path_text(path: Path) -> str | None:
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def _positive_int_from_text(text: str | None) -> int | None:
+    if text is None or text == "max":
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _cgroup_candidate_paths(controller: str, filename: str) -> list[Path]:
+    candidates = [
+        _CGROUP_ROOT / filename,
+        _CGROUP_ROOT / controller / filename,
+    ]
+    cgroup_text = _read_path_text(_PROC_SELF_CGROUP)
+    if not cgroup_text:
+        return candidates
+
+    for line in cgroup_text.splitlines():
+        parts = line.split(":", maxsplit=2)
+        if len(parts) != 3:
+            continue
+        controllers_text = parts[1]
+        relative = parts[2].strip().lstrip("/")
+        relative_path = Path(relative) if relative else Path()
+        controllers = [item for item in controllers_text.split(",") if item]
+        if controllers_text == "":
+            candidates.append(_CGROUP_ROOT / relative_path / filename)
+            continue
+        if controller not in controllers:
+            continue
+        candidates.append(_CGROUP_ROOT / controller / relative_path / filename)
+        candidates.append(
+            _CGROUP_ROOT / ",".join(controllers) / relative_path / filename
+        )
+        candidates.append(_CGROUP_ROOT / relative_path / filename)
+    return candidates
+
+
+def _read_first_cgroup_value(controller: str, filename: str) -> str | None:
+    seen: set[Path] = set()
+    for path in _cgroup_candidate_paths(controller, filename):
+        if path in seen:
+            continue
+        seen.add(path)
+        value = _read_path_text(path)
+        if value:
+            return value
+    return None
+
+
+def _cgroup_v2_cpu_count() -> float | None:
+    raw = _read_first_cgroup_value("unified", "cpu.max")
+    if raw is None:
+        return None
+    parts = raw.split()
+    if len(parts) < 2 or parts[0] == "max":
+        return None
+    try:
+        quota = int(parts[0])
+        period = int(parts[1])
+    except ValueError:
+        return None
+    if quota <= 0 or period <= 0:
+        return None
+    return quota / period
+
+
+def _cgroup_v1_cpu_count() -> float | None:
+    quota = _positive_int_from_text(_read_first_cgroup_value("cpu", "cpu.cfs_quota_us"))
+    period = _positive_int_from_text(
+        _read_first_cgroup_value("cpu", "cpu.cfs_period_us")
+    )
+    if quota is None or period is None:
+        return None
+    return quota / period
+
+
+def _cgroup_cpu_count() -> float | None:
+    return _cgroup_v2_cpu_count() or _cgroup_v1_cpu_count()
+
+
+def _cgroup_memory_limit_bytes() -> int | None:
+    v2_limit = _positive_int_from_text(
+        _read_first_cgroup_value("unified", "memory.max")
+    )
+    if v2_limit is not None:
+        return v2_limit
+    return _positive_int_from_text(
+        _read_first_cgroup_value("memory", "memory.limit_in_bytes")
+    )
+
+
+def _cgroup_memory_current_bytes() -> int | None:
+    v2_current = _positive_int_from_text(
+        _read_first_cgroup_value("unified", "memory.current")
+    )
+    if v2_current is not None:
+        return v2_current
+    return _positive_int_from_text(
+        _read_first_cgroup_value("memory", "memory.usage_in_bytes")
+    )
+
+
+def _cgroup_pids_limit() -> int | None:
+    v2_limit = _positive_int_from_text(_read_first_cgroup_value("unified", "pids.max"))
+    if v2_limit is not None:
+        return v2_limit
+    return _positive_int_from_text(_read_first_cgroup_value("pids", "pids.max"))
+
+
+def _cgroup_pids_current() -> int | None:
+    v2_current = _positive_int_from_text(
+        _read_first_cgroup_value("unified", "pids.current")
+    )
+    if v2_current is not None:
+        return v2_current
+    return _positive_int_from_text(_read_first_cgroup_value("pids", "pids.current"))
+
+
+def _anyio_threadpool_stats() -> dict[str, int | None]:
+    try:
+        from anyio.to_thread import current_default_thread_limiter
+
+        stats = current_default_thread_limiter().statistics()
+        return {
+            "anyio_threadpool_total": int(stats.total_tokens),
+            "anyio_threadpool_borrowed": int(stats.borrowed_tokens),
+            "anyio_threadpool_waiting": int(stats.tasks_waiting),
+        }
+    except Exception:  # noqa: BLE001 - best-effort diagnostics only
+        return {
+            "anyio_threadpool_total": None,
+            "anyio_threadpool_borrowed": None,
+            "anyio_threadpool_waiting": None,
+        }
+
+
+def publish_hardware_capacity_snapshot() -> dict[str, int | str | float | None]:
+    """Return hardware/threadpool diagnostics for publish concurrency tuning."""
+    host_cpu_count = os.cpu_count()
+    cgroup_cpu_count = _cgroup_cpu_count()
+    effective_cpu_count = cgroup_cpu_count or host_cpu_count
+    process_os_threads = _process_os_thread_count()
+    nproc_limit = _resource_limit_nproc()
+    threads_max = _linux_threads_max()
+    cgroup_pids_limit = _cgroup_pids_limit()
+    cgroup_pids_current = _cgroup_pids_current()
+    cgroup_memory_limit = _cgroup_memory_limit_bytes()
+    cgroup_memory_current = _cgroup_memory_current_bytes()
+    cgroup_available_memory = (
+        max(0, cgroup_memory_limit - cgroup_memory_current)
+        if cgroup_memory_limit is not None and cgroup_memory_current is not None
+        else None
+    )
+    anyio_stats = _anyio_threadpool_stats()
+    host_thread_budget_candidates = [
+        value - process_os_threads
+        for value in (nproc_limit, threads_max)
+        if isinstance(value, int) and process_os_threads is not None
+    ]
+    cgroup_pid_budget = (
+        cgroup_pids_limit - cgroup_pids_current
+        if cgroup_pids_limit is not None and cgroup_pids_current is not None
+        else None
+    )
+    thread_budget_candidates = [
+        value
+        for value in (cgroup_pid_budget, *host_thread_budget_candidates)
+        if isinstance(value, int)
+    ]
+    max_by_os_threads = (
+        max(1, min(thread_budget_candidates) // _ESTIMATED_THREADS_PER_PUBLISH)
+        if thread_budget_candidates
+        else None
+    )
+    guidance_candidates = [
+        value
+        for value in (
+            anyio_stats["anyio_threadpool_total"],
+            max_by_os_threads,
+            max(1, int(effective_cpu_count * 2))
+            if effective_cpu_count is not None
+            else None,
+        )
+        if isinstance(value, int) and value > 0
+    ]
+    hardware_guidance = min(guidance_candidates) if guidance_candidates else None
+    return {
+        "configured_publish_limit": _limit_for("publish"),
+        "publish_timeout_seconds": _timeout_for("publish"),
+        "hardware_guidance_publish_limit": hardware_guidance,
+        "estimated_threads_per_publish": _ESTIMATED_THREADS_PER_PUBLISH,
+        "effective_cpu_count": effective_cpu_count,
+        "logical_cpu_count": host_cpu_count,
+        "cgroup_cpu_count": cgroup_cpu_count,
+        "python_active_threads": threading.active_count(),
+        "process_os_threads": process_os_threads,
+        "rlimit_nproc_soft": nproc_limit,
+        "linux_threads_max": threads_max,
+        "cgroup_pids_limit": cgroup_pids_limit,
+        "cgroup_pids_current": cgroup_pids_current,
+        "cgroup_memory_limit_bytes": cgroup_memory_limit,
+        "cgroup_memory_current_bytes": cgroup_memory_current,
+        "available_memory_bytes": cgroup_available_memory
+        if cgroup_available_memory is not None
+        else _available_memory_bytes(),
+        **anyio_stats,
+    }
+
+
+def log_publish_hardware_capacity() -> None:
+    """Log one startup snapshot for publish concurrency hardware tuning."""
+    logger.info(
+        "publish_concurrency_hardware_capacity %s",
+        publish_hardware_capacity_snapshot(),
+    )
+
+
 def _state_for(org_id: str, operation: OperationName) -> _LimiterState:
     key = (str(org_id), operation)
     desired_limit = _limit_for(operation)
@@ -84,6 +366,7 @@ def _record_limiter_event(
     wait_ms: int,
     waiting: int,
     limit: int,
+    active: int,
 ) -> None:
     record_usage_event(
         org_id=org_id,
@@ -96,8 +379,21 @@ def _record_limiter_event(
             "operation": operation,
             "waiting": waiting,
             "limit": limit,
+            "active": active,
         },
     )
+
+
+def _should_log_publish_pressure(org_id: str, now: float) -> bool:
+    with _limiters_lock:
+        last_logged = _last_publish_pressure_log_by_org.get(org_id)
+        if (
+            last_logged is not None
+            and now - last_logged < _PUBLISH_PRESSURE_LOG_INTERVAL_SECONDS
+        ):
+            return False
+        _last_publish_pressure_log_by_org[org_id] = now
+        return True
 
 
 @contextmanager
@@ -138,6 +434,9 @@ def operation_limit(
         with _limiters_lock:
             state.waiting -= 1
             waiting_after = state.waiting
+            if acquired:
+                state.active += 1
+            active = state.active
         if not acquired:
             _record_limiter_event(
                 org_id=org_id,
@@ -147,9 +446,38 @@ def operation_limit(
                 wait_ms=wait_ms,
                 waiting=waiting_after,
                 limit=state.limit,
+                active=active,
             )
+            if operation == "publish":
+                logger.warning(
+                    "publish_limiter_timeout org_id=%s limit=%s active=%s "
+                    "waiting=%s wait_ms=%s timeout_seconds=%s hardware=%s",
+                    org_id,
+                    state.limit,
+                    active,
+                    waiting_after,
+                    wait_ms,
+                    timeout,
+                    publish_hardware_capacity_snapshot(),
+                )
             raise TimeoutError(
                 f"{operation} concurrency limit reached for org {org_id}"
+            )
+        if (
+            operation == "publish"
+            and wait_ms >= _PUBLISH_WAIT_LOG_THRESHOLD_MS
+            and _should_log_publish_pressure(str(org_id), time.monotonic())
+        ):
+            logger.info(
+                "publish_limiter_wait org_id=%s limit=%s active=%s waiting=%s "
+                "wait_ms=%s timeout_seconds=%s hardware=%s",
+                org_id,
+                state.limit,
+                active,
+                waiting_after,
+                wait_ms,
+                timeout,
+                publish_hardware_capacity_snapshot(),
             )
         _record_limiter_event(
             org_id=org_id,
@@ -159,10 +487,13 @@ def operation_limit(
             wait_ms=wait_ms,
             waiting=waiting,
             limit=state.limit,
+            active=active,
         )
         yield
     finally:
         if acquired:
+            with _limiters_lock:
+                state.active = max(0, state.active - 1)
             state.semaphore.release()
 
 
@@ -201,3 +532,4 @@ def limiter_http_exception(operation: OperationName) -> HTTPException:
 def reset_operation_limiters_for_tests() -> None:
     with _limiters_lock:
         _limiters.clear()
+        _last_publish_pressure_log_by_org.clear()

--- a/tests/server/test_operation_limiter.py
+++ b/tests/server/test_operation_limiter.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
+import logging
 import threading
 from contextlib import contextmanager
 
 import pytest
 from fastapi import status
 
+import reflexio.server.operation_limiter as operation_limiter_module
 from reflexio.server.operation_limiter import (
     limiter_http_exception,
     operation_limit,
+    publish_hardware_capacity_snapshot,
     reset_operation_limiters_for_tests,
 )
 from reflexio.server.tracing import configure_tracer
@@ -130,6 +133,183 @@ def test_operation_limiter_wait_forever_queues_until_slot_available(monkeypatch)
 
     assert finished.is_set()
     assert [event.event_name for event in events].count("limiter_acquired") == 2
+    assert all(
+        event.metadata["active"] == 1
+        for event in events
+        if event.event_name == "limiter_acquired"
+    )
+
+
+def test_publish_hardware_capacity_snapshot_reports_hardware_guidance(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "7")
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_TIMEOUT_SECONDS", "2.5")
+    monkeypatch.setattr(operation_limiter_module.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(operation_limiter_module, "_cgroup_cpu_count", lambda: None)
+    monkeypatch.setattr(
+        operation_limiter_module, "_cgroup_memory_limit_bytes", lambda: None
+    )
+    monkeypatch.setattr(
+        operation_limiter_module, "_cgroup_memory_current_bytes", lambda: None
+    )
+    monkeypatch.setattr(operation_limiter_module, "_cgroup_pids_limit", lambda: None)
+    monkeypatch.setattr(operation_limiter_module, "_cgroup_pids_current", lambda: None)
+    monkeypatch.setattr(
+        operation_limiter_module, "_process_os_thread_count", lambda: 10
+    )
+    monkeypatch.setattr(operation_limiter_module, "_resource_limit_nproc", lambda: 100)
+    monkeypatch.setattr(operation_limiter_module, "_linux_threads_max", lambda: 1000)
+    monkeypatch.setattr(operation_limiter_module, "_available_memory_bytes", lambda: 42)
+    monkeypatch.setattr(
+        operation_limiter_module,
+        "_anyio_threadpool_stats",
+        lambda: {
+            "anyio_threadpool_total": 40,
+            "anyio_threadpool_borrowed": 3,
+            "anyio_threadpool_waiting": 2,
+        },
+    )
+
+    snapshot = publish_hardware_capacity_snapshot()
+
+    assert snapshot["configured_publish_limit"] == 7
+    assert snapshot["publish_timeout_seconds"] == 2.5
+    assert snapshot["estimated_threads_per_publish"] == 3
+    assert snapshot["hardware_guidance_publish_limit"] == 30
+    assert snapshot["effective_cpu_count"] == 64
+    assert snapshot["logical_cpu_count"] == 64
+    assert snapshot["cgroup_cpu_count"] is None
+    assert snapshot["process_os_threads"] == 10
+    assert snapshot["rlimit_nproc_soft"] == 100
+    assert snapshot["linux_threads_max"] == 1000
+    assert snapshot["cgroup_pids_limit"] is None
+    assert snapshot["cgroup_pids_current"] is None
+    assert snapshot["cgroup_memory_limit_bytes"] is None
+    assert snapshot["cgroup_memory_current_bytes"] is None
+    assert snapshot["available_memory_bytes"] == 42
+    assert snapshot["anyio_threadpool_total"] == 40
+    assert snapshot["anyio_threadpool_borrowed"] == 3
+    assert snapshot["anyio_threadpool_waiting"] == 2
+
+
+def test_publish_hardware_capacity_snapshot_prefers_cgroup_v2(monkeypatch, tmp_path):
+    (tmp_path / "cpu.max").write_text("200000 100000")
+    (tmp_path / "memory.max").write_text("1000")
+    (tmp_path / "memory.current").write_text("600")
+    (tmp_path / "pids.max").write_text("20")
+    (tmp_path / "pids.current").write_text("5")
+    monkeypatch.setattr(operation_limiter_module, "_CGROUP_ROOT", tmp_path)
+    monkeypatch.setattr(
+        operation_limiter_module, "_PROC_SELF_CGROUP", tmp_path / "missing"
+    )
+    monkeypatch.setattr(operation_limiter_module.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(
+        operation_limiter_module, "_process_os_thread_count", lambda: 10
+    )
+    monkeypatch.setattr(operation_limiter_module, "_resource_limit_nproc", lambda: 100)
+    monkeypatch.setattr(operation_limiter_module, "_linux_threads_max", lambda: 1000)
+    monkeypatch.setattr(
+        operation_limiter_module,
+        "_anyio_threadpool_stats",
+        lambda: {
+            "anyio_threadpool_total": 40,
+            "anyio_threadpool_borrowed": 3,
+            "anyio_threadpool_waiting": 2,
+        },
+    )
+
+    snapshot = publish_hardware_capacity_snapshot()
+
+    assert snapshot["effective_cpu_count"] == 2.0
+    assert snapshot["cgroup_cpu_count"] == 2.0
+    assert snapshot["cgroup_pids_limit"] == 20
+    assert snapshot["cgroup_pids_current"] == 5
+    assert snapshot["cgroup_memory_limit_bytes"] == 1000
+    assert snapshot["cgroup_memory_current_bytes"] == 600
+    assert snapshot["available_memory_bytes"] == 400
+    assert snapshot["hardware_guidance_publish_limit"] == 4
+
+
+def test_publish_hardware_capacity_snapshot_reads_cgroup_v1(monkeypatch, tmp_path):
+    (tmp_path / "self.cgroup").write_text(
+        """2:cpu,cpuacct:/ecs/task
+3:memory:/ecs/task
+4:pids:/ecs/task"""
+    )
+    cpu_dir = tmp_path / "cpu" / "ecs" / "task"
+    memory_dir = tmp_path / "memory" / "ecs" / "task"
+    pids_dir = tmp_path / "pids" / "ecs" / "task"
+    cpu_dir.mkdir(parents=True)
+    memory_dir.mkdir(parents=True)
+    pids_dir.mkdir(parents=True)
+    (cpu_dir / "cpu.cfs_quota_us").write_text("150000")
+    (cpu_dir / "cpu.cfs_period_us").write_text("100000")
+    (memory_dir / "memory.limit_in_bytes").write_text("1000")
+    (memory_dir / "memory.usage_in_bytes").write_text("250")
+    (pids_dir / "pids.max").write_text("13")
+    (pids_dir / "pids.current").write_text("4")
+    monkeypatch.setattr(operation_limiter_module, "_CGROUP_ROOT", tmp_path)
+    monkeypatch.setattr(
+        operation_limiter_module, "_PROC_SELF_CGROUP", tmp_path / "self.cgroup"
+    )
+    monkeypatch.setattr(operation_limiter_module.os, "cpu_count", lambda: 64)
+    monkeypatch.setattr(
+        operation_limiter_module, "_process_os_thread_count", lambda: 10
+    )
+    monkeypatch.setattr(operation_limiter_module, "_resource_limit_nproc", lambda: 100)
+    monkeypatch.setattr(operation_limiter_module, "_linux_threads_max", lambda: 1000)
+    monkeypatch.setattr(
+        operation_limiter_module,
+        "_anyio_threadpool_stats",
+        lambda: {
+            "anyio_threadpool_total": 40,
+            "anyio_threadpool_borrowed": 3,
+            "anyio_threadpool_waiting": 2,
+        },
+    )
+
+    snapshot = publish_hardware_capacity_snapshot()
+
+    assert snapshot["effective_cpu_count"] == 1.5
+    assert snapshot["cgroup_cpu_count"] == 1.5
+    assert snapshot["cgroup_pids_limit"] == 13
+    assert snapshot["cgroup_pids_current"] == 4
+    assert snapshot["cgroup_memory_limit_bytes"] == 1000
+    assert snapshot["cgroup_memory_current_bytes"] == 250
+    assert snapshot["available_memory_bytes"] == 750
+    assert snapshot["hardware_guidance_publish_limit"] == 3
+
+
+def test_publish_limiter_timeout_logs_hardware_pressure(monkeypatch, caplog):
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "1")
+    monkeypatch.setattr(
+        operation_limiter_module,
+        "publish_hardware_capacity_snapshot",
+        lambda: {"hardware_guidance_publish_limit": 10},
+    )
+    ready = threading.Event()
+    release = threading.Event()
+
+    def _hold_limit() -> None:
+        with operation_limit("org_1", "publish", timeout_seconds=0.1):
+            ready.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=_hold_limit)
+    holder.start()
+    try:
+        assert ready.wait(timeout=5)
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(TimeoutError),
+            operation_limit("org_1", "publish", timeout_seconds=0.01),
+        ):
+            pass
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert "publish_limiter_timeout org_id=org_1 limit=1 active=1" in caplog.text
+    assert "hardware_guidance_publish_limit" in caplog.text
 
 
 def test_limiter_http_exception_maps_search_to_429():


### PR DESCRIPTION
## Summary
- Add cgroup-aware hardware diagnostics for tuning `REFLEXIO_PUBLISH_CONCURRENCY_LIMIT` in ECS/Fargate deployments.
- Emit a one-time startup capacity log plus runtime publish limiter pressure logs.
- Track active publish limiter slots so logs and usage metrics show configured, active, waiting, and timeout state.

## Changes
- Publish limiter diagnostics now prefer cgroup CPU, memory, and pids limits before falling back to host-level values.
- FastAPI data-plane startup logs `publish_concurrency_hardware_capacity` once per server process.
- Publish limiter waits and timeouts include hardware snapshots; wait logs are rate-limited per org and timeout logs are emitted for each failed acquire.
- Added unit coverage for host fallback, cgroup v1/v2 snapshots, active slot metrics, and timeout logging.

## Test Plan
- `uv run pytest --no-cov tests/server/test_operation_limiter.py`
- `uv run ruff check reflexio/server/operation_limiter.py reflexio/server/api.py tests/server/test_operation_limiter.py`
- `uv run ruff format --check reflexio/server/operation_limiter.py reflexio/server/api.py tests/server/test_operation_limiter.py`
- `uv run pyright reflexio/server/operation_limiter.py reflexio/server/api.py tests/server/test_operation_limiter.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup diagnostics for publish capacity, helping surface environment limits that affect throughput.
  * Improved publish queue logging with clearer context when requests are waiting or timing out.

* **Bug Fixes**
  * Enhanced concurrency handling so publish limits track both active and waiting work more accurately.
  * Reduced noisy repeat warnings by throttling repeated pressure logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->