### PR TITLE
feat: move OSS launcher to 806x ports and scope the no-auth org

### DIFF
--- a/.claude/commands/check-and-test/SKILL.md
+++ b/.claude/commands/check-and-test/SKILL.md
@@ -84,7 +84,7 @@ pytest reflexio/tests/ --ignore=reflexio/tests/e2e_tests/ -n 0 -v
 
 ### Step 2: Run E2E Tests
 
-E2E tests require the server to be running at http://localhost:8081. Run them separately:
+E2E tests require the server to be running at http://localhost:8061. Run them separately:
 ```bash
 pytest reflexio/tests/e2e_tests/ -n 0 -v
 ```
@@ -194,7 +194,7 @@ Location: Check `reflexio/tests/server/test_utils.py` for the decorator definiti
 ### E2E Tests
 
 End-to-end tests in `reflexio/tests/e2e_tests/`:
-- Require server running at http://localhost:8081
+- Require server running at http://localhost:8061
 - Use real database and external services
 - Test complete user workflows
 
@@ -216,7 +216,7 @@ Fast, isolated tests that:
 - E2E tests require running database (SQLite by default)
 
 ### Server Not Running
-- E2E tests need server at http://localhost:8081
+- E2E tests need server at http://localhost:8061
 - Start with appropriate command before running e2e tests
 
 ## Summary

--- a/.claude/commands/run-services/SKILL.md
+++ b/.claude/commands/run-services/SKILL.md
@@ -23,7 +23,7 @@ Ports are allocated in groups of 3 with a +10 offset between groups:
 
 | Group | Frontend | Backend | Docs |
 |-------|----------|---------|------|
-| Default | 8080 | 8081 | 8082 |
+| Default | 8080 | 8061 | 8062 |
 | +10 | 8090 | 8091 | 8092 |
 | +20 | 8100 | 8101 | 8102 |
 | +30 | 8110 | 8111 | 8112 |
@@ -32,8 +32,8 @@ Ports are allocated in groups of 3 with a +10 offset between groups:
 | Service | Env Var | Base Port |
 |---------|---------|-----------|
 | Frontend (Next.js) | `FRONTEND_PORT` | 8080 |
-| Backend (FastAPI) | `BACKEND_PORT` | 8081 |
-| Docs (Fumadocs) | `DOCS_PORT` | 8082 |
+| Backend (FastAPI) | `BACKEND_PORT` | 8061 |
+| Docs (Fumadocs) | `DOCS_PORT` | 8062 |
 Step 0 (Smart Port Selection) determines which group to use automatically, unless ports are already set via environment variables.
 
 ## Execution Steps
@@ -72,14 +72,14 @@ Then classify:
 **0.4** Export the chosen ports:
 ```bash
 export FRONTEND_PORT=<8080+N>
-export BACKEND_PORT=<8081+N>
-export DOCS_PORT=<8082+N>
+export BACKEND_PORT=<8061+N>
+export DOCS_PORT=<8062+N>
 export API_BACKEND_URL="http://localhost:${BACKEND_PORT}"
 ```
 
 Report which group was selected and why, e.g.:
-- "Using default ports (8080/8081/8082) — all free"
-- "Using default ports (8080/8081/8082) — restarting own services"
+- "Using default ports (8080/8061/8062) — all free"
+- "Using default ports (8080/8061/8062) — restarting own services"
 - "Using offset +10 ports (8090/8091/8092) — default ports occupied by another worktree"
 
 Also record whether any ports in the chosen group were "own" (needs stop) or all "free" (skip stop).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ See [developer.md](developer.md) for full development guidelines, project struct
 
 ## Quick Reference
 
-- Start services: `./run_services.sh` — runs FastAPI backend (port 8081) and Next.js docs (port 3000)
+- Start services: `./run_services.sh` — runs FastAPI backend (port 8061) and Next.js docs (port 8062)
 - Run commands in uv env: `uv run <cmd>` or activate `.venv`
 - Use `curl` for API testing (faster); use Chrome for frontend tasks
 - Never change env variable values in `.env` file — use shell exports for overrides

--- a/AI_AGENT_INTEGRATION.md
+++ b/AI_AGENT_INTEGRATION.md
@@ -146,11 +146,11 @@ For local development, start the backend:
 reflexio services start
 ```
 
-The local API defaults to `http://localhost:8081/`. If you need a different
+The local API defaults to `http://localhost:8061/`. If you need a different
 backend, read these values from environment or `~/.reflexio/.env`:
 
 ```shell
-REFLEXIO_URL="http://localhost:8081/"
+REFLEXIO_URL="http://localhost:8061/"
 REFLEXIO_API_KEY=""
 ```
 
@@ -203,7 +203,7 @@ end to end using the bundled `reflexio` CLI. This is the quickest onboarding
 smoke test:
 
 ```shell
-reflexio services start                        # backend on :8081 (+ docs), SQLite storage
+reflexio services start                        # backend on :8061 (+ docs), SQLite storage
 
 reflexio publish --user-id alice --wait --data '{
   "interactions": [
@@ -292,7 +292,7 @@ from reflexio import ReflexioClient
 
 def reflexio_client() -> ReflexioClient:
     return ReflexioClient(
-        url_endpoint=os.environ.get("REFLEXIO_URL", "http://localhost:8081/"),
+        url_endpoint=os.environ.get("REFLEXIO_URL", "http://localhost:8061/"),
         api_key=os.environ.get("REFLEXIO_API_KEY", ""),
         timeout=5,
     )

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ See [developer.md](developer.md) for full development guidelines, project struct
 
 ## Quick Reference
 
-- Start services: `./run_services.sh` — runs FastAPI backend (port 8081) and Next.js docs (port 3000)
+- Start services: `./run_services.sh` — runs FastAPI backend (port 8061) and Next.js docs (port 8062)
 - Run commands in uv env: `uv run <cmd>` or activate `.venv`
 - Use `curl` for API testing (faster); use Chrome for frontend tasks
 - Never change env variable values in `.env` file — use shell exports for overrides

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Publish conversations from your agent, and Reflexio closes the self-improvement 
 pip install reflexio-ai
 
 # start/stop services. data saved under ~/.reflexio
-reflexio services start           # API (8081), Docs (8082), SQLite storage
+reflexio services start           # API (8061), Docs (8062), SQLite storage
 reflexio services stop            # Stop all services
 ```
 
