### PR TITLE
feat: add final recency rerank for unified search

### DIFF
--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -162,6 +162,7 @@ class SearchMixin(ReflexioBase):
             storage = self._get_storage()
             prompt_manager = self.request_context.prompt_manager
             retrieval_floor = config.retrieval_floor if config else None
+            recency = getattr(storage, "recency", None)
 
         from reflexio.server.services.unified_search_service import run_unified_search
 
@@ -173,4 +174,5 @@ class SearchMixin(ReflexioBase):
             prompt_manager=prompt_manager,
             pre_retrieval_model_name=pre_retrieval_model_name,
             retrieval_floor=retrieval_floor,
+            recency=recency,
         )

--- a/reflexio/server/llm/rerank/cross_encoder_reranker.py
+++ b/reflexio/server/llm/rerank/cross_encoder_reranker.py
@@ -150,7 +150,18 @@ def score_pairs(query: str, docs: list[str]) -> list[float]:
         return []
     model = _get_model()
     pairs = [(query, doc) for doc in docs]
-    raw_scores = model.predict(pairs, show_progress_bar=False)
+    try:
+        from torch import nn
+    except ImportError as e:
+        raise CrossEncoderUnavailableError(
+            "torch is not installed; cannot use the cross-encoder reranker"
+        ) from e
+
+    raw_scores = model.predict(
+        pairs,
+        show_progress_bar=False,
+        activation_fn=nn.Identity(),
+    )
     # ``predict`` returns a numpy array; convert to plain Python floats so
     # the caller can serialise the result without numpy as a dependency.
     return [float(s) for s in raw_scores]

