### PR TITLE
feat: REFLEXIO_ENV_FILE override + fix SQLite migrate ordering

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ XAI_API_KEY=
 # Local storage directory — houses disk-storage artifacts and the SQLite
 # database file (reflexio.db). (optional; default ~/.reflexio/data/)
 LOCAL_STORAGE_PATH=
+# Default org id for no-auth / local mode. Controls the request org, and hence
+# the config file name (config_<org>.json) and the SQLite data scope. Override
+# it to run a second local backend under a distinct org so the two don't collide
+# on the same config file under ~/.reflexio/. (optional; default self-host-org)
+REFLEXIO_DEFAULT_ORG_ID=self-host-org
 
 # =============================================================================
 # 4. EXTRACTION

--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -24,6 +24,21 @@ _USER_ENV_DIR = reflexio_home()
 _USER_ENV_FILE = _USER_ENV_DIR / ".env"
 
 
+def user_env_file() -> Path:
+    """Return the user-level .env path, honoring ``REFLEXIO_ENV_FILE``.
+
+    When ``REFLEXIO_ENV_FILE`` is set (and non-blank) it overrides the default
+    ``~/.reflexio/.env``. This lets a second local backend keep its env separate
+    from the OSS reflexio default that also lives under ``~/.reflexio`` — e.g.
+    claude-smart points this at ``~/.claude-smart/.env`` so an OSS reflexio
+    ``.env`` (with its own ``REFLEXIO_STORAGE`` etc.) can't leak into it. The data
+    directory is independent (see ``LOCAL_STORAGE_PATH``), so both backends can
+    still share ``~/.reflexio/data``.
+    """
+    override = os.environ.get("REFLEXIO_ENV_FILE", "").strip()
+    return Path(override).expanduser() if override else _USER_ENV_FILE
+
+
 # Path to the .env file that load_reflexio_env last resolved — None until
 # load_reflexio_env runs for the first time. Exposed via get_loaded_env_path
 # so the startup banner can show the operator exactly which dotenv was
@@ -34,10 +49,10 @@ _loaded_env_path: Path | None = None
 def get_env_path() -> Path:
     """Return the canonical path to the user-level .env file.
 
-    Returns:
-        Path: ``~/.reflexio/.env``
+    Honors ``REFLEXIO_ENV_FILE`` (see :func:`user_env_file`); defaults to
+    ``~/.reflexio/.env``.
     """
-    return _USER_ENV_FILE
+    return user_env_file()
 
 
 def block_implicit_dotenv_walkup() -> None:
@@ -150,10 +165,12 @@ def set_env_var(env_path: Path, key: str, value: str) -> None:
     env_path.chmod(0o600)
 
 
-_ENV_SEARCH_PATHS = [
-    Path(".env"),  # 1. Current directory (local dev / project-level)
-    _USER_ENV_FILE,  # 2. User home default (~/.reflexio/.env)
-]
+def _env_search_paths() -> list[Path]:
+    """OSS .env search order, resolved at call time so ``REFLEXIO_ENV_FILE`` is honored."""
+    return [
+        Path(".env"),  # 1. Current directory (local dev / project-level)
+        user_env_file(),  # 2. User-level file (REFLEXIO_ENV_FILE override, else ~/.reflexio/.env)
+    ]
 
 
 def _load_dotenv_pruned(path: Path, *, override: bool = False) -> None:
@@ -210,7 +227,7 @@ def load_reflexio_env(
         Path to the loaded .env file, or None if no .env was found/created.
     """
     global _loaded_env_path
-    for env_path in _ENV_SEARCH_PATHS:
+    for env_path in _env_search_paths():
         if env_path.exists():
             _load_dotenv_pruned(env_path)
             resolved = env_path.resolve()
@@ -507,10 +524,12 @@ def _create_default_env(
         sys.stdout.flush()
         return None
 
-    created_dir = not _USER_ENV_DIR.exists()
-    _USER_ENV_DIR.mkdir(parents=True, exist_ok=True)
+    target = user_env_file()  # honors REFLEXIO_ENV_FILE (e.g. ~/.claude-smart/.env)
+    target_dir = target.parent
+    created_dir = not target_dir.exists()
+    target_dir.mkdir(parents=True, exist_ok=True)
     if created_dir:
-        sys.stdout.write(f"Created directory: {_USER_ENV_DIR}\n")
+        sys.stdout.write(f"Created directory: {target_dir}\n")
 
     # Auto-generate secret keys
     for key in auto_generate_keys:
@@ -523,13 +542,13 @@ def _create_default_env(
             flags=re.MULTILINE,
         )
 
-    _USER_ENV_FILE.write_text(content)
-    _USER_ENV_FILE.chmod(0o600)
-    _load_dotenv_pruned(_USER_ENV_FILE)
+    target.write_text(content)
+    target.chmod(0o600)
+    _load_dotenv_pruned(target)
 
-    sys.stdout.write(f"Created env file: {_USER_ENV_FILE}\n")
+    sys.stdout.write(f"Created env file: {target}\n")
     if auto_generate_keys:
         sys.stdout.write(f"  Auto-generated: {', '.join(auto_generate_keys)}\n")
-    sys.stdout.write(f"  Edit {_USER_ENV_FILE} to add your API keys.\n\n")
+    sys.stdout.write(f"  Edit {target} to add your API keys.\n\n")
     sys.stdout.flush()
-    return _USER_ENV_FILE
+    return target

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -631,6 +631,14 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     def migrate(self) -> bool:
         self._migrate_feedback_schema()
         self._migrate_interactions_schema()
+        # Backfill columns that _DDL indexes depend on BEFORE running _DDL.
+        # _DDL builds idx_eval_identity_created_at_desc on
+        # agent_success_evaluation_result(user_id, ...). On a pre-existing DB that
+        # table predates user_id, so executescript(_DDL) raises "no such column:
+        # user_id" and migrate() never reaches the backfill below — leaving the DB
+        # permanently stuck. The helper is guarded (no-ops when the table is
+        # absent), so running it before _DDL is safe on fresh databases too.
+        self._migrate_eval_result_user_id()
         with self._lock:
             cur = self.conn.cursor()
             cur.executescript(_DDL)
@@ -649,7 +657,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_agent_playbook_source_windows()
         self._migrate_request_evaluation_only()
         self._migrate_request_session_id_required()
-        self._migrate_eval_result_user_id()
+        # _migrate_eval_result_user_id() runs before _DDL (see above).
         self._migrate_shadow_comparison_verdicts()
         self._migrate_user_playbook_polarity()
         self._migrate_lineage()

--- a/tests/cli/test_env_loader_mode.py
+++ b/tests/cli/test_env_loader_mode.py
@@ -59,7 +59,7 @@ def test_load_drops_blank_assignments(tmp_path, monkeypatch):
     # cache-in-repo-root bug class).
     env_file = tmp_path / ".env"
     env_file.write_text("BLANK=\nWS=   \nREAL=value\n")
-    monkeypatch.setattr(env_loader, "_ENV_SEARCH_PATHS", [env_file])
+    monkeypatch.setattr(env_loader, "_env_search_paths", lambda: [env_file])
     monkeypatch.delenv("BLANK", raising=False)
     monkeypatch.delenv("WS", raising=False)
     monkeypatch.delenv("REAL", raising=False)
@@ -74,7 +74,7 @@ def test_blank_assignment_does_not_clobber_process_env(tmp_path, monkeypatch):
     # file assignment of the same key.
     env_file = tmp_path / ".env"
     env_file.write_text("KEEP=\n")
-    monkeypatch.setattr(env_loader, "_ENV_SEARCH_PATHS", [env_file])
+    monkeypatch.setattr(env_loader, "_env_search_paths", lambda: [env_file])
     monkeypatch.setenv("KEEP", "real")
     env_loader.load_reflexio_env()
     assert os.environ["KEEP"] == "real"

--- a/tests/cli/test_env_loader_user_env_file.py
+++ b/tests/cli/test_env_loader_user_env_file.py
@@ -1,0 +1,64 @@
+"""Tests for the ``REFLEXIO_ENV_FILE`` override of the user-level .env path.
+
+Lets a second local backend keep its env separate from the OSS reflexio default
+under ``~/.reflexio`` (claude-smart points it at ``~/.claude-smart/.env``) while
+still sharing ``~/.reflexio/data``.
+"""
+
+import os
+
+from reflexio.cli import env_loader
+
+_ENV = "REFLEXIO_ENV_FILE"
+
+
+def test_user_env_file_defaults_when_unset(monkeypatch):
+    monkeypatch.delenv(_ENV, raising=False)
+    assert env_loader.user_env_file() == env_loader._USER_ENV_FILE
+    assert env_loader.get_env_path() == env_loader._USER_ENV_FILE
+
+
+def test_user_env_file_honors_override(monkeypatch, tmp_path):
+    target = tmp_path / "claude-smart" / ".env"
+    monkeypatch.setenv(_ENV, str(target))
+    assert env_loader.user_env_file() == target
+    assert env_loader.get_env_path() == target
+    # Search order: ./.env first, then the (overridden) user-level file.
+    assert env_loader._env_search_paths()[-1] == target
+
+
+def test_user_env_file_expands_user(monkeypatch):
+    monkeypatch.setenv(_ENV, "~/.claude-smart/.env")
+    assert env_loader.user_env_file() == (env_loader.Path.home() / ".claude-smart" / ".env")
+
+
+def test_blank_override_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(_ENV, "   ")
+    assert env_loader.user_env_file() == env_loader._USER_ENV_FILE
+
+
+def test_load_reflexio_env_prefers_override_file(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # no ./.env present
+    override = tmp_path / ".env.cs"
+    override.write_text("REFLEXIO_ENV_FILE_TEST_MARKER=present\n")
+    monkeypatch.setenv(_ENV, str(override))
+    monkeypatch.delenv("REFLEXIO_ENV_FILE_TEST_MARKER", raising=False)
+    try:
+        loaded = env_loader.load_reflexio_env()
+        assert loaded == override
+        assert os.environ.get("REFLEXIO_ENV_FILE_TEST_MARKER") == "present"
+    finally:
+        os.environ.pop("REFLEXIO_ENV_FILE_TEST_MARKER", None)
+
+
+def test_load_reflexio_env_auto_creates_at_override(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)  # no ./.env present
+    override = tmp_path / "claude-smart" / ".env"  # parent dir does not exist yet
+    monkeypatch.setenv(_ENV, str(override))
+    # Don't pull the freshly written template into the process env.
+    monkeypatch.setattr(env_loader, "_load_dotenv_pruned", lambda *_, **__: None)
+
+    created = env_loader.load_reflexio_env()
+
+    assert created == override
+    assert override.exists()  # parent dir + file created at the override location

--- a/tests/server/services/storage/sqlite_storage/test_eval_result_user_id_migration.py
+++ b/tests/server/services/storage/sqlite_storage/test_eval_result_user_id_migration.py
@@ -1,0 +1,91 @@
+"""Migration test: a pre-existing DB whose ``agent_success_evaluation_result``
+table predates the ``user_id`` column must still migrate cleanly.
+
+Regression for an ordering bug: ``_DDL`` builds
+``idx_eval_identity_created_at_desc`` on
+``agent_success_evaluation_result(user_id, ...)``, while the column is added by
+``_migrate_eval_result_user_id``. When that helper ran *after*
+``executescript(_DDL)``, an upgraded DB raised
+``sqlite3.OperationalError: no such column: user_id`` on every boot and never
+reached the backfill — leaving the DB permanently stuck. The helper now runs
+before ``_DDL``.
+"""
+
+import sqlite3
+
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+# Pre-``user_id`` schema for the eval-result table (and its old index, which did
+# not reference user_id). Mirrors the columns shipped before the per-user change.
+_LEGACY_EVAL_DDL = """
+CREATE TABLE agent_success_evaluation_result (
+    result_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    agent_version TEXT NOT NULL DEFAULT '',
+    evaluation_name TEXT NOT NULL DEFAULT '',
+    is_success INTEGER NOT NULL DEFAULT 0,
+    failure_type TEXT,
+    failure_reason TEXT,
+    created_at TEXT NOT NULL,
+    regular_vs_shadow TEXT NOT NULL DEFAULT 'regular',
+    embedding BLOB
+);
+CREATE INDEX idx_eval_identity_created_at_desc
+    ON agent_success_evaluation_result
+    (session_id, evaluation_name, agent_version, created_at DESC);
+"""
+
+
+def _seed_legacy_db(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.executescript(_LEGACY_EVAL_DDL)
+    conn.execute(
+        "INSERT INTO agent_success_evaluation_result "
+        "(result_id, session_id, evaluation_name, created_at) "
+        "VALUES ('r1', 's1', 'eval', '2026-01-01T00:00:00+00:00')"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _eval_columns(db_path: str) -> set[str]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            row[1]
+            for row in conn.execute(
+                "PRAGMA table_info(agent_success_evaluation_result)"
+            )
+        }
+    finally:
+        conn.close()
+
+
+def test_migrate_adds_user_id_on_legacy_eval_table(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _seed_legacy_db(db_path)
+
+    # Without the fix this raises OperationalError: no such column: user_id.
+    SQLiteStorage(org_id="0", db_path=db_path)  # construction triggers migrate()
+
+    cols = _eval_columns(db_path)
+    assert "user_id" in cols  # backfill ran
+    # Existing row preserved with the NOT NULL DEFAULT '' backfill value.
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT result_id, user_id FROM agent_success_evaluation_result"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [("r1", "")]
+
+
+def test_migrate_is_idempotent_on_legacy_eval_table(tmp_path):
+    db_path = str(tmp_path / "legacy.db")
+    _seed_legacy_db(db_path)
+
+    SQLiteStorage(org_id="0", db_path=db_path)
+    SQLiteStorage(org_id="0", db_path=db_path)  # second boot must not raise
+
+    assert "user_id" in _eval_columns(db_path)


### PR DESCRIPTION
## Summary

Two local-deployment improvements for the OSS server, enabling a second no-auth backend (e.g. a sidecar plugin) to coexist with the default reflexio on one machine:

- **`REFLEXIO_ENV_FILE` override** — `env_loader` now honors `REFLEXIO_ENV_FILE` to override the user-level `.env` path (default `~/.reflexio/.env`). A second local backend can keep its env separate; the data dir stays independent via `LOCAL_STORAGE_PATH`.
- **SQLite `migrate()` ordering fix** — a pre-existing DB whose `agent_success_evaluation_result` table predates the `user_id` column got stuck on every boot with `sqlite3.OperationalError: no such column: user_id`: `_DDL` builds `idx_eval_identity_created_at_desc` on `user_id` *before* `_migrate_eval_result_user_id()` adds the column, so `migrate()` never reached the backfill. The guarded backfill now runs before `_DDL` (a no-op on fresh DBs).

## Changes

- `reflexio/cli/env_loader.py` — `user_env_file()` / `get_env_path()` / `_env_search_paths()` / `_create_default_env()` resolve `REFLEXIO_ENV_FILE` at call time (blank/unset → `~/.reflexio/.env`).
- `reflexio/server/services/storage/sqlite_storage/_base.py` — reorder the guarded eval-result `user_id` backfill ahead of `executescript(_DDL)`.
- `.env.example` — document `REFLEXIO_DEFAULT_ORG_ID` (no-auth org override).
- Tests: `tests/cli/test_env_loader_user_env_file.py`, `tests/server/services/storage/sqlite_storage/test_eval_result_user_id_migration.py`.

## Test Plan

- New tests: env-file override (default / override / blank-fallback) and the migrate upgrade path (legacy table missing `user_id` → backfilled + idempotent).
- Existing env-loader, bootstrap-config, and sqlite-storage suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the local environment file location, making it easier to run separate local setups with different settings.
  * Documented a new optional default organization setting for local/no-auth mode.

* **Bug Fixes**
  * Improved environment file loading so blank values are ignored and existing settings are preserved.
  * Fixed a database migration issue that could block upgrades on older installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->