@@ -137,13 +137,13 @@ uv sync                                    # Python (includes workspace packages
 npm --prefix docs install                  # API docs
 
 # start/stop services. data saved under ~/.reflexio
-uv run reflexio services start             # API (8081), Docs (8082), SQLite storage
+uv run reflexio services start             # API (8061), Docs (8062), SQLite storage
 uv run reflexio services stop              # Stop all services
 ```
 
 > Alternative: `python -m reflexio.cli services start` or `./run_services.sh`
 
-Once running, open **[http://localhost:8082](http://localhost:8082)** to interactively browse and try out the API.
+Once running, open **[http://localhost:8062](http://localhost:8062)** to interactively browse and try out the API.
 <p align="center">
   <img src="docs/images/doc_website.png" width="800px" alt="Reflexio Doc Website">
 </p>
@@ -174,7 +174,7 @@ One conversation, two artifacts: a user profile (`production region is us-west-2
 import reflexio
 
 client = reflexio.ReflexioClient(
-    url_endpoint="http://localhost:8081/"
+    url_endpoint="http://localhost:8061/"
 )
 
 # Publish a multi-turn conversation where the user corrects the agent —
@@ -256,7 +256,7 @@ pip install reflexio-client
 import reflexio
 
 client = reflexio.ReflexioClient(
-    url_endpoint="http://localhost:8081/"
+    url_endpoint="http://localhost:8061/"
 )
 
 # Publish interactions

--- a/benchmark/gdpval/config.py
+++ b/benchmark/gdpval/config.py
@@ -47,11 +47,11 @@ DEFAULT_PHASES = ["p1", "p2", "p3"]
 DEFAULT_TASK_LIST = OPENSPACE_ROOT / "gdpval_bench" / "tasks_50.json"
 
 # Reflexio backend. Honors `REFLEXIO_URL` first, then `BACKEND_PORT` (worktree
-# deployments export this to avoid colliding with the main checkout's 8081),
-# then falls back to the standard 8081.
+# deployments export this to avoid colliding with the main checkout's 8061),
+# then falls back to the standard 8061.
 DEFAULT_REFLEXIO_URL = os.environ.get(
     "REFLEXIO_URL",
-    f"http://localhost:{os.environ.get('BACKEND_PORT', '8081')}",
+    f"http://localhost:{os.environ.get('BACKEND_PORT', '8061')}",
 )
 DEFAULT_TOP_K = 10
 DEFAULT_SEARCH_THRESHOLD = 0.3
@@ -59,10 +59,23 @@ DEFAULT_SEARCH_THRESHOLD = 0.3
 # Evaluation (ClawWork LLMEvaluator).
 EVAL_MIN_THRESHOLD = 0.6  # 0.6 payment cliff, same as gdpval_bench
 EVAL_ARTIFACT_EXTENSIONS = {
-    ".pdf", ".docx", ".xlsx", ".pptx",
-    ".txt", ".csv", ".json", ".md",
-    ".py", ".js", ".html", ".css",
-    ".png", ".jpg", ".jpeg", ".gif", ".webp",
+    ".pdf",
+    ".docx",
+    ".xlsx",
+    ".pptx",
+    ".txt",
+    ".csv",
+    ".json",
+    ".md",
+    ".py",
+    ".js",
+    ".html",
+    ".css",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
 }
 
 # Output layout.

--- a/client_dist/README.md
+++ b/client_dist/README.md
@@ -44,7 +44,7 @@ client = ReflexioClient(api_key="your-api-key")
 # Or connect to a self-hosted instance
 client = ReflexioClient(
     api_key="your-api-key",
-    url_endpoint="http://localhost:8081",
+    url_endpoint="http://localhost:8061",
 )
 ```
 

--- a/developer.md
+++ b/developer.md
@@ -32,8 +32,8 @@ Two services, started together via `./run_services.sh`:
 
 | Service | Framework | Default Port | Env Var |
 |---------|-----------|-------------|---------|
-| Backend | FastAPI (uvicorn) | 8081 | `BACKEND_PORT` |
-| Docs | Next.js 16 | 8082 | `DOCS_PORT` |
+| Backend | FastAPI (uvicorn) | 8061 | `BACKEND_PORT` |
+| Docs | Next.js 16 | 8062 | `DOCS_PORT` |
 
 `API_BACKEND_URL` is derived automatically as `http://localhost:${BACKEND_PORT}`.
 
@@ -213,7 +213,7 @@ When working in a git worktree, services must run on different ports to avoid co
 
 | Problem | Solution |
 |---------|----------|
