### PR TITLE
feat: support exact profile lookup

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1844,6 +1844,8 @@ def get_all_profiles(
     request: Request,
     limit: int = 100,
     status_filter: str | None = None,
+    profile_id: str | None = None,
+    include_tombstones: bool = False,
     org_id: str = Depends(default_get_org_id),
 ) -> GetProfilesViewResponse:
     """Get all user profiles across all users.
@@ -1851,12 +1853,33 @@ def get_all_profiles(
     Args:
         limit (int, optional): Maximum number of profiles to return. Defaults to 100.
         status_filter (str, optional): Filter by profile status. Can be "current", "pending", or "archived".
+        profile_id (str, optional): Exact profile ID to retrieve.
+        include_tombstones (bool, optional): Include merged/superseded rows when
+            looking up a specific profile_id.
         org_id (str): Organization ID
 
     Returns:
         GetProfilesViewResponse: Response containing all user profiles
     """
     reflexio = get_reflexio(org_id=org_id)
+
+    if profile_id:
+        storage = reflexio.request_context.storage
+        if storage is None:
+            return GetProfilesViewResponse(
+                success=True,
+                user_profiles=[],
+                msg="Storage is not configured",
+            )
+        profile = storage.get_profile_by_id(
+            profile_id, include_tombstones=include_tombstones
+        )
+        profiles = [profile] if profile else []
+        return GetProfilesViewResponse(
+            success=True,
+            user_profiles=[to_profile_view(p) for p in profiles],
+            msg=f"Found {len(profiles)} profile(s)",
+        )
 
     # Map status_filter string to Status list
     status_filter_list = None

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from reflexio.models.api_schema.retriever_schema import (
+    GetProfilesViewResponse,
     SearchInteractionResponse,
     SearchUserProfileResponse,
     SetConfigResponse,
@@ -18,6 +19,8 @@ from reflexio.models.api_schema.retriever_schema import (
 )
 from reflexio.models.api_schema.service_schemas import (
     PublishUserInteractionResponse,
+    Status,
+    UserProfile,
 )
 from reflexio.models.config_schema import Config, StorageConfigSQLite
 
@@ -165,6 +168,56 @@ class TestSearchEndpoints:
     def test_search_profiles_missing_body_returns_422(self, client):
         response = client.post("/api/search_profiles")
         assert response.status_code == 422
+
+
+class TestGetAllProfilesRoute:
+    """Tests for GET /api/get_all_profiles."""
+
+    def test_exact_profile_lookup_includes_tombstones_when_requested(
+        self, client, patched_reflexio, mock_reflexio
+    ):
+        profile = UserProfile(
+            profile_id="p-superseded",
+            user_id="project-1",
+            content="old preference",
+            last_modified_timestamp=123,
+            generated_from_request_id="req-1",
+            status=Status.SUPERSEDED,
+        )
+        mock_storage = MagicMock()
+        mock_storage.get_profile_by_id.return_value = profile
+        mock_reflexio.request_context.storage = mock_storage
+
+        response = client.get(
+            "/api/get_all_profiles",
+            params={
+                "profile_id": "p-superseded",
+                "include_tombstones": "true",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["user_profiles"][0]["profile_id"] == "p-superseded"
+        assert data["user_profiles"][0]["status"] == "superseded"
+        mock_storage.get_profile_by_id.assert_called_once_with(
+            "p-superseded", include_tombstones=True
+        )
+
+    def test_list_profiles_still_uses_existing_reflexio_method(
+        self, client, patched_reflexio, mock_reflexio
+    ):
+        mock_reflexio.get_all_profiles.return_value = GetProfilesViewResponse(
+            success=True,
+            user_profiles=[],
+            msg="Found 0 profile(s)",
+        )
+
+        response = client.get("/api/get_all_profiles", params={"limit": 10})
+
+        assert response.status_code == 200
+        mock_reflexio.get_all_profiles.assert_called_once()
 
 
 class TestUpdateUserProfileRoute:


### PR DESCRIPTION
## Summary
- Add an exact profile lookup path to `GET /api/get_all_profiles` so callers can request a single profile by `profile_id`.
- Allow that exact lookup to include merged/superseded tombstone rows when requested for detail views.

## Changes
- Backend: accept `profile_id` and `include_tombstones` query params on `get_all_profiles`.
- Backend: route exact lookups through storage `get_profile_by_id` and convert the result to the existing profile view response.
- Tests: cover tombstone-inclusive exact lookup and the existing list path.

## Test Plan
- `uv run ruff check reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- `uv run pyright reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now retrieve a specific profile directly using a profile ID in the profile listing endpoint.
  * Added an option to include merged or superseded records when looking up that profile.
* **Bug Fixes**
  * Requests for a single profile now return a successful empty result when profile storage is unavailable, instead of failing.
* **Tests**
  * Added coverage for direct profile lookup, tombstone inclusion, and the existing list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->