### PR TITLE
Add learning provenance API

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -227,6 +227,7 @@ class UserProfile(BaseModel):
     )
     expanded_terms: str | None = None
     tags: list[str] | None = None  # None = not yet tagged; [] = tagged, no match
+    source_interaction_ids: list[int] = Field(default_factory=list)
     embedding: EmbeddingVector = []
     source_span: str | None = None
     notes: str | None = None

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -254,6 +254,30 @@ class GetAgentPlaybooksResponse(BaseModel):
     msg: str | None = None
 
 
+class GetLearningProvenanceRequest(BaseModel):
+    kind: Literal["profile", "user_playbook", "agent_playbook"]
+    id: str
+
+
+class SourceUserPlaybookProvenanceView(BaseModel):
+    user_playbook: UserPlaybookView
+    interactions: list[InteractionView] = Field(default_factory=list)
+    source_interaction_ids: list[int] = Field(default_factory=list)
+
+
+class LearningProvenanceViewResponse(BaseModel):
+    success: bool
+    target_kind: Literal["profile", "user_playbook", "agent_playbook"]
+    target_id: str
+    provenance_status: Literal["exact", "best_effort", "unavailable"] = "unavailable"
+    trigger_request_id: str | None = None
+    interactions: list[InteractionView] = Field(default_factory=list)
+    source_user_playbooks: list[SourceUserPlaybookProvenanceView] = Field(
+        default_factory=list
+    )
+    msg: str | None = None
+
+
 class SearchUserPlaybookRequest(BaseModel):
     """Request for searching user playbooks with semantic/text search and filtering.
 

--- a/reflexio/models/api_schema/ui/converters.py
+++ b/reflexio/models/api_schema/ui/converters.py
@@ -78,6 +78,7 @@ def to_profile_view(profile: UserProfile) -> ProfileView:
         status=profile.status,
         extractor_names=profile.extractor_names,
         source_span=profile.source_span,
+        source_interaction_ids=profile.source_interaction_ids,
         tags=profile.tags or [],
     )
 

--- a/reflexio/models/api_schema/ui/entities.py
+++ b/reflexio/models/api_schema/ui/entities.py
@@ -65,6 +65,7 @@ class ProfileView(BaseModel):
     status: Status | None = None
     extractor_names: list[str] | None = None
     source_span: str | None = None
+    source_interaction_ids: list[int] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
 
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -54,6 +54,7 @@ from reflexio.models.api_schema.retriever_schema import (
     GetEvaluationResultsViewResponse,
     GetInteractionsRequest,
     GetInteractionsViewResponse,
+    GetLearningProvenanceRequest,
     GetPlaybookApplicationStatsRequest,
     GetPlaybookApplicationStatsResponse,
     GetProfileStatisticsResponse,
@@ -63,6 +64,7 @@ from reflexio.models.api_schema.retriever_schema import (
     GetUserPlaybooksRequest,
     GetUserPlaybooksViewResponse,
     GetUserProfilesRequest,
+    LearningProvenanceViewResponse,
     ProfileChangeLogViewResponse,
     RequestDataView,
     RerankUserProfilesRequest,
@@ -76,6 +78,7 @@ from reflexio.models.api_schema.retriever_schema import (
     SearchUserProfileRequest,
     SessionView,
     SetConfigResponse,
+    SourceUserPlaybookProvenanceView,
     StorageStatsRequest,
     StorageStatsResponse,
     UnifiedSearchRequest,
@@ -155,6 +158,7 @@ from reflexio.models.api_schema.ui.converters import (
     to_user_playbook_view,
 )
 from reflexio.models.config_schema import (
+    DEFAULT_WINDOW_SIZE,
     SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
     Config,
 )
@@ -188,6 +192,10 @@ from reflexio.server.services.agent_success_evaluation.regen_jobs import (
 )
 from reflexio.server.services.agent_success_evaluation.runner import (
     run_group_evaluation,
+)
+from reflexio.server.services.extractor_interaction_utils import (
+    get_effective_source_filter,
+    get_extractor_window_params,
 )
 from reflexio.server.tracing import profile_step
 
@@ -1506,6 +1514,307 @@ def get_requests_endpoint(
         has_more=internal_response.has_more,
         msg=internal_response.msg,
     )
+
+
+def _learning_provenance_error(
+    payload: GetLearningProvenanceRequest,
+    msg: str,
+) -> LearningProvenanceViewResponse:
+    return LearningProvenanceViewResponse(
+        success=False,
+        target_kind=payload.kind,
+        target_id=payload.id,
+        provenance_status="unavailable",
+        msg=msg,
+    )
+
+
+def _parse_learning_target_int(
+    payload: GetLearningProvenanceRequest,
+) -> int | LearningProvenanceViewResponse:
+    try:
+        return int(payload.id)
+    except ValueError:
+        return _learning_provenance_error(
+            payload,
+            f"{payload.kind} id must be an integer",
+        )
+
+
+def _sort_interactions_by_time(interactions: list[Any]) -> list[Any]:
+    return sorted(
+        interactions,
+        key=lambda i: (
+            getattr(i, "created_at", 0) or 0,
+            getattr(i, "interaction_id", 0),
+        ),
+    )
+
+
+def _interaction_views(interactions: list[Any]) -> list[Any]:
+    return [to_interaction_view(i) for i in _sort_interactions_by_time(interactions)]
+
+
+def _effective_profile_provenance_window(
+    reflexio: Any, trigger_source: str | None
+) -> tuple[int, list[str] | None]:
+    config = reflexio.request_context.configurator.get_config()
+    profile_config = getattr(config, "profile_extractor_config", None)
+    if profile_config is None:
+        return getattr(config, "window_size", DEFAULT_WINDOW_SIZE), None
+
+    window_size, _ = get_extractor_window_params(
+        profile_config,
+        getattr(config, "window_size", None),
+        getattr(config, "stride_size", None),
+    )
+    should_skip, source_filter = get_effective_source_filter(
+        profile_config,
+        trigger_source,
+    )
+    if should_skip:
+        return window_size, None
+    return window_size, source_filter
+
+
+def _get_profile_learning_provenance(
+    payload: GetLearningProvenanceRequest,
+    reflexio: Any,
+) -> LearningProvenanceViewResponse:
+    storage = reflexio.request_context.storage
+    profile = storage.get_profile_by_id(payload.id)
+    if profile is None:
+        return _learning_provenance_error(payload, "Profile not found")
+
+    if profile.source_interaction_ids:
+        interactions = storage.get_interactions_by_ids(profile.source_interaction_ids)
+        return LearningProvenanceViewResponse(
+            success=True,
+            target_kind=payload.kind,
+            target_id=payload.id,
+            provenance_status="exact",
+            trigger_request_id=profile.generated_from_request_id,
+            interactions=_interaction_views(interactions),
+        )
+
+    if not profile.generated_from_request_id:
+        return _learning_provenance_error(
+            payload,
+            "Profile has no generation request for provenance reconstruction",
+        )
+
+    trigger_request = storage.get_request(profile.generated_from_request_id)
+    if trigger_request is None:
+        return _learning_provenance_error(
+            payload,
+            "Profile generation request was not found",
+        )
+
+    trigger_interactions = storage.get_interactions_by_request_ids(
+        [profile.generated_from_request_id]
+    )
+    anchor_time = (
+        max(i.created_at for i in trigger_interactions)
+        if trigger_interactions
+        else trigger_request.created_at
+    )
+    window_size, source_filter = _effective_profile_provenance_window(
+        reflexio,
+        trigger_request.source,
+    )
+    _, interactions = storage.get_last_k_interactions_grouped(
+        user_id=profile.user_id,
+        k=window_size,
+        sources=source_filter,
+        end_time=anchor_time,
+    )
+    return LearningProvenanceViewResponse(
+        success=True,
+        target_kind=payload.kind,
+        target_id=payload.id,
+        provenance_status="best_effort" if interactions else "unavailable",
+        trigger_request_id=profile.generated_from_request_id,
+        interactions=_interaction_views(interactions),
+        msg=None if interactions else "No interactions found for reconstructed window",
+    )
+
+
+def _get_user_playbook_learning_provenance(
+    payload: GetLearningProvenanceRequest,
+    reflexio: Any,
+) -> LearningProvenanceViewResponse:
+    parsed_id = _parse_learning_target_int(payload)
+    if isinstance(parsed_id, LearningProvenanceViewResponse):
+        return parsed_id
+
+    storage = reflexio.request_context.storage
+    playbook = storage.get_user_playbook_by_id(parsed_id)
+    if playbook is None:
+        return _learning_provenance_error(payload, "User playbook not found")
+
+    status = "exact"
+    if playbook.source_interaction_ids:
+        interactions = storage.get_interactions_by_ids(playbook.source_interaction_ids)
+    elif playbook.request_id:
+        status = "best_effort"
+        interactions = storage.get_interactions_by_request_ids([playbook.request_id])
+    else:
+        status = "unavailable"
+        interactions = []
+
+    return LearningProvenanceViewResponse(
+        success=True,
+        target_kind=payload.kind,
+        target_id=payload.id,
+        provenance_status=status if interactions else "unavailable",
+        trigger_request_id=playbook.request_id,
+        interactions=_interaction_views(interactions),
+        msg=None if interactions else "No interactions found for this user playbook",
+    )
+
+
+def _get_agent_playbook_learning_provenance(
+    payload: GetLearningProvenanceRequest,
+    reflexio: Any,
+) -> LearningProvenanceViewResponse:
+    parsed_id = _parse_learning_target_int(payload)
+    if isinstance(parsed_id, LearningProvenanceViewResponse):
+        return parsed_id
+
+    storage = reflexio.request_context.storage
+    agent_playbook = storage.get_agent_playbook_by_id(parsed_id)
+    if agent_playbook is None:
+        return _learning_provenance_error(payload, "Agent playbook not found")
+
+    windows = storage.get_source_windows_for_agent_playbook(parsed_id)
+    if not windows:
+        return LearningProvenanceViewResponse(
+            success=True,
+            target_kind=payload.kind,
+            target_id=payload.id,
+            provenance_status="unavailable",
+            msg="No source user playbooks are recorded for this agent playbook",
+        )
+
+    user_playbook_ids = [window.user_playbook_id for window in windows]
+    user_playbooks = storage.get_user_playbooks_by_ids_any_user(
+        user_playbook_ids,
+        status_filter=None,
+    )
+    user_playbooks_by_id = {
+        playbook.user_playbook_id: playbook for playbook in user_playbooks
+    }
+
+    interaction_ids_to_fetch: set[int] = set()
+    request_ids_to_fetch: set[str] = set()
+    group_sources: dict[int, tuple[list[int], str | None, bool]] = {}
+    for window in windows:
+        source_user_playbook = user_playbooks_by_id.get(window.user_playbook_id)
+        if source_user_playbook is None:
+            continue
+
+        source_ids = list(window.source_interaction_ids)
+        request_id: str | None = None
+        uses_fallback = False
+        if not source_ids and source_user_playbook.source_interaction_ids:
+            source_ids = list(source_user_playbook.source_interaction_ids)
+        elif not source_ids and source_user_playbook.request_id:
+            request_id = source_user_playbook.request_id
+            uses_fallback = True
+        elif not source_ids:
+            uses_fallback = True
+
+        interaction_ids_to_fetch.update(source_ids)
+        if request_id:
+            request_ids_to_fetch.add(request_id)
+        group_sources[window.user_playbook_id] = (source_ids, request_id, uses_fallback)
+
+    interactions_by_id = (
+        {
+            interaction.interaction_id: interaction
+            for interaction in storage.get_interactions_by_ids(
+                sorted(interaction_ids_to_fetch)
+            )
+        }
+        if interaction_ids_to_fetch
+        else {}
+    )
+    request_interactions: dict[str, list[Any]] = {}
+    if request_ids_to_fetch:
+        for interaction in storage.get_interactions_by_request_ids(
+            sorted(request_ids_to_fetch)
+        ):
+            request_interactions.setdefault(interaction.request_id, []).append(
+                interaction
+            )
+
+    groups: list[SourceUserPlaybookProvenanceView] = []
+    used_fallback = False
+    found_interactions = False
+    for window in windows:
+        source_user_playbook = user_playbooks_by_id.get(window.user_playbook_id)
+        if source_user_playbook is None:
+            used_fallback = True
+            continue
+
+        source_ids, request_id, uses_fallback = group_sources.get(
+            window.user_playbook_id,
+            ([], None, True),
+        )
+        used_fallback = used_fallback or uses_fallback
+        interactions = (
+            [interactions_by_id[i] for i in source_ids if i in interactions_by_id]
+            if source_ids
+            else request_interactions.get(request_id or "", [])
+        )
+
+        found_interactions = found_interactions or bool(interactions)
+        groups.append(
+            SourceUserPlaybookProvenanceView(
+                user_playbook=to_user_playbook_view(source_user_playbook),
+                interactions=_interaction_views(interactions),
+                source_interaction_ids=source_ids,
+            )
+        )
+
+    if not groups:
+        return _learning_provenance_error(
+            payload,
+            "Recorded source user playbooks were not found",
+        )
+
+    return LearningProvenanceViewResponse(
+        success=True,
+        target_kind=payload.kind,
+        target_id=payload.id,
+        provenance_status=(
+            "exact"
+            if found_interactions and not used_fallback
+            else "best_effort"
+            if found_interactions
+            else "unavailable"
+        ),
+        source_user_playbooks=groups,
+        msg=None if found_interactions else "No source interactions were found",
+    )
+
+
+@core_router.post(
+    "/api/get_learning_provenance",
+    response_model=LearningProvenanceViewResponse,
+    response_model_exclude_none=True,
+)
+def get_learning_provenance(
+    payload: GetLearningProvenanceRequest,
+    org_id: str = Depends(default_get_org_id),
+) -> LearningProvenanceViewResponse:
+    """Return read-only learning provenance for a generated learning row."""
+    reflexio = get_reflexio(org_id=org_id)
+    if payload.kind == "profile":
+        return _get_profile_learning_provenance(payload, reflexio)
+    if payload.kind == "user_playbook":
+        return _get_user_playbook_learning_provenance(payload, reflexio)
+    return _get_agent_playbook_learning_provenance(payload, reflexio)
 
 
 @core_router.post(

--- a/reflexio/server/services/profile/components/extractor.py
+++ b/reflexio/server/services/profile/components/extractor.py
@@ -245,10 +245,17 @@ class ProfileExtractor:
             ) from e
 
         logger.info("Generated raw profiles: %s", raw_profiles)
+        source_interaction_ids = [
+            interaction.interaction_id
+            for request_model in request_interaction_data_models
+            for interaction in request_model.interactions
+            if interaction.interaction_id
+        ]
         user_profiles = self._convert_raw_to_user_profiles(
             raw_profiles=raw_profiles or [],
             user_id=self.service_config.user_id,
             request_id=self.service_config.request_id,
+            source_interaction_ids=source_interaction_ids,
         )
         if raw_profiles:
             # Update operation state (bookmark) only when output was produced.
@@ -272,6 +279,7 @@ class ProfileExtractor:
         raw_profiles: list[dict],
         user_id: str,
         request_id: str,
+        source_interaction_ids: list[int],
     ) -> list[UserProfile]:
         """
         Convert raw profile dicts from LLM to UserProfile objects.