-| Port already in use | `./stop_services.sh` or `lsof -i :8081` to find the process |
+| Port already in use | `./stop_services.sh` or `lsof -i :8061` to find the process |
 | Services won't start | Check `.env` has at least one LLM API key set |
 | `uv sync` fails | Ensure Python >= 3.14, try `uv self update` |
 | Docs frontend won't start | Run `npm --prefix docs install` first |

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ npm install
 npm run dev
 ```
 
-The site runs on **port 3000** by default. When started via `run_services.sh` from the project root, it runs on port 8082 instead.
+The site runs on **port 3000** by default. When started via `run_services.sh` from the project root, it runs on port 8062 instead.
 
 ## Build
 

--- a/docs/components/layout/top-bar.tsx
+++ b/docs/components/layout/top-bar.tsx
@@ -35,7 +35,7 @@ export function TopBar() {
         <Input
           value={apiEndpoint}
           onChange={(e) => setApiEndpoint(e.target.value)}
-          placeholder="http://localhost:8081"
+          placeholder="http://localhost:8061"
           className="h-8 text-xs max-w-xs font-mono"
         />
       </div>

--- a/docs/hooks/use-settings.tsx
+++ b/docs/hooks/use-settings.tsx
@@ -21,7 +21,7 @@ interface SettingsContextValue extends Settings {
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 
 const STORAGE_KEY = "reflexio-docs-settings";
-const DEFAULT_SETTINGS: Settings = { apiEndpoint: "http://localhost:8081" };
+const DEFAULT_SETTINGS: Settings = { apiEndpoint: "http://localhost:8061" };
 
 function loadSettings(): Settings {
   if (typeof window === "undefined") {

--- a/docs/lib/execution/code-generator.ts
+++ b/docs/lib/execution/code-generator.ts
@@ -7,7 +7,7 @@ export function generatePythonCode(
   const lines: string[] = [
     "from reflexio import ReflexioClient",
     "",
-    'client = ReflexioClient(url_endpoint="http://localhost:8081")',
+    'client = ReflexioClient(url_endpoint="http://localhost:8061")',
     "",
   ];
 

--- a/notebooks/_display_helpers.py
+++ b/notebooks/_display_helpers.py
@@ -45,7 +45,7 @@ def load_env() -> tuple[str, str]:
             break
 
     url = os.environ.get(
-        "REFLEXIO_URL", f"http://localhost:{os.environ.get('BACKEND_PORT', '8081')}"
+        "REFLEXIO_URL", f"http://localhost:{os.environ.get('BACKEND_PORT', '8061')}"
     )
     api_key = os.environ.get("REFLEXIO_API_KEY", "")
 

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -62,7 +62,7 @@ Example: `uv run reflexio --json search "refund policy"`.
 Start and stop the backend, docs server, and optional local embedding daemon.
 
 ```shell
-uv run reflexio services start                          # backend :8081, docs :8082
+uv run reflexio services start                          # backend :8061, docs :8062
 uv run reflexio services start --storage sqlite         # sqlite (default) | supabase | postgres
 uv run reflexio services start --backend-port 9000 --docs-port 9001
 uv run reflexio services start --only backend --no-reload
@@ -216,7 +216,7 @@ uv run reflexio config pull                              # pull server config to
 ## Auth
 
 ```shell
-uv run reflexio auth login --api-key $REFLEXIO_API_KEY --server-url http://localhost:8081
+uv run reflexio auth login --api-key $REFLEXIO_API_KEY --server-url http://localhost:8061
 uv run reflexio auth status
 uv run reflexio auth logout
 ```

--- a/reflexio/cli/__main__.py
+++ b/reflexio/cli/__main__.py
@@ -36,8 +36,17 @@ def main(argv: list[str] | None = None) -> None:
     ``reflexio.cli`` entry-point group before falling back to the
     default open-source app factory.
     """
-    from reflexio.cli.env_loader import load_reflexio_env
+    from reflexio.cli.env_loader import (
+        block_implicit_dotenv_walkup,
+        load_reflexio_env,
+    )
 
+    # Stop third-party import-time ``load_dotenv()`` calls (notably litellm)
+    # from walking UP the tree and loading a parent ``.env`` — e.g. the
+    # enterprise-root ``.env`` when the OSS launcher runs from the
+    # ``open_source/reflexio`` submodule. Must precede any import that pulls in
+    # litellm. Reflexio's own scoped loader runs right after.
+    block_implicit_dotenv_walkup()
     load_reflexio_env()
 
     from importlib.metadata import entry_points

--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -20,6 +20,19 @@ _VALID_STORAGE_BACKENDS = frozenset({"sqlite", "supabase", "postgres"})
 _DEFAULT_ORG_ID = "self-host-org"
 _DEFAULT_STORAGE = "sqlite"
 
+
+def default_org_id() -> str:
+    """Resolve the default org id, honoring ``REFLEXIO_DEFAULT_ORG_ID``.
+
+    Mirrors :func:`reflexio.server._auth.default_get_org_id` so the local CLI
+    helpers (``setup``, ``config show`` / ``config local``) resolve the same
+    ``config_<org>.json`` the running no-auth server reads. Uses ``os.environ``
+    directly (not ``env_utils``) to keep this module's import lightweight — see
+    the ``_TYPE_TO_BACKEND`` note above.
+    """
+    return os.environ.get("REFLEXIO_DEFAULT_ORG_ID", "").strip() or _DEFAULT_ORG_ID
+
+
 # Maps StorageConfig subclass to backend string.  Lazy-imported in functions
 # that need it so module-level import stays lightweight (no Pydantic at import).
 _TYPE_TO_BACKEND: dict[type, str] = {}  # populated on first use
@@ -71,24 +84,26 @@ def default_config_path(base_dir: str | None = None) -> Path:
     Returns:
         Path: Absolute path to the default-org config file (may not exist).
     """
-    return _config_dir(base_dir) / f"config_{_DEFAULT_ORG_ID}.json"
+    return _config_dir(base_dir) / f"config_{default_org_id()}.json"
 
 
 def load_storage_from_config(
-    org_id: str = _DEFAULT_ORG_ID,
+    org_id: str | None = None,
     *,
     base_dir: str | None = None,
 ) -> str | None:
     """Read storage type from the local config file.
 
     Args:
-        org_id: Organization ID for the config file name.
+        org_id: Organization ID for the config file name. Defaults to the
+            ``REFLEXIO_DEFAULT_ORG_ID``-aware default org.
         base_dir: Override base directory (for testing). If None, uses ~/.reflexio/.
 
     Returns:
         Storage backend string ("sqlite", "supabase", "postgres") or None if
         no config file exists or storage_config is unset.
     """
+    org_id = org_id or default_org_id()
     config_path = _config_dir(base_dir) / f"config_{org_id}.json"
     if not config_path.exists():
         return None
