### PR TITLE
fix: persist interaction image encodings

### DIFF
--- a/reflexio/server/services/service_utils.py
+++ b/reflexio/server/services/service_utils.py
@@ -47,7 +47,7 @@ _content_token_encoding: tiktoken.Encoding | None = None
 _INVALID_MAX_TOKENS_WARNED = False
 
 
-def _image_mime_type_from_bytes(image_bytes: bytes) -> str:
+def _image_mime_type_from_bytes(image_bytes: bytes) -> str | None:
     if image_bytes.startswith(b"\xff\xd8\xff"):
         return "image/jpeg"
     if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
@@ -56,7 +56,7 @@ def _image_mime_type_from_bytes(image_bytes: bytes) -> str:
         return "image/gif"
     if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
         return "image/webp"
-    return "image/jpeg"
+    return None
 
 
 def _image_data_url_from_encoding(image_encoding: str) -> str:
@@ -68,11 +68,13 @@ def _image_data_url_from_encoding(image_encoding: str) -> str:
     prefix = compact_encoding[:64]
     prefix += "=" * (-len(prefix) % 4)
     try:
-        image_header = base64.b64decode(prefix)
+        image_header = base64.b64decode(prefix, validate=True)
     except (binascii.Error, ValueError):
-        return f"data:image/jpeg;base64,{compact_encoding}"
+        raise ValueError("image_encoding must be valid base64 image data") from None
 
     mime_type = _image_mime_type_from_bytes(image_header)
+    if mime_type is None:
+        raise ValueError("Unsupported image signature in image_encoding")
     return f"data:{mime_type};base64,{compact_encoding}"
 
 