@@ -280,6 +288,7 @@ class ProfileExtractor:
             raw_profiles: List of profile dicts with content, time_to_live, and optional metadata
             user_id: User ID
             request_id: Request ID
+            source_interaction_ids: Stored interaction ids used as the extraction window
 
         Returns:
             List of UserProfile objects
@@ -313,6 +322,7 @@ class ProfileExtractor:
                 expiration_timestamp=calculate_expiration_timestamp(now_ts, ttl),
                 custom_features=custom_features or None,
                 extractor_names=None,
+                source_interaction_ids=source_interaction_ids,
             )
 
             new_profiles.append(added_profile)

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -398,6 +398,7 @@ def _row_to_profile(row: sqlite3.Row) -> UserProfile:
         notes=d.get("notes"),
         reader_angle=d.get("reader_angle"),
         tags=_json_loads(d.get("tags")),
+        source_interaction_ids=_json_loads(d.get("source_interaction_ids")) or [],
         merged_into=d.get("merged_into"),
         superseded_by=d.get("superseded_by"),
     )
@@ -642,6 +643,8 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_pending_tool_calls_schema()
         self._migrate_expanded_terms()
         self._migrate_tags()
+        self._migrate_profile_source_interaction_ids()
+        self._migrate_interaction_window_indexes()
         self._migrate_agentic_signals()
         self._migrate_agent_playbook_source_windows()
         self._migrate_request_evaluation_only()