--- a/reflexio/server/services/retrieval/recency.py
+++ b/reflexio/server/services/retrieval/recency.py
@@ -1,0 +1,211 @@
+"""Recency adjustment helpers for unified search ranking."""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+
+from reflexio.server.env_utils import env_str, env_truthy
+
+logger = logging.getLogger(__name__)
+
+SECONDS_PER_DAY = 24 * 60 * 60
+PLAYBOOK_HALF_LIFE_SECONDS = 90 * SECONDS_PER_DAY
+_PROFILE_TTL_HALF_LIFE_FRACTION = 0.5
+
+
+@dataclass(frozen=True)
+class ScoredItem[T]:
+    item: T
+    score: float | None
+
+
+@dataclass(frozen=True)
+class RecencyConfig:
+    enabled: bool = True
+    max_penalty_frac: float = 0.15
+    max_penalty_logit: float = 0.2
+    pool_size: int = 20
+
+    @classmethod
+    def from_env(cls, *, env: Mapping[str, str] | None = None) -> RecencyConfig:
+        return cls(
+            enabled=env_truthy(
+                env_str("REFLEXIO_SEARCH_RECENCY_ENABLED", "true", env=env)
+            ),
+            max_penalty_frac=_float_env(
+                "REFLEXIO_SEARCH_RECENCY_MAX_PENALTY_FRAC",
+                cls.max_penalty_frac,
+                env=env,
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            max_penalty_logit=_float_env(
+                "REFLEXIO_SEARCH_RECENCY_MAX_PENALTY_LOGIT",
+                cls.max_penalty_logit,
+                env=env,
+                minimum=0.0,
+            ),
+            pool_size=_int_env(
+                "REFLEXIO_SEARCH_RECENCY_POOL_SIZE",
+                cls.pool_size,
+                env=env,
+                minimum=1,
+            ),
+        )
+
+    def with_overrides(self, values: Mapping[str, object] | None) -> RecencyConfig:
+        if not values:
+            return self
+        updates: dict[str, object] = {}
+        if "recency_enabled" in values:
+            updates["enabled"] = _bool_value(values["recency_enabled"], self.enabled)
+        if "recency_max_penalty_frac" in values:
+            updates["max_penalty_frac"] = _float_value(
+                values["recency_max_penalty_frac"],
+                self.max_penalty_frac,
+                minimum=0.0,
+                maximum=1.0,
+            )
+        if "recency_max_penalty_logit" in values:
+            updates["max_penalty_logit"] = _float_value(
+                values["recency_max_penalty_logit"],
+                self.max_penalty_logit,
+                minimum=0.0,
+            )
+        if "recency_pool_size" in values:
+            updates["pool_size"] = _int_value(
+                values["recency_pool_size"], self.pool_size, minimum=1
+            )
+        return replace(self, **updates)
+
+
+def decay_for_item(
+    item: object,
+    *,
+    entity_type: str,
+    now: int | None = None,
+) -> float:
+    """Return a freshness decay in [0, 1], where 1 means no penalty."""
+    now = now if now is not None else int(datetime.now(UTC).timestamp())
+    if entity_type == "profiles":
+        return _profile_decay(item, now=now)
+    return _timestamp_decay(
+        getattr(item, "created_at", None),
+        half_life_seconds=PLAYBOOK_HALF_LIFE_SECONDS,
+        now=now,
+    )
+
+
+def decay(age_seconds: float, half_life_seconds: float) -> float:
+    if half_life_seconds <= 0:
+        return 1.0
+    age_seconds = max(0.0, age_seconds)
+    return math.exp(-age_seconds / (half_life_seconds / math.log(2)))
+
+
+def multiplicative_factor(decay_value: float, max_penalty_frac: float) -> float:
+    return 1.0 - _clamp(max_penalty_frac, 0.0, 1.0) * (1.0 - _decay(decay_value))
+
+
+def additive_penalty(decay_value: float, max_penalty_logit: float) -> float:
+    return max(0.0, max_penalty_logit) * (1.0 - _decay(decay_value))
+
+
+def _profile_decay(item: object, *, now: int) -> float:
+    modified_at = _int_or_none(getattr(item, "last_modified_timestamp", None))
+    expires_at = _int_or_none(getattr(item, "expiration_timestamp", None))
+    if modified_at is None or expires_at is None or expires_at <= modified_at:
+        return 1.0
+    half_life = (expires_at - modified_at) * _PROFILE_TTL_HALF_LIFE_FRACTION
+    return decay(now - modified_at, half_life)
+
+
+def _timestamp_decay(value: object, *, half_life_seconds: int, now: int) -> float:
+    timestamp = _int_or_none(value)
+    if timestamp is None or timestamp <= 0:
+        return 1.0
+    return decay(now - timestamp, half_life_seconds)
+
+
+def _float_env(
+    name: str,
+    default: float,
+    *,
+    env: Mapping[str, str] | None,
+    minimum: float,
+    maximum: float | None = None,
+) -> float:
+    return _float_value(
+        env_str(name, str(default), env=env),
+        default,
+        minimum=minimum,
+        maximum=maximum,
+    )
+
+
+def _int_env(
+    name: str,
+    default: int,
+    *,
+    env: Mapping[str, str] | None,
+    minimum: int,
+) -> int:
+    return _int_value(env_str(name, str(default), env=env), default, minimum=minimum)
+
+
+def _bool_value(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str) and value.strip():
+        return env_truthy(value)
+    return default
+
+
+def _float_value(
+    value: object,
+    default: float,
+    *,
+    minimum: float,
+    maximum: float | None = None,
+) -> float:
+    try:
+        if not isinstance(value, str | int | float):
+            raise TypeError
+        parsed = float(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid recency float override %r; using %.3f", value, default)
+        return default
+    parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def _int_value(value: object, default: int, *, minimum: int) -> int:
+    try:
+        if not isinstance(value, str | int):
+            raise TypeError
+        parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid recency integer override %r; using %d", value, default)
+        return default
+    return max(minimum, parsed)
+
+
+def _int_or_none(value: object) -> int | None:
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _decay(value: float) -> float:
+    return _clamp(value, 0.0, 1.0)
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return min(high, max(low, value))

--- a/reflexio/server/services/retrieval/relevance_floor.py
+++ b/reflexio/server/services/retrieval/relevance_floor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from reflexio.server.llm.rerank import score_pairs
@@ -21,12 +22,20 @@ from reflexio.server.tracing import profile_step
 logger = logging.getLogger(__name__)
 
 
-def _floor_and_sort[T](items: list[T], scores: list[float], floor: float) -> list[T]:
-    """Return items scoring >= ``floor``, sorted by score descending."""
+@dataclass(frozen=True)
+class RelevanceFloorResult:
+    items: list[Any]
+    scores: list[float] | None
+
+
+def _floor_and_sort[T](
+    items: list[T], scores: list[float], floor: float
+) -> list[tuple[T, float]]:
+    """Return ``(item, score)`` pairs scoring >= ``floor``, sorted descending."""
     ranked = sorted(
         zip(items, scores, strict=True), key=lambda pair: pair[1], reverse=True
     )
-    return [item for item, score in ranked if score >= floor]
+    return [(item, score) for item, score in ranked if score >= floor]
 
 
 def apply_relevance_floor[T](
@@ -71,7 +80,7 @@ def apply_relevance_floor[T](
             return items[:top_k]
         span.set_data("available", True)
 
-        survivors = _floor_and_sort(items, scores, floor)
+        survivors = [item for item, _score in _floor_and_sort(items, scores, floor)]
         dropped = len(items) - len(survivors)
         span.set_data("kept", len(survivors))
         span.set_data("dropped", dropped)
@@ -92,7 +101,7 @@ def apply_relevance_floors(
     top_k: int,
     *,
     content_of: Callable[[Any], str] = lambda item: item.content,
-) -> list[list[Any]]:
+) -> list[RelevanceFloorResult]:
     """Floor every arm with a single cross-encoder batch.
 
     CPU cross-encoder inference does not parallelize across threads, so
@@ -108,12 +117,13 @@ def apply_relevance_floors(
         content_of: Extracts the text to score for an item.
 
     Returns:
-        One survivor list per arm, in input order — each sorted by score
-        descending and capped at ``top_k``. On reranker unavailability,
-        every arm returns ``items[:top_k]`` unchanged (logged).
+        One result per arm, in input order. Available reranker results are
+        sorted by score descending and left uncapped with the paired raw logits.
+        On reranker unavailability, every arm returns the original full item
+        pool with a ``None`` score sentinel (logged).
     """
     if not any(items for _, items, _ in arms):
-        return [[] for _ in arms]
+        return [RelevanceFloorResult([], []) for _ in arms]
     arm_names = [name for name, _, _ in arms]
     contents: list[str] = []
     for _, items, _ in arms:
@@ -123,20 +133,21 @@ def apply_relevance_floors(
         arm="all",
         arms=arm_names,
         items=len(contents),
+        top_k=top_k,
     ) as span:
         try:
             scores = score_pairs(query, contents)
         except CrossEncoderUnavailableError:
             span.set_data("available", False)
             logger.warning(
-                "event=relevance_floor_unavailable arms=%s items=%d (returning unfiltered top_k)",
+                "event=relevance_floor_unavailable arms=%s items=%d (returning unfiltered pool)",
                 arm_names,
                 len(contents),
             )
-            return [items[:top_k] for _, items, _ in arms]
+            return [RelevanceFloorResult(list(items), None) for _, items, _ in arms]
         span.set_data("available", True)
 
-        results: list[list[Any]] = []
+        results: list[RelevanceFloorResult] = []
         offset = 0
         for name, items, floor in arms:
             arm_scores = scores[offset : offset + len(items)]
@@ -153,5 +164,10 @@ def apply_relevance_floors(
                     dropped,
                     floor,
                 )
-            results.append(survivors[:top_k])
+            results.append(
+                RelevanceFloorResult(
+                    [item for item, _score in survivors],
+                    [score for _item, score in survivors],
+                )
+            )
         return results

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -17,6 +17,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from reflexio.models.api_schema.retriever_schema import (
@@ -41,6 +42,13 @@ from reflexio.models.config_schema import (
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.pre_retrieval import QueryReformulator
+from reflexio.server.services.retrieval.recency import (
+    RecencyConfig,
+    ScoredItem,
+    additive_penalty,
+    decay_for_item,
+    multiplicative_factor,
+)
 from reflexio.server.services.retrieval.relevance_floor import apply_relevance_floors
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.tracing import profile_step, set_span_data
@@ -102,6 +110,7 @@ def run_unified_search(
     prompt_manager: PromptManager,
     pre_retrieval_model_name: str | None = None,
     retrieval_floor: RetrievalFloorConfig | None = None,
+    recency: RecencyConfig | None = None,
 ) -> UnifiedSearchResponse:
     """
     Search across all entity types (profiles, agent playbooks, user playbooks) in parallel.
@@ -129,7 +138,12 @@ def run_unified_search(
 
     floor_cfg = retrieval_floor or RetrievalFloorConfig()
     floor_on = floor_cfg.enabled
-    fetch_k = max(top_k, floor_cfg.pool_size) if floor_on else top_k
+    recency_on = bool(recency and recency.enabled)
+    fetch_k = max(
+        top_k,
+        floor_cfg.pool_size if floor_on else 0,
+        recency.pool_size if recency_on and recency is not None else 0,
+    )
 
     # --- Phase A: query reformulation + embedding generation ---
     reformulated_query, embedding = _run_phase_a(
@@ -153,6 +167,7 @@ def run_unified_search(
         query=reformulated_query,
         top_k=fetch_k,
         threshold=threshold,
+        recency_on=recency_on,
     )
 
     if profiles is None:
@@ -166,7 +181,28 @@ def run_unified_search(
             user_playbooks=user_playbooks,  # type: ignore[arg-type]
             top_k=top_k,
             cfg=floor_cfg,
+            recency=recency if recency_on else None,
         )
+    elif recency_on and recency is not None:
+        profiles = _apply_combined_score_recency(
+            profiles or [], entity_type="profiles", top_k=top_k, cfg=recency
+        )
+        agent_playbooks = _apply_combined_score_recency(
+            agent_playbooks or [],
+            entity_type="agent_playbooks",
+            top_k=top_k,
+            cfg=recency,
+        )
+        user_playbooks = _apply_combined_score_recency(
+            user_playbooks or [],
+            entity_type="user_playbooks",
+            top_k=top_k,
+            cfg=recency,
+        )
+    else:
+        profiles = _unwrap_items(profiles or [])[:top_k]
+        agent_playbooks = _unwrap_items(agent_playbooks or [])[:top_k]
+        user_playbooks = _unwrap_items(user_playbooks or [])[:top_k]
 
     user_playbooks = _suppress_source_user_playbooks(
         storage=storage,
@@ -284,10 +320,11 @@ def _run_phase_b(
     query: str,
     top_k: int,
     threshold: float,
+    recency_on: bool = False,
 ) -> tuple[
-    list[UserProfile] | None,
-    list[AgentPlaybook] | None,
-    list[UserPlaybook] | None,
+    list[Any] | None,
+    list[Any] | None,
+    list[Any] | None,
 ]:
     """Run parallel searches across all entity types by delegating to storage methods.
 
@@ -314,9 +351,18 @@ def _run_phase_b(
             entity_types=sorted(entity_types),
             top_k=top_k,
         ) as span:
-            if (
+            # Recency needs the per-row ``combined_score``, which only the scored
+            # single-RPC method threads back. Backends that don't advertise
+            # ``supports_unified_hybrid_search`` (e.g. native Postgres, which still
+            # inherits ``unified_hybrid_search_scored`` and runs it via the same
+            # ``_rpc`` it already uses for ``hybrid_match_*``) opt into the scored
+            # path only when recency is on, so non-recency routing is unchanged.
+            wants_scored_single_rpc = recency_on and callable(
+                getattr(storage, "unified_hybrid_search_scored", None)
+            )
+            if _unified_single_rpc_enabled() and (
                 getattr(storage, "supports_unified_hybrid_search", False)
-                and _unified_single_rpc_enabled()
+                or wants_scored_single_rpc
             ):
                 combined = _run_phase_b_single_rpc(
                     request=request,
@@ -327,6 +373,7 @@ def _run_phase_b(
                     threshold=threshold,
                     entity_types=entity_types,
                     allowed_agent_statuses=allowed_agent_statuses,
+                    recency_on=recency_on,
                 )
                 if combined is not None:
                     profiles, agent_playbooks, user_playbooks = combined
@@ -437,7 +484,8 @@ def _run_phase_b_single_rpc(
     threshold: float,
     entity_types: set[str],
     allowed_agent_statuses: list[PlaybookStatus] | None,
-) -> tuple[list[UserProfile], list[AgentPlaybook], list[UserPlaybook]] | None:
+    recency_on: bool = False,
+) -> tuple[list[Any], list[Any], list[Any]] | None:
     """Run all Phase B arms through one combined storage round trip.
 
     Trades the per-arm round-trip overhead for serialized execution of the
@@ -458,8 +506,16 @@ def _run_phase_b_single_rpc(
     )
     # Resolve storage.unified_hybrid_search before submit so missing or stale
     # capability flags can fall back to the fan-out path.
-    unified_hybrid_search = getattr(storage, "unified_hybrid_search", None)
+    method_name = (
+        "unified_hybrid_search_scored" if recency_on else "unified_hybrid_search"
+    )
+    unified_hybrid_search = getattr(storage, method_name, None)
     if not callable(unified_hybrid_search):
+        if recency_on:
+            logger.warning(
+                "event=search_recency_missing_scores source=single_rpc method=%s",
+                method_name,
+            )
         return None
 
     future = _submit_with_current_context(
@@ -490,13 +546,14 @@ def _run_phase_b_single_rpc(
         return None
 
     # Mirror _search_agent_playbooks_via_storage: dedupe by id, cap at top_k.
-    deduped: list[AgentPlaybook] = []
+    deduped: list[Any] = []
     seen_ids: set[str] = set()
-    for playbook in agent_playbooks:
+    for candidate in agent_playbooks:
+        playbook = _unwrap_item(candidate)
         playbook_id = str(getattr(playbook, "agent_playbook_id", ""))
         if playbook_id and playbook_id not in seen_ids:
             seen_ids.add(playbook_id)
-            deduped.append(playbook)
+            deduped.append(candidate)
             if len(deduped) >= top_k:
                 break
     return profiles, deduped, user_playbooks
@@ -509,6 +566,7 @@ def _apply_floors(
     user_playbooks: list[UserPlaybook],
     top_k: int,
     cfg: RetrievalFloorConfig,
+    recency: RecencyConfig | None = None,
 ) -> tuple[list[UserProfile], list[AgentPlaybook], list[UserPlaybook]]:
     """Apply the per-arm relevance floor with one batched cross-encoder call."""
     floored_profiles, floored_agent, floored_user = apply_relevance_floors(
@@ -519,8 +577,91 @@ def _apply_floors(
             ("user_playbooks", user_playbooks, cfg.user_playbook_floor),
         ],
         top_k,
+        content_of=lambda item: _unwrap_item(item).content,
     )
-    return floored_profiles, floored_agent, floored_user
+    return (
+        _finalize_floor_arm(
+            floored_profiles, entity_type="profiles", top_k=top_k, recency=recency
+        ),
+        _finalize_floor_arm(
+            floored_agent,
+            entity_type="agent_playbooks",
+            top_k=top_k,
+            recency=recency,
+        ),
+        _finalize_floor_arm(
+            floored_user,
+            entity_type="user_playbooks",
+            top_k=top_k,
+            recency=recency,
+        ),
+    )
+
+
+def _finalize_floor_arm(
+    result: Any,
+    *,
+    entity_type: str,
+    top_k: int,
+    recency: RecencyConfig | None,
+) -> list[Any]:
+    if not recency or not recency.enabled:
+        return _unwrap_items(result.items)[:top_k]
+    if result.scores is None:
+        return _apply_combined_score_recency(
+            result.items, entity_type=entity_type, top_k=top_k, cfg=recency
+        )
+    now = int(datetime.now(UTC).timestamp())
+    rescored = []
+    for item, score in zip(result.items, result.scores, strict=True):
+        unwrapped = _unwrap_item(item)
+        freshness = decay_for_item(unwrapped, entity_type=entity_type, now=now)
+        rescored.append(
+            (unwrapped, score - additive_penalty(freshness, recency.max_penalty_logit))
+        )
+    rescored.sort(key=lambda pair: pair[1], reverse=True)
+    return [item for item, _score in rescored[:top_k]]
+
+
+def _apply_combined_score_recency(
+    items: list[Any],
+    *,
+    entity_type: str,
+    top_k: int,
+    cfg: RecencyConfig,
+) -> list[Any]:
+    if not items:
+        return []
+    scored_items: list[tuple[Any, float]] = []
+    for item in items:
+        if not isinstance(item, ScoredItem) or item.score is None:
+            logger.warning(
+                "event=search_recency_missing_scores entity_type=%s items=%d",
+                entity_type,
+                len(items),
+            )
+            return _unwrap_items(items)[:top_k]
+        scored_items.append((item.item, item.score))
+    now = int(datetime.now(UTC).timestamp())
+    rescored = []
+    for item, score in scored_items:
+        freshness = decay_for_item(item, entity_type=entity_type, now=now)
+        rescored.append(
+            (
+                item,
+                score * multiplicative_factor(freshness, cfg.max_penalty_frac),
+            )
+        )
+    rescored.sort(key=lambda pair: pair[1], reverse=True)
+    return [item for item, _score in rescored[:top_k]]
+
+
+def _unwrap_item(item: Any) -> Any:
+    return item.item if isinstance(item, ScoredItem) else item
+
+
+def _unwrap_items(items: list[Any]) -> list[Any]:
+    return [_unwrap_item(item) for item in items]
 
 
 def _suppress_source_user_playbooks(

--- a/tests/server/llm/rerank/test_cross_encoder_device.py
+++ b/tests/server/llm/rerank/test_cross_encoder_device.py
@@ -1,6 +1,6 @@
 """Device selection for the cross-encoder reranker singleton."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -41,4 +41,23 @@ def test_score_pairs_disables_progress_bar():
     model.predict.return_value = [0.5]
     reranker._MODEL = model
     reranker.score_pairs("query", ["doc"])
-    model.predict.assert_called_once_with([("query", "doc")], show_progress_bar=False)
+    model.predict.assert_called_once_with(
+        [("query", "doc")],
+        show_progress_bar=False,
+        activation_fn=ANY,
+    )
+
+
+def test_score_pairs_forces_identity_activation_for_raw_logits():
+    # The recency additive-logit math and the relevance floor both depend on
+    # raw, signed logits — not a sigmoid-activated [0, 1] score. Pin the
+    # activation to Identity so a library default can't silently change it.
+    from torch import nn
+
+    model = MagicMock()
+    model.predict.return_value = [-3.5]  # raw logits can be negative
+    reranker._MODEL = model
+    scores = reranker.score_pairs("query", ["doc"])
+    assert scores == [-3.5]
+    _, kwargs = model.predict.call_args
+    assert isinstance(kwargs["activation_fn"], nn.Identity)

--- a/tests/server/services/retrieval/test_recency.py
+++ b/tests/server/services/retrieval/test_recency.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import pytest
+
+from reflexio.server.services.retrieval.recency import (
+    RecencyConfig,
+    additive_penalty,
+    decay,
+    decay_for_item,
+    multiplicative_factor,
+)
+
+
+def test_decay_half_life_is_half():
+    assert decay(50, 100) > 0.70
+    assert decay(100, 100) == pytest.approx(0.5)
+
+
+def test_profile_decay_uses_ttl_lifespan():
+    profile = SimpleNamespace(
+        last_modified_timestamp=100,
+        expiration_timestamp=300,
+    )
+
+    assert decay_for_item(profile, entity_type="profiles", now=200) == pytest.approx(
+        0.5
+    )
+
+
+def test_missing_timestamps_are_noop():
+    item = SimpleNamespace(created_at=None)
+
+    assert decay_for_item(item, entity_type="user_playbooks", now=200) == 1.0
+
+
+def test_factor_and_penalty_bounds():
+    assert multiplicative_factor(0.0, 0.15) == 0.85
+    assert multiplicative_factor(1.0, 0.15) == 1.0
+    assert additive_penalty(0.0, 0.2) == 0.2
+    assert additive_penalty(1.0, 0.2) == 0.0
+
+
+def test_config_from_env_and_site_var_overrides():
+    cfg = RecencyConfig.from_env(
+        env={
+            "REFLEXIO_SEARCH_RECENCY_ENABLED": "false",
+            "REFLEXIO_SEARCH_RECENCY_MAX_PENALTY_FRAC": "2",
+            "REFLEXIO_SEARCH_RECENCY_MAX_PENALTY_LOGIT": "-1",
+            "REFLEXIO_SEARCH_RECENCY_POOL_SIZE": "0",
+        }
+    ).with_overrides(
+        {
+            "recency_enabled": True,
+            "recency_max_penalty_frac": 0.25,
+            "recency_max_penalty_logit": 0.4,
+            "recency_pool_size": 40,
+        }
+    )
+
+    assert cfg.enabled is True
+    assert cfg.max_penalty_frac == 0.25
+    assert cfg.max_penalty_logit == 0.4
+    assert cfg.pool_size == 40

--- a/tests/server/services/retrieval/test_relevance_floor.py
+++ b/tests/server/services/retrieval/test_relevance_floor.py
@@ -80,8 +80,10 @@ def test_batched_floors_score_once_and_apply_per_arm_floors():
     ) as mock_score:
         out = apply_relevance_floors("q", arms, top_k=10)
     mock_score.assert_called_once_with("q", ["p1", "p2", "q1"])
-    assert [i.content for i in out[0]] == ["p1"]  # -7.0 below -5.0 floor
-    assert out[1] == []  # 0.0 below the 0.5 floor
+    assert [i.content for i in out[0].items] == ["p1"]  # -7.0 below -5.0 floor
+    assert out[0].scores == [1.0]
+    assert out[1].items == []  # 0.0 below the 0.5 floor
+    assert out[1].scores == []
 
 
 def test_batched_floors_sort_desc_and_cap_per_arm():
@@ -91,7 +93,8 @@ def test_batched_floors_sort_desc_and_cap_per_arm():
         return_value=[1.0, 3.0, 2.0],
     ):
         out = apply_relevance_floors("q", arms, top_k=2)
-    assert [i.content for i in out[0]] == ["y", "z"]
+    assert [i.content for i in out[0].items] == ["y", "z", "x"]
+    assert out[0].scores == [3.0, 2.0, 1.0]
 
 
 def test_batched_floors_unavailable_degrades_each_arm():
@@ -108,8 +111,10 @@ def test_batched_floors_unavailable_degrades_each_arm():
         side_effect=CrossEncoderUnavailableError("no model"),
     ):
         out = apply_relevance_floors("q", arms, top_k=2)
-    assert [i.content for i in out[0]] == ["a", "b"]
-    assert [i.content for i in out[1]] == ["d"]
+    assert [i.content for i in out[0].items] == ["a", "b", "c"]
+    assert out[0].scores is None
+    assert [i.content for i in out[1].items] == ["d"]
+    assert out[1].scores is None
 
 
 def test_batched_floors_all_empty_skips_scoring():
@@ -117,7 +122,8 @@ def test_batched_floors_all_empty_skips_scoring():
         "reflexio.server.services.retrieval.relevance_floor.score_pairs"
     ) as mock_score:
         out = apply_relevance_floors("q", [("a1", [], -5.0), ("a2", [], -5.0)], top_k=5)
-    assert out == [[], []]
+    assert [result.items for result in out] == [[], []]
+    assert [result.scores for result in out] == [[], []]
     mock_score.assert_not_called()
 
 
@@ -131,5 +137,7 @@ def test_batched_floors_empty_arm_keeps_offsets_aligned():
         return_value=[2.0],
     ):
         out = apply_relevance_floors("q", arms, top_k=5)
-    assert out[0] == []
-    assert [i.content for i in out[1]] == ["x"]
+    assert out[0].items == []
+    assert out[0].scores == []
+    assert [i.content for i in out[1].items] == ["x"]
+    assert out[1].scores == [2.0]

--- a/tests/server/services/test_unified_search_floor.py
+++ b/tests/server/services/test_unified_search_floor.py
@@ -5,15 +5,26 @@ from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.models.api_schema.retriever_schema import UnifiedSearchRequest
 from reflexio.models.config_schema import RetrievalFloorConfig
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.rerank.cross_encoder_reranker import (
+    CrossEncoderUnavailableError,
+)
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services import unified_search_service as uss
+from reflexio.server.services.retrieval.recency import RecencyConfig, ScoredItem
 from reflexio.server.services.storage.storage_base import BaseStorage
 
 
-def _fake_user_playbook(content: str) -> UserPlaybook:
+def _fake_user_playbook(content: str, *, created_at: int | None = None) -> UserPlaybook:
     # run_unified_search builds a UnifiedSearchResponse, which validates
     # user_playbooks as real UserPlaybook instances, so back the test items
     # with the real entity (still keyed on .content for floor scoring).
+    if created_at is not None:
+        return UserPlaybook(
+            agent_version="v1",
+            request_id="r1",
+            content=content,
+            created_at=created_at,
+        )
     return UserPlaybook(agent_version="v1", request_id="r1", content=content)
 
 
@@ -55,6 +66,97 @@ def test_floor_applied_per_arm(monkeypatch):
     assert resp.success is True
     # junk dropped, sorted desc
     assert [p.content for p in resp.user_playbooks] == ["good", "ok"]
+
+
+def test_floor_recency_applied_after_logits(monkeypatch):
+    old = _fake_user_playbook("old", created_at=1)
+    fresh = _fake_user_playbook("fresh", created_at=4_102_444_800)
+    monkeypatch.setattr(uss, "_run_phase_a", lambda **_kw: ("q", None))
+    monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], [old, fresh]))
+
+    def fake_score(query, docs):  # noqa: ARG001
+        return [2.0 if doc == "old" else 1.9 for doc in docs]
+
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        side_effect=fake_score,
+    ):
+        resp = uss.run_unified_search(
+            request=UnifiedSearchRequest(query="q", user_id="u", top_k=2),
+            org_id="o",
+            storage=cast(BaseStorage, _FakeStorage()),
+            llm_client=cast(LiteLLMClient, object()),
+            prompt_manager=cast(PromptManager, object()),
+            retrieval_floor=RetrievalFloorConfig(
+                enabled=True, user_playbook_floor=-5.0
+            ),
+            recency=RecencyConfig(enabled=True, max_penalty_logit=1.0, pool_size=2),
+        )
+
+    assert [p.content for p in resp.user_playbooks] == ["fresh", "old"]
+
+
+def test_floor_recency_does_not_overtake_clearly_more_relevant(monkeypatch):
+    # Invariant: at the default penalty, recency must NOT reorder when the logit
+    # gap exceeds max_penalty_logit. An ancient but clearly-more-relevant item
+    # stays ahead of a brand-new but weaker one.
+    old = _fake_user_playbook("old", created_at=1)  # ancient -> max penalty
+    fresh = _fake_user_playbook("fresh", created_at=4_102_444_800)  # brand new
+    monkeypatch.setattr(uss, "_run_phase_a", lambda **_kw: ("q", None))
+    monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], [old, fresh]))
+
+    def fake_score(query, docs):  # noqa: ARG001
+        # 1.0 logit gap >> max_penalty_logit (0.2)
+        return [2.0 if doc == "old" else 1.0 for doc in docs]
+
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        side_effect=fake_score,
+    ):
+        resp = uss.run_unified_search(
+            request=UnifiedSearchRequest(query="q", user_id="u", top_k=2),
+            org_id="o",
+            storage=cast(BaseStorage, _FakeStorage()),
+            llm_client=cast(LiteLLMClient, object()),
+            prompt_manager=cast(PromptManager, object()),
+            retrieval_floor=RetrievalFloorConfig(
+                enabled=True, user_playbook_floor=-5.0
+            ),
+            recency=RecencyConfig(enabled=True, max_penalty_logit=0.2, pool_size=2),
+        )
+
+    assert [p.content for p in resp.user_playbooks] == ["old", "fresh"]
+
+
+def test_floor_recency_falls_back_to_combined_score_when_unavailable(monkeypatch):
+    # When the cross-encoder is unavailable, the floor pass returns the pool
+    # untruncated with no logits; recency must fall back to the combined_score
+    # (multiplicative) arm rather than crash or no-op.
+    old = ScoredItem(_fake_user_playbook("old", created_at=1), 1.0)
+    fresh = ScoredItem(_fake_user_playbook("fresh", created_at=4_102_444_800), 0.9)
+    monkeypatch.setattr(uss, "_run_phase_a", lambda **_kw: ("q", None))
+    monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], [old, fresh]))
+
+    def boom(query, docs):  # noqa: ARG001
+        raise CrossEncoderUnavailableError("no model")
+
+    with patch(
+        "reflexio.server.services.retrieval.relevance_floor.score_pairs",
+        side_effect=boom,
+    ):
+        resp = uss.run_unified_search(
+            request=UnifiedSearchRequest(query="q", user_id="u", top_k=2),
+            org_id="o",
+            storage=cast(BaseStorage, _FakeStorage()),
+            llm_client=cast(LiteLLMClient, object()),
+            prompt_manager=cast(PromptManager, object()),
+            retrieval_floor=RetrievalFloorConfig(
+                enabled=True, user_playbook_floor=-5.0
+            ),
+            recency=RecencyConfig(enabled=True, max_penalty_frac=1.0, pool_size=2),
+        )
+
+    assert [p.content for p in resp.user_playbooks] == ["fresh", "old"]
 
 
 def test_floor_disabled_returns_all(monkeypatch):

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -19,6 +19,7 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.models.config_schema import RetrievalFloorConfig, SearchOptions
 from reflexio.server.services.pre_retrieval import ReformulationResult
