### PR TITLE
test: guard extraction runtime module layout

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -407,10 +407,10 @@ Key files:
 - `reflection/components/extractor.py`: LLM extractor used by the reflection service
 - `extraction/resumable_agent.py`: Resumable extraction agent runtime
 - `extraction/resume_scheduler.py` and `extraction/resume_worker.py`: Background scheduling/worker loop for paused extraction runs
-- `extraction/tools.py` and `extraction/prior_answer_search.py`: Tool surface for async extraction agents
+- `extraction/pending_tool_call_dispatch.py` and `extraction/prior_answer_search.py`: Tool surface and prior-answer context for async extraction agents
 - `extraction/agent_run_records.py`: Persistence helpers for extraction-agent run state
 
-**Pattern**: Synchronous profile/playbook/evaluation services still follow `BaseGenerationService`; async extraction uses resumable agent-run records and worker scheduling so long-running or tool-mediated extraction can continue outside the request path.
+**Pattern**: Synchronous profile/playbook/evaluation services still follow `BaseGenerationService`; async extraction is a shared runtime package that uses resumable agent-run records and worker scheduling so long-running or tool-mediated extraction can continue outside the request path.
 
 ### Shadow Comparison and Evaluation Overview
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -41,7 +41,7 @@ strings before deleting old import paths in the same PR.
 
 | Directory | Purpose |
 |-----------|---------|
-| `extraction/` | Resumable extraction agent: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `tools.py`, `plan.py`, `agent_run_records.py`, `invariants.py`. Long-horizon / tool-mediated extraction continues outside the request path. |
+| `extraction/` | Shared async extraction runtime: `resumable_agent.py`, `resume_scheduler.py`, `resume_worker.py`, `pending_tool_call_dispatch.py` (`ask_human`), `prior_answer_search.py`, `agent_run_records.py`, and `outcome.py`. Long-horizon / tool-mediated extraction continues outside the request path. See [README](extraction/README.md). |
 
 ## Evaluation, Search & Integrations
 

--- a/reflexio/server/services/extraction/README.md
+++ b/reflexio/server/services/extraction/README.md
@@ -1,0 +1,31 @@
+# services/extraction
+
+Shared async extraction runtime for profile and playbook pipelines.
+
+This package is intentionally domain-neutral. Profile and playbook modules own
+their prompts, schemas, extractor semantics, and storage decisions; this package
+owns the reusable runtime needed when extraction pauses, waits for more
+information, and resumes outside the request path.
+
+## Files
+
+| File | Responsibility |
+|------|----------------|
+| `resumable_agent.py` | Runs extraction agents, records agent usage, injects resolved pending-tool context, and exposes pending tool-call helpers. |
+| `pending_tool_call_dispatch.py` | Implements the `ask_human` and pending-info tool dispatch flow. |
+| `prior_answer_search.py` | Finds and formats previous human answers for async extraction context. |
+| `agent_run_records.py` | Builds durable extraction-agent run records and source interaction identity. |
+| `resume_scheduler.py` | Schedules due paused extraction runs in a background singleton. |
+| `resume_worker.py` | Resumes paused runs, rebuilds request context, and records retry state. |
+| `outcome.py` | Provides the generic extraction outcome wrapper used by callers. |
+
+## Boundary Rules
+
+- Keep profile-specific and playbook-specific extraction behavior in their own
+  modules; call this package only for shared async runtime concerns.
+- Add a new file here when the behavior is shared by more than one extraction
+  caller or is part of the resumable runtime itself.
+- Split into subpackages only when a responsibility grows large enough that a
+  flat package stops being easier to scan.
+- Do not recreate removed legacy modules such as `tools.py`, `plan.py`, or
+  `invariants.py`; use the current focused files above.

