### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -35,6 +35,7 @@ Description: Shared data contracts and the Python SDK used by external applicati
 #### Main Entry Points
 - **API Schemas**: `models/api_schema/` - Pydantic request/response models for public API surfaces
 - **Internal Schemas**: `models/api_schema/internal_schema.py` - Storage-facing profile, playbook, request, evaluation, and agent-run models
+- **Structured Output Base**: `models/structured_output.py` - provider-safe Pydantic base for LLM response schemas and tool parameter schemas
 - **Validators**: `models/api_schema/validators.py` - Cross-schema validation helpers
 
 #### Purpose
@@ -43,6 +44,7 @@ Provides type-safe data contracts between client and server:
 2. **Retriever Schemas** - Search/get/set requests and responses
 3. **Login/Auth Schemas** - Credentials, API tokens, feature flags, and organization/account responses
 4. **Config Schema** - YAML/API configuration structure (`tool_can_use` at root `Config` level, shared across services)
+5. **Structured LLM Outputs** - `StrictStructuredOutput` folds discriminated-union JSON Schema (`oneOf`/`discriminator`) into provider-safe `anyOf` wire schemas without changing Pydantic validation.
 
 ### client
 **Path**: `client/`

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -35,6 +35,7 @@ Description: FastAPI backend server that processes user interactions to generate
 - **API**: `api.py` - FastAPI routes (only place to expose endpoints)
 - **Endpoint Helpers**: `api_endpoints/` - Bridge between routes and business logic
 - **Core Service**: `services/generation_service.py` - Main orchestrator
+- **Operation Limits**: `operation_limiter.py` - Per-org/process concurrency gates for search, publish, and aggregation hot paths
 
 ## Cache
 
@@ -94,6 +95,7 @@ Key files:
 - `openai_client.py`: OpenAI implementation (legacy, do not use directly)
 - `claude_client.py`: Claude implementation (legacy, do not use directly)
 - `llm_utils.py`: Helper functions for Pydantic model conversion
+- `models/structured_output.py`: `StrictStructuredOutput` base for provider-safe Pydantic response schemas (imported from the top-level `models` package)
 
 **Features**:
 - Uses LiteLLM for multi-provider support (OpenAI, Claude, Azure, OpenRouter, Gemini, custom endpoints, etc.)
@@ -126,6 +128,7 @@ response = client.generate_response("What is 2+2?", response_format=Answer)  # R
 **Rules**:
 - **ALWAYS use `LiteLLMClient`**, never import `OpenAIClient` or `ClaudeClient` directly
 - **ALWAYS use Pydantic models** for structured outputs (dict-based schemas are not supported)
+- **Prefer `StrictStructuredOutput`** for any model sent to an LLM response schema/tool schema so strict providers accept discriminated unions by construction.
 
 ## Prompts
 
@@ -238,6 +241,11 @@ Called by API endpoints via `Reflexio`
 - Stale lock timeout: 5 minutes (assumes crashed if lock held longer)
 - Lock scoping: Profile generation = per-user, Playbook generation = per-org
 - Re-run mechanism: If new request arrives during generation, `pending_request_id` is set and generation re-runs after completion
+
+**Process-local operation limiting** (`operation_limiter.py`):
+- Wraps search, publish, and playbook aggregation with per-org semaphores before expensive thread/LLM work begins.
+- Defaults: search=8, publish=4, aggregation=1; override with `REFLEXIO_<OP>_CONCURRENCY_LIMIT` and `REFLEXIO_<OP>_CONCURRENCY_TIMEOUT_SECONDS`.
+- Logs publish hardware/cgroup capacity at startup and records wait/timeout usage events so thread pressure is observable.
 
 ### Profile Generation
 
@@ -477,8 +485,8 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 
 | File | Purpose |
 |------|---------|
