### PR TITLE
Fix gate regressions in learning provenance flows

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -124,6 +124,7 @@ from .cache import InMemoryCache
 class _ClientConfigPayload(Config):
     model_config = ConfigDict(extra="allow")
 
+
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -484,11 +484,18 @@ class ExtractionResumeWorker:
         raw_profiles = [
             profile.model_dump() for profile in result.output.profiles or []
         ]
+        source_interaction_ids = [
+            interaction.interaction_id
+            for request_model in request_interaction_data_models
+            for interaction in request_model.interactions
+            if interaction.interaction_id
+        ]
         return (
             extractor._convert_raw_to_user_profiles(
                 raw_profiles=raw_profiles,
                 user_id=run.binding.user_id,
                 request_id=run.binding.request_id,
+                source_interaction_ids=source_interaction_ids,
             ),
             result.pending_tool_call_ids,
         )
@@ -698,6 +705,7 @@ class ExtractionResumeWorker:
                 raw_profiles=raw_profiles,
                 user_id=run.binding.user_id,
                 request_id=run.binding.request_id,
+                source_interaction_ids=list(run.binding.source_interaction_ids),
             ),
             run.pending_tool_call_ids,
         )

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -979,6 +979,22 @@ class PlaybookAggregator:
             # Remove archived playbooks after successful aggregation. ALWAYS soft-supersede
             # (never hard-delete) so the removal is reconstructable from lineage — mirrors the
             # profile dedup always-soft path (#206).
+            archived_ids_without_overlapping_changed_cluster: set[int] = set()
+            if new_playbooks and prev_fingerprints:
+                archived_id_set = set(archived_playbook_ids)
+                for prev_fp, fp_data in prev_fingerprints.items():
+                    playbook_id = fp_data.get("agent_playbook_id")
+                    if (
+                        playbook_id in archived_id_set
+                        and prev_fp not in changed_fps_by_previous_fp
+                    ):
+                        archived_ids_without_overlapping_changed_cluster.add(
+                            playbook_id
+                        )
+            ids_to_supersede = {
+                *selective_supersede_playbook_ids,
+                *archived_ids_without_overlapping_changed_cluster,
+            }
             if not _run_id:
                 # Empty request_id makes the removal unreconstructable (lineage events are keyed
                 # on it). Fail loud and skip removal — never silently hard-delete.
@@ -996,9 +1012,9 @@ class PlaybookAggregator:
                                 agent_version=self.agent_version,
                                 request_id=_run_id,
                             )
-                    elif selective_supersede_playbook_ids:
+                    elif ids_to_supersede:
                         self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[reportOptionalMemberAccess]
-                            sorted(selective_supersede_playbook_ids),
+                            sorted(ids_to_supersede),
                             request_id=_run_id,
                         )
                     elif archived_playbook_ids:

--- a/reflexio/server/services/profile/components/extractor.py
+++ b/reflexio/server/services/profile/components/extractor.py
@@ -279,7 +279,7 @@ class ProfileExtractor:
         raw_profiles: list[dict],
         user_id: str,
         request_id: str,
-        source_interaction_ids: list[int],
+        source_interaction_ids: list[int] | None = None,
     ) -> list[UserProfile]:
         """
         Convert raw profile dicts from LLM to UserProfile objects.
@@ -294,6 +294,7 @@ class ProfileExtractor:
             List of UserProfile objects
         """
         new_profiles = []
+        profile_source_interaction_ids = list(source_interaction_ids or [])
         for profile_content in raw_profiles:
             if (
                 not isinstance(profile_content, dict)
@@ -322,7 +323,7 @@ class ProfileExtractor:
                 expiration_timestamp=calculate_expiration_timestamp(now_ts, ttl),
                 custom_features=custom_features or None,
                 extractor_names=None,
-                source_interaction_ids=source_interaction_ids,
+                source_interaction_ids=profile_source_interaction_ids,
             )
 
             new_profiles.append(added_profile)