@@ -114,7 +129,7 @@ def load_storage_from_config(
 
 def save_storage_to_config(
     storage_type: str,
-    org_id: str = _DEFAULT_ORG_ID,
+    org_id: str | None = None,
     *,
     base_dir: str | None = None,
 ) -> None:
@@ -125,7 +140,8 @@ def save_storage_to_config(
 
     Args:
         storage_type: Backend name ("sqlite", "supabase", "postgres").
-        org_id: Organization ID for the config file name.
+        org_id: Organization ID for the config file name. Defaults to the
+            ``REFLEXIO_DEFAULT_ORG_ID``-aware default org.
         base_dir: Override base directory (for testing).
     """
     from reflexio.models.config_schema import (
@@ -137,6 +153,7 @@ def save_storage_to_config(
         LocalFileConfigStorage,
     )
 
+    org_id = org_id or default_org_id()
     storage_obj = LocalFileConfigStorage(org_id, base_dir=base_dir)
     config = storage_obj.load_config()
 

--- a/reflexio/cli/commands/services.py
+++ b/reflexio/cli/commands/services.py
@@ -166,13 +166,13 @@ def validate_storage_backend(storage: str | None) -> None:
 @app.command()
 def start(
     backend_port: Annotated[
-        int | None, typer.Option(help="Backend server port (default: 8081)")
+        int | None, typer.Option(help="Backend server port (default: 8061)")
     ] = None,
     docs_port: Annotated[
-        int | None, typer.Option(help="Docs server port (default: 8082)")
+        int | None, typer.Option(help="Docs server port (default: 8062)")
     ] = None,
     embedding_port: Annotated[
-        int | None, typer.Option(help="Embedding service port (default: 8072)")
+        int | None, typer.Option(help="Embedding service port (default: 8069)")
     ] = None,
     only: Annotated[
         str | None,
@@ -271,13 +271,13 @@ def start(
 @app.command()
 def stop(
     backend_port: Annotated[
-        int | None, typer.Option(help="Backend server port (default: 8081)")
+        int | None, typer.Option(help="Backend server port (default: 8061)")
     ] = None,
     docs_port: Annotated[
-        int | None, typer.Option(help="Docs server port (default: 8082)")
+        int | None, typer.Option(help="Docs server port (default: 8062)")
     ] = None,
     embedding_port: Annotated[
-        int | None, typer.Option(help="Embedding service port (default: 8072)")
+        int | None, typer.Option(help="Embedding service port (default: 8069)")
     ] = None,
     only: Annotated[
         str | None,

--- a/reflexio/cli/commands/setup_cmd.py
+++ b/reflexio/cli/commands/setup_cmd.py
@@ -275,12 +275,13 @@ def _write_embedding_model_to_org_config(model_name: str) -> None:
         model_name: Canonical model name to persist
             (e.g. ``"local/minilm-l6-v2"``).
     """
+    from reflexio.cli.bootstrap_config import default_org_id
     from reflexio.models.config_schema import LLMConfig
     from reflexio.server.services.configurator.local_file_config_storage import (
         LocalFileConfigStorage,
     )
 
-    storage = LocalFileConfigStorage("self-host-org")
+    storage = LocalFileConfigStorage(default_org_id())
     config = storage.load_config()
     if config.llm_config is None:
         config.llm_config = LLMConfig(embedding_model_name=model_name)
@@ -385,7 +386,7 @@ def _choose_embedding_provider(env_path: Path, *, embedding_flag: str) -> str | 
     return _provider_display(provider_key)
 
 
-_LOCAL_SERVER_URL = "http://localhost:8081"
+_LOCAL_SERVER_URL = "http://localhost:8061"
 
 
 def _prompt_local_sqlite(env_path: Path) -> str:

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -40,6 +40,68 @@ def get_env_path() -> Path:
     return _USER_ENV_FILE
 
 
+def block_implicit_dotenv_walkup() -> None:
+    """Neutralize path-less ``dotenv.load_dotenv()`` autoloads (the walk-up).
+
+    Third-party libraries — notably ``litellm`` at import time
+    (``litellm/__init__.py``) — call ``load_dotenv()`` with no arguments. With
+    no path, python-dotenv runs ``find_dotenv()``, which walks **up** the
+    directory tree and loads the first ``.env`` it finds. Run from the
+    ``open_source/reflexio`` submodule inside the enterprise monorepo, that
+    climbs to the enterprise-root ``.env`` (platform-configured) and leaks
+    ``BACKEND_PORT`` / ``DEPLOYMENT_MODE`` / ``REFLEXIO_STORAGE`` into the
+    process — silently overriding the OSS launcher's own ``806*`` defaults.
+
+    Reflexio loads env deliberately via :func:`load_reflexio_env`, scoped to
+    ``./.env`` + ``~/.reflexio/.env`` and never walking up, so a library's
+    implicit autoload is redundant. This installs a shim on
+    ``dotenv.load_dotenv`` that no-ops the path-less form while passing explicit
+    ``load_dotenv(dotenv_path=...)`` / ``stream=...`` calls through unchanged.
+    Reflexio's own loader binds ``load_dotenv`` at import and always passes an
+    explicit path, so it is unaffected regardless.
+
+    Must run before the first ``import litellm`` in the process — the CLI entry
+    point (:func:`reflexio.cli.__main__.main`) calls it first thing. Idempotent.
+    Only the CLI launcher installs this: the spawned server subprocesses bind
+    the parent-resolved ``--port`` and the OSS server never reads
+    ``DEPLOYMENT_MODE``, so the launcher process is the only place the leak
+    changes behavior.
+    """
+    import functools
+    from typing import IO
+
+    import dotenv
+
+    original = dotenv.load_dotenv
+    if getattr(original, "__reflexio_walkup_guarded__", False):
+        return
+
+    @functools.wraps(original)
+    def _guarded(
+        dotenv_path: str | os.PathLike[str] | None = None,
+        stream: IO[str] | None = None,
+        verbose: bool = False,
+        override: bool = False,
+        interpolate: bool = True,
+        encoding: str | None = "utf-8",
+    ) -> bool:
+        if dotenv_path is None and stream is None:
+            # Path-less call would walk up past reflexio's controlled search
+            # scope (./.env + ~/.reflexio/.env). Ignore it.
+            return False
+        return original(
+            dotenv_path,
+            stream,
+            verbose=verbose,
+            override=override,
+            interpolate=interpolate,
+            encoding=encoding,
+        )
+
+    _guarded.__reflexio_walkup_guarded__ = True  # type: ignore[attr-defined]
+    dotenv.load_dotenv = _guarded
+
+
 def get_loaded_env_path() -> Path | None:
     """Return the .env path that the most recent ``load_reflexio_env`` call
     resolved, or None if the loader hasn't run yet.

--- a/reflexio/cli/run_services.py
+++ b/reflexio/cli/run_services.py
@@ -27,6 +27,13 @@ _PACKAGE_DIR = Path(reflexio.__file__).resolve().parent
 _EDITABLE_REPO_ROOT = _PACKAGE_DIR.parent
 DOCS_DIR = _EDITABLE_REPO_ROOT / "docs"
 
+# Default local ports for the OSS launcher. OSS occupies the 806* range so it
+# never collides with claude-smart / openclaw-smart (807*), enterprise self-host
+# (808*), or enterprise platform (809*). Embedding sits in the *9 slot to mirror
+# the enterprise convention (8089 self-host, 8099 platform). Override per service
+# with the matching CLI flag or {BACKEND,DOCS,EMBEDDING}_PORT env var.
+DEFAULT_OSS_PORTS: dict[str, int] = {"backend": 8061, "docs": 8062, "embedding": 8069}
+
 
 def add_arguments(parser: argparse.ArgumentParser) -> None:
     """Add run-services arguments to the parser.
@@ -39,19 +46,19 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         "--backend-port",
         type=int,
         default=None,
-        help="Backend port (default: 8081, env: BACKEND_PORT)",
+        help="Backend port (default: 8061, env: BACKEND_PORT)",
     )
     parser.add_argument(
         "--docs-port",
         type=int,
         default=None,
-        help="Docs port (default: 8082, env: DOCS_PORT)",
+        help="Docs port (default: 8062, env: DOCS_PORT)",
     )
     parser.add_argument(
         "--embedding-port",
         type=int,
         default=None,
-        help="Embedding service port (default: 8072, env: EMBEDDING_PORT)",
+        help="Embedding service port (default: 8069, env: EMBEDDING_PORT)",
     )
     parser.add_argument(
         "--only",
@@ -323,9 +330,7 @@ def execute(args: argparse.Namespace) -> None:
     ts = time.strftime("%Y-%m-%d %H:%M:%S %Z")
     print(f"\n{bar}\n=== NEW REFLEXIO SERVER START — {ts} ===\n{bar}\n")
 
-    ports = resolve_ports(
-        args, defaults={"backend": 8081, "docs": 8082, "embedding": 8072}
-    )
+    ports = resolve_ports(args, defaults=DEFAULT_OSS_PORTS)
     os.environ["API_BACKEND_URL"] = os.environ.get(
         "API_BACKEND_URL", f"http://localhost:{ports['backend']}"
     )

--- a/reflexio/cli/stop_services.py
+++ b/reflexio/cli/stop_services.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import argparse
 
-from dotenv import load_dotenv
-
-from reflexio.cli.run_services import parse_only_flag, resolve_ports
+from reflexio.cli.env_loader import load_reflexio_env
+from reflexio.cli.run_services import (
+    DEFAULT_OSS_PORTS,
+    parse_only_flag,
+    resolve_ports,
+)
 from reflexio.cli.utils import stop_services
 
 
@@ -16,19 +19,19 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         "--backend-port",
         type=int,
         default=None,
-        help="Backend port (default: 8081, env: BACKEND_PORT)",
+        help="Backend port (default: 8061, env: BACKEND_PORT)",
     )
     parser.add_argument(
         "--docs-port",
         type=int,
         default=None,
-        help="Docs port (default: 8082, env: DOCS_PORT)",
+        help="Docs port (default: 8062, env: DOCS_PORT)",
     )
     parser.add_argument(
         "--embedding-port",
         type=int,
         default=None,
-        help="Embedding service port (default: 8072, env: EMBEDDING_PORT)",
+        help="Embedding service port (default: 8069, env: EMBEDDING_PORT)",
     )
     parser.add_argument(
         "--only",
@@ -79,11 +82,11 @@ def build_stop_targets(
 
 def execute(args: argparse.Namespace) -> None:
     """Execute the stop-services command."""
-    load_dotenv()
+    # Use reflexio's scoped loader (./.env + ~/.reflexio/.env), not a bare
+    # ``dotenv.load_dotenv()`` which walks up to a parent ``.env``.
+    load_reflexio_env()
 
-    ports = resolve_ports(
-        args, defaults={"backend": 8081, "docs": 8082, "embedding": 8072}
-    )
+    ports = resolve_ports(args, defaults=DEFAULT_OSS_PORTS)
     only = parse_only_flag(args.only, {"backend", "docs", "embedding"})
     port_map, process_patterns = build_stop_targets(only, ports)
 

--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -6,7 +6,7 @@ plus a Python (`openclaw_smart`) package that wires openClaw's plugin hooks
 into a local [Reflexio](https://github.com/reflexio-ai/reflexio) backend
 running at `http://localhost:8071/`. The port matches claude-smart so both
 plugins share one bundled reflexio (one SQLite store, one extractor), and
-leaves reflexio's own 8081 default free for developer use. Conversations
+leaves reflexio's own 8061 default free for developer use. Conversations
 are buffered to a JSONL session log, published for extraction (skills +
 preferences) via your own LLM, and the top-matching items are injected
 back into every subsequent turn as `prependContext`. The plugin degrades

--- a/reflexio/integrations/openclaw/plugin/scripts/backend-service.sh
+++ b/reflexio/integrations/openclaw/plugin/scripts/backend-service.sh
@@ -5,7 +5,7 @@
 #
 # Port choice: openclaw-smart shares 8071/8072 with the sibling claude-smart
 # plugin so the two plugins coexist on a single shared backend (one SQLite
-# store, one extractor process) — not reflexio's 8081 default, which is
+# store, one extractor process) — not reflexio's 8061 default, which is
 # reserved for a developer's own local reflexio instance.
 #
 # Subcommands:

--- a/reflexio/integrations/openclaw/plugin/tests/integration/test_publish_to_local_reflexio_integration.py
+++ b/reflexio/integrations/openclaw/plugin/tests/integration/test_publish_to_local_reflexio_integration.py
@@ -1,7 +1,7 @@
 """Integration: publish buffered turns to a local SQLite-backed reflexio.
 
 Requires a reflexio backend reachable at ``REFLEXIO_URL`` (default
-``http://localhost:8081/``). Skipped automatically when the backend is
+``http://localhost:8061/``). Skipped automatically when the backend is
 unreachable so the suite is portable across machines.
 """
 
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.integration
 
 
 def _reflexio_url() -> str:
-    return os.environ.get("REFLEXIO_URL", "http://localhost:8081/")
+    return os.environ.get("REFLEXIO_URL", "http://localhost:8061/")
 
 
 def _backend_alive(url: str) -> bool:

--- a/reflexio/integrations/openclaw/plugin/tests/integration/test_search_inject_integration.py
+++ b/reflexio/integrations/openclaw/plugin/tests/integration/test_search_inject_integration.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.integration
 
 
 def _reflexio_url() -> str:
-    return os.environ.get("REFLEXIO_URL", "http://localhost:8081/")
+    return os.environ.get("REFLEXIO_URL", "http://localhost:8061/")
 
 
 def _backend_alive(url: str) -> bool:

--- a/reflexio/integrations/openclaw/plugin/tests/test_reflexio_adapter.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_reflexio_adapter.py
@@ -9,7 +9,7 @@ from openclaw_smart.reflexio_adapter import Adapter
 
 def test_default_url_is_8071():
     # 8071/8072 matches claude-smart so the two plugins share one local
-    # reflexio backend; 8081 is reserved for a developer's own instance.
+    # reflexio backend; 8061 is reserved for a developer's own instance.
     adapter = Adapter()
     assert adapter.url == "http://localhost:8071/"
 

--- a/reflexio/server/OVERVIEW.md
+++ b/reflexio/server/OVERVIEW.md
@@ -41,7 +41,7 @@ cp .env.example .env                         # Configure environment (set at lea
 uv sync                                      # Install Python dependencies (includes workspace packages)
 npm --prefix src/website install         # Install frontend dependencies
 npm --prefix src/public_docs install     # Install docs dependencies
-./run_services.sh                             # Starts API (8081), Website (8080), Docs (8082)
+./run_services.sh                             # Starts API (8061), Website (8080), Docs (8062)
 ./stop_services.sh                            # Stop all services
 ```
 
@@ -56,7 +56,7 @@ npm --prefix src/public_docs install     # Install docs dependencies
 **Testing:**
 ```python
 import reflexio
-client = reflexio.ReflexioClient(api_key="your-api-key", url_endpoint="http://127.0.0.1:8081/")
+client = reflexio.ReflexioClient(api_key="your-api-key", url_endpoint="http://127.0.0.1:8061/")
 ```
 See `notebooks/reflexio_cookbook.ipynb` and `src/tests/readme.md`
 

--- a/reflexio/server/__main__.py
+++ b/reflexio/server/__main__.py
@@ -3,10 +3,10 @@
 Run the FastAPI backend with Reflexio's uvicorn log config applied upfront::
 
     # Dev mode (autoreload, single process):
-    python -m reflexio.server --port 8081 --reload
+    python -m reflexio.server --port 8061 --reload
 
     # Daemon mode (multi-worker with recycling):
-    python -m reflexio.server --port 8081 --workers 2 --max-requests 10000
+    python -m reflexio.server --port 8061 --workers 2 --max-requests 10000
 
 Flags mirror the subset of ``uvicorn`` CLI options that
 :func:`reflexio.cli.run_services.build_backend_service` uses.

--- a/reflexio/server/_auth.py
+++ b/reflexio/server/_auth.py
@@ -18,14 +18,25 @@ DEFAULT_ORG_ID = "self-host-org"
 def default_get_org_id() -> str:
     """Return the default organization ID for local hosting.
 
-    Enterprise deployments override this via
+    Reads ``REFLEXIO_DEFAULT_ORG_ID`` (unset/blank falls back to
+    :data:`DEFAULT_ORG_ID`) so a no-auth deployment can run under a distinct
+    org id without colliding with another local backend that shares
+    ``~/.reflexio/configs/``. claude-smart and the self-host backend otherwise
+    both default to ``self-host-org`` and fight over the same
+    ``config_self-host-org.json``.
+
+    Enterprise deployments never reach this: they override the dependency via
     ``app.dependency_overrides[default_get_org_id] = <bearer_auth_resolver>``
     inside :func:`reflexio.server.api.create_app`.
 
     Returns:
         str: The default org identifier used for self-hosted deployments.
     """
-    return DEFAULT_ORG_ID
+    # Lazy import keeps this deliberately cycle-free module independent of the
+    # ``reflexio.server`` package init (see module docstring).
+    from reflexio.server.env_utils import env_str
+
+    return env_str("REFLEXIO_DEFAULT_ORG_ID", DEFAULT_ORG_ID)
 
 
 def default_get_caller_type() -> str:

--- a/stop_services.sh
+++ b/stop_services.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Configurable ports (must match what was used in run_services.sh)
-BACKEND_PORT=${BACKEND_PORT:-8081}
-DOCS_PORT=${DOCS_PORT:-8082}
-EMBEDDING_PORT=${EMBEDDING_PORT:-8072}
+BACKEND_PORT=${BACKEND_PORT:-8061}
+DOCS_PORT=${DOCS_PORT:-8062}
+EMBEDDING_PORT=${EMBEDDING_PORT:-8069}
 
 echo "Stopping services..."
 

--- a/tests/cli/test_env_loader_walkup_guard.py
+++ b/tests/cli/test_env_loader_walkup_guard.py
@@ -1,0 +1,67 @@
+"""Tests for ``block_implicit_dotenv_walkup``.
+
+The OSS launcher, run from the ``open_source/reflexio`` submodule, must NOT pick
+up a parent-directory ``.env`` (e.g. the enterprise-root ``.env``). Reflexio's
+own loader is already scoped to ``./.env`` + ``~/.reflexio/.env``; the leak comes
+from third-party libraries (litellm) calling a path-less ``dotenv.load_dotenv()``
+at import time, which walks UP the tree. The guard neutralizes that path-less
+form while leaving explicit-path loads intact. These tests pin both halves.
+"""
+
+from __future__ import annotations
+
+import os
+
+import dotenv
+import pytest
+
+from reflexio.cli.env_loader import block_implicit_dotenv_walkup
+
+
+@pytest.fixture
+def restore_load_dotenv():
+    """Restore the global ``dotenv.load_dotenv`` so the guard never leaks
+    between tests."""
+    original = dotenv.load_dotenv
+    try:
+        yield
+    finally:
+        dotenv.load_dotenv = original
+
+
+def test_pathless_walkup_is_noop(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, restore_load_dotenv
+) -> None:
+    # A parent .env that a path-less load_dotenv() would discover by walking up.
+    (tmp_path / ".env").write_text("BACKEND_PORT=8091\n")
+    sub = tmp_path / "pkg" / "sub"
+    sub.mkdir(parents=True)
+    monkeypatch.chdir(sub)
+    monkeypatch.delenv("BACKEND_PORT", raising=False)
+
+    block_implicit_dotenv_walkup()
+    result = dotenv.load_dotenv()  # path-less -> would walk up to tmp_path/.env
+
+    assert result is False
+    assert "BACKEND_PORT" not in os.environ  # the parent .env did NOT leak
+
+
+def test_explicit_path_still_loads(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, restore_load_dotenv
+) -> None:
+    env = tmp_path / "explicit.env"
+    env.write_text("REFLEXIO_GUARD_EXPLICIT=yes\n")
+    monkeypatch.delenv("REFLEXIO_GUARD_EXPLICIT", raising=False)
+
+    block_implicit_dotenv_walkup()
+    result = dotenv.load_dotenv(dotenv_path=env)
+
+    assert result is True
+    assert os.environ["REFLEXIO_GUARD_EXPLICIT"] == "yes"
+
+
+def test_idempotent(restore_load_dotenv) -> None:
+    block_implicit_dotenv_walkup()
+    guarded = dotenv.load_dotenv
+    block_implicit_dotenv_walkup()
+    assert dotenv.load_dotenv is guarded  # not re-wrapped on the second call

--- a/tests/cli/test_service_builders.py
+++ b/tests/cli/test_service_builders.py
@@ -12,6 +12,7 @@ import typer
 
 from reflexio.cli.commands.services import validate_storage_backend
 from reflexio.cli.run_services import (
+    DEFAULT_OSS_PORTS,
     _ensure_nextjs_dependencies,
     build_backend_service,
     build_embedding_service,
@@ -77,6 +78,60 @@ class TestResolvePorts:
         with patch.dict(os.environ, env, clear=True):
             result = resolve_ports(args, {"backend": 8081})
         assert result["backend"] == 8081
+
+
+class TestDefaultOssPorts:
+    """The OSS launcher defaults live in the 806* range, distinct from
+    claude-smart/openclaw (807*), enterprise self-host (808*), and platform
+    (809*), so OSS never collides with a co-located claude-smart backend."""
+
+    def test_default_values(self) -> None:
+        assert DEFAULT_OSS_PORTS == {
+            "backend": 8061,
+            "docs": 8062,
+            "embedding": 8069,
+        }
+
+    def test_resolve_uses_defaults_when_no_override(self) -> None:
+        args = argparse.Namespace(
+            backend_port=None, docs_port=None, embedding_port=None
+        )
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {"BACKEND_PORT", "DOCS_PORT", "EMBEDDING_PORT"}
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = resolve_ports(args, DEFAULT_OSS_PORTS)
+        assert result == {"backend": 8061, "docs": 8062, "embedding": 8069}
+
+    def test_env_and_cli_still_override_defaults(self) -> None:
+        args = argparse.Namespace(
+            backend_port=9001, docs_port=None, embedding_port=None
+        )
+        # Start from an env with the port vars stripped so the test is hermetic
+        # regardless of what the developer's shell exports, then set only
+        # DOCS_PORT to exercise the env-override path.
+        base_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in {"BACKEND_PORT", "DOCS_PORT", "EMBEDDING_PORT"}
+        }
+        with patch.dict(os.environ, {**base_env, "DOCS_PORT": "9002"}, clear=True):
+            result = resolve_ports(args, DEFAULT_OSS_PORTS)
+        assert result["backend"] == 9001  # CLI flag wins
+        assert result["docs"] == 9002  # env var wins
+        assert result["embedding"] == 8069  # falls through to default
+
+    def test_stop_targets_stay_in_806x_never_claude_smart(self) -> None:
+        """`stop` with default ports must target 806*, never claude-smart's
+        8071/8072 — the safety property behind moving OSS off the 807* range."""
+        port_map, _ = build_stop_targets(
+            {"backend", "docs", "embedding"}, DEFAULT_OSS_PORTS
+        )
+        assert port_map == {"backend": 8061, "docs": 8062, "embedding": 8069}
+        assert 8071 not in port_map.values()
+        assert 8072 not in port_map.values()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -12,6 +12,7 @@ import typer
 from reflexio.cli.commands.setup_cmd import (
     _prompt_storage,
     _set_env_var,
+    _write_embedding_model_to_org_config,
 )
 from reflexio.models.api_schema.service_schemas import WhoamiResponse
 
@@ -127,7 +128,7 @@ class TestPromptStorage:
         with patch("typer.prompt", return_value=1):
             label = _prompt_storage(env)
         assert label == "SQLite (local)"
-        assert 'REFLEXIO_URL="http://localhost:8081"' in env.read_text()
+        assert 'REFLEXIO_URL="http://localhost:8061"' in env.read_text()
 
     def test_option_2_cloud_writes_reflexio_url_and_api_key(
         self, tmp_path: Path
@@ -814,3 +815,30 @@ class TestEnsureUserEnvForSetup:
         assert resolved is not None and resolved.exists()
         # CWD .env was untouched.
         assert cwd_env.read_text() == "CWD_ONLY=ignored\n"
+
+
+class TestWriteEmbeddingModelToOrgConfig:
+    """The embedding-choice writer must target the same org the running no-auth
+    server resolves (``REFLEXIO_DEFAULT_ORG_ID``-aware), not a hardcoded
+    ``self-host-org`` — otherwise the storage backend and the embedding model
+    land in different ``config_<org>.json`` files."""
+
+    _STORAGE_PATCH = (
+        "reflexio.server.services.configurator."
+        "local_file_config_storage.LocalFileConfigStorage"
+    )
+
+    def test_writes_to_env_resolved_org(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("REFLEXIO_DEFAULT_ORG_ID", "claude-smart")
+        with patch(self._STORAGE_PATCH) as mock_storage:
+            _write_embedding_model_to_org_config("local/minilm-l6-v2")
+        mock_storage.assert_called_once_with("claude-smart")
+        mock_storage.return_value.save_config.assert_called_once()
+
+    def test_defaults_to_self_host_org_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("REFLEXIO_DEFAULT_ORG_ID", raising=False)
+        with patch(self._STORAGE_PATCH) as mock_storage:
+            _write_embedding_model_to_org_config("local/minilm-l6-v2")
+        mock_storage.assert_called_once_with("self-host-org")

--- a/tests/e2e_tests/test_resumable_extraction_e2e.py
+++ b/tests/e2e_tests/test_resumable_extraction_e2e.py
@@ -182,7 +182,7 @@ def _load_live_e2e_settings() -> tuple[str, str]:
     base_url = (
         os.environ.get("REFLEXIO_URL")
         or dotenv_values_from_file.get("REFLEXIO_URL")
-        or "http://localhost:8081"
+        or "http://localhost:8061"
     )
 
     if not api_key:

--- a/tests/server/test_api_security_middleware.py
+++ b/tests/server/test_api_security_middleware.py
@@ -68,7 +68,7 @@ def test_cors_local_mode_allows_any_origin(monkeypatch):
     response = client.options(
         "/health",
         headers={
-            "Origin": "http://localhost:8082",
+            "Origin": "http://localhost:8062",
             "Access-Control-Request-Method": "GET",
         },
     )

--- a/tests/server/test_auth_default_org.py
+++ b/tests/server/test_auth_default_org.py
@@ -1,0 +1,36 @@
+"""Tests for the no-auth default org resolver.
+
+``default_get_org_id`` controls the request org for local / no-auth
+deployments, which in turn names the ``config_<org>.json`` file and scopes
+SQLite data. claude-smart sets ``REFLEXIO_DEFAULT_ORG_ID`` so it stops sharing
+``config_self-host-org.json`` with the self-host backend; these tests pin that
+contract (and its backward-compatible default).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.server._auth import DEFAULT_ORG_ID, default_get_org_id
+
+_ENV = "REFLEXIO_DEFAULT_ORG_ID"
+
+
+def test_defaults_to_self_host_org_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_ENV, raising=False)
+    assert default_get_org_id() == DEFAULT_ORG_ID == "self-host-org"
+
+
+def test_honors_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(_ENV, "claude-smart")
+    assert default_get_org_id() == "claude-smart"
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_value_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, blank: str
+) -> None:
+    # A blank ``KEY=`` line (python-dotenv exports "") must not strand the org
+    # at the empty string — it resolves to the default, like unset.
+    monkeypatch.setenv(_ENV, blank)
+    assert default_get_org_id() == DEFAULT_ORG_ID


### PR DESCRIPTION
## Summary

Lets the OSS launcher run alongside claude-smart and the enterprise backends on one machine without port or config collisions.

- **Ports → 806x.** OSS now defaults to backend `8061`, docs `8062`, embedding `8069` (was 808x), keeping it clear of claude-smart/openclaw-smart (807x), enterprise self-host (808x), and enterprise platform (809x). Defaults are centralized in `DEFAULT_OSS_PORTS` and shared by `start`/`stop`.
- **Scoped no-auth org id.** `default_get_org_id()` (and the CLI bootstrap mirror) now read `REFLEXIO_DEFAULT_ORG_ID`, falling back to `self-host-org` when unset/blank. A second no-auth backend can run under its own `config_<org>.json` instead of fighting over `config_self-host-org.json`.
- **dotenv walk-up guard.** `block_implicit_dotenv_walkup()` neutralizes the path-less `load_dotenv()` that litellm runs at import time, which otherwise walks up to a parent `.env` and leaks `BACKEND_PORT`/`DEPLOYMENT_MODE` into the process. `stop_services` now uses reflexio's scoped loader instead of a bare `load_dotenv()`.

## Changes

- `reflexio/cli/run_services.py`, `stop_services.py`, `commands/services.py`, `server/__main__.py` — 806x port defaults + help text.
- `reflexio/server/_auth.py`, `reflexio/cli/bootstrap_config.py`, `commands/setup_cmd.py` — `REFLEXIO_DEFAULT_ORG_ID`-aware org resolution.
- `reflexio/cli/env_loader.py`, `__main__.py` — `block_implicit_dotenv_walkup()` installed before the first litellm import.
- Docs/READMEs updated to the new ports.

## Test Plan

- `pytest tests/cli/test_env_loader_walkup_guard.py tests/server/test_auth_default_org.py tests/cli/test_service_builders.py tests/cli/test_setup_cmd.py` — 94 passed.
- New tests pin: path-less walk-up is a no-op while explicit-path loads pass through; guard is idempotent; org resolver honors the env var and treats blank as unset.
- `ruff check`/`format` and `pyright` clean on changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated local service defaults across the CLI and setup flows to use the new ports for backend, docs, and embedding services.
  * Improved configuration handling so local setup follows the active default organization more reliably.

* **Bug Fixes**
  * Prevented unintended `.env` files from being picked up from parent directories during startup.
  * Fixed various examples and defaults so local links, SDK snippets, and troubleshooting guidance point to the correct ports.

* **Documentation**
  * Refreshed setup, CLI, README, and developer guides to match the new local port values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->