### PR TITLE
fix(playbook): preserve agent playbooks on null aggregation

### DIFF
--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -810,6 +810,27 @@ class PlaybookAggregator:
             )
             new_playbooks = [playbook for playbook, _ in generated_pairs]
 
+            previous_fingerprints_for_changed_clusters = {}
+            if not playbook_aggregator_request.rerun and prev_fingerprints:
+                for cluster_playbooks in changed_clusters.values():
+                    fp = self._compute_cluster_fingerprint(cluster_playbooks)
+                    current_user_ids = {
+                        fb.user_playbook_id
+                        for fb in cluster_playbooks
+                        if fb.user_playbook_id is not None
+                    }
+                    matched_prev_fingerprints = {
+                        prev_fp: fp_data
+                        for prev_fp, fp_data in prev_fingerprints.items()
+                        if fp_data.get("agent_playbook_id") is not None
+                        and current_user_ids
+                        & set(fp_data.get("user_playbook_ids") or [])
+                    }
+                    if matched_prev_fingerprints:
+                        previous_fingerprints_for_changed_clusters[fp] = (
+                            matched_prev_fingerprints
+                        )
+
             # Lazy archive: only full-archive when the LLM produced replacements.
             # Skipping the archive when new_playbooks is empty preserves existing
             # PENDING/APPROVED playbooks that the LLM identified as duplicates.
@@ -832,9 +853,7 @@ class PlaybookAggregator:
 
             if not playbook_aggregator_request.rerun:
                 # Carry forward unchanged fingerprints from previous state
-                prev_fps = mgr.get_cluster_fingerprints(
-                    name=playbook_name, version=self.agent_version
-                )
+                prev_fps = prev_fingerprints
                 current_fp_set = set()
                 for cluster_playbooks in clusters.values():
                     fp = self._compute_cluster_fingerprint(cluster_playbooks)
@@ -855,19 +874,9 @@ class PlaybookAggregator:
                     }
                 )
 
-            # Initialize changed cluster fingerprints before assigning saved IDs
-            # below. ``generated_pairs`` preserves the exact source cluster for
-            # every non-duplicate playbook the LLM produced.
-            for cluster_playbooks in changed_clusters.values():
-                fp = self._compute_cluster_fingerprint(cluster_playbooks)
-                raw_ids = sorted(fb.user_playbook_id for fb in cluster_playbooks)
-
-                new_fingerprints[fp] = {
-                    "agent_playbook_id": None,
-                    "user_playbook_ids": raw_ids,
-                }
-
             saved_playbook_list: list[AgentPlaybook] = []
+            selective_supersede_playbook_ids = set()
+            replaced_previous_fingerprints = set()
 
             # Save each playbook + its aggregate event atomically, then assign
             # fingerprints and source-windows for the saved row.
@@ -892,6 +901,16 @@ class PlaybookAggregator:
                         "agent_playbook_id": saved_fb.agent_playbook_id,
                         "user_playbook_ids": raw_ids,
                     }
+                    for (
+                        prev_fp,
+                        fp_data,
+                    ) in previous_fingerprints_for_changed_clusters.get(
+                        fp_key, {}
+                    ).items():
+                        playbook_id = fp_data.get("agent_playbook_id")
+                        if playbook_id is not None:
+                            selective_supersede_playbook_ids.add(playbook_id)
+                            replaced_previous_fingerprints.add(prev_fp)
                     self.storage.set_source_windows_for_agent_playbook(  # type: ignore[reportOptionalMemberAccess]
                         saved_fb.agent_playbook_id,
                         [
@@ -905,6 +924,33 @@ class PlaybookAggregator:
                             )
                         ],
                     )
