### PR TITLE
refactor(profile): use canonical service and extractor paths

### DIFF
--- a/reflexio/lib/_generation.py
+++ b/reflexio/lib/_generation.py
@@ -99,7 +99,7 @@ class GenerationMixin(ReflexioBase):
         Returns:
             RerunProfileGenerationResponse: Response containing success status, message, and count of profiles generated
         """
-        from reflexio.server.services.profile.profile_generation_service import (
+        from reflexio.server.services.profile.service import (
             ProfileGenerationService,
         )
 
@@ -124,7 +124,7 @@ class GenerationMixin(ReflexioBase):
         Returns:
             ManualProfileGenerationResponse: Response containing success status, message, and count of profiles generated
         """
-        from reflexio.server.services.profile.profile_generation_service import (
+        from reflexio.server.services.profile.service import (
             ProfileGenerationService,
         )
 

--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -43,7 +43,7 @@ from reflexio.models.api_schema.service_schemas import (
     UpgradeProfilesRequest,
     UpgradeProfilesResponse,
 )
-from reflexio.server.services.profile.profile_generation_service import (
+from reflexio.server.services.profile.service import (
     ProfileGenerationService,
 )
 from reflexio.server.tracing import profile_step

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -244,8 +244,8 @@ Called by API endpoints via `Reflexio`
 **Directory**: `services/profile/`
 
 Key files:
-- `profile_generation_service.py`: Service orchestrator
-- `profile_extractor.py`: Extractor that generates profile updates
+- `profile/service.py`: Service orchestrator
+- `profile/components/extractor.py`: Extractor that generates profile updates
 - `profile_updater.py`: Applies updates (add/delete/mention) to storage
 - `components/consolidator.py`: Consolidates newly extracted profiles against existing DB profiles using LLM
 

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -244,12 +244,11 @@ Called by API endpoints via `Reflexio`
 **Directory**: `services/profile/`
 
 Key files:
-- `profile/service.py`: Service orchestrator
-- `profile/components/extractor.py`: Extractor that generates profile updates
-- `profile_updater.py`: Applies updates (add/delete/mention) to storage
+- `service.py`: Service orchestrator and profile persistence/finalization
+- `components/extractor.py`: Extractor that generates profile updates
 - `components/consolidator.py`: Consolidates newly extracted profiles against existing DB profiles using LLM
 
-**Flow**: Interactions → ProfileExtractor (extraction-only) → ProfileConsolidator (deduplicates new vs existing DB profiles) → ProfileUpdater → Storage
+**Flow**: Interactions → ProfileExtractor (extraction-only) → ProfileConsolidator (deduplicates new vs existing DB profiles) → ProfileGenerationService → Storage
 
 **Generation Modes** (detailed comparison):
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -32,7 +32,7 @@ strings before deleting old import paths in the same PR.
 
 | Directory | Entry class | Key files |
 |-----------|-------------|-----------|
-| `profile/` | `ProfileGenerationService` | `profile_extractor.py`, `components/consolidator.py`, `profile_updater.py` |
+| `profile/` | `ProfileGenerationService` | `service.py`, `components/extractor.py`, `components/consolidator.py` |
 | `playbook/` | `PlaybookGenerationService` | `components/extractor.py`, `components/consolidator.py`, `components/aggregator.py` (cluster-fingerprint change detection) — has its own [README](playbook/README.md) |
 | `agent_success_evaluation/` | `AgentSuccessEvaluationService` | `service.py` (session-level service), `runner.py` (`run_group_evaluation`), `scheduler.py` (`GroupEvaluationScheduler`, 10-min defer), `regen_jobs.py`, `components/evaluator.py` |
 | `reflection/` | `ReflectionService` | `service.py`, `components/extractor.py` — post-horizon reflection; runs **before** extraction so extractors read post-reflection state |

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -39,17 +39,17 @@ from reflexio.server.services.playbook.service import (
     PlaybookGenerationService,
     PlaybookGenerationServiceConfig,
 )
-from reflexio.server.services.profile.profile_extractor import (
+from reflexio.server.services.profile.components.extractor import (
     MAX_EXISTING_PROFILES_FOR_CONTEXT,
     ProfileExtractor,
-)
-from reflexio.server.services.profile.profile_generation_service import (
-    ProfileGenerationService,
-    ProfileGenerationServiceConfig,
 )
 from reflexio.server.services.profile.profile_generation_service_utils import (
     StructuredProfilesOutput,
     construct_profile_extraction_messages_from_sessions,
+)
+from reflexio.server.services.profile.service import (
+    ProfileGenerationService,
+    ProfileGenerationServiceConfig,
 )
 from reflexio.server.services.service_utils import (
     extract_interactions_from_request_interaction_data_models,

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -35,11 +35,11 @@ from reflexio.server.services.playbook.playbook_service_utils import (
 from reflexio.server.services.playbook.service import (
     PlaybookGenerationService,
 )
-from reflexio.server.services.profile.profile_generation_service import (
-    ProfileGenerationService,
-)
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileGenerationRequest,
+)
+from reflexio.server.services.profile.service import (
+    ProfileGenerationService,
 )
 from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionServiceRequest,

--- a/reflexio/server/services/profile/components/__init__.py
+++ b/reflexio/server/services/profile/components/__init__.py
@@ -6,10 +6,12 @@ from reflexio.server.services.profile.components.consolidator import (
     ProfileDeletionDirective,
     ProfileDuplicateGroup,
 )
+from reflexio.server.services.profile.components.extractor import ProfileExtractor
 
 __all__ = [
     "ProfileConsolidator",
     "ProfileDeduplicationOutput",
     "ProfileDeletionDirective",
     "ProfileDuplicateGroup",
+    "ProfileExtractor",
 ]

--- a/reflexio/server/services/profile/components/extractor.py
+++ b/reflexio/server/services/profile/components/extractor.py
@@ -26,7 +26,7 @@ from reflexio.server.services.extractor_interaction_utils import (
 from reflexio.server.services.operation_state_utils import OperationStateManager
 
 if TYPE_CHECKING:
-    from reflexio.server.services.profile.profile_generation_service import (
+    from reflexio.server.services.profile.service import (
         ProfileGenerationServiceConfig,
     )
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name

--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -27,7 +27,7 @@ from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     StatusChangeOperation,
 )
-from reflexio.server.services.profile.profile_extractor import ProfileExtractor
+from reflexio.server.services.profile.components.extractor import ProfileExtractor
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileGenerationRequest,
     ProfileGenerationServiceConstants,

--- a/tests/eval/extraction/providers.py
+++ b/tests/eval/extraction/providers.py
@@ -45,8 +45,8 @@ from reflexio.server.services.playbook.components.extractor import PlaybookExtra
 from reflexio.server.services.playbook.service import (
     PlaybookGenerationServiceConfig,
 )
-from reflexio.server.services.profile.profile_extractor import ProfileExtractor
-from reflexio.server.services.profile.profile_generation_service import (
+from reflexio.server.services.profile.components.extractor import ProfileExtractor
+from reflexio.server.services.profile.service import (
     ProfileGenerationServiceConfig,
 )
 

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -27,7 +27,7 @@ from reflexio.models.api_schema.service_schemas import (
     Status,
     UpgradeProfilesRequest,
 )
-from reflexio.server.services.profile.profile_extractor import (
+from reflexio.server.services.profile.components.extractor import (
     ProfileExtractorConfig,
 )
 

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -220,7 +220,7 @@ def test_resume_worker_retries_finalization_without_rerunning_agent(
     with (
         patch("litellm.completion", side_effect=[response]),
         patch(
-            "reflexio.server.services.profile.profile_generation_service."
+            "reflexio.server.services.profile.service."
             "ProfileGenerationService._finalize_extracted_items",
             side_effect=RuntimeError("storage write failed"),
         ),
@@ -247,7 +247,7 @@ def test_resume_worker_retries_finalization_without_rerunning_agent(
             side_effect=AssertionError("finalization retry must not call LLM"),
         ),
         patch(
-            "reflexio.server.services.profile.profile_generation_service."
+            "reflexio.server.services.profile.service."
             "ProfileGenerationService._finalize_extracted_items",
             return_value=None,
         ) as finalize,

--- a/tests/server/services/profile/test_dedup_always_soft_integration.py
+++ b/tests/server/services/profile/test_dedup_always_soft_integration.py
@@ -35,7 +35,7 @@ import pytest
 from reflexio.lib._profiles import reconstruct_profile_change_log
 from reflexio.models.api_schema.domain.enums import ProfileTimeToLive, Status
 from reflexio.models.api_schema.service_schemas import UserProfile
-from reflexio.server.services.profile.profile_generation_service import (
+from reflexio.server.services.profile.service import (
     ProfileGenerationService,
     ProfileGenerationServiceConfig,
 )
@@ -48,7 +48,7 @@ _DEDUP_CLS = (
     "reflexio.server.services.profile.components.consolidator.ProfileConsolidator"
 )
 _CAPTURE_ANOMALY = (
-    "reflexio.server.services.profile.profile_generation_service.capture_anomaly"
+    "reflexio.server.services.profile.service.capture_anomaly"
 )
 
 

--- a/tests/server/services/profile/test_profile_extractor.py
+++ b/tests/server/services/profile/test_profile_extractor.py
@@ -30,12 +30,12 @@ from reflexio.models.config_schema import (
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.extraction.outcome import ExtractionOutcome
-from reflexio.server.services.profile.profile_extractor import ProfileExtractor
-from reflexio.server.services.profile.profile_generation_service import (
-    ProfileGenerationServiceConfig,
-)
+from reflexio.server.services.profile.components.extractor import ProfileExtractor
 from reflexio.server.services.profile.profile_generation_service_utils import (
     StructuredProfilesOutput,
+)
+from reflexio.server.services.profile.service import (
+    ProfileGenerationServiceConfig,
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base import (

--- a/tests/server/services/profile/test_profile_generation_service.py
+++ b/tests/server/services/profile/test_profile_generation_service.py
@@ -24,12 +24,12 @@ from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.base_generation_service import StatusChangeOperation
-from reflexio.server.services.profile.profile_generation_service import (
-    ProfileGenerationService,
-    ProfileGenerationServiceConfig,
-)
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileGenerationRequest,
+)
+from reflexio.server.services.profile.service import (
+    ProfileGenerationService,
+    ProfileGenerationServiceConfig,
 )
 
 # ===============================

--- a/tests/server/services/profile/test_profile_module_contract.py
+++ b/tests/server/services/profile/test_profile_module_contract.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+_PROFILE_DIR = (
+    Path(__file__).resolve().parents[4]
+    / "reflexio"
+    / "server"
+    / "services"
+    / "profile"
+)
+_REMOVED_FILES = {"profile_generation_service.py", "profile_extractor.py"}
+
+
+def test_profile_canonical_imports_work() -> None:
+    from reflexio.server.services.profile.components.consolidator import (
+        ProfileConsolidator,
+    )
+    from reflexio.server.services.profile.components.extractor import ProfileExtractor
+    from reflexio.server.services.profile.service import (
+        ProfileGenerationService,
+        ProfileGenerationServiceConfig,
+    )
+
+    assert ProfileGenerationService.__name__ == "ProfileGenerationService"
+    assert ProfileGenerationServiceConfig.__name__ == "ProfileGenerationServiceConfig"
+    assert ProfileExtractor.__name__ == "ProfileExtractor"
+    assert ProfileConsolidator.__name__ == "ProfileConsolidator"
+
+
+def test_profile_file_layout_uses_canonical_paths() -> None:
+    components_dir = _PROFILE_DIR / "components"
+
+    assert (_PROFILE_DIR / "service.py").exists()
+    assert (_PROFILE_DIR / "profile_generation_service_utils.py").exists()
+    assert (components_dir / "__init__.py").exists()
+    assert (components_dir / "extractor.py").exists()
+    assert (components_dir / "consolidator.py").exists()
+    for removed_file in _REMOVED_FILES:
+        assert not (_PROFILE_DIR / removed_file).exists()
+
+
+def test_profile_durable_names_remain_stable() -> None:
+    from reflexio.models.config_schema import Config
+    from reflexio.server.services.profile.profile_generation_service_utils import (
+        ProfileGenerationServiceConstants,
+    )
+
+    assert "profile_extractor_config" in Config.model_fields
+    assert (
+        ProfileGenerationServiceConstants.PROFILE_SHOULD_GENERATE_PROMPT_ID
+        == "profile_should_generate"
+    )
+    assert (
+        ProfileGenerationServiceConstants.PROFILE_UPDATE_MAIN_PROMPT_ID
+        == "profile_update_main"
+    )

--- a/tests/server/services/test_generation_billing_emission.py
+++ b/tests/server/services/test_generation_billing_emission.py
@@ -28,7 +28,7 @@ from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     PreparedGenerationRun,
 )
-from reflexio.server.services.profile.profile_generation_service import (
+from reflexio.server.services.profile.service import (
     ProfileGenerationService,
     ProfileGenerationServiceConfig,
 )

--- a/tests/server/services/test_generation_billing_emission.py
+++ b/tests/server/services/test_generation_billing_emission.py
@@ -28,12 +28,12 @@ from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     PreparedGenerationRun,
 )
+from reflexio.server.services.profile.profile_generation_service_utils import (
+    ProfileGenerationRequest,
+)
 from reflexio.server.services.profile.service import (
     ProfileGenerationService,
     ProfileGenerationServiceConfig,
-)
-from reflexio.server.services.profile.profile_generation_service_utils import (
-    ProfileGenerationRequest,
 )
 from reflexio.server.services.service_utils import format_sessions_to_history_string
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -29,13 +29,13 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.generation_service import GenerationService
-from reflexio.server.services.profile.service import (
-    ProfileGenerationService,
-)
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileAddItem,
     ProfileGenerationRequest,
     StructuredProfilesOutput,
+)
+from reflexio.server.services.profile.service import (
+    ProfileGenerationService,
 )
 from tests import test_data
 from tests.server.test_utils import encode_image_to_base64

--- a/tests/server/services/test_profile_generation_service.py
+++ b/tests/server/services/test_profile_generation_service.py
@@ -29,7 +29,7 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.generation_service import GenerationService
-from reflexio.server.services.profile.profile_generation_service import (
+from reflexio.server.services.profile.service import (
     ProfileGenerationService,
 )
 from reflexio.server.services.profile.profile_generation_service_utils import (

--- a/tests/server/services/test_profile_source_filtering.py
+++ b/tests/server/services/test_profile_source_filtering.py
@@ -16,12 +16,13 @@ from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.generation_service import GenerationService
-from reflexio.server.services.profile.service import (
-    ProfileGenerationService,
-)
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileGenerationRequest,
 )
+from reflexio.server.services.profile.service import (
+    ProfileGenerationService,
+)
+from reflexio.server.services.storage.storage_base import BaseStorage
 
 
 @pytest.fixture
@@ -47,6 +48,12 @@ def mock_chat_completion():
         side_effect=mock_generate_chat_response_side_effect,
     ):
         yield
+
+
+def _storage(service: ProfileGenerationService) -> BaseStorage:
+    storage = service.storage
+    assert storage is not None
+    return storage
 
 
 def test_profile_extractor_filters_by_source_api(mock_chat_completion):
@@ -99,11 +106,9 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
             session_id="test_session",
             source="api",
         )
-        profile_generation_service.storage.add_request(request_obj)
+        _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            profile_generation_service.storage.add_user_interaction(
-                user_id, interaction_obj
-            )
+            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -115,7 +120,7 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
         profile_generation_service.run(profile_generation_request)
 
         # Profile should be created (config1 should run)
-        profiles = profile_generation_service.storage.get_user_profile(user_id)
+        profiles = _storage(profile_generation_service).get_user_profile(user_id)
         assert len(profiles) == 1
 
 
@@ -167,11 +172,9 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
             session_id="test_session",
             source="webhook",
         )
-        profile_generation_service.storage.add_request(request_obj)
+        _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            profile_generation_service.storage.add_user_interaction(
-                user_id, interaction_obj
-            )
+            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -183,7 +186,7 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
         profile_generation_service.run(profile_generation_request)
 
         # No profile should be created (config should be filtered out)
-        profiles = profile_generation_service.storage.get_user_profile(user_id)
+        profiles = _storage(profile_generation_service).get_user_profile(user_id)
         assert len(profiles) == 0
 
 
@@ -235,11 +238,9 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
             session_id="test_session",
             source="random_source",
         )
-        profile_generation_service.storage.add_request(request_obj)
+        _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            profile_generation_service.storage.add_user_interaction(
-                user_id, interaction_obj
-            )
+            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -251,7 +252,7 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
         profile_generation_service.run(profile_generation_request)
 
         # Profile should be created (None means all sources enabled)
-        profiles = profile_generation_service.storage.get_user_profile(user_id)
+        profiles = _storage(profile_generation_service).get_user_profile(user_id)
         assert len(profiles) == 1
 
 
@@ -303,11 +304,9 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
             session_id="test_session",
             source="another_random_source",
         )
-        profile_generation_service.storage.add_request(request_obj)
+        _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            profile_generation_service.storage.add_user_interaction(
-                user_id, interaction_obj
-            )
+            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -319,7 +318,7 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
         profile_generation_service.run(profile_generation_request)
 
         # Profile should be created (empty list means all sources enabled)
-        profiles = profile_generation_service.storage.get_user_profile(user_id)
+        profiles = _storage(profile_generation_service).get_user_profile(user_id)
         assert len(profiles) == 1
 
 

--- a/tests/server/services/test_profile_source_filtering.py
+++ b/tests/server/services/test_profile_source_filtering.py
@@ -16,7 +16,7 @@ from reflexio.models.config_schema import ProfileExtractorConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.generation_service import GenerationService
-from reflexio.server.services.profile.profile_generation_service import (
+from reflexio.server.services.profile.service import (
     ProfileGenerationService,
 )
 from reflexio.server.services.profile.profile_generation_service_utils import (


### PR DESCRIPTION
## Summary
- Complete the profile package-shape cutover by moving the request-path service and extractor to canonical module paths.
- Keep durable profile vocabulary unchanged: `profile_extractor_config`, `profile_extractor`, prompt IDs, operation-state keys, storage behavior, SDK behavior, and HTTP routes are unchanged.
- Add a profile module contract test that guards canonical imports and verifies the legacy files stay removed.

## Changes
- Profile package layout
  - `profile/profile_generation_service.py` -> `profile/service.py`
  - `profile/profile_extractor.py` -> `profile/components/extractor.py`
  - `profile/components/__init__.py` now exports `ProfileExtractor` alongside `ProfileConsolidator`.
- Consumers and docs
  - Updated runtime imports, lazy imports, eval providers, profile tests, extraction resume-worker tests, and service README entries.
- Tests
  - Added `tests/server/services/profile/test_profile_module_contract.py`.
  - Fixed typed profile utility test data to use `UserActionType` enum values.

## Test Plan
- `uv run pytest open_source/reflexio/tests/server/services/profile/test_profile_module_contract.py open_source/reflexio/tests/server/services/profile/test_profile_extractor.py open_source/reflexio/tests/server/services/profile/test_profile_generation_service.py open_source/reflexio/tests/server/services/profile/test_profile_consolidator.py open_source/reflexio/tests/server/services/extraction/test_resume_worker.py reflexio_ext/tests/server/services/profile/test_profile_extractor.py -q -o 'addopts='` -> `122 passed`
- `uv run pytest open_source/reflexio/tests/lib/test_profiles_unit.py open_source/reflexio/tests/lib/test_generation_unit.py open_source/reflexio/tests/eval/extraction/test_extraction_eval.py -q -o 'addopts='` -> `71 passed, 2 skipped`
- `uv run ruff check open_source/reflexio/reflexio/server/services/profile open_source/reflexio/reflexio/server/services/generation_service.py open_source/reflexio/reflexio/server/services/extraction/resume_worker.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_generation.py open_source/reflexio/tests/server/services/profile open_source/reflexio/tests/server/services/extraction/test_resume_worker.py reflexio_ext/tests/server/services/profile/test_profile_extractor.py`
- `uv run pyright open_source/reflexio/reflexio/server/services/profile open_source/reflexio/reflexio/server/services/generation_service.py open_source/reflexio/reflexio/server/services/extraction/resume_worker.py open_source/reflexio/reflexio/lib/_profiles.py open_source/reflexio/reflexio/lib/_generation.py open_source/reflexio/tests/server/services/profile open_source/reflexio/tests/server/services/extraction/test_resume_worker.py reflexio_ext/tests/server/services/profile/test_profile_extractor.py` -> `0 errors`
- `uv run python -c "import reflexio; print('import OK')"`
- `rg -n -P "profile\.profile_generation_service(?!_utils)|profile\.profile_extractor|profile_generation_service\.py|profile_extractor\.py" open_source/reflexio/reflexio open_source/reflexio/tests reflexio_ext --glob '*.py' --glob '*.md' --glob '*.mdx'` -> only the removed-file assertion in the new contract test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated profile-generation docs to reflect the current workflow and file organization.
  * Clarified the profile generation flow and key service components in the service guides.

* **Tests**
  * Added coverage to verify profile-related imports and file layout remain consistent.
  * Updated existing profile workflow tests to match the current service structure and keep behavior checks intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->