@@ -1156,6 +1159,27 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             if "tags" not in cols:
                 self.conn.execute(f"ALTER TABLE {table} ADD COLUMN tags TEXT")
                 logger.info("Added tags column to %s", table)
+        self.conn.commit()
+
+    def _migrate_profile_source_interaction_ids(self) -> None:
+        """Add profile source interaction ids for provenance on existing DBs."""
+        cols = {
+            row["name"]
+            for row in self.conn.execute("PRAGMA table_info(profiles)").fetchall()
+        }
+        if "source_interaction_ids" not in cols:
+            self.conn.execute(
+                "ALTER TABLE profiles ADD COLUMN source_interaction_ids TEXT"
+            )
+            logger.info("Added source_interaction_ids column to profiles")
+        self.conn.commit()
+
+    def _migrate_interaction_window_indexes(self) -> None:
+        """Add composite indexes used by sliding-window provenance lookups."""
+        self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_interactions_user_created_at_desc "
+            "ON interactions(user_id, created_at DESC, interaction_id DESC)"
+        )
         self.conn.commit()
 
     def _migrate_agent_runs_schema(self) -> None:
@@ -1971,6 +1995,7 @@ CREATE TABLE IF NOT EXISTS profiles (
     extractor_names TEXT,
     expanded_terms TEXT,
     tags TEXT,
+    source_interaction_ids TEXT,
     source_span TEXT,
     notes TEXT,
     reader_angle TEXT,
@@ -2002,6 +2027,8 @@ CREATE TABLE IF NOT EXISTS interactions (
 CREATE INDEX IF NOT EXISTS idx_interactions_user_id ON interactions(user_id);
 CREATE INDEX IF NOT EXISTS idx_interactions_request_id ON interactions(request_id);
 CREATE INDEX IF NOT EXISTS idx_interactions_created_at ON interactions(created_at);
+CREATE INDEX IF NOT EXISTS idx_interactions_user_created_at_desc
+    ON interactions(user_id, created_at DESC, interaction_id DESC);
 
 CREATE TABLE IF NOT EXISTS requests (
     request_id TEXT PRIMARY KEY,

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -156,10 +156,10 @@ class ProfileMixin:
                    (profile_id, user_id, content, last_modified_timestamp,
                     generated_from_request_id, profile_time_to_live,
                     expiration_timestamp, custom_features, embedding, source,
-                    status, extractor_names, expanded_terms,
-                    source_span, notes, reader_angle, tags, created_at,
+                   status, extractor_names, expanded_terms,
+                    source_span, notes, reader_angle, tags, source_interaction_ids, created_at,
                     merged_into, superseded_by)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                 (
                     profile.profile_id,
                     profile.user_id,
@@ -178,6 +178,7 @@ class ProfileMixin:
                     profile.notes,
                     profile.reader_angle,
                     _json_dumps(profile.tags),
+                    _json_dumps(profile.source_interaction_ids),
                     _iso_now(),
                     profile.merged_into,
                     profile.superseded_by,
@@ -227,7 +228,7 @@ class ProfileMixin:
                    generated_from_request_id=?, profile_time_to_live=?,
                    expiration_timestamp=?, custom_features=?, embedding=?,
                    source=?, status=?, extractor_names=?, expanded_terms=?,
-                   source_span=?, notes=?, reader_angle=?, tags=?
+                   source_span=?, notes=?, reader_angle=?, tags=?, source_interaction_ids=?
                    WHERE profile_id=?""",
                 (
                     new_profile.content,
@@ -245,6 +246,7 @@ class ProfileMixin:
                     new_profile.notes,
                     new_profile.reader_angle,
                     _json_dumps(new_profile.tags),
+                    _json_dumps(new_profile.source_interaction_ids),
                     profile_id,
                 ),
             )

--- a/tests/server/test_learning_provenance_api.py
+++ b/tests/server/test_learning_provenance_api.py
@@ -1,0 +1,293 @@
+from types import SimpleNamespace
+
+from reflexio.models.api_schema.domain import (
+    AgentPlaybook,
+    AgentPlaybookSourceWindow,
+    Interaction,
+    Request,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.retriever_schema import GetLearningProvenanceRequest
+from reflexio.server.api import (
+    _get_agent_playbook_learning_provenance,
+    _get_profile_learning_provenance,
+    _get_user_playbook_learning_provenance,
+)
+
+
+def _interaction(
+    interaction_id: int,
+    request_id: str,
+    *,
+    user_id: str = "user-1",
+    created_at: int,
+) -> Interaction:
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id=user_id,
+        request_id=request_id,
+        created_at=created_at,
+        content=f"interaction {interaction_id}",
+    )
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self.profiles: dict[str, UserProfile] = {}
+        self.requests: dict[str, Request] = {}
+        self.interactions: list[Interaction] = []
+        self.user_playbooks: dict[int, UserPlaybook] = {}
+        self.agent_playbooks: dict[int, AgentPlaybook] = {}
+        self.agent_source_windows: dict[int, list[AgentPlaybookSourceWindow]] = {}
+        self.interactions_by_ids_calls = 0
+        self.interactions_by_request_ids_calls = 0
+
+    def get_profile_by_id(
+        self, profile_id: str, *, include_tombstones: bool = False
+    ) -> UserProfile | None:
+        del include_tombstones
+        return self.profiles.get(profile_id)
+
+    def get_request(self, request_id: str) -> Request | None:
+        return self.requests.get(request_id)
+
+    def get_interactions_by_request_ids(
+        self, request_ids: list[str]
+    ) -> list[Interaction]:
+        self.interactions_by_request_ids_calls += 1
+        request_id_set = set(request_ids)
+        return sorted(
+            [i for i in self.interactions if i.request_id in request_id_set],
+            key=lambda i: i.created_at,
+        )
+
+    def get_interactions_by_ids(self, interaction_ids: list[int]) -> list[Interaction]:
+        self.interactions_by_ids_calls += 1
+        id_set = set(interaction_ids)
+        return sorted(
+            [i for i in self.interactions if i.interaction_id in id_set],
+            key=lambda i: i.created_at,
+        )
+
+    def get_last_k_interactions_grouped(
+        self,
+        user_id: str | None,
+        k: int,
+        sources: list[str] | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+        agent_version: str | None = None,
+    ) -> tuple[list[object], list[Interaction]]:
+        del sources, agent_version
+        filtered = [
+            i for i in self.interactions if user_id is None or i.user_id == user_id
+        ]
+        if start_time is not None:
+            filtered = [i for i in filtered if i.created_at >= start_time]
+        if end_time is not None:
+            filtered = [i for i in filtered if i.created_at <= end_time]
+        return [], sorted(filtered, key=lambda i: i.created_at, reverse=True)[:k]
+
+    def get_user_playbook_by_id(
+        self, user_playbook_id: int, *, include_tombstones: bool = False
+    ) -> UserPlaybook | None:
+        del include_tombstones
+        return self.user_playbooks.get(user_playbook_id)
+
+    def get_agent_playbook_by_id(
+        self, agent_playbook_id: int, *, include_tombstones: bool = False
+    ) -> AgentPlaybook | None:
+        del include_tombstones
+        return self.agent_playbooks.get(agent_playbook_id)
+
+    def get_source_windows_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[AgentPlaybookSourceWindow]:
+        return self.agent_source_windows.get(agent_playbook_id, [])
+
+    def get_user_playbooks_by_ids_any_user(
+        self,
+        user_playbook_ids: list[int],
+        status_filter: list[object] | None = None,
+    ) -> list[UserPlaybook]:
+        del status_filter
+        return [
+            self.user_playbooks[user_playbook_id]
+            for user_playbook_id in user_playbook_ids
+            if user_playbook_id in self.user_playbooks
+        ]
+
+
+def _reflexio(storage: FakeStorage) -> SimpleNamespace:
+    config = SimpleNamespace(
+        window_size=2,
+        stride_size=1,
+        profile_extractor_config=SimpleNamespace(
+            window_size_override=None,
+            stride_size_override=None,
+            request_sources_enabled=None,
+        ),
+    )
+    return SimpleNamespace(
+        request_context=SimpleNamespace(
+            storage=storage,
+            configurator=SimpleNamespace(get_config=lambda: config),
+        )
+    )
+
+
+def test_profile_provenance_returns_exact_interactions_when_source_ids_exist() -> None:
+    storage = FakeStorage()
+    storage.interactions = [
+        _interaction(2, "req-2", created_at=20),
+        _interaction(1, "req-1", created_at=10),
+    ]
+    storage.profiles["profile-1"] = UserProfile(
+        profile_id="profile-1",
+        user_id="user-1",
+        content="profile",
+        last_modified_timestamp=30,
+        generated_from_request_id="req-2",
+        source_interaction_ids=[2, 1],
+    )
+
+    response = _get_profile_learning_provenance(
+        GetLearningProvenanceRequest(kind="profile", id="profile-1"),
+        _reflexio(storage),
+    )
+
+    assert response.success is True
+    assert response.provenance_status == "exact"
+    assert [i.interaction_id for i in response.interactions] == [1, 2]
+
+
+def test_profile_provenance_reconstructs_best_effort_window_without_source_ids() -> (
+    None
+):
+    storage = FakeStorage()
+    storage.requests["req-3"] = Request(
+        request_id="req-3",
+        user_id="user-1",
+        created_at=30,
+        source="web",
+        session_id="session-1",
+    )
+    storage.interactions = [
+        _interaction(1, "req-1", created_at=10),
+        _interaction(2, "req-2", created_at=20),
+        _interaction(3, "req-3", created_at=30),
+    ]
+    storage.profiles["profile-1"] = UserProfile(
+        profile_id="profile-1",
+        user_id="user-1",
+        content="profile",
+        last_modified_timestamp=30,
+        generated_from_request_id="req-3",
+    )
+
+    response = _get_profile_learning_provenance(
+        GetLearningProvenanceRequest(kind="profile", id="profile-1"),
+        _reflexio(storage),
+    )
+
+    assert response.success is True
+    assert response.provenance_status == "best_effort"
+    assert [i.interaction_id for i in response.interactions] == [2, 3]
+
+
+def test_user_playbook_provenance_uses_source_ids_and_falls_back_to_request() -> None:
+    storage = FakeStorage()
+    storage.interactions = [
+        _interaction(1, "req-1", created_at=10),
+        _interaction(2, "req-2", created_at=20),
+    ]
+    storage.user_playbooks[7] = UserPlaybook(
+        user_playbook_id=7,
+        user_id="user-1",
+        agent_version="v1",
+        request_id="req-2",
+        content="playbook",
+        source_interaction_ids=[],
+    )
+
+    response = _get_user_playbook_learning_provenance(
+        GetLearningProvenanceRequest(kind="user_playbook", id="7"),
+        _reflexio(storage),
+    )
+
+    assert response.success is True
+    assert response.provenance_status == "best_effort"
+    assert [i.interaction_id for i in response.interactions] == [2]
+
+    storage.user_playbooks[7].source_interaction_ids = [1]
+    response = _get_user_playbook_learning_provenance(
+        GetLearningProvenanceRequest(kind="user_playbook", id="7"),
+        _reflexio(storage),
+    )
+
+    assert response.provenance_status == "exact"
+    assert [i.interaction_id for i in response.interactions] == [1]
+
+
+def test_agent_playbook_provenance_groups_by_source_user_playbook() -> None:
+    storage = FakeStorage()
+    storage.interactions = [
+        _interaction(1, "req-1", created_at=10),
+        _interaction(2, "req-1", created_at=20),
+        _interaction(3, "req-2", created_at=30),
+    ]
+    storage.user_playbooks[11] = UserPlaybook(
+        user_playbook_id=11,
+        user_id="user-1",
+        agent_version="v1",
+        request_id="req-1",
+        content="source 1",
+    )
+    storage.user_playbooks[12] = UserPlaybook(
+        user_playbook_id=12,
+        user_id="user-1",
+        agent_version="v1",
+        request_id="req-2",
+        content="source 2",
+    )
+    storage.agent_playbooks[3] = AgentPlaybook(
+        agent_playbook_id=3,
+        agent_version="v1",
+        content="agent playbook",
+    )
+    storage.agent_source_windows[3] = [
+        AgentPlaybookSourceWindow(user_playbook_id=11, source_interaction_ids=[2, 1]),
+        AgentPlaybookSourceWindow(user_playbook_id=12, source_interaction_ids=[3]),
+    ]
+
+    response = _get_agent_playbook_learning_provenance(
+        GetLearningProvenanceRequest(kind="agent_playbook", id="3"),
+        _reflexio(storage),
+    )
+
+    assert response.success is True
+    assert response.provenance_status == "exact"
+    assert [
+        g.user_playbook.user_playbook_id for g in response.source_user_playbooks
+    ] == [
+        11,
+        12,
+    ]
+    assert [
+        [i.interaction_id for i in group.interactions]
+        for group in response.source_user_playbooks
+    ] == [[1, 2], [3]]
+    assert storage.interactions_by_ids_calls == 1
+    assert storage.interactions_by_request_ids_calls == 0
+
+
+def test_missing_learning_target_returns_structured_failure() -> None:
+    response = _get_profile_learning_provenance(
+        GetLearningProvenanceRequest(kind="profile", id="missing"),
+        _reflexio(FakeStorage()),
+    )
+
+    assert response.success is False
+    assert response.provenance_status == "unavailable"
+    assert response.msg == "Profile not found"


### PR DESCRIPTION
## Summary
Adds a read-only learning provenance API so product surfaces can show which interactions contributed to generated profiles and playbooks.

## Changes
- Adds provenance response/request schemas for profiles, user playbooks, and agent playbooks.
- Adds `POST /api/get_learning_provenance` with exact, best-effort, and unavailable provenance statuses.
- Persists `source_interaction_ids` on newly extracted profiles for exact future attribution.
- Reconstructs older profile provenance from the trigger request and extractor window when exact ids are unavailable.
- Adds SQLite migration-on-open handling and focused backend tests.

## Test Plan
- `uv run ruff check ...`
- `uv run ruff format ...`
- `uv run pyright ...`
- `PYTEST_ADDOPTS=--no-cov uv run pytest tests/server/test_learning_provenance_api.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added learning provenance support, including a new API response for checking how generated learning rows were sourced.
  * Profile views now include source interaction IDs, making provenance visible to end-users.
  * Added support for retrieving provenance details for profiles, user playbooks, and agent playbooks.

* **Bug Fixes**
  * Improved fallback handling when source interaction data is missing, returning clearer status and results.
  * Kept profile provenance data in sync across storage and UI views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->