--- a/tests/server/services/extraction/test_module_contract.py
+++ b/tests/server/services/extraction/test_module_contract.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_MODULE_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "reflexio"
+    / "server"
+    / "services"
+    / "extraction"
+)
+_EXPECTED_FILES = {
+    "__init__.py",
+    "agent_run_records.py",
+    "outcome.py",
+    "pending_tool_call_dispatch.py",
+    "prior_answer_search.py",
+    "resumable_agent.py",
+    "resume_scheduler.py",
+    "resume_worker.py",
+    "README.md",
+}
+_REMOVED_FILES = {"tools.py", "plan.py", "invariants.py"}
+
+
+def test_extraction_canonical_imports_work() -> None:
+    from reflexio.server.services.extraction.agent_run_records import (
+        build_extractor_agent_run_record,
+    )
+    from reflexio.server.services.extraction.outcome import ExtractionOutcome
+    from reflexio.server.services.extraction.pending_tool_call_dispatch import (
+        PendingToolCallToolContext,
+        create_ask_human_tool,
+        create_attach_pending_info_request_tool,
+    )
+    from reflexio.server.services.extraction.prior_answer_search import (
+        append_prior_knowledge_context,
+    )
+    from reflexio.server.services.extraction.resumable_agent import (
+        AgentRunResult,
+        ResumableExtractionAgent,
+        run_resumable_extraction_agent,
+    )
+    from reflexio.server.services.extraction.resume_scheduler import (
+        ExtractionResumeScheduler,
+        maybe_start_resume_scheduler,
+    )
+    from reflexio.server.services.extraction.resume_worker import (
+        ExtractionResumeWorker,
+        ResumeWorkerError,
+    )
+
+    assert ExtractionOutcome.__name__ == "ExtractionOutcome"
+    assert build_extractor_agent_run_record.__name__ == (
+        "build_extractor_agent_run_record"
+    )
+    assert PendingToolCallToolContext.__name__ == "PendingToolCallToolContext"
+    assert create_ask_human_tool.__name__ == "create_ask_human_tool"
+    assert create_attach_pending_info_request_tool.__name__ == (
+        "create_attach_pending_info_request_tool"
+    )
+    assert append_prior_knowledge_context.__name__ == "append_prior_knowledge_context"
+    assert AgentRunResult.__name__ == "AgentRunResult"
+    assert ResumableExtractionAgent.__name__ == "ResumableExtractionAgent"
+    assert run_resumable_extraction_agent.__name__ == "run_resumable_extraction_agent"
+    assert ExtractionResumeScheduler.__name__ == "ExtractionResumeScheduler"
+    assert maybe_start_resume_scheduler.__name__ == "maybe_start_resume_scheduler"
+    assert ExtractionResumeWorker.__name__ == "ExtractionResumeWorker"
+    assert ResumeWorkerError.__name__ == "ResumeWorkerError"
+
+
+def test_extraction_file_layout_stays_compact_and_current() -> None:
+    source_files = {path.name for path in _MODULE_DIR.iterdir() if path.is_file()}
+
+    assert source_files >= _EXPECTED_FILES
+    assert source_files.isdisjoint(_REMOVED_FILES)


### PR DESCRIPTION
## Summary
- Preserve `services/extraction/` as a compact, domain-neutral async extraction runtime instead of forcing a profile/playbook-style component split.
- Add package-level documentation for the extraction runtime boundary and file responsibilities.
- Add a module contract test that verifies canonical imports and prevents removed legacy files from returning.
- Update service catalogs so they reference the current extraction files instead of stale `tools.py`, `plan.py`, and `invariants.py` paths.

## Changes
- Documentation:
  - Added `services/extraction/README.md` with boundary rules and file ownership.
  - Updated `server/README.md` and `server/services/README.md` extraction catalog entries.
- Tests:
  - Added `tests/server/services/extraction/test_module_contract.py` for canonical imports and compact file layout.

## Test Plan
- `uv run pytest open_source/reflexio/tests/server/services/extraction/test_module_contract.py -q -o 'addopts='`
- `uv run pytest open_source/reflexio/tests/server/services/extraction -q -o 'addopts='`
- `uv run pytest open_source/reflexio/tests/server/services/profile/test_profile_extractor.py open_source/reflexio/tests/server/services/playbook/test_playbook_extractor.py -q -o 'addopts='`
- `uv run ruff check open_source/reflexio/reflexio/server/services/extraction open_source/reflexio/tests/server/services/extraction/test_module_contract.py`
- `uv run pyright open_source/reflexio/reflexio/server/services/extraction open_source/reflexio/tests/server/services/extraction/test_module_contract.py`
- `uv run python -c "import reflexio; print('import OK')"`
- `rg -n 'extraction/(tools|plan|invariants)\.py|services\.extraction\.(tools|plan|invariants)' open_source/reflexio/reflexio open_source/reflexio/tests`
