### PR TITLE
feat: add governance RTBF local parity

### DIFF
--- a/reflexio/models/api_schema/domain/__init__.py
+++ b/reflexio/models/api_schema/domain/__init__.py
@@ -1,3 +1,4 @@
 from ..common import *  # noqa: F401, F403
 from .entities import *  # noqa: F401, F403
 from .enums import *  # noqa: F401, F403
+from .governance import *  # noqa: F401, F403

--- a/reflexio/models/api_schema/domain/governance.py
+++ b/reflexio/models/api_schema/domain/governance.py
@@ -53,7 +53,7 @@ class AuditEvent(BaseModel):
     entity_type: AuditEntityType
     entity_id: str | None = None
     subject_ref: str | None = None
-    request_ref: str | None = None
+    request_ref: str
     idempotency_key: str | None = None
     status: AuditStatus = "ok"
     detail: dict[str, Any] | None = None

--- a/reflexio/models/api_schema/domain/governance.py
+++ b/reflexio/models/api_schema/domain/governance.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+AuditActorType = Literal["api_token", "jwt", "system"]
+AuditOperation = Literal["READ", "EXPORT", "ERASE", "CREATE", "UPDATE", "DELETE"]
+AuditEntityType = Literal[
+    "profile",
+    "user_playbook",
+    "agent_playbook",
+    "interaction",
+    "request",
+    "session",
+    "agent_success_evaluation_result",
+    "playbook_retrieval_log",
+    "org",
+]
+AuditStatus = Literal["ok", "error"]
+PurgeOperationType = Literal["user_erasure", "org_purge"]
+PurgeScopeType = Literal["user", "org"]
+PurgeStatus = Literal["pending", "running", "failed", "complete"]
+PurgeTargetStatus = Literal["pending", "running", "failed", "complete"]
+
+__all__ = [
+    "AuditActorType",
+    "AuditOperation",
+    "AuditEntityType",
+    "AuditStatus",
+    "PurgeOperationType",
+    "PurgeScopeType",
+    "PurgeStatus",
+    "PurgeTargetStatus",
+    "AuditEvent",
+    "PurgeOperation",
+    "PurgeOperationTarget",
+    "UserExportResult",
+    "UserEraseResult",
+]
+
+
+def _now_epoch() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+class AuditEvent(BaseModel):
+    org_id: str
+    actor_type: AuditActorType = "system"
+    actor_ref: str | None = None
+    operation: AuditOperation
+    entity_type: AuditEntityType
+    entity_id: str | None = None
+    subject_ref: str | None = None
+    request_ref: str | None = None
+    idempotency_key: str | None = None
+    status: AuditStatus = "ok"
+    detail: dict[str, Any] | None = None
+    created_at: int = Field(default_factory=_now_epoch)
+
+
+class PurgeOperation(BaseModel):
+    purge_id: str
+    org_id: str
+    operation_type: PurgeOperationType
+    scope_type: PurgeScopeType
+    subject_ref: str | None = None
+    request_ref: str
+    idempotency_key: str
+    status: PurgeStatus = "pending"
+    error_code: str | None = None
+    error_detail: str | None = None
+    created_at: int = Field(default_factory=_now_epoch)
+    updated_at: int = Field(default_factory=_now_epoch)
+    completed_at: int | None = None
+
+
+class PurgeOperationTarget(BaseModel):
+    purge_id: str
+    target_name: str
+    target_ref: str = ""
+    phase: str
+    status: PurgeTargetStatus = "pending"
+    detail: dict[str, Any] | None = None
+    deleted_count: int = 0
+    error_detail: str | None = None
+    started_at: int | None = None
+    completed_at: int | None = None
+
+
+class UserExportResult(BaseModel):
+    subject_ref: str
+    export_id: str
+    bundle: dict[str, Any]
+
+
+class UserEraseResult(BaseModel):
+    subject_ref: str
+    purge_id: str
+    status: PurgeStatus
+    deleted_counts: dict[str, int] = Field(default_factory=dict)
+    rebuilt_agent_playbook_ids: list[int] = Field(default_factory=list)

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -708,6 +708,14 @@ class LineageGCConfig(BaseModel):
     poll_interval_seconds: int = Field(default=86400, gt=0)
 
 
+class GovernanceRetentionConfig(BaseModel):
+    purge_expired_profiles_enabled: bool = False
+    row_count_retention_enabled: bool = False
+    audit_events_retention_enabled: bool = False
+    audit_events_retention_days: int = Field(default=365, gt=0)
+    audit_events_delete_batch_limit: int = Field(default=500, gt=0)
+
+
 @dataclass(frozen=True)
 class EffectivePendingToolCallConfig:
     """Resolved pending-tool-call settings after applying tool overrides."""
@@ -847,6 +855,9 @@ class Config(BaseModel):
     )
     # Tombstone GC job gate (opt-in, off by default — see LineageGCConfig)
     lineage_gc: LineageGCConfig = Field(default_factory=LineageGCConfig)
+    governance_retention: GovernanceRetentionConfig = Field(
+        default_factory=GovernanceRetentionConfig
+    )
     # Optional non-blocking async information tools for classic extraction.
     pending_tool_call_config: PendingToolCallConfig = Field(
         default_factory=PendingToolCallConfig
@@ -905,6 +916,7 @@ class Config(BaseModel):
                 "reflection_config",
                 "playbook_optimizer_config",
                 "lineage_gc",
+                "governance_retention",
                 "pending_tool_call_config",
                 "retrieval_floor",
             ):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -709,8 +709,6 @@ class LineageGCConfig(BaseModel):
 
 
 class GovernanceRetentionConfig(BaseModel):
-    purge_expired_profiles_enabled: bool = False
-    row_count_retention_enabled: bool = False
     audit_events_retention_enabled: bool = False
     audit_events_retention_days: int = Field(default=365, gt=0)
     audit_events_delete_batch_limit: int = Field(default=500, gt=0)

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from typing import Any
+
+from reflexio.models.api_schema.domain.governance import (
+    AuditEvent,
+    PurgeOperationTarget,
+    UserEraseResult,
+    UserExportResult,
+)
+from reflexio.server.services.governance.subject_refs import (
+    request_ref,
+    stable_id,
+    subject_ref,
+)
+
+_DELETE_TARGET_NAME_TO_RESULT_KEY = {
+    "interaction": "interactions",
+    "user_playbook": "user_playbooks",
+    "profile": "profiles",
+    "request": "requests",
+    "profile_purge": "purged_profiles",
+    "user_playbook_purge": "purged_user_playbooks",
+}
+_REQUIRED_DELETE_TARGET_NAMES = tuple(_DELETE_TARGET_NAME_TO_RESULT_KEY)
+
+
+class GovernanceService:
+    def __init__(self, *, storage: Any, org_id: str, ref_secret: str) -> None:
+        self.storage = storage
+        self.org_id = org_id
+        self.ref_secret = ref_secret
+
+    def export_user(self, *, user_id: str, request_id: str) -> UserExportResult:
+        subref = subject_ref(user_id, self.ref_secret)
+        reqref = request_ref(request_id, self.ref_secret)
+        export_id = stable_id("export", f"{self.org_id}:export:{subref}:{reqref}")
+        requests, sessions = self._load_user_requests_and_sessions(user_id)
+        bundle: dict[str, Any] = {
+            "profiles": [
+                profile.model_dump() for profile in self.storage.get_user_profile(user_id)
+            ],
+            "interactions": [
+                interaction.model_dump()
+                for interaction in self.storage.get_user_interaction(user_id)
+            ],
+            "requests": [request.model_dump() for request in requests],
+            "sessions": sessions,
+            "user_playbooks": [
+                playbook.model_dump()
+                for playbook in self.storage.get_user_playbooks(
+                    user_id=user_id,
+                    limit=1_000_000,
+                )
+            ],
+        }
+        self.storage.append_audit_event(
+            AuditEvent(
+                org_id=self.org_id,
+                operation="EXPORT",
+                entity_type="request",
+                subject_ref=subref,
+                request_ref=reqref,
+                idempotency_key=export_id,
+                detail={"count": sum(len(items) for items in bundle.values())},
+            )
+        )
+        return UserExportResult(subject_ref=subref, export_id=export_id, bundle=bundle)
+
+    def erase_user(self, *, user_id: str, request_id: str) -> UserEraseResult:
+        subref = subject_ref(user_id, self.ref_secret)
+        reqref = request_ref(request_id, self.ref_secret)
+        idempotency_key = stable_id(
+            "idem",
+            f"{self.org_id}:user_erasure:{subref}:{reqref}",
+        )
+        purge_id = stable_id("purge", idempotency_key)
+        purge = self.storage.begin_purge_operation(
+            purge_id=purge_id,
+            idempotency_key=idempotency_key,
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=subref,
+            request_ref=reqref,
+        )
+        if purge.status == "complete":
+            return UserEraseResult(subject_ref=subref, purge_id=purge_id, status="complete")
+
+        if not self.storage.purge_targets_prepared(purge_id):
+            owned_user_playbook_ids = {
+                int(playbook.user_playbook_id)
+                for playbook in self.storage.get_user_playbooks(
+                    user_id=user_id,
+                    limit=1_000_000,
+                )
+                if playbook.user_playbook_id
+            }
+            self.storage.prepare_governance_erase_targets(
+                purge_id,
+                user_id,
+                owned_user_playbook_ids,
+            )
+
+        self.storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+        if not self._delete_targets_complete(purge_id):
+            self.storage.apply_governance_user_data_delete(purge_id, user_id)
+        deleted_counts = self._deleted_counts_from_targets(purge_id)
+
+        rebuilt_agent_playbook_ids = self._rebuild_agent_playbooks(purge_id)
+        completed = self.storage.complete_purge_operation_with_audit(
+            purge_id,
+            AuditEvent(
+                org_id=self.org_id,
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=subref,
+                request_ref=reqref,
+                idempotency_key=purge_id,
+                detail={
+                    "deleted_counts": deleted_counts,
+                    "rebuilt_agent_playbook_ids": rebuilt_agent_playbook_ids,
+                },
+            ),
+        )
+        return UserEraseResult(
+            subject_ref=subref,
+            purge_id=purge_id,
+            status=completed.status,
+            deleted_counts=deleted_counts,
+            rebuilt_agent_playbook_ids=rebuilt_agent_playbook_ids,
+        )
+
+    def _load_user_requests_and_sessions(self, user_id: str) -> tuple[list[Any], list[dict[str, Any]]]:
+        requests: list[Any] = []
+        sessions_by_id: dict[str, list[str]] = {}
+        offset = 0
+        page_size = 1000
+
+        while True:
+            grouped_sessions = self.storage.get_sessions(
+                user_id=user_id,
+                top_k=page_size,
+                offset=offset,
+            )
+            page_count = 0
+            for session_id, rows in grouped_sessions.items():
+                request_ids = sessions_by_id.setdefault(session_id, [])
+                for row in rows:
+                    if row.request is None:
+                        continue
+                    requests.append(row.request)
+                    request_ids.append(row.request.request_id)
+                    page_count += 1
+            if page_count < page_size:
+                break
+            offset += page_size
+
+        sessions = [
+            {"session_id": session_id, "request_ids": request_ids}
+            for session_id, request_ids in sessions_by_id.items()
+        ]
+        return requests, sessions
+
+    def _delete_targets_complete(self, purge_id: str) -> bool:
+        delete_targets = {
+            target.target_name: target
+            for target in self.storage.list_purge_targets(purge_id, phase="delete")
+        }
+        return all(
+            delete_targets.get(target_name) is not None
+            and delete_targets[target_name].status == "complete"
+            for target_name in _REQUIRED_DELETE_TARGET_NAMES
+        )
+
+    def _deleted_counts_from_targets(self, purge_id: str) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for target in self.storage.list_purge_targets(purge_id, phase="delete"):
+            result_key = _DELETE_TARGET_NAME_TO_RESULT_KEY.get(target.target_name)
+            if result_key is None:
+                continue
+            counts[result_key] = int(target.deleted_count)
+        return counts
+
+    def _rebuild_agent_playbooks(self, purge_id: str) -> list[int]:
+        rebuilt_ids: list[int] = []
+        for target in self.storage.list_purge_targets(
+            purge_id,
+            phase="rebuild_without_erased_sources",
+        ):
+            if target.target_name != "agent_playbook" or not target.target_ref:
+                continue
+            agent_playbook_id = int(target.target_ref)
+            if target.status == "complete":
+                rebuilt_ids.append(agent_playbook_id)
+                continue
+            remaining_source_windows = self._remaining_source_windows(target)
+            rebuild_fields = self._build_rebuilt_agent_playbook_fields(
+                remaining_source_windows
+            )
+            self.storage.apply_governance_agent_playbook_rebuild(
+                purge_id=purge_id,
+                agent_playbook_id=agent_playbook_id,
+                remaining_source_windows=remaining_source_windows,
+                content=rebuild_fields["content"],
+                trigger=rebuild_fields["trigger"],
+                rationale=rebuild_fields["rationale"],
+                blocking_issue=rebuild_fields["blocking_issue"],
+                expanded_terms=rebuild_fields["expanded_terms"],
+                tags=rebuild_fields["tags"],
+            )
+            rebuilt_ids.append(agent_playbook_id)
+        return rebuilt_ids
+
+    def _remaining_source_windows(
+        self,
+        target: PurgeOperationTarget,
+    ) -> list[dict[str, object]]:
+        detail = target.detail or {}
+        remaining = detail.get("remaining_source_windows", [])
+        if not isinstance(remaining, list):
+            raise ValueError("remaining_source_windows must be a list")
+        return remaining
+
+    def _build_rebuilt_agent_playbook_fields(
+        self,
+        remaining_source_windows: list[dict[str, object]],
+    ) -> dict[str, Any]:
+        user_playbook_ids: list[int] = []
+        for window in remaining_source_windows:
+            raw_user_playbook_id = window.get("user_playbook_id")
+            if isinstance(raw_user_playbook_id, int):
+                user_playbook_ids.append(raw_user_playbook_id)
+        playbooks_by_id = {
+            playbook.user_playbook_id: playbook
+            for playbook in self.storage.get_user_playbooks_by_ids_any_user(
+                user_playbook_ids
+            )
+            if playbook.user_playbook_id
+        }
+        remaining_playbooks = [
+            playbooks_by_id[user_playbook_id]
+            for user_playbook_id in user_playbook_ids
+            if user_playbook_id in playbooks_by_id
+        ]
+        return {
+            "content": self._join_non_empty_strings(
+                playbook.content for playbook in remaining_playbooks
+            ),
+            "trigger": self._join_non_empty_strings(
+                playbook.trigger for playbook in remaining_playbooks
+            ),
+            "rationale": self._join_non_empty_strings(
+                playbook.rationale for playbook in remaining_playbooks
+            ),
+            "blocking_issue": next(
+                (
+                    playbook.blocking_issue.model_dump()
+                    for playbook in remaining_playbooks
+                    if playbook.blocking_issue is not None
+                ),
+                None,
+            ),
+            "expanded_terms": self._join_non_empty_strings(
+                playbook.expanded_terms for playbook in remaining_playbooks
+            ),
+            "tags": self._merge_tags(remaining_playbooks),
+        }
+
+    def _join_non_empty_strings(self, values: Any) -> str | None:
+        joined = "\n".join(value for value in values if value)
+        return joined or None
+
+    def _merge_tags(self, playbooks: list[Any]) -> list[str] | None:
+        merged_tags: list[str] = []
+        for playbook in playbooks:
+            for tag in playbook.tags or []:
+                if tag not in merged_tags:
+                    merged_tags.append(tag)
+        return merged_tags or None

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -90,15 +90,9 @@ class GovernanceService:
 
         try:
             if not self.storage.purge_targets_prepared(purge_id):
-                owned_user_playbook_ids = {
-                    int(playbook.user_playbook_id)
-                    for playbook in self._iter_user_playbooks(user_id)
-                    if playbook.user_playbook_id
-                }
                 self.storage.prepare_governance_erase_targets(
                     purge_id,
                     user_id,
-                    owned_user_playbook_ids,
                 )
 
             self.storage.hide_governance_agent_playbooks_for_rebuild(purge_id)

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -19,6 +19,7 @@ _DELETE_TARGET_NAME_TO_RESULT_KEY = {
     "user_playbook": "user_playbooks",
     "profile": "profiles",
     "request": "requests",
+    "agent_success_evaluation_result": "agent_success_evaluation_results",
     "profile_purge": "purged_profiles",
     "user_playbook_purge": "purged_user_playbooks",
 }
@@ -38,7 +39,8 @@ class GovernanceService:
         requests, sessions = self._load_user_requests_and_sessions(user_id)
         bundle: dict[str, Any] = {
             "profiles": [
-                profile.model_dump() for profile in self.storage.get_user_profile(user_id)
+                profile.model_dump()
+                for profile in self.storage.get_user_profile(user_id)
             ],
             "interactions": [
                 interaction.model_dump()
@@ -84,7 +86,9 @@ class GovernanceService:
             request_ref=reqref,
         )
         if purge.status == "complete":
-            return UserEraseResult(subject_ref=subref, purge_id=purge_id, status="complete")
+            return UserEraseResult(
+                subject_ref=subref, purge_id=purge_id, status="complete"
+            )
 
         if not self.storage.purge_targets_prepared(purge_id):
             owned_user_playbook_ids = {
@@ -131,7 +135,9 @@ class GovernanceService:
             rebuilt_agent_playbook_ids=rebuilt_agent_playbook_ids,
         )
 
-    def _load_user_requests_and_sessions(self, user_id: str) -> tuple[list[Any], list[dict[str, Any]]]:
+    def _load_user_requests_and_sessions(
+        self, user_id: str
+    ) -> tuple[list[Any], list[dict[str, Any]]]:
         requests: list[Any] = []
         sessions_by_id: dict[str, list[str]] = {}
         offset = 0

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import Any
 
 from reflexio.models.api_schema.domain.governance import (
@@ -24,6 +25,7 @@ _DELETE_TARGET_NAME_TO_RESULT_KEY = {
     "user_playbook_purge": "purged_user_playbooks",
 }
 _REQUIRED_DELETE_TARGET_NAMES = tuple(_DELETE_TARGET_NAME_TO_RESULT_KEY)
+_USER_PLAYBOOK_PAGE_SIZE = 1000
 
 
 class GovernanceService:
@@ -49,11 +51,7 @@ class GovernanceService:
             "requests": [request.model_dump() for request in requests],
             "sessions": sessions,
             "user_playbooks": [
-                playbook.model_dump()
-                for playbook in self.storage.get_user_playbooks(
-                    user_id=user_id,
-                    limit=1_000_000,
-                )
+                playbook.model_dump() for playbook in self._iter_user_playbooks(user_id)
             ],
         }
         self.storage.append_audit_event(
@@ -90,43 +88,49 @@ class GovernanceService:
                 subject_ref=subref, purge_id=purge_id, status="complete"
             )
 
-        if not self.storage.purge_targets_prepared(purge_id):
-            owned_user_playbook_ids = {
-                int(playbook.user_playbook_id)
-                for playbook in self.storage.get_user_playbooks(
-                    user_id=user_id,
-                    limit=1_000_000,
+        try:
+            if not self.storage.purge_targets_prepared(purge_id):
+                owned_user_playbook_ids = {
+                    int(playbook.user_playbook_id)
+                    for playbook in self._iter_user_playbooks(user_id)
+                    if playbook.user_playbook_id
+                }
+                self.storage.prepare_governance_erase_targets(
+                    purge_id,
+                    user_id,
+                    owned_user_playbook_ids,
                 )
-                if playbook.user_playbook_id
-            }
-            self.storage.prepare_governance_erase_targets(
+
+            self.storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+            if not self._delete_targets_complete(purge_id):
+                self.storage.apply_governance_user_data_delete(purge_id, user_id)
+            deleted_counts = self._deleted_counts_from_targets(purge_id)
+
+            rebuilt_agent_playbook_ids = self._rebuild_agent_playbooks(purge_id)
+            completed = self.storage.complete_purge_operation_with_audit(
                 purge_id,
-                user_id,
-                owned_user_playbook_ids,
+                AuditEvent(
+                    org_id=self.org_id,
+                    operation="ERASE",
+                    entity_type="request",
+                    subject_ref=subref,
+                    request_ref=reqref,
+                    idempotency_key=purge_id,
+                    detail={
+                        "deleted_counts": deleted_counts,
+                        "rebuilt_agent_playbook_ids": rebuilt_agent_playbook_ids,
+                    },
+                ),
             )
-
-        self.storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
-
-        if not self._delete_targets_complete(purge_id):
-            self.storage.apply_governance_user_data_delete(purge_id, user_id)
-        deleted_counts = self._deleted_counts_from_targets(purge_id)
-
-        rebuilt_agent_playbook_ids = self._rebuild_agent_playbooks(purge_id)
-        completed = self.storage.complete_purge_operation_with_audit(
-            purge_id,
-            AuditEvent(
-                org_id=self.org_id,
-                operation="ERASE",
-                entity_type="request",
-                subject_ref=subref,
-                request_ref=reqref,
-                idempotency_key=purge_id,
-                detail={
-                    "deleted_counts": deleted_counts,
-                    "rebuilt_agent_playbook_ids": rebuilt_agent_playbook_ids,
-                },
-            ),
-        )
+        except Exception as exc:
+            with suppress(Exception):
+                self.storage.fail_purge_operation(
+                    purge_id,
+                    error_code="governance_erase_failed",
+                    error_detail=type(exc).__name__,
+                )
+            raise
         return UserEraseResult(
             subject_ref=subref,
             purge_id=purge_id,
@@ -149,16 +153,16 @@ class GovernanceService:
                 top_k=page_size,
                 offset=offset,
             )
-            page_count = 0
+            returned_rows = 0
             for session_id, rows in grouped_sessions.items():
+                returned_rows += len(rows)
                 request_ids = sessions_by_id.setdefault(session_id, [])
                 for row in rows:
                     if row.request is None:
                         continue
                     requests.append(row.request)
                     request_ids.append(row.request.request_id)
-                    page_count += 1
-            if page_count < page_size:
+            if returned_rows < page_size:
                 break
             offset += page_size
 
@@ -167,6 +171,21 @@ class GovernanceService:
             for session_id, request_ids in sessions_by_id.items()
         ]
         return requests, sessions
+
+    def _iter_user_playbooks(self, user_id: str) -> list[Any]:
+        playbooks: list[Any] = []
+        offset = 0
+        while True:
+            page = self.storage.get_user_playbooks(
+                user_id=user_id,
+                limit=_USER_PLAYBOOK_PAGE_SIZE,
+                offset=offset,
+            )
+            playbooks.extend(page)
+            if len(page) < _USER_PLAYBOOK_PAGE_SIZE:
+                break
+            offset += _USER_PLAYBOOK_PAGE_SIZE
+        return playbooks
 
     def _delete_targets_complete(self, purge_id: str) -> bool:
         delete_targets = {

--- a/reflexio/server/services/governance/subject_refs.py
+++ b/reflexio/server/services/governance/subject_refs.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+
+def _hmac_ref(prefix: str, raw: str, secret: str) -> str:
+    if not raw:
+        raise ValueError("raw value must be non-empty")
+    if not secret:
+        raise ValueError("secret must be non-empty")
+    digest = hmac.new(secret.encode(), raw.encode(), hashlib.sha256).hexdigest()[:32]
+    return f"{prefix}_v1_{digest}"
+
+
+def subject_ref(raw: str, secret: str) -> str:
+    return _hmac_ref("subref", raw, secret)
+
+
+def actor_ref(raw: str, secret: str) -> str:
+    return _hmac_ref("actref", raw, secret)
+
+
+def request_ref(raw: str, secret: str) -> str:
+    return _hmac_ref("reqref", raw, secret)
+
+
+def stable_id(prefix: str, material: str) -> str:
+    if not prefix:
+        raise ValueError("prefix must be non-empty")
+    if not material:
+        raise ValueError("material must be non-empty")
+    digest = hashlib.sha256(material.encode()).hexdigest()[:32]
+    return f"{prefix}_{digest}"

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -34,11 +34,7 @@ _ENTITY_TYPES = ("user_playbook", "agent_playbook", "profile")
 def _is_governance_retention_enabled(
     governance_retention: GovernanceRetentionConfig,
 ) -> bool:
-    return (
-        governance_retention.purge_expired_profiles_enabled
-        or governance_retention.row_count_retention_enabled
-        or governance_retention.audit_events_retention_enabled
-    )
+    return governance_retention.audit_events_retention_enabled
 
 
 class LineageGCScheduler:

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -14,6 +14,7 @@ import threading
 import time
 from collections.abc import Callable
 
+from reflexio.models.config_schema import GovernanceRetentionConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.tracing import capture_anomaly
 
@@ -27,6 +28,16 @@ _MIN_POLL_SECONDS = 1
 _HIGH_VOLUME_THRESHOLD = 1000
 
 _ENTITY_TYPES = ("user_playbook", "agent_playbook", "profile")
+
+
+def _is_governance_retention_enabled(
+    governance_retention: GovernanceRetentionConfig,
+) -> bool:
+    return (
+        governance_retention.purge_expired_profiles_enabled
+        or governance_retention.row_count_retention_enabled
+        or governance_retention.audit_events_retention_enabled
+    )
 
 
 class LineageGCScheduler:
@@ -97,21 +108,31 @@ class LineageGCScheduler:
             try:
                 ctx = self.request_context_factory(org_id)
                 cfg = ctx.configurator.get_config()
-                if not cfg.lineage_gc.enabled:
-                    continue
                 if ctx.storage is None:
                     continue
-                older_than_epoch = (
-                    int(time.time())
-                    - cfg.lineage_gc.tombstone_grace_window_days * 86400
+                run_tombstone_gc = cfg.lineage_gc.enabled
+                run_governance_gc = _is_governance_retention_enabled(
+                    cfg.governance_retention
                 )
+                if not run_tombstone_gc and not run_governance_gc:
+                    continue
+
                 total_deleted = 0
-                for entity_type in _ENTITY_TYPES:
-                    count = ctx.storage.gc_expired_tombstones(
-                        entity_type=entity_type,
-                        older_than_epoch=older_than_epoch,
+                if run_tombstone_gc:
+                    older_than_epoch = (
+                        int(time.time())
+                        - cfg.lineage_gc.tombstone_grace_window_days * 86400
                     )
-                    total_deleted += count
+                    for entity_type in _ENTITY_TYPES:
+                        count = ctx.storage.gc_expired_tombstones(
+                            entity_type=entity_type,
+                            older_than_epoch=older_than_epoch,
+                        )
+                        total_deleted += count
+                if run_governance_gc:
+                    total_deleted += ctx.storage.gc_governance_retention(
+                        config=cfg.governance_retention
+                    )
                 if total_deleted:
                     logger.info(
                         "event=lineage_gc_tick org_id=%s deleted=%d",

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -112,8 +112,11 @@ class LineageGCScheduler:
                 if ctx.storage is None:
                     continue
                 run_tombstone_gc = cfg.lineage_gc.enabled
+                governance_retention = getattr(
+                    cfg, "governance_retention", GovernanceRetentionConfig()
+                )
                 run_governance_gc = _is_governance_retention_enabled(
-                    cfg.governance_retention
+                    governance_retention
                 )
                 if not run_tombstone_gc and not run_governance_gc:
                     continue
@@ -133,7 +136,7 @@ class LineageGCScheduler:
                 governance_deleted = 0
                 if run_governance_gc:
                     governance_deleted = ctx.storage.gc_governance_retention(
-                        config=cfg.governance_retention
+                        config=governance_retention
                     )
                 total_deleted = tombstone_deleted + governance_deleted
                 if total_deleted:
@@ -205,8 +208,11 @@ def maybe_start_lineage_gc(
     try:
         ctx = request_context_factory(bootstrap_org_id)
         cfg = ctx.configurator.get_config()
+        governance_retention = getattr(
+            cfg, "governance_retention", GovernanceRetentionConfig()
+        )
         if not cfg.lineage_gc.enabled and not _is_governance_retention_enabled(
-            cfg.governance_retention
+            governance_retention
         ):
             return None
     except Exception as exc:

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -1,10 +1,10 @@
-"""Process-local scheduler for lineage tombstone garbage collection.
+"""Process-local scheduler for lineage cleanup.
 
-The scheduler is per-org and config-gated: each tick it discovers every org,
-reads that org's ``lineage_gc`` config, and — if enabled — hard-deletes
-tombstone rows older than the configured grace window.  One org's failure
-never stalls the loop; errors are captured as Sentry anomalies and the
-scheduler continues to the next org.
+Startup is bootstrap-config-gated. Each tick then evaluates every org
+independently, running tombstone GC from ``lineage_gc`` and governance
+retention GC from ``governance_retention`` according to that org's config.
+One org's failure never stalls the loop; errors are captured as Sentry
+anomalies and the scheduler continues to the next org.
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ _MIN_POLL_SECONDS = 1
 
 # Window-misconfiguration tripwire: if a single tick deletes more than this
 # many tombstones for one org, something is likely wrong with the grace window.
+# Governance retention uses separate policy knobs and must not trigger this.
 _HIGH_VOLUME_THRESHOLD = 1000
 
 _ENTITY_TYPES = ("user_playbook", "agent_playbook", "profile")
@@ -41,7 +42,7 @@ def _is_governance_retention_enabled(
 
 
 class LineageGCScheduler:
-    """Polling daemon that garbage-collects expired lineage tombstones per org."""
+    """Polling daemon that runs tombstone GC and governance retention per org."""
 
     def __init__(
         self,
@@ -117,7 +118,7 @@ class LineageGCScheduler:
                 if not run_tombstone_gc and not run_governance_gc:
                     continue
 
-                total_deleted = 0
+                tombstone_deleted = 0
                 if run_tombstone_gc:
                     older_than_epoch = (
                         int(time.time())
@@ -128,22 +129,29 @@ class LineageGCScheduler:
                             entity_type=entity_type,
                             older_than_epoch=older_than_epoch,
                         )
-                        total_deleted += count
+                        tombstone_deleted += count
+                governance_deleted = 0
                 if run_governance_gc:
-                    total_deleted += ctx.storage.gc_governance_retention(
+                    governance_deleted = ctx.storage.gc_governance_retention(
                         config=cfg.governance_retention
                     )
+                total_deleted = tombstone_deleted + governance_deleted
                 if total_deleted:
                     logger.info(
-                        "event=lineage_gc_tick org_id=%s deleted=%d",
+                        (
+                            "event=lineage_gc_tick org_id=%s deleted=%d "
+                            "tombstone_deleted=%d governance_deleted=%d"
+                        ),
                         org_id,
                         total_deleted,
+                        tombstone_deleted,
+                        governance_deleted,
                     )
-                if total_deleted > _HIGH_VOLUME_THRESHOLD:
+                if tombstone_deleted > _HIGH_VOLUME_THRESHOLD:
                     capture_anomaly(
                         "lineage.gc.high_volume",
                         org_id=org_id,
-                        count=total_deleted,
+                        count=tombstone_deleted,
                     )
             except Exception:
                 capture_anomaly("lineage.gc.run_failed", org_id=org_id)
@@ -168,10 +176,11 @@ def maybe_start_lineage_gc(
     *,
     bootstrap_org_id: str,
 ) -> LineageGCScheduler | None:
-    """Start the GC scheduler only when the bootstrap-org config enables it.
+    """Start the scheduler only when bootstrap config enables some GC work.
 
-    Off by default. Enablement criteria (must ALL hold before enabling for a
-    production org):
+    Off by default. Startup requires bootstrap-org config to enable tombstone GC
+    or any governance retention gate. Tombstone-GC enablement criteria (must
+    ALL hold before enabling for a production org):
 
     1. **Mechanism**: GC ages tombstones by ``retired_at`` (the INTEGER epoch
        written at every tombstone write-path).  Rows with ``retired_at = NULL``
@@ -196,7 +205,9 @@ def maybe_start_lineage_gc(
     try:
         ctx = request_context_factory(bootstrap_org_id)
         cfg = ctx.configurator.get_config()
-        if not cfg.lineage_gc.enabled:
+        if not cfg.lineage_gc.enabled and not _is_governance_retention_enabled(
+            cfg.governance_retention
+        ):
             return None
     except Exception as exc:
         logger.warning(

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -8,6 +8,7 @@ from ._base import (
     _vector_rank_rows,
 )
 from ._extras import ExtrasMixin
+from ._governance import SQLiteGovernanceMixin
 from ._lineage import SQLiteLineageMixin
 from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
@@ -32,6 +33,7 @@ class SQLiteStorage(
     ProfileMixin,
     RequestMixin,
     PlaybookMixin,
+    SQLiteGovernanceMixin,
     SQLiteLineageMixin,
     OperationMixin,
     ExtrasMixin,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -62,6 +62,7 @@ from reflexio.server.services.storage.retention_mixin import (
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.site_var.site_var_manager import SiteVarManager
 
+from ._governance import init_governance_tables
 from ._stall_state import init_stall_state_table
 
 logger = logging.getLogger(__name__)
@@ -642,6 +643,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         with self._lock:
             cur = self.conn.cursor()
             cur.executescript(_DDL)
+            init_governance_tables(self.conn)
             self.conn.commit()
         if self._has_sqlite_vec:
             self._create_vec_tables()

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1444,6 +1444,8 @@ class SQLiteGovernanceMixin:
     ) -> None:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
         with self._lock:
+            if self.purge_targets_prepared(purge_id):
+                return
             try:
                 self.conn.execute("BEGIN")
                 targets = self._planned_governance_delete_counts(

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -117,6 +117,7 @@ _ALLOWED_DETAIL_KEYS = frozenset(
         "affected_agent_playbook_ids",
         "agent_playbook_id",
         "count",
+        "deleted_counts",
         "deleted_count",
         "erased_source_ids",
         "owned_user_playbook_ids",
@@ -177,6 +178,16 @@ _ALLOWED_ENUM_LIKE_VALUES = frozenset(
         "rebuild",
         "rebuild_without_erased_sources",
         "running",
+    }
+)
+_ALLOWED_DELETED_COUNTS_KEYS = frozenset(
+    {
+        "interactions",
+        "user_playbooks",
+        "profiles",
+        "requests",
+        "purged_profiles",
+        "purged_user_playbooks",
     }
 )
 
@@ -309,6 +320,20 @@ def _validate_governance_int_list(field_name: str, value: Any) -> None:
         _validate_governance_int(field_name, item)
 
 
+def _validate_governance_deleted_counts(
+    field_name: str, value: Any
+) -> dict[str, int]:
+    if not isinstance(value, dict):
+        _raise_governance_validation_error(field_name, "expected dict[str, int]")
+    normalized_counts: dict[str, int] = {}
+    for raw_key, raw_value in value.items():
+        key = str(raw_key).strip()
+        if key not in _ALLOWED_DELETED_COUNTS_KEYS:
+            _raise_governance_validation_error(field_name, key)
+        normalized_counts[key] = _validate_governance_deleted_count(raw_value)
+    return normalized_counts
+
+
 def _normalize_governance_window_item(
     field_name: str, index: int, item: object
 ) -> dict[str, Any]:
@@ -397,6 +422,9 @@ def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> 
         _raise_governance_validation_error(field_name, key)
     if key in {"count", "deleted_count", "agent_playbook_id", "user_playbook_id"}:
         _validate_governance_int(field_name, value)
+        return
+    if key == "deleted_counts":
+        _validate_governance_deleted_counts(field_name, value)
         return
     if key in {
         "affected_agent_playbook_ids",
@@ -938,103 +966,116 @@ class SQLiteGovernanceMixin:
         self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
     ) -> None:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
-        deps = self._deps()
-        request_row = deps._fetchone(
-            "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
-            (user_id,),
-        )
-        interaction_row = deps._fetchone(
-            "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
-            (user_id,),
-        )
-        profile_row = deps._fetchone(
-            "SELECT COUNT(*) AS cnt FROM profiles WHERE user_id = ?",
-            (user_id,),
-        )
-        if request_row is None or interaction_row is None or profile_row is None:
-            raise ValueError("Missing governance count rows")
-        request_count = request_row["cnt"]
-        interaction_count = interaction_row["cnt"]
-        profile_count = profile_row["cnt"]
-        playbook_count = len(owned_user_playbook_ids)
-        affected_agent_playbook_ids: list[int] = []
-        rebuild_details_by_agent_playbook_id: dict[int, dict[str, object]] = {}
-        if owned_user_playbook_ids:
-            placeholders = ",".join("?" for _ in owned_user_playbook_ids)
-            rows = deps._fetchall(
-                f"""SELECT DISTINCT agent_playbook_id
-                    FROM agent_playbook_source_user_playbooks
-                    WHERE user_playbook_id IN ({placeholders})
-                    ORDER BY agent_playbook_id ASC""",
-                sorted(owned_user_playbook_ids),
-            )
-            affected_agent_playbook_ids = [int(row["agent_playbook_id"]) for row in rows]
-            for agent_playbook_id in affected_agent_playbook_ids:
-                original_windows = deps.get_source_windows_for_agent_playbook(
-                    agent_playbook_id
-                )
-                original_window_dicts = [
-                    {
-                        "user_playbook_id": int(window.user_playbook_id),
-                        "source_interaction_ids": [
-                            int(source_id)
-                            for source_id in (window.source_interaction_ids or [])
-                        ],
-                    }
-                    for window in original_windows
-                ]
-                remaining_window_dicts = [
-                    window
-                    for window in original_window_dicts
-                    if int(window["user_playbook_id"]) not in owned_user_playbook_ids
-                ]
-                rebuild_details_by_agent_playbook_id[agent_playbook_id] = {
-                    "original_source_windows": original_window_dicts,
-                    "remaining_source_windows": remaining_window_dicts,
-                }
-        targets = {
-            "request": request_count,
-            "interaction": interaction_count,
-            "profile": profile_count,
-            "user_playbook": playbook_count,
-        }
         with self._lock:
-            for target_name, count in targets.items():
+            try:
+                self.conn.execute("BEGIN")
+                request_row = self.conn.execute(
+                    "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
+                    (user_id,),
+                ).fetchone()
+                interaction_row = self.conn.execute(
+                    "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
+                    (user_id,),
+                ).fetchone()
+                profile_row = self.conn.execute(
+                    "SELECT COUNT(*) AS cnt FROM profiles WHERE user_id = ?",
+                    (user_id,),
+                ).fetchone()
+                if request_row is None or interaction_row is None or profile_row is None:
+                    raise ValueError("Missing governance count rows")
+                request_count = int(request_row["cnt"])
+                interaction_count = int(interaction_row["cnt"])
+                profile_count = int(profile_row["cnt"])
+                playbook_count = len(owned_user_playbook_ids)
+                affected_agent_playbook_ids: list[int] = []
+                rebuild_details_by_agent_playbook_id: dict[int, dict[str, object]] = {}
+                if owned_user_playbook_ids:
+                    placeholders = ",".join("?" for _ in owned_user_playbook_ids)
+                    rows = self.conn.execute(
+                        f"""SELECT DISTINCT agent_playbook_id
+                            FROM agent_playbook_source_user_playbooks
+                            WHERE user_playbook_id IN ({placeholders})
+                            ORDER BY agent_playbook_id ASC""",
+                        sorted(owned_user_playbook_ids),
+                    ).fetchall()
+                    affected_agent_playbook_ids = [
+                        int(row["agent_playbook_id"]) for row in rows
+                    ]
+                    for agent_playbook_id in affected_agent_playbook_ids:
+                        window_rows = self.conn.execute(
+                            """SELECT user_playbook_id, source_interaction_ids
+                               FROM agent_playbook_source_user_playbooks
+                               WHERE agent_playbook_id = ?
+                               ORDER BY user_playbook_id ASC""",
+                            (agent_playbook_id,),
+                        ).fetchall()
+                        original_window_dicts = [
+                            {
+                                "user_playbook_id": int(row["user_playbook_id"]),
+                                "source_interaction_ids": [
+                                    int(source_id)
+                                    for source_id in (
+                                        _json_loads(row["source_interaction_ids"]) or []
+                                    )
+                                ],
+                            }
+                            for row in window_rows
+                        ]
+                        remaining_window_dicts = [
+                            window
+                            for window in original_window_dicts
+                            if int(window["user_playbook_id"])
+                            not in owned_user_playbook_ids
+                        ]
+                        rebuild_details_by_agent_playbook_id[agent_playbook_id] = {
+                            "original_source_windows": original_window_dicts,
+                            "remaining_source_windows": remaining_window_dicts,
+                        }
+                targets = {
+                    "request": request_count,
+                    "interaction": interaction_count,
+                    "profile": profile_count,
+                    "user_playbook": playbook_count,
+                }
+                for target_name, count in targets.items():
+                    self._record_purge_target_locked(
+                        purge_id=purge_id,
+                        target_name=target_name,
+                        target_ref="all",
+                        phase="delete",
+                        status="pending",
+                        detail={"count": count},
+                        deleted_count=0,
+                        error_detail=None,
+                    )
+                for agent_playbook_id in affected_agent_playbook_ids:
+                    self._record_purge_target_locked(
+                        purge_id=purge_id,
+                        target_name="agent_playbook",
+                        target_ref=str(agent_playbook_id),
+                        phase="rebuild_without_erased_sources",
+                        status="pending",
+                        detail=rebuild_details_by_agent_playbook_id[agent_playbook_id],
+                        deleted_count=0,
+                        error_detail=None,
+                    )
                 self._record_purge_target_locked(
                     purge_id=purge_id,
-                    target_name=target_name,
+                    target_name=_SNAPSHOT_TARGET_NAME,
                     target_ref="all",
-                    phase="delete",
-                    status="pending",
-                    detail={"count": int(count)},
+                    phase=_PREPARE_PHASE,
+                    status="complete",
+                    detail={
+                        "owned_user_playbook_ids": sorted(owned_user_playbook_ids),
+                        "affected_agent_playbook_ids": affected_agent_playbook_ids,
+                    },
                     deleted_count=0,
                     error_detail=None,
                 )
-            for agent_playbook_id in affected_agent_playbook_ids:
-                self._record_purge_target_locked(
-                    purge_id=purge_id,
-                    target_name="agent_playbook",
-                    target_ref=str(agent_playbook_id),
-                    phase="rebuild_without_erased_sources",
-                    status="pending",
-                    detail=rebuild_details_by_agent_playbook_id[agent_playbook_id],
-                    deleted_count=0,
-                    error_detail=None,
-                )
-            self._record_purge_target_locked(
-                purge_id=purge_id,
-                target_name=_SNAPSHOT_TARGET_NAME,
-                target_ref="all",
-                phase=_PREPARE_PHASE,
-                status="complete",
-                detail={
-                    "owned_user_playbook_ids": sorted(owned_user_playbook_ids),
-                    "affected_agent_playbook_ids": affected_agent_playbook_ids,
-                },
-                deleted_count=0,
-                error_detail=None,
-            )
-            self.conn.commit()
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     def hide_governance_agent_playbooks_for_rebuild(self, purge_id: str) -> list[int]:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -7,7 +7,7 @@ import threading
 from datetime import UTC, datetime
 from typing import Any, Literal, NoReturn, Protocol, cast, get_args
 
-from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
+from reflexio.models.api_schema.domain import AgentPlaybook, AgentPlaybookSourceWindow
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.domain.governance import (
     AuditActorType,
@@ -893,6 +893,17 @@ class _SQLiteGovernanceDeps(Protocol):
     ) -> list[AgentPlaybookSourceWindow]:
         ...
 
+    def get_agent_playbook_by_id(
+        self,
+        agent_playbook_id: int,
+        *,
+        include_tombstones: bool = False,
+    ) -> AgentPlaybook | None:
+        ...
+
+    def _index_agent_playbook_fts_vec(self, ap: AgentPlaybook) -> None:
+        ...
+
 
 class SQLiteGovernanceMixin:
     """SQLite governance storage primitives."""
@@ -1660,6 +1671,7 @@ class SQLiteGovernanceMixin:
             "remaining_source_windows", remaining_source_windows
         )
         canonical_remaining_windows = [window.model_dump() for window in windows]
+        rebuilt_playbook_id: int | None = None
         with self._lock:
             try:
                 self.conn.execute("BEGIN")
@@ -1737,9 +1749,19 @@ class SQLiteGovernanceMixin:
                     error_detail=None,
                 )
                 self.conn.commit()
+                rebuilt_playbook_id = agent_playbook_id
             except Exception:
                 self.conn.rollback()
                 raise
+        if rebuilt_playbook_id is None:
+            raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
+        rebuilt_playbook = self._deps().get_agent_playbook_by_id(
+            rebuilt_playbook_id,
+            include_tombstones=True,
+        )
+        if rebuilt_playbook is None:
+            raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
+        self._deps()._index_agent_playbook_fts_vec(rebuilt_playbook)
 
     def complete_purge_operation_with_audit(
         self, purge_id: str, audit_event: AuditEvent

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -166,21 +166,23 @@ _IDENTIFIERISH_ERROR_CODE_RE = re.compile(
     r"^(?:user|subject|request|req|actor|email)[-_.:]?[A-Za-z0-9_.:-]+$",
     re.IGNORECASE,
 )
-_ALLOWED_ENUM_LIKE_VALUES = frozenset(
+_ALLOWED_DETAIL_STATUS_VALUES = frozenset(
     {
         "archive_in_progress",
-        "hide_for_rebuild",
-        "archived",
         "complete",
-        "delete",
         "error",
         "failed",
         "ok",
         "pending",
-        "prepare_targets",
-        "rebuild",
-        "rebuild_without_erased_sources",
         "running",
+    }
+)
+_ALLOWED_DETAIL_ROUTE_VALUES = frozenset(
+    {
+        "prepare_targets",
+        "delete",
+        "hide_for_rebuild",
+        "rebuild_without_erased_sources",
     }
 )
 _ALLOWED_DELETED_COUNTS_KEYS = frozenset(
@@ -250,7 +252,6 @@ def _validate_governance_code_shaped(
     value: str,
     *,
     allow_minimized_ref: bool,
-    allow_enum_like_word: bool,
 ) -> str:
     if not value:
         _raise_governance_validation_error(field_name, "required")
@@ -268,8 +269,6 @@ def _validate_governance_code_shaped(
         return value
     if _CODE_SHAPED_VALUE_RE.fullmatch(value):
         return value
-    if allow_enum_like_word and value in _ALLOWED_ENUM_LIKE_VALUES:
-        return value
     if _USER_LIKE_TARGET_REF_RE.fullmatch(value):
         _raise_governance_validation_error(field_name, "user-like identifier")
     _raise_governance_validation_error(field_name, "must be minimized, internal, or code-shaped")
@@ -285,8 +284,18 @@ def _validate_governance_idempotency_key(
         field_name,
         value,
         allow_minimized_ref=False,
-        allow_enum_like_word=False,
     )
+
+
+def _validate_governance_detail_enum(
+    field_name: str, value: Any, *, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str):
+        _raise_governance_validation_error(field_name, "expected str")
+    _validate_governance_string(field_name, value)
+    if value not in allowed_values:
+        _raise_governance_validation_error(field_name, "must be canonical")
+    return value
 
 
 def _validate_governance_purge_id(field_name: str, value: str) -> str:
@@ -493,14 +502,17 @@ def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> 
         if not isinstance(value, bool):
             _raise_governance_validation_error(field_name, "expected bool")
         return value
-    if key in {"route", "status"}:
-        if not isinstance(value, str):
-            _raise_governance_validation_error(field_name, "expected str")
-        return _validate_governance_code_shaped(
+    if key == "route":
+        return _validate_governance_detail_enum(
             field_name,
             value,
-            allow_minimized_ref=False,
-            allow_enum_like_word=True,
+            allowed_values=_ALLOWED_DETAIL_ROUTE_VALUES,
+        )
+    if key == "status":
+        return _validate_governance_detail_enum(
+            field_name,
+            value,
+            allowed_values=_ALLOWED_DETAIL_STATUS_VALUES,
         )
     _raise_governance_validation_error(field_name, key)
 
@@ -615,7 +627,6 @@ def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
             "entity_id",
             event.entity_id,
             allow_minimized_ref=True,
-            allow_enum_like_word=False,
         )
     _validate_governance_idempotency_key("idempotency_key", event.idempotency_key)
     _validate_governance_detail("audit_event.detail", event.detail)

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -883,6 +883,9 @@ class _SQLiteGovernanceDeps(Protocol):
     ) -> None:
         ...
 
+    def _get_embedding(self, text: str) -> list[float]:
+        ...
+
     def set_source_windows_for_agent_playbook(
         self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
     ) -> None:
@@ -931,6 +934,43 @@ class SQLiteGovernanceMixin:
                    (agent_playbook_id, user_playbook_id, source_interaction_ids)
                    VALUES (?, ?, ?)""",
                 source_window_rows,
+            )
+
+    def _delete_agent_playbook_search_rows_locked(self, agent_playbook_id: int) -> None:
+        self.conn.execute(
+            "DELETE FROM agent_playbooks_fts WHERE rowid = ?",
+            (agent_playbook_id,),
+        )
+        if self._deps()._has_sqlite_vec:
+            self.conn.execute(
+                "DELETE FROM agent_playbooks_vec WHERE rowid = ?",
+                (agent_playbook_id,),
+            )
+
+    def _upsert_agent_playbook_search_rows_locked(
+        self,
+        *,
+        agent_playbook_id: int,
+        trigger: str | None,
+        content: str,
+        expanded_terms: str | None,
+        embedding: list[float],
+    ) -> None:
+        self._delete_agent_playbook_search_rows_locked(agent_playbook_id)
+        fts_parts = [trigger or "", content]
+        if expanded_terms:
+            fts_parts.append(expanded_terms)
+        self.conn.execute(
+            "INSERT INTO agent_playbooks_fts(rowid, search_text) VALUES (?, ?)",
+            (
+                agent_playbook_id,
+                " ".join(part for part in fts_parts if part) or "",
+            ),
+        )
+        if self._deps()._has_sqlite_vec and embedding:
+            self.conn.execute(
+                "INSERT INTO agent_playbooks_vec(rowid, embedding) VALUES (?, ?)",
+                (agent_playbook_id, json.dumps(embedding)),
             )
 
     def _validate_prepared_delete_target_matrix_locked(self, purge_id: str) -> None:
@@ -1671,7 +1711,10 @@ class SQLiteGovernanceMixin:
             "remaining_source_windows", remaining_source_windows
         )
         canonical_remaining_windows = [window.model_dump() for window in windows]
-        rebuilt_playbook_id: int | None = None
+        content_value = content or ""
+        trigger_value = trigger or None
+        embedding_text = trigger_value or content_value
+        embedding = self._deps()._get_embedding(embedding_text) if embedding_text else []
         with self._lock:
             try:
                 self.conn.execute("BEGIN")
@@ -1715,29 +1758,52 @@ class SQLiteGovernanceMixin:
                 ).fetchone()
                 if hide_target_row is None or hide_target_row["status"] != "complete":
                     raise ValueError("hide_for_rebuild target must be complete")
-                cur = self.conn.execute(
-                    """UPDATE agent_playbooks
-                       SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,
-                           expanded_terms = ?, tags = ?, status = ?
-                       WHERE agent_playbook_id = ?""",
-                    (
-                        content or "",
-                        trigger,
-                        rationale,
-                        json.dumps(blocking_issue) if blocking_issue is not None else None,
-                        expanded_terms,
-                        _json_dumps(tags),
-                        previous_lifecycle_status,
-                        agent_playbook_id,
-                    ),
-                )
-                if cur.rowcount == 0:
-                    raise ValueError(
-                        f"Agent playbook with ID {agent_playbook_id} not found"
+                if windows:
+                    cur = self.conn.execute(
+                        """UPDATE agent_playbooks
+                           SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,
+                               embedding = ?, expanded_terms = ?, tags = ?, status = ?
+                           WHERE agent_playbook_id = ?""",
+                        (
+                            content_value,
+                            trigger_value,
+                            rationale,
+                            json.dumps(blocking_issue) if blocking_issue is not None else None,
+                            _json_dumps(embedding),
+                            expanded_terms,
+                            _json_dumps(tags),
+                            previous_lifecycle_status,
+                            agent_playbook_id,
+                        ),
                     )
-                self._replace_agent_playbook_source_windows_locked(
-                    agent_playbook_id, windows
-                )
+                    if cur.rowcount == 0:
+                        raise ValueError(
+                            f"Agent playbook with ID {agent_playbook_id} not found"
+                        )
+                    self._replace_agent_playbook_source_windows_locked(
+                        agent_playbook_id, windows
+                    )
+                    self._upsert_agent_playbook_search_rows_locked(
+                        agent_playbook_id=agent_playbook_id,
+                        trigger=trigger_value,
+                        content=content_value,
+                        expanded_terms=expanded_terms,
+                        embedding=embedding,
+                    )
+                else:
+                    self._delete_agent_playbook_search_rows_locked(agent_playbook_id)
+                    self.conn.execute(
+                        "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
+                        (agent_playbook_id,),
+                    )
+                    cur = self.conn.execute(
+                        "DELETE FROM agent_playbooks WHERE agent_playbook_id = ?",
+                        (agent_playbook_id,),
+                    )
+                    if cur.rowcount == 0:
+                        raise ValueError(
+                            f"Agent playbook with ID {agent_playbook_id} not found"
+                        )
                 self._record_purge_target_locked(
                     purge_id=purge_id,
                     target_name="agent_playbook",
@@ -1749,19 +1815,9 @@ class SQLiteGovernanceMixin:
                     error_detail=None,
                 )
                 self.conn.commit()
-                rebuilt_playbook_id = agent_playbook_id
             except Exception:
                 self.conn.rollback()
                 raise
-        if rebuilt_playbook_id is None:
-            raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
-        rebuilt_playbook = self._deps().get_agent_playbook_by_id(
-            rebuilt_playbook_id,
-            include_tombstones=True,
-        )
-        if rebuilt_playbook is None:
-            raise ValueError(f"Agent playbook with ID {agent_playbook_id} not found")
-        self._deps()._index_agent_playbook_fts_vec(rebuilt_playbook)
 
     def complete_purge_operation_with_audit(
         self, purge_id: str, audit_event: AuditEvent

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -615,12 +615,18 @@ def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> N
                org_id, purge_id, target_name, target_ref, phase, status, detail,
                deleted_count, error_detail, started_at, completed_at
            )
-           SELECT purge_operations.org_id, legacy.purge_id, legacy.target_name,
+           SELECT uniquely_mapped_purges.org_id, legacy.purge_id, legacy.target_name,
                   legacy.target_ref, legacy.phase, legacy.status, legacy.detail,
                   legacy.deleted_count, legacy.error_detail, legacy.started_at,
                   legacy.completed_at
            FROM purge_operation_targets_legacy AS legacy
-           JOIN purge_operations ON purge_operations.purge_id = legacy.purge_id"""
+           JOIN (
+               SELECT MIN(org_id) AS org_id, purge_id
+               FROM purge_operations
+               GROUP BY purge_id
+               HAVING COUNT(*) = 1
+           ) AS uniquely_mapped_purges
+             ON uniquely_mapped_purges.purge_id = legacy.purge_id"""
     )
     conn.execute("DROP TABLE purge_operation_targets_legacy")
 
@@ -1397,5 +1403,6 @@ class SQLiteGovernanceMixin:
             raise ValueError(f"Purge operation {purge_id!r} not found")
         return _row_to_purge_operation(row)
 
-    def gc_governance_retention(self, *, _config: Any) -> int:
+    def gc_governance_retention(self, *, config: Any) -> int:
+        del config
         return 0

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -5,13 +5,20 @@ import re
 import sqlite3
 import threading
 from datetime import UTC, datetime
-from typing import Any, Literal, NoReturn, Protocol, cast
+from typing import Any, Literal, NoReturn, Protocol, cast, get_args
 
 from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
 from reflexio.models.api_schema.domain.governance import (
+    AuditActorType,
+    AuditEntityType,
     AuditEvent,
+    AuditOperation,
+    AuditStatus,
     PurgeOperation,
     PurgeOperationTarget,
+    PurgeOperationType,
+    PurgeScopeType,
+    PurgeTargetStatus,
 )
 
 GOVERNANCE_DDL = """
@@ -74,6 +81,26 @@ CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
 
 _PREPARE_PHASE = "prepare_targets"
 _SNAPSHOT_TARGET_NAME = "target_snapshot"
+_ALLOWED_AUDIT_ACTOR_TYPES = frozenset(get_args(AuditActorType))
+_ALLOWED_AUDIT_OPERATIONS = frozenset(get_args(AuditOperation))
+_ALLOWED_AUDIT_ENTITY_TYPES = frozenset(get_args(AuditEntityType))
+_ALLOWED_AUDIT_STATUSES = frozenset(get_args(AuditStatus))
+_ALLOWED_PURGE_OPERATION_TYPES = frozenset(get_args(PurgeOperationType))
+_ALLOWED_PURGE_SCOPE_TYPES = frozenset(get_args(PurgeScopeType))
+_ALLOWED_PURGE_TARGET_STATUSES = frozenset(get_args(PurgeTargetStatus))
+_ALLOWED_PURGE_TARGET_NAMES = frozenset(
+    {
+        _SNAPSHOT_TARGET_NAME,
+        "request",
+        "interaction",
+        "profile",
+        "user_playbook",
+        "agent_playbook",
+        "profile_purge",
+        "user_playbook_purge",
+    }
+)
+_ALLOWED_PURGE_TARGET_PHASES = frozenset({_PREPARE_PHASE, "delete", "rebuild"})
 _ALLOWED_DETAIL_KEYS = frozenset(
     {
         "affected_agent_playbook_ids",
@@ -392,7 +419,57 @@ def _validate_governance_error_code(error_code: str) -> str:
     return _validate_governance_code_like("error_code", error_code)
 
 
+def _validate_governance_enum(
+    field_name: str, value: str, *, allowed: frozenset[str]
+) -> str:
+    if value not in allowed:
+        _raise_governance_validation_error(
+            field_name,
+            f"must be one of {', '.join(sorted(allowed))}",
+        )
+    return value
+
+
+def _normalize_governance_detail_for_identity(
+    detail: dict[str, object] | None,
+) -> str | None:
+    if detail is None:
+        return None
+    normalized_detail: dict[str, object] = {}
+    for key, value in detail.items():
+        normalized_key = str(key).strip().lower()
+        if normalized_key in {"original_source_windows", "remaining_source_windows"}:
+            normalized_windows = [
+                _normalize_governance_window_item(normalized_key, index, item)
+                for index, item in enumerate(cast(list[object], value))
+            ]
+            normalized_detail[normalized_key] = normalized_windows
+            continue
+        normalized_detail[normalized_key] = value
+    return json.dumps(normalized_detail, sort_keys=True, separators=(",", ":"))
+
+
 def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
+    _validate_governance_enum(
+        "actor_type",
+        event.actor_type,
+        allowed=_ALLOWED_AUDIT_ACTOR_TYPES,
+    )
+    _validate_governance_enum(
+        "operation",
+        event.operation,
+        allowed=_ALLOWED_AUDIT_OPERATIONS,
+    )
+    _validate_governance_enum(
+        "entity_type",
+        event.entity_type,
+        allowed=_ALLOWED_AUDIT_ENTITY_TYPES,
+    )
+    _validate_governance_enum(
+        "status",
+        event.status,
+        allowed=_ALLOWED_AUDIT_STATUSES,
+    )
     _validate_governance_prefixed_ref("actor_ref", event.actor_ref, prefix="actref_v1_")
     _validate_governance_prefixed_ref(
         "subject_ref", event.subject_ref, prefix="subref_v1_"
@@ -422,15 +499,35 @@ def _is_successful_erase_event(event: AuditEvent, *, purge_id: str | None = None
     )
 
 
-def _successful_erase_identity(event: AuditEvent) -> tuple[str, str, str, str | None, str | None, str, str | None]:
+def _successful_erase_identity(
+    event: AuditEvent,
+) -> tuple[
+    str,
+    str,
+    str | None,
+    str,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    str | None,
+    str | None,
+]:
     return (
         event.org_id,
+        event.actor_type,
+        event.actor_ref,
         event.operation,
         event.entity_type,
+        event.entity_id,
         event.subject_ref,
         event.request_ref,
         event.status,
         event.idempotency_key,
+        _normalize_governance_detail_for_identity(
+            cast(dict[str, object] | None, event.detail)
+        ),
     )
 
 
@@ -638,6 +735,16 @@ class SQLiteGovernanceMixin:
         subject_ref: str | None,
         request_ref: str,
     ) -> PurgeOperation:
+        _validate_governance_enum(
+            "operation_type",
+            operation_type,
+            allowed=_ALLOWED_PURGE_OPERATION_TYPES,
+        )
+        _validate_governance_enum(
+            "scope_type",
+            scope_type,
+            allowed=_ALLOWED_PURGE_SCOPE_TYPES,
+        )
         _validate_governance_prefixed_ref(
             "subject_ref", subject_ref, prefix="subref_v1_"
         )
@@ -688,6 +795,21 @@ class SQLiteGovernanceMixin:
         deleted_count: int = 0,
         error_detail: str | None = None,
     ) -> None:
+        _validate_governance_enum(
+            "target_name",
+            target_name,
+            allowed=_ALLOWED_PURGE_TARGET_NAMES,
+        )
+        _validate_governance_enum(
+            "phase",
+            phase,
+            allowed=_ALLOWED_PURGE_TARGET_PHASES,
+        )
+        _validate_governance_enum(
+            "status",
+            status,
+            allowed=_ALLOWED_PURGE_TARGET_STATUSES,
+        )
         with self._lock:
             self._record_purge_target_locked(
                 purge_id=purge_id,

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -813,6 +813,7 @@ class SQLiteGovernanceMixin:
         deleted_count: int = 0,
         error_detail: str | None = None,
     ) -> None:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         _validate_governance_enum(
             "target_name",
             target_name,
@@ -844,6 +845,7 @@ class SQLiteGovernanceMixin:
     def list_purge_targets(
         self, purge_id: str, phase: str | None = None
     ) -> list[PurgeOperationTarget]:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         deps = self._deps()
         sql = "SELECT * FROM purge_operation_targets WHERE purge_id = ?"
         params: list[Any] = [purge_id]
@@ -855,6 +857,7 @@ class SQLiteGovernanceMixin:
         return [_row_to_purge_target(row) for row in rows]
 
     def purge_targets_prepared(self, purge_id: str) -> bool:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         row = self._deps()._fetchone(
             """SELECT 1 FROM purge_operation_targets
                WHERE purge_id = ? AND target_name = ? AND target_ref = 'all'
@@ -866,6 +869,7 @@ class SQLiteGovernanceMixin:
     def prepare_governance_erase_targets(
         self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
     ) -> None:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         deps = self._deps()
         request_row = deps._fetchone(
             "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
@@ -941,6 +945,7 @@ class SQLiteGovernanceMixin:
             self.conn.commit()
 
     def hide_governance_agent_playbooks_for_rebuild(self, purge_id: str) -> list[int]:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         targets = self.list_purge_targets(purge_id, phase="rebuild")
         agent_playbook_ids = [
             int(target.target_ref)
@@ -975,6 +980,7 @@ class SQLiteGovernanceMixin:
     def apply_governance_user_data_delete(
         self, purge_id: str, user_id: str
     ) -> dict[str, int]:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         counts = self._deps().clear_user_data(user_id)
         name_map = {
             "interactions": "interaction",
@@ -1011,6 +1017,7 @@ class SQLiteGovernanceMixin:
         expanded_terms: str | None,
         tags: list[str] | None,
     ) -> None:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         windows = _parse_governance_window_list(
             "remaining_source_windows", remaining_source_windows
         )
@@ -1147,6 +1154,7 @@ class SQLiteGovernanceMixin:
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str
     ) -> PurgeOperation:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         validated_error_code = _validate_governance_error_code(error_code)
         validated_error_detail = _validate_governance_error_detail(error_detail)
         now = _epoch_now()
@@ -1171,6 +1179,7 @@ class SQLiteGovernanceMixin:
         return self.get_purge_operation(purge_id)
 
     def get_purge_operation(self, purge_id: str) -> PurgeOperation:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         row = self._deps()._fetchone(
             "SELECT * FROM purge_operations WHERE purge_id = ? AND org_id = ?",
             (purge_id, self.org_id),

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -21,6 +21,7 @@ from reflexio.models.api_schema.domain.governance import (
     PurgeScopeType,
     PurgeTargetStatus,
 )
+from reflexio.models.config_schema import GovernanceRetentionConfig
 
 _PURGE_OPERATION_TARGETS_TABLE_DDL = """
 CREATE TABLE IF NOT EXISTS purge_operation_targets (
@@ -61,6 +62,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_events_org_idem
     WHERE idempotency_key IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_audit_events_subject_created
     ON audit_events(org_id, subject_ref, created_at, event_id);
+CREATE INDEX IF NOT EXISTS idx_audit_events_org_created
+    ON audit_events(org_id, created_at, event_id);
 
 CREATE TABLE IF NOT EXISTS purge_operations (
     org_id TEXT NOT NULL,
@@ -1295,6 +1298,13 @@ class SQLiteGovernanceMixin:
                 (user_id,),
             ).fetchall()
         ]
+        request_ids = [
+            str(row["request_id"])
+            for row in self.conn.execute(
+                "SELECT request_id FROM requests WHERE user_id = ?",
+                (user_id,),
+            ).fetchall()
+        ]
         profile_rows = self.conn.execute(
             "SELECT rowid, profile_id FROM profiles WHERE user_id = ?",
             (user_id,),
@@ -1314,6 +1324,40 @@ class SQLiteGovernanceMixin:
         )
         purge_upb_ids = [int(entity_id) for entity_id in purge_upb_str_ids]
         delete_upb_ids = [int(entity_id) for entity_id in delete_upb_str_ids]
+        erased_entity_ids = [
+            *request_ids,
+            *[str(interaction_id) for interaction_id in interaction_ids],
+            *all_profile_ids,
+            *[str(user_playbook_id) for user_playbook_id in raw_upb_ids],
+        ]
+        if erased_entity_ids:
+            erased_entity_id_set = set(erased_entity_ids)
+            lineage_source_event_ids: list[int] = []
+            for row in self.conn.execute(
+                "SELECT event_id, source_ids FROM lineage_event WHERE org_id = ?",
+                (self.org_id,),
+            ).fetchall():
+                try:
+                    source_ids = json.loads(str(row["source_ids"] or "[]"))
+                except json.JSONDecodeError:
+                    source_ids = []
+                if any(
+                    str(source_id) in erased_entity_id_set for source_id in source_ids
+                ):
+                    lineage_source_event_ids.append(int(row["event_id"]))
+            deps._delete_in_chunks(
+                "lineage_event", "event_id", lineage_source_event_ids
+            )
+            placeholders = ",".join("?" for _ in erased_entity_ids)
+            self.conn.execute(
+                f"""DELETE FROM lineage_event
+                    WHERE org_id = ?
+                      AND (
+                        request_id IN ({placeholders})
+                        OR entity_id IN ({placeholders})
+                      )""",  # noqa: S608
+                [self.org_id, *erased_entity_ids, *erased_entity_ids],
+            )
         delete_profile_rowids = [
             profile_rowid_by_id[profile_id]
             for profile_id in delete_profile_ids
@@ -2018,6 +2062,26 @@ class SQLiteGovernanceMixin:
             raise ValueError(f"Purge operation {purge_id!r} not found")
         return _row_to_purge_operation(row)
 
-    def gc_governance_retention(self, *, config: Any) -> int:
-        del config
-        return 0
+    def gc_governance_retention(self, *, config: GovernanceRetentionConfig) -> int:
+        if not config.audit_events_retention_enabled:
+            return 0
+        cutoff_epoch = _epoch_now() - config.audit_events_retention_days * 24 * 60 * 60
+        with self._lock:
+            cur = self.conn.execute(
+                """DELETE FROM audit_events
+                   WHERE event_id IN (
+                       SELECT event_id
+                       FROM audit_events
+                       WHERE org_id = ? AND created_at < ?
+                       ORDER BY created_at ASC, event_id ASC
+                       LIMIT ?
+                   )""",
+                (
+                    self.org_id,
+                    cutoff_epoch,
+                    config.audit_events_delete_batch_limit,
+                ),
+            )
+            deleted = int(cur.rowcount or 0)
+            self.conn.commit()
+        return deleted

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -319,11 +319,15 @@ def _validate_governance_int(field_name: str, value: Any) -> None:
         _raise_governance_validation_error(field_name, "expected int")
 
 
-def _validate_governance_deleted_count(value: Any) -> int:
-    _validate_governance_int("deleted_count", value)
+def _validate_governance_nonnegative_int(field_name: str, value: Any) -> int:
+    _validate_governance_int(field_name, value)
     if value < 0:
-        _raise_governance_validation_error("deleted_count", "must be nonnegative")
+        _raise_governance_validation_error(field_name, "must be nonnegative")
     return cast(int, value)
+
+
+def _validate_governance_deleted_count(value: Any) -> int:
+    return _validate_governance_nonnegative_int("deleted_count", value)
 
 
 def _validate_governance_int_list(field_name: str, value: Any) -> list[int]:
@@ -483,7 +487,9 @@ def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> 
         _raise_governance_validation_error(field_name, key)
     if key not in _ALLOWED_DETAIL_KEYS:
         _raise_governance_validation_error(field_name, key)
-    if key in {"count", "deleted_count", "agent_playbook_id", "user_playbook_id"}:
+    if key in {"count", "deleted_count"}:
+        return _validate_governance_nonnegative_int(field_name, value)
+    if key in {"agent_playbook_id", "user_playbook_id"}:
         _validate_governance_int(field_name, value)
         return cast(int, value)
     if key == "deleted_counts":

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -23,6 +23,8 @@ from reflexio.models.api_schema.domain.governance import (
 )
 from reflexio.models.config_schema import GovernanceRetentionConfig
 
+_LEGACY_AUDIT_REQUEST_REF = "reqref_v1_legacy_unknown"
+
 _PURGE_OPERATION_TARGETS_TABLE_DDL = """
 CREATE TABLE IF NOT EXISTS purge_operation_targets (
     org_id TEXT NOT NULL,
@@ -51,7 +53,7 @@ CREATE TABLE IF NOT EXISTS audit_events (
     entity_type TEXT NOT NULL,
     entity_id TEXT,
     subject_ref TEXT,
-    request_ref TEXT,
+    request_ref TEXT NOT NULL,
     idempotency_key TEXT,
     status TEXT NOT NULL DEFAULT 'ok',
     detail TEXT,
@@ -229,6 +231,7 @@ _ALLOWED_DELETED_COUNTS_KEYS = frozenset(
 def init_governance_tables(conn: sqlite3.Connection) -> None:
     _upgrade_legacy_purge_operation_targets_table(conn)
     conn.executescript(GOVERNANCE_DDL)
+    _enforce_audit_request_ref_not_null(conn)
 
 
 def _epoch_now() -> int:
@@ -778,6 +781,26 @@ def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> N
     conn.execute("DROP TABLE purge_operation_targets_legacy")
 
 
+def _enforce_audit_request_ref_not_null(conn: sqlite3.Connection) -> None:
+    audit_columns = [row[1] for row in conn.execute("PRAGMA table_info(audit_events)")]
+    if not audit_columns:
+        return
+    conn.execute(
+        "UPDATE audit_events SET request_ref = ? WHERE request_ref IS NULL",
+        (_LEGACY_AUDIT_REQUEST_REF,),
+    )
+    conn.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS audit_events_request_ref_not_null
+        BEFORE INSERT ON audit_events
+        WHEN NEW.request_ref IS NULL
+        BEGIN
+            SELECT RAISE(ABORT, 'audit_events.request_ref is required');
+        END
+        """
+    )
+
+
 def _is_successful_erase_event(
     event: AuditEvent, *, purge_id: str | None = None
 ) -> bool:
@@ -1090,6 +1113,34 @@ class SQLiteGovernanceMixin:
             "user_playbook_purge": len(purge_playbook_ids),
         }
 
+    def _owned_user_playbook_ids_locked(self, user_id: str) -> set[int]:
+        return {
+            int(row["user_playbook_id"])
+            for row in self.conn.execute(
+                "SELECT user_playbook_id FROM user_playbooks WHERE user_id = ?",
+                (user_id,),
+            ).fetchall()
+        }
+
+    def _prepared_owned_user_playbook_ids_locked(self, purge_id: str) -> set[int]:
+        row = self.conn.execute(
+            """SELECT detail FROM purge_operation_targets
+               WHERE org_id = ? AND purge_id = ? AND target_name = ?
+                 AND target_ref = 'all' AND phase = ? AND status = 'complete'""",
+            (self.org_id, purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+        ).fetchone()
+        if row is None:
+            raise ValueError("Prepared target snapshot is missing")
+        detail = _json_loads(row["detail"])
+        if not isinstance(detail, dict):
+            raise ValueError("Prepared target snapshot detail is missing")
+        return set(
+            _validate_governance_int_list(
+                "owned_user_playbook_ids",
+                detail.get("owned_user_playbook_ids"),
+            )
+        )
+
     def _append_audit_event_with_cursor(
         self, cur: sqlite3.Connection | sqlite3.Cursor, event: AuditEvent
     ) -> bool:
@@ -1282,7 +1333,12 @@ class SQLiteGovernanceMixin:
                 )
         return True
 
-    def _clear_user_data_for_governance_locked(self, user_id: str) -> dict[str, int]:
+    def _clear_user_data_for_governance_locked(
+        self,
+        user_id: str,
+        *,
+        expected_user_playbook_ids: set[int] | None = None,
+    ) -> dict[str, int]:
         deps = self._deps()
         interaction_ids = [
             int(row["interaction_id"])
@@ -1298,6 +1354,13 @@ class SQLiteGovernanceMixin:
                 (user_id,),
             ).fetchall()
         ]
+        if (
+            expected_user_playbook_ids is not None
+            and set(raw_upb_ids) != expected_user_playbook_ids
+        ):
+            raise ValueError(
+                "Current user playbooks no longer match prepared purge snapshot"
+            )
         request_ids = [
             str(row["request_id"])
             for row in self.conn.execute(
@@ -1562,14 +1625,22 @@ class SQLiteGovernanceMixin:
         return row is not None
 
     def prepare_governance_erase_targets(
-        self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
+        self,
+        purge_id: str,
+        user_id: str,
+        owned_user_playbook_ids: set[int] | None = None,
     ) -> None:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
         with self._lock:
             if self.purge_targets_prepared(purge_id):
                 return
             try:
-                self.conn.execute("BEGIN")
+                self.conn.execute("BEGIN IMMEDIATE")
+                owned_user_playbook_ids = (
+                    set(owned_user_playbook_ids)
+                    if owned_user_playbook_ids is not None
+                    else self._owned_user_playbook_ids_locked(user_id)
+                )
                 targets = self._planned_governance_delete_counts(
                     user_id,
                     owned_user_playbook_ids,
@@ -1744,7 +1815,13 @@ class SQLiteGovernanceMixin:
                 self.conn.execute("BEGIN")
                 self._validate_prepared_delete_target_matrix_locked(purge_id)
                 self._validate_hide_for_rebuild_targets_locked(purge_id)
-                counts = self._clear_user_data_for_governance_locked(user_id)
+                expected_user_playbook_ids = (
+                    self._prepared_owned_user_playbook_ids_locked(purge_id)
+                )
+                counts = self._clear_user_data_for_governance_locked(
+                    user_id,
+                    expected_user_playbook_ids=expected_user_playbook_ids,
+                )
                 for key, value in counts.items():
                     self._record_purge_target_locked(
                         purge_id=purge_id,
@@ -2024,7 +2101,7 @@ class SQLiteGovernanceMixin:
                            error_code = NULL,
                            error_detail = NULL,
                            updated_at = ?,
-                           completed_at = COALESCE(completed_at, ?)
+                           completed_at = ?
                        WHERE purge_id = ? AND org_id = ?""",
                     (now, now, purge_id, self.org_id),
                 )

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -115,7 +115,18 @@ _ALLOWED_PURGE_TARGET_PHASES = frozenset(
         "rebuild_without_erased_sources",
     }
 )
-_ALLOWED_DETAIL_KEYS = frozenset(
+_ALLOWED_AUDIT_DETAIL_KEYS = frozenset(
+    {
+        "agent_playbook_id",
+        "count",
+        "deleted_counts",
+        "deleted_count",
+        "rebuilt_agent_playbook_ids",
+        "route",
+        "status",
+    }
+)
+_ALLOWED_PURGE_TARGET_DETAIL_KEYS = frozenset(
     {
         "affected_agent_playbook_ids",
         "agent_playbook_id",
@@ -482,10 +493,16 @@ def _validate_governance_target_ref(
     raise AssertionError("unreachable")
 
 
-def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> object:
+def _validate_governance_detail_entry(
+    field_name: str,
+    key: str,
+    value: Any,
+    *,
+    allowed_keys: frozenset[str],
+) -> object:
     if key in _DISALLOWED_DETAIL_KEYS:
         _raise_governance_validation_error(field_name, key)
-    if key not in _ALLOWED_DETAIL_KEYS:
+    if key not in allowed_keys:
         _raise_governance_validation_error(field_name, key)
     if key in {"count", "deleted_count"}:
         return _validate_governance_nonnegative_int(field_name, value)
@@ -524,7 +541,10 @@ def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> 
 
 
 def _validate_governance_detail(
-    field_name: str, detail: dict[str, object] | None
+    field_name: str,
+    detail: dict[str, object] | None,
+    *,
+    allowed_keys: frozenset[str],
 ) -> dict[str, object] | None:
     if detail is None:
         return None
@@ -538,7 +558,10 @@ def _validate_governance_detail(
                 field_name, f"duplicate key {normalized_key}"
             )
         normalized_detail[normalized_key] = _validate_governance_detail_entry(
-            f"{field_name}.{normalized_key}", normalized_key, value
+            f"{field_name}.{normalized_key}",
+            normalized_key,
+            value,
+            allowed_keys=allowed_keys,
         )
     return normalized_detail
 
@@ -635,13 +658,23 @@ def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
             allow_minimized_ref=True,
         )
     _validate_governance_idempotency_key("idempotency_key", event.idempotency_key)
-    _validate_governance_detail("audit_event.detail", event.detail)
+    _validate_governance_detail(
+        "audit_event.detail",
+        event.detail,
+        allowed_keys=_ALLOWED_AUDIT_DETAIL_KEYS,
+    )
 
 
 def _canonicalize_audit_event_for_persistence(event: AuditEvent) -> AuditEvent:
     _validate_audit_event_for_persistence(event)
     return event.model_copy(
-        update={"detail": _validate_governance_detail("audit_event.detail", event.detail)}
+        update={
+            "detail": _validate_governance_detail(
+                "audit_event.detail",
+                event.detail,
+                allowed_keys=_ALLOWED_AUDIT_DETAIL_KEYS,
+            )
+        }
     )
 
 
@@ -894,7 +927,11 @@ class SQLiteGovernanceMixin:
             status,
             allowed=_ALLOWED_PURGE_TARGET_STATUSES,
         )
-        detail = _validate_governance_detail("detail", detail)
+        detail = _validate_governance_detail(
+            "detail",
+            detail,
+            allowed_keys=_ALLOWED_PURGE_TARGET_DETAIL_KEYS,
+        )
         error_detail = _validate_governance_error_detail(error_detail)
         target_ref = _validate_governance_target_ref(
             target_name=target_name,
@@ -971,8 +1008,10 @@ class SQLiteGovernanceMixin:
         self, subject_ref: str | None = None, *, org_id: str | None = None
     ) -> list[AuditEvent]:
         deps = self._deps()
+        if org_id is not None and org_id != self.org_id:
+            raise ValueError("Audit event org_id must match storage org_id")
         sql = "SELECT * FROM audit_events WHERE org_id = ?"
-        params: list[Any] = [org_id or deps.org_id]
+        params: list[Any] = [self.org_id]
         if subject_ref is not None:
             sql += " AND subject_ref = ?"
             params.append(subject_ref)

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1389,6 +1389,32 @@ class SQLiteGovernanceMixin:
         with self._lock:
             try:
                 self.conn.execute("BEGIN")
+                rebuild_target_row = self.conn.execute(
+                    """SELECT detail
+                       FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ? AND target_name = 'agent_playbook'
+                         AND target_ref = ? AND phase = 'rebuild_without_erased_sources'""",
+                    (self.org_id, purge_id, str(agent_playbook_id)),
+                ).fetchone()
+                if rebuild_target_row is None:
+                    raise ValueError("planned rebuild target does not exist")
+                rebuild_detail = _json_loads(rebuild_target_row["detail"])
+                if not isinstance(rebuild_detail, dict) or not {
+                    "original_source_windows",
+                    "remaining_source_windows",
+                }.issubset(rebuild_detail):
+                    raise ValueError(
+                        "planned rebuild target is missing source window detail"
+                    )
+                hide_target_row = self.conn.execute(
+                    """SELECT status
+                       FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ? AND target_name = 'agent_playbook'
+                         AND target_ref = ? AND phase = 'hide_for_rebuild'""",
+                    (self.org_id, purge_id, str(agent_playbook_id)),
+                ).fetchone()
+                if hide_target_row is None or hide_target_row["status"] != "complete":
+                    raise ValueError("hide_for_rebuild target must be complete")
                 cur = self.conn.execute(
                     """UPDATE agent_playbooks
                        SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -332,7 +332,7 @@ def _validate_governance_purge_id(field_name: str, value: str) -> str:
     suffix = value[len("purge_") :]
     if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(suffix):
         _raise_governance_validation_error(field_name, "identifier")
-    if suffix.isdecimal() and len(suffix) > 1:
+    if suffix.isdecimal():
         _raise_governance_validation_error(field_name, "numeric identifier")
     return value
 

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -114,6 +114,11 @@ _TOKEN_NAME_RE = re.compile(
 _RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
 _SAFE_INTERNAL_ID_RE = re.compile(r"^[0-9]+$")
 _USER_LIKE_TARGET_REF_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+_SAFE_ERROR_CODE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,127}$")
+_IDENTIFIERISH_ERROR_CODE_RE = re.compile(
+    r"^(?:user|subject|request|req|actor|email)[-_.:]?[A-Za-z0-9_.:-]+$",
+    re.IGNORECASE,
+)
 
 
 def init_governance_tables(conn: sqlite3.Connection) -> None:
@@ -300,6 +305,21 @@ def _validate_governance_error_detail(error_detail: str | None) -> str | None:
     return error_detail
 
 
+def _validate_governance_error_code(error_code: str) -> str:
+    if not error_code:
+        _raise_governance_validation_error("error_code", "required")
+    _validate_governance_string("error_code", error_code)
+    if error_code.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error("error_code", "identifier")
+    if _IDENTIFIERISH_ERROR_CODE_RE.fullmatch(error_code):
+        _raise_governance_validation_error("error_code", "identifier")
+    if not _SAFE_ERROR_CODE_RE.fullmatch(error_code):
+        _raise_governance_validation_error(
+            "error_code", "must be a stable diagnostic code"
+        )
+    return error_code
+
+
 def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
     _validate_governance_prefixed_ref("actor_ref", event.actor_ref, prefix="actref_v1_")
     _validate_governance_prefixed_ref(
@@ -321,6 +341,18 @@ def _is_successful_erase_event(event: AuditEvent, *, purge_id: str | None = None
         and event.status == "ok"
         and event.idempotency_key is not None
         and (purge_id is None or event.idempotency_key == purge_id)
+    )
+
+
+def _successful_erase_identity(event: AuditEvent) -> tuple[str, str, str, str | None, str | None, str, str | None]:
+    return (
+        event.org_id,
+        event.operation,
+        event.entity_type,
+        event.subject_ref,
+        event.request_ref,
+        event.status,
+        event.idempotency_key,
     )
 
 
@@ -841,6 +873,13 @@ class SQLiteGovernanceMixin:
                             "Existing audit row for purge_id must be the matching "
                             "successful ERASE row"
                         )
+                    if _successful_erase_identity(existing_event) != _successful_erase_identity(
+                        audit_event
+                    ):
+                        raise ValueError(
+                            "Existing audit row for purge_id must be the matching "
+                            "successful ERASE row"
+                        )
                 else:
                     self._append_audit_event_with_cursor(self.conn, audit_event)
                     existing_audit_row = self.conn.execute(
@@ -855,6 +894,13 @@ class SQLiteGovernanceMixin:
                     )
                 existing_event = _row_to_audit_event(existing_audit_row)
                 if not _is_successful_erase_event(existing_event, purge_id=purge_id):
+                    raise ValueError(
+                        "Completion requires exactly one matching successful ERASE "
+                        "audit row for the purge_id"
+                    )
+                if _successful_erase_identity(existing_event) != _successful_erase_identity(
+                    audit_event
+                ):
                     raise ValueError(
                         "Completion requires exactly one matching successful ERASE "
                         "audit row for the purge_id"
@@ -878,6 +924,7 @@ class SQLiteGovernanceMixin:
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str
     ) -> PurgeOperation:
+        validated_error_code = _validate_governance_error_code(error_code)
         validated_error_detail = _validate_governance_error_detail(error_detail)
         now = _epoch_now()
         with self._lock:
@@ -886,7 +933,14 @@ class SQLiteGovernanceMixin:
                    SET status = 'failed', error_code = ?, error_detail = ?,
                    updated_at = ?, completed_at = ?
                    WHERE purge_id = ? AND org_id = ?""",
-                (error_code, validated_error_detail, now, now, purge_id, self.org_id),
+                (
+                    validated_error_code,
+                    validated_error_detail,
+                    now,
+                    now,
+                    purge_id,
+                    self.org_id,
+                ),
             )
             if cur.rowcount == 0:
                 raise ValueError(f"Purge operation {purge_id!r} not found")

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -250,13 +250,17 @@ def _validate_governance_string(field_name: str, value: str) -> None:
         _raise_governance_validation_error(field_name, "email")
     if _REQUEST_ID_RE.search(value):
         _raise_governance_validation_error(field_name, "request_id")
-    lowered = value.lower()
-    if "prompt" in lowered or "content" in lowered:
-        _raise_governance_validation_error(field_name, "prompt/content")
     if _TOKEN_NAME_RE.search(value):
         _raise_governance_validation_error(field_name, "token")
     if _RAW_EXCEPTION_RE.search(value):
         _raise_governance_validation_error(field_name, "raw exception text")
+
+
+def _validate_governance_prose_string(field_name: str, value: str) -> None:
+    _validate_governance_string(field_name, value)
+    lowered = value.lower()
+    if "prompt" in lowered or "content" in lowered:
+        _raise_governance_validation_error(field_name, "prompt/content")
 
 
 def _validate_governance_prefixed_ref(
@@ -317,7 +321,7 @@ def _validate_governance_detail_enum(
 ) -> str:
     if not isinstance(value, str):
         _raise_governance_validation_error(field_name, "expected str")
-    _validate_governance_string(field_name, value)
+    _validate_governance_prose_string(field_name, value)
     if value not in allowed_values:
         _raise_governance_validation_error(field_name, "must be canonical")
     return value

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -254,6 +254,19 @@ def _validate_governance_idempotency_key(
     )
 
 
+def _validate_governance_purge_id(field_name: str, value: str) -> str:
+    if not value:
+        _raise_governance_validation_error(field_name, "required")
+    _validate_governance_string(field_name, value)
+    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error(field_name, "identifier")
+    if not value.startswith("purge_"):
+        _raise_governance_validation_error(field_name, "must start with purge_")
+    if _CODE_SHAPED_VALUE_RE.fullmatch(value) is None:
+        _raise_governance_validation_error(field_name, "must be code-shaped")
+    return value
+
+
 def _validate_governance_int(field_name: str, value: Any) -> None:
     if isinstance(value, bool) or not isinstance(value, int):
         _raise_governance_validation_error(field_name, "expected int")
@@ -296,11 +309,14 @@ def _validate_governance_window_list(field_name: str, value: Any) -> None:
             _raise_governance_validation_error(
                 f"{field_name}[{index}]", sorted(unexpected_keys)[0]
             )
-        if "user_playbook_id" in normalized_item:
-            _validate_governance_int(
-                f"{field_name}[{index}].user_playbook_id",
-                normalized_item["user_playbook_id"],
+        if "user_playbook_id" not in normalized_item:
+            _raise_governance_validation_error(
+                f"{field_name}[{index}].user_playbook_id", "required"
             )
+        _validate_governance_int(
+            f"{field_name}[{index}].user_playbook_id",
+            normalized_item["user_playbook_id"],
+        )
         if "source_interaction_ids" in normalized_item:
             _validate_governance_int_list(
                 f"{field_name}[{index}].source_interaction_ids",
@@ -648,6 +664,7 @@ class SQLiteGovernanceMixin:
         deleted_count: int,
         error_detail: str | None,
     ) -> None:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         detail = _validate_governance_detail("detail", detail)
         error_detail = _validate_governance_error_detail(error_detail)
         _validate_governance_target_ref(target_ref)
@@ -751,6 +768,7 @@ class SQLiteGovernanceMixin:
         _validate_governance_prefixed_ref(
             "request_ref", request_ref, prefix="reqref_v1_"
         )
+        validated_purge_id = _validate_governance_purge_id("purge_id", purge_id)
         validated_idempotency_key = cast(
             str,
             _validate_governance_idempotency_key("idempotency_key", idempotency_key),
@@ -770,7 +788,7 @@ class SQLiteGovernanceMixin:
                        request_ref, idempotency_key, status, created_at, updated_at
                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
                 (
-                    purge_id,
+                    validated_purge_id,
                     self.org_id,
                     operation_type,
                     scope_type,
@@ -782,7 +800,7 @@ class SQLiteGovernanceMixin:
                 ),
             )
             self.conn.commit()
-        return self.get_purge_operation(purge_id)
+        return self.get_purge_operation(validated_purge_id)
 
     def record_purge_target(
         self,
@@ -1029,6 +1047,7 @@ class SQLiteGovernanceMixin:
     def complete_purge_operation_with_audit(
         self, purge_id: str, audit_event: AuditEvent
     ) -> PurgeOperation:
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
         if audit_event.org_id != self.org_id:
             raise ValueError("Audit event org_id must match storage org_id")
         if audit_event.idempotency_key != purge_id:

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -423,10 +423,29 @@ def _validate_governance_target_ref(
         if target_ref != "all":
             _raise_governance_validation_error("target_ref", "must be all")
         return target_ref
-    if (
-        target_name == "agent_playbook"
-        and phase in {"hide_for_rebuild", "rebuild_without_erased_sources"}
-    ):
+    if target_name in {
+        "request",
+        "interaction",
+        "profile",
+        "user_playbook",
+        "profile_purge",
+        "user_playbook_purge",
+    }:
+        if phase != "delete":
+            _raise_governance_validation_error(
+                phase,
+                f"{target_name} targets must use delete phase",
+            )
+        if target_ref != "all":
+            _raise_governance_validation_error("target_ref", "must be all")
+        return target_ref
+    if target_name == "agent_playbook":
+        if phase not in {"hide_for_rebuild", "rebuild_without_erased_sources"}:
+            _raise_governance_validation_error(
+                phase,
+                "agent_playbook targets must use hide_for_rebuild or "
+                "rebuild_without_erased_sources",
+            )
         if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
             return target_ref
         _raise_governance_validation_error(
@@ -1289,6 +1308,7 @@ class SQLiteGovernanceMixin:
         now = _epoch_now()
         with self._lock:
             try:
+                self.conn.execute("BEGIN IMMEDIATE")
                 row = self.conn.execute(
                     "SELECT * FROM purge_operations WHERE purge_id = ? AND org_id = ?",
                     (purge_id, self.org_id),

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1,0 +1,600 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
+from reflexio.models.api_schema.domain.governance import (
+    AuditEvent,
+    PurgeOperation,
+    PurgeOperationTarget,
+)
+
+GOVERNANCE_DDL = """
+CREATE TABLE IF NOT EXISTS audit_events (
+    event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    org_id TEXT NOT NULL,
+    actor_type TEXT NOT NULL DEFAULT 'system',
+    actor_ref TEXT,
+    operation TEXT NOT NULL,
+    entity_type TEXT NOT NULL,
+    entity_id TEXT,
+    subject_ref TEXT,
+    request_ref TEXT,
+    idempotency_key TEXT,
+    status TEXT NOT NULL DEFAULT 'ok',
+    detail TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_events_org_idem
+    ON audit_events(org_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_audit_events_subject_created
+    ON audit_events(org_id, subject_ref, created_at, event_id);
+
+CREATE TABLE IF NOT EXISTS purge_operations (
+    purge_id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    operation_type TEXT NOT NULL,
+    scope_type TEXT NOT NULL,
+    subject_ref TEXT,
+    request_ref TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    error_code TEXT,
+    error_detail TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    completed_at INTEGER
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_purge_operations_org_idem
+    ON purge_operations(org_id, idempotency_key);
+
+CREATE TABLE IF NOT EXISTS purge_operation_targets (
+    purge_id TEXT NOT NULL,
+    target_name TEXT NOT NULL,
+    target_ref TEXT NOT NULL DEFAULT '',
+    phase TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    detail TEXT,
+    deleted_count INTEGER NOT NULL DEFAULT 0,
+    error_detail TEXT,
+    started_at INTEGER,
+    completed_at INTEGER,
+    PRIMARY KEY (purge_id, target_name, target_ref, phase),
+    FOREIGN KEY (purge_id) REFERENCES purge_operations(purge_id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
+    ON purge_operation_targets(purge_id, phase, status);
+"""
+
+_PREPARE_PHASE = "prepare_targets"
+_SNAPSHOT_TARGET_NAME = "target_snapshot"
+
+
+def init_governance_tables(conn: sqlite3.Connection) -> None:
+    conn.executescript(GOVERNANCE_DDL)
+
+
+def _epoch_now() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+def _json_dumps(obj: Any) -> str | None:
+    if obj is None:
+        return None
+    return json.dumps(obj, default=str)
+
+
+def _json_loads(text: str | None) -> Any:
+    if not text:
+        return None
+    return json.loads(text)
+
+
+def _row_to_audit_event(row: sqlite3.Row) -> AuditEvent:
+    return AuditEvent(
+        org_id=row["org_id"],
+        actor_type=row["actor_type"],
+        actor_ref=row["actor_ref"],
+        operation=row["operation"],
+        entity_type=row["entity_type"],
+        entity_id=row["entity_id"],
+        subject_ref=row["subject_ref"],
+        request_ref=row["request_ref"],
+        idempotency_key=row["idempotency_key"],
+        status=row["status"],
+        detail=_json_loads(row["detail"]),
+        created_at=row["created_at"],
+    )
+
+
+def _row_to_purge_operation(row: sqlite3.Row) -> PurgeOperation:
+    return PurgeOperation(
+        purge_id=row["purge_id"],
+        org_id=row["org_id"],
+        operation_type=row["operation_type"],
+        scope_type=row["scope_type"],
+        subject_ref=row["subject_ref"],
+        request_ref=row["request_ref"],
+        idempotency_key=row["idempotency_key"],
+        status=row["status"],
+        error_code=row["error_code"],
+        error_detail=row["error_detail"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+        completed_at=row["completed_at"],
+    )
+
+
+def _row_to_purge_target(row: sqlite3.Row) -> PurgeOperationTarget:
+    return PurgeOperationTarget(
+        purge_id=row["purge_id"],
+        target_name=row["target_name"],
+        target_ref=row["target_ref"],
+        phase=row["phase"],
+        status=row["status"],
+        detail=_json_loads(row["detail"]),
+        deleted_count=row["deleted_count"],
+        error_detail=row["error_detail"],
+        started_at=row["started_at"],
+        completed_at=row["completed_at"],
+    )
+
+
+class SQLiteGovernanceMixin:
+    """SQLite governance storage primitives."""
+
+    conn: sqlite3.Connection
+    _lock: threading.RLock
+    org_id: str
+
+    def _append_audit_event_with_cursor(
+        self, cur: sqlite3.Cursor, event: AuditEvent
+    ) -> bool:
+        inserted = cur.execute(
+            """INSERT OR IGNORE INTO audit_events (
+                   org_id, actor_type, actor_ref, operation, entity_type, entity_id,
+                   subject_ref, request_ref, idempotency_key, status, detail, created_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                event.org_id,
+                event.actor_type,
+                event.actor_ref,
+                event.operation,
+                event.entity_type,
+                event.entity_id,
+                event.subject_ref,
+                event.request_ref,
+                event.idempotency_key,
+                event.status,
+                _json_dumps(event.detail),
+                event.created_at,
+            ),
+        )
+        return inserted.rowcount > 0
+
+    def _record_purge_target_locked(
+        self,
+        *,
+        purge_id: str,
+        target_name: str,
+        target_ref: str,
+        phase: str,
+        status: Literal["pending", "running", "failed", "complete"],
+        detail: dict[str, object] | None,
+        deleted_count: int,
+        error_detail: str | None,
+    ) -> None:
+        now = _epoch_now()
+        existing = self.conn.execute(
+            """SELECT started_at, completed_at
+               FROM purge_operation_targets
+               WHERE purge_id = ? AND target_name = ? AND target_ref = ? AND phase = ?""",
+            (purge_id, target_name, target_ref, phase),
+        ).fetchone()
+        started_at = existing["started_at"] if existing else None
+        completed_at = existing["completed_at"] if existing else None
+        if started_at is None and status in {"running", "failed", "complete"}:
+            started_at = now
+        if status in {"failed", "complete"}:
+            completed_at = now
+        self.conn.execute(
+            """INSERT INTO purge_operation_targets (
+                   purge_id, target_name, target_ref, phase, status, detail,
+                   deleted_count, error_detail, started_at, completed_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(purge_id, target_name, target_ref, phase) DO UPDATE SET
+                   status = excluded.status,
+                   detail = excluded.detail,
+                   deleted_count = excluded.deleted_count,
+                   error_detail = excluded.error_detail,
+                   started_at = COALESCE(purge_operation_targets.started_at, excluded.started_at),
+                   completed_at = excluded.completed_at""",
+            (
+                purge_id,
+                target_name,
+                target_ref,
+                phase,
+                status,
+                _json_dumps(detail),
+                deleted_count,
+                error_detail,
+                started_at,
+                completed_at,
+            ),
+        )
+        self.conn.execute(
+            """UPDATE purge_operations
+               SET status = CASE
+                   WHEN status IN ('complete', 'failed') THEN status
+                   WHEN ? IN ('running', 'complete') THEN 'running'
+                   ELSE status
+               END,
+                   updated_at = ?
+               WHERE purge_id = ? AND org_id = ?""",
+            (status, now, purge_id, self.org_id),
+        )
+
+    def append_audit_event(self, event: AuditEvent) -> bool:
+        with self._lock:
+            inserted = self._append_audit_event_with_cursor(self.conn, event)
+            self.conn.commit()
+            return inserted
+
+    def list_audit_events(
+        self, subject_ref: str | None = None, *, org_id: str | None = None
+    ) -> list[AuditEvent]:
+        sql = "SELECT * FROM audit_events WHERE org_id = ?"
+        params: list[Any] = [org_id or self.org_id]
+        if subject_ref is not None:
+            sql += " AND subject_ref = ?"
+            params.append(subject_ref)
+        sql += " ORDER BY created_at ASC, event_id ASC"
+        rows = self._fetchall(sql, params)
+        return [_row_to_audit_event(row) for row in rows]
+
+    def begin_purge_operation(
+        self,
+        purge_id: str,
+        idempotency_key: str,
+        operation_type: Literal["user_erasure", "org_purge"],
+        scope_type: Literal["user", "org"],
+        subject_ref: str | None,
+        request_ref: str,
+    ) -> PurgeOperation:
+        now = _epoch_now()
+        with self._lock:
+            existing = self.conn.execute(
+                """SELECT * FROM purge_operations
+                   WHERE org_id = ? AND idempotency_key = ?""",
+                (self.org_id, idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                return _row_to_purge_operation(existing)
+            self.conn.execute(
+                """INSERT INTO purge_operations (
+                       purge_id, org_id, operation_type, scope_type, subject_ref,
+                       request_ref, idempotency_key, status, created_at, updated_at
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
+                (
+                    purge_id,
+                    self.org_id,
+                    operation_type,
+                    scope_type,
+                    subject_ref,
+                    request_ref,
+                    idempotency_key,
+                    now,
+                    now,
+                ),
+            )
+            self.conn.commit()
+        return self.get_purge_operation(purge_id)
+
+    def record_purge_target(
+        self,
+        purge_id: str,
+        target_name: str,
+        phase: str,
+        status: Literal["pending", "running", "failed", "complete"],
+        target_ref: str = "",
+        detail: dict[str, object] | None = None,
+        deleted_count: int = 0,
+        error_detail: str | None = None,
+    ) -> None:
+        with self._lock:
+            self._record_purge_target_locked(
+                purge_id=purge_id,
+                target_name=target_name,
+                target_ref=target_ref,
+                phase=phase,
+                status=status,
+                detail=detail,
+                deleted_count=deleted_count,
+                error_detail=error_detail,
+            )
+            self.conn.commit()
+
+    def list_purge_targets(
+        self, purge_id: str, phase: str | None = None
+    ) -> list[PurgeOperationTarget]:
+        sql = "SELECT * FROM purge_operation_targets WHERE purge_id = ?"
+        params: list[Any] = [purge_id]
+        if phase is not None:
+            sql += " AND phase = ?"
+            params.append(phase)
+        sql += " ORDER BY phase ASC, target_name ASC, target_ref ASC"
+        rows = self._fetchall(sql, params)
+        return [_row_to_purge_target(row) for row in rows]
+
+    def purge_targets_prepared(self, purge_id: str) -> bool:
+        row = self._fetchone(
+            """SELECT 1 FROM purge_operation_targets
+               WHERE purge_id = ? AND target_name = ? AND target_ref = 'all'
+                 AND phase = ? AND status = 'complete'""",
+            (purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+        )
+        return row is not None
+
+    def prepare_governance_erase_targets(
+        self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
+    ) -> None:
+        request_count = self._fetchone(
+            "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
+            (user_id,),
+        )["cnt"]
+        interaction_count = self._fetchone(
+            "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
+            (user_id,),
+        )["cnt"]
+        profile_count = self._fetchone(
+            "SELECT COUNT(*) AS cnt FROM profiles WHERE user_id = ?",
+            (user_id,),
+        )["cnt"]
+        playbook_count = len(owned_user_playbook_ids)
+        affected_agent_playbook_ids: list[int] = []
+        if owned_user_playbook_ids:
+            placeholders = ",".join("?" for _ in owned_user_playbook_ids)
+            rows = self._fetchall(
+                f"""SELECT DISTINCT agent_playbook_id
+                    FROM agent_playbook_source_user_playbooks
+                    WHERE user_playbook_id IN ({placeholders})
+                    ORDER BY agent_playbook_id ASC""",
+                sorted(owned_user_playbook_ids),
+            )
+            affected_agent_playbook_ids = [int(row["agent_playbook_id"]) for row in rows]
+        targets = {
+            "request": request_count,
+            "interaction": interaction_count,
+            "profile": profile_count,
+            "user_playbook": playbook_count,
+        }
+        with self._lock:
+            for target_name, count in targets.items():
+                self._record_purge_target_locked(
+                    purge_id=purge_id,
+                    target_name=target_name,
+                    target_ref="all",
+                    phase="delete",
+                    status="pending",
+                    detail={"count": int(count)},
+                    deleted_count=0,
+                    error_detail=None,
+                )
+            for agent_playbook_id in affected_agent_playbook_ids:
+                self._record_purge_target_locked(
+                    purge_id=purge_id,
+                    target_name="agent_playbook",
+                    target_ref=str(agent_playbook_id),
+                    phase="rebuild",
+                    status="pending",
+                    detail=None,
+                    deleted_count=0,
+                    error_detail=None,
+                )
+            self._record_purge_target_locked(
+                purge_id=purge_id,
+                target_name=_SNAPSHOT_TARGET_NAME,
+                target_ref="all",
+                phase=_PREPARE_PHASE,
+                status="complete",
+                detail={
+                    "user_id": user_id,
+                    "owned_user_playbook_ids": sorted(owned_user_playbook_ids),
+                    "affected_agent_playbook_ids": affected_agent_playbook_ids,
+                },
+                deleted_count=0,
+                error_detail=None,
+            )
+            self.conn.commit()
+
+    def hide_governance_agent_playbooks_for_rebuild(self, purge_id: str) -> list[int]:
+        targets = self.list_purge_targets(purge_id, phase="rebuild")
+        agent_playbook_ids = [
+            int(target.target_ref)
+            for target in targets
+            if target.target_name == "agent_playbook" and target.target_ref
+        ]
+        if not agent_playbook_ids:
+            return []
+        placeholders = ",".join("?" for _ in agent_playbook_ids)
+        with self._lock:
+            self.conn.execute(
+                f"""UPDATE agent_playbooks
+                    SET status = 'archived'
+                    WHERE agent_playbook_id IN ({placeholders})
+                      AND status IS NULL""",
+                agent_playbook_ids,
+            )
+            for agent_playbook_id in agent_playbook_ids:
+                self._record_purge_target_locked(
+                    purge_id=purge_id,
+                    target_name="agent_playbook",
+                    target_ref=str(agent_playbook_id),
+                    phase="rebuild",
+                    status="running",
+                    detail=None,
+                    deleted_count=0,
+                    error_detail=None,
+                )
+            self.conn.commit()
+        return agent_playbook_ids
+
+    def apply_governance_user_data_delete(
+        self, purge_id: str, user_id: str
+    ) -> dict[str, int]:
+        counts = self.clear_user_data(user_id)
+        name_map = {
+            "interactions": "interaction",
+            "user_playbooks": "user_playbook",
+            "profiles": "profile",
+            "requests": "request",
+            "purged_profiles": "profile_purge",
+            "purged_user_playbooks": "user_playbook_purge",
+        }
+        with self._lock:
+            for key, value in counts.items():
+                self._record_purge_target_locked(
+                    purge_id=purge_id,
+                    target_name=name_map.get(key, key),
+                    target_ref="all",
+                    phase="delete",
+                    status="complete",
+                    detail={"user_id": user_id},
+                    deleted_count=int(value),
+                    error_detail=None,
+                )
+            self.conn.commit()
+        return counts
+
+    def apply_governance_agent_playbook_rebuild(
+        self,
+        purge_id: str,
+        agent_playbook_id: int,
+        remaining_source_windows: list[dict[str, object]],
+        content: str | None,
+        trigger: str | None,
+        rationale: str | None,
+        blocking_issue: dict[str, object] | None,
+        expanded_terms: str | None,
+        tags: list[str] | None,
+    ) -> None:
+        windows = [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=int(window["user_playbook_id"]),
+                source_interaction_ids=[
+                    int(source_id)
+                    for source_id in (window.get("source_interaction_ids") or [])
+                ],
+            )
+            for window in remaining_source_windows
+        ]
+        with self._lock:
+            cur = self.conn.execute(
+                """UPDATE agent_playbooks
+                   SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,
+                       expanded_terms = ?, tags = ?, status = NULL
+                   WHERE agent_playbook_id = ?""",
+                (
+                    content or "",
+                    trigger,
+                    rationale,
+                    json.dumps(blocking_issue) if blocking_issue is not None else None,
+                    expanded_terms,
+                    _json_dumps(tags),
+                    agent_playbook_id,
+                ),
+            )
+            if cur.rowcount == 0:
+                raise ValueError(
+                    f"Agent playbook with ID {agent_playbook_id} not found"
+                )
+            self.conn.commit()
+        self.set_source_windows_for_agent_playbook(agent_playbook_id, windows)
+        self.record_purge_target(
+            purge_id=purge_id,
+            target_name="agent_playbook",
+            target_ref=str(agent_playbook_id),
+            phase="rebuild",
+            status="complete",
+        )
+
+    def complete_purge_operation_with_audit(
+        self, purge_id: str, audit_event: AuditEvent
+    ) -> PurgeOperation:
+        now = _epoch_now()
+        with self._lock:
+            try:
+                row = self.conn.execute(
+                    "SELECT * FROM purge_operations WHERE purge_id = ? AND org_id = ?",
+                    (purge_id, self.org_id),
+                ).fetchone()
+                if row is None:
+                    raise ValueError(f"Purge operation {purge_id!r} not found")
+                snapshot = self.conn.execute(
+                    """SELECT 1 FROM purge_operation_targets
+                       WHERE purge_id = ? AND target_name = ? AND target_ref = 'all'
+                         AND phase = ? AND status = 'complete'""",
+                    (purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+                ).fetchone()
+                if snapshot is None:
+                    raise ValueError(
+                        "Cannot complete purge without target snapshot marker"
+                    )
+                incomplete = self.conn.execute(
+                    """SELECT 1 FROM purge_operation_targets
+                       WHERE purge_id = ? AND status != 'complete'
+                       LIMIT 1""",
+                    (purge_id,),
+                ).fetchone()
+                if incomplete is not None:
+                    raise ValueError("Cannot complete purge with incomplete targets")
+                self._append_audit_event_with_cursor(self.conn, audit_event)
+                self.conn.execute(
+                    """UPDATE purge_operations
+                       SET status = 'complete',
+                           error_code = NULL,
+                           error_detail = NULL,
+                           updated_at = ?,
+                           completed_at = COALESCE(completed_at, ?)
+                       WHERE purge_id = ? AND org_id = ?""",
+                    (now, now, purge_id, self.org_id),
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        return self.get_purge_operation(purge_id)
+
+    def fail_purge_operation(
+        self, purge_id: str, error_code: str, error_detail: str
+    ) -> PurgeOperation:
+        now = _epoch_now()
+        with self._lock:
+            cur = self.conn.execute(
+                """UPDATE purge_operations
+                   SET status = 'failed', error_code = ?, error_detail = ?,
+                       updated_at = ?, completed_at = ?
+                   WHERE purge_id = ? AND org_id = ?""",
+                (error_code, error_detail, now, now, purge_id, self.org_id),
+            )
+            if cur.rowcount == 0:
+                raise ValueError(f"Purge operation {purge_id!r} not found")
+            self.conn.commit()
+        return self.get_purge_operation(purge_id)
+
+    def get_purge_operation(self, purge_id: str) -> PurgeOperation:
+        row = self._fetchone(
+            "SELECT * FROM purge_operations WHERE purge_id = ? AND org_id = ?",
+            (purge_id, self.org_id),
+        )
+        if row is None:
+            raise ValueError(f"Purge operation {purge_id!r} not found")
+        return _row_to_purge_operation(row)
+
+    def gc_governance_retention(self, *, _config: Any) -> int:
+        return 0

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -144,6 +144,7 @@ _ALLOWED_PURGE_TARGET_DETAIL_KEYS = frozenset(
         "erased_source_ids",
         "owned_user_playbook_ids",
         "original_source_windows",
+        "previous_lifecycle_status",
         "prepared",
         "rebuilt_agent_playbook_ids",
         "remaining_source_windows",
@@ -195,6 +196,9 @@ _ALLOWED_DETAIL_STATUS_VALUES = frozenset(
         "pending",
         "running",
     }
+)
+_ALLOWED_PREVIOUS_LIFECYCLE_STATUS_VALUES = frozenset(
+    status.value for status in Status if status.value is not None
 )
 _ALLOWED_DETAIL_ROUTE_VALUES = frozenset(
     {
@@ -563,6 +567,14 @@ def _validate_governance_detail_entry(
         return _validate_governance_int_list(field_name, value)
     if key in {"original_source_windows", "remaining_source_windows"}:
         return _validate_governance_window_list(field_name, value)
+    if key == "previous_lifecycle_status":
+        if value is None:
+            return None
+        return _validate_governance_detail_enum(
+            field_name,
+            value,
+            allowed_values=_ALLOWED_PREVIOUS_LIFECYCLE_STATUS_VALUES,
+        )
     if key == "prepared":
         if not isinstance(value, bool):
             _raise_governance_validation_error(field_name, "expected bool")
@@ -1443,16 +1455,29 @@ class SQLiteGovernanceMixin:
                 if owned_user_playbook_ids:
                     placeholders = ",".join("?" for _ in owned_user_playbook_ids)
                     rows = self.conn.execute(
-                        f"""SELECT DISTINCT agent_playbook_id
+                        f"""SELECT DISTINCT apsup.agent_playbook_id
                             FROM agent_playbook_source_user_playbooks
+                            AS apsup
+                            JOIN agent_playbooks ap
+                              ON ap.agent_playbook_id = apsup.agent_playbook_id
                             WHERE user_playbook_id IN ({placeholders})
-                            ORDER BY agent_playbook_id ASC""",
+                            ORDER BY apsup.agent_playbook_id ASC""",
                         sorted(owned_user_playbook_ids),
                     ).fetchall()
                     affected_agent_playbook_ids = [
                         int(row["agent_playbook_id"]) for row in rows
                     ]
                     for agent_playbook_id in affected_agent_playbook_ids:
+                        status_row = self.conn.execute(
+                            """SELECT status
+                               FROM agent_playbooks
+                               WHERE agent_playbook_id = ?""",
+                            (agent_playbook_id,),
+                        ).fetchone()
+                        if status_row is None:
+                            raise ValueError(
+                                f"Agent playbook with ID {agent_playbook_id} not found"
+                            )
                         window_rows = self.conn.execute(
                             """SELECT user_playbook_id, source_interaction_ids
                                FROM agent_playbook_source_user_playbooks
@@ -1480,6 +1505,7 @@ class SQLiteGovernanceMixin:
                         ]
                         rebuild_details_by_agent_playbook_id[agent_playbook_id] = {
                             "original_source_windows": original_window_dicts,
+                            "previous_lifecycle_status": status_row["status"],
                             "remaining_source_windows": remaining_window_dicts,
                         }
                 for target_name, count in targets.items():
@@ -1527,11 +1553,14 @@ class SQLiteGovernanceMixin:
         targets = self.list_purge_targets(
             purge_id, phase="rebuild_without_erased_sources"
         )
-        agent_playbook_ids = [
-            int(target.target_ref)
+        eligible_targets = [
+            target
             for target in targets
-            if target.target_name == "agent_playbook" and target.target_ref
+            if target.target_name == "agent_playbook"
+            and target.target_ref
+            and target.status != "complete"
         ]
+        agent_playbook_ids = [int(target.target_ref) for target in eligible_targets]
         if not agent_playbook_ids:
             return []
         placeholders = ",".join("?" for _ in agent_playbook_ids)
@@ -1633,6 +1662,7 @@ class SQLiteGovernanceMixin:
                 rebuild_detail = _json_loads(rebuild_target_row["detail"])
                 if not isinstance(rebuild_detail, dict) or not {
                     "original_source_windows",
+                    "previous_lifecycle_status",
                     "remaining_source_windows",
                 }.issubset(rebuild_detail):
                     raise ValueError(
@@ -1646,6 +1676,9 @@ class SQLiteGovernanceMixin:
                     raise ValueError(
                         "remaining_source_windows must match the planned rebuild target"
                     )
+                previous_lifecycle_status = cast(
+                    str | None, rebuild_detail["previous_lifecycle_status"]
+                )
                 hide_target_row = self.conn.execute(
                     """SELECT status
                        FROM purge_operation_targets
@@ -1658,7 +1691,7 @@ class SQLiteGovernanceMixin:
                 cur = self.conn.execute(
                     """UPDATE agent_playbooks
                        SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,
-                           expanded_terms = ?, tags = ?, status = NULL
+                           expanded_terms = ?, tags = ?, status = ?
                        WHERE agent_playbook_id = ?""",
                     (
                         content or "",
@@ -1667,6 +1700,7 @@ class SQLiteGovernanceMixin:
                         json.dumps(blocking_issue) if blocking_issue is not None else None,
                         expanded_terms,
                         _json_dumps(tags),
+                        previous_lifecycle_status,
                         agent_playbook_id,
                     ),
                 )

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -281,6 +281,13 @@ def _validate_governance_int(field_name: str, value: Any) -> None:
         _raise_governance_validation_error(field_name, "expected int")
 
 
+def _validate_governance_deleted_count(value: Any) -> int:
+    _validate_governance_int("deleted_count", value)
+    if value < 0:
+        _raise_governance_validation_error("deleted_count", "must be nonnegative")
+    return cast(int, value)
+
+
 def _validate_governance_int_list(field_name: str, value: Any) -> None:
     if not isinstance(value, list):
         _raise_governance_validation_error(field_name, "expected list[int]")
@@ -674,9 +681,25 @@ class SQLiteGovernanceMixin:
         error_detail: str | None,
     ) -> None:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
+        _validate_governance_enum(
+            "target_name",
+            target_name,
+            allowed=_ALLOWED_PURGE_TARGET_NAMES,
+        )
+        _validate_governance_enum(
+            "phase",
+            phase,
+            allowed=_ALLOWED_PURGE_TARGET_PHASES,
+        )
+        _validate_governance_enum(
+            "status",
+            status,
+            allowed=_ALLOWED_PURGE_TARGET_STATUSES,
+        )
         detail = _validate_governance_detail("detail", detail)
         error_detail = _validate_governance_error_detail(error_detail)
         _validate_governance_target_ref(target_ref)
+        deleted_count = _validate_governance_deleted_count(deleted_count)
         now = _epoch_now()
         existing = self.conn.execute(
             """SELECT started_at, completed_at
@@ -733,6 +756,8 @@ class SQLiteGovernanceMixin:
                 "Successful ERASE audit rows may only be written by "
                 "complete_purge_operation_with_audit()"
             )
+        if event.org_id != self.org_id:
+            raise ValueError("Audit event org_id must match storage org_id")
         _validate_audit_event_for_persistence(event)
         with self._lock:
             inserted = self._append_audit_event_with_cursor(self.conn, event)

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -142,6 +142,10 @@ _RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:
 _SAFE_INTERNAL_ID_RE = re.compile(r"^[0-9]+$")
 _USER_LIKE_TARGET_REF_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
 _CODE_SHAPED_VALUE_RE = re.compile(r"^[A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)+$")
+_IDENTIFIERISH_CODE_VALUE_RE = re.compile(
+    r"^(?:user|subject|actor)[_.:-][A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)*$",
+    re.IGNORECASE,
+)
 _SAFE_ERROR_CODE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,127}$")
 _IDENTIFIERISH_ERROR_CODE_RE = re.compile(
     r"^(?:user|subject|request|req|actor|email)[-_.:]?[A-Za-z0-9_.:-]+$",
@@ -229,6 +233,8 @@ def _validate_governance_code_shaped(
         return value
     if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
         _raise_governance_validation_error(field_name, "identifier")
+    if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "identifier")
     if _SAFE_INTERNAL_ID_RE.fullmatch(value):
         return value
     if _CODE_SHAPED_VALUE_RE.fullmatch(value):
@@ -264,6 +270,9 @@ def _validate_governance_purge_id(field_name: str, value: str) -> str:
         _raise_governance_validation_error(field_name, "must start with purge_")
     if _CODE_SHAPED_VALUE_RE.fullmatch(value) is None:
         _raise_governance_validation_error(field_name, "must be code-shaped")
+    suffix = value[len("purge_") :]
+    if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(suffix):
+        _raise_governance_validation_error(field_name, "identifier")
     return value
 
 

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -773,6 +773,11 @@ class _SQLiteGovernanceDeps(Protocol):
     def clear_user_data(self, user_id: str) -> dict[str, int]:
         ...
 
+    def _partition_purge_vs_delete(
+        self, entity_type: Literal["profile", "user_playbook"], ids: list[str]
+    ) -> tuple[list[str], list[str]]:
+        ...
+
     def set_source_windows_for_agent_playbook(
         self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
     ) -> None:
@@ -793,6 +798,42 @@ class SQLiteGovernanceMixin:
 
     def _deps(self) -> _SQLiteGovernanceDeps:
         return cast(_SQLiteGovernanceDeps, self)
+
+    def _planned_governance_delete_counts(
+        self, user_id: str, owned_user_playbook_ids: set[int]
+    ) -> dict[str, int]:
+        request_row = self.conn.execute(
+            "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+        interaction_row = self.conn.execute(
+            "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()
+        profile_rows = self.conn.execute(
+            "SELECT profile_id FROM profiles WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+        if request_row is None or interaction_row is None:
+            raise ValueError("Missing governance count rows")
+        profile_ids = [str(row["profile_id"]) for row in profile_rows]
+        purge_profile_ids, delete_profile_ids = self._deps()._partition_purge_vs_delete(
+            "profile",
+            profile_ids,
+        )
+        playbook_ids = [str(user_playbook_id) for user_playbook_id in sorted(owned_user_playbook_ids)]
+        purge_playbook_ids, delete_playbook_ids = self._deps()._partition_purge_vs_delete(
+            "user_playbook",
+            playbook_ids,
+        )
+        return {
+            "request": int(request_row["cnt"]),
+            "interaction": int(interaction_row["cnt"]),
+            "profile": len(delete_profile_ids),
+            "profile_purge": len(purge_profile_ids),
+            "user_playbook": len(delete_playbook_ids),
+            "user_playbook_purge": len(purge_playbook_ids),
+        }
 
     def _append_audit_event_with_cursor(
         self, cur: sqlite3.Connection | sqlite3.Cursor, event: AuditEvent
@@ -1077,24 +1118,10 @@ class SQLiteGovernanceMixin:
         with self._lock:
             try:
                 self.conn.execute("BEGIN")
-                request_row = self.conn.execute(
-                    "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
-                    (user_id,),
-                ).fetchone()
-                interaction_row = self.conn.execute(
-                    "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
-                    (user_id,),
-                ).fetchone()
-                profile_row = self.conn.execute(
-                    "SELECT COUNT(*) AS cnt FROM profiles WHERE user_id = ?",
-                    (user_id,),
-                ).fetchone()
-                if request_row is None or interaction_row is None or profile_row is None:
-                    raise ValueError("Missing governance count rows")
-                request_count = int(request_row["cnt"])
-                interaction_count = int(interaction_row["cnt"])
-                profile_count = int(profile_row["cnt"])
-                playbook_count = len(owned_user_playbook_ids)
+                targets = self._planned_governance_delete_counts(
+                    user_id,
+                    owned_user_playbook_ids,
+                )
                 affected_agent_playbook_ids: list[int] = []
                 rebuild_details_by_agent_playbook_id: dict[int, dict[str, object]] = {}
                 if owned_user_playbook_ids:
@@ -1139,12 +1166,6 @@ class SQLiteGovernanceMixin:
                             "original_source_windows": original_window_dicts,
                             "remaining_source_windows": remaining_window_dicts,
                         }
-                targets = {
-                    "request": request_count,
-                    "interaction": interaction_count,
-                    "profile": profile_count,
-                    "user_playbook": playbook_count,
-                }
                 for target_name, count in targets.items():
                     self._record_purge_target_locked(
                         purge_id=purge_id,
@@ -1326,6 +1347,15 @@ class SQLiteGovernanceMixin:
                 ).fetchone()
                 if row is None:
                     raise ValueError(f"Purge operation {purge_id!r} not found")
+                purge_operation = _row_to_purge_operation(row)
+                if purge_operation.subject_ref != audit_event.subject_ref:
+                    raise ValueError(
+                        "Audit event subject_ref must match purge operation subject_ref"
+                    )
+                if purge_operation.request_ref != audit_event.request_ref:
+                    raise ValueError(
+                        "Audit event request_ref must match purge operation request_ref"
+                    )
                 snapshot = self.conn.execute(
                     """SELECT 1 FROM purge_operation_targets
                        WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = 'all'

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1550,49 +1550,56 @@ class SQLiteGovernanceMixin:
 
     def hide_governance_agent_playbooks_for_rebuild(self, purge_id: str) -> list[int]:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
-        targets = self.list_purge_targets(
-            purge_id, phase="rebuild_without_erased_sources"
-        )
-        eligible_targets = [
-            target
-            for target in targets
-            if target.target_name == "agent_playbook"
-            and target.target_ref
-            and target.status != "complete"
-        ]
-        agent_playbook_ids = [int(target.target_ref) for target in eligible_targets]
-        if not agent_playbook_ids:
-            return []
-        placeholders = ",".join("?" for _ in agent_playbook_ids)
         with self._lock:
-            self.conn.execute(
-                f"""UPDATE agent_playbooks
-                    SET status = ?
-                    WHERE agent_playbook_id IN ({placeholders})""",
-                [Status.ARCHIVE_IN_PROGRESS.value, *agent_playbook_ids],
-            )
-            for agent_playbook_id in agent_playbook_ids:
-                self._record_purge_target_locked(
-                    purge_id=purge_id,
-                    target_name="agent_playbook",
-                    target_ref=str(agent_playbook_id),
-                    phase="hide_for_rebuild",
-                    status="complete",
-                    detail=None,
-                    deleted_count=0,
-                    error_detail=None,
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                target_rows = self.conn.execute(
+                    """SELECT target_ref
+                       FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ?
+                         AND target_name = 'agent_playbook'
+                         AND phase = 'rebuild_without_erased_sources'
+                         AND target_ref != ''
+                         AND status != 'complete'
+                       ORDER BY CAST(target_ref AS INTEGER) ASC""",
+                    (self.org_id, purge_id),
+                ).fetchall()
+                agent_playbook_ids = [int(row["target_ref"]) for row in target_rows]
+                if not agent_playbook_ids:
+                    self.conn.commit()
+                    return []
+                placeholders = ",".join("?" for _ in agent_playbook_ids)
+                self.conn.execute(
+                    f"""UPDATE agent_playbooks
+                        SET status = ?
+                        WHERE agent_playbook_id IN ({placeholders})""",
+                    [Status.ARCHIVE_IN_PROGRESS.value, *agent_playbook_ids],
                 )
-                self._record_purge_target_locked(
-                    purge_id=purge_id,
-                    target_name="agent_playbook",
-                    target_ref=str(agent_playbook_id),
-                    phase="rebuild_without_erased_sources",
-                    status="running",
-                    detail=None,
-                    deleted_count=0,
-                    error_detail=None,
-                )
-            self.conn.commit()
+                for agent_playbook_id in agent_playbook_ids:
+                    self._record_purge_target_locked(
+                        purge_id=purge_id,
+                        target_name="agent_playbook",
+                        target_ref=str(agent_playbook_id),
+                        phase="hide_for_rebuild",
+                        status="complete",
+                        detail=None,
+                        deleted_count=0,
+                        error_detail=None,
+                    )
+                    self._record_purge_target_locked(
+                        purge_id=purge_id,
+                        target_name="agent_playbook",
+                        target_ref=str(agent_playbook_id),
+                        phase="rebuild_without_erased_sources",
+                        status="running",
+                        detail=None,
+                        deleted_count=0,
+                        error_detail=None,
+                    )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
         return agent_playbook_ids
 
     def apply_governance_user_data_delete(
@@ -1651,7 +1658,7 @@ class SQLiteGovernanceMixin:
             try:
                 self.conn.execute("BEGIN")
                 rebuild_target_row = self.conn.execute(
-                    """SELECT detail
+                    """SELECT status, detail
                        FROM purge_operation_targets
                        WHERE org_id = ? AND purge_id = ? AND target_name = 'agent_playbook'
                          AND target_ref = ? AND phase = 'rebuild_without_erased_sources'""",
@@ -1659,6 +1666,8 @@ class SQLiteGovernanceMixin:
                 ).fetchone()
                 if rebuild_target_row is None:
                     raise ValueError("planned rebuild target does not exist")
+                if rebuild_target_row["status"] == "complete":
+                    raise ValueError("planned rebuild target is already complete")
                 rebuild_detail = _json_loads(rebuild_target_row["detail"])
                 if not isinstance(rebuild_detail, dict) or not {
                     "original_source_windows",

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -778,12 +778,11 @@ def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> N
 def _is_successful_erase_event(
     event: AuditEvent, *, purge_id: str | None = None
 ) -> bool:
-    return (
-        event.operation == "ERASE"
-        and event.status == "ok"
-        and event.idempotency_key is not None
-        and (purge_id is None or event.idempotency_key == purge_id)
-    )
+    if event.operation != "ERASE" or event.status != "ok":
+        return False
+    if purge_id is not None:
+        return event.idempotency_key == purge_id
+    return True
 
 
 def _successful_erase_identity(

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -80,8 +80,15 @@ _ALLOWED_DETAIL_KEYS = frozenset(
         "agent_playbook_id",
         "count",
         "deleted_count",
+        "erased_source_ids",
         "owned_user_playbook_ids",
+        "original_source_windows",
+        "prepared",
+        "rebuilt_agent_playbook_ids",
+        "remaining_source_windows",
+        "route",
         "source_interaction_ids",
+        "status",
         "user_playbook_id",
     }
 )
@@ -96,7 +103,14 @@ _DISALLOWED_DETAIL_KEYS = frozenset(
     }
 )
 _EMAIL_RE = re.compile(r"\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
-_REQUEST_ID_RE = re.compile(r"\b(?:reqref|request)[_-][A-Za-z0-9_-]+\b", re.IGNORECASE)
+_REQUEST_ID_RE = re.compile(
+    r"\b(?:reqref_(?!v1_)|request[_-]|req[_-])[A-Za-z0-9_-]*\b",
+    re.IGNORECASE,
+)
+_TOKEN_NAME_RE = re.compile(
+    r"\b(?:api[-_ ]?token|token[-_ ]?name|bearer|secret[-_ ]?key)\b",
+    re.IGNORECASE,
+)
 _RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
 
 
@@ -129,35 +143,91 @@ def _validate_governance_string(field_name: str, value: str) -> None:
         _raise_governance_validation_error(field_name, "email")
     if _REQUEST_ID_RE.search(value):
         _raise_governance_validation_error(field_name, "request_id")
+    lowered = value.lower()
+    if "prompt" in lowered or "content" in lowered:
+        _raise_governance_validation_error(field_name, "prompt/content")
+    if _TOKEN_NAME_RE.search(value):
+        _raise_governance_validation_error(field_name, "token")
     if _RAW_EXCEPTION_RE.search(value):
         _raise_governance_validation_error(field_name, "raw exception text")
 
 
-def _validate_governance_detail_value(field_name: str, value: Any) -> None:
-    if value is None or isinstance(value, bool | int | float):
+def _validate_governance_prefixed_ref(
+    field_name: str, value: str | None, *, prefix: str
+) -> None:
+    if value is None:
         return
-    if isinstance(value, str):
+    if not value.startswith(prefix):
+        _raise_governance_validation_error(field_name, f"must start with {prefix}")
+
+
+def _validate_governance_int(field_name: str, value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        _raise_governance_validation_error(field_name, "expected int")
+
+
+def _validate_governance_int_list(field_name: str, value: Any) -> None:
+    if not isinstance(value, list):
+        _raise_governance_validation_error(field_name, "expected list[int]")
+    for item in value:
+        _validate_governance_int(field_name, item)
+
+
+def _validate_governance_window_list(field_name: str, value: Any) -> None:
+    if not isinstance(value, list):
+        _raise_governance_validation_error(field_name, "expected list[window]")
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            _raise_governance_validation_error(
+                f"{field_name}[{index}]", "expected window dict"
+            )
+        normalized_keys = {str(key).strip().lower() for key in item}
+        unexpected_keys = normalized_keys - {"user_playbook_id", "source_interaction_ids"}
+        if unexpected_keys:
+            _raise_governance_validation_error(
+                f"{field_name}[{index}]", sorted(unexpected_keys)[0]
+            )
+        if "user_playbook_id" in item:
+            _validate_governance_int(
+                f"{field_name}[{index}].user_playbook_id", item["user_playbook_id"]
+            )
+        if "source_interaction_ids" in item:
+            _validate_governance_int_list(
+                f"{field_name}[{index}].source_interaction_ids",
+                item["source_interaction_ids"],
+            )
+
+
+def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> None:
+    if key in _DISALLOWED_DETAIL_KEYS:
+        _raise_governance_validation_error(field_name, key)
+    if key not in _ALLOWED_DETAIL_KEYS:
+        _raise_governance_validation_error(field_name, key)
+    if key in {"count", "deleted_count", "agent_playbook_id", "user_playbook_id"}:
+        _validate_governance_int(field_name, value)
+        return
+    if key in {
+        "affected_agent_playbook_ids",
+        "erased_source_ids",
+        "owned_user_playbook_ids",
+        "rebuilt_agent_playbook_ids",
+        "source_interaction_ids",
+    }:
+        _validate_governance_int_list(field_name, value)
+        return
+    if key in {"original_source_windows", "remaining_source_windows"}:
+        _validate_governance_window_list(field_name, value)
+        return
+    if key == "prepared":
+        if not isinstance(value, bool):
+            _raise_governance_validation_error(field_name, "expected bool")
+        return
+    if key in {"route", "status"}:
+        if not isinstance(value, str):
+            _raise_governance_validation_error(field_name, "expected str")
         _validate_governance_string(field_name, value)
         return
-    if isinstance(value, list):
-        for item in value:
-            _validate_governance_detail_value(field_name, item)
-        return
-    if isinstance(value, dict):
-        for key, nested_value in value.items():
-            normalized_key = str(key).strip().lower()
-            if normalized_key in _DISALLOWED_DETAIL_KEYS:
-                _raise_governance_validation_error(field_name, normalized_key)
-            if (
-                normalized_key not in _ALLOWED_DETAIL_KEYS
-                and ("prompt" in normalized_key or "content" in normalized_key)
-            ):
-                _raise_governance_validation_error(field_name, normalized_key)
-            _validate_governance_detail_value(field_name, nested_value)
-        return
-    _raise_governance_validation_error(
-        field_name, f"unsupported value type {type(value).__name__}"
-    )
+    _raise_governance_validation_error(field_name, key)
 
 
 def _validate_governance_detail(
@@ -165,7 +235,11 @@ def _validate_governance_detail(
 ) -> dict[str, object] | None:
     if detail is None:
         return None
-    _validate_governance_detail_value(field_name, detail)
+    if not isinstance(detail, dict):
+        _raise_governance_validation_error(field_name, "expected dict")
+    for key, value in detail.items():
+        normalized_key = str(key).strip().lower()
+        _validate_governance_detail_entry(f"{field_name}.{normalized_key}", normalized_key, value)
     return detail
 
 
@@ -173,10 +247,20 @@ def _validate_governance_error_detail(error_detail: str | None) -> str | None:
     if error_detail is None:
         return None
     _validate_governance_string("error_detail", error_detail)
-    lowered = error_detail.lower()
-    if "prompt" in lowered or "content" in lowered:
-        _raise_governance_validation_error("error_detail", "prompt/content")
     return error_detail
+
+
+def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
+    _validate_governance_prefixed_ref("actor_ref", event.actor_ref, prefix="actref_v1_")
+    _validate_governance_prefixed_ref(
+        "subject_ref", event.subject_ref, prefix="subref_v1_"
+    )
+    _validate_governance_prefixed_ref(
+        "request_ref", event.request_ref, prefix="reqref_v1_"
+    )
+    if event.entity_id is not None:
+        _validate_governance_string("entity_id", event.entity_id)
+    _validate_governance_detail("audit_event.detail", event.detail)
 
 
 def _is_successful_erase_event(event: AuditEvent, *, purge_id: str | None = None) -> bool:
@@ -340,7 +424,7 @@ class SQLiteGovernanceMixin:
                 "Successful ERASE audit rows may only be written by "
                 "complete_purge_operation_with_audit()"
             )
-        _validate_governance_detail("audit_event.detail", event.detail)
+        _validate_audit_event_for_persistence(event)
         with self._lock:
             inserted = self._append_audit_event_with_cursor(self.conn, event)
             self.conn.commit()
@@ -367,6 +451,12 @@ class SQLiteGovernanceMixin:
         subject_ref: str | None,
         request_ref: str,
     ) -> PurgeOperation:
+        _validate_governance_prefixed_ref(
+            "subject_ref", subject_ref, prefix="subref_v1_"
+        )
+        _validate_governance_prefixed_ref(
+            "request_ref", request_ref, prefix="reqref_v1_"
+        )
         now = _epoch_now()
         with self._lock:
             existing = self.conn.execute(
@@ -634,7 +724,7 @@ class SQLiteGovernanceMixin:
             raise ValueError(
                 "Completion requires a successful ERASE audit event for this purge"
             )
-        _validate_governance_detail("audit_event.detail", audit_event.detail)
+        _validate_audit_event_for_persistence(audit_event)
         now = _epoch_now()
         with self._lock:
             try:

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -299,6 +299,8 @@ def _validate_governance_idempotency_key(
 ) -> str | None:
     if value is None:
         return None
+    if _SAFE_INTERNAL_ID_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "numeric identifier")
     return _validate_governance_code_shaped(
         field_name,
         value,
@@ -330,6 +332,8 @@ def _validate_governance_purge_id(field_name: str, value: str) -> str:
     suffix = value[len("purge_") :]
     if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(suffix):
         _raise_governance_validation_error(field_name, "identifier")
+    if suffix.isdecimal() and len(suffix) > 1:
+        _raise_governance_validation_error(field_name, "numeric identifier")
     return value
 
 

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -5,7 +5,7 @@ import re
 import sqlite3
 import threading
 from datetime import UTC, datetime
-from typing import Any, Literal
+from typing import Any, Literal, Protocol, cast
 
 from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
 from reflexio.models.api_schema.domain.governance import (
@@ -112,6 +112,8 @@ _TOKEN_NAME_RE = re.compile(
     re.IGNORECASE,
 )
 _RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
+_SAFE_INTERNAL_ID_RE = re.compile(r"^[0-9]+$")
+_USER_LIKE_TARGET_REF_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
 
 
 def init_governance_tables(conn: sqlite3.Connection) -> None:
@@ -173,29 +175,77 @@ def _validate_governance_int_list(field_name: str, value: Any) -> None:
         _validate_governance_int(field_name, item)
 
 
+def _normalize_governance_window_item(
+    field_name: str, index: int, item: object
+) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        _raise_governance_validation_error(
+            f"{field_name}[{index}]", "expected window dict"
+        )
+    window_item = cast(dict[Any, Any], item)
+    normalized_item: dict[str, Any] = {}
+    for raw_key, raw_value in window_item.items():
+        normalized_key = str(raw_key).strip().lower()
+        if normalized_key in normalized_item:
+            _raise_governance_validation_error(
+                f"{field_name}[{index}]", f"duplicate key {normalized_key}"
+            )
+        normalized_item[normalized_key] = raw_value
+    return normalized_item
+
+
 def _validate_governance_window_list(field_name: str, value: Any) -> None:
     if not isinstance(value, list):
         _raise_governance_validation_error(field_name, "expected list[window]")
     for index, item in enumerate(value):
-        if not isinstance(item, dict):
-            _raise_governance_validation_error(
-                f"{field_name}[{index}]", "expected window dict"
-            )
-        normalized_keys = {str(key).strip().lower() for key in item}
+        normalized_item = _normalize_governance_window_item(field_name, index, item)
+        normalized_keys = set(normalized_item)
         unexpected_keys = normalized_keys - {"user_playbook_id", "source_interaction_ids"}
         if unexpected_keys:
             _raise_governance_validation_error(
                 f"{field_name}[{index}]", sorted(unexpected_keys)[0]
             )
-        if "user_playbook_id" in item:
+        if "user_playbook_id" in normalized_item:
             _validate_governance_int(
-                f"{field_name}[{index}].user_playbook_id", item["user_playbook_id"]
+                f"{field_name}[{index}].user_playbook_id",
+                normalized_item["user_playbook_id"],
             )
-        if "source_interaction_ids" in item:
+        if "source_interaction_ids" in normalized_item:
             _validate_governance_int_list(
                 f"{field_name}[{index}].source_interaction_ids",
-                item["source_interaction_ids"],
+                normalized_item["source_interaction_ids"],
             )
+
+
+def _parse_governance_window_list(
+    field_name: str, value: list[dict[str, object]]
+) -> list[AgentPlaybookSourceWindow]:
+    _validate_governance_window_list(field_name, value)
+    windows: list[AgentPlaybookSourceWindow] = []
+    for index, item in enumerate(value):
+        normalized_item = _normalize_governance_window_item(field_name, index, item)
+        user_playbook_id = int(normalized_item["user_playbook_id"])
+        source_ids = normalized_item.get("source_interaction_ids") or []
+        windows.append(
+            AgentPlaybookSourceWindow(
+                user_playbook_id=user_playbook_id,
+                source_interaction_ids=[int(source_id) for source_id in source_ids],
+            )
+        )
+    return windows
+
+
+def _validate_governance_target_ref(target_ref: str) -> None:
+    if target_ref in {"", "all"}:
+        return
+    if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
+        return
+    if target_ref.startswith(("reqref_v1_", "subref_v1_", "actref_v1_")):
+        return
+    _validate_governance_string("target_ref", target_ref)
+    if _USER_LIKE_TARGET_REF_RE.fullmatch(target_ref):
+        _raise_governance_validation_error("target_ref", "user-like identifier")
+    _raise_governance_validation_error("target_ref", "must be minimized or internal")
 
 
 def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> None:
@@ -255,6 +305,8 @@ def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
     _validate_governance_prefixed_ref(
         "subject_ref", event.subject_ref, prefix="subref_v1_"
     )
+    if event.request_ref is None:
+        _raise_governance_validation_error("request_ref", "required")
     _validate_governance_prefixed_ref(
         "request_ref", event.request_ref, prefix="reqref_v1_"
     )
@@ -322,6 +374,26 @@ def _row_to_purge_target(row: sqlite3.Row) -> PurgeOperationTarget:
     )
 
 
+class _SQLiteGovernanceDeps(Protocol):
+    conn: sqlite3.Connection
+    _lock: threading.RLock
+    org_id: str
+
+    def _fetchall(self, sql: str, params: list[Any] | tuple[Any, ...]) -> list[sqlite3.Row]:
+        ...
+
+    def _fetchone(self, sql: str, params: list[Any] | tuple[Any, ...]) -> sqlite3.Row | None:
+        ...
+
+    def clear_user_data(self, user_id: str) -> dict[str, int]:
+        ...
+
+    def set_source_windows_for_agent_playbook(
+        self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
+    ) -> None:
+        ...
+
+
 class SQLiteGovernanceMixin:
     """SQLite governance storage primitives."""
 
@@ -329,8 +401,11 @@ class SQLiteGovernanceMixin:
     _lock: threading.RLock
     org_id: str
 
+    def _deps(self) -> _SQLiteGovernanceDeps:
+        return cast(_SQLiteGovernanceDeps, self)
+
     def _append_audit_event_with_cursor(
-        self, cur: sqlite3.Cursor, event: AuditEvent
+        self, cur: sqlite3.Connection | sqlite3.Cursor, event: AuditEvent
     ) -> bool:
         inserted = cur.execute(
             """INSERT OR IGNORE INTO audit_events (
@@ -368,6 +443,7 @@ class SQLiteGovernanceMixin:
     ) -> None:
         detail = _validate_governance_detail("detail", detail)
         error_detail = _validate_governance_error_detail(error_detail)
+        _validate_governance_target_ref(target_ref)
         now = _epoch_now()
         existing = self.conn.execute(
             """SELECT started_at, completed_at
@@ -433,13 +509,14 @@ class SQLiteGovernanceMixin:
     def list_audit_events(
         self, subject_ref: str | None = None, *, org_id: str | None = None
     ) -> list[AuditEvent]:
+        deps = self._deps()
         sql = "SELECT * FROM audit_events WHERE org_id = ?"
-        params: list[Any] = [org_id or self.org_id]
+        params: list[Any] = [org_id or deps.org_id]
         if subject_ref is not None:
             sql += " AND subject_ref = ?"
             params.append(subject_ref)
         sql += " ORDER BY created_at ASC, event_id ASC"
-        rows = self._fetchall(sql, params)
+        rows = deps._fetchall(sql, params)
         return [_row_to_audit_event(row) for row in rows]
 
     def begin_purge_operation(
@@ -513,17 +590,18 @@ class SQLiteGovernanceMixin:
     def list_purge_targets(
         self, purge_id: str, phase: str | None = None
     ) -> list[PurgeOperationTarget]:
+        deps = self._deps()
         sql = "SELECT * FROM purge_operation_targets WHERE purge_id = ?"
         params: list[Any] = [purge_id]
         if phase is not None:
             sql += " AND phase = ?"
             params.append(phase)
         sql += " ORDER BY phase ASC, target_name ASC, target_ref ASC"
-        rows = self._fetchall(sql, params)
+        rows = deps._fetchall(sql, params)
         return [_row_to_purge_target(row) for row in rows]
 
     def purge_targets_prepared(self, purge_id: str) -> bool:
-        row = self._fetchone(
+        row = self._deps()._fetchone(
             """SELECT 1 FROM purge_operation_targets
                WHERE purge_id = ? AND target_name = ? AND target_ref = 'all'
                  AND phase = ? AND status = 'complete'""",
@@ -534,23 +612,29 @@ class SQLiteGovernanceMixin:
     def prepare_governance_erase_targets(
         self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
     ) -> None:
-        request_count = self._fetchone(
+        deps = self._deps()
+        request_row = deps._fetchone(
             "SELECT COUNT(*) AS cnt FROM requests WHERE user_id = ?",
             (user_id,),
-        )["cnt"]
-        interaction_count = self._fetchone(
+        )
+        interaction_row = deps._fetchone(
             "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
             (user_id,),
-        )["cnt"]
-        profile_count = self._fetchone(
+        )
+        profile_row = deps._fetchone(
             "SELECT COUNT(*) AS cnt FROM profiles WHERE user_id = ?",
             (user_id,),
-        )["cnt"]
+        )
+        if request_row is None or interaction_row is None or profile_row is None:
+            raise ValueError("Missing governance count rows")
+        request_count = request_row["cnt"]
+        interaction_count = interaction_row["cnt"]
+        profile_count = profile_row["cnt"]
         playbook_count = len(owned_user_playbook_ids)
         affected_agent_playbook_ids: list[int] = []
         if owned_user_playbook_ids:
             placeholders = ",".join("?" for _ in owned_user_playbook_ids)
-            rows = self._fetchall(
+            rows = deps._fetchall(
                 f"""SELECT DISTINCT agent_playbook_id
                     FROM agent_playbook_source_user_playbooks
                     WHERE user_playbook_id IN ({placeholders})
@@ -637,7 +721,7 @@ class SQLiteGovernanceMixin:
     def apply_governance_user_data_delete(
         self, purge_id: str, user_id: str
     ) -> dict[str, int]:
-        counts = self.clear_user_data(user_id)
+        counts = self._deps().clear_user_data(user_id)
         name_map = {
             "interactions": "interaction",
             "user_playbooks": "user_playbook",
@@ -673,16 +757,9 @@ class SQLiteGovernanceMixin:
         expanded_terms: str | None,
         tags: list[str] | None,
     ) -> None:
-        windows = [
-            AgentPlaybookSourceWindow(
-                user_playbook_id=int(window["user_playbook_id"]),
-                source_interaction_ids=[
-                    int(source_id)
-                    for source_id in (window.get("source_interaction_ids") or [])
-                ],
-            )
-            for window in remaining_source_windows
-        ]
+        windows = _parse_governance_window_list(
+            "remaining_source_windows", remaining_source_windows
+        )
         with self._lock:
             cur = self.conn.execute(
                 """UPDATE agent_playbooks
@@ -704,7 +781,7 @@ class SQLiteGovernanceMixin:
                     f"Agent playbook with ID {agent_playbook_id} not found"
                 )
             self.conn.commit()
-        self.set_source_windows_for_agent_playbook(agent_playbook_id, windows)
+        self._deps().set_source_windows_for_agent_playbook(agent_playbook_id, windows)
         self.record_purge_target(
             purge_id=purge_id,
             target_name="agent_playbook",
@@ -801,15 +878,15 @@ class SQLiteGovernanceMixin:
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str
     ) -> PurgeOperation:
-        error_detail = _validate_governance_error_detail(error_detail)
+        validated_error_detail = _validate_governance_error_detail(error_detail)
         now = _epoch_now()
         with self._lock:
             cur = self.conn.execute(
                 """UPDATE purge_operations
                    SET status = 'failed', error_code = ?, error_detail = ?,
-                       updated_at = ?, completed_at = ?
+                   updated_at = ?, completed_at = ?
                    WHERE purge_id = ? AND org_id = ?""",
-                (error_code, error_detail, now, now, purge_id, self.org_id),
+                (error_code, validated_error_detail, now, now, purge_id, self.org_id),
             )
             if cur.rowcount == 0:
                 raise ValueError(f"Purge operation {purge_id!r} not found")
@@ -817,7 +894,7 @@ class SQLiteGovernanceMixin:
         return self.get_purge_operation(purge_id)
 
     def get_purge_operation(self, purge_id: str) -> PurgeOperation:
-        row = self._fetchone(
+        row = self._deps()._fetchone(
             "SELECT * FROM purge_operations WHERE purge_id = ? AND org_id = ?",
             (purge_id, self.org_id),
         )

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import threading
 from datetime import UTC, datetime
@@ -73,6 +74,30 @@ CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
 
 _PREPARE_PHASE = "prepare_targets"
 _SNAPSHOT_TARGET_NAME = "target_snapshot"
+_ALLOWED_DETAIL_KEYS = frozenset(
+    {
+        "affected_agent_playbook_ids",
+        "agent_playbook_id",
+        "count",
+        "deleted_count",
+        "owned_user_playbook_ids",
+        "source_interaction_ids",
+        "user_playbook_id",
+    }
+)
+_DISALLOWED_DETAIL_KEYS = frozenset(
+    {
+        "content",
+        "email",
+        "prompt",
+        "request_id",
+        "request_ref",
+        "user_id",
+    }
+)
+_EMAIL_RE = re.compile(r"\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
+_REQUEST_ID_RE = re.compile(r"\b(?:reqref|request)[_-][A-Za-z0-9_-]+\b", re.IGNORECASE)
+_RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
 
 
 def init_governance_tables(conn: sqlite3.Connection) -> None:
@@ -93,6 +118,74 @@ def _json_loads(text: str | None) -> Any:
     if not text:
         return None
     return json.loads(text)
+
+
+def _raise_governance_validation_error(field_name: str, reason: str) -> None:
+    raise ValueError(f"Unsafe governance {field_name}: {reason}")
+
+
+def _validate_governance_string(field_name: str, value: str) -> None:
+    if _EMAIL_RE.search(value):
+        _raise_governance_validation_error(field_name, "email")
+    if _REQUEST_ID_RE.search(value):
+        _raise_governance_validation_error(field_name, "request_id")
+    if _RAW_EXCEPTION_RE.search(value):
+        _raise_governance_validation_error(field_name, "raw exception text")
+
+
+def _validate_governance_detail_value(field_name: str, value: Any) -> None:
+    if value is None or isinstance(value, bool | int | float):
+        return
+    if isinstance(value, str):
+        _validate_governance_string(field_name, value)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _validate_governance_detail_value(field_name, item)
+        return
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            normalized_key = str(key).strip().lower()
+            if normalized_key in _DISALLOWED_DETAIL_KEYS:
+                _raise_governance_validation_error(field_name, normalized_key)
+            if (
+                normalized_key not in _ALLOWED_DETAIL_KEYS
+                and ("prompt" in normalized_key or "content" in normalized_key)
+            ):
+                _raise_governance_validation_error(field_name, normalized_key)
+            _validate_governance_detail_value(field_name, nested_value)
+        return
+    _raise_governance_validation_error(
+        field_name, f"unsupported value type {type(value).__name__}"
+    )
+
+
+def _validate_governance_detail(
+    field_name: str, detail: dict[str, object] | None
+) -> dict[str, object] | None:
+    if detail is None:
+        return None
+    _validate_governance_detail_value(field_name, detail)
+    return detail
+
+
+def _validate_governance_error_detail(error_detail: str | None) -> str | None:
+    if error_detail is None:
+        return None
+    _validate_governance_string("error_detail", error_detail)
+    lowered = error_detail.lower()
+    if "prompt" in lowered or "content" in lowered:
+        _raise_governance_validation_error("error_detail", "prompt/content")
+    return error_detail
+
+
+def _is_successful_erase_event(event: AuditEvent, *, purge_id: str | None = None) -> bool:
+    return (
+        event.operation == "ERASE"
+        and event.status == "ok"
+        and event.idempotency_key is not None
+        and (purge_id is None or event.idempotency_key == purge_id)
+    )
 
 
 def _row_to_audit_event(row: sqlite3.Row) -> AuditEvent:
@@ -189,6 +282,8 @@ class SQLiteGovernanceMixin:
         deleted_count: int,
         error_detail: str | None,
     ) -> None:
+        detail = _validate_governance_detail("detail", detail)
+        error_detail = _validate_governance_error_detail(error_detail)
         now = _epoch_now()
         existing = self.conn.execute(
             """SELECT started_at, completed_at
@@ -240,6 +335,12 @@ class SQLiteGovernanceMixin:
         )
 
     def append_audit_event(self, event: AuditEvent) -> bool:
+        if _is_successful_erase_event(event):
+            raise ValueError(
+                "Successful ERASE audit rows may only be written by "
+                "complete_purge_operation_with_audit()"
+            )
+        _validate_governance_detail("audit_event.detail", event.detail)
         with self._lock:
             inserted = self._append_audit_event_with_cursor(self.conn, event)
             self.conn.commit()
@@ -403,7 +504,6 @@ class SQLiteGovernanceMixin:
                 phase=_PREPARE_PHASE,
                 status="complete",
                 detail={
-                    "user_id": user_id,
                     "owned_user_playbook_ids": sorted(owned_user_playbook_ids),
                     "affected_agent_playbook_ids": affected_agent_playbook_ids,
                 },
@@ -464,7 +564,7 @@ class SQLiteGovernanceMixin:
                     target_ref="all",
                     phase="delete",
                     status="complete",
-                    detail={"user_id": user_id},
+                    detail={"count": int(value)},
                     deleted_count=int(value),
                     error_detail=None,
                 )
@@ -526,6 +626,15 @@ class SQLiteGovernanceMixin:
     def complete_purge_operation_with_audit(
         self, purge_id: str, audit_event: AuditEvent
     ) -> PurgeOperation:
+        if audit_event.org_id != self.org_id:
+            raise ValueError("Audit event org_id must match storage org_id")
+        if audit_event.idempotency_key != purge_id:
+            raise ValueError("Audit event idempotency key must match purge_id")
+        if not _is_successful_erase_event(audit_event, purge_id=purge_id):
+            raise ValueError(
+                "Completion requires a successful ERASE audit event for this purge"
+            )
+        _validate_governance_detail("audit_event.detail", audit_event.detail)
         now = _epoch_now()
         with self._lock:
             try:
@@ -553,7 +662,36 @@ class SQLiteGovernanceMixin:
                 ).fetchone()
                 if incomplete is not None:
                     raise ValueError("Cannot complete purge with incomplete targets")
-                self._append_audit_event_with_cursor(self.conn, audit_event)
+                existing_audit_row = self.conn.execute(
+                    """SELECT * FROM audit_events
+                       WHERE org_id = ? AND idempotency_key = ?""",
+                    (self.org_id, purge_id),
+                ).fetchone()
+                if existing_audit_row is not None:
+                    existing_event = _row_to_audit_event(existing_audit_row)
+                    if not _is_successful_erase_event(existing_event, purge_id=purge_id):
+                        raise ValueError(
+                            "Existing audit row for purge_id must be the matching "
+                            "successful ERASE row"
+                        )
+                else:
+                    self._append_audit_event_with_cursor(self.conn, audit_event)
+                    existing_audit_row = self.conn.execute(
+                        """SELECT * FROM audit_events
+                           WHERE org_id = ? AND idempotency_key = ?""",
+                        (self.org_id, purge_id),
+                    ).fetchone()
+                if existing_audit_row is None:
+                    raise ValueError(
+                        "Completion requires exactly one successful ERASE audit row "
+                        "for the purge_id"
+                    )
+                existing_event = _row_to_audit_event(existing_audit_row)
+                if not _is_successful_erase_event(existing_event, purge_id=purge_id):
+                    raise ValueError(
+                        "Completion requires exactly one matching successful ERASE "
+                        "audit row for the purge_id"
+                    )
                 self.conn.execute(
                     """UPDATE purge_operations
                        SET status = 'complete',
@@ -573,6 +711,7 @@ class SQLiteGovernanceMixin:
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str
     ) -> PurgeOperation:
+        error_detail = _validate_governance_error_detail(error_detail)
         now = _epoch_now()
         with self._lock:
             cur = self.conn.execute(

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1866,6 +1866,8 @@ class SQLiteGovernanceMixin:
                         embedding=embedding,
                     )
                 else:
+                    from ._playbook import _emit_hard_delete_playbook
+
                     self._delete_agent_playbook_search_rows_locked(agent_playbook_id)
                     self.conn.execute(
                         "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
@@ -1879,6 +1881,13 @@ class SQLiteGovernanceMixin:
                         raise ValueError(
                             f"Agent playbook with ID {agent_playbook_id} not found"
                         )
+                    _emit_hard_delete_playbook(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="agent_playbook",
+                        entity_id=str(agent_playbook_id),
+                        request_id=purge_id,
+                    )
                 self._record_purge_target_locked(
                     purge_id=purge_id,
                     target_name="agent_playbook",

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -45,8 +45,8 @@ CREATE INDEX IF NOT EXISTS idx_audit_events_subject_created
     ON audit_events(org_id, subject_ref, created_at, event_id);
 
 CREATE TABLE IF NOT EXISTS purge_operations (
-    purge_id TEXT PRIMARY KEY,
     org_id TEXT NOT NULL,
+    purge_id TEXT NOT NULL,
     operation_type TEXT NOT NULL,
     scope_type TEXT NOT NULL,
     subject_ref TEXT,
@@ -57,12 +57,14 @@ CREATE TABLE IF NOT EXISTS purge_operations (
     error_detail TEXT,
     created_at INTEGER NOT NULL,
     updated_at INTEGER NOT NULL,
-    completed_at INTEGER
+    completed_at INTEGER,
+    PRIMARY KEY (org_id, purge_id)
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_purge_operations_org_idem
     ON purge_operations(org_id, idempotency_key);
 
 CREATE TABLE IF NOT EXISTS purge_operation_targets (
+    org_id TEXT NOT NULL,
     purge_id TEXT NOT NULL,
     target_name TEXT NOT NULL,
     target_ref TEXT NOT NULL DEFAULT '',
@@ -73,11 +75,11 @@ CREATE TABLE IF NOT EXISTS purge_operation_targets (
     error_detail TEXT,
     started_at INTEGER,
     completed_at INTEGER,
-    PRIMARY KEY (purge_id, target_name, target_ref, phase),
-    FOREIGN KEY (purge_id) REFERENCES purge_operations(purge_id) ON DELETE CASCADE
+    PRIMARY KEY (org_id, purge_id, target_name, target_ref, phase),
+    FOREIGN KEY (org_id, purge_id) REFERENCES purge_operations(org_id, purge_id) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
-    ON purge_operation_targets(purge_id, phase, status);
+    ON purge_operation_targets(org_id, purge_id, phase, status);
 """
 
 _PREPARE_PHASE = "prepare_targets"
@@ -721,8 +723,8 @@ class SQLiteGovernanceMixin:
         existing = self.conn.execute(
             """SELECT started_at, completed_at
                FROM purge_operation_targets
-               WHERE purge_id = ? AND target_name = ? AND target_ref = ? AND phase = ?""",
-            (purge_id, target_name, target_ref, phase),
+               WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = ? AND phase = ?""",
+            (self.org_id, purge_id, target_name, target_ref, phase),
         ).fetchone()
         started_at = existing["started_at"] if existing else None
         completed_at = existing["completed_at"] if existing else None
@@ -732,17 +734,18 @@ class SQLiteGovernanceMixin:
             completed_at = now
         self.conn.execute(
             """INSERT INTO purge_operation_targets (
-                   purge_id, target_name, target_ref, phase, status, detail,
+                   org_id, purge_id, target_name, target_ref, phase, status, detail,
                    deleted_count, error_detail, started_at, completed_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-               ON CONFLICT(purge_id, target_name, target_ref, phase) DO UPDATE SET
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(org_id, purge_id, target_name, target_ref, phase) DO UPDATE SET
                    status = excluded.status,
-                   detail = excluded.detail,
+                   detail = COALESCE(excluded.detail, purge_operation_targets.detail),
                    deleted_count = excluded.deleted_count,
                    error_detail = excluded.error_detail,
                    started_at = COALESCE(purge_operation_targets.started_at, excluded.started_at),
                    completed_at = excluded.completed_at""",
             (
+                self.org_id,
                 purge_id,
                 target_name,
                 target_ref,
@@ -912,8 +915,8 @@ class SQLiteGovernanceMixin:
     ) -> list[PurgeOperationTarget]:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
         deps = self._deps()
-        sql = "SELECT * FROM purge_operation_targets WHERE purge_id = ?"
-        params: list[Any] = [purge_id]
+        sql = "SELECT * FROM purge_operation_targets WHERE org_id = ? AND purge_id = ?"
+        params: list[Any] = [self.org_id, purge_id]
         if phase is not None:
             sql += " AND phase = ?"
             params.append(phase)
@@ -925,9 +928,9 @@ class SQLiteGovernanceMixin:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
         row = self._deps()._fetchone(
             """SELECT 1 FROM purge_operation_targets
-               WHERE purge_id = ? AND target_name = ? AND target_ref = 'all'
+               WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = 'all'
                  AND phase = ? AND status = 'complete'""",
-            (purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+            (self.org_id, purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
         )
         return row is not None
 
@@ -1175,9 +1178,9 @@ class SQLiteGovernanceMixin:
                     raise ValueError(f"Purge operation {purge_id!r} not found")
                 snapshot = self.conn.execute(
                     """SELECT 1 FROM purge_operation_targets
-                       WHERE purge_id = ? AND target_name = ? AND target_ref = 'all'
+                       WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = 'all'
                          AND phase = ? AND status = 'complete'""",
-                    (purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+                    (self.org_id, purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
                 ).fetchone()
                 if snapshot is None:
                     raise ValueError(
@@ -1185,9 +1188,9 @@ class SQLiteGovernanceMixin:
                     )
                 incomplete = self.conn.execute(
                     """SELECT 1 FROM purge_operation_targets
-                       WHERE purge_id = ? AND status != 'complete'
+                       WHERE org_id = ? AND purge_id = ? AND status != 'complete'
                        LIMIT 1""",
-                    (purge_id,),
+                    (self.org_id, purge_id),
                 ).fetchone()
                 if incomplete is not None:
                     raise ValueError("Cannot complete purge with incomplete targets")

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -444,6 +444,15 @@ def _parse_governance_window_list(
     return windows
 
 
+def _canonicalize_governance_windows(
+    field_name: str, value: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    return [
+        window.model_dump()
+        for window in _parse_governance_window_list(field_name, value)
+    ]
+
+
 def _build_agent_playbook_source_window_rows(
     agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
 ) -> list[tuple[int, int, str]]:
@@ -883,6 +892,35 @@ class SQLiteGovernanceMixin:
                    (agent_playbook_id, user_playbook_id, source_interaction_ids)
                    VALUES (?, ?, ?)""",
                 source_window_rows,
+            )
+
+    def _validate_prepared_delete_target_matrix_locked(self, purge_id: str) -> None:
+        snapshot = self.conn.execute(
+            """SELECT 1 FROM purge_operation_targets
+               WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = 'all'
+                 AND phase = ? AND status = 'complete'""",
+            (self.org_id, purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+        ).fetchone()
+        if snapshot is None:
+            raise ValueError("Cannot delete user data without target snapshot marker")
+        delete_rows = self.conn.execute(
+            """SELECT target_name, status FROM purge_operation_targets
+               WHERE org_id = ? AND purge_id = ? AND phase = 'delete'
+                 AND target_ref = 'all'""",
+            (self.org_id, purge_id),
+        ).fetchall()
+        delete_statuses = {
+            str(row["target_name"]): str(row["status"]) for row in delete_rows
+        }
+        missing_delete_targets = [
+            target_name
+            for target_name in _CANONICAL_DELETE_TARGET_NAMES
+            if delete_statuses.get(target_name) not in {"pending", "complete"}
+        ]
+        if missing_delete_targets:
+            raise ValueError(
+                "Cannot delete user data without complete delete target matrix: "
+                + ", ".join(missing_delete_targets)
             )
 
     def _planned_governance_delete_counts(
@@ -1346,7 +1384,6 @@ class SQLiteGovernanceMixin:
         self, purge_id: str, user_id: str
     ) -> dict[str, int]:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
-        counts = self._deps().clear_user_data(user_id)
         name_map = {
             "interactions": "interaction",
             "user_playbooks": "user_playbook",
@@ -1356,6 +1393,8 @@ class SQLiteGovernanceMixin:
             "purged_user_playbooks": "user_playbook_purge",
         }
         with self._lock:
+            self._validate_prepared_delete_target_matrix_locked(purge_id)
+            counts = self._deps().clear_user_data(user_id)
             for key, value in counts.items():
                 self._record_purge_target_locked(
                     purge_id=purge_id,
@@ -1386,6 +1425,7 @@ class SQLiteGovernanceMixin:
         windows = _parse_governance_window_list(
             "remaining_source_windows", remaining_source_windows
         )
+        canonical_remaining_windows = [window.model_dump() for window in windows]
         with self._lock:
             try:
                 self.conn.execute("BEGIN")
@@ -1405,6 +1445,14 @@ class SQLiteGovernanceMixin:
                 }.issubset(rebuild_detail):
                     raise ValueError(
                         "planned rebuild target is missing source window detail"
+                    )
+                planned_remaining_windows = _canonicalize_governance_windows(
+                    "planned remaining_source_windows",
+                    cast(list[dict[str, object]], rebuild_detail["remaining_source_windows"]),
+                )
+                if planned_remaining_windows != canonical_remaining_windows:
+                    raise ValueError(
+                        "remaining_source_windows must match the planned rebuild target"
                     )
                 hide_target_row = self.conn.execute(
                     """SELECT status

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -93,6 +93,7 @@ _CANONICAL_DELETE_TARGET_NAMES = (
     "interaction",
     "profile",
     "user_playbook",
+    "agent_success_evaluation_result",
     "profile_purge",
     "user_playbook_purge",
 )
@@ -110,6 +111,7 @@ _ALLOWED_PURGE_TARGET_NAMES = frozenset(
         "interaction",
         "profile",
         "user_playbook",
+        "agent_success_evaluation_result",
         "agent_playbook",
         "profile_purge",
         "user_playbook_purge",
@@ -214,6 +216,7 @@ _ALLOWED_DELETED_COUNTS_KEYS = frozenset(
         "user_playbooks",
         "profiles",
         "requests",
+        "agent_success_evaluation_results",
         "purged_profiles",
         "purged_user_playbooks",
     }
@@ -298,7 +301,9 @@ def _validate_governance_code_shaped(
         return value
     if _USER_LIKE_TARGET_REF_RE.fullmatch(value):
         _raise_governance_validation_error(field_name, "user-like identifier")
-    _raise_governance_validation_error(field_name, "must be minimized, internal, or code-shaped")
+    _raise_governance_validation_error(
+        field_name, "must be minimized, internal, or code-shaped"
+    )
     raise AssertionError("unreachable")
 
 
@@ -371,9 +376,7 @@ def _validate_governance_int_list(field_name: str, value: Any) -> list[int]:
     return normalized_items
 
 
-def _validate_governance_deleted_counts(
-    field_name: str, value: Any
-) -> dict[str, int]:
+def _validate_governance_deleted_counts(field_name: str, value: Any) -> dict[str, int]:
     if not isinstance(value, dict):
         _raise_governance_validation_error(field_name, "expected dict[str, int]")
     normalized_counts: dict[str, int] = {}
@@ -415,7 +418,10 @@ def _validate_governance_window_list(
     for index, item in enumerate(value):
         normalized_item = _normalize_governance_window_item(field_name, index, item)
         normalized_keys = set(normalized_item)
-        unexpected_keys = normalized_keys - {"user_playbook_id", "source_interaction_ids"}
+        unexpected_keys = normalized_keys - {
+            "user_playbook_id",
+            "source_interaction_ids",
+        }
         if unexpected_keys:
             _raise_governance_validation_error(
                 f"{field_name}[{index}]", sorted(unexpected_keys)[0]
@@ -446,7 +452,9 @@ def _parse_governance_window_list(
     windows: list[AgentPlaybookSourceWindow] = []
     for normalized_item in _validate_governance_window_list(field_name, value):
         user_playbook_id = cast(int, normalized_item["user_playbook_id"])
-        source_ids = cast(list[int], normalized_item.get("source_interaction_ids") or [])
+        source_ids = cast(
+            list[int], normalized_item.get("source_interaction_ids") or []
+        )
         windows.append(
             AgentPlaybookSourceWindow(
                 user_playbook_id=user_playbook_id,
@@ -742,7 +750,9 @@ def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> N
     ]
     if not target_columns or "org_id" in target_columns:
         return
-    conn.execute("ALTER TABLE purge_operation_targets RENAME TO purge_operation_targets_legacy")
+    conn.execute(
+        "ALTER TABLE purge_operation_targets RENAME TO purge_operation_targets_legacy"
+    )
     conn.executescript(_PURGE_OPERATION_TARGETS_TABLE_DDL)
     conn.execute(
         """INSERT INTO purge_operation_targets (
@@ -765,7 +775,9 @@ def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> N
     conn.execute("DROP TABLE purge_operation_targets_legacy")
 
 
-def _is_successful_erase_event(event: AuditEvent, *, purge_id: str | None = None) -> bool:
+def _is_successful_erase_event(
+    event: AuditEvent, *, purge_id: str | None = None
+) -> bool:
     return (
         event.operation == "ERASE"
         and event.status == "ok"
@@ -862,50 +874,44 @@ class _SQLiteGovernanceDeps(Protocol):
     org_id: str
     _has_sqlite_vec: bool
 
-    def _fetchall(self, sql: str, params: list[Any] | tuple[Any, ...]) -> list[sqlite3.Row]:
-        ...
+    def _fetchall(
+        self, sql: str, params: list[Any] | tuple[Any, ...]
+    ) -> list[sqlite3.Row]: ...
 
-    def _fetchone(self, sql: str, params: list[Any] | tuple[Any, ...]) -> sqlite3.Row | None:
-        ...
+    def _fetchone(
+        self, sql: str, params: list[Any] | tuple[Any, ...]
+    ) -> sqlite3.Row | None: ...
 
     def _partition_purge_vs_delete(
         self, entity_type: Literal["profile", "user_playbook"], ids: list[str]
-    ) -> tuple[list[str], list[str]]:
-        ...
+    ) -> tuple[list[str], list[str]]: ...
 
     def _delete_in_chunks(
         self, table_name: str, column_name: str, values: list[Any]
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def _delete_source_windows_for_user_playbook_ids(
         self, user_playbook_ids: list[int]
-    ) -> None:
-        ...
+    ) -> None: ...
 
-    def _get_embedding(self, text: str) -> list[float]:
-        ...
+    def _get_embedding(self, text: str) -> list[float]: ...
 
     def set_source_windows_for_agent_playbook(
         self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def get_source_windows_for_agent_playbook(
         self, agent_playbook_id: int
-    ) -> list[AgentPlaybookSourceWindow]:
-        ...
+    ) -> list[AgentPlaybookSourceWindow]: ...
 
     def get_agent_playbook_by_id(
         self,
         agent_playbook_id: int,
         *,
         include_tombstones: bool = False,
-    ) -> AgentPlaybook | None:
-        ...
+    ) -> AgentPlaybook | None: ...
 
-    def _index_agent_playbook_fts_vec(self, ap: AgentPlaybook) -> None:
-        ...
+    def _index_agent_playbook_fts_vec(self, ap: AgentPlaybook) -> None: ...
 
 
 class SQLiteGovernanceMixin:
@@ -1045,21 +1051,32 @@ class SQLiteGovernanceMixin:
             "SELECT COUNT(*) AS cnt FROM interactions WHERE user_id = ?",
             (user_id,),
         ).fetchone()
+        eval_result_row = self.conn.execute(
+            """SELECT COUNT(*) AS cnt
+               FROM agent_success_evaluation_result
+               WHERE user_id = ?""",
+            (user_id,),
+        ).fetchone()
         profile_rows = self.conn.execute(
             "SELECT profile_id FROM profiles WHERE user_id = ?",
             (user_id,),
         ).fetchall()
-        if request_row is None or interaction_row is None:
+        if request_row is None or interaction_row is None or eval_result_row is None:
             raise ValueError("Missing governance count rows")
         profile_ids = [str(row["profile_id"]) for row in profile_rows]
         purge_profile_ids, delete_profile_ids = self._deps()._partition_purge_vs_delete(
             "profile",
             profile_ids,
         )
-        playbook_ids = [str(user_playbook_id) for user_playbook_id in sorted(owned_user_playbook_ids)]
-        purge_playbook_ids, delete_playbook_ids = self._deps()._partition_purge_vs_delete(
-            "user_playbook",
-            playbook_ids,
+        playbook_ids = [
+            str(user_playbook_id)
+            for user_playbook_id in sorted(owned_user_playbook_ids)
+        ]
+        purge_playbook_ids, delete_playbook_ids = (
+            self._deps()._partition_purge_vs_delete(
+                "user_playbook",
+                playbook_ids,
+            )
         )
         return {
             "request": int(request_row["cnt"]),
@@ -1067,6 +1084,7 @@ class SQLiteGovernanceMixin:
             "profile": len(delete_profile_ids),
             "profile_purge": len(purge_profile_ids),
             "user_playbook": len(delete_playbook_ids),
+            "agent_success_evaluation_result": int(eval_result_row["cnt"]),
             "user_playbook_purge": len(purge_playbook_ids),
         }
 
@@ -1315,6 +1333,11 @@ class SQLiteGovernanceMixin:
             "DELETE FROM interactions WHERE user_id = ?",
             (user_id,),
         )
+        eval_results_cur = self.conn.execute(
+            """DELETE FROM agent_success_evaluation_result
+               WHERE user_id = ?""",
+            (user_id,),
+        )
         requests_cur = self.conn.execute(
             "DELETE FROM requests WHERE user_id = ?",
             (user_id,),
@@ -1353,6 +1376,7 @@ class SQLiteGovernanceMixin:
             "user_playbooks": len(delete_upb_ids),
             "profiles": len(delete_profile_ids),
             "requests": requests_cur.rowcount,
+            "agent_success_evaluation_results": eval_results_cur.rowcount,
             "purged_profiles": purged_profiles,
             "purged_user_playbooks": purged_user_playbooks,
         }
@@ -1668,6 +1692,7 @@ class SQLiteGovernanceMixin:
             "user_playbooks": "user_playbook",
             "profiles": "profile",
             "requests": "request",
+            "agent_success_evaluation_results": "agent_success_evaluation_result",
             "purged_profiles": "profile_purge",
             "purged_user_playbooks": "user_playbook_purge",
         }
@@ -1714,7 +1739,9 @@ class SQLiteGovernanceMixin:
         content_value = content or ""
         trigger_value = trigger or None
         embedding_text = trigger_value or content_value
-        embedding = self._deps()._get_embedding(embedding_text) if embedding_text else []
+        embedding = (
+            self._deps()._get_embedding(embedding_text) if embedding_text else []
+        )
         with self._lock:
             try:
                 self.conn.execute("BEGIN")
@@ -1740,7 +1767,10 @@ class SQLiteGovernanceMixin:
                     )
                 planned_remaining_windows = _canonicalize_governance_windows(
                     "planned remaining_source_windows",
-                    cast(list[dict[str, object]], rebuild_detail["remaining_source_windows"]),
+                    cast(
+                        list[dict[str, object]],
+                        rebuild_detail["remaining_source_windows"],
+                    ),
                 )
                 if planned_remaining_windows != canonical_remaining_windows:
                     raise ValueError(
@@ -1768,7 +1798,9 @@ class SQLiteGovernanceMixin:
                             content_value,
                             trigger_value,
                             rationale,
-                            json.dumps(blocking_issue) if blocking_issue is not None else None,
+                            json.dumps(blocking_issue)
+                            if blocking_issue is not None
+                            else None,
                             _json_dumps(embedding),
                             expanded_terms,
                             _json_dumps(tags),
@@ -1895,14 +1927,16 @@ class SQLiteGovernanceMixin:
                 ).fetchone()
                 if existing_audit_row is not None:
                     existing_event = _row_to_audit_event(existing_audit_row)
-                    if not _is_successful_erase_event(existing_event, purge_id=purge_id):
+                    if not _is_successful_erase_event(
+                        existing_event, purge_id=purge_id
+                    ):
                         raise ValueError(
                             "Existing audit row for purge_id must be the matching "
                             "successful ERASE row"
                         )
-                    if _successful_erase_identity(existing_event) != _successful_erase_identity(
-                        audit_event
-                    ):
+                    if _successful_erase_identity(
+                        existing_event
+                    ) != _successful_erase_identity(audit_event):
                         raise ValueError(
                             "Existing audit row for purge_id must be the matching "
                             "successful ERASE row"
@@ -1925,9 +1959,9 @@ class SQLiteGovernanceMixin:
                         "Completion requires exactly one matching successful ERASE "
                         "audit row for the purge_id"
                     )
-                if _successful_erase_identity(existing_event) != _successful_erase_identity(
-                    audit_event
-                ):
+                if _successful_erase_identity(
+                    existing_event
+                ) != _successful_erase_identity(audit_event):
                     raise ValueError(
                         "Completion requires exactly one matching successful ERASE "
                         "audit row for the purge_id"

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -815,6 +815,20 @@ class SQLiteGovernanceMixin:
                 (self.org_id, validated_idempotency_key),
             ).fetchone()
             if existing is not None:
+                existing_operation = _row_to_purge_operation(existing)
+                expected_identity = {
+                    "purge_id": validated_purge_id,
+                    "operation_type": operation_type,
+                    "scope_type": scope_type,
+                    "subject_ref": subject_ref,
+                    "request_ref": request_ref,
+                }
+                for field_name, expected_value in expected_identity.items():
+                    if getattr(existing_operation, field_name) != expected_value:
+                        raise ValueError(
+                            "Existing purge operation for idempotency_key has "
+                            f"mismatched {field_name}"
+                        )
                 return _row_to_purge_operation(existing)
             self.conn.execute(
                 """INSERT INTO purge_operations (

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -5,7 +5,7 @@ import re
 import sqlite3
 import threading
 from datetime import UTC, datetime
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Literal, NoReturn, Protocol, cast
 
 from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
 from reflexio.models.api_schema.domain.governance import (
@@ -114,10 +114,25 @@ _TOKEN_NAME_RE = re.compile(
 _RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
 _SAFE_INTERNAL_ID_RE = re.compile(r"^[0-9]+$")
 _USER_LIKE_TARGET_REF_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+_CODE_SHAPED_VALUE_RE = re.compile(r"^[A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)+$")
 _SAFE_ERROR_CODE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,127}$")
 _IDENTIFIERISH_ERROR_CODE_RE = re.compile(
     r"^(?:user|subject|request|req|actor|email)[-_.:]?[A-Za-z0-9_.:-]+$",
     re.IGNORECASE,
+)
+_ALLOWED_ENUM_LIKE_VALUES = frozenset(
+    {
+        "archived",
+        "complete",
+        "delete",
+        "error",
+        "failed",
+        "ok",
+        "pending",
+        "prepare_targets",
+        "rebuild",
+        "running",
+    }
 )
 
 
@@ -141,7 +156,7 @@ def _json_loads(text: str | None) -> Any:
     return json.loads(text)
 
 
-def _raise_governance_validation_error(field_name: str, reason: str) -> None:
+def _raise_governance_validation_error(field_name: str, reason: str) -> NoReturn:
     raise ValueError(f"Unsafe governance {field_name}: {reason}")
 
 
@@ -164,8 +179,52 @@ def _validate_governance_prefixed_ref(
 ) -> None:
     if value is None:
         return
-    if not value.startswith(prefix):
-        _raise_governance_validation_error(field_name, f"must start with {prefix}")
+    if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", value) is None:
+        _raise_governance_validation_error(
+            field_name, f"must match {prefix}<32 lowercase hex chars>"
+        )
+
+
+def _validate_governance_code_shaped(
+    field_name: str,
+    value: str,
+    *,
+    allow_minimized_ref: bool,
+    allow_enum_like_word: bool,
+) -> str:
+    if not value:
+        _raise_governance_validation_error(field_name, "required")
+    _validate_governance_string(field_name, value)
+    if allow_minimized_ref and any(
+        re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", value)
+        for prefix in ("subref_v1_", "reqref_v1_", "actref_v1_")
+    ):
+        return value
+    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error(field_name, "identifier")
+    if _SAFE_INTERNAL_ID_RE.fullmatch(value):
+        return value
+    if _CODE_SHAPED_VALUE_RE.fullmatch(value):
+        return value
+    if allow_enum_like_word and value in _ALLOWED_ENUM_LIKE_VALUES:
+        return value
+    if _USER_LIKE_TARGET_REF_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "user-like identifier")
+    _raise_governance_validation_error(field_name, "must be minimized, internal, or code-shaped")
+    raise AssertionError("unreachable")
+
+
+def _validate_governance_idempotency_key(
+    field_name: str, value: str | None
+) -> str | None:
+    if value is None:
+        return None
+    return _validate_governance_code_shaped(
+        field_name,
+        value,
+        allow_minimized_ref=False,
+        allow_enum_like_word=False,
+    )
 
 
 def _validate_governance_int(field_name: str, value: Any) -> None:
@@ -245,8 +304,13 @@ def _validate_governance_target_ref(target_ref: str) -> None:
         return
     if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
         return
-    if target_ref.startswith(("reqref_v1_", "subref_v1_", "actref_v1_")):
-        return
+    for prefix in ("reqref_v1_", "subref_v1_", "actref_v1_"):
+        if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", target_ref):
+            return
+        if target_ref.startswith(prefix):
+            _raise_governance_validation_error(
+                "target_ref", f"must match {prefix}<32 lowercase hex chars>"
+            )
     _validate_governance_string("target_ref", target_ref)
     if _USER_LIKE_TARGET_REF_RE.fullmatch(target_ref):
         _raise_governance_validation_error("target_ref", "user-like identifier")
@@ -280,7 +344,12 @@ def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> 
     if key in {"route", "status"}:
         if not isinstance(value, str):
             _raise_governance_validation_error(field_name, "expected str")
-        _validate_governance_string(field_name, value)
+        _validate_governance_code_shaped(
+            field_name,
+            value,
+            allow_minimized_ref=False,
+            allow_enum_like_word=True,
+        )
         return
     _raise_governance_validation_error(field_name, key)
 
@@ -334,7 +403,13 @@ def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
         "request_ref", event.request_ref, prefix="reqref_v1_"
     )
     if event.entity_id is not None:
-        _validate_governance_string("entity_id", event.entity_id)
+        _validate_governance_code_shaped(
+            "entity_id",
+            event.entity_id,
+            allow_minimized_ref=True,
+            allow_enum_like_word=False,
+        )
+    _validate_governance_idempotency_key("idempotency_key", event.idempotency_key)
     _validate_governance_detail("audit_event.detail", event.detail)
 
 
@@ -569,12 +644,16 @@ class SQLiteGovernanceMixin:
         _validate_governance_prefixed_ref(
             "request_ref", request_ref, prefix="reqref_v1_"
         )
+        validated_idempotency_key = cast(
+            str,
+            _validate_governance_idempotency_key("idempotency_key", idempotency_key),
+        )
         now = _epoch_now()
         with self._lock:
             existing = self.conn.execute(
                 """SELECT * FROM purge_operations
                    WHERE org_id = ? AND idempotency_key = ?""",
-                (self.org_id, idempotency_key),
+                (self.org_id, validated_idempotency_key),
             ).fetchone()
             if existing is not None:
                 return _row_to_purge_operation(existing)
@@ -590,7 +669,7 @@ class SQLiteGovernanceMixin:
                     scope_type,
                     subject_ref,
                     request_ref,
-                    idempotency_key,
+                    validated_idempotency_key,
                     now,
                     now,
                 ),

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any, Literal, NoReturn, Protocol, cast, get_args
 
 from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
+from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.domain.governance import (
     AuditActorType,
     AuditEntityType,
@@ -100,7 +101,15 @@ _ALLOWED_PURGE_TARGET_NAMES = frozenset(
         "user_playbook_purge",
     }
 )
-_ALLOWED_PURGE_TARGET_PHASES = frozenset({_PREPARE_PHASE, "delete", "rebuild"})
+_ALLOWED_PURGE_TARGET_PHASES = frozenset(
+    {
+        _PREPARE_PHASE,
+        "delete",
+        "rebuild",
+        "hide_for_rebuild",
+        "rebuild_without_erased_sources",
+    }
+)
 _ALLOWED_DETAIL_KEYS = frozenset(
     {
         "affected_agent_playbook_ids",
@@ -153,6 +162,8 @@ _IDENTIFIERISH_ERROR_CODE_RE = re.compile(
 )
 _ALLOWED_ENUM_LIKE_VALUES = frozenset(
     {
+        "archive_in_progress",
+        "hide_for_rebuild",
         "archived",
         "complete",
         "delete",
@@ -162,6 +173,7 @@ _ALLOWED_ENUM_LIKE_VALUES = frozenset(
         "pending",
         "prepare_targets",
         "rebuild",
+        "rebuild_without_erased_sources",
         "running",
     }
 )
@@ -632,6 +644,11 @@ class _SQLiteGovernanceDeps(Protocol):
     ) -> None:
         ...
 
+    def get_source_windows_for_agent_playbook(
+        self, agent_playbook_id: int
+    ) -> list[AgentPlaybookSourceWindow]:
+        ...
+
 
 class SQLiteGovernanceMixin:
     """SQLite governance storage primitives."""
@@ -938,6 +955,7 @@ class SQLiteGovernanceMixin:
         profile_count = profile_row["cnt"]
         playbook_count = len(owned_user_playbook_ids)
         affected_agent_playbook_ids: list[int] = []
+        rebuild_details_by_agent_playbook_id: dict[int, dict[str, object]] = {}
         if owned_user_playbook_ids:
             placeholders = ",".join("?" for _ in owned_user_playbook_ids)
             rows = deps._fetchall(
@@ -948,6 +966,29 @@ class SQLiteGovernanceMixin:
                 sorted(owned_user_playbook_ids),
             )
             affected_agent_playbook_ids = [int(row["agent_playbook_id"]) for row in rows]
+            for agent_playbook_id in affected_agent_playbook_ids:
+                original_windows = deps.get_source_windows_for_agent_playbook(
+                    agent_playbook_id
+                )
+                original_window_dicts = [
+                    {
+                        "user_playbook_id": int(window.user_playbook_id),
+                        "source_interaction_ids": [
+                            int(source_id)
+                            for source_id in (window.source_interaction_ids or [])
+                        ],
+                    }
+                    for window in original_windows
+                ]
+                remaining_window_dicts = [
+                    window
+                    for window in original_window_dicts
+                    if int(window["user_playbook_id"]) not in owned_user_playbook_ids
+                ]
+                rebuild_details_by_agent_playbook_id[agent_playbook_id] = {
+                    "original_source_windows": original_window_dicts,
+                    "remaining_source_windows": remaining_window_dicts,
+                }
         targets = {
             "request": request_count,
             "interaction": interaction_count,
@@ -971,9 +1012,9 @@ class SQLiteGovernanceMixin:
                     purge_id=purge_id,
                     target_name="agent_playbook",
                     target_ref=str(agent_playbook_id),
-                    phase="rebuild",
+                    phase="rebuild_without_erased_sources",
                     status="pending",
-                    detail=None,
+                    detail=rebuild_details_by_agent_playbook_id[agent_playbook_id],
                     deleted_count=0,
                     error_detail=None,
                 )
@@ -994,7 +1035,9 @@ class SQLiteGovernanceMixin:
 
     def hide_governance_agent_playbooks_for_rebuild(self, purge_id: str) -> list[int]:
         purge_id = _validate_governance_purge_id("purge_id", purge_id)
-        targets = self.list_purge_targets(purge_id, phase="rebuild")
+        targets = self.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
         agent_playbook_ids = [
             int(target.target_ref)
             for target in targets
@@ -1006,17 +1049,26 @@ class SQLiteGovernanceMixin:
         with self._lock:
             self.conn.execute(
                 f"""UPDATE agent_playbooks
-                    SET status = 'archived'
-                    WHERE agent_playbook_id IN ({placeholders})
-                      AND status IS NULL""",
-                agent_playbook_ids,
+                    SET status = ?
+                    WHERE agent_playbook_id IN ({placeholders})""",
+                [Status.ARCHIVE_IN_PROGRESS.value, *agent_playbook_ids],
             )
             for agent_playbook_id in agent_playbook_ids:
                 self._record_purge_target_locked(
                     purge_id=purge_id,
                     target_name="agent_playbook",
                     target_ref=str(agent_playbook_id),
-                    phase="rebuild",
+                    phase="hide_for_rebuild",
+                    status="complete",
+                    detail=None,
+                    deleted_count=0,
+                    error_detail=None,
+                )
+                self._record_purge_target_locked(
+                    purge_id=purge_id,
+                    target_name="agent_playbook",
+                    target_ref=str(agent_playbook_id),
+                    phase="rebuild_without_erased_sources",
                     status="running",
                     detail=None,
                     deleted_count=0,
@@ -1095,7 +1147,7 @@ class SQLiteGovernanceMixin:
             purge_id=purge_id,
             target_name="agent_playbook",
             target_ref=str(agent_playbook_id),
-            phase="rebuild",
+            phase="rebuild_without_erased_sources",
             status="complete",
         )
 

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -88,6 +88,14 @@ CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
 
 _PREPARE_PHASE = "prepare_targets"
 _SNAPSHOT_TARGET_NAME = "target_snapshot"
+_CANONICAL_DELETE_TARGET_NAMES = (
+    "request",
+    "interaction",
+    "profile",
+    "user_playbook",
+    "profile_purge",
+    "user_playbook_purge",
+)
 _ALLOWED_AUDIT_ACTOR_TYPES = frozenset(get_args(AuditActorType))
 _ALLOWED_AUDIT_OPERATIONS = frozenset(get_args(AuditOperation))
 _ALLOWED_AUDIT_ENTITY_TYPES = frozenset(get_args(AuditEntityType))
@@ -434,6 +442,27 @@ def _parse_governance_window_list(
             )
         )
     return windows
+
+
+def _build_agent_playbook_source_window_rows(
+    agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
+) -> list[tuple[int, int, str]]:
+    by_id: dict[int, list[int]] = {}
+    for window in windows:
+        ids = by_id.setdefault(window.user_playbook_id, [])
+        seen = set(ids)
+        for source_id in window.source_interaction_ids:
+            if source_id not in seen:
+                ids.append(source_id)
+                seen.add(source_id)
+    return [
+        (
+            agent_playbook_id,
+            user_playbook_id,
+            _json_dumps(source_interaction_ids) or "[]",
+        )
+        for user_playbook_id, source_interaction_ids in by_id.items()
+    ]
 
 
 def _validate_governance_target_ref(
@@ -837,6 +866,24 @@ class SQLiteGovernanceMixin:
 
     def _deps(self) -> _SQLiteGovernanceDeps:
         return cast(_SQLiteGovernanceDeps, self)
+
+    def _replace_agent_playbook_source_windows_locked(
+        self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
+    ) -> None:
+        self.conn.execute(
+            "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
+            (agent_playbook_id,),
+        )
+        source_window_rows = _build_agent_playbook_source_window_rows(
+            agent_playbook_id, windows
+        )
+        if source_window_rows:
+            self.conn.executemany(
+                """INSERT OR IGNORE INTO agent_playbook_source_user_playbooks
+                   (agent_playbook_id, user_playbook_id, source_interaction_ids)
+                   VALUES (?, ?, ?)""",
+                source_window_rows,
+            )
 
     def _planned_governance_delete_counts(
         self, user_id: str, owned_user_playbook_ids: set[int]
@@ -1340,34 +1387,44 @@ class SQLiteGovernanceMixin:
             "remaining_source_windows", remaining_source_windows
         )
         with self._lock:
-            cur = self.conn.execute(
-                """UPDATE agent_playbooks
-                   SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,
-                       expanded_terms = ?, tags = ?, status = NULL
-                   WHERE agent_playbook_id = ?""",
-                (
-                    content or "",
-                    trigger,
-                    rationale,
-                    json.dumps(blocking_issue) if blocking_issue is not None else None,
-                    expanded_terms,
-                    _json_dumps(tags),
-                    agent_playbook_id,
-                ),
-            )
-            if cur.rowcount == 0:
-                raise ValueError(
-                    f"Agent playbook with ID {agent_playbook_id} not found"
+            try:
+                self.conn.execute("BEGIN")
+                cur = self.conn.execute(
+                    """UPDATE agent_playbooks
+                       SET content = ?, trigger = ?, rationale = ?, blocking_issue = ?,
+                           expanded_terms = ?, tags = ?, status = NULL
+                       WHERE agent_playbook_id = ?""",
+                    (
+                        content or "",
+                        trigger,
+                        rationale,
+                        json.dumps(blocking_issue) if blocking_issue is not None else None,
+                        expanded_terms,
+                        _json_dumps(tags),
+                        agent_playbook_id,
+                    ),
                 )
-            self.conn.commit()
-        self._deps().set_source_windows_for_agent_playbook(agent_playbook_id, windows)
-        self.record_purge_target(
-            purge_id=purge_id,
-            target_name="agent_playbook",
-            target_ref=str(agent_playbook_id),
-            phase="rebuild_without_erased_sources",
-            status="complete",
-        )
+                if cur.rowcount == 0:
+                    raise ValueError(
+                        f"Agent playbook with ID {agent_playbook_id} not found"
+                    )
+                self._replace_agent_playbook_source_windows_locked(
+                    agent_playbook_id, windows
+                )
+                self._record_purge_target_locked(
+                    purge_id=purge_id,
+                    target_name="agent_playbook",
+                    target_ref=str(agent_playbook_id),
+                    phase="rebuild_without_erased_sources",
+                    status="complete",
+                    detail=None,
+                    deleted_count=0,
+                    error_detail=None,
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     def complete_purge_operation_with_audit(
         self, purge_id: str, audit_event: AuditEvent
@@ -1410,6 +1467,25 @@ class SQLiteGovernanceMixin:
                 if snapshot is None:
                     raise ValueError(
                         "Cannot complete purge without target snapshot marker"
+                    )
+                delete_rows = self.conn.execute(
+                    """SELECT target_name, status FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ? AND phase = 'delete'
+                         AND target_ref = 'all'""",
+                    (self.org_id, purge_id),
+                ).fetchall()
+                delete_statuses = {
+                    str(row["target_name"]): str(row["status"]) for row in delete_rows
+                }
+                missing_delete_targets = [
+                    target_name
+                    for target_name in _CANONICAL_DELETE_TARGET_NAMES
+                    if delete_statuses.get(target_name) != "complete"
+                ]
+                if missing_delete_targets:
+                    raise ValueError(
+                        "Cannot complete purge without complete delete target matrix: "
+                        + ", ".join(missing_delete_targets)
                     )
                 incomplete = self.conn.execute(
                     """SELECT 1 FROM purge_operation_targets

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -844,6 +844,7 @@ class _SQLiteGovernanceDeps(Protocol):
     conn: sqlite3.Connection
     _lock: threading.RLock
     org_id: str
+    _has_sqlite_vec: bool
 
     def _fetchall(self, sql: str, params: list[Any] | tuple[Any, ...]) -> list[sqlite3.Row]:
         ...
@@ -851,12 +852,19 @@ class _SQLiteGovernanceDeps(Protocol):
     def _fetchone(self, sql: str, params: list[Any] | tuple[Any, ...]) -> sqlite3.Row | None:
         ...
 
-    def clear_user_data(self, user_id: str) -> dict[str, int]:
-        ...
-
     def _partition_purge_vs_delete(
         self, entity_type: Literal["profile", "user_playbook"], ids: list[str]
     ) -> tuple[list[str], list[str]]:
+        ...
+
+    def _delete_in_chunks(
+        self, table_name: str, column_name: str, values: list[Any]
+    ) -> None:
+        ...
+
+    def _delete_source_windows_for_user_playbook_ids(
+        self, user_playbook_ids: list[int]
+    ) -> None:
         ...
 
     def set_source_windows_for_agent_playbook(
@@ -925,6 +933,38 @@ class SQLiteGovernanceMixin:
             raise ValueError(
                 "Cannot delete user data without complete delete target matrix: "
                 + ", ".join(missing_delete_targets)
+            )
+
+    def _validate_hide_for_rebuild_targets_locked(self, purge_id: str) -> None:
+        rebuild_rows = self.conn.execute(
+            """SELECT DISTINCT target_ref
+               FROM purge_operation_targets
+               WHERE org_id = ? AND purge_id = ? AND target_name = 'agent_playbook'
+                 AND phase = 'rebuild_without_erased_sources' AND target_ref != ''
+               ORDER BY target_ref ASC""",
+            (self.org_id, purge_id),
+        ).fetchall()
+        if not rebuild_rows:
+            return
+        hidden_refs = {
+            str(row["target_ref"])
+            for row in self.conn.execute(
+                """SELECT target_ref
+                   FROM purge_operation_targets
+                   WHERE org_id = ? AND purge_id = ? AND target_name = 'agent_playbook'
+                     AND phase = 'hide_for_rebuild' AND status = 'complete'""",
+                (self.org_id, purge_id),
+            ).fetchall()
+        }
+        missing_hidden_refs = [
+            str(row["target_ref"])
+            for row in rebuild_rows
+            if str(row["target_ref"]) not in hidden_refs
+        ]
+        if missing_hidden_refs:
+            raise ValueError(
+                "Cannot delete user data before hide_for_rebuild completes for "
+                f"planned agent_playbooks: {', '.join(missing_hidden_refs)}"
             )
 
     def _planned_governance_delete_counts(
@@ -1107,6 +1147,148 @@ class SQLiteGovernanceMixin:
         sql += " ORDER BY created_at ASC, event_id ASC"
         rows = deps._fetchall(sql, params)
         return [_row_to_audit_event(row) for row in rows]
+
+    def _purge_governance_entity_content_locked(
+        self,
+        *,
+        entity_type: Literal["profile", "user_playbook"],
+        entity_id: str,
+        rowid: int,
+    ) -> bool:
+        from ._lineage import _PURGE_SQL, _append_event_stmt
+
+        sql = _PURGE_SQL[entity_type]
+        cur = self.conn.execute(sql, (entity_id,))
+        if cur.rowcount <= 0:
+            return False
+        _append_event_stmt(
+            self.conn,
+            org_id=self.org_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            op="purge",
+            prov="wasPurged",
+            source_ids=[],
+            actor="erasure",
+            request_id=f"purge_{entity_id}",
+            reason="content_purge",
+        )
+        if entity_type == "profile":
+            self.conn.execute(
+                "DELETE FROM profiles_fts WHERE profile_id = ?",
+                (entity_id,),
+            )
+            if self._deps()._has_sqlite_vec:
+                self.conn.execute(
+                    "DELETE FROM profiles_vec WHERE rowid = ?",
+                    (rowid,),
+                )
+        else:
+            self.conn.execute(
+                "DELETE FROM user_playbooks_fts WHERE rowid = ?",
+                (rowid,),
+            )
+            if self._deps()._has_sqlite_vec:
+                self.conn.execute(
+                    "DELETE FROM user_playbooks_vec WHERE rowid = ?",
+                    (rowid,),
+                )
+        return True
+
+    def _clear_user_data_for_governance_locked(self, user_id: str) -> dict[str, int]:
+        deps = self._deps()
+        interaction_ids = [
+            int(row["interaction_id"])
+            for row in self.conn.execute(
+                "SELECT interaction_id FROM interactions WHERE user_id = ?",
+                (user_id,),
+            ).fetchall()
+        ]
+        raw_upb_ids = [
+            int(row["user_playbook_id"])
+            for row in self.conn.execute(
+                "SELECT user_playbook_id FROM user_playbooks WHERE user_id = ?",
+                (user_id,),
+            ).fetchall()
+        ]
+        profile_rows = self.conn.execute(
+            "SELECT rowid, profile_id FROM profiles WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+        profile_rowid_by_id = {
+            str(row["profile_id"]): int(row["rowid"]) for row in profile_rows
+        }
+        all_profile_ids = list(profile_rowid_by_id)
+
+        purge_profile_ids, delete_profile_ids = deps._partition_purge_vs_delete(
+            "profile",
+            all_profile_ids,
+        )
+        purge_upb_str_ids, delete_upb_str_ids = deps._partition_purge_vs_delete(
+            "user_playbook",
+            [str(user_playbook_id) for user_playbook_id in raw_upb_ids],
+        )
+        purge_upb_ids = [int(entity_id) for entity_id in purge_upb_str_ids]
+        delete_upb_ids = [int(entity_id) for entity_id in delete_upb_str_ids]
+        delete_profile_rowids = [
+            profile_rowid_by_id[profile_id]
+            for profile_id in delete_profile_ids
+            if profile_id in profile_rowid_by_id
+        ]
+
+        deps._delete_in_chunks("interactions_fts", "rowid", interaction_ids)
+        deps._delete_in_chunks("user_playbooks_fts", "rowid", delete_upb_ids)
+        deps._delete_in_chunks("profiles_fts", "profile_id", delete_profile_ids)
+        if deps._has_sqlite_vec:
+            deps._delete_in_chunks("interactions_vec", "rowid", interaction_ids)
+            deps._delete_in_chunks("user_playbooks_vec", "rowid", delete_upb_ids)
+            deps._delete_in_chunks("profiles_vec", "rowid", delete_profile_rowids)
+
+        interactions_cur = self.conn.execute(
+            "DELETE FROM interactions WHERE user_id = ?",
+            (user_id,),
+        )
+        requests_cur = self.conn.execute(
+            "DELETE FROM requests WHERE user_id = ?",
+            (user_id,),
+        )
+        if delete_upb_ids:
+            deps._delete_source_windows_for_user_playbook_ids(delete_upb_ids)
+            deps._delete_in_chunks("user_playbooks", "user_playbook_id", delete_upb_ids)
+        if delete_profile_ids:
+            deps._delete_in_chunks("profiles", "profile_id", delete_profile_ids)
+
+        purged_profiles = 0
+        for profile_id in purge_profile_ids:
+            rowid = profile_rowid_by_id.get(profile_id)
+            if rowid is None:
+                continue
+            purged_profiles += int(
+                self._purge_governance_entity_content_locked(
+                    entity_type="profile",
+                    entity_id=profile_id,
+                    rowid=rowid,
+                )
+            )
+
+        purged_user_playbooks = 0
+        for user_playbook_id in purge_upb_ids:
+            purged_user_playbooks += int(
+                self._purge_governance_entity_content_locked(
+                    entity_type="user_playbook",
+                    entity_id=str(user_playbook_id),
+                    rowid=user_playbook_id,
+                )
+            )
+
+        return {
+            "interactions": interactions_cur.rowcount,
+            "user_playbooks": len(delete_upb_ids),
+            "profiles": len(delete_profile_ids),
+            "requests": requests_cur.rowcount,
+            "purged_profiles": purged_profiles,
+            "purged_user_playbooks": purged_user_playbooks,
+        }
 
     def begin_purge_operation(
         self,
@@ -1397,20 +1579,26 @@ class SQLiteGovernanceMixin:
             "purged_user_playbooks": "user_playbook_purge",
         }
         with self._lock:
-            self._validate_prepared_delete_target_matrix_locked(purge_id)
-            counts = self._deps().clear_user_data(user_id)
-            for key, value in counts.items():
-                self._record_purge_target_locked(
-                    purge_id=purge_id,
-                    target_name=name_map.get(key, key),
-                    target_ref="all",
-                    phase="delete",
-                    status="complete",
-                    detail={"count": int(value)},
-                    deleted_count=int(value),
-                    error_detail=None,
-                )
-            self.conn.commit()
+            try:
+                self.conn.execute("BEGIN")
+                self._validate_prepared_delete_target_matrix_locked(purge_id)
+                self._validate_hide_for_rebuild_targets_locked(purge_id)
+                counts = self._clear_user_data_for_governance_locked(user_id)
+                for key, value in counts.items():
+                    self._record_purge_target_locked(
+                        purge_id=purge_id,
+                        target_name=name_map.get(key, key),
+                        target_ref="all",
+                        phase="delete",
+                        status="complete",
+                        detail={"count": int(value)},
+                        deleted_count=int(value),
+                        error_detail=None,
+                    )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
         return counts
 
     def apply_governance_agent_playbook_rebuild(

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -111,7 +111,6 @@ _ALLOWED_PURGE_TARGET_PHASES = frozenset(
     {
         _PREPARE_PHASE,
         "delete",
-        "rebuild",
         "hide_for_rebuild",
         "rebuild_without_erased_sources",
     }
@@ -416,6 +415,14 @@ def _parse_governance_window_list(
 def _validate_governance_target_ref(
     *, target_name: str, phase: str, target_ref: str
 ) -> str:
+    if target_name == _SNAPSHOT_TARGET_NAME:
+        if phase != _PREPARE_PHASE:
+            _raise_governance_validation_error(
+                _SNAPSHOT_TARGET_NAME, "must use prepare_targets phase"
+            )
+        if target_ref != "all":
+            _raise_governance_validation_error("target_ref", "must be all")
+        return target_ref
     if (
         target_name == "agent_playbook"
         and phase in {"hide_for_rebuild", "rebuild_without_erased_sources"}

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -22,7 +22,25 @@ from reflexio.models.api_schema.domain.governance import (
     PurgeTargetStatus,
 )
 
-GOVERNANCE_DDL = """
+_PURGE_OPERATION_TARGETS_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS purge_operation_targets (
+    org_id TEXT NOT NULL,
+    purge_id TEXT NOT NULL,
+    target_name TEXT NOT NULL,
+    target_ref TEXT NOT NULL DEFAULT '',
+    phase TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    detail TEXT,
+    deleted_count INTEGER NOT NULL DEFAULT 0,
+    error_detail TEXT,
+    started_at INTEGER,
+    completed_at INTEGER,
+    PRIMARY KEY (org_id, purge_id, target_name, target_ref, phase),
+    FOREIGN KEY (org_id, purge_id) REFERENCES purge_operations(org_id, purge_id) ON DELETE CASCADE
+);
+"""
+
+GOVERNANCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS audit_events (
     event_id INTEGER PRIMARY KEY AUTOINCREMENT,
     org_id TEXT NOT NULL,
@@ -63,21 +81,7 @@ CREATE TABLE IF NOT EXISTS purge_operations (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_purge_operations_org_idem
     ON purge_operations(org_id, idempotency_key);
 
-CREATE TABLE IF NOT EXISTS purge_operation_targets (
-    org_id TEXT NOT NULL,
-    purge_id TEXT NOT NULL,
-    target_name TEXT NOT NULL,
-    target_ref TEXT NOT NULL DEFAULT '',
-    phase TEXT NOT NULL,
-    status TEXT NOT NULL DEFAULT 'pending',
-    detail TEXT,
-    deleted_count INTEGER NOT NULL DEFAULT 0,
-    error_detail TEXT,
-    started_at INTEGER,
-    completed_at INTEGER,
-    PRIMARY KEY (org_id, purge_id, target_name, target_ref, phase),
-    FOREIGN KEY (org_id, purge_id) REFERENCES purge_operations(org_id, purge_id) ON DELETE CASCADE
-);
+{_PURGE_OPERATION_TARGETS_TABLE_DDL}
 CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
     ON purge_operation_targets(org_id, purge_id, phase, status);
 """
@@ -193,6 +197,7 @@ _ALLOWED_DELETED_COUNTS_KEYS = frozenset(
 
 
 def init_governance_tables(conn: sqlite3.Connection) -> None:
+    _upgrade_legacy_purge_operation_targets_table(conn)
     conn.executescript(GOVERNANCE_DDL)
 
 
@@ -313,11 +318,14 @@ def _validate_governance_deleted_count(value: Any) -> int:
     return cast(int, value)
 
 
-def _validate_governance_int_list(field_name: str, value: Any) -> None:
+def _validate_governance_int_list(field_name: str, value: Any) -> list[int]:
     if not isinstance(value, list):
         _raise_governance_validation_error(field_name, "expected list[int]")
+    normalized_items: list[int] = []
     for item in value:
         _validate_governance_int(field_name, item)
+        normalized_items.append(cast(int, item))
+    return normalized_items
 
 
 def _validate_governance_deleted_counts(
@@ -327,7 +335,9 @@ def _validate_governance_deleted_counts(
         _raise_governance_validation_error(field_name, "expected dict[str, int]")
     normalized_counts: dict[str, int] = {}
     for raw_key, raw_value in value.items():
-        key = str(raw_key).strip()
+        key = str(raw_key).strip().lower()
+        if key in normalized_counts:
+            _raise_governance_validation_error(field_name, f"duplicate key {key}")
         if key not in _ALLOWED_DELETED_COUNTS_KEYS:
             _raise_governance_validation_error(field_name, key)
         normalized_counts[key] = _validate_governance_deleted_count(raw_value)
@@ -353,9 +363,12 @@ def _normalize_governance_window_item(
     return normalized_item
 
 
-def _validate_governance_window_list(field_name: str, value: Any) -> None:
+def _validate_governance_window_list(
+    field_name: str, value: Any
+) -> list[dict[str, object]]:
     if not isinstance(value, list):
         _raise_governance_validation_error(field_name, "expected list[window]")
+    normalized_windows: list[dict[str, object]] = []
     for index, item in enumerate(value):
         normalized_item = _normalize_governance_window_item(field_name, index, item)
         normalized_keys = set(normalized_item)
@@ -372,22 +385,25 @@ def _validate_governance_window_list(field_name: str, value: Any) -> None:
             f"{field_name}[{index}].user_playbook_id",
             normalized_item["user_playbook_id"],
         )
+        canonical_item: dict[str, object] = {
+            "user_playbook_id": cast(int, normalized_item["user_playbook_id"])
+        }
         if "source_interaction_ids" in normalized_item:
-            _validate_governance_int_list(
+            canonical_item["source_interaction_ids"] = _validate_governance_int_list(
                 f"{field_name}[{index}].source_interaction_ids",
                 normalized_item["source_interaction_ids"],
             )
+        normalized_windows.append(canonical_item)
+    return normalized_windows
 
 
 def _parse_governance_window_list(
     field_name: str, value: list[dict[str, object]]
 ) -> list[AgentPlaybookSourceWindow]:
-    _validate_governance_window_list(field_name, value)
     windows: list[AgentPlaybookSourceWindow] = []
-    for index, item in enumerate(value):
-        normalized_item = _normalize_governance_window_item(field_name, index, item)
-        user_playbook_id = int(normalized_item["user_playbook_id"])
-        source_ids = normalized_item.get("source_interaction_ids") or []
+    for normalized_item in _validate_governance_window_list(field_name, value):
+        user_playbook_id = cast(int, normalized_item["user_playbook_id"])
+        source_ids = cast(list[int], normalized_item.get("source_interaction_ids") or [])
         windows.append(
             AgentPlaybookSourceWindow(
                 user_playbook_id=user_playbook_id,
@@ -397,14 +413,25 @@ def _parse_governance_window_list(
     return windows
 
 
-def _validate_governance_target_ref(target_ref: str) -> None:
+def _validate_governance_target_ref(
+    *, target_name: str, phase: str, target_ref: str
+) -> str:
+    if (
+        target_name == "agent_playbook"
+        and phase in {"hide_for_rebuild", "rebuild_without_erased_sources"}
+    ):
+        if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
+            return target_ref
+        _raise_governance_validation_error(
+            "target_ref", "must be a numeric internal id"
+        )
     if target_ref in {"", "all"}:
-        return
+        return target_ref
     if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
-        return
+        return target_ref
     for prefix in ("reqref_v1_", "subref_v1_", "actref_v1_"):
         if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", target_ref):
-            return
+            return target_ref
         if target_ref.startswith(prefix):
             _raise_governance_validation_error(
                 "target_ref", f"must match {prefix}<32 lowercase hex chars>"
@@ -413,19 +440,19 @@ def _validate_governance_target_ref(target_ref: str) -> None:
     if _USER_LIKE_TARGET_REF_RE.fullmatch(target_ref):
         _raise_governance_validation_error("target_ref", "user-like identifier")
     _raise_governance_validation_error("target_ref", "must be minimized or internal")
+    raise AssertionError("unreachable")
 
 
-def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> None:
+def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> object:
     if key in _DISALLOWED_DETAIL_KEYS:
         _raise_governance_validation_error(field_name, key)
     if key not in _ALLOWED_DETAIL_KEYS:
         _raise_governance_validation_error(field_name, key)
     if key in {"count", "deleted_count", "agent_playbook_id", "user_playbook_id"}:
         _validate_governance_int(field_name, value)
-        return
+        return cast(int, value)
     if key == "deleted_counts":
-        _validate_governance_deleted_counts(field_name, value)
-        return
+        return _validate_governance_deleted_counts(field_name, value)
     if key in {
         "affected_agent_playbook_ids",
         "erased_source_ids",
@@ -433,25 +460,22 @@ def _validate_governance_detail_entry(field_name: str, key: str, value: Any) -> 
         "rebuilt_agent_playbook_ids",
         "source_interaction_ids",
     }:
-        _validate_governance_int_list(field_name, value)
-        return
+        return _validate_governance_int_list(field_name, value)
     if key in {"original_source_windows", "remaining_source_windows"}:
-        _validate_governance_window_list(field_name, value)
-        return
+        return _validate_governance_window_list(field_name, value)
     if key == "prepared":
         if not isinstance(value, bool):
             _raise_governance_validation_error(field_name, "expected bool")
-        return
+        return value
     if key in {"route", "status"}:
         if not isinstance(value, str):
             _raise_governance_validation_error(field_name, "expected str")
-        _validate_governance_code_shaped(
+        return _validate_governance_code_shaped(
             field_name,
             value,
             allow_minimized_ref=False,
             allow_enum_like_word=True,
         )
-        return
     _raise_governance_validation_error(field_name, key)
 
 
@@ -462,10 +486,17 @@ def _validate_governance_detail(
         return None
     if not isinstance(detail, dict):
         _raise_governance_validation_error(field_name, "expected dict")
+    normalized_detail: dict[str, object] = {}
     for key, value in detail.items():
         normalized_key = str(key).strip().lower()
-        _validate_governance_detail_entry(f"{field_name}.{normalized_key}", normalized_key, value)
-    return detail
+        if normalized_key in normalized_detail:
+            _raise_governance_validation_error(
+                field_name, f"duplicate key {normalized_key}"
+            )
+        normalized_detail[normalized_key] = _validate_governance_detail_entry(
+            f"{field_name}.{normalized_key}", normalized_key, value
+        )
+    return normalized_detail
 
 
 def _validate_governance_code_like(field_name: str, value: str) -> str:
@@ -562,6 +593,36 @@ def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
         )
     _validate_governance_idempotency_key("idempotency_key", event.idempotency_key)
     _validate_governance_detail("audit_event.detail", event.detail)
+
+
+def _canonicalize_audit_event_for_persistence(event: AuditEvent) -> AuditEvent:
+    _validate_audit_event_for_persistence(event)
+    return event.model_copy(
+        update={"detail": _validate_governance_detail("audit_event.detail", event.detail)}
+    )
+
+
+def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> None:
+    target_columns = [
+        row[1] for row in conn.execute("PRAGMA table_info(purge_operation_targets)")
+    ]
+    if not target_columns or "org_id" in target_columns:
+        return
+    conn.execute("ALTER TABLE purge_operation_targets RENAME TO purge_operation_targets_legacy")
+    conn.executescript(_PURGE_OPERATION_TARGETS_TABLE_DDL)
+    conn.execute(
+        """INSERT INTO purge_operation_targets (
+               org_id, purge_id, target_name, target_ref, phase, status, detail,
+               deleted_count, error_detail, started_at, completed_at
+           )
+           SELECT purge_operations.org_id, legacy.purge_id, legacy.target_name,
+                  legacy.target_ref, legacy.phase, legacy.status, legacy.detail,
+                  legacy.deleted_count, legacy.error_detail, legacy.started_at,
+                  legacy.completed_at
+           FROM purge_operation_targets_legacy AS legacy
+           JOIN purge_operations ON purge_operations.purge_id = legacy.purge_id"""
+    )
+    conn.execute("DROP TABLE purge_operation_targets_legacy")
 
 
 def _is_successful_erase_event(event: AuditEvent, *, purge_id: str | None = None) -> bool:
@@ -745,7 +806,11 @@ class SQLiteGovernanceMixin:
         )
         detail = _validate_governance_detail("detail", detail)
         error_detail = _validate_governance_error_detail(error_detail)
-        _validate_governance_target_ref(target_ref)
+        target_ref = _validate_governance_target_ref(
+            target_name=target_name,
+            phase=phase,
+            target_ref=target_ref,
+        )
         deleted_count = _validate_governance_deleted_count(deleted_count)
         now = _epoch_now()
         existing = self.conn.execute(
@@ -806,7 +871,7 @@ class SQLiteGovernanceMixin:
             )
         if event.org_id != self.org_id:
             raise ValueError("Audit event org_id must match storage org_id")
-        _validate_audit_event_for_persistence(event)
+        event = _canonicalize_audit_event_for_persistence(event)
         with self._lock:
             inserted = self._append_audit_event_with_cursor(self.conn, event)
             self.conn.commit()
@@ -1207,7 +1272,7 @@ class SQLiteGovernanceMixin:
             raise ValueError(
                 "Completion requires a successful ERASE audit event for this purge"
             )
-        _validate_audit_event_for_persistence(audit_event)
+        audit_event = _canonicalize_audit_event_for_persistence(audit_event)
         now = _epoch_now()
         with self._lock:
             try:

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -298,26 +298,29 @@ def _validate_governance_detail(
     return detail
 
 
+def _validate_governance_code_like(field_name: str, value: str) -> str:
+    if not value:
+        _raise_governance_validation_error(field_name, "required")
+    _validate_governance_string(field_name, value)
+    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error(field_name, "identifier")
+    if _IDENTIFIERISH_ERROR_CODE_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "identifier")
+    if not _SAFE_ERROR_CODE_RE.fullmatch(value):
+        _raise_governance_validation_error(
+            field_name, "must be a stable diagnostic code"
+        )
+    return value
+
+
 def _validate_governance_error_detail(error_detail: str | None) -> str | None:
     if error_detail is None:
         return None
-    _validate_governance_string("error_detail", error_detail)
-    return error_detail
+    return _validate_governance_code_like("error_detail", error_detail)
 
 
 def _validate_governance_error_code(error_code: str) -> str:
-    if not error_code:
-        _raise_governance_validation_error("error_code", "required")
-    _validate_governance_string("error_code", error_code)
-    if error_code.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
-        _raise_governance_validation_error("error_code", "identifier")
-    if _IDENTIFIERISH_ERROR_CODE_RE.fullmatch(error_code):
-        _raise_governance_validation_error("error_code", "identifier")
-    if not _SAFE_ERROR_CODE_RE.fullmatch(error_code):
-        _raise_governance_validation_error(
-            "error_code", "must be a stable diagnostic code"
-        )
-    return error_code
+    return _validate_governance_code_like("error_code", error_code)
 
 
 def _validate_audit_event_for_persistence(event: AuditEvent) -> None:

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -100,7 +100,7 @@ _PROFILE_PURGE_SQL = (
 )
 _USER_PLAYBOOK_PURGE_SQL = (
     "UPDATE user_playbooks SET "
-    "content='', user_id=NULL, source=NULL, "
+    "content='', user_id=NULL, request_id='', source=NULL, "
     "trigger=NULL, rationale=NULL, blocking_issue=NULL, "
     "source_interaction_ids=NULL, embedding=NULL, expanded_terms=NULL, "
     "tags=NULL, source_span=NULL, notes=NULL, reader_angle=NULL "

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -318,7 +318,7 @@ class PlaybookMixin:
             sql += f" AND {tag_frag}"
             params.extend(tag_params)
 
-        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        sql += " ORDER BY created_at DESC, user_playbook_id DESC LIMIT ? OFFSET ?"
         params.extend([limit, offset])
         rows = self._fetchall(sql, params)
         return [

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -285,6 +285,7 @@ class PlaybookMixin:
         end_time: int | None = None,
         include_embedding: bool = False,
         tags: list[str] | None = None,
+        offset: int = 0,
     ) -> list[UserPlaybook]:
         sql = "SELECT * FROM user_playbooks WHERE 1=1"
         params: list[Any] = []
@@ -317,8 +318,8 @@ class PlaybookMixin:
             sql += f" AND {tag_frag}"
             params.extend(tag_params)
 
-        sql += " ORDER BY created_at DESC LIMIT ?"
-        params.append(limit)
+        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
         rows = self._fetchall(sql, params)
         return [
             _row_to_user_playbook(r, include_embedding=include_embedding) for r in rows

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -50,6 +50,11 @@ from ._base import (
 )
 from ._lineage import _GC_ELIGIBLE_STATUSES, _append_event_stmt
 
+_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES = (
+    *_TOMBSTONE_STATUS_VALUES,
+    Status.ARCHIVE_IN_PROGRESS.value,
+)
+
 
 def _emit_hard_delete_playbook(
     conn: sqlite3.Connection,
@@ -1007,8 +1012,11 @@ class PlaybookMixin:
     ) -> AgentPlaybook | None:
         sql = "SELECT * FROM agent_playbooks WHERE agent_playbook_id = ?"
         if not include_tombstones:
-            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
-            row = self._fetchone(sql, (agent_playbook_id, *_TOMBSTONE_STATUS_VALUES))
+            sql += " AND (status IS NULL OR status NOT IN (?, ?, ?))"
+            row = self._fetchone(
+                sql,
+                (agent_playbook_id, *_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES),
+            )
         else:
             row = self._fetchone(sql, (agent_playbook_id,))
         return _row_to_agent_playbook(row) if row else None
@@ -1950,9 +1958,8 @@ class PlaybookMixin:
             conditions.append(frag)
             params.extend(sparams)
         else:
-            # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
-            conditions.append("(ap.status IS NULL OR ap.status NOT IN (?, ?))")
-            params.extend(_TOMBSTONE_STATUS_VALUES)
+            conditions.append("(ap.status IS NULL OR ap.status NOT IN (?, ?, ?))")
+            params.extend(_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES)
         tag_frag, tag_params = _build_tags_sql("ap", request.tags)
         if tag_frag:
             conditions.append(tag_frag)

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -23,6 +23,7 @@ from ._agent_run import (
 )
 from ._base import BaseStorageCore, matches_status_filter
 from ._extras import ExtrasMixin
+from ._governance import GovernanceMixin
 from ._lineage import EntityType, LineageEventMixin
 from ._operations import OperationMixin
 from ._playbook import PlaybookMixin
@@ -40,6 +41,7 @@ class BaseStorage(
     RequestMixin,
     PlaybookMixin,
     RetrievalLogMixin,
+    GovernanceMixin,
     LineageEventMixin,
     OperationMixin,
     ExtrasMixin,

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -62,7 +62,10 @@ class GovernanceMixin:
 
     @abstractmethod
     def prepare_governance_erase_targets(
-        self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
+        self,
+        purge_id: str,
+        user_id: str,
+        owned_user_playbook_ids: set[int] | None = None,
     ) -> None:
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Any, Literal
+from typing import Literal
 
 from reflexio.models.api_schema.domain.governance import (
     AuditEvent,
     PurgeOperation,
     PurgeOperationTarget,
 )
+from reflexio.models.config_schema import GovernanceRetentionConfig
 
 
 class GovernanceMixin:
@@ -107,5 +108,5 @@ class GovernanceMixin:
         raise NotImplementedError
 
     @abstractmethod
-    def gc_governance_retention(self, *, config: Any) -> int:
+    def gc_governance_retention(self, *, config: GovernanceRetentionConfig) -> int:
         raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Literal
+
+from reflexio.models.api_schema.domain.governance import (
+    AuditEvent,
+    PurgeOperation,
+    PurgeOperationTarget,
+)
+
+
+class GovernanceMixin:
+    """Mixin for backend-neutral governance storage primitives."""
+
+    @abstractmethod
+    def append_audit_event(self, event: AuditEvent) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_audit_events(
+        self, subject_ref: str | None = None, *, org_id: str | None = None
+    ) -> list[AuditEvent]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def begin_purge_operation(
+        self,
+        purge_id: str,
+        idempotency_key: str,
+        operation_type: Literal["user_erasure", "org_purge"],
+        scope_type: Literal["user", "org"],
+        subject_ref: str | None,
+        request_ref: str,
+    ) -> PurgeOperation:
+        raise NotImplementedError
+
+    @abstractmethod
+    def record_purge_target(
+        self,
+        purge_id: str,
+        target_name: str,
+        phase: str,
+        status: Literal["pending", "running", "failed", "complete"],
+        target_ref: str = "",
+        detail: dict[str, object] | None = None,
+        deleted_count: int = 0,
+        error_detail: str | None = None,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_purge_targets(
+        self, purge_id: str, phase: str | None = None
+    ) -> list[PurgeOperationTarget]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def purge_targets_prepared(self, purge_id: str) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare_governance_erase_targets(
+        self, purge_id: str, user_id: str, owned_user_playbook_ids: set[int]
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def hide_governance_agent_playbooks_for_rebuild(self, purge_id: str) -> list[int]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_governance_user_data_delete(
+        self, purge_id: str, user_id: str
+    ) -> dict[str, int]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply_governance_agent_playbook_rebuild(
+        self,
+        purge_id: str,
+        agent_playbook_id: int,
+        remaining_source_windows: list[dict[str, object]],
+        content: str | None,
+        trigger: str | None,
+        rationale: str | None,
+        blocking_issue: dict[str, object] | None,
+        expanded_terms: str | None,
+        tags: list[str] | None,
+    ) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def complete_purge_operation_with_audit(
+        self, purge_id: str, audit_event: AuditEvent
+    ) -> PurgeOperation:
+        raise NotImplementedError
+
+    @abstractmethod
+    def fail_purge_operation(
+        self, purge_id: str, error_code: str, error_detail: str
+    ) -> PurgeOperation:
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_purge_operation(self, purge_id: str) -> PurgeOperation:
+        raise NotImplementedError
+
+    @abstractmethod
+    def gc_governance_retention(self, *, config: Any) -> int:
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -56,6 +56,7 @@ class PlaybookMixin:
         end_time: int | None = None,
         include_embedding: bool = False,
         tags: list[str] | None = None,
+        offset: int = 0,
     ) -> list[UserPlaybook]:
         """Get user playbooks from storage.
 
@@ -71,6 +72,7 @@ class PlaybookMixin:
             end_time (int, optional): Unix timestamp. Only return playbooks created at or before this time.
             include_embedding (bool): If True, fetch and parse embedding vectors. Defaults to False.
             tags (list[str], optional): Match playbooks having any of these tags.
+            offset (int): Number of matching rows to skip. Defaults to 0.
 
         Returns:
             list[UserPlaybook]: List of user playbook objects

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -141,6 +141,14 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
         rationale="alicerationaleunique",
     )
     storage.save_user_playbooks([alice_playbook])
+    alice_orphan_playbook = _user_playbook(
+        user_id="alice",
+        request_id=alice_request_id,
+        content="aliceorphansourcetoken",
+        trigger="aliceorphantrigger",
+        rationale="aliceorphanrationale",
+    )
+    storage.save_user_playbooks([alice_orphan_playbook])
 
     storage.add_request(
         _request(request_id=bob_request_id, user_id="bob", session_id="sess-bob")
@@ -195,6 +203,24 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
             ),
         ],
     )
+    orphan_playbook = storage.save_agent_playbooks(
+        [
+            _agent_playbook(
+                content="aliceorphansourcetoken",
+                trigger="aliceorphantrigger",
+                rationale="aliceorphanrationale",
+            )
+        ]
+    )[0]
+    storage.set_source_windows_for_agent_playbook(
+        orphan_playbook.agent_playbook_id,
+        [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=alice_orphan_playbook.user_playbook_id,
+                source_interaction_ids=[303],
+            ),
+        ],
+    )
 
     service = GovernanceService(
         storage=storage,
@@ -215,9 +241,10 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert [request["request_id"] for request in exported.bundle["requests"]] == [
         alice_request_id
     ]
-    assert [playbook["user_playbook_id"] for playbook in exported.bundle["user_playbooks"]] == [
-        alice_playbook.user_playbook_id
-    ]
+    assert {playbook["user_playbook_id"] for playbook in exported.bundle["user_playbooks"]} == {
+        alice_playbook.user_playbook_id,
+        alice_orphan_playbook.user_playbook_id,
+    }
 
     export_events = [
         event
@@ -225,7 +252,7 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
         if event.operation == "EXPORT"
     ]
     assert len(export_events) == 1
-    assert export_events[0].detail == {"count": 5}
+    assert export_events[0].detail == {"count": 6}
     export_dump = export_events[0].model_dump_json()
     assert "alice" not in export_dump
     assert alice_request_id not in export_dump
@@ -237,8 +264,11 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert erased.deleted_counts["interactions"] == 1
     assert erased.deleted_counts["profiles"] == 1
     assert erased.deleted_counts["requests"] == 1
-    assert erased.deleted_counts["user_playbooks"] == 1
-    assert erased.rebuilt_agent_playbook_ids == [shared_playbook.agent_playbook_id]
+    assert erased.deleted_counts["user_playbooks"] == 2
+    assert set(erased.rebuilt_agent_playbook_ids) == {
+        shared_playbook.agent_playbook_id,
+        orphan_playbook.agent_playbook_id,
+    }
 
     assert storage.get_user_interaction("alice") == []
     assert storage.get_user_profile("alice") == []
@@ -262,10 +292,25 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
             source_interaction_ids=[202],
         )
     ]
+    assert storage.get_agent_playbook_by_id(orphan_playbook.agent_playbook_id) is None
+    assert orphan_playbook.agent_playbook_id not in {
+        playbook.agent_playbook_id for playbook in storage.get_agent_playbooks(limit=10)
+    }
+    assert (
+        storage.get_source_windows_for_agent_playbook(orphan_playbook.agent_playbook_id)
+        == []
+    )
 
     assert storage.search_agent_playbooks(
         SearchAgentPlaybookRequest(
             query="aliceuniquesourcetoken",
+            top_k=10,
+            search_mode=SearchMode.FTS,
+        )
+    ) == []
+    assert storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="aliceorphansourcetoken",
             top_k=10,
             search_mode=SearchMode.FTS,
         )

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    AgentPlaybookSourceWindow,
+    Interaction,
+    Request,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.domain.enums import PlaybookStatus
+from reflexio.models.api_schema.retriever_schema import SearchAgentPlaybookRequest
+from reflexio.models.config_schema import SearchMode
+from reflexio.server.services.governance.service import GovernanceService
+from reflexio.server.services.governance.subject_refs import subject_ref
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _now() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+def _request(*, request_id: str, user_id: str, session_id: str) -> Request:
+    return Request(
+        request_id=request_id,
+        user_id=user_id,
+        session_id=session_id,
+        created_at=_now(),
+        source="governance-local-e2e",
+        agent_version="agent-v1",
+    )
+
+
+def _interaction(
+    *,
+    user_id: str,
+    request_id: str,
+    content: str,
+    interaction_id: int = 0,
+) -> Interaction:
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id=user_id,
+        request_id=request_id,
+        created_at=_now(),
+        content=content,
+    )
+
+
+def _profile(*, profile_id: str, user_id: str, content: str, request_id: str) -> UserProfile:
+    return UserProfile(
+        profile_id=profile_id,
+        user_id=user_id,
+        content=content,
+        last_modified_timestamp=_now(),
+        generated_from_request_id=request_id,
+    )
+
+
+def _user_playbook(
+    *,
+    user_id: str,
+    request_id: str,
+    content: str,
+    trigger: str,
+    rationale: str,
+) -> UserPlaybook:
+    return UserPlaybook(
+        user_id=user_id,
+        agent_version="agent-v1",
+        request_id=request_id,
+        playbook_name="shared-governance-playbook",
+        created_at=_now(),
+        content=content,
+        trigger=trigger,
+        rationale=rationale,
+        source="governance-local-e2e",
+    )
+
+
+def _agent_playbook(*, content: str, trigger: str, rationale: str) -> AgentPlaybook:
+    return AgentPlaybook(
+        playbook_name="shared-governance-playbook",
+        agent_version="agent-v1",
+        created_at=_now(),
+        content=content,
+        trigger=trigger,
+        rationale=rationale,
+        playbook_status=PlaybookStatus.APPROVED,
+    )
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> Generator[SQLiteStorage, None, None]:
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        yield SQLiteStorage(org_id="org-local", db_path=str(tmp_path / "governance.db"))
+
+
+def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregate(
+    storage: SQLiteStorage,
+) -> None:
+    alice_request_id = "req-alice"
+    bob_request_id = "req-bob"
+
+    storage.add_request(
+        _request(request_id=alice_request_id, user_id="alice", session_id="sess-alice")
+    )
+    storage.add_user_interaction(
+        "alice",
+        _interaction(
+            user_id="alice",
+            request_id=alice_request_id,
+            content="aliceprivateinteractiontoken",
+        ),
+    )
+    storage.add_user_profile(
+        "alice",
+        [
+            _profile(
+                profile_id="profile-alice",
+                user_id="alice",
+                content="aliceprivateprofiletoken",
+                request_id=alice_request_id,
+            )
+        ],
+    )
+    alice_playbook = _user_playbook(
+        user_id="alice",
+        request_id=alice_request_id,
+        content="aliceuniquesourcetoken",
+        trigger="alicetriggerunique",
+        rationale="alicerationaleunique",
+    )
+    storage.save_user_playbooks([alice_playbook])
+
+    storage.add_request(
+        _request(request_id=bob_request_id, user_id="bob", session_id="sess-bob")
+    )
+    storage.add_user_interaction(
+        "bob",
+        _interaction(
+            user_id="bob",
+            request_id=bob_request_id,
+            content="bobprivateinteractiontoken",
+        ),
+    )
+    storage.add_user_profile(
+        "bob",
+        [
+            _profile(
+                profile_id="profile-bob",
+                user_id="bob",
+                content="bobprivateprofiletoken",
+                request_id=bob_request_id,
+            )
+        ],
+    )
+    bob_playbook = _user_playbook(
+        user_id="bob",
+        request_id=bob_request_id,
+        content="bobuniquesourcetoken",
+        trigger="bobtriggerunique",
+        rationale="bobrationaleunique",
+    )
+    storage.save_user_playbooks([bob_playbook])
+
+    shared_playbook = storage.save_agent_playbooks(
+        [
+            _agent_playbook(
+                content="aliceuniquesourcetoken\nbobuniquesourcetoken",
+                trigger="alicetriggerunique\nbobtriggerunique",
+                rationale="alicerationaleunique\nbobrationaleunique",
+            )
+        ]
+    )[0]
+    storage.set_source_windows_for_agent_playbook(
+        shared_playbook.agent_playbook_id,
+        [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=alice_playbook.user_playbook_id,
+                source_interaction_ids=[101],
+            ),
+            AgentPlaybookSourceWindow(
+                user_playbook_id=bob_playbook.user_playbook_id,
+                source_interaction_ids=[202],
+            ),
+        ],
+    )
+
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    exported = service.export_user(user_id="alice", request_id="export-request-1")
+
+    assert exported.subject_ref == subject_ref("alice", "test-governance-secret")
+    assert exported.export_id.startswith("export_")
+    assert [profile["profile_id"] for profile in exported.bundle["profiles"]] == [
+        "profile-alice"
+    ]
+    assert [interaction["request_id"] for interaction in exported.bundle["interactions"]] == [
+        alice_request_id
+    ]
+    assert [request["request_id"] for request in exported.bundle["requests"]] == [
+        alice_request_id
+    ]
+    assert [playbook["user_playbook_id"] for playbook in exported.bundle["user_playbooks"]] == [
+        alice_playbook.user_playbook_id
+    ]
+
+    export_events = [
+        event
+        for event in storage.list_audit_events(subject_ref=exported.subject_ref)
+        if event.operation == "EXPORT"
+    ]
+    assert len(export_events) == 1
+    assert export_events[0].detail == {"count": 5}
+    export_dump = export_events[0].model_dump_json()
+    assert "alice" not in export_dump
+    assert alice_request_id not in export_dump
+
+    erased = service.erase_user(user_id="alice", request_id="erase-request-1")
+
+    assert erased.status == "complete"
+    assert erased.subject_ref == exported.subject_ref
+    assert erased.deleted_counts["interactions"] == 1
+    assert erased.deleted_counts["profiles"] == 1
+    assert erased.deleted_counts["requests"] == 1
+    assert erased.deleted_counts["user_playbooks"] == 1
+    assert erased.rebuilt_agent_playbook_ids == [shared_playbook.agent_playbook_id]
+
+    assert storage.get_user_interaction("alice") == []
+    assert storage.get_user_profile("alice") == []
+    assert storage.get_requests_by_session("alice", "sess-alice") == []
+    assert storage.get_user_playbooks(user_id="alice", limit=10) == []
+
+    assert len(storage.get_user_interaction("bob")) == 1
+    assert len(storage.get_user_profile("bob")) == 1
+    assert len(storage.get_requests_by_session("bob", "sess-bob")) == 1
+    assert len(storage.get_user_playbooks(user_id="bob", limit=10)) == 1
+
+    rebuilt_playbook = storage.get_agent_playbook_by_id(shared_playbook.agent_playbook_id)
+    assert rebuilt_playbook is not None
+    assert "aliceuniquesourcetoken" not in rebuilt_playbook.content
+    assert rebuilt_playbook.content == "bobuniquesourcetoken"
+    assert rebuilt_playbook.trigger == "bobtriggerunique"
+    assert rebuilt_playbook.rationale == "bobrationaleunique"
+    assert storage.get_source_windows_for_agent_playbook(shared_playbook.agent_playbook_id) == [
+        AgentPlaybookSourceWindow(
+            user_playbook_id=bob_playbook.user_playbook_id,
+            source_interaction_ids=[202],
+        )
+    ]
+
+    assert storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="aliceuniquesourcetoken",
+            top_k=10,
+            search_mode=SearchMode.FTS,
+        )
+    ) == []
+    bob_search_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="bobuniquesourcetoken",
+            top_k=10,
+            search_mode=SearchMode.FTS,
+        )
+    )
+    assert [playbook.agent_playbook_id for playbook in bob_search_results] == [
+        shared_playbook.agent_playbook_id
+    ]
+
+    erase_events = [
+        event
+        for event in storage.list_audit_events(subject_ref=exported.subject_ref)
+        if event.operation == "ERASE" and event.status == "ok"
+    ]
+    assert len(erase_events) == 1
+    assert erase_events[0].idempotency_key == erased.purge_id
+    erase_dump = erase_events[0].model_dump_json()
+    assert "alice" not in erase_dump
+    assert alice_request_id not in erase_dump
+
+    retried = service.erase_user(user_id="alice", request_id="erase-request-1")
+
+    assert retried.purge_id == erased.purge_id
+    assert retried.status == "complete"
+    assert retried.deleted_counts == {}
+    assert retried.rebuilt_agent_playbook_ids == []
+    erase_events_after_retry = [
+        event
+        for event in storage.list_audit_events(subject_ref=exported.subject_ref)
+        if event.operation == "ERASE" and event.status == "ok"
+    ]
+    assert len(erase_events_after_retry) == 1

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -10,6 +10,7 @@ import pytest
 from reflexio.models.api_schema.domain.entities import (
     AgentPlaybook,
     AgentPlaybookSourceWindow,
+    AgentSuccessEvaluationResult,
     Interaction,
     Request,
     UserPlaybook,
@@ -56,7 +57,9 @@ def _interaction(
     )
 
 
-def _profile(*, profile_id: str, user_id: str, content: str, request_id: str) -> UserProfile:
+def _profile(
+    *, profile_id: str, user_id: str, content: str, request_id: str
+) -> UserProfile:
     return UserProfile(
         profile_id=profile_id,
         user_id=user_id,
@@ -99,6 +102,18 @@ def _agent_playbook(*, content: str, trigger: str, rationale: str) -> AgentPlayb
     )
 
 
+def _eval_result(
+    *, user_id: str, session_id: str, agent_version: str
+) -> AgentSuccessEvaluationResult:
+    return AgentSuccessEvaluationResult(
+        user_id=user_id,
+        session_id=session_id,
+        agent_version=agent_version,
+        evaluation_name="governance-local-e2e",
+        is_success=True,
+    )
+
+
 @pytest.fixture
 def storage(tmp_path: Path) -> Generator[SQLiteStorage, None, None]:
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
@@ -113,6 +128,13 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
 
     storage.add_request(
         _request(request_id=alice_request_id, user_id="alice", session_id="sess-alice")
+    )
+    storage.save_agent_success_evaluation_results(
+        [
+            _eval_result(
+                user_id="alice", session_id="sess-alice", agent_version="agent-v1"
+            )
+        ]
     )
     storage.add_user_interaction(
         "alice",
@@ -152,6 +174,9 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
 
     storage.add_request(
         _request(request_id=bob_request_id, user_id="bob", session_id="sess-bob")
+    )
+    storage.save_agent_success_evaluation_results(
+        [_eval_result(user_id="bob", session_id="sess-bob", agent_version="agent-v1")]
     )
     storage.add_user_interaction(
         "bob",
@@ -235,13 +260,15 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert [profile["profile_id"] for profile in exported.bundle["profiles"]] == [
         "profile-alice"
     ]
-    assert [interaction["request_id"] for interaction in exported.bundle["interactions"]] == [
-        alice_request_id
-    ]
+    assert [
+        interaction["request_id"] for interaction in exported.bundle["interactions"]
+    ] == [alice_request_id]
     assert [request["request_id"] for request in exported.bundle["requests"]] == [
         alice_request_id
     ]
-    assert {playbook["user_playbook_id"] for playbook in exported.bundle["user_playbooks"]} == {
+    assert {
+        playbook["user_playbook_id"] for playbook in exported.bundle["user_playbooks"]
+    } == {
         alice_playbook.user_playbook_id,
         alice_orphan_playbook.user_playbook_id,
     }
@@ -265,6 +292,7 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert erased.deleted_counts["profiles"] == 1
     assert erased.deleted_counts["requests"] == 1
     assert erased.deleted_counts["user_playbooks"] == 2
+    assert erased.deleted_counts["agent_success_evaluation_results"] == 1
     assert set(erased.rebuilt_agent_playbook_ids) == {
         shared_playbook.agent_playbook_id,
         orphan_playbook.agent_playbook_id,
@@ -274,19 +302,47 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert storage.get_user_profile("alice") == []
     assert storage.get_requests_by_session("alice", "sess-alice") == []
     assert storage.get_user_playbooks(user_id="alice", limit=10) == []
+    assert (
+        storage.get_agent_success_evaluation_result_ids(
+            "alice",
+            "sess-alice",
+            "governance-local-e2e",
+            "agent-v1",
+        )
+        == []
+    )
 
     assert len(storage.get_user_interaction("bob")) == 1
     assert len(storage.get_user_profile("bob")) == 1
     assert len(storage.get_requests_by_session("bob", "sess-bob")) == 1
+    assert (
+        storage.get_agent_success_evaluation_result_ids(
+            "bob",
+            "sess-bob",
+            "governance-local-e2e",
+            "agent-v1",
+        )
+        != []
+    )
+    delete_targets = {
+        target.target_name: target
+        for target in storage.list_purge_targets(erased.purge_id, phase="delete")
+    }
+    assert delete_targets["agent_success_evaluation_result"].status == "complete"
+    assert delete_targets["agent_success_evaluation_result"].deleted_count == 1
     assert len(storage.get_user_playbooks(user_id="bob", limit=10)) == 1
 
-    rebuilt_playbook = storage.get_agent_playbook_by_id(shared_playbook.agent_playbook_id)
+    rebuilt_playbook = storage.get_agent_playbook_by_id(
+        shared_playbook.agent_playbook_id
+    )
     assert rebuilt_playbook is not None
     assert "aliceuniquesourcetoken" not in rebuilt_playbook.content
     assert rebuilt_playbook.content == "bobuniquesourcetoken"
     assert rebuilt_playbook.trigger == "bobtriggerunique"
     assert rebuilt_playbook.rationale == "bobrationaleunique"
-    assert storage.get_source_windows_for_agent_playbook(shared_playbook.agent_playbook_id) == [
+    assert storage.get_source_windows_for_agent_playbook(
+        shared_playbook.agent_playbook_id
+    ) == [
         AgentPlaybookSourceWindow(
             user_playbook_id=bob_playbook.user_playbook_id,
             source_interaction_ids=[202],
@@ -301,20 +357,26 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
         == []
     )
 
-    assert storage.search_agent_playbooks(
-        SearchAgentPlaybookRequest(
-            query="aliceuniquesourcetoken",
-            top_k=10,
-            search_mode=SearchMode.FTS,
+    assert (
+        storage.search_agent_playbooks(
+            SearchAgentPlaybookRequest(
+                query="aliceuniquesourcetoken",
+                top_k=10,
+                search_mode=SearchMode.FTS,
+            )
         )
-    ) == []
-    assert storage.search_agent_playbooks(
-        SearchAgentPlaybookRequest(
-            query="aliceorphansourcetoken",
-            top_k=10,
-            search_mode=SearchMode.FTS,
+        == []
+    )
+    assert (
+        storage.search_agent_playbooks(
+            SearchAgentPlaybookRequest(
+                query="aliceorphansourcetoken",
+                top_k=10,
+                search_mode=SearchMode.FTS,
+            )
         )
-    ) == []
+        == []
+    )
     bob_search_results = storage.search_agent_playbooks(
         SearchAgentPlaybookRequest(
             query="bobuniquesourcetoken",

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,7 @@ from reflexio.models.api_schema.domain.entities import (
 from reflexio.models.api_schema.domain.enums import PlaybookStatus
 from reflexio.models.api_schema.retriever_schema import SearchAgentPlaybookRequest
 from reflexio.models.config_schema import SearchMode
+from reflexio.server.services.governance import service as governance_service_module
 from reflexio.server.services.governance.service import GovernanceService
 from reflexio.server.services.governance.subject_refs import subject_ref
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
@@ -122,7 +124,9 @@ def storage(tmp_path: Path) -> Generator[SQLiteStorage, None, None]:
 
 def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregate(
     storage: SQLiteStorage,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(governance_service_module, "_USER_PLAYBOOK_PAGE_SIZE", 1)
     alice_request_id = "req-alice"
     bob_request_id = "req-bob"
 
@@ -356,6 +360,16 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
         storage.get_source_windows_for_agent_playbook(orphan_playbook.agent_playbook_id)
         == []
     )
+    hard_delete_events = [
+        event
+        for event in storage.get_lineage_events(
+            entity_type="agent_playbook",
+            entity_id=str(orphan_playbook.agent_playbook_id),
+        )
+        if event.op == "hard_delete"
+    ]
+    assert len(hard_delete_events) == 1
+    assert hard_delete_events[0].request_id == erased.purge_id
 
     assert (
         storage.search_agent_playbooks(
@@ -411,3 +425,59 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
         if event.operation == "ERASE" and event.status == "ok"
     ]
     assert len(erase_events_after_retry) == 1
+
+
+def test_governance_erase_marks_purge_failed_when_workflow_raises(
+    storage: SQLiteStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    def _raise_prepare(*args, **kwargs) -> None:
+        raise RuntimeError("forced prepare failure")
+
+    monkeypatch.setattr(storage, "prepare_governance_erase_targets", _raise_prepare)
+
+    with pytest.raises(RuntimeError, match="forced prepare failure"):
+        service.erase_user(user_id="alice", request_id="erase-failure-request")
+
+    failed_purges = [
+        row
+        for row in storage.conn.execute(
+            "SELECT status, error_code, error_detail FROM purge_operations"
+        ).fetchall()
+        if row["status"] == "failed"
+    ]
+    assert len(failed_purges) == 1
+    assert failed_purges[0]["error_code"] == "governance_erase_failed"
+    assert failed_purges[0]["error_detail"] == "RuntimeError"
+
+
+def test_session_export_paginates_by_returned_rows_when_requests_are_missing() -> None:
+    class _Storage:
+        def __init__(self) -> None:
+            self.calls: list[int] = []
+
+        def get_sessions(self, *, user_id: str, top_k: int, offset: int):
+            self.calls.append(offset)
+            if offset == 0:
+                return {
+                    "session-a": [
+                        *[SimpleNamespace(request=None) for _ in range(999)],
+                        SimpleNamespace(request=SimpleNamespace(request_id="req-1")),
+                    ]
+                }
+            return {}
+
+    storage = _Storage()
+    service = GovernanceService(storage=storage, org_id="org", ref_secret="secret")
+
+    requests, sessions = service._load_user_requests_and_sessions("user-1")
+
+    assert storage.calls == [0, 1000]
+    assert [request.request_id for request in requests] == ["req-1"]
+    assert sessions == [{"session_id": "session-a", "request_ids": ["req-1"]}]

--- a/tests/server/services/governance/test_subject_refs.py
+++ b/tests/server/services/governance/test_subject_refs.py
@@ -1,0 +1,31 @@
+from reflexio.server.services.governance.subject_refs import (
+    actor_ref,
+    request_ref,
+    stable_id,
+    subject_ref,
+)
+
+
+def test_refs_are_deterministic_prefixed_and_do_not_leak_raw_values():
+    secret = "test-secret"
+
+    sub = subject_ref("alice@example.com", secret)
+    actor = actor_ref("api-token-name", secret)
+    req = request_ref("request-id-with-alice@example.com", secret)
+
+    assert sub == subject_ref("alice@example.com", secret)
+    assert sub.startswith("subref_v1_")
+    assert actor.startswith("actref_v1_")
+    assert req.startswith("reqref_v1_")
+    assert "alice" not in sub
+    assert "example.com" not in sub
+    assert "api-token-name" not in actor
+    assert "request-id" not in req
+
+
+def test_stable_id_is_deterministic_and_prefixed():
+    first = stable_id("purge", "org1:user_erasure:subref:reqref")
+    second = stable_id("purge", "org1:user_erasure:subref:reqref")
+
+    assert first == second
+    assert first.startswith("purge_")

--- a/tests/server/services/lineage/test_governance_retention_gates.py
+++ b/tests/server/services/lineage/test_governance_retention_gates.py
@@ -22,21 +22,19 @@ from reflexio.server.services.lineage.gc_scheduler import (
 def _make_ctx(
     *,
     lineage_gc_enabled: bool,
-    purge_expired_profiles_enabled: bool = False,
-    row_count_retention_enabled: bool = False,
     audit_events_retention_enabled: bool = False,
+    include_governance_retention: bool = True,
 ):
     storage = MagicMock()
     storage.gc_expired_tombstones.return_value = 0
     storage.gc_governance_retention.return_value = 0
     config = SimpleNamespace(
         lineage_gc=LineageGCConfig(enabled=lineage_gc_enabled),
-        governance_retention=SimpleNamespace(
-            purge_expired_profiles_enabled=purge_expired_profiles_enabled,
-            row_count_retention_enabled=row_count_retention_enabled,
-            audit_events_retention_enabled=audit_events_retention_enabled,
-        ),
     )
+    if include_governance_retention:
+        config.governance_retention = SimpleNamespace(
+            audit_events_retention_enabled=audit_events_retention_enabled,
+        )
     return SimpleNamespace(
         org_id="org_1",
         storage=storage,
@@ -63,15 +61,18 @@ def test_config_exposes_governance_retention_defaults():
     cfg = Config(storage_config=None)
 
     assert isinstance(cfg.governance_retention, governance_cls)
-    assert cfg.governance_retention.purge_expired_profiles_enabled is False
-    assert cfg.governance_retention.row_count_retention_enabled is False
     assert cfg.governance_retention.audit_events_retention_enabled is False
     assert cfg.governance_retention.audit_events_retention_days == 365
     assert cfg.governance_retention.audit_events_delete_batch_limit == 500
 
 
 @pytest.mark.parametrize(
-    ("lineage_gc_enabled", "governance_gate_enabled", "expect_tombstone_gc", "expect_governance_gc"),
+    (
+        "lineage_gc_enabled",
+        "governance_gate_enabled",
+        "expect_tombstone_gc",
+        "expect_governance_gc",
+    ),
     [
         (False, False, False, False),
         (True, False, True, False),
@@ -87,7 +88,7 @@ def test_gc_tick_gates_tombstone_and_governance_paths(
 ):
     ctx = _make_ctx(
         lineage_gc_enabled=lineage_gc_enabled,
-        purge_expired_profiles_enabled=governance_gate_enabled,
+        audit_events_retention_enabled=governance_gate_enabled,
     )
 
     sched = _scheduler(ctx)
@@ -106,16 +107,8 @@ def test_gc_tick_gates_tombstone_and_governance_paths(
         ctx.storage.gc_governance_retention.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    "flag_name",
-    [
-        "purge_expired_profiles_enabled",
-        "row_count_retention_enabled",
-        "audit_events_retention_enabled",
-    ],
-)
-def test_gc_tick_runs_governance_gc_for_each_individual_gate(flag_name: str):
-    ctx = _make_ctx(lineage_gc_enabled=False, **_with_governance_flag(flag_name))
+def test_gc_tick_runs_governance_gc_for_audit_event_retention_gate():
+    ctx = _make_ctx(lineage_gc_enabled=False, audit_events_retention_enabled=True)
 
     sched = _scheduler(ctx)
     sched._gc_tick(["org_1"])
@@ -127,7 +120,7 @@ def test_gc_tick_runs_governance_gc_for_each_individual_gate(flag_name: str):
 
 
 def test_gc_tick_high_volume_anomaly_ignores_governance_deletions():
-    ctx = _make_ctx(lineage_gc_enabled=False, purge_expired_profiles_enabled=True)
+    ctx = _make_ctx(lineage_gc_enabled=False, audit_events_retention_enabled=True)
     ctx.storage.gc_governance_retention.return_value = _HIGH_VOLUME_THRESHOLD + 1
 
     sched = _scheduler(ctx)
@@ -139,7 +132,39 @@ def test_gc_tick_high_volume_anomaly_ignores_governance_deletions():
 
 
 def test_maybe_start_lineage_gc_starts_for_governance_retention_only():
-    ctx = _make_ctx(lineage_gc_enabled=False, row_count_retention_enabled=True)
+    ctx = _make_ctx(lineage_gc_enabled=False, audit_events_retention_enabled=True)
+    request_context_factory = cast(
+        Callable[[str], RequestContext],
+        lambda _: ctx,
+    )
+
+    with patch.object(LineageGCScheduler, "start") as mock_start:
+        sched = maybe_start_lineage_gc(
+            request_context_factory, bootstrap_org_id="org_1"
+        )
+
+    assert sched is not None
+    mock_start.assert_called_once_with()
+
+
+def test_gc_tick_legacy_config_without_governance_retention_runs_tombstone_only():
+    ctx = _make_ctx(
+        lineage_gc_enabled=True,
+        include_governance_retention=False,
+    )
+
+    sched = _scheduler(ctx)
+    sched._gc_tick(["org_1"])
+
+    assert ctx.storage.gc_expired_tombstones.call_count == len(_ENTITY_TYPES)
+    ctx.storage.gc_governance_retention.assert_not_called()
+
+
+def test_maybe_start_lineage_gc_legacy_config_without_governance_retention():
+    ctx = _make_ctx(
+        lineage_gc_enabled=True,
+        include_governance_retention=False,
+    )
     request_context_factory = cast(
         Callable[[str], RequestContext],
         lambda _: ctx,

--- a/tests/server/services/lineage/test_governance_retention_gates.py
+++ b/tests/server/services/lineage/test_governance_retention_gates.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.models import config_schema
+from reflexio.models.config_schema import Config, LineageGCConfig
+from reflexio.server.services.lineage.gc_scheduler import (
+    _ENTITY_TYPES,
+    LineageGCScheduler,
+)
+
+
+def _make_ctx(*, lineage_gc_enabled: bool, governance_gate_enabled: bool):
+    storage = MagicMock()
+    storage.gc_expired_tombstones.return_value = 0
+    storage.gc_governance_retention.return_value = 0
+    config = SimpleNamespace(
+        lineage_gc=LineageGCConfig(enabled=lineage_gc_enabled),
+        governance_retention=SimpleNamespace(
+            purge_expired_profiles_enabled=governance_gate_enabled,
+            row_count_retention_enabled=False,
+            audit_events_retention_enabled=False,
+        ),
+    )
+    return SimpleNamespace(
+        org_id="org_1",
+        storage=storage,
+        configurator=SimpleNamespace(get_config=MagicMock(return_value=config)),
+    )
+
+
+def _scheduler(ctx) -> LineageGCScheduler:
+    return LineageGCScheduler(
+        request_context_factory=lambda _: ctx,
+        bootstrap_org_id="org_1",
+    )
+
+
+def test_config_exposes_governance_retention_defaults():
+    governance_cls = getattr(config_schema, "GovernanceRetentionConfig", None)
+
+    assert governance_cls is not None
+
+    cfg = Config(storage_config=None)
+
+    assert isinstance(cfg.governance_retention, governance_cls)
+    assert cfg.governance_retention.purge_expired_profiles_enabled is False
+    assert cfg.governance_retention.row_count_retention_enabled is False
+    assert cfg.governance_retention.audit_events_retention_enabled is False
+    assert cfg.governance_retention.audit_events_retention_days == 365
+    assert cfg.governance_retention.audit_events_delete_batch_limit == 500
+
+
+@pytest.mark.parametrize(
+    ("lineage_gc_enabled", "governance_gate_enabled", "expect_tombstone_gc", "expect_governance_gc"),
+    [
+        (False, False, False, False),
+        (True, False, True, False),
+        (False, True, False, True),
+        (True, True, True, True),
+    ],
+)
+def test_gc_tick_gates_tombstone_and_governance_paths(
+    lineage_gc_enabled: bool,
+    governance_gate_enabled: bool,
+    expect_tombstone_gc: bool,
+    expect_governance_gc: bool,
+):
+    ctx = _make_ctx(
+        lineage_gc_enabled=lineage_gc_enabled,
+        governance_gate_enabled=governance_gate_enabled,
+    )
+
+    sched = _scheduler(ctx)
+    sched._gc_tick(["org_1"])
+
+    if expect_tombstone_gc:
+        assert ctx.storage.gc_expired_tombstones.call_count == len(_ENTITY_TYPES)
+    else:
+        ctx.storage.gc_expired_tombstones.assert_not_called()
+
+    if expect_governance_gc:
+        ctx.storage.gc_governance_retention.assert_called_once_with(
+            config=ctx.configurator.get_config.return_value.governance_retention
+        )
+    else:
+        ctx.storage.gc_governance_retention.assert_not_called()

--- a/tests/server/services/lineage/test_governance_retention_gates.py
+++ b/tests/server/services/lineage/test_governance_retention_gates.py
@@ -1,28 +1,40 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from typing import cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from reflexio.models import config_schema
 from reflexio.models.config_schema import Config, LineageGCConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.lineage import gc_scheduler
 from reflexio.server.services.lineage.gc_scheduler import (
     _ENTITY_TYPES,
+    _HIGH_VOLUME_THRESHOLD,
     LineageGCScheduler,
+    maybe_start_lineage_gc,
 )
 
 
-def _make_ctx(*, lineage_gc_enabled: bool, governance_gate_enabled: bool):
+def _make_ctx(
+    *,
+    lineage_gc_enabled: bool,
+    purge_expired_profiles_enabled: bool = False,
+    row_count_retention_enabled: bool = False,
+    audit_events_retention_enabled: bool = False,
+):
     storage = MagicMock()
     storage.gc_expired_tombstones.return_value = 0
     storage.gc_governance_retention.return_value = 0
     config = SimpleNamespace(
         lineage_gc=LineageGCConfig(enabled=lineage_gc_enabled),
         governance_retention=SimpleNamespace(
-            purge_expired_profiles_enabled=governance_gate_enabled,
-            row_count_retention_enabled=False,
-            audit_events_retention_enabled=False,
+            purge_expired_profiles_enabled=purge_expired_profiles_enabled,
+            row_count_retention_enabled=row_count_retention_enabled,
+            audit_events_retention_enabled=audit_events_retention_enabled,
         ),
     )
     return SimpleNamespace(
@@ -37,6 +49,10 @@ def _scheduler(ctx) -> LineageGCScheduler:
         request_context_factory=lambda _: ctx,
         bootstrap_org_id="org_1",
     )
+
+
+def _with_governance_flag(flag_name: str) -> dict[str, bool]:
+    return {flag_name: True}
 
 
 def test_config_exposes_governance_retention_defaults():
@@ -71,7 +87,7 @@ def test_gc_tick_gates_tombstone_and_governance_paths(
 ):
     ctx = _make_ctx(
         lineage_gc_enabled=lineage_gc_enabled,
-        governance_gate_enabled=governance_gate_enabled,
+        purge_expired_profiles_enabled=governance_gate_enabled,
     )
 
     sched = _scheduler(ctx)
@@ -88,3 +104,51 @@ def test_gc_tick_gates_tombstone_and_governance_paths(
         )
     else:
         ctx.storage.gc_governance_retention.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "flag_name",
+    [
+        "purge_expired_profiles_enabled",
+        "row_count_retention_enabled",
+        "audit_events_retention_enabled",
+    ],
+)
+def test_gc_tick_runs_governance_gc_for_each_individual_gate(flag_name: str):
+    ctx = _make_ctx(lineage_gc_enabled=False, **_with_governance_flag(flag_name))
+
+    sched = _scheduler(ctx)
+    sched._gc_tick(["org_1"])
+
+    ctx.storage.gc_expired_tombstones.assert_not_called()
+    ctx.storage.gc_governance_retention.assert_called_once_with(
+        config=ctx.configurator.get_config.return_value.governance_retention
+    )
+
+
+def test_gc_tick_high_volume_anomaly_ignores_governance_deletions():
+    ctx = _make_ctx(lineage_gc_enabled=False, purge_expired_profiles_enabled=True)
+    ctx.storage.gc_governance_retention.return_value = _HIGH_VOLUME_THRESHOLD + 1
+
+    sched = _scheduler(ctx)
+
+    with patch.object(gc_scheduler, "capture_anomaly") as mock_anomaly:
+        sched._gc_tick(["org_1"])
+
+    mock_anomaly.assert_not_called()
+
+
+def test_maybe_start_lineage_gc_starts_for_governance_retention_only():
+    ctx = _make_ctx(lineage_gc_enabled=False, row_count_retention_enabled=True)
+    request_context_factory = cast(
+        Callable[[str], RequestContext],
+        lambda _: ctx,
+    )
+
+    with patch.object(LineageGCScheduler, "start") as mock_start:
+        sched = maybe_start_lineage_gc(
+            request_context_factory, bootstrap_org_id="org_1"
+        )
+
+    assert sched is not None
+    mock_start.assert_called_once_with()

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -33,6 +33,15 @@ def storage(tmp_path):
         yield SQLiteStorage(org_id="org1", db_path=str(tmp_path / "g.db"))
 
 
+@pytest.fixture
+def storage_factory(tmp_path):
+    def _make_storage(org_id: str) -> SQLiteStorage:
+        return SQLiteStorage(org_id=org_id, db_path=str(tmp_path / "shared-g.db"))
+
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        yield _make_storage
+
+
 def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
     purge = storage.begin_purge_operation(
         purge_id=purge_id,
@@ -485,6 +494,15 @@ def test_hide_governance_agent_playbooks_for_rebuild_sets_archive_in_progress_an
         user_id="user-hide-rebuild",
         owned_user_playbook_ids={7},
     )
+    expected_detail = {
+        "original_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [101]},
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        "remaining_source_windows": [
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+    }
 
     hidden_ids = storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
 
@@ -510,6 +528,7 @@ def test_hide_governance_agent_playbooks_for_rebuild_sets_archive_in_progress_an
         and target.target_ref == str(agent_playbook_id)
     )
     assert rebuild_target.status == "running"
+    assert rebuild_target.detail == expected_detail
 
 
 def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage):
@@ -546,6 +565,15 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
             ],
         },
     )
+    expected_detail = {
+        "original_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [101]},
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        "remaining_source_windows": [
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+    }
 
     storage.apply_governance_agent_playbook_rebuild(
         purge_id=purge_id,
@@ -570,6 +598,88 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
         and target.target_ref == str(agent_playbook_id)
     )
     assert rebuild_target.status == "complete"
+    assert rebuild_target.detail == expected_detail
+
+
+def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
+    storage_org1 = storage_factory("org1")
+    storage_org2 = storage_factory("org2")
+    purge_id = "purge_shared_scope"
+
+    for storage_instance, request_ref in (
+        (storage_org1, REQUEST_REF),
+        (storage_org2, OTHER_REQUEST_REF),
+    ):
+        storage_instance.begin_purge_operation(
+            purge_id=purge_id,
+            idempotency_key=f"idem_{storage_instance.org_id}_{purge_id}",
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=SUBJECT_REF,
+            request_ref=request_ref,
+        )
+
+    storage_org1.record_purge_target(
+        purge_id=purge_id,
+        target_name="target_snapshot",
+        target_ref="all",
+        phase="prepare_targets",
+        status="complete",
+        detail={"prepared": True},
+    )
+    storage_org1.record_purge_target(
+        purge_id=purge_id,
+        target_name="request",
+        target_ref=REQUEST_REF,
+        phase="delete",
+        status="pending",
+        detail={"count": 1},
+    )
+    storage_org2.record_purge_target(
+        purge_id=purge_id,
+        target_name="request",
+        target_ref=OTHER_REQUEST_REF,
+        phase="delete",
+        status="complete",
+        detail={"count": 2},
+        deleted_count=2,
+    )
+
+    org1_targets = storage_org1.list_purge_targets(purge_id)
+    org2_targets = storage_org2.list_purge_targets(purge_id)
+
+    assert {(target.phase, target.target_ref, target.status) for target in org1_targets} == {
+        ("delete", REQUEST_REF, "pending"),
+        ("prepare_targets", "all", "complete"),
+    }
+    assert {(target.phase, target.target_ref, target.status) for target in org2_targets} == {
+        ("delete", OTHER_REQUEST_REF, "complete"),
+    }
+    assert storage_org1.purge_targets_prepared(purge_id) is True
+    assert storage_org2.purge_targets_prepared(purge_id) is False
+
+    storage_org2.record_purge_target(
+        purge_id=purge_id,
+        target_name="request",
+        target_ref=REQUEST_REF,
+        phase="delete",
+        status="running",
+        detail={"count": 3},
+    )
+
+    org1_request_target = next(
+        target
+        for target in storage_org1.list_purge_targets(purge_id, phase="delete")
+        if target.target_ref == REQUEST_REF
+    )
+    org2_delete_targets = storage_org2.list_purge_targets(purge_id, phase="delete")
+
+    assert org1_request_target.status == "pending"
+    assert org1_request_target.detail == {"count": 1}
+    assert {(target.target_ref, target.status, target.deleted_count) for target in org2_delete_targets} == {
+        (OTHER_REQUEST_REF, "complete", 2),
+        (REQUEST_REF, "running", 0),
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -264,6 +264,22 @@ def test_audit_event_idempotency(storage):
     assert rows[0].idempotency_key == "export_1"
 
 
+def test_append_audit_event_rejects_numeric_idempotency_key(storage):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="12345",
+    )
+
+    with pytest.raises(ValueError, match="idempotency_key"):
+        storage.append_audit_event(event)
+
+    assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
+
+
 def test_append_audit_event_rejects_mismatched_org_id(storage):
     event = AuditEvent(
         org_id="org2",
@@ -482,6 +498,36 @@ def test_begin_purge_operation_rejects_mismatched_idempotent_retry(
     assert purge.request_ref == REQUEST_REF
     assert purge.scope_type == "user"
     assert purge.purge_id == "purge_begin_retry"
+
+
+def test_begin_purge_operation_rejects_numeric_idempotency_key(storage):
+    with pytest.raises(ValueError, match="idempotency_key"):
+        storage.begin_purge_operation(
+            purge_id="purge_numeric_idem",
+            idempotency_key="12345",
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+        )
+
+    with pytest.raises(ValueError, match="not found"):
+        storage.get_purge_operation("purge_numeric_idem")
+
+
+def test_begin_purge_operation_rejects_raw_numeric_purge_suffix(storage):
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.begin_purge_operation(
+            purge_id="purge_123",
+            idempotency_key="idem_purge_123",
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+        )
+
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.get_purge_operation("purge_123")
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -120,6 +120,83 @@ def _seed_user_scoped_rows(storage: SQLiteStorage, *, user_id: str) -> None:
     storage.conn.commit()
 
 
+def _seed_prepare_counts_user_data(storage: SQLiteStorage, *, user_id: str) -> set[int]:
+    created_at = "2026-01-01T00:00:00.000Z"
+    storage.conn.execute(
+        """INSERT INTO requests (
+               request_id, user_id, created_at, source, agent_version, session_id, evaluation_only
+           ) VALUES (?, ?, ?, '', '', ?, 0)""",
+        ("request_seed", user_id, created_at, "session_seed"),
+    )
+    storage.conn.execute(
+        """INSERT INTO interactions (
+               user_id, content, request_id, created_at, role, user_action,
+               user_action_description, interacted_image_url, image_encoding,
+               shadow_content, expert_content, tools_used, citations, embedding
+           ) VALUES (?, '', ?, ?, 'User', 'none', '', '', '', '', '', '[]', '[]', '[]')""",
+        (user_id, "request_seed", created_at),
+    )
+    storage.conn.execute(
+        """INSERT INTO profiles (
+               profile_id, user_id, content, last_modified_timestamp,
+               generated_from_request_id, profile_time_to_live, expiration_timestamp,
+               embedding, source_interaction_ids, created_at
+           ) VALUES (?, ?, ?, ?, ?, 'infinity', ?, '[]', '[]', ?)""",
+        (
+            "profile_seed",
+            user_id,
+            "profile-content",
+            1,
+            "request_seed",
+            4102444800,
+            created_at,
+        ),
+    )
+    storage.conn.execute(
+        """INSERT INTO profiles (
+               profile_id, user_id, content, last_modified_timestamp,
+               generated_from_request_id, profile_time_to_live, expiration_timestamp,
+               embedding, source_interaction_ids, merged_into, created_at
+           ) VALUES (?, ?, ?, ?, ?, 'infinity', ?, '[]', '[]', ?, ?)""",
+        (
+            "profile_purge_seed",
+            user_id,
+            "profile-purge-content",
+            2,
+            "request_seed",
+            4102444800,
+            "profile_external_survivor",
+            created_at,
+        ),
+    )
+    delete_cursor = storage.conn.execute(
+        """INSERT INTO user_playbooks (
+               user_id, playbook_name, created_at, request_id, agent_version,
+               content, source_interaction_ids, embedding
+           ) VALUES (?, '', ?, ?, '', ?, '[]', '[]')""",
+        (user_id, created_at, "request_seed", "playbook-delete-content"),
+    )
+    assert delete_cursor.lastrowid is not None
+    delete_playbook_id = int(delete_cursor.lastrowid)
+    purge_cursor = storage.conn.execute(
+        """INSERT INTO user_playbooks (
+               user_id, playbook_name, created_at, request_id, agent_version,
+               content, source_interaction_ids, embedding, merged_into
+           ) VALUES (?, '', ?, ?, '', ?, '[]', '[]', ?)""",
+        (
+            user_id,
+            created_at,
+            "request_seed",
+            "playbook-purge-content",
+            999999,
+        ),
+    )
+    assert purge_cursor.lastrowid is not None
+    purge_playbook_id = int(purge_cursor.lastrowid)
+    storage.conn.commit()
+    return {delete_playbook_id, purge_playbook_id}
+
+
 def _seed_agent_playbook(
     storage: SQLiteStorage,
     *,
@@ -289,6 +366,28 @@ def test_complete_purge_operation_with_audit_accepts_planned_success_detail(stor
         "deleted_counts": deleted_counts,
         "rebuilt_agent_playbook_ids": rebuilt_ids,
     }
+
+
+@pytest.mark.parametrize(
+    ("event_kwargs", "match"),
+    [
+        pytest.param({"subject_ref": OTHER_SUBJECT_REF}, "subject_ref", id="subject-ref"),
+        pytest.param({"request_ref": OTHER_REQUEST_REF}, "request_ref", id="request-ref"),
+    ],
+)
+def test_complete_purge_operation_rejects_audit_refs_that_mismatch_persisted_purge(
+    storage, event_kwargs, match
+):
+    purge_id = _begin_purge(storage, "purge_row_ref_mismatch")
+    event = _erase_event(purge_id=purge_id).model_copy(update=event_kwargs)
+
+    with pytest.raises(ValueError, match=match):
+        storage.complete_purge_operation_with_audit(purge_id, event)
+
+    assert storage.get_purge_operation(purge_id).status == "running"
+    assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
+    if event.subject_ref is not None:
+        assert storage.list_audit_events(subject_ref=event.subject_ref) == []
 
 
 @pytest.mark.parametrize(
@@ -532,6 +631,53 @@ def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storag
         "remaining_source_windows": [
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
+    }
+
+
+def test_prepare_governance_erase_targets_records_full_delete_matrix_counts(storage):
+    purge_id = "purge_prepare_counts"
+    user_id = "user_prepare_counts"
+    owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_prepare_counts",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id=user_id,
+        owned_user_playbook_ids=owned_user_playbook_ids,
+    )
+
+    delete_targets = {
+        target.target_name: target
+        for target in storage.list_purge_targets(purge_id, phase="delete")
+    }
+    assert delete_targets["request"].target_ref == "all"
+    assert delete_targets["request"].detail == {"count": 1}
+    assert delete_targets["interaction"].target_ref == "all"
+    assert delete_targets["interaction"].detail == {"count": 1}
+    assert delete_targets["profile"].target_ref == "all"
+    assert delete_targets["profile"].detail == {"count": 1}
+    assert delete_targets["profile_purge"].target_ref == "all"
+    assert delete_targets["profile_purge"].detail == {"count": 1}
+    assert delete_targets["user_playbook"].target_ref == "all"
+    assert delete_targets["user_playbook"].detail == {"count": 1}
+    assert delete_targets["user_playbook_purge"].target_ref == "all"
+    assert delete_targets["user_playbook_purge"].detail == {"count": 1}
+
+    counts = storage.clear_user_data(user_id)
+    assert counts == {
+        "interactions": 1,
+        "user_playbooks": 1,
+        "profiles": 1,
+        "requests": 1,
+        "purged_profiles": 1,
+        "purged_user_playbooks": 1,
     }
 
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1214,13 +1214,13 @@ def test_apply_governance_agent_playbook_rebuild_succeeds_after_prepare_and_hide
     ]
 
 
-def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_failure(
+def test_apply_governance_agent_playbook_rebuild_does_not_complete_target_when_search_refresh_fails(
     storage, monkeypatch
 ):
-    purge_id = "purge_rebuild_rollback"
+    purge_id = "purge_rebuild_search_refresh_failure"
     storage.begin_purge_operation(
         purge_id=purge_id,
-        idempotency_key="idem_purge_rebuild_rollback",
+        idempotency_key="idem_purge_rebuild_search_refresh_failure",
         operation_type="user_erasure",
         scope_type="user",
         subject_ref=SUBJECT_REF,
@@ -1266,14 +1266,22 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
     ).fetchone()
     assert original_row is not None
     original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
-    original_record = storage._record_purge_target_locked
+    original_fts_row = storage.conn.execute(
+        "SELECT search_text FROM agent_playbooks_fts WHERE rowid = ?",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert original_fts_row is not None
 
-    def fail_record_target(*args, **kwargs):
-        raise RuntimeError("target completion failed")
+    def fail_search_refresh(*args, **kwargs):
+        raise RuntimeError("search refresh failed")
 
-    monkeypatch.setattr(storage, "_record_purge_target_locked", fail_record_target)
+    monkeypatch.setattr(
+        storage,
+        "_upsert_agent_playbook_search_rows_locked",
+        fail_search_refresh,
+    )
 
-    with pytest.raises(RuntimeError, match="target completion failed"):
+    with pytest.raises(RuntimeError, match="search refresh failed"):
         storage.apply_governance_agent_playbook_rebuild(
             purge_id=purge_id,
             agent_playbook_id=agent_playbook_id,
@@ -1288,7 +1296,6 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
             tags=["rebuilt"],
         )
 
-    monkeypatch.setattr(storage, "_record_purge_target_locked", original_record)
     assert (
         storage.conn.execute(
             """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
@@ -1299,6 +1306,13 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
         == original_row
     )
     assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    assert (
+        storage.conn.execute(
+            "SELECT search_text FROM agent_playbooks_fts WHERE rowid = ?",
+            (agent_playbook_id,),
+        ).fetchone()
+        == original_fts_row
+    )
     rebuild_target = next(
         target
         for target in storage.list_purge_targets(
@@ -1308,6 +1322,101 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
         and target.target_ref == str(agent_playbook_id)
     )
     assert rebuild_target.status == "running"
+
+
+def test_apply_governance_agent_playbook_rebuild_removes_orphaned_aggregate_when_no_sources_remain(
+    storage,
+):
+    purge_id = "purge_rebuild_remove_orphan"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_remove_orphan",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+        ],
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+            ],
+            "previous_lifecycle_status": Status.ARCHIVED.value,
+            "remaining_source_windows": [],
+        },
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="hide_for_rebuild",
+        status="complete",
+    )
+
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[],
+        content=None,
+        trigger=None,
+        rationale=None,
+        blocking_issue=None,
+        expanded_terms=None,
+        tags=None,
+    )
+
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "complete"
+    assert storage.get_agent_playbook_by_id(agent_playbook_id) is None
+    assert storage.get_agent_playbook_by_id(
+        agent_playbook_id,
+        include_tombstones=True,
+    ) is None
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == []
+    assert (
+        storage.conn.execute(
+            "SELECT COUNT(*) FROM agent_playbooks WHERE agent_playbook_id = ?",
+            (agent_playbook_id,),
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        storage.conn.execute(
+            "SELECT COUNT(*) FROM agent_playbooks_fts WHERE rowid = ?",
+            (agent_playbook_id,),
+        ).fetchone()[0]
+        == 0
+    )
+    if storage._has_sqlite_vec:
+        assert (
+            storage.conn.execute(
+                "SELECT COUNT(*) FROM agent_playbooks_vec WHERE rowid = ?",
+                (agent_playbook_id,),
+            ).fetchone()[0]
+            == 0
+        )
+    assert storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(query="original content", top_k=10)
+    ) == []
 
 
 def test_apply_governance_agent_playbook_rebuild_restores_previous_lifecycle_status(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1363,6 +1363,108 @@ def test_apply_governance_agent_playbook_rebuild_restores_previous_lifecycle_sta
     assert rebuilt_status == Status.SUPERSEDED.value
 
 
+def test_apply_governance_agent_playbook_rebuild_rejects_second_call_after_completion(
+    storage,
+):
+    purge_id = "purge_rebuild_second_call"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_second_call",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVED,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id="user-rebuild-second-call",
+        owned_user_playbook_ids={7},
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    before_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert before_row is not None
+    before_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+    before_hide_target = next(
+        target
+        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    before_rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+
+    with pytest.raises(ValueError, match="already complete"):
+        storage.apply_governance_agent_playbook_rebuild(
+            purge_id=purge_id,
+            agent_playbook_id=agent_playbook_id,
+            remaining_source_windows=[
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            content="mutated content",
+            trigger="mutated trigger",
+            rationale="mutated rationale",
+            blocking_issue={"issue": "should not persist"},
+            expanded_terms="mutated terms",
+            tags=["mutated"],
+        )
+
+    after_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert after_row == before_row
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
+    assert next(
+        target
+        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    ) == before_hide_target
+    assert next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    ) == before_rebuild_target
+
+
 def test_hide_governance_agent_playbooks_for_rebuild_is_idempotent_after_completed_rebuild(
     storage,
 ):
@@ -1449,6 +1551,104 @@ def test_hide_governance_agent_playbooks_for_rebuild_is_idempotent_after_complet
     assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
     assert after_hide_target == before_hide_target
     assert after_rebuild_target == before_rebuild_target
+
+
+def test_hide_governance_agent_playbooks_for_rebuild_does_not_reopen_complete_target_from_stale_prelock_state(
+    storage, monkeypatch
+):
+    purge_id = "purge_hide_stale_prelock"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_hide_stale_prelock",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVED,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id="user-hide-stale-prelock",
+        owned_user_playbook_ids={7},
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    before_status = storage.conn.execute(
+        "SELECT status FROM agent_playbooks WHERE agent_playbook_id = ?",
+        (agent_playbook_id,),
+    ).fetchone()[0]
+    before_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+    before_hide_target = next(
+        target
+        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    before_rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+
+    stale_targets = [
+        before_rebuild_target.model_copy(update={"status": "pending"}),
+    ]
+    original_list_purge_targets = storage.list_purge_targets
+
+    def stale_list_purge_targets(*_args, **_kwargs):
+        return stale_targets
+
+    monkeypatch.setattr(storage, "list_purge_targets", stale_list_purge_targets)
+
+    hidden_ids = storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+    assert hidden_ids == []
+    assert (
+        storage.conn.execute(
+            "SELECT status FROM agent_playbooks WHERE agent_playbook_id = ?",
+            (agent_playbook_id,),
+        ).fetchone()[0]
+        == before_status
+        == Status.ARCHIVED.value
+    )
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
+    assert next(
+        target
+        for target in original_list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    ) == before_hide_target
+    assert next(
+        target
+        for target in original_list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    ) == before_rebuild_target
 
 
 def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -190,7 +190,7 @@ def test_purge_targets_require_snapshot_marker(storage):
     storage.record_purge_target(
         purge_id=purge.purge_id,
         target_name="request",
-        target_ref=REQUEST_REF,
+        target_ref="all",
         phase="delete",
         status="complete",
         deleted_count=1,
@@ -227,6 +227,31 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
     )
     assert same.status == "complete"
     assert len(storage.list_audit_events(subject_ref=SUBJECT_REF)) == 1
+
+
+def test_complete_purge_operation_with_audit_begins_immediate_transaction_before_reads(
+    storage,
+):
+    purge_id = _begin_purge(storage, "purge_begin_immediate")
+    statements: list[str] = []
+    storage.conn.set_trace_callback(statements.append)
+    try:
+        storage.complete_purge_operation_with_audit(
+            purge_id,
+            _erase_event(purge_id=purge_id),
+        )
+    finally:
+        storage.conn.set_trace_callback(None)
+
+    begin_index = next(
+        i for i, statement in enumerate(statements) if statement == "BEGIN IMMEDIATE"
+    )
+    first_validation_read_index = next(
+        i
+        for i, statement in enumerate(statements)
+        if "SELECT * FROM purge_operations" in statement
+    )
+    assert begin_index < first_validation_read_index
 
 
 def test_complete_purge_operation_with_audit_accepts_planned_success_detail(storage):
@@ -671,7 +696,7 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     storage_org1.record_purge_target(
         purge_id=purge_id,
         target_name="request",
-        target_ref=REQUEST_REF,
+        target_ref="all",
         phase="delete",
         status="pending",
         detail={"count": 1},
@@ -679,7 +704,7 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     storage_org2.record_purge_target(
         purge_id=purge_id,
         target_name="request",
-        target_ref=OTHER_REQUEST_REF,
+        target_ref="all",
         phase="delete",
         status="complete",
         detail={"count": 2},
@@ -690,11 +715,11 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     org2_targets = storage_org2.list_purge_targets(purge_id)
 
     assert {(target.phase, target.target_ref, target.status) for target in org1_targets} == {
-        ("delete", REQUEST_REF, "pending"),
+        ("delete", "all", "pending"),
         ("prepare_targets", "all", "complete"),
     }
     assert {(target.phase, target.target_ref, target.status) for target in org2_targets} == {
-        ("delete", OTHER_REQUEST_REF, "complete"),
+        ("delete", "all", "complete"),
     }
     assert storage_org1.purge_targets_prepared(purge_id) is True
     assert storage_org2.purge_targets_prepared(purge_id) is False
@@ -702,7 +727,7 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     storage_org2.record_purge_target(
         purge_id=purge_id,
         target_name="request",
-        target_ref=REQUEST_REF,
+        target_ref="all",
         phase="delete",
         status="running",
         detail={"count": 3},
@@ -711,15 +736,14 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     org1_request_target = next(
         target
         for target in storage_org1.list_purge_targets(purge_id, phase="delete")
-        if target.target_ref == REQUEST_REF
+        if target.target_ref == "all"
     )
     org2_delete_targets = storage_org2.list_purge_targets(purge_id, phase="delete")
 
     assert org1_request_target.status == "pending"
     assert org1_request_target.detail == {"count": 1}
     assert {(target.target_ref, target.status, target.deleted_count) for target in org2_delete_targets} == {
-        (OTHER_REQUEST_REF, "complete", 2),
-        (REQUEST_REF, "running", 0),
+        ("all", "running", 0),
     }
 
 
@@ -1192,10 +1216,10 @@ def test_record_purge_target_requires_window_user_playbook_id(storage, detail_ke
     ("target_ref", "match"),
     [
         pytest.param("all", None, id="marker-all"),
-        pytest.param("17", None, id="internal-numeric-id"),
-        pytest.param(REQUEST_REF, None, id="minimized-request-ref"),
-        pytest.param(SUBJECT_REF, None, id="minimized-subject-ref"),
-        pytest.param("", None, id="empty-default"),
+        pytest.param("17", "target_ref", id="internal-numeric-id"),
+        pytest.param(REQUEST_REF, "target_ref", id="minimized-request-ref"),
+        pytest.param(SUBJECT_REF, "target_ref", id="minimized-subject-ref"),
+        pytest.param("", "target_ref", id="empty-default"),
         pytest.param("alice@example.com", "target_ref", id="raw-email"),
         pytest.param("request_12345", "target_ref", id="raw-request-id"),
         pytest.param("alice", "target_ref", id="raw-user-like"),
@@ -1628,18 +1652,60 @@ def test_governance_detail_rejects_duplicate_normalized_keys(storage, persistenc
         ),
         pytest.param(
             "target_snapshot",
+            "prepare_targets",
+            "",
+            "target_ref",
+            id="snapshot-rejects-empty-ref",
+        ),
+        pytest.param(
+            "target_snapshot",
             "delete",
             "all",
             "target_snapshot",
             id="snapshot-rejects-wrong-phase",
         ),
+        pytest.param(
+            "request",
+            "prepare_targets",
+            "all",
+            "prepare_targets",
+            id="request-rejects-prepare-targets",
+        ),
         pytest.param("request", "delete", "all", None, id="aggregate-delete-all"),
+        pytest.param(
+            "request",
+            "hide_for_rebuild",
+            "all",
+            "hide_for_rebuild",
+            id="request-rejects-hide",
+        ),
+        pytest.param(
+            "profile",
+            "rebuild_without_erased_sources",
+            "all",
+            "rebuild_without_erased_sources",
+            id="profile-rejects-rebuild",
+        ),
+        pytest.param(
+            "interaction",
+            "delete",
+            REQUEST_REF,
+            "target_ref",
+            id="interaction-delete-rejects-non-all-ref",
+        ),
         pytest.param(
             "agent_playbook",
             "hide_for_rebuild",
             "17",
             None,
             id="row-target-hide-internal-id",
+        ),
+        pytest.param(
+            "agent_playbook",
+            "prepare_targets",
+            "17",
+            "prepare_targets",
+            id="agent-playbook-rejects-prepare-targets",
         ),
         pytest.param(
             "agent_playbook",

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -768,6 +768,7 @@ def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storag
             {"user_playbook_id": 7, "source_interaction_ids": [101, 102]},
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
+        "previous_lifecycle_status": Status.ARCHIVED.value,
         "remaining_source_windows": [
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
@@ -851,6 +852,7 @@ def test_hide_governance_agent_playbooks_for_rebuild_sets_archive_in_progress_an
             {"user_playbook_id": 7, "source_interaction_ids": [101]},
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
+        "previous_lifecycle_status": None,
         "remaining_source_windows": [
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
@@ -912,6 +914,7 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
                 {"user_playbook_id": 7, "source_interaction_ids": [101]},
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
+            "previous_lifecycle_status": Status.ARCHIVED.value,
             "remaining_source_windows": [
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
@@ -929,6 +932,7 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
             {"user_playbook_id": 7, "source_interaction_ids": [101]},
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
+        "previous_lifecycle_status": Status.ARCHIVED.value,
         "remaining_source_windows": [
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
@@ -972,7 +976,7 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
         None,
         "rebuilt terms",
         json.dumps(["rebuilt"]),
-        None,
+        Status.ARCHIVED.value,
     )
     assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == [
         AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201])
@@ -1069,6 +1073,7 @@ def test_apply_governance_agent_playbook_rebuild_rejects_rebuild_before_hide_pha
                 {"user_playbook_id": 7, "source_interaction_ids": [101]},
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
+            "previous_lifecycle_status": Status.ARCHIVE_IN_PROGRESS.value,
             "remaining_source_windows": [
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
@@ -1124,6 +1129,7 @@ def test_apply_governance_agent_playbook_rebuild_rejects_rebuild_before_hide_pha
             {"user_playbook_id": 7, "source_interaction_ids": [101]},
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
+        "previous_lifecycle_status": Status.ARCHIVE_IN_PROGRESS.value,
         "remaining_source_windows": [
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
@@ -1185,6 +1191,7 @@ def test_apply_governance_agent_playbook_rebuild_succeeds_after_prepare_and_hide
             {"user_playbook_id": 7, "source_interaction_ids": [101]},
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
+        "previous_lifecycle_status": None,
         "remaining_source_windows": [
             {"user_playbook_id": 9, "source_interaction_ids": [201]},
         ],
@@ -1225,6 +1232,7 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
                 {"user_playbook_id": 7, "source_interaction_ids": [101]},
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
+            "previous_lifecycle_status": Status.ARCHIVE_IN_PROGRESS.value,
             "remaining_source_windows": [
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
@@ -1287,6 +1295,160 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
         and target.target_ref == str(agent_playbook_id)
     )
     assert rebuild_target.status == "running"
+
+
+def test_apply_governance_agent_playbook_rebuild_restores_previous_lifecycle_status(
+    storage,
+):
+    purge_id = "purge_rebuild_restore_archived"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_restore_archived",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            "previous_lifecycle_status": Status.SUPERSEDED.value,
+            "remaining_source_windows": [
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+        },
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="hide_for_rebuild",
+        status="complete",
+    )
+
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    rebuilt_status = storage.conn.execute(
+        "SELECT status FROM agent_playbooks WHERE agent_playbook_id = ?",
+        (agent_playbook_id,),
+    ).fetchone()[0]
+    assert rebuilt_status == Status.SUPERSEDED.value
+
+
+def test_hide_governance_agent_playbooks_for_rebuild_is_idempotent_after_completed_rebuild(
+    storage,
+):
+    purge_id = "purge_hide_after_complete"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_hide_after_complete",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVED,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id="user-hide-after-complete",
+        owned_user_playbook_ids={7},
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    before_status = storage.conn.execute(
+        "SELECT status FROM agent_playbooks WHERE agent_playbook_id = ?",
+        (agent_playbook_id,),
+    ).fetchone()[0]
+    before_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+    before_hide_target = next(
+        target
+        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    before_rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+
+    hidden_ids = storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+    after_status = storage.conn.execute(
+        "SELECT status FROM agent_playbooks WHERE agent_playbook_id = ?",
+        (agent_playbook_id,),
+    ).fetchone()[0]
+    after_hide_target = next(
+        target
+        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    after_rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+
+    assert hidden_ids == []
+    assert after_status == before_status == Status.ARCHIVED.value
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
+    assert after_hide_target == before_hide_target
+    assert after_rebuild_target == before_rebuild_target
 
 
 def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
@@ -1589,6 +1751,7 @@ def test_record_purge_target_accepts_target_detail_shapes(storage):
         "original_source_windows": [
             {"user_playbook_id": 7, "source_interaction_ids": [11, 12]}
         ],
+        "previous_lifecycle_status": Status.ARCHIVED.value,
         "remaining_source_windows": [
             {"user_playbook_id": 7, "source_interaction_ids": [12]}
         ],
@@ -1955,6 +2118,105 @@ def test_record_purge_target_requires_window_user_playbook_id(storage, detail_ke
             phase="rebuild_without_erased_sources",
             status="running",
             detail={detail_key: [{"source_interaction_ids": [1, 2]}]},
+        )
+
+
+@pytest.mark.parametrize(
+    "previous_lifecycle_status",
+    [None, Status.ARCHIVED.value, Status.SUPERSEDED.value],
+)
+def test_record_purge_target_accepts_previous_lifecycle_status_for_rebuild_targets(
+    storage, previous_lifecycle_status
+):
+    purge_id = _begin_purge(
+        storage, f"purge_prev_lifecycle_{previous_lifecycle_status or 'current'}"
+    )
+
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref="7",
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [11, 12]}
+            ],
+            "previous_lifecycle_status": previous_lifecycle_status,
+            "remaining_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [12]}
+            ],
+        },
+    )
+
+    stored = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_ref == "7"
+    )
+    assert stored.detail is not None
+    assert stored.detail["previous_lifecycle_status"] == previous_lifecycle_status
+
+
+@pytest.mark.parametrize(
+    ("detail", "match"),
+    [
+        pytest.param(
+            {
+                "original_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [11, 12]}
+                ],
+                "previous_lifecycle_status": "approved",
+                "remaining_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [12]}
+                ],
+            },
+            "previous_lifecycle_status",
+            id="rejects-non-lifecycle-status",
+        ),
+        pytest.param(
+            {
+                "original_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [11, 12]}
+                ],
+                "previous_lifecycle_status": {"status": Status.ARCHIVED.value},
+                "remaining_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [12]}
+                ],
+            },
+            "previous_lifecycle_status",
+            id="rejects-non-string-status-shape",
+        ),
+        pytest.param(
+            {
+                "original_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [11, 12]}
+                ],
+                "remaining_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [12]}
+                ],
+                "arbitrary_status_copy": Status.ARCHIVED.value,
+            },
+            "arbitrary_status_copy",
+            id="rejects-arbitrary-detail-key",
+        ),
+    ],
+)
+def test_record_purge_target_rejects_invalid_previous_lifecycle_status_detail(
+    storage, detail, match
+):
+    purge_id = _begin_purge(storage, "purge_prev_lifecycle_invalid")
+
+    with pytest.raises(ValueError, match=match):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="agent_playbook",
+            target_ref="7",
+            phase="rebuild_without_erased_sources",
+            status="running",
+            detail=detail,
         )
 
 
@@ -2463,6 +2725,7 @@ def test_apply_governance_agent_playbook_rebuild_rejects_mismatched_remaining_so
                 {"user_playbook_id": 7, "source_interaction_ids": [101]},
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
+            "previous_lifecycle_status": Status.ARCHIVE_IN_PROGRESS.value,
             "remaining_source_windows": [
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -2016,6 +2016,15 @@ def test_apply_governance_user_data_delete_rejects_unexpected_target_name_from_i
     storage, monkeypatch
 ):
     purge_id = _begin_purge(storage, "purge_internal_target_name")
+    for target_name in CANONICAL_DELETE_TARGET_NAMES:
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name=target_name,
+            target_ref="all",
+            phase="delete",
+            status="pending",
+            detail={"count": 0},
+        )
 
     def _stub_clear_user_data(self: SQLiteStorage, user_id: str) -> dict[str, int]:
         del self, user_id
@@ -2035,6 +2044,55 @@ def test_apply_governance_user_data_delete_rejects_unexpected_target_name_from_i
 
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
     assert all(target.target_name != "surprise_target" for target in delete_targets)
+
+
+def test_apply_governance_user_data_delete_requires_complete_prepared_delete_matrix(
+    storage, monkeypatch
+):
+    purge_id = _begin_purge(storage, "purge_delete_requires_prepared_matrix")
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="request",
+        target_ref="all",
+        phase="delete",
+        status="pending",
+        detail={"count": 1},
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="interaction",
+        target_ref="all",
+        phase="delete",
+        status="complete",
+        detail={"count": 0},
+        deleted_count=0,
+    )
+
+    clear_user_data_called = False
+
+    def _stub_clear_user_data(self: SQLiteStorage, user_id: str) -> dict[str, int]:
+        nonlocal clear_user_data_called
+        del self, user_id
+        clear_user_data_called = True
+        return {"requests": 1}
+
+    monkeypatch.setattr(SQLiteStorage, "clear_user_data", _stub_clear_user_data)
+
+    with pytest.raises(ValueError, match="complete delete target matrix"):
+        storage.apply_governance_user_data_delete(
+            purge_id=purge_id,
+            user_id="user-delete-seed",
+        )
+
+    assert clear_user_data_called is False
+    delete_targets = storage.list_purge_targets(purge_id, phase="delete")
+    assert {
+        (target.target_name, target.status)
+        for target in delete_targets
+    } == {
+        ("request", "pending"),
+        ("interaction", "complete"),
+    }
 
 
 def test_apply_governance_agent_playbook_rebuild_rejects_unsafe_purge_id_before_side_effects(
@@ -2088,6 +2146,92 @@ def test_fail_purge_operation_rejects_unsafe_purge_id_before_side_effects(storag
     assert failed.status == "running"
     assert failed.error_code is None
     assert failed.error_detail is None
+
+
+def test_apply_governance_agent_playbook_rebuild_rejects_mismatched_remaining_source_windows(
+    storage,
+):
+    purge_id = "purge_rebuild_windows_mismatch"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_windows_mismatch",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            "remaining_source_windows": [
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+        },
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="hide_for_rebuild",
+        status="complete",
+    )
+    original_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert original_row is not None
+    original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+
+    with pytest.raises(ValueError, match="remaining_source_windows"):
+        storage.apply_governance_agent_playbook_rebuild(
+            purge_id=purge_id,
+            agent_playbook_id=agent_playbook_id,
+            remaining_source_windows=[
+                {"user_playbook_id": 9, "source_interaction_ids": [999]},
+            ],
+            content="rebuilt content",
+            trigger="rebuilt trigger",
+            rationale="rebuilt rationale",
+            blocking_issue=None,
+            expanded_terms="rebuilt terms",
+            tags=["rebuilt"],
+        )
+
+    rebuilt_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert rebuilt_row == original_row
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "running"
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -17,6 +18,9 @@ from reflexio.models.api_schema.domain.governance import (
     AuditStatus,
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage._governance import (
+    init_governance_tables,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -1538,3 +1542,217 @@ def test_begin_purge_operation_rejects_identifier_like_purge_suffix(storage, pur
             subject_ref=SUBJECT_REF,
             request_ref=REQUEST_REF,
         )
+
+
+def test_append_audit_event_canonicalizes_detail_keys_before_persistence(storage):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_canonical_detail",
+        detail={" Deleted_Counts ": {"requests": 1}},
+    )
+
+    storage.append_audit_event(event)
+
+    rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
+    assert rows[-1].detail == {"deleted_counts": {"requests": 1}}
+
+
+def test_record_purge_target_canonicalizes_detail_keys_before_persistence(storage):
+    purge_id = _begin_purge(storage, "purge_canonical_detail")
+
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="request",
+        target_ref="all",
+        phase="delete",
+        status="complete",
+        detail={" Deleted_Counts ": {"requests": 2}},
+        deleted_count=2,
+    )
+
+    rows = storage.list_purge_targets(purge_id, phase="delete")
+    assert len(rows) == 1
+    assert rows[0].detail == {"deleted_counts": {"requests": 2}}
+
+
+@pytest.mark.parametrize("persistence_path", ["audit_event", "purge_target"])
+def test_governance_detail_rejects_duplicate_normalized_keys(storage, persistence_path):
+    detail = {"status": "complete", " Status ": "complete"}
+
+    if persistence_path == "audit_event":
+        event = AuditEvent(
+            org_id="org1",
+            operation="EXPORT",
+            entity_type="request",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+            idempotency_key="export_duplicate_detail_key",
+            detail=detail,
+        )
+        with pytest.raises(ValueError, match="duplicate key status"):
+            storage.append_audit_event(event)
+        return
+
+    purge_id = _begin_purge(storage, "purge_duplicate_detail_key")
+    with pytest.raises(ValueError, match="duplicate key status"):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref="all",
+            phase="delete",
+            status="complete",
+            detail=detail,
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_name", "phase", "target_ref", "match"),
+    [
+        pytest.param(
+            "target_snapshot",
+            "prepare_targets",
+            "all",
+            None,
+            id="snapshot-marker-all",
+        ),
+        pytest.param("request", "delete", "all", None, id="aggregate-delete-all"),
+        pytest.param(
+            "agent_playbook",
+            "hide_for_rebuild",
+            "17",
+            None,
+            id="row-target-hide-internal-id",
+        ),
+        pytest.param(
+            "agent_playbook",
+            "rebuild_without_erased_sources",
+            "19",
+            None,
+            id="row-target-rebuild-internal-id",
+        ),
+        pytest.param(
+            "agent_playbook",
+            "hide_for_rebuild",
+            "all",
+            "target_ref",
+            id="row-target-hide-rejects-all",
+        ),
+        pytest.param(
+            "agent_playbook",
+            "rebuild_without_erased_sources",
+            "all",
+            "target_ref",
+            id="row-target-rebuild-rejects-all",
+        ),
+        pytest.param(
+            "agent_playbook",
+            "rebuild_without_erased_sources",
+            REQUEST_REF,
+            "target_ref",
+            id="row-target-rebuild-rejects-minimized-ref",
+        ),
+    ],
+)
+def test_record_purge_target_validates_target_ref_by_phase_and_name(
+    storage, target_name, phase, target_ref, match
+):
+    purge_id = _begin_purge(storage, "purge_target_ref_phase_specific")
+
+    if match is None:
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name=target_name,
+            target_ref=target_ref,
+            phase=phase,
+            status="running",
+        )
+        return
+
+    with pytest.raises(ValueError, match=match):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name=target_name,
+            target_ref=target_ref,
+            phase=phase,
+            status="running",
+        )
+
+
+def test_init_governance_tables_upgrades_legacy_purge_target_table(tmp_path):
+    db_path = tmp_path / "legacy-governance.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE purge_operations (
+            org_id TEXT NOT NULL,
+            purge_id TEXT NOT NULL,
+            operation_type TEXT NOT NULL,
+            scope_type TEXT NOT NULL,
+            subject_ref TEXT,
+            request_ref TEXT NOT NULL,
+            idempotency_key TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            error_code TEXT,
+            error_detail TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            completed_at INTEGER,
+            PRIMARY KEY (org_id, purge_id)
+        );
+        CREATE TABLE purge_operation_targets (
+            purge_id TEXT NOT NULL,
+            target_name TEXT NOT NULL,
+            target_ref TEXT NOT NULL DEFAULT '',
+            phase TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            detail TEXT,
+            deleted_count INTEGER NOT NULL DEFAULT 0,
+            error_detail TEXT,
+            started_at INTEGER,
+            completed_at INTEGER,
+            PRIMARY KEY (purge_id, target_name, target_ref, phase)
+        );
+        """
+    )
+    conn.commit()
+
+    init_governance_tables(conn)
+
+    target_columns = {
+        row[1]: {"pk": row[5], "notnull": row[3]}
+        for row in conn.execute("PRAGMA table_info(purge_operation_targets)")
+    }
+    assert "org_id" in target_columns
+    assert target_columns["org_id"]["pk"] == 1
+    assert target_columns["org_id"]["notnull"] == 1
+
+    index_names = {
+        row[1] for row in conn.execute("PRAGMA index_list(purge_operation_targets)")
+    }
+    assert "idx_purge_targets_purge_phase" in index_names
+    conn.close()
+
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage = SQLiteStorage(org_id="org1", db_path=str(db_path))
+
+    purge_id = storage.begin_purge_operation(
+        purge_id="purge_legacy_upgrade",
+        idempotency_key="idem_legacy_upgrade",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    ).purge_id
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="target_snapshot",
+        target_ref="all",
+        phase="prepare_targets",
+        status="complete",
+    )
+
+    assert storage.purge_targets_prepared(purge_id) is True

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -2707,6 +2707,10 @@ def test_apply_governance_user_data_delete_requires_complete_prepared_delete_mat
     storage, monkeypatch
 ):
     purge_id = _begin_purge(storage, "purge_delete_requires_prepared_matrix")
+    user_id = "user-delete-seed"
+    expected_user_id = user_id
+    _seed_user_scoped_rows(storage, user_id=user_id)
+    baseline_counts = _user_scoped_row_counts(storage, user_id=user_id)
     storage.record_purge_target(
         purge_id=purge_id,
         target_name="request",
@@ -2725,23 +2729,31 @@ def test_apply_governance_user_data_delete_requires_complete_prepared_delete_mat
         deleted_count=0,
     )
 
-    clear_user_data_called = False
+    clear_locked_called = False
 
-    def _stub_clear_user_data(self: SQLiteStorage, user_id: str) -> dict[str, int]:
-        nonlocal clear_user_data_called
-        del self, user_id
-        clear_user_data_called = True
+    def _stub_clear_user_data_for_governance_locked(
+        self: SQLiteStorage, patched_user_id: str
+    ) -> dict[str, int]:
+        nonlocal clear_locked_called
+        del self
+        clear_locked_called = True
+        assert patched_user_id == expected_user_id
         return {"requests": 1}
 
-    monkeypatch.setattr(SQLiteStorage, "clear_user_data", _stub_clear_user_data)
+    monkeypatch.setattr(
+        SQLiteStorage,
+        "_clear_user_data_for_governance_locked",
+        _stub_clear_user_data_for_governance_locked,
+    )
 
     with pytest.raises(ValueError, match="complete delete target matrix"):
         storage.apply_governance_user_data_delete(
             purge_id=purge_id,
-            user_id="user-delete-seed",
+            user_id=user_id,
         )
 
-    assert clear_user_data_called is False
+    assert clear_locked_called is False
+    assert _user_scoped_row_counts(storage, user_id=user_id) == baseline_counts
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
     assert {
         (target.target_name, target.status)

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -29,6 +29,14 @@ OTHER_SUBJECT_REF = "subref_v1_" + "c" * 32
 REQUEST_REF = "reqref_v1_" + "b" * 32
 OTHER_REQUEST_REF = "reqref_v1_" + "d" * 32
 ACTOR_REF = "actref_v1_" + "e" * 32
+CANONICAL_DELETE_TARGET_NAMES = (
+    "request",
+    "interaction",
+    "profile",
+    "user_playbook",
+    "profile_purge",
+    "user_playbook_purge",
+)
 
 
 @pytest.fixture
@@ -67,6 +75,23 @@ def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
         },
     )
     return purge.purge_id
+
+
+def _add_complete_delete_target_matrix(storage: SQLiteStorage, purge_id: str) -> None:
+    for target_name in CANONICAL_DELETE_TARGET_NAMES:
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name=target_name,
+            target_ref="all",
+            phase="delete",
+            status="complete",
+        )
+
+
+def _begin_completeable_purge(storage: SQLiteStorage, purge_id: str) -> str:
+    purge_id = _begin_purge(storage, purge_id)
+    _add_complete_delete_target_matrix(storage, purge_id)
+    return purge_id
 
 
 def _erase_event(
@@ -322,7 +347,7 @@ def test_purge_targets_require_snapshot_marker(storage):
 
 
 def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
-    purge_id = _begin_purge(storage, "purge_2")
+    purge_id = _begin_completeable_purge(storage, "purge_2")
     complete = storage.complete_purge_operation_with_audit(
         purge_id,
         _erase_event(purge_id=purge_id),
@@ -342,7 +367,7 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
 def test_complete_purge_operation_with_audit_begins_immediate_transaction_before_reads(
     storage,
 ):
-    purge_id = _begin_purge(storage, "purge_begin_immediate")
+    purge_id = _begin_completeable_purge(storage, "purge_begin_immediate")
     statements: list[str] = []
     storage.conn.set_trace_callback(statements.append)
     try:
@@ -365,7 +390,7 @@ def test_complete_purge_operation_with_audit_begins_immediate_transaction_before
 
 
 def test_complete_purge_operation_with_audit_accepts_planned_success_detail(storage):
-    purge_id = _begin_purge(storage, "purge_success_detail")
+    purge_id = _begin_completeable_purge(storage, "purge_success_detail")
     deleted_counts = {
         "interactions": 3,
         "user_playbooks": 2,
@@ -411,7 +436,7 @@ def test_complete_purge_operation_with_audit_accepts_planned_success_detail(stor
 def test_complete_purge_operation_rejects_audit_refs_that_mismatch_persisted_purge(
     storage, event_kwargs, match
 ):
-    purge_id = _begin_purge(storage, "purge_row_ref_mismatch")
+    purge_id = _begin_completeable_purge(storage, "purge_row_ref_mismatch")
     event = _erase_event(purge_id=purge_id).model_copy(update=event_kwargs)
 
     with pytest.raises(ValueError, match=match):
@@ -501,7 +526,7 @@ def test_begin_purge_operation_rejects_mismatched_idempotent_retry(
     ],
 )
 def test_complete_purge_operation_rejects_invalid_audit_event(storage, event, match):
-    purge_id = _begin_purge(storage, "purge_invalid")
+    purge_id = _begin_completeable_purge(storage, "purge_invalid")
 
     with pytest.raises(ValueError, match=match):
         storage.complete_purge_operation_with_audit(purge_id, event)
@@ -528,7 +553,7 @@ def test_complete_purge_operation_rejects_invalid_audit_event(storage, event, ma
 def test_complete_purge_operation_requires_matching_existing_erase_row(
     storage, seed_event, match
 ):
-    purge_id = _begin_purge(storage, "purge_seeded")
+    purge_id = _begin_completeable_purge(storage, "purge_seeded")
     assert storage.append_audit_event(seed_event) is True
 
     with pytest.raises(ValueError, match=match):
@@ -558,7 +583,7 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
 def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
     storage, field_name, seed_kwargs
 ):
-    purge_id = _begin_purge(storage, "purge_seeded_mismatch")
+    purge_id = _begin_completeable_purge(storage, "purge_seeded_mismatch")
     seeded_event = _erase_event(purge_id=purge_id).model_copy(update=seed_kwargs)
     storage.conn.execute(
         """INSERT INTO audit_events (
@@ -596,6 +621,19 @@ def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
 def test_append_audit_event_rejects_successful_erase(storage):
     with pytest.raises(ValueError, match="Successful ERASE audit rows"):
         storage.append_audit_event(_erase_event(purge_id="purge_append"))
+
+
+def test_complete_purge_operation_requires_full_delete_target_matrix(storage):
+    purge_id = _begin_purge(storage, "purge_snapshot_only")
+
+    with pytest.raises(ValueError, match="delete target matrix"):
+        storage.complete_purge_operation_with_audit(
+            purge_id,
+            _erase_event(purge_id=purge_id),
+        )
+
+    assert storage.get_purge_operation(purge_id).status == "running"
+    assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
 
 
 def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
@@ -844,6 +882,113 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
     )
     assert rebuild_target.status == "complete"
     assert rebuild_target.detail == expected_detail
+    rebuilt_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert rebuilt_row is not None
+    assert tuple(rebuilt_row) == (
+        "rebuilt content",
+        "rebuilt trigger",
+        "rebuilt rationale",
+        None,
+        "rebuilt terms",
+        json.dumps(["rebuilt"]),
+        None,
+    )
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == [
+        AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201])
+    ]
+
+
+def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_failure(
+    storage, monkeypatch
+):
+    purge_id = "purge_rebuild_rollback"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_rollback",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            "remaining_source_windows": [
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+        },
+    )
+    original_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert original_row is not None
+    original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+    original_record = storage._record_purge_target_locked
+
+    def fail_record_target(*args, **kwargs):
+        raise RuntimeError("target completion failed")
+
+    monkeypatch.setattr(storage, "_record_purge_target_locked", fail_record_target)
+
+    with pytest.raises(RuntimeError, match="target completion failed"):
+        storage.apply_governance_agent_playbook_rebuild(
+            purge_id=purge_id,
+            agent_playbook_id=agent_playbook_id,
+            remaining_source_windows=[
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            content="rebuilt content",
+            trigger="rebuilt trigger",
+            rationale="rebuilt rationale",
+            blocking_issue=None,
+            expanded_terms="rebuilt terms",
+            tags=["rebuilt"],
+        )
+
+    monkeypatch.setattr(storage, "_record_purge_target_locked", original_record)
+    assert (
+        storage.conn.execute(
+            """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+               FROM agent_playbooks
+               WHERE agent_playbook_id = ?""",
+            (agent_playbook_id,),
+        ).fetchone()
+        == original_row
+    )
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "running"
 
 
 def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1025,7 +1025,15 @@ def test_append_audit_event_rejects_prefix_only_refs(storage, field_name, value)
 
 @pytest.mark.parametrize(
     "idempotency_key",
-    ["alice@example.com", "request_123", "reqref_v1_target", "alice"],
+    [
+        "alice@example.com",
+        "request_123",
+        "reqref_v1_target",
+        "alice",
+        "user_123",
+        "subject_42",
+        "actor.alpha",
+    ],
 )
 def test_governance_persistence_rejects_unsafe_idempotency_keys(storage, idempotency_key):
     event = AuditEvent(
@@ -1065,7 +1073,35 @@ def test_append_audit_event_rejects_user_like_entity_id(storage):
         storage.append_audit_event(event)
 
 
-@pytest.mark.parametrize("detail", [{"status": "alice"}, {"route": "alice"}])
+@pytest.mark.parametrize(
+    "entity_id",
+    ["user_123", "subject_42", "actor.alpha"],
+)
+def test_append_audit_event_rejects_identifier_like_entity_id(storage, entity_id):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        entity_id=entity_id,
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_identifier_like_entity",
+    )
+
+    with pytest.raises(ValueError, match="entity_id"):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        {"status": "alice"},
+        {"route": "alice"},
+        {"status": "user_123"},
+        {"route": "subject_42"},
+        {"status": "actor.alpha"},
+    ],
+)
 def test_governance_detail_rejects_user_like_status_and_route(storage, detail):
     event = AuditEvent(
         org_id="org1",
@@ -1079,3 +1115,19 @@ def test_governance_detail_rejects_user_like_status_and_route(storage, detail):
 
     with pytest.raises(ValueError, match="status|route"):
         storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize(
+    "purge_id",
+    ["purge_user_123", "purge_subject_42", "purge_actor_alpha"],
+)
+def test_begin_purge_operation_rejects_identifier_like_purge_suffix(storage, purge_id):
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.begin_purge_operation(
+            purge_id=purge_id,
+            idempotency_key="idem_purge_identifier_suffix",
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+        )

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -337,6 +337,13 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
         ),
         pytest.param(
             {
+                "error_detail": "stable failure detail",
+            },
+            "error_detail",
+            id="error-detail-freeform-prose",
+        ),
+        pytest.param(
+            {
                 "error_detail": "Request reqref_123 failed for bob@example.com",
             },
             "error_detail",
@@ -423,6 +430,32 @@ def test_fail_purge_operation_rejects_raw_error_detail(storage):
     assert storage.get_purge_operation(purge_id).error_detail is None
 
 
+def test_fail_purge_operation_rejects_freeform_error_detail(storage):
+    purge_id = _begin_purge(storage, "purge_fail_freeform")
+
+    with pytest.raises(ValueError, match="error_detail"):
+        storage.fail_purge_operation(
+            purge_id,
+            error_code="PURGE_TARGET_FAILED",
+            error_detail="stable failure detail",
+        )
+
+    assert storage.get_purge_operation(purge_id).error_detail is None
+
+
+def test_fail_purge_operation_persists_code_shaped_error_detail(storage):
+    purge_id = _begin_purge(storage, "purge_fail_code_detail")
+
+    failed = storage.fail_purge_operation(
+        purge_id,
+        error_code="PURGE_TARGET_FAILED",
+        error_detail="target_delete_failed",
+    )
+
+    assert failed.status == "failed"
+    assert failed.error_detail == "target_delete_failed"
+
+
 @pytest.mark.parametrize(
     ("error_code", "match"),
     [
@@ -439,7 +472,7 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
         failed = storage.fail_purge_operation(
             purge_id,
             error_code=error_code,
-            error_detail="stable failure detail",
+            error_detail="target_delete_failed",
         )
         assert failed.status == "failed"
         assert failed.error_code == error_code
@@ -449,7 +482,7 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
         storage.fail_purge_operation(
             purge_id,
             error_code=error_code,
-            error_detail="stable failure detail",
+            error_detail="target_delete_failed",
         )
 
     assert storage.get_purge_operation(purge_id).error_code is None

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -213,6 +213,52 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
     assert rows[0].status == seed_event.status
 
 
+@pytest.mark.parametrize(
+    ("field_name", "seed_kwargs"),
+    [
+        pytest.param("entity_type", {"entity_type": "session"}, id="entity-type"),
+        pytest.param("subject_ref", {"subject_ref": "subref_v1_other"}, id="subject-ref"),
+        pytest.param("request_ref", {"request_ref": "reqref_v1_other"}, id="request-ref"),
+    ],
+)
+def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
+    storage, field_name, seed_kwargs
+):
+    purge_id = _begin_purge(storage, "purge_seeded_mismatch")
+    seeded_event = _erase_event(purge_id=purge_id).model_copy(update=seed_kwargs)
+    storage.conn.execute(
+        """INSERT INTO audit_events (
+               org_id, actor_type, actor_ref, operation, entity_type, entity_id,
+               subject_ref, request_ref, idempotency_key, status, detail, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            seeded_event.org_id,
+            seeded_event.actor_type,
+            seeded_event.actor_ref,
+            seeded_event.operation,
+            seeded_event.entity_type,
+            seeded_event.entity_id,
+            seeded_event.subject_ref,
+            seeded_event.request_ref,
+            seeded_event.idempotency_key,
+            seeded_event.status,
+            None,
+            seeded_event.created_at,
+        ),
+    )
+    storage.conn.commit()
+
+    with pytest.raises(ValueError, match="matching successful ERASE"):
+        storage.complete_purge_operation_with_audit(
+            purge_id, _erase_event(purge_id=purge_id)
+        )
+
+    assert storage.get_purge_operation(purge_id).status == "running"
+    rows = storage.list_audit_events(subject_ref=seeded_event.subject_ref)
+    assert len(rows) == 1
+    assert getattr(rows[0], field_name) == getattr(seeded_event, field_name)
+
+
 def test_append_audit_event_rejects_successful_erase(storage):
     with pytest.raises(ValueError, match="Successful ERASE audit rows"):
         storage.append_audit_event(_erase_event(purge_id="purge_append"))
@@ -375,6 +421,38 @@ def test_fail_purge_operation_rejects_raw_error_detail(storage):
         )
 
     assert storage.get_purge_operation(purge_id).error_detail is None
+
+
+@pytest.mark.parametrize(
+    ("error_code", "match"),
+    [
+        pytest.param("PURGE_TARGET_FAILED", None, id="stable-code"),
+        pytest.param("alice@example.com", "error_code", id="email"),
+        pytest.param("request_12345", "error_code", id="request-id"),
+        pytest.param("user_123", "error_code", id="user-like"),
+    ],
+)
+def test_fail_purge_operation_validates_error_code(storage, error_code, match):
+    purge_id = _begin_purge(storage, f"purge_error_code_{error_code.replace('@', '_')}")
+
+    if match is None:
+        failed = storage.fail_purge_operation(
+            purge_id,
+            error_code=error_code,
+            error_detail="stable failure detail",
+        )
+        assert failed.status == "failed"
+        assert failed.error_code == error_code
+        return
+
+    with pytest.raises(ValueError, match=match):
+        storage.fail_purge_operation(
+            purge_id,
+            error_code=error_code,
+            error_detail="stable failure detail",
+        )
+
+    assert storage.get_purge_operation(purge_id).error_code is None
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1756,3 +1756,73 @@ def test_init_governance_tables_upgrades_legacy_purge_target_table(tmp_path):
     )
 
     assert storage.purge_targets_prepared(purge_id) is True
+
+
+def test_init_governance_tables_skips_ambiguous_legacy_purge_target_rows(tmp_path):
+    db_path = tmp_path / "legacy-governance-ambiguous.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE purge_operations (
+            org_id TEXT NOT NULL,
+            purge_id TEXT NOT NULL,
+            operation_type TEXT NOT NULL,
+            scope_type TEXT NOT NULL,
+            subject_ref TEXT,
+            request_ref TEXT NOT NULL,
+            idempotency_key TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            error_code TEXT,
+            error_detail TEXT,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL,
+            completed_at INTEGER,
+            PRIMARY KEY (org_id, purge_id)
+        );
+        INSERT INTO purge_operations (
+            org_id, purge_id, operation_type, scope_type, subject_ref, request_ref,
+            idempotency_key, status, created_at, updated_at
+        ) VALUES
+            ('org1', 'purge_shared', 'user_erasure', 'user', NULL, 'reqref_v1_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'idem_org1', 'pending', 1, 1),
+            ('org2', 'purge_shared', 'user_erasure', 'user', NULL, 'reqref_v1_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'idem_org2', 'pending', 1, 1),
+            ('org1', 'purge_unique', 'user_erasure', 'user', NULL, 'reqref_v1_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', 'idem_unique', 'pending', 1, 1);
+        CREATE TABLE purge_operation_targets (
+            purge_id TEXT NOT NULL,
+            target_name TEXT NOT NULL,
+            target_ref TEXT NOT NULL DEFAULT '',
+            phase TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            detail TEXT,
+            deleted_count INTEGER NOT NULL DEFAULT 0,
+            error_detail TEXT,
+            started_at INTEGER,
+            completed_at INTEGER,
+            PRIMARY KEY (purge_id, target_name, target_ref, phase)
+        );
+        INSERT INTO purge_operation_targets (
+            purge_id, target_name, target_ref, phase, status
+        ) VALUES
+            ('purge_shared', 'target_snapshot', 'all', 'prepare_targets', 'complete'),
+            ('purge_unique', 'target_snapshot', 'all', 'prepare_targets', 'complete');
+        """
+    )
+    conn.commit()
+
+    init_governance_tables(conn)
+
+    upgraded_rows = conn.execute(
+        """
+        SELECT org_id, purge_id, target_name, target_ref, phase, status
+        FROM purge_operation_targets
+        ORDER BY purge_id, org_id
+        """
+    ).fetchall()
+    conn.close()
+
+    assert upgraded_rows == [
+        ("org1", "purge_unique", "target_snapshot", "all", "prepare_targets", "complete")
+    ]
+
+
+def test_gc_governance_retention_accepts_config_keyword(storage):
+    assert storage.gc_governance_retention(config=object()) == 0

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -10,6 +10,7 @@ import pytest
 from reflexio.models.api_schema.domain.entities import (
     AgentPlaybook,
     AgentPlaybookSourceWindow,
+    AgentSuccessEvaluationResult,
 )
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.domain.governance import (
@@ -35,6 +36,7 @@ CANONICAL_DELETE_TARGET_NAMES = (
     "interaction",
     "profile",
     "user_playbook",
+    "agent_success_evaluation_result",
     "profile_purge",
     "user_playbook_purge",
 )
@@ -134,7 +136,15 @@ def _seed_user_scoped_rows(storage: SQLiteStorage, *, user_id: str) -> None:
                generated_from_request_id, profile_time_to_live, expiration_timestamp,
                embedding, source_interaction_ids, created_at
            ) VALUES (?, ?, ?, ?, ?, 'infinity', ?, '[]', '[]', ?)""",
-        ("profile_seed", user_id, "profile-content", 1, "request_seed", 4102444800, created_at),
+        (
+            "profile_seed",
+            user_id,
+            "profile-content",
+            1,
+            "request_seed",
+            4102444800,
+            created_at,
+        ),
     )
     storage.conn.execute(
         """INSERT INTO user_playbooks (
@@ -244,6 +254,27 @@ def _seed_prepare_counts_user_data(storage: SQLiteStorage, *, user_id: str) -> s
     return {delete_playbook_id, purge_playbook_id}
 
 
+def _seed_eval_result(
+    storage: SQLiteStorage,
+    *,
+    user_id: str,
+    session_id: str,
+    evaluation_name: str,
+    agent_version: str = "agent-v1",
+) -> None:
+    storage.save_agent_success_evaluation_results(
+        [
+            AgentSuccessEvaluationResult(
+                user_id=user_id,
+                session_id=session_id,
+                evaluation_name=evaluation_name,
+                agent_version=agent_version,
+                is_success=True,
+            )
+        ]
+    )
+
+
 def _seed_agent_playbook(
     storage: SQLiteStorage,
     *,
@@ -263,7 +294,9 @@ def _seed_agent_playbook(
     storage.set_source_windows_for_agent_playbook(
         saved.agent_playbook_id,
         source_windows
-        or [AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])],
+        or [
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])
+        ],
     )
     return saved.agent_playbook_id
 
@@ -467,8 +500,12 @@ def test_complete_purge_operation_with_audit_accepts_planned_success_detail(stor
 @pytest.mark.parametrize(
     ("event_kwargs", "match"),
     [
-        pytest.param({"subject_ref": OTHER_SUBJECT_REF}, "subject_ref", id="subject-ref"),
-        pytest.param({"request_ref": OTHER_REQUEST_REF}, "request_ref", id="request-ref"),
+        pytest.param(
+            {"subject_ref": OTHER_SUBJECT_REF}, "subject_ref", id="subject-ref"
+        ),
+        pytest.param(
+            {"request_ref": OTHER_REQUEST_REF}, "request_ref", id="request-ref"
+        ),
     ],
 )
 def test_complete_purge_operation_rejects_audit_refs_that_mismatch_persisted_purge(
@@ -489,8 +526,12 @@ def test_complete_purge_operation_rejects_audit_refs_that_mismatch_persisted_pur
 @pytest.mark.parametrize(
     ("retry_kwargs", "match"),
     [
-        pytest.param({"purge_id": "purge_begin_retry_other"}, "purge_id", id="purge-id"),
-        pytest.param({"request_ref": OTHER_REQUEST_REF}, "request_ref", id="request-ref"),
+        pytest.param(
+            {"purge_id": "purge_begin_retry_other"}, "purge_id", id="purge-id"
+        ),
+        pytest.param(
+            {"request_ref": OTHER_REQUEST_REF}, "request_ref", id="request-ref"
+        ),
         pytest.param({"scope_type": "org"}, "scope_type", id="scope-type"),
     ],
 )
@@ -537,7 +578,9 @@ def test_begin_purge_operation_rejects_numeric_idempotency_key(storage):
         storage.get_purge_operation("purge_numeric_idem")
 
 
-def test_begin_purge_operation_accepts_code_shaped_idempotency_key_with_content(storage):
+def test_begin_purge_operation_accepts_code_shaped_idempotency_key_with_content(
+    storage,
+):
     purge = storage.begin_purge_operation(
         purge_id="purge_content_retry",
         idempotency_key="content_purge_retry_1",
@@ -654,8 +697,12 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
     ("field_name", "seed_kwargs"),
     [
         pytest.param("entity_type", {"entity_type": "session"}, id="entity-type"),
-        pytest.param("subject_ref", {"subject_ref": OTHER_SUBJECT_REF}, id="subject-ref"),
-        pytest.param("request_ref", {"request_ref": OTHER_REQUEST_REF}, id="request-ref"),
+        pytest.param(
+            "subject_ref", {"subject_ref": OTHER_SUBJECT_REF}, id="subject-ref"
+        ),
+        pytest.param(
+            "request_ref", {"request_ref": OTHER_REQUEST_REF}, id="request-ref"
+        ),
         pytest.param("actor_type", {"actor_type": "jwt"}, id="actor-type"),
         pytest.param("actor_ref", {"actor_ref": ACTOR_REF}, id="actor-ref"),
         pytest.param("entity_id", {"entity_id": "17"}, id="entity-id"),
@@ -683,7 +730,9 @@ def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
             seeded_event.request_ref,
             seeded_event.idempotency_key,
             seeded_event.status,
-            json.dumps(seeded_event.detail) if seeded_event.detail is not None else None,
+            json.dumps(seeded_event.detail)
+            if seeded_event.detail is not None
+            else None,
             seeded_event.created_at,
         ),
     )
@@ -735,7 +784,9 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
 
     snapshot = next(
         target
-        for target in storage.list_purge_targets("purge_detail", phase="prepare_targets")
+        for target in storage.list_purge_targets(
+            "purge_detail", phase="prepare_targets"
+        )
         if target.target_name == "target_snapshot"
     )
     assert snapshot.detail == {
@@ -756,7 +807,9 @@ def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storag
     agent_playbook_id = _seed_agent_playbook(
         storage,
         source_windows=[
-            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101, 102]),
+            AgentPlaybookSourceWindow(
+                user_playbook_id=7, source_interaction_ids=[101, 102]
+            ),
             AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
         ],
     )
@@ -792,6 +845,12 @@ def test_prepare_governance_erase_targets_records_full_delete_matrix_counts(stor
     purge_id = "purge_prepare_counts"
     user_id = "user_prepare_counts"
     owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    _seed_eval_result(
+        storage,
+        user_id=user_id,
+        session_id="session_seed",
+        evaluation_name="governance_prepare_counts",
+    )
     storage.begin_purge_operation(
         purge_id=purge_id,
         idempotency_key="idem_purge_prepare_counts",
@@ -821,6 +880,8 @@ def test_prepare_governance_erase_targets_records_full_delete_matrix_counts(stor
     assert delete_targets["profile_purge"].detail == {"count": 1}
     assert delete_targets["user_playbook"].target_ref == "all"
     assert delete_targets["user_playbook"].detail == {"count": 1}
+    assert delete_targets["agent_success_evaluation_result"].target_ref == "all"
+    assert delete_targets["agent_success_evaluation_result"].detail == {"count": 1}
     assert delete_targets["user_playbook_purge"].target_ref == "all"
     assert delete_targets["user_playbook_purge"].detail == {"count": 1}
 
@@ -1025,9 +1086,7 @@ def test_apply_governance_agent_playbook_rebuild_rejects_ad_hoc_rebuild_without_
     assert original_row is not None
     original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
 
-    with pytest.raises(
-        ValueError, match="planned rebuild target does not exist"
-    ):
+    with pytest.raises(ValueError, match="planned rebuild target does not exist"):
         storage.apply_governance_agent_playbook_rebuild(
             purge_id=purge_id,
             agent_playbook_id=agent_playbook_id,
@@ -1051,8 +1110,14 @@ def test_apply_governance_agent_playbook_rebuild_rejects_ad_hoc_rebuild_without_
         ).fetchone()
         == original_row
     )
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
-    assert storage.list_purge_targets(purge_id, phase="rebuild_without_erased_sources") == []
+    assert (
+        storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+        == original_windows
+    )
+    assert (
+        storage.list_purge_targets(purge_id, phase="rebuild_without_erased_sources")
+        == []
+    )
 
 
 def test_apply_governance_agent_playbook_rebuild_rejects_rebuild_before_hide_phase_complete(
@@ -1101,9 +1166,7 @@ def test_apply_governance_agent_playbook_rebuild_rejects_rebuild_before_hide_pha
     assert original_row is not None
     original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
 
-    with pytest.raises(
-        ValueError, match="hide_for_rebuild target must be complete"
-    ):
+    with pytest.raises(ValueError, match="hide_for_rebuild target must be complete"):
         storage.apply_governance_agent_playbook_rebuild(
             purge_id=purge_id,
             agent_playbook_id=agent_playbook_id,
@@ -1127,7 +1190,10 @@ def test_apply_governance_agent_playbook_rebuild_rejects_rebuild_before_hide_pha
         ).fetchone()
         == original_row
     )
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    assert (
+        storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+        == original_windows
+    )
     rebuild_target = next(
         target
         for target in storage.list_purge_targets(
@@ -1305,7 +1371,10 @@ def test_apply_governance_agent_playbook_rebuild_does_not_complete_target_when_s
         ).fetchone()
         == original_row
     )
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    assert (
+        storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+        == original_windows
+    )
     assert (
         storage.conn.execute(
             "SELECT search_text FROM agent_playbooks_fts WHERE rowid = ?",
@@ -1387,10 +1456,13 @@ def test_apply_governance_agent_playbook_rebuild_removes_orphaned_aggregate_when
     )
     assert rebuild_target.status == "complete"
     assert storage.get_agent_playbook_by_id(agent_playbook_id) is None
-    assert storage.get_agent_playbook_by_id(
-        agent_playbook_id,
-        include_tombstones=True,
-    ) is None
+    assert (
+        storage.get_agent_playbook_by_id(
+            agent_playbook_id,
+            include_tombstones=True,
+        )
+        is None
+    )
     assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == []
     assert (
         storage.conn.execute(
@@ -1414,9 +1486,12 @@ def test_apply_governance_agent_playbook_rebuild_removes_orphaned_aggregate_when
             ).fetchone()[0]
             == 0
         )
-    assert storage.search_agent_playbooks(
-        SearchAgentPlaybookRequest(query="original content", top_k=10)
-    ) == []
+    assert (
+        storage.search_agent_playbooks(
+            SearchAgentPlaybookRequest(query="original content", top_k=10)
+        )
+        == []
+    )
 
 
 def test_apply_governance_agent_playbook_rebuild_restores_previous_lifecycle_status(
@@ -1570,21 +1645,30 @@ def test_apply_governance_agent_playbook_rebuild_rejects_second_call_after_compl
         (agent_playbook_id,),
     ).fetchone()
     assert after_row == before_row
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
-    assert next(
-        target
-        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
-        if target.target_name == "agent_playbook"
-        and target.target_ref == str(agent_playbook_id)
-    ) == before_hide_target
-    assert next(
-        target
-        for target in storage.list_purge_targets(
-            purge_id, phase="rebuild_without_erased_sources"
+    assert (
+        storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+        == before_windows
+    )
+    assert (
+        next(
+            target
+            for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+            if target.target_name == "agent_playbook"
+            and target.target_ref == str(agent_playbook_id)
         )
-        if target.target_name == "agent_playbook"
-        and target.target_ref == str(agent_playbook_id)
-    ) == before_rebuild_target
+        == before_hide_target
+    )
+    assert (
+        next(
+            target
+            for target in storage.list_purge_targets(
+                purge_id, phase="rebuild_without_erased_sources"
+            )
+            if target.target_name == "agent_playbook"
+            and target.target_ref == str(agent_playbook_id)
+        )
+        == before_rebuild_target
+    )
 
 
 def test_hide_governance_agent_playbooks_for_rebuild_is_idempotent_after_completed_rebuild(
@@ -1670,7 +1754,10 @@ def test_hide_governance_agent_playbooks_for_rebuild_is_idempotent_after_complet
 
     assert hidden_ids == []
     assert after_status == before_status == Status.ARCHIVED.value
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
+    assert (
+        storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+        == before_windows
+    )
     assert after_hide_target == before_hide_target
     assert after_rebuild_target == before_rebuild_target
 
@@ -1756,21 +1843,32 @@ def test_hide_governance_agent_playbooks_for_rebuild_does_not_reopen_complete_ta
         == before_status
         == Status.ARCHIVED.value
     )
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == before_windows
-    assert next(
-        target
-        for target in original_list_purge_targets(purge_id, phase="hide_for_rebuild")
-        if target.target_name == "agent_playbook"
-        and target.target_ref == str(agent_playbook_id)
-    ) == before_hide_target
-    assert next(
-        target
-        for target in original_list_purge_targets(
-            purge_id, phase="rebuild_without_erased_sources"
+    assert (
+        storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+        == before_windows
+    )
+    assert (
+        next(
+            target
+            for target in original_list_purge_targets(
+                purge_id, phase="hide_for_rebuild"
+            )
+            if target.target_name == "agent_playbook"
+            and target.target_ref == str(agent_playbook_id)
         )
-        if target.target_name == "agent_playbook"
-        and target.target_ref == str(agent_playbook_id)
-    ) == before_rebuild_target
+        == before_hide_target
+    )
+    assert (
+        next(
+            target
+            for target in original_list_purge_targets(
+                purge_id, phase="rebuild_without_erased_sources"
+            )
+            if target.target_name == "agent_playbook"
+            and target.target_ref == str(agent_playbook_id)
+        )
+        == before_rebuild_target
+    )
 
 
 def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot_and_rebuild(
@@ -1787,6 +1885,12 @@ def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot
         request_ref=REQUEST_REF,
     )
     owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    _seed_eval_result(
+        storage,
+        user_id=user_id,
+        session_id="session-delete-hide-complete",
+        evaluation_name="governance_delete_hide_complete",
+    )
     affected_user_playbook_id = min(owned_user_playbook_ids)
     agent_playbook_id = _seed_agent_playbook(
         storage,
@@ -1796,7 +1900,9 @@ def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot
                 user_playbook_id=affected_user_playbook_id,
                 source_interaction_ids=[101],
             ),
-            AgentPlaybookSourceWindow(user_playbook_id=999999, source_interaction_ids=[201]),
+            AgentPlaybookSourceWindow(
+                user_playbook_id=999999, source_interaction_ids=[201]
+            ),
         ],
     )
     storage.prepare_governance_erase_targets(
@@ -1919,11 +2025,15 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     org1_targets = storage_org1.list_purge_targets(purge_id)
     org2_targets = storage_org2.list_purge_targets(purge_id)
 
-    assert {(target.phase, target.target_ref, target.status) for target in org1_targets} == {
+    assert {
+        (target.phase, target.target_ref, target.status) for target in org1_targets
+    } == {
         ("delete", "all", "pending"),
         ("prepare_targets", "all", "complete"),
     }
-    assert {(target.phase, target.target_ref, target.status) for target in org2_targets} == {
+    assert {
+        (target.phase, target.target_ref, target.status) for target in org2_targets
+    } == {
         ("delete", "all", "complete"),
     }
     assert storage_org1.purge_targets_prepared(purge_id) is True
@@ -1947,7 +2057,10 @@ def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
 
     assert org1_request_target.status == "pending"
     assert org1_request_target.detail == {"count": 1}
-    assert {(target.target_ref, target.status, target.deleted_count) for target in org2_delete_targets} == {
+    assert {
+        (target.target_ref, target.status, target.deleted_count)
+        for target in org2_delete_targets
+    } == {
         ("all", "running", 0),
     }
 
@@ -2034,7 +2147,8 @@ def test_record_purge_target_validates_governance_fields(storage, kwargs, match)
     if match is None:
         storage.record_purge_target(**params)
         target = next(
-            row for row in storage.list_purge_targets(purge_id, phase="delete")
+            row
+            for row in storage.list_purge_targets(purge_id, phase="delete")
             if row.target_name == "request"
         )
         assert target.detail == kwargs["detail"]
@@ -2052,7 +2166,9 @@ def test_record_purge_target_validates_governance_fields(storage, kwargs, match)
         pytest.param(-1, "deleted_count", id="negative"),
     ],
 )
-def test_record_purge_target_rejects_invalid_deleted_count(storage, deleted_count, match):
+def test_record_purge_target_rejects_invalid_deleted_count(
+    storage, deleted_count, match
+):
     purge_id = _begin_purge(storage, "purge_deleted_count")
 
     with pytest.raises(ValueError, match=match):
@@ -2070,7 +2186,9 @@ def test_record_purge_target_rejects_invalid_deleted_count(storage, deleted_coun
 def test_record_purge_target_accepts_nonnegative_detail_deleted_count(
     storage, detail_deleted_count
 ):
-    purge_id = _begin_purge(storage, f"purge_detail_deleted_count_{detail_deleted_count}")
+    purge_id = _begin_purge(
+        storage, f"purge_detail_deleted_count_{detail_deleted_count}"
+    )
 
     storage.record_purge_target(
         purge_id=purge_id,
@@ -2082,7 +2200,8 @@ def test_record_purge_target_accepts_nonnegative_detail_deleted_count(
     )
 
     target = next(
-        row for row in storage.list_purge_targets(purge_id, phase="delete")
+        row
+        for row in storage.list_purge_targets(purge_id, phase="delete")
         if row.target_name == "request"
     )
     assert target.detail == {"deleted_count": detail_deleted_count}
@@ -2106,10 +2225,20 @@ def test_record_purge_target_rejects_negative_detail_deleted_count(storage):
     ("detail", "match"),
     [
         pytest.param({"email": "bob@example.com"}, "email", id="audit-detail-email"),
-        pytest.param({"request_id": "reqref_123"}, "request_id", id="audit-detail-request-id"),
-        pytest.param({"content": "verbatim prompt"}, "content", id="audit-detail-content"),
-        pytest.param({"note": "arbitrary string"}, "note", id="audit-detail-neutral-note"),
-        pytest.param({"status": "prompt-ready"}, "prompt/content", id="audit-detail-promptish-string"),
+        pytest.param(
+            {"request_id": "reqref_123"}, "request_id", id="audit-detail-request-id"
+        ),
+        pytest.param(
+            {"content": "verbatim prompt"}, "content", id="audit-detail-content"
+        ),
+        pytest.param(
+            {"note": "arbitrary string"}, "note", id="audit-detail-neutral-note"
+        ),
+        pytest.param(
+            {"status": "prompt-ready"},
+            "prompt/content",
+            id="audit-detail-promptish-string",
+        ),
         pytest.param(
             {"owned_user_playbook_ids": [7]},
             "owned_user_playbook_ids",
@@ -2121,19 +2250,35 @@ def test_record_purge_target_rejects_negative_detail_deleted_count(storage):
             id="audit-detail-rejects-source-interaction-ids",
         ),
         pytest.param(
-            {"original_source_windows": [{"user_playbook_id": 7, "source_interaction_ids": [1]}]},
+            {
+                "original_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [1]}
+                ]
+            },
             "original_source_windows",
             id="audit-detail-rejects-original-source-windows",
         ),
         pytest.param(
-            {"remaining_source_windows": [{"user_playbook_id": 7, "source_interaction_ids": [1]}]},
+            {
+                "remaining_source_windows": [
+                    {"user_playbook_id": 7, "source_interaction_ids": [1]}
+                ]
+            },
             "remaining_source_windows",
             id="audit-detail-rejects-remaining-source-windows",
         ),
         pytest.param({"count": 2}, None, id="audit-detail-allowed-count"),
-        pytest.param({"deleted_count": 1}, None, id="audit-detail-allowed-deleted-count"),
-        pytest.param({"deleted_counts": {"requests": 1}}, None, id="audit-detail-allowed-deleted-counts"),
-        pytest.param({"agent_playbook_id": 7}, None, id="audit-detail-allowed-agent-playbook-id"),
+        pytest.param(
+            {"deleted_count": 1}, None, id="audit-detail-allowed-deleted-count"
+        ),
+        pytest.param(
+            {"deleted_counts": {"requests": 1}},
+            None,
+            id="audit-detail-allowed-deleted-counts",
+        ),
+        pytest.param(
+            {"agent_playbook_id": 7}, None, id="audit-detail-allowed-agent-playbook-id"
+        ),
         pytest.param(
             {"rebuilt_agent_playbook_ids": [7, 8]},
             None,
@@ -2266,7 +2411,9 @@ def test_fail_purge_operation_persists_code_shaped_error_detail(storage):
     assert failed.error_detail == "target_delete_failed"
 
 
-@pytest.mark.parametrize("error_code", ["content_purge_failed", "prompt_redaction_route"])
+@pytest.mark.parametrize(
+    "error_code", ["content_purge_failed", "prompt_redaction_route"]
+)
 def test_fail_purge_operation_accepts_code_shaped_error_code_with_prompt_or_content(
     storage, error_code
 ):
@@ -2395,7 +2542,9 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
         ),
     ],
 )
-def test_append_audit_event_validates_top_level_governance_fields(storage, event, match):
+def test_append_audit_event_validates_top_level_governance_fields(
+    storage, event, match
+):
     with pytest.raises(ValueError, match=match):
         storage.append_audit_event(event)
 
@@ -2449,7 +2598,9 @@ def test_append_audit_event_requires_minimized_request_ref(storage):
 @pytest.mark.parametrize(
     ("subject_ref", "request_ref", "match"),
     [
-        pytest.param(SUBJECT_REF, "request_12345", "request_ref", id="purge-request-ref"),
+        pytest.param(
+            SUBJECT_REF, "request_12345", "request_ref", id="purge-request-ref"
+        ),
         pytest.param("raw-user-id", REQUEST_REF, "subject_ref", id="purge-subject-ref"),
     ],
 )
@@ -2470,8 +2621,12 @@ def test_begin_purge_operation_validates_top_level_refs(
 @pytest.mark.parametrize(
     ("operation_type", "scope_type", "match"),
     [
-        pytest.param(cast(Any, "erase_user"), "user", "operation_type", id="operation-type"),
-        pytest.param("user_erasure", cast(Any, "workspace"), "scope_type", id="scope-type"),
+        pytest.param(
+            cast(Any, "erase_user"), "user", "operation_type", id="operation-type"
+        ),
+        pytest.param(
+            "user_erasure", cast(Any, "workspace"), "scope_type", id="scope-type"
+        ),
     ],
 )
 def test_begin_purge_operation_rejects_invalid_enum_values(
@@ -2509,7 +2664,9 @@ def test_begin_purge_operation_rejects_unsafe_purge_id(storage, purge_id):
         )
 
 
-@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+@pytest.mark.parametrize(
+    "detail_key", ["remaining_source_windows", "original_source_windows"]
+)
 def test_append_audit_event_rejects_mixed_case_window_keys(storage, detail_key):
     event = AuditEvent(
         org_id="org1",
@@ -2525,7 +2682,9 @@ def test_append_audit_event_rejects_mixed_case_window_keys(storage, detail_key):
         storage.append_audit_event(event)
 
 
-@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+@pytest.mark.parametrize(
+    "detail_key", ["remaining_source_windows", "original_source_windows"]
+)
 def test_record_purge_target_rejects_mixed_case_window_keys(storage, detail_key):
     purge_id = _begin_purge(storage, f"purge_{detail_key}")
 
@@ -2540,7 +2699,9 @@ def test_record_purge_target_rejects_mixed_case_window_keys(storage, detail_key)
         )
 
 
-@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+@pytest.mark.parametrize(
+    "detail_key", ["remaining_source_windows", "original_source_windows"]
+)
 def test_append_audit_event_requires_window_user_playbook_id(storage, detail_key):
     event = AuditEvent(
         org_id="org1",
@@ -2556,7 +2717,9 @@ def test_append_audit_event_requires_window_user_playbook_id(storage, detail_key
         storage.append_audit_event(event)
 
 
-@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+@pytest.mark.parametrize(
+    "detail_key", ["remaining_source_windows", "original_source_windows"]
+)
 def test_record_purge_target_requires_window_user_playbook_id(storage, detail_key):
     purge_id = _begin_purge(storage, f"purge_missing_upb_{detail_key}")
 
@@ -2706,7 +2869,9 @@ def test_record_purge_target_validates_target_ref_contract(storage, target_ref, 
         )
 
 
-@pytest.mark.parametrize("purge_id", ["alice@example.com", "request_12345", "alice", SUBJECT_REF])
+@pytest.mark.parametrize(
+    "purge_id", ["alice@example.com", "request_12345", "alice", SUBJECT_REF]
+)
 def test_persistence_paths_reject_unsafe_purge_id(storage, purge_id):
     now = 1
     storage.conn.execute(
@@ -2864,10 +3029,7 @@ def test_apply_governance_user_data_delete_requires_complete_prepared_delete_mat
     assert clear_locked_called is False
     assert _user_scoped_row_counts(storage, user_id=user_id) == baseline_counts
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
-    assert {
-        (target.target_name, target.status)
-        for target in delete_targets
-    } == {
+    assert {(target.target_name, target.status) for target in delete_targets} == {
         ("request", "pending"),
         ("interaction", "complete"),
     }
@@ -2887,6 +3049,12 @@ def test_apply_governance_user_data_delete_requires_hide_targets_for_planned_reb
         request_ref=REQUEST_REF,
     )
     owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    _seed_eval_result(
+        storage,
+        user_id=user_id,
+        session_id="session-delete-hide-complete",
+        evaluation_name="governance_delete_hide_complete",
+    )
     affected_user_playbook_id = min(owned_user_playbook_ids)
     _seed_agent_playbook(
         storage,
@@ -2936,6 +3104,12 @@ def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
         request_ref=REQUEST_REF,
     )
     owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    _seed_eval_result(
+        storage,
+        user_id=user_id,
+        session_id="session-delete-hide-complete",
+        evaluation_name="governance_delete_hide_complete",
+    )
     affected_user_playbook_id = min(owned_user_playbook_ids)
     _seed_agent_playbook(
         storage,
@@ -2964,6 +3138,7 @@ def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
         "user_playbooks": 1,
         "profiles": 1,
         "requests": 1,
+        "agent_success_evaluation_results": 1,
         "purged_profiles": 1,
         "purged_user_playbooks": 1,
     }
@@ -2973,31 +3148,36 @@ def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
         "profiles": 0,
         "user_playbooks": 0,
     }
-    assert storage.conn.execute(
-        """SELECT COUNT(*)
+    assert (
+        storage.conn.execute(
+            """SELECT COUNT(*)
            FROM profiles
            WHERE merged_into IS NOT NULL AND content = '' AND user_id = ''"""
-    ).fetchone()[0] == 1
-    assert storage.conn.execute(
-        """SELECT COUNT(*)
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        storage.conn.execute(
+            """SELECT COUNT(*)
            FROM user_playbooks
            WHERE merged_into IS NOT NULL AND content = '' AND user_id IS NULL"""
-    ).fetchone()[0] == 1
+        ).fetchone()[0]
+        == 1
+    )
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
     assert {target.target_name: target.deleted_count for target in delete_targets} == {
         "request": 1,
         "interaction": 1,
         "profile": 1,
         "user_playbook": 1,
+        "agent_success_evaluation_result": 1,
         "profile_purge": 1,
         "user_playbook_purge": 1,
     }
     assert all(target.status == "complete" for target in delete_targets)
 
 
-def test_apply_governance_user_data_delete_is_failure_atomic(
-    storage, monkeypatch
-):
+def test_apply_governance_user_data_delete_is_failure_atomic(storage, monkeypatch):
     purge_id = "purge_delete_atomic"
     user_id = "user-delete-atomic"
     storage.begin_purge_operation(
@@ -3120,7 +3300,9 @@ def test_apply_governance_agent_playbook_rebuild_rejects_unsafe_purge_id_before_
         storage.apply_governance_agent_playbook_rebuild(
             purge_id="request_12345",
             agent_playbook_id=agent_playbook_id,
-            remaining_source_windows=[{"user_playbook_id": 99, "source_interaction_ids": [202]}],
+            remaining_source_windows=[
+                {"user_playbook_id": 99, "source_interaction_ids": [202]}
+            ],
             content="updated content",
             trigger="updated trigger",
             rationale="updated rationale",
@@ -3228,7 +3410,7 @@ def test_apply_governance_agent_playbook_rebuild_rejects_mismatched_remaining_so
            FROM agent_playbooks
            WHERE agent_playbook_id = ?""",
         (agent_playbook_id,),
-        ).fetchone()
+    ).fetchone()
     assert rebuilt_row == original_row
 
 
@@ -3259,8 +3441,7 @@ def test_get_agent_playbooks_default_excludes_archive_in_progress(storage):
     )
 
     default_ids = {
-        playbook.agent_playbook_id
-        for playbook in storage.get_agent_playbooks(limit=10)
+        playbook.agent_playbook_id for playbook in storage.get_agent_playbooks(limit=10)
     }
     hidden_only_ids = {
         playbook.agent_playbook_id
@@ -3311,9 +3492,7 @@ def test_search_agent_playbooks_default_excludes_archive_in_progress_and_explici
         SearchAgentPlaybookRequest(query="visible-search-token", top_k=10)
     )
 
-    assert hidden_id not in {
-        playbook.agent_playbook_id for playbook in default_results
-    }
+    assert hidden_id not in {playbook.agent_playbook_id for playbook in default_results}
     assert [playbook.agent_playbook_id for playbook in explicit_hidden_results] == [
         hidden_id
     ]
@@ -3323,7 +3502,9 @@ def test_search_agent_playbooks_default_excludes_archive_in_progress_and_explici
 @pytest.mark.parametrize(
     ("target_name", "phase", "status", "match"),
     [
-        pytest.param(cast(Any, "session"), "delete", "running", "target_name", id="target-name"),
+        pytest.param(
+            cast(Any, "session"), "delete", "running", "target_name", id="target-name"
+        ),
         pytest.param("request", cast(Any, "archive"), "running", "phase", id="phase"),
         pytest.param("request", "delete", cast(Any, "done"), "status", id="status"),
     ],
@@ -3377,7 +3558,9 @@ def test_append_audit_event_rejects_prefix_only_refs(storage, field_name, value)
         "actor.alpha",
     ],
 )
-def test_governance_persistence_rejects_unsafe_idempotency_keys(storage, idempotency_key):
+def test_governance_persistence_rejects_unsafe_idempotency_keys(
+    storage, idempotency_key
+):
     event = AuditEvent(
         org_id="org1",
         operation="EXPORT",
@@ -3854,7 +4037,14 @@ def test_init_governance_tables_skips_ambiguous_legacy_purge_target_rows(tmp_pat
     conn.close()
 
     assert upgraded_rows == [
-        ("org1", "purge_unique", "target_snapshot", "all", "prepare_targets", "complete")
+        (
+            "org1",
+            "purge_unique",
+            "target_snapshot",
+            "all",
+            "prepare_targets",
+            "complete",
+        )
     ]
 
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -662,6 +662,27 @@ def test_begin_purge_operation_rejects_invalid_enum_values(
         )
 
 
+@pytest.mark.parametrize(
+    "purge_id",
+    [
+        "alice@example.com",
+        "request_12345",
+        "alice",
+        SUBJECT_REF,
+    ],
+)
+def test_begin_purge_operation_rejects_unsafe_purge_id(storage, purge_id):
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.begin_purge_operation(
+            purge_id=purge_id,
+            idempotency_key="idem_purge_invalid_id",
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+        )
+
+
 @pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
 def test_append_audit_event_rejects_mixed_case_window_keys(storage, detail_key):
     event = AuditEvent(
@@ -690,6 +711,37 @@ def test_record_purge_target_rejects_mixed_case_window_keys(storage, detail_key)
             phase="rebuild",
             status="running",
             detail={detail_key: [{"User_Playbook_Id": "alice@example.com"}]},
+        )
+
+
+@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+def test_append_audit_event_requires_window_user_playbook_id(storage, detail_key):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key=f"missing_upb_{detail_key}",
+        detail={detail_key: [{"source_interaction_ids": [1, 2]}]},
+    )
+
+    with pytest.raises(ValueError, match="user_playbook_id"):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+def test_record_purge_target_requires_window_user_playbook_id(storage, detail_key):
+    purge_id = _begin_purge(storage, f"purge_missing_upb_{detail_key}")
+
+    with pytest.raises(ValueError, match="user_playbook_id"):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="agent_playbook",
+            target_ref="7",
+            phase="rebuild",
+            status="running",
+            detail={detail_key: [{"source_interaction_ids": [1, 2]}]},
         )
 
 
@@ -727,6 +779,54 @@ def test_record_purge_target_validates_target_ref_contract(storage, target_ref, 
             phase="delete",
             status="running",
         )
+
+
+@pytest.mark.parametrize("purge_id", ["alice@example.com", "request_12345", "alice", SUBJECT_REF])
+def test_persistence_paths_reject_unsafe_purge_id(storage, purge_id):
+    now = 1
+    storage.conn.execute(
+        """INSERT INTO purge_operations (
+               purge_id, org_id, operation_type, scope_type, subject_ref, request_ref,
+               idempotency_key, status, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, 'running', ?, ?)""",
+        (
+            purge_id,
+            "org1",
+            "user_erasure",
+            "user",
+            SUBJECT_REF,
+            REQUEST_REF,
+            "idem_seeded_invalid_purge_id",
+            now,
+            now,
+        ),
+    )
+    storage.conn.commit()
+
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref="all",
+            phase="delete",
+            status="running",
+        )
+
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.complete_purge_operation_with_audit(
+            purge_id,
+            AuditEvent(
+                org_id="org1",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
+                idempotency_key=purge_id,
+            ),
+        )
+
+    assert storage.list_purge_targets(purge_id) == []
+    assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.governance import AuditEvent
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def storage(tmp_path):
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        yield SQLiteStorage(org_id="org1", db_path=str(tmp_path / "g.db"))
+
+
+def test_audit_event_idempotency(storage):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref="subref_abc",
+        request_ref="reqref_r1",
+        idempotency_key="export_1",
+        detail={"requests": 1},
+    )
+
+    assert storage.append_audit_event(event) is True
+    assert storage.append_audit_event(event) is False
+    rows = storage.list_audit_events(subject_ref="subref_abc")
+    assert len(rows) == 1
+    assert rows[0].idempotency_key == "export_1"
+
+
+def test_purge_targets_require_snapshot_marker(storage):
+    purge = storage.begin_purge_operation(
+        purge_id="purge_1",
+        idempotency_key="idem_1",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref="subref_abc",
+        request_ref="reqref_r1",
+    )
+    storage.record_purge_target(
+        purge_id=purge.purge_id,
+        target_name="request",
+        target_ref="req1",
+        phase="delete",
+        status="complete",
+        deleted_count=1,
+    )
+
+    assert storage.purge_targets_prepared(purge.purge_id) is False
+    with pytest.raises(ValueError, match="target snapshot"):
+        storage.complete_purge_operation_with_audit(
+            purge.purge_id,
+            AuditEvent(
+                org_id="org1",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref="subref_abc",
+                request_ref="reqref_r1",
+                idempotency_key=purge.purge_id,
+            ),
+        )
+
+
+def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
+    purge = storage.begin_purge_operation(
+        purge_id="purge_2",
+        idempotency_key="idem_2",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref="subref_abc",
+        request_ref="reqref_r2",
+    )
+    storage.record_purge_target(
+        purge_id=purge.purge_id,
+        target_name="target_snapshot",
+        target_ref="all",
+        phase="prepare_targets",
+        status="complete",
+    )
+    complete = storage.complete_purge_operation_with_audit(
+        purge.purge_id,
+        AuditEvent(
+            org_id="org1",
+            operation="ERASE",
+            entity_type="request",
+            subject_ref="subref_abc",
+            request_ref="reqref_r2",
+            idempotency_key=purge.purge_id,
+        ),
+    )
+
+    assert complete.status == "complete"
+    rows = storage.list_audit_events(subject_ref="subref_abc")
+    assert [row.operation for row in rows] == ["ERASE"]
+    same = storage.complete_purge_operation_with_audit(
+        purge.purge_id,
+        AuditEvent(
+            org_id="org1",
+            operation="ERASE",
+            entity_type="request",
+            subject_ref="subref_abc",
+            request_ref="reqref_r2",
+            idempotency_key=purge.purge_id,
+        ),
+    )
+    assert same.status == "complete"
+    assert len(storage.list_audit_events(subject_ref="subref_abc")) == 1

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1651,6 +1651,105 @@ def test_hide_governance_agent_playbooks_for_rebuild_does_not_reopen_complete_ta
     ) == before_rebuild_target
 
 
+def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot_and_rebuild(
+    storage,
+):
+    purge_id = "purge_prepare_idempotent_after_rebuild"
+    user_id = "user-prepare-idempotent-after-rebuild"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_prepare_idempotent_after_rebuild",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    affected_user_playbook_id = min(owned_user_playbook_ids)
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVED,
+        source_windows=[
+            AgentPlaybookSourceWindow(
+                user_playbook_id=affected_user_playbook_id,
+                source_interaction_ids=[101],
+            ),
+            AgentPlaybookSourceWindow(user_playbook_id=999999, source_interaction_ids=[201]),
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id=user_id,
+        owned_user_playbook_ids=owned_user_playbook_ids,
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 999999, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    before_targets = [
+        (
+            target.target_name,
+            target.target_ref,
+            target.phase,
+            target.status,
+            target.detail,
+            target.deleted_count,
+        )
+        for target in storage.list_purge_targets(purge_id)
+        if target.target_name
+        in {*CANONICAL_DELETE_TARGET_NAMES, "agent_playbook", "target_snapshot"}
+    ]
+    before_playbook_row = storage.conn.execute(
+        """SELECT status, content, trigger, rationale, tags
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    before_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id=user_id,
+        owned_user_playbook_ids=owned_user_playbook_ids,
+    )
+
+    after_targets = [
+        (
+            target.target_name,
+            target.target_ref,
+            target.phase,
+            target.status,
+            target.detail,
+            target.deleted_count,
+        )
+        for target in storage.list_purge_targets(purge_id)
+        if target.target_name
+        in {*CANONICAL_DELETE_TARGET_NAMES, "agent_playbook", "target_snapshot"}
+    ]
+    after_playbook_row = storage.conn.execute(
+        """SELECT status, content, trigger, rationale, tags
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    after_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+
+    assert after_targets == before_targets
+    assert after_playbook_row == before_playbook_row
+    assert after_windows == before_windows
+
+
 def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
     storage_org1 = storage_factory("org1")
     storage_org2 = storage_factory("org2")

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -331,8 +331,8 @@ def test_list_audit_events_rejects_cross_org_override(storage_factory):
 
 def test_purge_targets_require_snapshot_marker(storage):
     purge = storage.begin_purge_operation(
-        purge_id="purge_1",
-        idempotency_key="idem_1",
+        purge_id="purge_snapshot_marker",
+        idempotency_key="idem_snapshot_marker",
         operation_type="user_erasure",
         scope_type="user",
         subject_ref=SUBJECT_REF,
@@ -363,7 +363,7 @@ def test_purge_targets_require_snapshot_marker(storage):
 
 
 def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
-    purge_id = _begin_completeable_purge(storage, "purge_2")
+    purge_id = _begin_completeable_purge(storage, "purge_atomic_success")
     complete = storage.complete_purge_operation_with_audit(
         purge_id,
         _erase_event(purge_id=purge_id),
@@ -515,11 +515,12 @@ def test_begin_purge_operation_rejects_numeric_idempotency_key(storage):
         storage.get_purge_operation("purge_numeric_idem")
 
 
-def test_begin_purge_operation_rejects_raw_numeric_purge_suffix(storage):
+@pytest.mark.parametrize("purge_id", ["purge_1", "purge_123"])
+def test_begin_purge_operation_rejects_raw_numeric_purge_suffix(storage, purge_id):
     with pytest.raises(ValueError, match="purge_id"):
         storage.begin_purge_operation(
-            purge_id="purge_123",
-            idempotency_key="idem_purge_123",
+            purge_id=purge_id,
+            idempotency_key=f"idem_{purge_id}",
             operation_type="user_erasure",
             scope_type="user",
             subject_ref=SUBJECT_REF,
@@ -527,7 +528,7 @@ def test_begin_purge_operation_rejects_raw_numeric_purge_suffix(storage):
         )
 
     with pytest.raises(ValueError, match="purge_id"):
-        storage.get_purge_operation("purge_123")
+        storage.get_purge_operation(purge_id)
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -225,6 +227,10 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
         pytest.param("entity_type", {"entity_type": "session"}, id="entity-type"),
         pytest.param("subject_ref", {"subject_ref": OTHER_SUBJECT_REF}, id="subject-ref"),
         pytest.param("request_ref", {"request_ref": OTHER_REQUEST_REF}, id="request-ref"),
+        pytest.param("actor_type", {"actor_type": "jwt"}, id="actor-type"),
+        pytest.param("actor_ref", {"actor_ref": ACTOR_REF}, id="actor-ref"),
+        pytest.param("entity_id", {"entity_id": "17"}, id="entity-id"),
+        pytest.param("detail", {"detail": {"count": 2}}, id="detail"),
     ],
 )
 def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
@@ -248,7 +254,7 @@ def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
             seeded_event.request_ref,
             seeded_event.idempotency_key,
             seeded_event.status,
-            None,
+            json.dumps(seeded_event.detail) if seeded_event.detail is not None else None,
             seeded_event.created_at,
         ),
     )
@@ -568,6 +574,38 @@ def test_append_audit_event_validates_top_level_governance_fields(storage, event
         storage.append_audit_event(event)
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        pytest.param("actor_type", "person", id="actor-type"),
+        pytest.param("operation", "PURGE", id="operation"),
+        pytest.param("entity_type", "message", id="entity-type"),
+        pytest.param("status", "done", id="status"),
+    ],
+)
+def test_append_audit_event_rejects_invalid_top_level_enum_values(
+    storage, field_name, value
+):
+    event = AuditEvent.model_construct(
+        org_id="org1",
+        actor_type="system",
+        actor_ref=None,
+        operation="EXPORT",
+        entity_type="request",
+        entity_id=None,
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key=f"invalid_{field_name}",
+        status="ok",
+        detail=None,
+        created_at=1,
+    )
+    setattr(event, field_name, value)
+
+    with pytest.raises(ValueError, match=field_name):
+        storage.append_audit_event(event)
+
+
 def test_append_audit_event_requires_minimized_request_ref(storage):
     event = AuditEvent(
         org_id="org1",
@@ -600,6 +638,27 @@ def test_begin_purge_operation_validates_top_level_refs(
             scope_type="user",
             subject_ref=subject_ref,
             request_ref=request_ref,
+        )
+
+
+@pytest.mark.parametrize(
+    ("operation_type", "scope_type", "match"),
+    [
+        pytest.param(cast(Any, "erase_user"), "user", "operation_type", id="operation-type"),
+        pytest.param("user_erasure", cast(Any, "workspace"), "scope_type", id="scope-type"),
+    ],
+)
+def test_begin_purge_operation_rejects_invalid_enum_values(
+    storage, operation_type, scope_type, match
+):
+    with pytest.raises(ValueError, match=match):
+        storage.begin_purge_operation(
+            purge_id="purge_invalid_enum",
+            idempotency_key="idem_purge_invalid_enum",
+            operation_type=operation_type,
+            scope_type=scope_type,
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
         )
 
 
@@ -667,6 +726,29 @@ def test_record_purge_target_validates_target_ref_contract(storage, target_ref, 
             target_ref=target_ref,
             phase="delete",
             status="running",
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_name", "phase", "status", "match"),
+    [
+        pytest.param(cast(Any, "session"), "delete", "running", "target_name", id="target-name"),
+        pytest.param("request", cast(Any, "archive"), "running", "phase", id="phase"),
+        pytest.param("request", "delete", cast(Any, "done"), "status", id="status"),
+    ],
+)
+def test_record_purge_target_rejects_invalid_enum_values(
+    storage, target_name, phase, status, match
+):
+    purge_id = _begin_purge(storage, "purge_target_invalid_enum")
+
+    with pytest.raises(ValueError, match=match):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name=target_name,
+            target_ref="all",
+            phase=phase,
+            status=status,
         )
 
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1007,6 +1007,42 @@ def test_record_purge_target_rejects_invalid_deleted_count(storage, deleted_coun
         )
 
 
+@pytest.mark.parametrize("detail_deleted_count", [0, 2])
+def test_record_purge_target_accepts_nonnegative_detail_deleted_count(
+    storage, detail_deleted_count
+):
+    purge_id = _begin_purge(storage, f"purge_detail_deleted_count_{detail_deleted_count}")
+
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="request",
+        target_ref="all",
+        phase="delete",
+        status="complete",
+        detail={"deleted_count": detail_deleted_count},
+    )
+
+    target = next(
+        row for row in storage.list_purge_targets(purge_id, phase="delete")
+        if row.target_name == "request"
+    )
+    assert target.detail == {"deleted_count": detail_deleted_count}
+
+
+def test_record_purge_target_rejects_negative_detail_deleted_count(storage):
+    purge_id = _begin_purge(storage, "purge_detail_deleted_count_negative")
+
+    with pytest.raises(ValueError, match="deleted_count"):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref="all",
+            phase="delete",
+            status="complete",
+            detail={"deleted_count": -1},
+        )
+
+
 @pytest.mark.parametrize(
     ("detail", "match"),
     [
@@ -1040,6 +1076,39 @@ def test_append_audit_event_validates_governance_detail(storage, detail, match):
         return
 
     with pytest.raises(ValueError, match=match):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize("count", [0, 2])
+def test_append_audit_event_accepts_nonnegative_detail_count(storage, count):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key=f"export_detail_count_{count}",
+        detail={"count": count},
+    )
+
+    assert storage.append_audit_event(event) is True
+    rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
+    stored = next(row for row in rows if row.idempotency_key == event.idempotency_key)
+    assert stored.detail == {"count": count}
+
+
+def test_append_audit_event_rejects_negative_detail_count(storage):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_detail_count_negative",
+        detail={"count": -1},
+    )
+
+    with pytest.raises(ValueError, match="count"):
         storage.append_audit_event(event)
 
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -22,6 +22,9 @@ from reflexio.models.api_schema.domain.governance import (
 from reflexio.models.api_schema.retriever_schema import SearchAgentPlaybookRequest
 from reflexio.models.config_schema import GovernanceRetentionConfig
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage import (
+    _governance as governance_module,
+)
 from reflexio.server.services.storage.sqlite_storage._governance import (
     init_governance_tables,
 )
@@ -319,6 +322,50 @@ def test_audit_event_idempotency(storage):
     rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
     assert len(rows) == 1
     assert rows[0].idempotency_key == "export_1"
+
+
+def test_init_governance_tables_backfills_legacy_null_audit_request_ref(tmp_path):
+    db_path = tmp_path / "legacy-audit.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE audit_events (
+               event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+               org_id TEXT NOT NULL,
+               actor_type TEXT NOT NULL DEFAULT 'system',
+               actor_ref TEXT,
+               operation TEXT NOT NULL,
+               entity_type TEXT NOT NULL,
+               entity_id TEXT,
+               subject_ref TEXT,
+               request_ref TEXT,
+               idempotency_key TEXT,
+               status TEXT NOT NULL DEFAULT 'ok',
+               detail TEXT,
+               created_at INTEGER NOT NULL
+           )"""
+    )
+    conn.execute(
+        """INSERT INTO audit_events (
+               org_id, actor_type, operation, entity_type, subject_ref,
+               request_ref, status, created_at
+           ) VALUES (?, 'system', 'EXPORT', 'request', ?, NULL, 'ok', 1)""",
+        ("org1", SUBJECT_REF),
+    )
+    conn.commit()
+    conn.close()
+
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage = SQLiteStorage(org_id="org1", db_path=str(db_path))
+
+    events = storage.list_audit_events(subject_ref=SUBJECT_REF)
+    assert len(events) == 1
+    assert events[0].request_ref == "reqref_v1_legacy_unknown"
+    with pytest.raises(sqlite3.IntegrityError, match="request_ref"):
+        storage.conn.execute(
+            """INSERT INTO audit_events (
+                   org_id, actor_type, operation, entity_type, request_ref, status, created_at
+               ) VALUES ('org1', 'system', 'EXPORT', 'request', NULL, 'ok', 2)"""
+        )
 
 
 def test_append_audit_event_rejects_numeric_idempotency_key(storage):
@@ -784,6 +831,26 @@ def test_complete_purge_operation_requires_full_delete_target_matrix(storage):
     assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
 
 
+def test_complete_retry_replaces_failed_completed_at(storage):
+    purge_id = _begin_completeable_purge(storage, "purge_retry_completion_time")
+    with patch.object(governance_module, "_epoch_now", return_value=111):
+        failed = storage.fail_purge_operation(
+            purge_id,
+            error_code="governance_erase_failed",
+            error_detail="RuntimeError",
+        )
+    assert failed.completed_at == 111
+
+    with patch.object(governance_module, "_epoch_now", return_value=222):
+        completed = storage.complete_purge_operation_with_audit(
+            purge_id,
+            _erase_event(purge_id=purge_id),
+        )
+
+    assert completed.status == "complete"
+    assert completed.completed_at == 222
+
+
 def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
     storage.begin_purge_operation(
         purge_id="purge_detail",
@@ -810,6 +877,48 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
         "owned_user_playbook_ids": [7],
         "affected_agent_playbook_ids": [],
     }
+
+
+def test_apply_governance_user_data_delete_rejects_playbook_snapshot_drift(storage):
+    user_id = "user-snapshot-drift"
+    owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    storage.begin_purge_operation(
+        purge_id="purge_snapshot_drift",
+        idempotency_key="idem_purge_snapshot_drift",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id="purge_snapshot_drift",
+        user_id=user_id,
+    )
+    storage.conn.execute(
+        """INSERT INTO user_playbooks (
+               user_id, playbook_name, created_at, request_id, agent_version,
+               content, source_interaction_ids, embedding
+           ) VALUES (?, '', ?, ?, '', ?, '[]', '[]')""",
+        (
+            user_id,
+            "2026-01-01T00:00:00.000Z",
+            "request_seed",
+            "late-playbook-content",
+        ),
+    )
+    storage.conn.commit()
+
+    with pytest.raises(ValueError, match="prepared purge snapshot"):
+        storage.apply_governance_user_data_delete("purge_snapshot_drift", user_id)
+
+    remaining_ids = {
+        int(row["user_playbook_id"])
+        for row in storage.conn.execute(
+            "SELECT user_playbook_id FROM user_playbooks WHERE user_id = ?",
+            (user_id,),
+        ).fetchall()
+    }
+    assert owned_user_playbook_ids < remaining_ids
 
 
 def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storage):
@@ -2972,9 +3081,12 @@ def test_apply_governance_user_data_delete_rejects_unexpected_target_name_from_i
         )
 
     def _stub_clear_user_data_for_governance_locked(
-        self: SQLiteStorage, user_id: str
+        self: SQLiteStorage,
+        user_id: str,
+        *,
+        expected_user_playbook_ids: set[int] | None = None,
     ) -> dict[str, int]:
-        del self, user_id
+        del self, user_id, expected_user_playbook_ids
         return {"requests": 1, "surprise_target": 2}
 
     monkeypatch.setattr(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -225,6 +225,43 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
     assert len(storage.list_audit_events(subject_ref=SUBJECT_REF)) == 1
 
 
+def test_complete_purge_operation_with_audit_accepts_planned_success_detail(storage):
+    purge_id = _begin_purge(storage, "purge_success_detail")
+    deleted_counts = {
+        "interactions": 3,
+        "user_playbooks": 2,
+        "profiles": 1,
+        "requests": 1,
+        "purged_profiles": 0,
+        "purged_user_playbooks": 0,
+    }
+    rebuilt_ids = [17, 21]
+
+    complete = storage.complete_purge_operation_with_audit(
+        purge_id,
+        AuditEvent(
+            org_id="org1",
+            operation="ERASE",
+            entity_type="request",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+            idempotency_key=purge_id,
+            detail={
+                "deleted_counts": deleted_counts,
+                "rebuilt_agent_playbook_ids": rebuilt_ids,
+            },
+        ),
+    )
+
+    assert complete.status == "complete"
+    audit_rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
+    assert len(audit_rows) == 1
+    assert audit_rows[0].detail == {
+        "deleted_counts": deleted_counts,
+        "rebuilt_agent_playbook_ids": rebuilt_ids,
+    }
+
+
 @pytest.mark.parametrize(
     ("retry_kwargs", "match"),
     [

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -16,6 +16,41 @@ def storage(tmp_path):
         yield SQLiteStorage(org_id="org1", db_path=str(tmp_path / "g.db"))
 
 
+def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
+    purge = storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key=f"idem_{purge_id}",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref="subref_abc",
+        request_ref=f"reqref_{purge_id}",
+    )
+    storage.record_purge_target(
+        purge_id=purge.purge_id,
+        target_name="target_snapshot",
+        target_ref="all",
+        phase="prepare_targets",
+        status="complete",
+        detail={
+            "owned_user_playbook_ids": [11],
+            "affected_agent_playbook_ids": [22],
+        },
+    )
+    return purge.purge_id
+
+
+def _erase_event(*, purge_id: str, status: str = "ok", operation: str = "ERASE"):
+    return AuditEvent(
+        org_id="org1",
+        operation=operation,
+        entity_type="request",
+        subject_ref="subref_abc",
+        request_ref=f"reqref_{purge_id}",
+        idempotency_key=purge_id,
+        status=status,
+    )
+
+
 def test_audit_event_idempotency(storage):
     event = AuditEvent(
         org_id="org1",
@@ -68,46 +103,238 @@ def test_purge_targets_require_snapshot_marker(storage):
 
 
 def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
-    purge = storage.begin_purge_operation(
-        purge_id="purge_2",
-        idempotency_key="idem_2",
-        operation_type="user_erasure",
-        scope_type="user",
-        subject_ref="subref_abc",
-        request_ref="reqref_r2",
-    )
-    storage.record_purge_target(
-        purge_id=purge.purge_id,
-        target_name="target_snapshot",
-        target_ref="all",
-        phase="prepare_targets",
-        status="complete",
-    )
+    purge_id = _begin_purge(storage, "purge_2")
     complete = storage.complete_purge_operation_with_audit(
-        purge.purge_id,
-        AuditEvent(
-            org_id="org1",
-            operation="ERASE",
-            entity_type="request",
-            subject_ref="subref_abc",
-            request_ref="reqref_r2",
-            idempotency_key=purge.purge_id,
-        ),
+        purge_id,
+        _erase_event(purge_id=purge_id),
     )
 
     assert complete.status == "complete"
     rows = storage.list_audit_events(subject_ref="subref_abc")
     assert [row.operation for row in rows] == ["ERASE"]
     same = storage.complete_purge_operation_with_audit(
-        purge.purge_id,
-        AuditEvent(
-            org_id="org1",
-            operation="ERASE",
-            entity_type="request",
-            subject_ref="subref_abc",
-            request_ref="reqref_r2",
-            idempotency_key=purge.purge_id,
-        ),
+        purge_id,
+        _erase_event(purge_id=purge_id),
     )
     assert same.status == "complete"
     assert len(storage.list_audit_events(subject_ref="subref_abc")) == 1
+
+
+@pytest.mark.parametrize(
+    ("event", "match"),
+    [
+        pytest.param(
+            _erase_event(purge_id="purge_invalid", operation="EXPORT"),
+            "successful ERASE audit event",
+            id="wrong-operation",
+        ),
+        pytest.param(
+            _erase_event(purge_id="purge_invalid", status="error"),
+            "successful ERASE audit event",
+            id="wrong-status",
+        ),
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref="subref_abc",
+                request_ref="reqref_purge_invalid",
+                idempotency_key="different_key",
+                status="ok",
+            ),
+            "idempotency key",
+            id="wrong-idempotency-key",
+        ),
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref="subref_abc",
+                request_ref="reqref_purge_invalid",
+                idempotency_key=None,
+                status="ok",
+            ),
+            "idempotency key",
+            id="missing-idempotency-key",
+        ),
+    ],
+)
+def test_complete_purge_operation_rejects_invalid_audit_event(storage, event, match):
+    purge_id = _begin_purge(storage, "purge_invalid")
+
+    with pytest.raises(ValueError, match=match):
+        storage.complete_purge_operation_with_audit(purge_id, event)
+
+    assert storage.get_purge_operation(purge_id).status == "running"
+    assert storage.list_audit_events(subject_ref="subref_abc") == []
+
+
+@pytest.mark.parametrize(
+    ("seed_event", "match"),
+    [
+        pytest.param(
+            _erase_event(purge_id="purge_seeded", operation="EXPORT"),
+            "matching successful ERASE",
+            id="seeded-wrong-operation",
+        ),
+        pytest.param(
+            _erase_event(purge_id="purge_seeded", status="error"),
+            "matching successful ERASE",
+            id="seeded-wrong-status",
+        ),
+    ],
+)
+def test_complete_purge_operation_requires_matching_existing_erase_row(
+    storage, seed_event, match
+):
+    purge_id = _begin_purge(storage, "purge_seeded")
+    assert storage.append_audit_event(seed_event) is True
+
+    with pytest.raises(ValueError, match=match):
+        storage.complete_purge_operation_with_audit(
+            purge_id, _erase_event(purge_id=purge_id)
+        )
+
+    assert storage.get_purge_operation(purge_id).status == "running"
+    rows = storage.list_audit_events(subject_ref="subref_abc")
+    assert len(rows) == 1
+    assert rows[0].operation == seed_event.operation
+    assert rows[0].status == seed_event.status
+
+
+def test_append_audit_event_rejects_successful_erase(storage):
+    with pytest.raises(ValueError, match="Successful ERASE audit rows"):
+        storage.append_audit_event(_erase_event(purge_id="purge_append"))
+
+
+def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
+    storage.begin_purge_operation(
+        purge_id="purge_detail",
+        idempotency_key="idem_purge_detail",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref="subref_abc",
+        request_ref="reqref_purge_detail",
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id="purge_detail",
+        user_id="user_123@example.com",
+        owned_user_playbook_ids={7},
+    )
+
+    snapshot = next(
+        target
+        for target in storage.list_purge_targets("purge_detail", phase="prepare_targets")
+        if target.target_name == "target_snapshot"
+    )
+    assert snapshot.detail == {
+        "owned_user_playbook_ids": [7],
+        "affected_agent_playbook_ids": [],
+    }
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        pytest.param(
+            {
+                "detail": {"user_id": "user_123"},
+            },
+            "user_id",
+            id="target-detail-user-id",
+        ),
+        pytest.param(
+            {
+                "detail": {"prompt": "tell me the secret"},
+            },
+            "prompt",
+            id="target-detail-prompt",
+        ),
+        pytest.param(
+            {
+                "detail": {"agent_playbook_id": 7, "source_interaction_ids": [1, 2]},
+            },
+            None,
+            id="target-detail-allowed-internal-ids",
+        ),
+        pytest.param(
+            {
+                "error_detail": "Request reqref_123 failed for bob@example.com",
+            },
+            "error_detail",
+            id="error-detail-request-email",
+        ),
+        pytest.param(
+            {
+                "error_detail": "ValueError: prompt leaked from upstream",
+            },
+            "error_detail",
+            id="error-detail-raw-exception",
+        ),
+    ],
+)
+def test_record_purge_target_validates_governance_fields(storage, kwargs, match):
+    purge_id = _begin_purge(storage, "purge_record")
+    params = {
+        "purge_id": purge_id,
+        "target_name": "request",
+        "phase": "delete",
+        "status": "running",
+        "target_ref": "all",
+    }
+    params.update(kwargs)
+
+    if match is None:
+        storage.record_purge_target(**params)
+        target = next(
+            row for row in storage.list_purge_targets(purge_id, phase="delete")
+            if row.target_name == "request"
+        )
+        assert target.detail == kwargs["detail"]
+        return
+
+    with pytest.raises(ValueError, match=match):
+        storage.record_purge_target(**params)
+
+
+@pytest.mark.parametrize(
+    ("detail", "match"),
+    [
+        pytest.param({"email": "bob@example.com"}, "email", id="audit-detail-email"),
+        pytest.param({"request_id": "reqref_123"}, "request_id", id="audit-detail-request-id"),
+        pytest.param({"content": "verbatim prompt"}, "content", id="audit-detail-content"),
+        pytest.param({"agent_playbook_id": 7, "source_interaction_ids": [1]}, None, id="audit-detail-allowed-internal-ids"),
+    ],
+)
+def test_append_audit_event_validates_governance_detail(storage, detail, match):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref="subref_abc",
+        request_ref="reqref_safe",
+        idempotency_key=f"export_{hash(str(detail))}",
+        detail=detail,
+    )
+
+    if match is None:
+        assert storage.append_audit_event(event) is True
+        return
+
+    with pytest.raises(ValueError, match=match):
+        storage.append_audit_event(event)
+
+
+def test_fail_purge_operation_rejects_raw_error_detail(storage):
+    purge_id = _begin_purge(storage, "purge_fail")
+
+    with pytest.raises(ValueError, match="error_detail"):
+        storage.fail_purge_operation(
+            purge_id,
+            error_code="boom",
+            error_detail="RuntimeError: request reqref_123 for alice@example.com",
+        )
+
+    assert storage.get_purge_operation(purge_id).error_detail is None

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -255,6 +255,39 @@ def test_append_audit_event_rejects_mismatched_org_id(storage):
     assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
 
 
+def test_list_audit_events_rejects_cross_org_override(storage_factory):
+    storage_org1 = storage_factory("org1")
+    storage_org2 = storage_factory("org2")
+
+    org1_event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="audit_scope_org1",
+        detail={"count": 1},
+    )
+    org2_event = AuditEvent(
+        org_id="org2",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=OTHER_SUBJECT_REF,
+        request_ref=OTHER_REQUEST_REF,
+        idempotency_key="audit_scope_org2",
+        detail={"count": 2},
+    )
+
+    assert storage_org1.append_audit_event(org1_event) is True
+    assert storage_org2.append_audit_event(org2_event) is True
+
+    org1_rows = storage_org1.list_audit_events()
+
+    assert [row.idempotency_key for row in org1_rows] == ["audit_scope_org1"]
+    with pytest.raises(ValueError, match="org_id"):
+        storage_org1.list_audit_events(org_id="org2")
+
+
 def test_purge_targets_require_snapshot_marker(storage):
     purge = storage.begin_purge_operation(
         purge_id="purge_1",
@@ -1052,11 +1085,36 @@ def test_record_purge_target_rejects_negative_detail_deleted_count(storage):
         pytest.param({"note": "arbitrary string"}, "note", id="audit-detail-neutral-note"),
         pytest.param({"status": "prompt-ready"}, "prompt/content", id="audit-detail-promptish-string"),
         pytest.param(
-            {"remaining_source_windows": [{"user_playbook_id": 7, "source_interaction_ids": [1]}]},
-            None,
-            id="audit-detail-allowed-window-shape",
+            {"owned_user_playbook_ids": [7]},
+            "owned_user_playbook_ids",
+            id="audit-detail-rejects-owned-user-playbook-ids",
         ),
-        pytest.param({"agent_playbook_id": 7, "source_interaction_ids": [1]}, None, id="audit-detail-allowed-internal-ids"),
+        pytest.param(
+            {"source_interaction_ids": [1]},
+            "source_interaction_ids",
+            id="audit-detail-rejects-source-interaction-ids",
+        ),
+        pytest.param(
+            {"original_source_windows": [{"user_playbook_id": 7, "source_interaction_ids": [1]}]},
+            "original_source_windows",
+            id="audit-detail-rejects-original-source-windows",
+        ),
+        pytest.param(
+            {"remaining_source_windows": [{"user_playbook_id": 7, "source_interaction_ids": [1]}]},
+            "remaining_source_windows",
+            id="audit-detail-rejects-remaining-source-windows",
+        ),
+        pytest.param({"count": 2}, None, id="audit-detail-allowed-count"),
+        pytest.param({"deleted_count": 1}, None, id="audit-detail-allowed-deleted-count"),
+        pytest.param({"deleted_counts": {"requests": 1}}, None, id="audit-detail-allowed-deleted-counts"),
+        pytest.param({"agent_playbook_id": 7}, None, id="audit-detail-allowed-agent-playbook-id"),
+        pytest.param(
+            {"rebuilt_agent_playbook_ids": [7, 8]},
+            None,
+            id="audit-detail-allowed-rebuilt-agent-playbook-ids",
+        ),
+        pytest.param({"status": "ok"}, None, id="audit-detail-allowed-status"),
+        pytest.param({"route": "delete"}, None, id="audit-detail-allowed-route"),
     ],
 )
 def test_append_audit_event_validates_governance_detail(storage, detail, match):
@@ -1077,6 +1135,36 @@ def test_append_audit_event_validates_governance_detail(storage, detail, match):
 
     with pytest.raises(ValueError, match=match):
         storage.append_audit_event(event)
+
+
+def test_record_purge_target_accepts_target_detail_shapes(storage):
+    purge_id = _begin_purge(storage, "purge_target_detail_shapes")
+
+    detail = {
+        "owned_user_playbook_ids": [7],
+        "source_interaction_ids": [11, 12],
+        "original_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [11, 12]}
+        ],
+        "remaining_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [12]}
+        ],
+    }
+
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref="7",
+        phase="rebuild_without_erased_sources",
+        status="complete",
+        detail=detail,
+    )
+
+    targets = storage.list_purge_targets(
+        purge_id, phase="rebuild_without_erased_sources"
+    )
+    stored = next(target for target in targets if target.target_ref == "7")
+    assert stored.detail == detail
 
 
 @pytest.mark.parametrize("count", [0, 2])
@@ -1377,7 +1465,7 @@ def test_append_audit_event_rejects_mixed_case_window_keys(storage, detail_key):
         detail={detail_key: [{"User_Playbook_Id": "alice@example.com"}]},
     )
 
-    with pytest.raises(ValueError, match="user_playbook_id"):
+    with pytest.raises(ValueError, match=detail_key):
         storage.append_audit_event(event)
 
 
@@ -1408,7 +1496,7 @@ def test_append_audit_event_requires_window_user_playbook_id(storage, detail_key
         detail={detail_key: [{"source_interaction_ids": [1, 2]}]},
     )
 
-    with pytest.raises(ValueError, match="user_playbook_id"):
+    with pytest.raises(ValueError, match=detail_key):
         storage.append_audit_event(event)
 
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -19,6 +19,7 @@ from reflexio.models.api_schema.domain.governance import (
     AuditStatus,
 )
 from reflexio.models.api_schema.retriever_schema import SearchAgentPlaybookRequest
+from reflexio.models.config_schema import GovernanceRetentionConfig
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.sqlite_storage._governance import (
     init_governance_tables,
@@ -3136,6 +3137,16 @@ def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
             )
         ],
     )
+    storage.conn.execute(
+        """INSERT INTO lineage_event (
+               org_id, entity_type, entity_id, op, prov_relation, source_ids,
+               actor, request_id, reason, created_at
+           )
+           VALUES (?, 'agent_playbook', 'agent_survivor', 'merge', 'wasDerivedFrom',
+                   ?, 'test', 'req-unrelated', 'source-user-playbook', 1)""",
+        (storage.org_id, json.dumps([str(affected_user_playbook_id)])),
+    )
+    storage.conn.commit()
     storage.prepare_governance_erase_targets(
         purge_id=purge_id,
         user_id=user_id,
@@ -3175,9 +3186,34 @@ def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
         storage.conn.execute(
             """SELECT COUNT(*)
            FROM user_playbooks
-           WHERE merged_into IS NOT NULL AND content = '' AND user_id IS NULL"""
+           WHERE merged_into IS NOT NULL
+             AND content = ''
+             AND user_id IS NULL
+             AND request_id = ''"""
         ).fetchone()[0]
         == 1
+    )
+    assert (
+        storage.conn.execute(
+            """SELECT COUNT(*)
+               FROM lineage_event
+               WHERE org_id = ?
+                 AND (
+                    request_id = ?
+                    OR entity_id IN (?, ?, ?, ?)
+                    OR source_ids = ?
+                 )""",
+            (
+                storage.org_id,
+                "req-delete-hide-complete",
+                "req-delete-hide-complete",
+                "101",
+                "profile_seed",
+                str(affected_user_playbook_id),
+                json.dumps([str(affected_user_playbook_id)]),
+            ),
+        ).fetchone()[0]
+        == 0
     )
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
     assert {target.target_name: target.deleted_count for target in delete_targets} == {
@@ -4063,5 +4099,67 @@ def test_init_governance_tables_skips_ambiguous_legacy_purge_target_rows(tmp_pat
     ]
 
 
-def test_gc_governance_retention_accepts_config_keyword(storage):
-    assert storage.gc_governance_retention(config=object()) == 0
+def test_gc_governance_retention_deletes_expired_audit_rows_in_batches(storage):
+    old_event = AuditEvent(
+        org_id=storage.org_id,
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="audit_old",
+        created_at=1,
+    )
+    newer_event = AuditEvent(
+        org_id=storage.org_id,
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="audit_new",
+    )
+    other_org_event = AuditEvent(
+        org_id="org2",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="audit_other",
+        created_at=1,
+    )
+    storage.append_audit_event(old_event)
+    storage.append_audit_event(newer_event)
+    other_storage = SQLiteStorage(org_id="org2", db_path=storage.db_path)
+    other_storage.append_audit_event(other_org_event)
+
+    deleted = storage.gc_governance_retention(
+        config=GovernanceRetentionConfig(
+            audit_events_retention_enabled=True,
+            audit_events_retention_days=1,
+            audit_events_delete_batch_limit=1,
+        )
+    )
+
+    assert deleted == 1
+    assert [event.idempotency_key for event in storage.list_audit_events()] == [
+        "audit_new"
+    ]
+    assert [event.idempotency_key for event in other_storage.list_audit_events()] == [
+        "audit_other"
+    ]
+
+
+def test_gc_governance_retention_noops_when_audit_retention_disabled(storage):
+    storage.append_audit_event(
+        AuditEvent(
+            org_id=storage.org_id,
+            operation="EXPORT",
+            entity_type="request",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+            idempotency_key="audit_disabled",
+            created_at=1,
+        )
+    )
+
+    assert storage.gc_governance_retention(config=GovernanceRetentionConfig()) == 0
+    assert len(storage.list_audit_events()) == 1

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -143,6 +143,22 @@ def test_audit_event_idempotency(storage):
     assert rows[0].idempotency_key == "export_1"
 
 
+def test_append_audit_event_rejects_mismatched_org_id(storage):
+    event = AuditEvent(
+        org_id="org2",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_wrong_org",
+    )
+
+    with pytest.raises(ValueError, match="org_id"):
+        storage.append_audit_event(event)
+
+    assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
+
+
 def test_purge_targets_require_snapshot_marker(storage):
     purge = storage.begin_purge_operation(
         purge_id="purge_1",
@@ -449,6 +465,28 @@ def test_record_purge_target_validates_governance_fields(storage, kwargs, match)
 
     with pytest.raises(ValueError, match=match):
         storage.record_purge_target(**params)
+
+
+@pytest.mark.parametrize(
+    ("deleted_count", "match"),
+    [
+        pytest.param(cast(Any, True), "deleted_count", id="bool"),
+        pytest.param(cast(Any, 1.5), "deleted_count", id="float"),
+        pytest.param(-1, "deleted_count", id="negative"),
+    ],
+)
+def test_record_purge_target_rejects_invalid_deleted_count(storage, deleted_count, match):
+    purge_id = _begin_purge(storage, "purge_deleted_count")
+
+    with pytest.raises(ValueError, match=match):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref="all",
+            phase="delete",
+            status="complete",
+            deleted_count=deleted_count,
+        )
 
 
 @pytest.mark.parametrize(
@@ -923,6 +961,31 @@ def test_apply_governance_user_data_delete_rejects_unsafe_purge_id_before_side_e
         "profiles": 1,
         "user_playbooks": 1,
     }
+
+
+def test_apply_governance_user_data_delete_rejects_unexpected_target_name_from_internal_counts(
+    storage, monkeypatch
+):
+    purge_id = _begin_purge(storage, "purge_internal_target_name")
+
+    def _stub_clear_user_data(self: SQLiteStorage, user_id: str) -> dict[str, int]:
+        del self, user_id
+        return {"requests": 1, "surprise_target": 2}
+
+    monkeypatch.setattr(
+        SQLiteStorage,
+        "clear_user_data",
+        _stub_clear_user_data,
+    )
+
+    with pytest.raises(ValueError, match="target_name"):
+        storage.apply_governance_user_data_delete(
+            purge_id=purge_id,
+            user_id="user-delete-seed",
+        )
+
+    delete_targets = storage.list_purge_targets(purge_id, phase="delete")
+    assert all(target.target_name != "surprise_target" for target in delete_targets)
 
 
 def test_apply_governance_agent_playbook_rebuild_rejects_unsafe_purge_id_before_side_effects(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -107,20 +107,26 @@ def _seed_user_scoped_rows(storage: SQLiteStorage, *, user_id: str) -> None:
     storage.conn.commit()
 
 
-def _seed_agent_playbook(storage: SQLiteStorage) -> int:
+def _seed_agent_playbook(
+    storage: SQLiteStorage,
+    *,
+    status: Status | None = Status.ARCHIVED,
+    source_windows: list[AgentPlaybookSourceWindow] | None = None,
+) -> int:
     playbook = AgentPlaybook(
         playbook_name="governance-rebuild",
         agent_version="test-agent",
         content="original content",
         trigger="original trigger",
         rationale="original rationale",
-        status=Status.ARCHIVED,
+        status=status,
         tags=["seed"],
     )
     saved = storage.save_agent_playbooks([playbook])[0]
     storage.set_source_windows_for_agent_playbook(
         saved.agent_playbook_id,
-        [AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])],
+        source_windows
+        or [AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])],
     )
     return saved.agent_playbook_id
 
@@ -409,6 +415,161 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
         "owned_user_playbook_ids": [7],
         "affected_agent_playbook_ids": [],
     }
+
+
+def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storage):
+    storage.begin_purge_operation(
+        purge_id="purge_rebuild_windows",
+        idempotency_key="idem_purge_rebuild_windows",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101, 102]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+
+    storage.prepare_governance_erase_targets(
+        purge_id="purge_rebuild_windows",
+        user_id="user-rebuild-windows",
+        owned_user_playbook_ids={7},
+    )
+
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            "purge_rebuild_windows", phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "pending"
+    assert rebuild_target.detail == {
+        "original_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [101, 102]},
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        "remaining_source_windows": [
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+    }
+
+
+def test_hide_governance_agent_playbooks_for_rebuild_sets_archive_in_progress_and_hide_marker(
+    storage,
+):
+    purge_id = "purge_hide_rebuild"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_hide_rebuild",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=None,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id="user-hide-rebuild",
+        owned_user_playbook_ids={7},
+    )
+
+    hidden_ids = storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+    assert hidden_ids == [agent_playbook_id]
+    status = storage.conn.execute(
+        "SELECT status FROM agent_playbooks WHERE agent_playbook_id = ?",
+        (agent_playbook_id,),
+    ).fetchone()[0]
+    assert status == Status.ARCHIVE_IN_PROGRESS.value
+    hide_target = next(
+        target
+        for target in storage.list_purge_targets(purge_id, phase="hide_for_rebuild")
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert hide_target.status == "complete"
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "running"
+
+
+def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage):
+    purge_id = "purge_rebuild_complete"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_complete",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            "remaining_source_windows": [
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+        },
+    )
+
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "complete"
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -13,6 +13,12 @@ from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
 
+SUBJECT_REF = "subref_v1_" + "a" * 32
+OTHER_SUBJECT_REF = "subref_v1_" + "c" * 32
+REQUEST_REF = "reqref_v1_" + "b" * 32
+OTHER_REQUEST_REF = "reqref_v1_" + "d" * 32
+ACTOR_REF = "actref_v1_" + "e" * 32
+
 
 @pytest.fixture
 def storage(tmp_path):
@@ -26,8 +32,8 @@ def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
         idempotency_key=f"idem_{purge_id}",
         operation_type="user_erasure",
         scope_type="user",
-        subject_ref="subref_v1_abc",
-        request_ref=f"reqref_v1_{purge_id}",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
     )
     storage.record_purge_target(
         purge_id=purge.purge_id,
@@ -53,8 +59,8 @@ def _erase_event(
         org_id="org1",
         operation=operation,
         entity_type="request",
-        subject_ref="subref_v1_abc",
-        request_ref=f"reqref_v1_{purge_id}",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
         idempotency_key=purge_id,
         status=status,
     )
@@ -65,15 +71,15 @@ def test_audit_event_idempotency(storage):
         org_id="org1",
         operation="EXPORT",
         entity_type="request",
-        subject_ref="subref_v1_abc",
-        request_ref="reqref_v1_r1",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
         idempotency_key="export_1",
         detail={"count": 1},
     )
 
     assert storage.append_audit_event(event) is True
     assert storage.append_audit_event(event) is False
-    rows = storage.list_audit_events(subject_ref="subref_v1_abc")
+    rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
     assert len(rows) == 1
     assert rows[0].idempotency_key == "export_1"
 
@@ -84,13 +90,13 @@ def test_purge_targets_require_snapshot_marker(storage):
         idempotency_key="idem_1",
         operation_type="user_erasure",
         scope_type="user",
-        subject_ref="subref_v1_abc",
-        request_ref="reqref_v1_r1",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
     )
     storage.record_purge_target(
         purge_id=purge.purge_id,
         target_name="request",
-        target_ref="reqref_v1_r1",
+        target_ref=REQUEST_REF,
         phase="delete",
         status="complete",
         deleted_count=1,
@@ -104,8 +110,8 @@ def test_purge_targets_require_snapshot_marker(storage):
                 org_id="org1",
                 operation="ERASE",
                 entity_type="request",
-                subject_ref="subref_v1_abc",
-                request_ref="reqref_v1_r1",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
                 idempotency_key=purge.purge_id,
             ),
         )
@@ -119,14 +125,14 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
     )
 
     assert complete.status == "complete"
-    rows = storage.list_audit_events(subject_ref="subref_v1_abc")
+    rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
     assert [row.operation for row in rows] == ["ERASE"]
     same = storage.complete_purge_operation_with_audit(
         purge_id,
         _erase_event(purge_id=purge_id),
     )
     assert same.status == "complete"
-    assert len(storage.list_audit_events(subject_ref="subref_v1_abc")) == 1
+    assert len(storage.list_audit_events(subject_ref=SUBJECT_REF)) == 1
 
 
 @pytest.mark.parametrize(
@@ -147,8 +153,8 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
                 org_id="org1",
                 operation="ERASE",
                 entity_type="request",
-                subject_ref="subref_v1_abc",
-                request_ref="reqref_v1_purge_invalid",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
                 idempotency_key="different_key",
                 status="ok",
             ),
@@ -160,8 +166,8 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
                 org_id="org1",
                 operation="ERASE",
                 entity_type="request",
-                subject_ref="subref_v1_abc",
-                request_ref="reqref_v1_purge_invalid",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
                 idempotency_key=None,
                 status="ok",
             ),
@@ -177,7 +183,7 @@ def test_complete_purge_operation_rejects_invalid_audit_event(storage, event, ma
         storage.complete_purge_operation_with_audit(purge_id, event)
 
     assert storage.get_purge_operation(purge_id).status == "running"
-    assert storage.list_audit_events(subject_ref="subref_v1_abc") == []
+    assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
 
 
 @pytest.mark.parametrize(
@@ -207,7 +213,7 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
         )
 
     assert storage.get_purge_operation(purge_id).status == "running"
-    rows = storage.list_audit_events(subject_ref="subref_v1_abc")
+    rows = storage.list_audit_events(subject_ref=SUBJECT_REF)
     assert len(rows) == 1
     assert rows[0].operation == seed_event.operation
     assert rows[0].status == seed_event.status
@@ -217,8 +223,8 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
     ("field_name", "seed_kwargs"),
     [
         pytest.param("entity_type", {"entity_type": "session"}, id="entity-type"),
-        pytest.param("subject_ref", {"subject_ref": "subref_v1_other"}, id="subject-ref"),
-        pytest.param("request_ref", {"request_ref": "reqref_v1_other"}, id="request-ref"),
+        pytest.param("subject_ref", {"subject_ref": OTHER_SUBJECT_REF}, id="subject-ref"),
+        pytest.param("request_ref", {"request_ref": OTHER_REQUEST_REF}, id="request-ref"),
     ],
 )
 def test_complete_purge_operation_rejects_mismatched_existing_erase_row(
@@ -270,8 +276,8 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
         idempotency_key="idem_purge_detail",
         operation_type="user_erasure",
         scope_type="user",
-        subject_ref="subref_v1_abc",
-        request_ref="reqref_v1_purge_detail",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
     )
     storage.prepare_governance_erase_targets(
         purge_id="purge_detail",
@@ -399,13 +405,14 @@ def test_record_purge_target_validates_governance_fields(storage, kwargs, match)
     ],
 )
 def test_append_audit_event_validates_governance_detail(storage, detail, match):
+    detail_key = next(iter(detail))
     event = AuditEvent(
         org_id="org1",
         operation="EXPORT",
         entity_type="request",
-        subject_ref="subref_v1_abc",
-        request_ref="reqref_v1_safe",
-        idempotency_key=f"export_{hash(str(detail))}",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key=f"export_detail_{detail_key}",
         detail=detail,
     )
 
@@ -494,11 +501,11 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
         pytest.param(
             AuditEvent(
                 org_id="org1",
-                actor_ref="token-name",
+                actor_ref=ACTOR_REF[:-1],
                 operation="EXPORT",
                 entity_type="request",
-                subject_ref="subref_v1_abc",
-                request_ref="reqref_v1_top_level",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
                 idempotency_key="top_level_actor",
             ),
             "actor_ref",
@@ -510,7 +517,7 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
                 operation="EXPORT",
                 entity_type="request",
                 subject_ref="user@example.com",
-                request_ref="reqref_v1_top_level",
+                request_ref=REQUEST_REF,
                 idempotency_key="top_level_subject",
             ),
             "subject_ref",
@@ -521,7 +528,7 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
                 org_id="org1",
                 operation="EXPORT",
                 entity_type="request",
-                subject_ref="subref_v1_abc",
+                subject_ref=SUBJECT_REF,
                 request_ref="request_12345",
                 idempotency_key="top_level_request",
             ),
@@ -534,8 +541,8 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
                 operation="EXPORT",
                 entity_type="request",
                 entity_id="alice@example.com",
-                subject_ref="subref_v1_abc",
-                request_ref="reqref_v1_top_level",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
                 idempotency_key="top_level_entity_email",
             ),
             "entity_id",
@@ -547,8 +554,8 @@ def test_fail_purge_operation_validates_error_code(storage, error_code, match):
                 operation="EXPORT",
                 entity_type="request",
                 entity_id="api-token-name",
-                subject_ref="subref_v1_abc",
-                request_ref="reqref_v1_top_level",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
                 idempotency_key="top_level_entity_token",
             ),
             "entity_id",
@@ -566,7 +573,7 @@ def test_append_audit_event_requires_minimized_request_ref(storage):
         org_id="org1",
         operation="EXPORT",
         entity_type="request",
-        subject_ref="subref_v1_abc",
+        subject_ref=SUBJECT_REF,
         request_ref=None,
         idempotency_key="missing_request_ref",
     )
@@ -578,8 +585,8 @@ def test_append_audit_event_requires_minimized_request_ref(storage):
 @pytest.mark.parametrize(
     ("subject_ref", "request_ref", "match"),
     [
-        pytest.param("subref_v1_abc", "request_12345", "request_ref", id="purge-request-ref"),
-        pytest.param("raw-user-id", "reqref_v1_purge", "subject_ref", id="purge-subject-ref"),
+        pytest.param(SUBJECT_REF, "request_12345", "request_ref", id="purge-request-ref"),
+        pytest.param("raw-user-id", REQUEST_REF, "subject_ref", id="purge-subject-ref"),
     ],
 )
 def test_begin_purge_operation_validates_top_level_refs(
@@ -602,8 +609,8 @@ def test_append_audit_event_rejects_mixed_case_window_keys(storage, detail_key):
         org_id="org1",
         operation="EXPORT",
         entity_type="request",
-        subject_ref="subref_v1_abc",
-        request_ref="reqref_v1_mixed_case",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
         idempotency_key=f"mixed_case_{detail_key}",
         detail={detail_key: [{"User_Playbook_Id": "alice@example.com"}]},
     )
@@ -632,8 +639,8 @@ def test_record_purge_target_rejects_mixed_case_window_keys(storage, detail_key)
     [
         pytest.param("all", None, id="marker-all"),
         pytest.param("17", None, id="internal-numeric-id"),
-        pytest.param("reqref_v1_target", None, id="minimized-request-ref"),
-        pytest.param("subref_v1_target", None, id="minimized-subject-ref"),
+        pytest.param(REQUEST_REF, None, id="minimized-request-ref"),
+        pytest.param(SUBJECT_REF, None, id="minimized-subject-ref"),
         pytest.param("", None, id="empty-default"),
         pytest.param("alice@example.com", "target_ref", id="raw-email"),
         pytest.param("request_12345", "target_ref", id="raw-request-id"),
@@ -661,3 +668,83 @@ def test_record_purge_target_validates_target_ref_contract(storage, target_ref, 
             phase="delete",
             status="running",
         )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        pytest.param("subject_ref", "subref_v1_alice@example.com", id="subject-email"),
+        pytest.param("request_ref", "reqref_v1_request_123", id="request-like"),
+        pytest.param("request_ref", "reqref_v1_target", id="request-placeholder"),
+    ],
+)
+def test_append_audit_event_rejects_prefix_only_refs(storage, field_name, value):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_2",
+    ).model_copy(update={field_name: value})
+
+    with pytest.raises(ValueError, match=field_name):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize(
+    "idempotency_key",
+    ["alice@example.com", "request_123", "reqref_v1_target", "alice"],
+)
+def test_governance_persistence_rejects_unsafe_idempotency_keys(storage, idempotency_key):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key=idempotency_key,
+    )
+    with pytest.raises(ValueError, match="idempotency_key"):
+        storage.append_audit_event(event)
+
+    with pytest.raises(ValueError, match="idempotency_key"):
+        storage.begin_purge_operation(
+            purge_id="purge_unsafe_idem",
+            idempotency_key=idempotency_key,
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+        )
+
+
+def test_append_audit_event_rejects_user_like_entity_id(storage):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        entity_id="alice",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_3",
+    )
+
+    with pytest.raises(ValueError, match="entity_id"):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize("detail", [{"status": "alice"}, {"route": "alice"}])
+def test_governance_detail_rejects_user_like_status_and_route(storage, detail):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+        idempotency_key="export_4",
+        detail=detail,
+    )
+
+    with pytest.raises(ValueError, match="status|route"):
+        storage.append_audit_event(event)

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import Any, cast
+from typing import Any, Literal, cast
 from unittest.mock import patch
 
 import pytest
@@ -17,6 +17,7 @@ from reflexio.models.api_schema.domain.governance import (
     AuditOperation,
     AuditStatus,
 )
+from reflexio.models.api_schema.retriever_schema import SearchAgentPlaybookRequest
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.sqlite_storage._governance import (
     init_governance_tables,
@@ -143,6 +144,27 @@ def _seed_user_scoped_rows(storage: SQLiteStorage, *, user_id: str) -> None:
         (user_id, created_at, "request_seed", "playbook-content"),
     )
     storage.conn.commit()
+
+
+def _user_scoped_row_counts(storage: SQLiteStorage, *, user_id: str) -> dict[str, int]:
+    return {
+        "requests": storage.conn.execute(
+            "SELECT COUNT(*) FROM requests WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+        "interactions": storage.conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+        "profiles": storage.conn.execute(
+            "SELECT COUNT(*) FROM profiles WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+        "user_playbooks": storage.conn.execute(
+            "SELECT COUNT(*) FROM user_playbooks WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+    }
 
 
 def _seed_prepare_counts_user_data(storage: SQLiteStorage, *, user_id: str) -> set[int]:
@@ -2033,24 +2055,7 @@ def test_apply_governance_user_data_delete_rejects_unsafe_purge_id_before_side_e
             user_id=user_id,
         )
 
-    remaining = {
-        "requests": storage.conn.execute(
-            "SELECT COUNT(*) FROM requests WHERE user_id = ?",
-            (user_id,),
-        ).fetchone()[0],
-        "interactions": storage.conn.execute(
-            "SELECT COUNT(*) FROM interactions WHERE user_id = ?",
-            (user_id,),
-        ).fetchone()[0],
-        "profiles": storage.conn.execute(
-            "SELECT COUNT(*) FROM profiles WHERE user_id = ?",
-            (user_id,),
-        ).fetchone()[0],
-        "user_playbooks": storage.conn.execute(
-            "SELECT COUNT(*) FROM user_playbooks WHERE user_id = ?",
-            (user_id,),
-        ).fetchone()[0],
-    }
+    remaining = _user_scoped_row_counts(storage, user_id=user_id)
     assert remaining == {
         "requests": 1,
         "interactions": 1,
@@ -2073,14 +2078,16 @@ def test_apply_governance_user_data_delete_rejects_unexpected_target_name_from_i
             detail={"count": 0},
         )
 
-    def _stub_clear_user_data(self: SQLiteStorage, user_id: str) -> dict[str, int]:
+    def _stub_clear_user_data_for_governance_locked(
+        self: SQLiteStorage, user_id: str
+    ) -> dict[str, int]:
         del self, user_id
         return {"requests": 1, "surprise_target": 2}
 
     monkeypatch.setattr(
         SQLiteStorage,
-        "clear_user_data",
-        _stub_clear_user_data,
+        "_clear_user_data_for_governance_locked",
+        _stub_clear_user_data_for_governance_locked,
     )
 
     with pytest.raises(ValueError, match="target_name"):
@@ -2139,6 +2146,236 @@ def test_apply_governance_user_data_delete_requires_complete_prepared_delete_mat
     } == {
         ("request", "pending"),
         ("interaction", "complete"),
+    }
+
+
+def test_apply_governance_user_data_delete_requires_hide_targets_for_planned_rebuilds(
+    storage,
+):
+    purge_id = "purge_delete_requires_hide"
+    user_id = "user-delete-hide-required"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_delete_requires_hide",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    affected_user_playbook_id = min(owned_user_playbook_ids)
+    _seed_agent_playbook(
+        storage,
+        status=None,
+        source_windows=[
+            AgentPlaybookSourceWindow(
+                user_playbook_id=affected_user_playbook_id,
+                source_interaction_ids=[101],
+            )
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id=user_id,
+        owned_user_playbook_ids=owned_user_playbook_ids,
+    )
+
+    with pytest.raises(ValueError, match="hide_for_rebuild"):
+        storage.apply_governance_user_data_delete(
+            purge_id=purge_id,
+            user_id=user_id,
+        )
+
+    assert _user_scoped_row_counts(storage, user_id=user_id) == {
+        "requests": 1,
+        "interactions": 1,
+        "profiles": 2,
+        "user_playbooks": 2,
+    }
+    delete_targets = storage.list_purge_targets(purge_id, phase="delete")
+    assert {(target.target_name, target.status) for target in delete_targets} == {
+        (target_name, "pending") for target_name in CANONICAL_DELETE_TARGET_NAMES
+    }
+
+
+def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
+    storage,
+):
+    purge_id = "purge_delete_after_hide"
+    user_id = "user-delete-hide-complete"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_delete_after_hide",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    affected_user_playbook_id = min(owned_user_playbook_ids)
+    _seed_agent_playbook(
+        storage,
+        status=None,
+        source_windows=[
+            AgentPlaybookSourceWindow(
+                user_playbook_id=affected_user_playbook_id,
+                source_interaction_ids=[101],
+            )
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id=user_id,
+        owned_user_playbook_ids=owned_user_playbook_ids,
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+    counts = storage.apply_governance_user_data_delete(
+        purge_id=purge_id,
+        user_id=user_id,
+    )
+
+    assert counts == {
+        "interactions": 1,
+        "user_playbooks": 1,
+        "profiles": 1,
+        "requests": 1,
+        "purged_profiles": 1,
+        "purged_user_playbooks": 1,
+    }
+    assert _user_scoped_row_counts(storage, user_id=user_id) == {
+        "requests": 0,
+        "interactions": 0,
+        "profiles": 0,
+        "user_playbooks": 0,
+    }
+    assert storage.conn.execute(
+        """SELECT COUNT(*)
+           FROM profiles
+           WHERE merged_into IS NOT NULL AND content = '' AND user_id = ''"""
+    ).fetchone()[0] == 1
+    assert storage.conn.execute(
+        """SELECT COUNT(*)
+           FROM user_playbooks
+           WHERE merged_into IS NOT NULL AND content = '' AND user_id IS NULL"""
+    ).fetchone()[0] == 1
+    delete_targets = storage.list_purge_targets(purge_id, phase="delete")
+    assert {target.target_name: target.deleted_count for target in delete_targets} == {
+        "request": 1,
+        "interaction": 1,
+        "profile": 1,
+        "user_playbook": 1,
+        "profile_purge": 1,
+        "user_playbook_purge": 1,
+    }
+    assert all(target.status == "complete" for target in delete_targets)
+
+
+def test_apply_governance_user_data_delete_is_failure_atomic(
+    storage, monkeypatch
+):
+    purge_id = "purge_delete_atomic"
+    user_id = "user-delete-atomic"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_delete_atomic",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
+    affected_user_playbook_id = min(owned_user_playbook_ids)
+    _seed_agent_playbook(
+        storage,
+        status=None,
+        source_windows=[
+            AgentPlaybookSourceWindow(
+                user_playbook_id=affected_user_playbook_id,
+                source_interaction_ids=[101],
+            )
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id=user_id,
+        owned_user_playbook_ids=owned_user_playbook_ids,
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+    before_counts = _user_scoped_row_counts(storage, user_id=user_id)
+    before_profile_rows = storage.conn.execute(
+        """SELECT profile_id, content, user_id
+           FROM profiles
+           WHERE profile_id IN ('profile_seed', 'profile_purge_seed')
+           ORDER BY profile_id ASC"""
+    ).fetchall()
+    before_playbook_rows = storage.conn.execute(
+        """SELECT user_playbook_id, content, user_id
+           FROM user_playbooks
+           WHERE user_id = ?
+           ORDER BY user_playbook_id ASC""",
+        (user_id,),
+    ).fetchall()
+    original_record_purge_target_locked = SQLiteStorage._record_purge_target_locked
+
+    def _raising_record_purge_target_locked(
+        self: SQLiteStorage,
+        *,
+        purge_id: str,
+        target_name: str,
+        target_ref: str,
+        phase: str,
+        status: Literal["pending", "running", "failed", "complete"],
+        detail: dict[str, object] | None,
+        deleted_count: int,
+        error_detail: str | None,
+    ) -> None:
+        if phase == "delete" and status == "complete" and target_name == "request":
+            raise RuntimeError("inject target completion failure")
+        original_record_purge_target_locked(
+            self,
+            purge_id=purge_id,
+            target_name=target_name,
+            target_ref=target_ref,
+            phase=phase,
+            status=status,
+            detail=detail,
+            deleted_count=deleted_count,
+            error_detail=error_detail,
+        )
+
+    monkeypatch.setattr(
+        SQLiteStorage,
+        "_record_purge_target_locked",
+        _raising_record_purge_target_locked,
+    )
+
+    with pytest.raises(RuntimeError, match="inject target completion failure"):
+        storage.apply_governance_user_data_delete(
+            purge_id=purge_id,
+            user_id=user_id,
+        )
+
+    assert _user_scoped_row_counts(storage, user_id=user_id) == before_counts
+    after_profile_rows = storage.conn.execute(
+        """SELECT profile_id, content, user_id
+           FROM profiles
+           WHERE profile_id IN ('profile_seed', 'profile_purge_seed')
+           ORDER BY profile_id ASC"""
+    ).fetchall()
+    after_playbook_rows = storage.conn.execute(
+        """SELECT user_playbook_id, content, user_id
+           FROM user_playbooks
+           WHERE user_id = ?
+           ORDER BY user_playbook_id ASC""",
+        (user_id,),
+    ).fetchall()
+    assert after_profile_rows == before_profile_rows
+    assert after_playbook_rows == before_playbook_rows
+    delete_targets = storage.list_purge_targets(purge_id, phase="delete")
+    assert {(target.target_name, target.status) for target in delete_targets} == {
+        (target_name, "pending") for target_name in CANONICAL_DELETE_TARGET_NAMES
     }
 
 
@@ -2245,7 +2482,6 @@ def test_apply_governance_agent_playbook_rebuild_rejects_mismatched_remaining_so
         (agent_playbook_id,),
     ).fetchone()
     assert original_row is not None
-    original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
 
     with pytest.raises(ValueError, match="remaining_source_windows"):
         storage.apply_governance_agent_playbook_rebuild(
@@ -2267,18 +2503,96 @@ def test_apply_governance_agent_playbook_rebuild_rejects_mismatched_remaining_so
            FROM agent_playbooks
            WHERE agent_playbook_id = ?""",
         (agent_playbook_id,),
-    ).fetchone()
+        ).fetchone()
     assert rebuilt_row == original_row
-    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
-    rebuild_target = next(
-        target
-        for target in storage.list_purge_targets(
-            purge_id, phase="rebuild_without_erased_sources"
-        )
-        if target.target_name == "agent_playbook"
-        and target.target_ref == str(agent_playbook_id)
+
+
+def test_get_agent_playbook_by_id_default_excludes_archive_in_progress(storage):
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
     )
-    assert rebuild_target.status == "running"
+
+    assert storage.get_agent_playbook_by_id(agent_playbook_id) is None
+    included = storage.get_agent_playbook_by_id(
+        agent_playbook_id,
+        include_tombstones=True,
+    )
+    assert included is not None
+    assert included.agent_playbook_id == agent_playbook_id
+    assert included.status == Status.ARCHIVE_IN_PROGRESS
+
+
+def test_get_agent_playbooks_default_excludes_archive_in_progress(storage):
+    hidden_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+    )
+    visible_id = _seed_agent_playbook(
+        storage,
+        status=None,
+    )
+
+    default_ids = {
+        playbook.agent_playbook_id
+        for playbook in storage.get_agent_playbooks(limit=10)
+    }
+    hidden_only_ids = {
+        playbook.agent_playbook_id
+        for playbook in storage.get_agent_playbooks(
+            limit=10,
+            status_filter=[Status.ARCHIVE_IN_PROGRESS],
+        )
+    }
+
+    assert visible_id in default_ids
+    assert hidden_id not in default_ids
+    assert hidden_only_ids == {hidden_id}
+
+
+def test_search_agent_playbooks_default_excludes_archive_in_progress_and_explicit_filter_includes_it(
+    storage,
+):
+    hidden_playbook = AgentPlaybook(
+        playbook_name="governance-hidden-search",
+        agent_version="test-agent",
+        content="hidden-search-token",
+        trigger="hidden-search-token",
+        rationale="hidden-search-rationale",
+        status=Status.ARCHIVE_IN_PROGRESS,
+    )
+    visible_playbook = AgentPlaybook(
+        playbook_name="governance-visible-search",
+        agent_version="test-agent",
+        content="visible-search-token",
+        trigger="visible-search-token",
+        rationale="visible-search-rationale",
+        status=None,
+    )
+    hidden_id = storage.save_agent_playbooks([hidden_playbook])[0].agent_playbook_id
+    visible_id = storage.save_agent_playbooks([visible_playbook])[0].agent_playbook_id
+
+    default_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(query="hidden-search-token", top_k=10)
+    )
+    explicit_hidden_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="hidden-search-token",
+            top_k=10,
+            status_filter=[Status.ARCHIVE_IN_PROGRESS],
+        )
+    )
+    visible_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(query="visible-search-token", top_k=10)
+    )
+
+    assert hidden_id not in {
+        playbook.agent_playbook_id for playbook in default_results
+    }
+    assert [playbook.agent_playbook_id for playbook in explicit_hidden_results] == [
+        hidden_id
+    ]
+    assert [playbook.agent_playbook_id for playbook in visible_results] == [visible_id]
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -4,7 +4,11 @@ from unittest.mock import patch
 
 import pytest
 
-from reflexio.models.api_schema.domain.governance import AuditEvent
+from reflexio.models.api_schema.domain.governance import (
+    AuditEvent,
+    AuditOperation,
+    AuditStatus,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -39,7 +43,12 @@ def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
     return purge.purge_id
 
 
-def _erase_event(*, purge_id: str, status: str = "ok", operation: str = "ERASE"):
+def _erase_event(
+    *,
+    purge_id: str,
+    status: AuditStatus = "ok",
+    operation: AuditOperation = "ERASE",
+):
     return AuditEvent(
         org_id="org1",
         operation=operation,
@@ -81,7 +90,7 @@ def test_purge_targets_require_snapshot_marker(storage):
     storage.record_purge_target(
         purge_id=purge.purge_id,
         target_name="request",
-        target_ref="req1",
+        target_ref="reqref_v1_r1",
         phase="delete",
         status="complete",
         deleted_count=1,
@@ -441,6 +450,20 @@ def test_append_audit_event_validates_top_level_governance_fields(storage, event
         storage.append_audit_event(event)
 
 
+def test_append_audit_event_requires_minimized_request_ref(storage):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref="subref_v1_abc",
+        request_ref=None,
+        idempotency_key="missing_request_ref",
+    )
+
+    with pytest.raises(ValueError, match="request_ref"):
+        storage.append_audit_event(event)
+
+
 @pytest.mark.parametrize(
     ("subject_ref", "request_ref", "match"),
     [
@@ -459,4 +482,71 @@ def test_begin_purge_operation_validates_top_level_refs(
             scope_type="user",
             subject_ref=subject_ref,
             request_ref=request_ref,
+        )
+
+
+@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+def test_append_audit_event_rejects_mixed_case_window_keys(storage, detail_key):
+    event = AuditEvent(
+        org_id="org1",
+        operation="EXPORT",
+        entity_type="request",
+        subject_ref="subref_v1_abc",
+        request_ref="reqref_v1_mixed_case",
+        idempotency_key=f"mixed_case_{detail_key}",
+        detail={detail_key: [{"User_Playbook_Id": "alice@example.com"}]},
+    )
+
+    with pytest.raises(ValueError, match="user_playbook_id"):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize("detail_key", ["remaining_source_windows", "original_source_windows"])
+def test_record_purge_target_rejects_mixed_case_window_keys(storage, detail_key):
+    purge_id = _begin_purge(storage, f"purge_{detail_key}")
+
+    with pytest.raises(ValueError, match="user_playbook_id"):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="agent_playbook",
+            target_ref="7",
+            phase="rebuild",
+            status="running",
+            detail={detail_key: [{"User_Playbook_Id": "alice@example.com"}]},
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_ref", "match"),
+    [
+        pytest.param("all", None, id="marker-all"),
+        pytest.param("17", None, id="internal-numeric-id"),
+        pytest.param("reqref_v1_target", None, id="minimized-request-ref"),
+        pytest.param("subref_v1_target", None, id="minimized-subject-ref"),
+        pytest.param("", None, id="empty-default"),
+        pytest.param("alice@example.com", "target_ref", id="raw-email"),
+        pytest.param("request_12345", "target_ref", id="raw-request-id"),
+        pytest.param("alice", "target_ref", id="raw-user-like"),
+    ],
+)
+def test_record_purge_target_validates_target_ref_contract(storage, target_ref, match):
+    purge_id = _begin_purge(storage, "purge_target_ref")
+
+    if match is None:
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref=target_ref,
+            phase="delete",
+            status="running",
+        )
+        return
+
+    with pytest.raises(ValueError, match=match):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref=target_ref,
+            phase="delete",
+            status="running",
         )

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -211,6 +211,42 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
 
 
 @pytest.mark.parametrize(
+    ("retry_kwargs", "match"),
+    [
+        pytest.param({"purge_id": "purge_begin_retry_other"}, "purge_id", id="purge-id"),
+        pytest.param({"request_ref": OTHER_REQUEST_REF}, "request_ref", id="request-ref"),
+        pytest.param({"scope_type": "org"}, "scope_type", id="scope-type"),
+    ],
+)
+def test_begin_purge_operation_rejects_mismatched_idempotent_retry(
+    storage, retry_kwargs, match
+):
+    storage.begin_purge_operation(
+        purge_id="purge_begin_retry",
+        idempotency_key="idem_begin_retry",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        storage.begin_purge_operation(
+            purge_id=retry_kwargs.get("purge_id", "purge_begin_retry"),
+            idempotency_key="idem_begin_retry",
+            operation_type=retry_kwargs.get("operation_type", "user_erasure"),
+            scope_type=retry_kwargs.get("scope_type", "user"),
+            subject_ref=retry_kwargs.get("subject_ref", SUBJECT_REF),
+            request_ref=retry_kwargs.get("request_ref", REQUEST_REF),
+        )
+
+    purge = storage.get_purge_operation("purge_begin_retry")
+    assert purge.request_ref == REQUEST_REF
+    assert purge.scope_type == "user"
+    assert purge.purge_id == "purge_begin_retry"
+
+
+@pytest.mark.parametrize(
     ("event", "match"),
     [
         pytest.param(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -848,6 +848,13 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
             ],
         },
     )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="hide_for_rebuild",
+        status="complete",
+    )
     expected_detail = {
         "original_source_windows": [
             {"user_playbook_id": 7, "source_interaction_ids": [101]},
@@ -903,6 +910,221 @@ def test_apply_governance_agent_playbook_rebuild_completes_planned_phase(storage
     ]
 
 
+def test_apply_governance_agent_playbook_rebuild_rejects_ad_hoc_rebuild_without_prepared_target(
+    storage,
+):
+    purge_id = "purge_rebuild_requires_target"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_requires_target",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    original_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert original_row is not None
+    original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+
+    with pytest.raises(
+        ValueError, match="planned rebuild target does not exist"
+    ):
+        storage.apply_governance_agent_playbook_rebuild(
+            purge_id=purge_id,
+            agent_playbook_id=agent_playbook_id,
+            remaining_source_windows=[
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            content="rebuilt content",
+            trigger="rebuilt trigger",
+            rationale="rebuilt rationale",
+            blocking_issue=None,
+            expanded_terms="rebuilt terms",
+            tags=["rebuilt"],
+        )
+
+    assert (
+        storage.conn.execute(
+            """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+               FROM agent_playbooks
+               WHERE agent_playbook_id = ?""",
+            (agent_playbook_id,),
+        ).fetchone()
+        == original_row
+    )
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    assert storage.list_purge_targets(purge_id, phase="rebuild_without_erased_sources") == []
+
+
+def test_apply_governance_agent_playbook_rebuild_rejects_rebuild_before_hide_phase_complete(
+    storage,
+):
+    purge_id = "purge_rebuild_requires_hide"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_requires_hide",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=Status.ARCHIVE_IN_PROGRESS,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status="running",
+        detail={
+            "original_source_windows": [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            "remaining_source_windows": [
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+        },
+    )
+    original_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    assert original_row is not None
+    original_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+
+    with pytest.raises(
+        ValueError, match="hide_for_rebuild target must be complete"
+    ):
+        storage.apply_governance_agent_playbook_rebuild(
+            purge_id=purge_id,
+            agent_playbook_id=agent_playbook_id,
+            remaining_source_windows=[
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            content="rebuilt content",
+            trigger="rebuilt trigger",
+            rationale="rebuilt rationale",
+            blocking_issue=None,
+            expanded_terms="rebuilt terms",
+            tags=["rebuilt"],
+        )
+
+    assert (
+        storage.conn.execute(
+            """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status
+               FROM agent_playbooks
+               WHERE agent_playbook_id = ?""",
+            (agent_playbook_id,),
+        ).fetchone()
+        == original_row
+    )
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == original_windows
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "running"
+    assert rebuild_target.detail == {
+        "original_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [101]},
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        "remaining_source_windows": [
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+    }
+
+
+def test_apply_governance_agent_playbook_rebuild_succeeds_after_prepare_and_hide(
+    storage,
+):
+    purge_id = "purge_rebuild_prepare_hide"
+    storage.begin_purge_operation(
+        purge_id=purge_id,
+        idempotency_key="idem_purge_rebuild_prepare_hide",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+    agent_playbook_id = _seed_agent_playbook(
+        storage,
+        status=None,
+        source_windows=[
+            AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101]),
+            AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
+        ],
+    )
+    storage.prepare_governance_erase_targets(
+        purge_id=purge_id,
+        user_id="user-hide-rebuild",
+        owned_user_playbook_ids={7},
+    )
+    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
+
+    storage.apply_governance_agent_playbook_rebuild(
+        purge_id=purge_id,
+        agent_playbook_id=agent_playbook_id,
+        remaining_source_windows=[
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        content="rebuilt content",
+        trigger="rebuilt trigger",
+        rationale="rebuilt rationale",
+        blocking_issue=None,
+        expanded_terms="rebuilt terms",
+        tags=["rebuilt"],
+    )
+
+    rebuild_target = next(
+        target
+        for target in storage.list_purge_targets(
+            purge_id, phase="rebuild_without_erased_sources"
+        )
+        if target.target_name == "agent_playbook"
+        and target.target_ref == str(agent_playbook_id)
+    )
+    assert rebuild_target.status == "complete"
+    assert rebuild_target.detail == {
+        "original_source_windows": [
+            {"user_playbook_id": 7, "source_interaction_ids": [101]},
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+        "remaining_source_windows": [
+            {"user_playbook_id": 9, "source_interaction_ids": [201]},
+        ],
+    }
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == [
+        AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201])
+    ]
+
+
 def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_failure(
     storage, monkeypatch
 ):
@@ -938,6 +1160,13 @@ def test_apply_governance_agent_playbook_rebuild_rolls_back_partial_updates_on_f
                 {"user_playbook_id": 9, "source_interaction_ids": [201]},
             ],
         },
+    )
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="hide_for_rebuild",
+        status="complete",
     )
     original_row = storage.conn.execute(
         """SELECT content, trigger, rationale, blocking_issue, expanded_terms, tags, status

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -754,6 +754,21 @@ def test_append_audit_event_rejects_successful_erase(storage):
         storage.append_audit_event(_erase_event(purge_id="purge_append"))
 
 
+def test_append_audit_event_rejects_successful_erase_without_idempotency_key(storage):
+    with pytest.raises(ValueError, match="Successful ERASE audit rows"):
+        storage.append_audit_event(
+            AuditEvent(
+                org_id="org1",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=SUBJECT_REF,
+                request_ref=REQUEST_REF,
+                idempotency_key=None,
+                status="ok",
+            )
+        )
+
+
 def test_complete_purge_operation_requires_full_delete_target_matrix(storage):
     purge_id = _begin_purge(storage, "purge_snapshot_only")
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -22,8 +22,8 @@ def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
         idempotency_key=f"idem_{purge_id}",
         operation_type="user_erasure",
         scope_type="user",
-        subject_ref="subref_abc",
-        request_ref=f"reqref_{purge_id}",
+        subject_ref="subref_v1_abc",
+        request_ref=f"reqref_v1_{purge_id}",
     )
     storage.record_purge_target(
         purge_id=purge.purge_id,
@@ -44,8 +44,8 @@ def _erase_event(*, purge_id: str, status: str = "ok", operation: str = "ERASE")
         org_id="org1",
         operation=operation,
         entity_type="request",
-        subject_ref="subref_abc",
-        request_ref=f"reqref_{purge_id}",
+        subject_ref="subref_v1_abc",
+        request_ref=f"reqref_v1_{purge_id}",
         idempotency_key=purge_id,
         status=status,
     )
@@ -56,15 +56,15 @@ def test_audit_event_idempotency(storage):
         org_id="org1",
         operation="EXPORT",
         entity_type="request",
-        subject_ref="subref_abc",
-        request_ref="reqref_r1",
+        subject_ref="subref_v1_abc",
+        request_ref="reqref_v1_r1",
         idempotency_key="export_1",
-        detail={"requests": 1},
+        detail={"count": 1},
     )
 
     assert storage.append_audit_event(event) is True
     assert storage.append_audit_event(event) is False
-    rows = storage.list_audit_events(subject_ref="subref_abc")
+    rows = storage.list_audit_events(subject_ref="subref_v1_abc")
     assert len(rows) == 1
     assert rows[0].idempotency_key == "export_1"
 
@@ -75,8 +75,8 @@ def test_purge_targets_require_snapshot_marker(storage):
         idempotency_key="idem_1",
         operation_type="user_erasure",
         scope_type="user",
-        subject_ref="subref_abc",
-        request_ref="reqref_r1",
+        subject_ref="subref_v1_abc",
+        request_ref="reqref_v1_r1",
     )
     storage.record_purge_target(
         purge_id=purge.purge_id,
@@ -95,8 +95,8 @@ def test_purge_targets_require_snapshot_marker(storage):
                 org_id="org1",
                 operation="ERASE",
                 entity_type="request",
-                subject_ref="subref_abc",
-                request_ref="reqref_r1",
+                subject_ref="subref_v1_abc",
+                request_ref="reqref_v1_r1",
                 idempotency_key=purge.purge_id,
             ),
         )
@@ -110,14 +110,14 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
     )
 
     assert complete.status == "complete"
-    rows = storage.list_audit_events(subject_ref="subref_abc")
+    rows = storage.list_audit_events(subject_ref="subref_v1_abc")
     assert [row.operation for row in rows] == ["ERASE"]
     same = storage.complete_purge_operation_with_audit(
         purge_id,
         _erase_event(purge_id=purge_id),
     )
     assert same.status == "complete"
-    assert len(storage.list_audit_events(subject_ref="subref_abc")) == 1
+    assert len(storage.list_audit_events(subject_ref="subref_v1_abc")) == 1
 
 
 @pytest.mark.parametrize(
@@ -138,8 +138,8 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
                 org_id="org1",
                 operation="ERASE",
                 entity_type="request",
-                subject_ref="subref_abc",
-                request_ref="reqref_purge_invalid",
+                subject_ref="subref_v1_abc",
+                request_ref="reqref_v1_purge_invalid",
                 idempotency_key="different_key",
                 status="ok",
             ),
@@ -151,8 +151,8 @@ def test_complete_purge_operation_with_audit_is_atomic_success_path(storage):
                 org_id="org1",
                 operation="ERASE",
                 entity_type="request",
-                subject_ref="subref_abc",
-                request_ref="reqref_purge_invalid",
+                subject_ref="subref_v1_abc",
+                request_ref="reqref_v1_purge_invalid",
                 idempotency_key=None,
                 status="ok",
             ),
@@ -168,7 +168,7 @@ def test_complete_purge_operation_rejects_invalid_audit_event(storage, event, ma
         storage.complete_purge_operation_with_audit(purge_id, event)
 
     assert storage.get_purge_operation(purge_id).status == "running"
-    assert storage.list_audit_events(subject_ref="subref_abc") == []
+    assert storage.list_audit_events(subject_ref="subref_v1_abc") == []
 
 
 @pytest.mark.parametrize(
@@ -198,7 +198,7 @@ def test_complete_purge_operation_requires_matching_existing_erase_row(
         )
 
     assert storage.get_purge_operation(purge_id).status == "running"
-    rows = storage.list_audit_events(subject_ref="subref_abc")
+    rows = storage.list_audit_events(subject_ref="subref_v1_abc")
     assert len(rows) == 1
     assert rows[0].operation == seed_event.operation
     assert rows[0].status == seed_event.status
@@ -215,8 +215,8 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
         idempotency_key="idem_purge_detail",
         operation_type="user_erasure",
         scope_type="user",
-        subject_ref="subref_abc",
-        request_ref="reqref_purge_detail",
+        subject_ref="subref_v1_abc",
+        request_ref="reqref_v1_purge_detail",
     )
     storage.prepare_governance_erase_targets(
         purge_id="purge_detail",
@@ -258,6 +258,27 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
             },
             None,
             id="target-detail-allowed-internal-ids",
+        ),
+        pytest.param(
+            {
+                "detail": {"remaining_source_windows": [{"user_playbook_id": 7}]},
+            },
+            None,
+            id="target-detail-allowed-window-ids",
+        ),
+        pytest.param(
+            {
+                "detail": {"note": "safe-looking but arbitrary"},
+            },
+            "note",
+            id="target-detail-neutral-string-key",
+        ),
+        pytest.param(
+            {
+                "detail": {"status": "api-token-name"},
+            },
+            "token",
+            id="target-detail-token-name-string",
         ),
         pytest.param(
             {
@@ -305,6 +326,13 @@ def test_record_purge_target_validates_governance_fields(storage, kwargs, match)
         pytest.param({"email": "bob@example.com"}, "email", id="audit-detail-email"),
         pytest.param({"request_id": "reqref_123"}, "request_id", id="audit-detail-request-id"),
         pytest.param({"content": "verbatim prompt"}, "content", id="audit-detail-content"),
+        pytest.param({"note": "arbitrary string"}, "note", id="audit-detail-neutral-note"),
+        pytest.param({"status": "prompt-ready"}, "prompt/content", id="audit-detail-promptish-string"),
+        pytest.param(
+            {"remaining_source_windows": [{"user_playbook_id": 7, "source_interaction_ids": [1]}]},
+            None,
+            id="audit-detail-allowed-window-shape",
+        ),
         pytest.param({"agent_playbook_id": 7, "source_interaction_ids": [1]}, None, id="audit-detail-allowed-internal-ids"),
     ],
 )
@@ -313,8 +341,8 @@ def test_append_audit_event_validates_governance_detail(storage, detail, match):
         org_id="org1",
         operation="EXPORT",
         entity_type="request",
-        subject_ref="subref_abc",
-        request_ref="reqref_safe",
+        subject_ref="subref_v1_abc",
+        request_ref="reqref_v1_safe",
         idempotency_key=f"export_{hash(str(detail))}",
         detail=detail,
     )
@@ -338,3 +366,97 @@ def test_fail_purge_operation_rejects_raw_error_detail(storage):
         )
 
     assert storage.get_purge_operation(purge_id).error_detail is None
+
+
+@pytest.mark.parametrize(
+    ("event", "match"),
+    [
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                actor_ref="token-name",
+                operation="EXPORT",
+                entity_type="request",
+                subject_ref="subref_v1_abc",
+                request_ref="reqref_v1_top_level",
+                idempotency_key="top_level_actor",
+            ),
+            "actor_ref",
+            id="actor-ref-must-be-minimized",
+        ),
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                operation="EXPORT",
+                entity_type="request",
+                subject_ref="user@example.com",
+                request_ref="reqref_v1_top_level",
+                idempotency_key="top_level_subject",
+            ),
+            "subject_ref",
+            id="subject-ref-must-be-minimized",
+        ),
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                operation="EXPORT",
+                entity_type="request",
+                subject_ref="subref_v1_abc",
+                request_ref="request_12345",
+                idempotency_key="top_level_request",
+            ),
+            "request_ref",
+            id="request-ref-must-be-minimized",
+        ),
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                operation="EXPORT",
+                entity_type="request",
+                entity_id="alice@example.com",
+                subject_ref="subref_v1_abc",
+                request_ref="reqref_v1_top_level",
+                idempotency_key="top_level_entity_email",
+            ),
+            "entity_id",
+            id="entity-id-email",
+        ),
+        pytest.param(
+            AuditEvent(
+                org_id="org1",
+                operation="EXPORT",
+                entity_type="request",
+                entity_id="api-token-name",
+                subject_ref="subref_v1_abc",
+                request_ref="reqref_v1_top_level",
+                idempotency_key="top_level_entity_token",
+            ),
+            "entity_id",
+            id="entity-id-token-name",
+        ),
+    ],
+)
+def test_append_audit_event_validates_top_level_governance_fields(storage, event, match):
+    with pytest.raises(ValueError, match=match):
+        storage.append_audit_event(event)
+
+
+@pytest.mark.parametrize(
+    ("subject_ref", "request_ref", "match"),
+    [
+        pytest.param("subref_v1_abc", "request_12345", "request_ref", id="purge-request-ref"),
+        pytest.param("raw-user-id", "reqref_v1_purge", "subject_ref", id="purge-subject-ref"),
+    ],
+)
+def test_begin_purge_operation_validates_top_level_refs(
+    storage, subject_ref, request_ref, match
+):
+    with pytest.raises(ValueError, match=match):
+        storage.begin_purge_operation(
+            purge_id="purge_top_level_refs",
+            idempotency_key="idem_purge_top_level_refs",
+            operation_type="user_erasure",
+            scope_type="user",
+            subject_ref=subject_ref,
+            request_ref=request_ref,
+        )

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -537,6 +537,19 @@ def test_begin_purge_operation_rejects_numeric_idempotency_key(storage):
         storage.get_purge_operation("purge_numeric_idem")
 
 
+def test_begin_purge_operation_accepts_code_shaped_idempotency_key_with_content(storage):
+    purge = storage.begin_purge_operation(
+        purge_id="purge_content_retry",
+        idempotency_key="content_purge_retry_1",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=SUBJECT_REF,
+        request_ref=REQUEST_REF,
+    )
+
+    assert purge.idempotency_key == "content_purge_retry_1"
+
+
 @pytest.mark.parametrize("purge_id", ["purge_1", "purge_123"])
 def test_begin_purge_operation_rejects_raw_numeric_purge_suffix(storage, purge_id):
     with pytest.raises(ValueError, match="purge_id"):
@@ -2142,6 +2155,35 @@ def test_fail_purge_operation_persists_code_shaped_error_detail(storage):
 
     assert failed.status == "failed"
     assert failed.error_detail == "target_delete_failed"
+
+
+@pytest.mark.parametrize("error_code", ["content_purge_failed", "prompt_redaction_route"])
+def test_fail_purge_operation_accepts_code_shaped_error_code_with_prompt_or_content(
+    storage, error_code
+):
+    purge_id = _begin_purge(storage, f"purge_error_code_{error_code}")
+
+    failed = storage.fail_purge_operation(
+        purge_id,
+        error_code=error_code,
+        error_detail="target_delete_failed",
+    )
+
+    assert failed.status == "failed"
+    assert failed.error_code == error_code
+
+
+def test_fail_purge_operation_rejects_prompt_content_prose_error_detail(storage):
+    purge_id = _begin_purge(storage, "purge_fail_prompt_content_prose")
+
+    with pytest.raises(ValueError, match="error_detail"):
+        storage.fail_purge_operation(
+            purge_id,
+            error_code="PURGE_TARGET_FAILED",
+            error_detail="prompt content leaked from upstream",
+        )
+
+    assert storage.get_purge_operation(purge_id).error_detail is None
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1151,7 +1151,7 @@ def test_record_purge_target_rejects_mixed_case_window_keys(storage, detail_key)
             purge_id=purge_id,
             target_name="agent_playbook",
             target_ref="7",
-            phase="rebuild",
+            phase="rebuild_without_erased_sources",
             status="running",
             detail={detail_key: [{"User_Playbook_Id": "alice@example.com"}]},
         )
@@ -1182,7 +1182,7 @@ def test_record_purge_target_requires_window_user_playbook_id(storage, detail_ke
             purge_id=purge_id,
             target_name="agent_playbook",
             target_ref="7",
-            phase="rebuild",
+            phase="rebuild_without_erased_sources",
             status="running",
             detail={detail_key: [{"source_interaction_ids": [1, 2]}]},
         )
@@ -1619,6 +1619,20 @@ def test_governance_detail_rejects_duplicate_normalized_keys(storage, persistenc
             None,
             id="snapshot-marker-all",
         ),
+        pytest.param(
+            "target_snapshot",
+            "prepare_targets",
+            "17",
+            "target_ref",
+            id="snapshot-rejects-row-ref",
+        ),
+        pytest.param(
+            "target_snapshot",
+            "delete",
+            "all",
+            "target_snapshot",
+            id="snapshot-rejects-wrong-phase",
+        ),
         pytest.param("request", "delete", "all", None, id="aggregate-delete-all"),
         pytest.param(
             "agent_playbook",
@@ -1654,6 +1668,13 @@ def test_governance_detail_rejects_duplicate_normalized_keys(storage, persistenc
             REQUEST_REF,
             "target_ref",
             id="row-target-rebuild-rejects-minimized-ref",
+        ),
+        pytest.param(
+            "agent_playbook",
+            "rebuild",
+            "19",
+            "phase",
+            id="rebuild-phase-rejected",
         ),
     ],
 )

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -1553,6 +1553,46 @@ def test_governance_detail_rejects_user_like_status_and_route(storage, detail):
 
 
 @pytest.mark.parametrize(
+    "detail",
+    [
+        pytest.param({"status": "archived"}, id="status-archived"),
+        pytest.param({"route": "rebuild"}, id="route-rebuild"),
+        pytest.param({"route": "custom.route"}, id="route-custom-dot"),
+        pytest.param({"route": "alice.team"}, id="route-alice-team"),
+    ],
+)
+@pytest.mark.parametrize("persistence_path", ["audit_event", "purge_target"])
+def test_governance_detail_rejects_noncanonical_status_and_route(
+    storage, detail, persistence_path
+):
+    if persistence_path == "audit_event":
+        event = AuditEvent(
+            org_id="org1",
+            operation="EXPORT",
+            entity_type="request",
+            subject_ref=SUBJECT_REF,
+            request_ref=REQUEST_REF,
+            idempotency_key=f"export_noncanonical_{next(iter(detail))}",
+            detail=detail,
+        )
+
+        with pytest.raises(ValueError, match="status|route"):
+            storage.append_audit_event(event)
+        return
+
+    purge_id = _begin_purge(storage, f"purge_noncanonical_{next(iter(detail))}")
+    with pytest.raises(ValueError, match="status|route"):
+        storage.record_purge_target(
+            purge_id=purge_id,
+            target_name="request",
+            target_ref="all",
+            phase="delete",
+            status="running",
+            detail=detail,
+        )
+
+
+@pytest.mark.parametrize(
     "purge_id",
     ["purge_user_123", "purge_subject_42", "purge_actor_alpha"],
 )

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -6,6 +6,11 @@ from unittest.mock import patch
 
 import pytest
 
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    AgentPlaybookSourceWindow,
+)
+from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.domain.governance import (
     AuditEvent,
     AuditOperation,
@@ -66,6 +71,58 @@ def _erase_event(
         idempotency_key=purge_id,
         status=status,
     )
+
+
+def _seed_user_scoped_rows(storage: SQLiteStorage, *, user_id: str) -> None:
+    created_at = "2026-01-01T00:00:00.000Z"
+    storage.conn.execute(
+        """INSERT INTO requests (
+               request_id, user_id, created_at, source, agent_version, session_id, evaluation_only
+           ) VALUES (?, ?, ?, '', '', ?, 0)""",
+        ("request_seed", user_id, created_at, "session_seed"),
+    )
+    storage.conn.execute(
+        """INSERT INTO interactions (
+               user_id, content, request_id, created_at, role, user_action,
+               user_action_description, interacted_image_url, image_encoding,
+               shadow_content, expert_content, tools_used, citations, embedding
+           ) VALUES (?, '', ?, ?, 'User', 'none', '', '', '', '', '', '[]', '[]', '[]')""",
+        (user_id, "request_seed", created_at),
+    )
+    storage.conn.execute(
+        """INSERT INTO profiles (
+               profile_id, user_id, content, last_modified_timestamp,
+               generated_from_request_id, profile_time_to_live, expiration_timestamp,
+               embedding, source_interaction_ids, created_at
+           ) VALUES (?, ?, ?, ?, ?, 'infinity', ?, '[]', '[]', ?)""",
+        ("profile_seed", user_id, "profile-content", 1, "request_seed", 4102444800, created_at),
+    )
+    storage.conn.execute(
+        """INSERT INTO user_playbooks (
+               user_id, playbook_name, created_at, request_id, agent_version,
+               content, source_interaction_ids, embedding
+           ) VALUES (?, '', ?, ?, '', ?, '[]', '[]')""",
+        (user_id, created_at, "request_seed", "playbook-content"),
+    )
+    storage.conn.commit()
+
+
+def _seed_agent_playbook(storage: SQLiteStorage) -> int:
+    playbook = AgentPlaybook(
+        playbook_name="governance-rebuild",
+        agent_version="test-agent",
+        content="original content",
+        trigger="original trigger",
+        rationale="original rationale",
+        status=Status.ARCHIVED,
+        tags=["seed"],
+    )
+    saved = storage.save_agent_playbooks([playbook])[0]
+    storage.set_source_windows_for_agent_playbook(
+        saved.agent_playbook_id,
+        [AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])],
+    )
+    return saved.agent_playbook_id
 
 
 def test_audit_event_idempotency(storage):
@@ -825,8 +882,100 @@ def test_persistence_paths_reject_unsafe_purge_id(storage, purge_id):
             ),
         )
 
-    assert storage.list_purge_targets(purge_id) == []
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.list_purge_targets(purge_id)
     assert storage.list_audit_events(subject_ref=SUBJECT_REF) == []
+
+
+def test_apply_governance_user_data_delete_rejects_unsafe_purge_id_before_side_effects(
+    storage,
+):
+    user_id = "user-delete-seed"
+    _seed_user_scoped_rows(storage, user_id=user_id)
+
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.apply_governance_user_data_delete(
+            purge_id="alice@example.com",
+            user_id=user_id,
+        )
+
+    remaining = {
+        "requests": storage.conn.execute(
+            "SELECT COUNT(*) FROM requests WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+        "interactions": storage.conn.execute(
+            "SELECT COUNT(*) FROM interactions WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+        "profiles": storage.conn.execute(
+            "SELECT COUNT(*) FROM profiles WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+        "user_playbooks": storage.conn.execute(
+            "SELECT COUNT(*) FROM user_playbooks WHERE user_id = ?",
+            (user_id,),
+        ).fetchone()[0],
+    }
+    assert remaining == {
+        "requests": 1,
+        "interactions": 1,
+        "profiles": 1,
+        "user_playbooks": 1,
+    }
+
+
+def test_apply_governance_agent_playbook_rebuild_rejects_unsafe_purge_id_before_side_effects(
+    storage,
+):
+    agent_playbook_id = _seed_agent_playbook(storage)
+
+    before_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, status, tags
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    before_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.apply_governance_agent_playbook_rebuild(
+            purge_id="request_12345",
+            agent_playbook_id=agent_playbook_id,
+            remaining_source_windows=[{"user_playbook_id": 99, "source_interaction_ids": [202]}],
+            content="updated content",
+            trigger="updated trigger",
+            rationale="updated rationale",
+            blocking_issue=None,
+            expanded_terms="updated terms",
+            tags=["updated"],
+        )
+
+    after_row = storage.conn.execute(
+        """SELECT content, trigger, rationale, status, tags
+           FROM agent_playbooks
+           WHERE agent_playbook_id = ?""",
+        (agent_playbook_id,),
+    ).fetchone()
+    after_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
+    assert tuple(before_row) == tuple(after_row)
+    assert before_windows == after_windows
+
+
+def test_fail_purge_operation_rejects_unsafe_purge_id_before_side_effects(storage):
+    purge_id = _begin_purge(storage, "purge_fail_unsafe_id")
+
+    with pytest.raises(ValueError, match="purge_id"):
+        storage.fail_purge_operation(
+            SUBJECT_REF,
+            "governance.error",
+            "detail.code",
+        )
+
+    failed = storage.get_purge_operation(purge_id)
+    assert failed.status == "running"
+    assert failed.error_code is None
+    assert failed.error_detail is None
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, cast
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from reflexio.models.api_schema.domain.entities import (
     AgentPlaybook,
@@ -2597,18 +2598,17 @@ def test_append_audit_event_rejects_invalid_top_level_enum_values(
         storage.append_audit_event(event)
 
 
-def test_append_audit_event_requires_minimized_request_ref(storage):
-    event = AuditEvent(
-        org_id="org1",
-        operation="EXPORT",
-        entity_type="request",
-        subject_ref=SUBJECT_REF,
-        request_ref=None,
-        idempotency_key="missing_request_ref",
-    )
-
-    with pytest.raises(ValueError, match="request_ref"):
-        storage.append_audit_event(event)
+def test_audit_event_requires_request_ref():
+    with pytest.raises(ValidationError, match="request_ref"):
+        AuditEvent.model_validate(
+            {
+                "org_id": "org1",
+                "operation": "EXPORT",
+                "entity_type": "request",
+                "subject_ref": SUBJECT_REF,
+                "idempotency_key": "missing_request_ref",
+            }
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/storage/test_agent_playbook_rebuild_exclusion.py
+++ b/tests/server/services/storage/test_agent_playbook_rebuild_exclusion.py
@@ -1,0 +1,106 @@
+"""Regression coverage for excluding rebuilding agent playbooks from default reads."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.models.api_schema.retriever_schema import (
+    SearchAgentPlaybookRequest,
+    UnifiedSearchRequest,
+)
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    PlaybookStatus,
+    Status,
+)
+from reflexio.server.services.pre_retrieval import ReformulationResult
+from reflexio.server.services.unified_search_service import run_unified_search
+
+pytestmark = pytest.mark.integration
+
+
+def _make_agent_playbook(
+    playbook_id: int,
+    *,
+    playbook_name: str,
+    content: str,
+) -> AgentPlaybook:
+    return AgentPlaybook(
+        agent_playbook_id=playbook_id,
+        playbook_name=playbook_name,
+        agent_version="claude-code",
+        content=content,
+        created_at=1_700_000_000 + playbook_id,
+        playbook_status=PlaybookStatus.APPROVED,
+    )
+
+
+def _mark_archive_in_progress(storage, agent_playbook_id: int) -> None:
+    storage.conn.execute(
+        "UPDATE agent_playbooks SET status = ? WHERE agent_playbook_id = ?",
+        (Status.ARCHIVE_IN_PROGRESS.value, agent_playbook_id),
+    )
+    storage.conn.commit()
+
+
+def test_rebuilding_agent_playbook_is_excluded_from_default_reads_and_search(
+    storage,
+) -> None:
+    current = _make_agent_playbook(
+        1,
+        playbook_name="visible-rule",
+        content="visible guidance for escalations only",
+    )
+    rebuilding = _make_agent_playbook(
+        2,
+        playbook_name="rebuild-rule",
+        content="rtbf_rebuild_hidden_token guidance should stay hidden",
+    )
+    storage.save_agent_playbooks([current, rebuilding])
+    _mark_archive_in_progress(storage, rebuilding.agent_playbook_id)
+
+    assert storage.get_agent_playbook_by_id(rebuilding.agent_playbook_id) is None
+
+    listed = storage.get_agent_playbooks()
+    assert [playbook.agent_playbook_id for playbook in listed] == [
+        current.agent_playbook_id
+    ]
+
+    search_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="rtbf_rebuild_hidden_token",
+            top_k=5,
+        )
+    )
+    assert search_results == []
+
+
+def test_rebuilding_agent_playbook_is_excluded_from_unified_search(storage) -> None:
+    rebuilding = _make_agent_playbook(
+        3,
+        playbook_name="rebuild-only",
+        content="rtbf_unified_hidden_token guidance",
+    )
+    storage.save_agent_playbooks([rebuilding])
+    _mark_archive_in_progress(storage, rebuilding.agent_playbook_id)
+
+    with patch(
+        "reflexio.server.services.unified_search_service.QueryReformulator"
+    ) as reformulator_cls:
+        reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="rtbf_unified_hidden_token"
+        )
+        result = run_unified_search(
+            request=UnifiedSearchRequest(
+                query="rtbf_unified_hidden_token",
+                entity_types=["agent_playbooks"],
+                top_k=5,
+            ),
+            org_id="contract_test",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+    assert result.success is True
+    assert result.agent_playbooks == []

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -70,6 +70,22 @@ class TestUserPlaybookCRUD:
         result = storage.get_user_playbooks(playbook_name="fb")
         assert len(result) == 2
 
+    def test_get_user_playbooks_orders_tied_timestamps_deterministically(self, storage):
+        rfs = [
+            _make_user_playbook(1, "u1", "fb", "v1"),
+            _make_user_playbook(2, "u1", "fb", "v1"),
+            _make_user_playbook(3, "u1", "fb", "v1"),
+        ]
+        for playbook in rfs:
+            playbook.created_at = 1_700_000_000
+        storage.save_user_playbooks(rfs)
+
+        first_page = storage.get_user_playbooks(user_id="u1", limit=2, offset=0)
+        second_page = storage.get_user_playbooks(user_id="u1", limit=2, offset=2)
+
+        assert [p.user_playbook_id for p in first_page] == [3, 2]
+        assert [p.user_playbook_id for p in second_page] == [1]
+
     def test_update_user_playbook_tags_round_trip(self, storage):
         storage.save_user_playbooks([_make_user_playbook(1, "u1", "fb", "v1")])
         saved = storage.get_user_playbooks(user_id="u1", status_filter=[None])


### PR DESCRIPTION
## Summary
- Add the OSS/local proof for Governance RTBF: typed governance models, stable subject/request refs, and a service-level export/erase flow.
- Add SQLite governance storage for purge operations, audit events, delete planning, rebuild-safe agent playbook handling, and retention hooks.
- Harden RTBF minimization and rebuild invariants from review-loop findings, including lineage cleanup, purged playbook request-id removal, idempotent erase audit handling, and scheduler config compatibility.

## Changes
- Governance API/models: add RTBF domain models, subject-ref helpers, and GovernanceService export/erase orchestration.
- SQLite storage: add governance audit/purge tables, storage contract methods, target planning, data deletion/minimization, rebuild exclusion, and audit retention GC.
- Lineage/GC: gate governance retention in the existing GC scheduler while preserving compatibility with configs that only expose lineage_gc.
- Tests: add local governance e2e coverage, SQLite governance storage contract coverage, subject-ref tests, retention gate tests, and rebuild-exclusion regressions.

## Test Plan
- `uv run ruff check reflexio/server/services/lineage/gc_scheduler.py reflexio/server/services/storage/sqlite_storage/_governance.py reflexio/server/services/storage/sqlite_storage/_lineage.py tests/server/services/storage/sqlite_storage/test_governance_storage.py`
- `uv run pyright reflexio/server/services/lineage/gc_scheduler.py reflexio/server/services/storage/sqlite_storage/_governance.py reflexio/server/services/storage/sqlite_storage/_lineage.py tests/server/services/storage/sqlite_storage/test_governance_storage.py`
- `uv run pytest --no-cov tests/server/services/storage/sqlite_storage/test_governance_storage.py -q -o 'addopts='` (207 passed)
- `uv run pytest --no-cov tests/server/services/lineage/test_gc_scheduler.py tests/server/services/lineage/test_governance_retention_gates.py -q -o 'addopts='` (22 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added governance/audit support with user export and user erasure workflows.
  * Introduced governance purge tracking with deterministic subject/actor/request identifiers.
  * Added governance audit-event retention configuration and periodic retention cleanup.
* **Bug Fixes**
  * Improved config fallback so governance retention defaults apply when values are missing.
  * Excluded “archive in progress” items from default reads and search results.
  * Strengthened erasure to remove related request identifiers and linked content.
* **Tests**
  * Added governance and reference-generation coverage, including end-to-end erasure/rebuild behavior and pagination/contract checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->