### PR TITLE
feat(billing): meter production search requests

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -562,6 +562,38 @@ def _meter_applied_learnings(
         )
 
 
+def _meter_search_request(
+    *,
+    org_id: str,
+    caller_type: str,
+    request_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Emit one production-agent search request metric.
+
+    Args:
+        org_id: Organization ID for the requesting caller.
+        caller_type: Resolved caller classification.
+        request_id: Optional request correlation ID from the payload.
+        session_id: Optional session ID from the payload.
+    """
+    if caller_type != "production_agent":
+        return
+    try:
+        from reflexio.server.billing_meter import record_search_request
+
+        record_search_request(
+            org_id=org_id,
+            caller_type=caller_type,
+            request_id=request_id,
+            session_id=session_id,
+        )
+    except Exception:
+        logger.warning(
+            "search-request metering failed for org %s", org_id, exc_info=True
+        )
+
+
 @core_router.get("/")
 def root() -> dict[str, str]:
     return {
@@ -768,6 +800,12 @@ def search_user_profiles(
         user_profiles=[to_profile_view(p) for p in response.user_profiles],
         msg=response.msg,
     )
+    _meter_search_request(
+        org_id=org_id,
+        caller_type=caller_type,
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
+    )
     _meter_applied_learnings(
         org_id=org_id,
         caller_type=caller_type,
@@ -902,6 +940,12 @@ def search_user_playbooks_endpoint(
         user_playbooks=[to_user_playbook_view(rf) for rf in response.user_playbooks],
         msg=response.msg,
     )
+    _meter_search_request(
+        org_id=org_id,
+        caller_type=caller_type,
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
+    )
     _meter_applied_learnings(
         org_id=org_id,
         caller_type=caller_type,
@@ -948,6 +992,12 @@ def search_agent_playbooks_endpoint(
         success=response.success,
         agent_playbooks=[to_agent_playbook_view(fb) for fb in response.agent_playbooks],
         msg=response.msg,
+    )
+    _meter_search_request(
+        org_id=org_id,
+        caller_type=caller_type,
+        request_id=getattr(payload, "request_id", None),
+        session_id=getattr(payload, "session_id", None),
     )
     _meter_applied_learnings(
         org_id=org_id,
@@ -1027,6 +1077,13 @@ def unified_search_endpoint(
                 agent_trace=response.agent_trace,
                 rehydrated_text=response.rehydrated_text,
             )
+        background_tasks.add_task(
+            _meter_search_request,
+            org_id=org_id,
+            caller_type=caller_type,
+            request_id=getattr(payload, "request_id", None),
+            session_id=getattr(payload, "session_id", None),
+        )
         background_tasks.add_task(
             _meter_applied_learnings,
             org_id=org_id,

--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -139,3 +139,35 @@ def record_applied_learnings(
         platform_storage=platform_storage,
         caller_type=caller_type,
     )
+
+
+def record_search_request(
+    *,
+    org_id: str,
+    caller_type: str,
+    request_id: str | None = None,
+    session_id: str | None = None,
+) -> None:
+    """Emit one analytics-only search request count for production agents.
+
+    No-op unless ``caller_type == "production_agent"``. Unlike
+    :func:`record_applied_learnings`, empty search responses still count because
+    this measures requests made, not learnings surfaced.
+
+    Args:
+        org_id: Organisation identifier.
+        caller_type: Caller classification string.
+        request_id: Optional request correlation ID.
+        session_id: Optional session ID.
+    """
+    if caller_type != "production_agent":
+        return
+    record_usage_event(
+        org_id=org_id,
+        event_name="search_request",
+        event_category="application",
+        request_id=request_id,
+        session_id=session_id,
+        count_value=1,
+        caller_type=caller_type,
+    )

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -1,8 +1,9 @@
-"""Tests for applied-learnings metering at search endpoints.
+"""Tests for search and applied-learnings metering at search endpoints.
 
 Verifies that ``_meter_applied_learnings`` emits exactly one ``learning_applied``
 usage event when a production-agent caller surfaces >= 1 result, and nothing for
-dashboard callers or empty result sets.
+dashboard callers or empty result sets. Verifies that production-agent calls to
+the core search endpoints also emit one ``search_request`` event per request.
 """
 
 from contextlib import contextmanager
@@ -140,6 +141,10 @@ def test_production_agent_search_meters_surfaced_count() -> None:
         applied[0].count_value == 3
     )  # 2 profiles + 1 agent_playbook + 0 user_playbooks
     assert applied[0].caller_type == "production_agent"