+
+            # Changed clusters that did not get a replacement keep their previous
+            # fingerprint/playbook mapping so a later successful replacement can
+            # supersede the old playbook. Brand-new duplicate clusters still get
+            # a None marker to avoid repeated LLM calls for the same fingerprint.
+            for cluster_playbooks in changed_clusters.values():
+                fp = self._compute_cluster_fingerprint(cluster_playbooks)
+                if fp in new_fingerprints:
+                    continue
+
+                previous_for_cluster = previous_fingerprints_for_changed_clusters.get(
+                    fp, {}
+                )
+                preserved_previous = {
+                    prev_fp: fp_data
+                    for prev_fp, fp_data in previous_for_cluster.items()
+                    if prev_fp not in replaced_previous_fingerprints
+                }
+                if preserved_previous:
+                    new_fingerprints.update(preserved_previous)
+                    continue
+
+                raw_ids = sorted(fb.user_playbook_id for fb in cluster_playbooks)
+                new_fingerprints[fp] = {
+                    "agent_playbook_id": None,
+                    "user_playbook_ids": raw_ids,
+                }
 
             # Store fingerprints in operation state
             mgr.update_cluster_fingerprints(
@@ -936,9 +982,10 @@ class PlaybookAggregator:
                                 agent_version=self.agent_version,
                                 request_id=_run_id,
                             )
-                    elif archived_playbook_ids and new_playbooks:
+                    elif selective_supersede_playbook_ids:
                         self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[reportOptionalMemberAccess]