--- a/tests/eval/extraction/providers.py
+++ b/tests/eval/extraction/providers.py
@@ -194,6 +194,11 @@ def make_extraction_provider(
             raw_profiles=raw_profiles,
             user_id=_EVAL_USER_ID,
             request_id=_EVAL_REQUEST_ID,
+            source_interaction_ids=[
+                interaction.interaction_id
+                for interaction in ridm.interactions
+                if interaction.interaction_id
+            ],
         )
         return (profiles, playbooks)
 

--- a/tests/server/services/extraction/test_pending_tool_call_dispatch.py
+++ b/tests/server/services/extraction/test_pending_tool_call_dispatch.py
@@ -181,7 +181,7 @@ def test_soft_cap_logs_but_still_accepts_human_request(storage, caplog):
 
 
 def test_attach_pending_info_request_links_existing_org_scoped_request(storage):
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     storage.create_agent_run(_agent_run("run_1", user_id="user_1"))
     scope = human_feedback_scope("org_1")
     pending = storage.create_pending_tool_call(
@@ -221,7 +221,7 @@ def test_attach_pending_info_request_links_existing_org_scoped_request(storage):
 def test_attach_pending_info_request_returns_resolved_result_without_dependency(
     storage,
 ):
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     storage.create_agent_run(_agent_run("run_1"))
     scope = human_feedback_scope("org_1")
     resolved = storage.create_pending_tool_call(

--- a/tests/server/services/extraction/test_prior_answer_search.py
+++ b/tests/server/services/extraction/test_prior_answer_search.py
@@ -33,7 +33,7 @@ class _ExtractorConfig:
 
 
 def test_append_prior_knowledge_context_adds_resolved_and_pending_entries(storage):
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     scope = human_feedback_scope("org_1")
     storage.create_pending_tool_call(
         PendingToolCallRecord(
@@ -115,7 +115,7 @@ def test_append_prior_knowledge_context_returns_original_messages_without_matche
 
 
 def test_append_prior_knowledge_context_filters_below_similarity_threshold(storage):
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     scope = human_feedback_scope("org_1")
     storage.create_pending_tool_call(
         PendingToolCallRecord(

--- a/tests/server/services/extraction/test_resumable_agent.py
+++ b/tests/server/services/extraction/test_resumable_agent.py
@@ -339,7 +339,7 @@ def test_resumable_agent_resume_injects_resolved_tool_result(
     run = storage.create_agent_run(_agent_run("run_resume"))
     question = "Which deployment standard should be treated as canonical?"
     scope = human_feedback_scope("org_1")
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     pending = storage.create_pending_tool_call(
         PendingToolCallRecord(
             id="ptc_resume",
@@ -434,7 +434,7 @@ def test_resumable_agent_resume_uses_persisted_step_budget(
             max_steps_remaining=1,
         )
     )
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     resolved = PendingToolCallRecord(
         id="ptc_budget",
         org_id="org_1",

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -114,7 +114,7 @@ def _seed_ready_run(storage: SQLiteStorage) -> None:
             generation_request_snapshot={"request_id": "request_1"},
         )
     )
-    now = datetime(2026, 5, 28, tzinfo=UTC)
+    now = datetime.now(UTC)
     question = "What is the deployment target?"
     scope = human_feedback_scope("org_1")
     storage.create_pending_tool_call(


### PR DESCRIPTION
## Summary
- propagate source interaction IDs through profile extraction resume paths and eval providers
- harden playbook aggregation supersede handling for null/current candidate edges
- make extraction resume tests use current UTC timestamps instead of stale fixed dates

## Verification
- `uv run ruff check --fix <changed OSS files>`
- `uv run ruff format <changed OSS files>`
- `uv run ruff check <changed OSS files>`
- `uv run pyright <changed OSS files>`
- Earlier full gate run before PR creation: Ruff, Pyright, Biome, tsc passed; OSS non-e2e `3667 passed, 70 skipped, 6 subtests passed`; OSS e2e `41 passed, 47 skipped`; enterprise `3311 passed, 47 skipped`; backend pipeline `9/9` phases and `17/17` checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume flows now preserve interaction history when rebuilding profiles, helping maintain more complete profile details after retries.
  * Archived playbooks are now superseded more consistently when their clusters no longer overlap with recent changes.

* **Bug Fixes**
  * Improved profile reconstruction so source interaction data is always handled safely, reducing missing metadata in generated profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->