--- a/reflexio/server/services/service_utils.py
+++ b/reflexio/server/services/service_utils.py
@@ -3,6 +3,8 @@ Utils for service layer
 """
 
 import ast
+import base64
+import binascii
 import json
 import logging
 import os
@@ -43,6 +45,35 @@ _CONTENT_ENCODING_NAME = "cl100k_base"
 _content_token_encoding: tiktoken.Encoding | None = None
 # Guards against logging the same malformed env value on every call.
 _INVALID_MAX_TOKENS_WARNED = False
+
+
+def _image_mime_type_from_bytes(image_bytes: bytes) -> str:
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    return "image/jpeg"
+
+
+def _image_data_url_from_encoding(image_encoding: str) -> str:
+    image_encoding = image_encoding.strip()
+    if image_encoding.startswith("data:image/"):
+        return image_encoding
+
+    compact_encoding = "".join(image_encoding.split())
+    prefix = compact_encoding[:64]
+    prefix += "=" * (-len(prefix) % 4)
+    try:
+        image_header = base64.b64decode(prefix)
+    except (binascii.Error, ValueError):
+        return f"data:image/jpeg;base64,{compact_encoding}"
+
+    mime_type = _image_mime_type_from_bytes(image_header)
+    return f"data:{mime_type};base64,{compact_encoding}"
 
 
 def _get_content_token_encoding() -> tiktoken.Encoding:
@@ -500,7 +531,9 @@ def construct_messages_from_interactions(
                 {
                     "type": "image_url",
                     "image_url": {
-                        "url": f"data:image/jpeg;base64,{last_interaction.image_encoding}"
+                        "url": _image_data_url_from_encoding(
+                            last_interaction.image_encoding
+                        )
                     },
                 }
             )

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -427,6 +427,7 @@ def _row_to_interaction(row: sqlite3.Row) -> Interaction:
         user_action=UserActionType(d["user_action"]),
         user_action_description=d["user_action_description"],
         interacted_image_url=d["interacted_image_url"],
+        image_encoding=d.get("image_encoding") or "",
         shadow_content=d.get("shadow_content") or "",
         expert_content=d.get("expert_content") or "",
         tools_used=tools_used,
@@ -973,6 +974,14 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             logger.info("Adding citations column to interactions table.")
             with self._lock:
                 self.conn.execute("ALTER TABLE interactions ADD COLUMN citations TEXT")
+                self.conn.commit()
+
+        if "image_encoding" not in columns:
+            logger.info("Adding image_encoding column to interactions table.")
+            with self._lock:
+                self.conn.execute(
+                    "ALTER TABLE interactions ADD COLUMN image_encoding TEXT NOT NULL DEFAULT ''"
+                )
                 self.conn.commit()
 
     def _migrate_feedback_schema(self) -> None:
@@ -1983,6 +1992,7 @@ CREATE TABLE IF NOT EXISTS interactions (
     user_action TEXT NOT NULL DEFAULT 'none',
     user_action_description TEXT NOT NULL DEFAULT '',
     interacted_image_url TEXT NOT NULL DEFAULT '',
+    image_encoding TEXT NOT NULL DEFAULT '',
     shadow_content TEXT NOT NULL DEFAULT '',
     expert_content TEXT NOT NULL DEFAULT '',
     tools_used TEXT,

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -748,9 +748,9 @@ class ProfileMixin:
                     """INSERT OR REPLACE INTO interactions
                        (interaction_id, user_id, content, request_id, created_at,
                         role, user_action, user_action_description,
-                        interacted_image_url, shadow_content, expert_content,
-                        tools_used, citations, embedding)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        interacted_image_url, image_encoding, shadow_content,
+                        expert_content, tools_used, citations, embedding)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     (
                         interaction.interaction_id,
                         interaction.user_id,
@@ -761,6 +761,7 @@ class ProfileMixin:
                         interaction.user_action.value,
                         interaction.user_action_description,
                         interaction.interacted_image_url,
+                        interaction.image_encoding,
                         interaction.shadow_content,
                         interaction.expert_content,
                         _json_dumps([t.model_dump() for t in interaction.tools_used]),
@@ -774,9 +775,9 @@ class ProfileMixin:
                     """INSERT INTO interactions
                        (user_id, content, request_id, created_at,
                         role, user_action, user_action_description,
-                        interacted_image_url, shadow_content, expert_content,
-                        tools_used, citations, embedding)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        interacted_image_url, image_encoding, shadow_content,
+                        expert_content, tools_used, citations, embedding)
+                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                     (
                         interaction.user_id,
                         interaction.content,
@@ -786,6 +787,7 @@ class ProfileMixin:
                         interaction.user_action.value,
                         interaction.user_action_description,
                         interaction.interacted_image_url,
+                        interaction.image_encoding,
                         interaction.shadow_content,
                         interaction.expert_content,
                         _json_dumps([t.model_dump() for t in interaction.tools_used]),

--- a/tests/server/services/profile/test_profile_generation_service_utils.py
+++ b/tests/server/services/profile/test_profile_generation_service_utils.py
@@ -1,6 +1,9 @@
 """Tests for profile generation service utility functions."""
 
+import tempfile
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +13,7 @@ from reflexio.models.api_schema.service_schemas import (
     Interaction,
     ProfileTimeToLive,
     Request,
+    UserActionType,
     UserProfile,
 )
 from reflexio.server.prompt.prompt_manager import PromptManager
@@ -17,6 +21,9 @@ from reflexio.server.services.profile.profile_generation_service_utils import (
     calculate_expiration_timestamp,
     construct_profile_extraction_messages_from_sessions,
 )
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from tests import test_data
+from tests.server.test_utils import encode_image_to_base64
 
 
 def test_construct_profile_extraction_messages_with_sessions():
@@ -31,7 +38,7 @@ def test_construct_profile_extraction_messages_with_sessions():
             content="I love Italian food",
             role="user",
             created_at=timestamp,
-            user_action="none",
+            user_action=UserActionType.NONE,
             user_action_description="",
         ),
         Interaction(
@@ -41,7 +48,7 @@ def test_construct_profile_extraction_messages_with_sessions():
             content="I also enjoy sushi",
             role="user",
             created_at=timestamp,
-            user_action="click",
+            user_action=UserActionType.CLICK,
             user_action_description="restaurant menu",
         ),
     ]
@@ -133,6 +140,63 @@ def test_construct_profile_extraction_messages_with_sessions():
                 break
 
     assert found_interactions, "Did not find interactions in the rendered prompt"
+
+
+def test_profile_extraction_prompt_keeps_image_encoding_after_storage_round_trip():
+    timestamp = int(datetime.now(UTC).timestamp())
+    user_id = "visual-user"
+    request = Request(
+        request_id="visual-request",
+        user_id=user_id,
+        created_at=timestamp,
+        source="api",
+        agent_version="v1",
+        session_id="visual-session",
+    )
+    image_fp = str(Path(test_data.__file__).parent / "sushi.png")
+    image_encoding = encode_image_to_base64(image_fp)
+    interaction = Interaction(
+        interaction_id=1,
+        user_id=user_id,
+        request_id=request.request_id,
+        content="what I had for lunch today",
+        role="user",
+        created_at=timestamp,
+        image_encoding=image_encoding,
+    )
+
+    with (
+        tempfile.TemporaryDirectory() as temp_dir,
+        patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
+    ):
+        storage = SQLiteStorage(org_id="visual-test", db_path=f"{temp_dir}/test.db")
+        storage.add_request(request)
+        storage.add_user_interaction(user_id, interaction)
+
+        sessions, flat = storage.get_last_k_interactions_grouped(user_id, 10)
+        assert flat[0].image_encoding == image_encoding
+
+        messages = construct_profile_extraction_messages_from_sessions(
+            prompt_manager=PromptManager(),
+            request_interaction_data_models=sessions,
+            existing_profiles=[],
+            agent_context_prompt="Test agent context",
+            context_prompt="Test context",
+            extraction_definition_prompt="food preferences",
+        )
+
+    user_message = messages[-1]
+    assert isinstance(user_message["content"], list)
+    image_blocks = [
+        block
+        for block in user_message["content"]
+        if isinstance(block, dict) and block.get("type") == "image_url"
+    ]
+    assert len(image_blocks) == 1
+    assert (
+        image_blocks[0]["image_url"]["url"]
+        == f"data:image/jpeg;base64,{image_encoding}"
+    )
 
 
 def test_construct_profile_extraction_messages_with_empty_sessions():

--- a/tests/server/services/profile/test_profile_generation_service_utils.py
+++ b/tests/server/services/profile/test_profile_generation_service_utils.py
@@ -26,6 +26,19 @@ from tests import test_data
 from tests.server.test_utils import encode_image_to_base64
 
 
+def _mime_type_from_image_fixture(image_path: Path) -> str:
+    image_bytes = image_path.read_bytes()
+    if image_bytes.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if image_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if image_bytes.startswith(b"RIFF") and image_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    raise AssertionError(f"Unsupported test fixture image type: {image_path}")
+
+
 def test_construct_profile_extraction_messages_with_sessions():
     """Test that construct_profile_extraction_messages_from_sessions formats interactions correctly in the rendered prompt."""
     # Create test interactions with both content and actions
@@ -153,8 +166,9 @@ def test_profile_extraction_prompt_keeps_image_encoding_after_storage_round_trip
         agent_version="v1",
         session_id="visual-session",
     )
-    image_fp = str(Path(test_data.__file__).parent / "sushi.png")
-    image_encoding = encode_image_to_base64(image_fp)
+    image_path = Path(test_data.__file__).parent / "sushi.png"
+    expected_mime_type = _mime_type_from_image_fixture(image_path)
+    image_encoding = encode_image_to_base64(str(image_path))
     interaction = Interaction(
         interaction_id=1,
         user_id=user_id,
@@ -195,7 +209,7 @@ def test_profile_extraction_prompt_keeps_image_encoding_after_storage_round_trip
     assert len(image_blocks) == 1
     assert (
         image_blocks[0]["image_url"]["url"]
-        == f"data:image/jpeg;base64,{image_encoding}"
+        == f"data:{expected_mime_type};base64,{image_encoding}"
     )
 
 

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -11,6 +11,7 @@ from reflexio.models.api_schema.service_schemas import (
     DeleteUserProfileRequest,
     Interaction,
     ProfileTimeToLive,
+    Request,
     UserActionType,
     UserProfile,
 )
@@ -399,3 +400,52 @@ class TestInteractionCRUD:
         result = storage.get_user_interaction("u1")
         assert len(result) == 1
         assert result[0].citations == []
+
+    def test_interaction_image_encoding_round_trips_through_extraction_reads(
+        self, storage: BaseStorage
+    ) -> None:
+        timestamp = int(datetime.now(UTC).timestamp())
+        request = Request(
+            request_id="req-image",
+            user_id="u1",
+            created_at=timestamp,
+            source="api",
+            agent_version="v1",
+            session_id="session-image",
+        )
+        storage.add_request(request)
+        interaction = Interaction(
+            interaction_id=1,
+            user_id="u1",
+            request_id=request.request_id,
+            content="describe this",
+            created_at=timestamp,
+            user_action=UserActionType.NONE,
+            user_action_description="",
+            image_encoding="base64-image-data",
+        )
+        storage.add_user_interaction("u1", interaction)
+
+        direct_rows = storage.get_user_interaction("u1")
+        assert len(direct_rows) == 1
+        assert direct_rows[0].image_encoding == "base64-image-data"
+
+        grouped, flat = storage.get_last_k_interactions_grouped(
+            "u1", 10, sources=["api"]
+        )
+        assert flat[0].image_encoding == "base64-image-data"
+        assert grouped[0].interactions[0].image_encoding == "base64-image-data"
+
+        storage.upsert_operation_state(
+            "image-extraction-test",
+            {
+                "last_processed_timestamp": timestamp - 1,
+                "last_processed_interaction_ids": [],
+            },
+        )
+        _state, new_groups = storage.get_operation_state_with_new_request_interaction(
+            "image-extraction-test",
+            "u1",
+            sources=["api"],
+        )
+        assert new_groups[0].interactions[0].image_encoding == "base64-image-data"

--- a/tests/server/services/test_service_utils_extended.py
+++ b/tests/server/services/test_service_utils_extended.py
@@ -4,6 +4,8 @@ import base64
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
     ToolUsed,
@@ -11,6 +13,7 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.server.services.service_utils import (
     MessageConstructionConfig,
     PromptConfig,
+    _image_data_url_from_encoding,
     construct_messages_from_interactions,
     extract_json_from_string,
     format_interactions_to_history_string,
@@ -134,8 +137,16 @@ def test_construct_messages_with_image_encoding():
     image_blocks = [b for b in user_msg["content"] if b.get("type") == "image_url"]
     assert len(image_blocks) == 1
     assert (
-        image_blocks[0]["image_url"]["url"] == f"data:image/webp;base64,{image_encoding}"
+        image_blocks[0]["image_url"]["url"]
+        == f"data:image/webp;base64,{image_encoding}"
     )
+
+
+def test_image_data_url_from_encoding_rejects_unknown_signature():
+    image_encoding = base64.b64encode(b"not-an-image").decode("ascii")
+
+    with pytest.raises(ValueError, match="Unsupported image signature"):
+        _image_data_url_from_encoding(image_encoding)
 
 
 def test_construct_messages_text_flattening():

--- a/tests/server/services/test_service_utils_extended.py
+++ b/tests/server/services/test_service_utils_extended.py
@@ -1,5 +1,6 @@
 """Extended tests for service_utils -- covers functions not tested in test_service_utils.py."""
 
+import base64
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
@@ -112,6 +113,7 @@ def test_construct_messages_with_image_url():
 
 def test_construct_messages_with_image_encoding():
     pm = _make_prompt_manager()
+    image_encoding = base64.b64encode(b"RIFF\x00\x00\x00\x00WEBP").decode("ascii")
     interaction = Interaction(
         interaction_id=1,
         user_id="u1",
@@ -119,7 +121,7 @@ def test_construct_messages_with_image_encoding():
         content="describe this",
         role="user",
         created_at=int(datetime.now(UTC).timestamp()),
-        image_encoding="abc123base64data",
+        image_encoding=image_encoding,
     )
     config = MessageConstructionConfig(
         prompt_manager=pm,
@@ -132,7 +134,7 @@ def test_construct_messages_with_image_encoding():
     image_blocks = [b for b in user_msg["content"] if b.get("type") == "image_url"]
     assert len(image_blocks) == 1
     assert (
-        image_blocks[0]["image_url"]["url"] == "data:image/jpeg;base64,abc123base64data"
+        image_blocks[0]["image_url"]["url"] == f"data:image/webp;base64,{image_encoding}"
     )
 
 


### PR DESCRIPTION
## Summary
- Persist base64 interaction images through SQLite storage so extraction reads can use visual context after publish.
- Keep legacy SQLite databases compatible by adding a defaulted `image_encoding` column during schema migration.
- Add focused coverage for direct reads, extraction-window reads, and prompt construction after a storage round trip.

## Changes
- SQLite storage writes and reads `Interaction.image_encoding` alongside existing interaction media fields.
- SQLite DDL and migration add `image_encoding TEXT NOT NULL DEFAULT ''`.
- Tests assert image encodings survive storage and appear as `image_url` blocks in profile extraction prompts.

## Test Plan
- `uv run ruff check ...`
- `uv run pyright ...`
- `uv run pytest -o 'addopts=' tests/server/services/storage/test_storage_contract_profiles.py::TestInteractionCRUD::test_interaction_image_encoding_round_trips_through_extraction_reads tests/server/services/profile/test_profile_generation_service_utils.py::test_profile_extraction_prompt_keeps_image_encoding_after_storage_round_trip -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `image_encoding` on interactions, including persistence and return across storage and profile-extraction flows.
  * Profile message images now generate correctly typed `data:<mime>;base64,...` URLs (JPEG/PNG/GIF/WebP), not just JPEG.
* **Bug Fixes**
  * Prevented `image_encoding` from being dropped or changed during saves, schema migrations, and grouped/flat reads.
* **Tests**
  * Added round-trip and contract tests to verify `image_encoding` preservation and correct MIME/data-URL construction, including rejection of unsupported signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->