-                            archived_playbook_ids, request_id=_run_id
+                            sorted(selective_supersede_playbook_ids),
+                            request_id=_run_id,
                         )
                     elif archived_playbook_ids:
                         logger.info(

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -811,6 +811,9 @@ class PlaybookAggregator:
             new_playbooks = [playbook for playbook, _ in generated_pairs]
 
             previous_fingerprints_for_changed_clusters = {}
+            changed_fps_by_previous_fp = {}
+            changed_fps_with_replacements = set()
+            previous_playbook_id_by_fp = {}
             if not playbook_aggregator_request.rerun and prev_fingerprints:
                 for cluster_playbooks in changed_clusters.values():
                     fp = self._compute_cluster_fingerprint(cluster_playbooks)
@@ -830,6 +833,13 @@ class PlaybookAggregator:
                         previous_fingerprints_for_changed_clusters[fp] = (
                             matched_prev_fingerprints
                         )
+                        for prev_fp, fp_data in matched_prev_fingerprints.items():
+                            changed_fps_by_previous_fp.setdefault(prev_fp, set()).add(
+                                fp
+                            )
+                            playbook_id = fp_data.get("agent_playbook_id")
+                            if playbook_id is not None:
+                                previous_playbook_id_by_fp[prev_fp] = playbook_id
 
             # Lazy archive: only full-archive when the LLM produced replacements.
             # Skipping the archive when new_playbooks is empty preserves existing
@@ -896,21 +906,25 @@ class PlaybookAggregator:
                 saved_playbook_list.append(saved_fb)
                 if saved_fb and saved_fb.agent_playbook_id:
                     fp_key = self._compute_cluster_fingerprint(cluster_playbooks)
+                    changed_fps_with_replacements.add(fp_key)
                     raw_ids = sorted(fb.user_playbook_id for fb in cluster_playbooks)
                     new_fingerprints[fp_key] = {
                         "agent_playbook_id": saved_fb.agent_playbook_id,
                         "user_playbook_ids": raw_ids,
                     }
-                    for (
-                        prev_fp,
-                        fp_data,
-                    ) in previous_fingerprints_for_changed_clusters.get(
+                    for prev_fp in previous_fingerprints_for_changed_clusters.get(
                         fp_key, {}
-                    ).items():
-                        playbook_id = fp_data.get("agent_playbook_id")
-                        if playbook_id is not None:
-                            selective_supersede_playbook_ids.add(playbook_id)
+                    ):
+                        all_overlapping_clusters_replaced = (
+                            changed_fps_by_previous_fp.get(prev_fp, set()).issubset(
+                                changed_fps_with_replacements
+                            )
+                        )
+                        playbook_id = previous_playbook_id_by_fp.get(prev_fp)
+                        if all_overlapping_clusters_replaced:
                             replaced_previous_fingerprints.add(prev_fp)
+                            if playbook_id is not None:
+                                selective_supersede_playbook_ids.add(playbook_id)
                     self.storage.set_source_windows_for_agent_playbook(  # type: ignore[reportOptionalMemberAccess]
                         saved_fb.agent_playbook_id,
                         [

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -789,10 +789,6 @@ class PlaybookAggregator:
                     len(archived_playbook_ids),
                 )
 
-                # Selectively archive only playbooks from changed/disappeared clusters
-                if archived_playbook_ids:
-                    self.storage.archive_agent_playbooks_by_ids(archived_playbook_ids)  # type: ignore[reportOptionalMemberAccess]
-
         try:
             # Emit the started event inside the protected block so any failure
             # from here on is paired with an aggregation_failed event.
@@ -940,9 +936,15 @@ class PlaybookAggregator:
                                 agent_version=self.agent_version,
                                 request_id=_run_id,
                             )
-                    elif archived_playbook_ids:
+                    elif archived_playbook_ids and new_playbooks:
                         self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[reportOptionalMemberAccess]
                             archived_playbook_ids, request_id=_run_id
+                        )
+                    elif archived_playbook_ids:
+                        logger.info(
+                            "Skipping selective supersede of %s (agent_version=%s): LLM produced 0 new playbooks; existing PENDING/APPROVED playbooks preserved",
+                            archived_playbook_ids,
+                            self.agent_version,
                         )
                 except Exception:
                     with sentry_tags(

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -941,7 +941,7 @@ class TestRun:
         with patch.object(PlaybookAggregator, "_create_state_manager") as mock_csm:
             mgr = MagicMock()
             mgr.get_cluster_fingerprints.return_value = {
-                "old_fp": {"agent_playbook_id": 50, "user_playbook_ids": [1, 2]}
+                "old_fp": {"agent_playbook_id": 50, "user_playbook_ids": [5]}
             }
             mock_csm.return_value = mgr
 
@@ -979,6 +979,56 @@ class TestRun:
         agg.storage.archive_agent_playbooks_by_ids.assert_not_called()
         agg.storage.supersede_agent_playbooks_by_ids.assert_not_called()
         agg.storage.delete_agent_playbooks_by_ids.assert_not_called()
+
+    @patch.object(PlaybookAggregator, "get_clusters")
+    @patch.object(PlaybookAggregator, "_generate_playbooks_with_source_clusters")
+    def test_incremental_mixed_generation_supersedes_only_replaced_cluster(
+        self, mock_gen, mock_clust
+    ):
+        """A null changed cluster keeps its old playbook when a sibling generates."""
+        agg = self._make_runnable_aggregator()
+        null_cluster = [_raw(rid=1), _raw(rid=2), _raw(rid=5)]
+        generated_cluster = [_raw(rid=3), _raw(rid=4), _raw(rid=6)]
+        agg.storage.get_user_playbooks.return_value = null_cluster + generated_cluster
+        mock_clust.return_value = {0: null_cluster, 1: generated_cluster}
+        generated = _agent_playbook(fid=200)
+        generated.agent_playbook_id = 200
+        mock_gen.return_value = [(generated, generated_cluster)]
+        agg.storage.save_agent_playbook_with_aggregate_event.return_value = generated
+        fp_null_old = PlaybookAggregator._compute_cluster_fingerprint(
+            [_raw(rid=1), _raw(rid=2)]
+        )
+        fp_generated_old = PlaybookAggregator._compute_cluster_fingerprint(
+            [_raw(rid=3), _raw(rid=4)]
+        )
+        fp_generated_new = PlaybookAggregator._compute_cluster_fingerprint(
+            generated_cluster
+        )
+
+        with patch.object(PlaybookAggregator, "_create_state_manager") as mock_csm:
+            mgr = MagicMock()
+            mgr.get_cluster_fingerprints.return_value = {
+                fp_null_old: {"agent_playbook_id": 50, "user_playbook_ids": [1, 2]},
+                fp_generated_old: {
+                    "agent_playbook_id": 60,
+                    "user_playbook_ids": [3, 4],
+                },
+            }
+            mock_csm.return_value = mgr
+
+            req = PlaybookAggregatorRequest(agent_version="v1")
+            agg.run(req)
+
+        agg.storage.supersede_agent_playbooks_by_ids.assert_called_once_with(
+            [60], request_id=ANY
+        )
+        call_kwargs = mgr.update_cluster_fingerprints.call_args
+        new_fps = call_kwargs.kwargs.get("fingerprints") or call_kwargs[1].get(
+            "fingerprints"
+        )
+        assert new_fps[fp_null_old]["agent_playbook_id"] == 50
+        assert new_fps[fp_generated_new]["agent_playbook_id"] == 200
+        assert fp_generated_old not in new_fps
 
     @patch.object(PlaybookAggregator, "get_clusters")
     @patch.object(PlaybookAggregator, "_generate_playbooks_with_source_clusters")

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1032,6 +1032,49 @@ class TestRun:
 
     @patch.object(PlaybookAggregator, "get_clusters")
     @patch.object(PlaybookAggregator, "_generate_playbooks_with_source_clusters")
+    def test_incremental_split_cluster_preserves_shared_prior_until_all_replaced(
+        self, mock_gen, mock_clust
+    ):
+        """A split cluster keeps the old playbook while any split branch is null."""
+        agg = self._make_runnable_aggregator()
+        null_cluster = [_raw(rid=1), _raw(rid=2), _raw(rid=5)]
+        generated_cluster = [_raw(rid=3), _raw(rid=4), _raw(rid=6)]
+        agg.storage.get_user_playbooks.return_value = null_cluster + generated_cluster
+        mock_clust.return_value = {0: null_cluster, 1: generated_cluster}
+        generated = _agent_playbook(fid=200)
+        generated.agent_playbook_id = 200
+        mock_gen.return_value = [(generated, generated_cluster)]
+        agg.storage.save_agent_playbook_with_aggregate_event.return_value = generated
+        fp_old = PlaybookAggregator._compute_cluster_fingerprint(
+            [_raw(rid=1), _raw(rid=2), _raw(rid=3), _raw(rid=4)]
+        )
+        fp_generated_new = PlaybookAggregator._compute_cluster_fingerprint(
+            generated_cluster
+        )
+
+        with patch.object(PlaybookAggregator, "_create_state_manager") as mock_csm:
+            mgr = MagicMock()
+            mgr.get_cluster_fingerprints.return_value = {
+                fp_old: {
+                    "agent_playbook_id": 50,
+                    "user_playbook_ids": [1, 2, 3, 4],
+                },
+            }
+            mock_csm.return_value = mgr
+
+            req = PlaybookAggregatorRequest(agent_version="v1")
+            agg.run(req)
+
+        agg.storage.supersede_agent_playbooks_by_ids.assert_not_called()
+        call_kwargs = mgr.update_cluster_fingerprints.call_args
+        new_fps = call_kwargs.kwargs.get("fingerprints") or call_kwargs[1].get(
+            "fingerprints"
+        )
+        assert new_fps[fp_old]["agent_playbook_id"] == 50
+        assert new_fps[fp_generated_new]["agent_playbook_id"] == 200
+
+    @patch.object(PlaybookAggregator, "get_clusters")
+    @patch.object(PlaybookAggregator, "_generate_playbooks_with_source_clusters")
     def test_save_exception_restores_full_archive(self, mock_gen, mock_clust):
         """Exception during save_agent_playbooks in full-archive mode restores playbooks."""
         agg = self._make_runnable_aggregator()

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -948,10 +948,36 @@ class TestRun:
             req = PlaybookAggregatorRequest(agent_version="v1")
             agg.run(req)
 
-        agg.storage.archive_agent_playbooks_by_ids.assert_called_once_with([50])
+        agg.storage.archive_agent_playbooks_by_ids.assert_not_called()
         agg.storage.supersede_agent_playbooks_by_ids.assert_called_once_with(
             [50], request_id=ANY
         )
+        agg.storage.delete_agent_playbooks_by_ids.assert_not_called()
+
+    @patch.object(PlaybookAggregator, "get_clusters")
+    @patch.object(PlaybookAggregator, "_generate_playbooks_with_source_clusters")
+    def test_incremental_null_generation_preserves_existing_playbooks(
+        self, mock_gen, mock_clust
+    ):
+        """Incremental mode preserves existing playbooks when LLM produces no replacement."""
+        agg = self._make_runnable_aggregator()
+        raws_new = [_raw(rid=5), _raw(rid=6)]
+        agg.storage.get_user_playbooks.return_value = raws_new
+        mock_clust.return_value = {0: raws_new}
+        mock_gen.return_value = []
+
+        with patch.object(PlaybookAggregator, "_create_state_manager") as mock_csm:
+            mgr = MagicMock()
+            mgr.get_cluster_fingerprints.return_value = {
+                "old_fp": {"agent_playbook_id": 50, "user_playbook_ids": [1, 2]}
+            }
+            mock_csm.return_value = mgr
+
+            req = PlaybookAggregatorRequest(agent_version="v1")
+            agg.run(req)
+
+        agg.storage.archive_agent_playbooks_by_ids.assert_not_called()
+        agg.storage.supersede_agent_playbooks_by_ids.assert_not_called()
         agg.storage.delete_agent_playbooks_by_ids.assert_not_called()
 
     @patch.object(PlaybookAggregator, "get_clusters")
@@ -1666,9 +1692,7 @@ def test_aggregation_prompt_extra_instructions_ignore_non_string_values():
     class StripperWithInvalidPromptInstructions(_MappingAwareStripper):
         prompt_extra_instructions: Any = object()
 
-    agg = _make_aggregator(
-        user_detail_stripper=StripperWithInvalidPromptInstructions()
-    )
+    agg = _make_aggregator(user_detail_stripper=StripperWithInvalidPromptInstructions())
 
     assert agg.aggregation_prompt_extra_instructions == ""
 


### PR DESCRIPTION
## Summary
- Preserve existing current agent playbooks when incremental aggregation detects changed clusters but the LLM returns no replacement.
- Prevent null/duplicate aggregation output from leaving the visible agent-playbook set empty.
- Add regression coverage for the null-generation preservation path.

## Changes
- Deferred selective supersede until after replacement playbooks are generated.
- Log and preserve existing playbooks when changed cluster IDs exist but generation returns zero new playbooks.
- Updated aggregator unit expectations for deferred supersede behavior.

## Test Plan
- `uv run ruff format --check reflexio/server/services/playbook/components/aggregator.py tests/server/services/playbook/test_playbook_aggregator.py`
- `uv run ruff check reflexio/server/services/playbook/components/aggregator.py tests/server/services/playbook/test_playbook_aggregator.py`
- `uv run pytest tests/server/services/playbook/test_playbook_aggregator.py -o 'addopts='`
- Verified through enterprise backend pipeline E2E in linked enterprise PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental playbook aggregation so existing PENDING/APPROVED playbooks remain untouched when no replacements are generated.
  * Updated superseding behavior to apply selective supersedes only when new replacement playbooks are produced; otherwise, selective superseding is skipped.
  * Preserved prior fingerprint-to-playbook state safely to avoid carrying forward already-replaced items.
* **Tests**
  * Adjusted assertions to reflect the new incremental “no new playbooks” behavior and updated formatting for prompt-related test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->