-| `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_lineage.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
-| `sqlite_storage/` | SQLite-backed implementation split across the same domains, including lineage/tombstone support in `_lineage.py` |
+| `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_lineage.py`, `_retrieval_log.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
+| `sqlite_storage/` | SQLite-backed implementation split across the same domains, including lineage/tombstone support in `_lineage.py` and purge helpers in `_base.py` |
 | `retention.py`, `retention_mixin.py` | Data retention and cleanup helpers |
 | `constants.py`, `error.py` | Storage constants and shared errors |
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -12,6 +12,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 | `generation_service.py` | `GenerationService` — saves interactions, runs profile + playbook generation in parallel (ThreadPoolExecutor), schedules deferred evaluation when `session_id` is present. |
 | `base_generation_service.py` | `BaseGenerationService` — abstract base; the **Service Pattern** (load configs → create actors → run in parallel → save results). Per-extractor timeout `EXTRACTOR_TIMEOUT_SECONDS = 300`. |
 | `operation_state_utils.py` | `OperationStateManager` — all `_operation_state` access (progress, concurrency locks, extractor/aggregator bookmarks, cluster fingerprints, cancellation). |
+| `../operation_limiter.py` | Process-local per-org concurrency limits around search, publish, and aggregation hot paths. |
 | `extractor_config_utils.py`, `extractor_interaction_utils.py` | Filter extractors by source / `allow_manual_trigger` / names; per-extractor stride + window + bookmark handling. |
 | `deduplication_utils.py`, `service_utils.py`, `embedding_text.py` | LLM dedup helpers (used by `ProfileDeduplicator` + `PlaybookConsolidator`), message construction / JSON extraction / response logging, embedding text builders. |
 
@@ -47,7 +48,7 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 
 | Path | Purpose |
 |------|---------|
-| `storage/` | `storage_base/` (`BaseStorage` split by domain, including `_lineage.py`) + `sqlite_storage/` (including lineage/tombstones) + `retention*.py`. Access via `request_context.storage` only. |
+| `storage/` | `storage_base/` (`BaseStorage` split by domain, including `_lineage.py` and `_retrieval_log.py`) + `sqlite_storage/` (including lineage/tombstones and purge helpers) + `retention*.py`. Access via `request_context.storage` only. |
 | `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
 
 ## Key Rules
@@ -56,4 +57,5 @@ Description: Core business-logic layer — LLM orchestration, extraction, evalua
 - **NEVER import storage implementations directly** — use `request_context.storage` (`BaseStorage`).
 - **ALWAYS use `LiteLLMClient`** for completions/embeddings and `request_context.prompt_manager.render_prompt(...)` for prompts — no hardcoded prompts, no direct OpenAI/Claude clients.
 - **All `_operation_state` writes go through `OperationStateManager`** — don't touch the table directly (it backs locks, bookmarks, progress, and cancellation).
+- **Hot-path concurrency goes through `operation_limiter.py`** — don't create ad hoc per-endpoint semaphores for search, publish, or aggregation.
 - **`tool_can_use` lives at root `Config`** — shared by playbook extraction and success evaluation, not per-service.

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -43,7 +43,7 @@ Extends `BaseGenerationService` extractor pattern. Each extractor:
 
 ### Playbook Aggregation (`playbook_aggregator.py`)
 
-Triggered manually via `/api/run_playbook_aggregation`. Clusters user playbooks and generates consolidated insights.
+Triggered manually via `/api/run_playbook_aggregation`. Clusters user playbooks and generates consolidated insights. Calls run through `server/operation_limiter.py` (`aggregation` limit, default 1 per org/process) before expensive embedding/LLM work begins.
 
 **Key Methods**:
 - `get_clusters(user_playbooks, config)` - HDBSCAN/Agglomerative clustering on embeddings


### PR DESCRIPTION
## Summary
- Updates Reflexio code-map READMEs for the latest server/model structure.
- Documents the new provider-safe structured-output base, process-local operation limiter, storage retrieval-log split, and aggregation concurrency path.

## Repositories/submodules reviewed
- Parent repository: ReflexioAI/reflexio-enterprise
- Submodules: ReflexioAI/reflexio, ReflexioAI/claude-smart

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`
- `reflexio/server/services/playbook/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py . reflexio/README.md reflexio/server/README.md reflexio/server/services/README.md reflexio/server/services/playbook/README.md`

## Notes/Risks
- Updates follow `/root/reflexio-enterprise/how_to_write_readme.md` and are scoped to model-facing code-map READMEs.
- `open_source/reflexio/README.md` was intentionally not rewritten because it is the public/user-facing README excluded by the policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README guides with clearer notes on structured AI outputs, including support for safer schema handling.
  * Added guidance for server operation limits, including how search, publish, and aggregation workloads are managed.
  * Updated service and playbook docs to reflect the latest storage layout and aggregation workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->