+    searches = [e for e in events if e.event_name == "search_request"]
+    assert len(searches) == 1
+    assert searches[0].count_value == 1
+    assert searches[0].caller_type == "production_agent"
 
 
 def test_dashboard_search_meters_nothing() -> None:
@@ -154,6 +159,7 @@ def test_dashboard_search_meters_nothing() -> None:
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+    assert [e for e in events if e.event_name == "search_request"] == []
 
 
 def test_empty_result_meters_nothing() -> None:
@@ -168,6 +174,9 @@ def test_empty_result_meters_nothing() -> None:
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+    searches = [e for e in events if e.event_name == "search_request"]
+    assert len(searches) == 1
+    assert searches[0].count_value == 1
 
 
 def test_unified_search_records_threadpool_diagnostics_on_endpoint_span() -> None:
@@ -332,6 +341,8 @@ _ENDPOINT_CASES = [
     ),
 ]
 
+_CORE_SEARCH_ENDPOINT_CASES = _ENDPOINT_CASES[:3]
+
 
 @pytest.mark.parametrize(
     ("path", "payload", "method_name", "response_attr", "make_item"),
@@ -381,6 +392,7 @@ def test_dashboard_per_endpoint_meters_nothing(
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+    assert [e for e in events if e.event_name == "search_request"] == []
 
 
 @pytest.mark.parametrize(
@@ -404,3 +416,59 @@ def test_empty_result_per_endpoint_meters_nothing(
         configure_usage_event_recorder(None)
 
     assert [e for e in events if e.event_name == "learning_applied"] == []
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "method_name", "response_attr", "make_item"),
+    _CORE_SEARCH_ENDPOINT_CASES,
+)
+def test_production_agent_core_search_endpoints_meter_search_request(
+    path: str,
+    payload: dict,
+    method_name: str,
+    response_attr: str,
+    make_item,
+) -> None:
+    """The three core per-resource search routes emit one search_request."""
+    events = _capture()
+    try:
+        with _patch_service_method(method_name, response_attr, [make_item()]):
+            resp = _client("production_agent").post(path, json=payload)
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    searches = [e for e in events if e.event_name == "search_request"]
+    assert len(searches) == 1
+    assert searches[0].count_value == 1
+    assert searches[0].caller_type == "production_agent"
+
+
+def test_get_agent_playbooks_does_not_meter_search_request() -> None:
+    """The get-style playbook route remains excluded from search_request counts."""
+    events = _capture()
+    try:
+        with _patch_service_method(
+            "get_agent_playbooks", "agent_playbooks", [_make_agent_playbook_view()]
+        ):
+            resp = _client("production_agent").post("/api/get_agent_playbooks", json={})
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert [e for e in events if e.event_name == "search_request"] == []
+
+
+def test_search_interactions_does_not_meter_search_request() -> None:
+    """The interaction search route remains excluded from search_request counts."""
+    events = _capture()
+    try:
+        with _patch_service_method("search_interactions", "interactions", []):
+            resp = _client("production_agent").post(
+                "/api/search_interactions", json={"user_id": "u1"}
+            )
+        assert resp.status_code == 200
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert [e for e in events if e.event_name == "search_request"] == []


### PR DESCRIPTION
## Summary
- Add a production-agent `search_request` usage event for core search API calls.
- Count search requests even when the search returns no learnings, so request volume is tracked separately from `learning_applied`.
- Keep dashboard/internal callers and non-search/get-style endpoints excluded.

## Changes
- Added `record_search_request` to the OSS billing meter.
- Wired search request metering into profile, user playbook, agent playbook, and unified search endpoints.
- Expanded endpoint metering tests to cover production-agent search events and excluded routes.

## Test Plan
- `uv run ruff check open_source/reflexio/reflexio/server/api.py open_source/reflexio/reflexio/server/billing_meter.py open_source/reflexio/tests/server/api_endpoints/test_applied_learnings_metering.py`
- `uv run pyright open_source/reflexio/reflexio/server/api.py open_source/reflexio/reflexio/server/billing_meter.py open_source/reflexio/tests/server/api_endpoints/test_applied_learnings_metering.py`
- Included in enterprise end-to-end validation against platform and self-host services.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added usage tracking for search requests in production-agent searches.
  * Search activity now records a single request event even when no results are returned.

* **Bug Fixes**
  * Improved consistency of search-related analytics across unified and per-resource search endpoints.
  * Non-production searches continue to avoid emitting these usage events.

* **Tests**
  * Expanded coverage for search metering behavior across supported search routes and caller types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->