+from reflexio.server.services.retrieval.recency import RecencyConfig, ScoredItem
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.services.unified_search_service import (
     _search_agent_playbooks_via_storage,
@@ -240,6 +241,155 @@ class TestRunUnifiedSearch(unittest.TestCase):
 
         self.assertTrue(result.success)
         self.assertEqual(captured, [("req-1", "test-org", [10], [102])])
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_recency_uses_pool_and_combined_score_after_phase_b(
+        self, _reformulator_cls
+    ):
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="same query"
+        )
+        storage = _mock_storage()
+        old = UserPlaybook(
+            user_playbook_id=1,
+            user_id="user-1",
+            agent_version="v1",
+            request_id="r1",
+            playbook_name="pb",
+            content="old",
+            created_at=1,
+        )
+        fresh = UserPlaybook(
+            user_playbook_id=2,
+            user_id="user-1",
+            agent_version="v1",
+            request_id="r2",
+            playbook_name="pb",
+            content="fresh",
+            created_at=4_102_444_800,
+        )
+        seen_top_k = []
+
+        def fake_phase_b(**kwargs):
+            seen_top_k.append(kwargs["top_k"])
+            return ([], [], [ScoredItem(old, 1.0), ScoredItem(fresh, 0.9)])
+
+        with patch(
+            "reflexio.server.services.unified_search_service._run_phase_b",
+            side_effect=fake_phase_b,
+        ):
+            result = run_unified_search(
+                request=UnifiedSearchRequest(
+                    query="same query", user_id="user-1", top_k=1
+                ),
+                org_id="test-org",
+                storage=storage,
+                llm_client=MagicMock(),
+                prompt_manager=MagicMock(),
+                retrieval_floor=RetrievalFloorConfig(enabled=False),
+                recency=RecencyConfig(enabled=True, max_penalty_frac=1.0, pool_size=2),
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(seen_top_k, [2])
+        self.assertEqual([pb.content for pb in result.user_playbooks], ["fresh"])
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_recency_does_not_overtake_clearly_more_relevant_combined_score(
+        self, _reformulator_cls
+    ):
+        # Invariant on the default (combined_score) arm: at the default penalty
+        # fraction, an ancient but clearly-more-relevant item is never overtaken
+        # by a fresher, weaker one (0.040 vs 0.024 is a 1.67x gap >> 15%).
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="q"
+        )
+        storage = _mock_storage()
+        relevant = UserPlaybook(
+            user_playbook_id=1,
+            user_id="user-1",
+            agent_version="v1",
+            request_id="r1",
+            playbook_name="pb",
+            content="relevant",
+            created_at=1,
+        )
+        fresh = UserPlaybook(
+            user_playbook_id=2,
+            user_id="user-1",
+            agent_version="v1",
+            request_id="r2",
+            playbook_name="pb",
+            content="fresh",
+            created_at=4_102_444_800,
+        )
+
+        def fake_phase_b(**_kwargs):
+            return ([], [], [ScoredItem(relevant, 0.040), ScoredItem(fresh, 0.024)])
+
+        with patch(
+            "reflexio.server.services.unified_search_service._run_phase_b",
+            side_effect=fake_phase_b,
+        ):
+            result = run_unified_search(
+                request=UnifiedSearchRequest(query="q", user_id="user-1", top_k=2),
+                org_id="test-org",
+                storage=storage,
+                llm_client=MagicMock(),
+                prompt_manager=MagicMock(),
+                retrieval_floor=RetrievalFloorConfig(enabled=False),
+                recency=RecencyConfig(enabled=True, max_penalty_frac=0.15, pool_size=2),
+            )
+
+        self.assertEqual(
+            [pb.content for pb in result.user_playbooks], ["relevant", "fresh"]
+        )
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_recency_routes_scored_single_rpc_without_support_flag(
+        self, _reformulator_cls
+    ):
+        # Native-Postgres shape: supports_unified_hybrid_search=False but the
+        # inherited unified_hybrid_search_scored is present. Recency must still
+        # route through the scored single-RPC path (not silently no-op).
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="q"
+        )
+
+        class _PgLikeStorage:
+            supports_embedding = False
+            supports_unified_hybrid_search = False
+
+            def unified_hybrid_search_scored(self, **_kwargs):
+                return ([], [], [])
+
+        seen: dict[str, object] = {}
+
+        def fake_single_rpc(**kwargs):
+            seen["recency_on"] = kwargs.get("recency_on")
+            return ([], [], [])
+
+        with (
+            patch(
+                "reflexio.server.services.unified_search_service._run_phase_a",
+                return_value=("q", None),
+            ),
+            patch(
+                "reflexio.server.services.unified_search_service._run_phase_b_single_rpc",
+                side_effect=fake_single_rpc,
+            ),
+        ):
+            run_unified_search(
+                request=UnifiedSearchRequest(query="q", user_id="u", top_k=2),
+                org_id="o",
+                storage=cast(BaseStorage, _PgLikeStorage()),
+                llm_client=MagicMock(),
+                prompt_manager=MagicMock(),
+                retrieval_floor=RetrievalFloorConfig(enabled=False),
+                recency=RecencyConfig(enabled=True, pool_size=2),
+            )
+
+        self.assertTrue(seen.get("recency_on"))
 
 
 def _agent_playbook(agent_playbook_id: int, status: PlaybookStatus) -> AgentPlaybook:


### PR DESCRIPTION
## Summary
- add a final recency rerank pass for unified search after SQL hybrid scoring and any cross-encoder relevance floor
- preserve the stronger relevance signal by using multiplicative penalties for combined SQL scores and bounded additive penalties for cross-encoder logits
- add single-RPC scored sidecar support so enterprise storage can provide combined scores without changing response payloads

## Changes
- introduce `RecencyConfig`/`ScoredItem` and final rerank helpers
- thread optional recency configuration through `run_unified_search` and the client search path
- keep relevance-floor pools available for final reranking and use raw cross-encoder logits for floor decisions
- add tests for recency math, ordering, fallback behavior, single-RPC scored calls, and floor interaction

## Test Plan
- `uv run ruff format ...`
- `uv run ruff check ...`
- `uv run pyright ...`
- `uv run pytest --no-cov tests/server/services/retrieval/test_recency.py tests/server/services/retrieval/test_relevance_floor.py tests/server/services/test_unified_search_floor.py tests/server/services/test_unified_search_service.py tests/server/services/test_unified_search_single_rpc.py tests/server/llm/rerank/test_cross_encoder_device.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results can now take recency into account, helping newer content rank more naturally.
  * Unified search now better balances freshness with relevance when returning results.

* **Bug Fixes**
  * Improved handling when the ranking model is unavailable, reducing failures and ensuring search still returns results.
  * Search scoring now preserves raw ranking signals more accurately, improving consistency of result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->