### PR TITLE
feat: enforce governance subject barriers

### DIFF
--- a/reflexio/models/api_schema/domain/governance.py
+++ b/reflexio/models/api_schema/domain/governance.py
@@ -23,6 +23,7 @@ PurgeOperationType = Literal["user_erasure", "org_purge"]
 PurgeScopeType = Literal["user", "org"]
 PurgeStatus = Literal["pending", "running", "failed", "complete"]
 PurgeTargetStatus = Literal["pending", "running", "failed", "complete"]
+SubjectBarrierStatus = Literal["erasing", "erased", "failed"]
 
 __all__ = [
     "AuditActorType",
@@ -33,9 +34,11 @@ __all__ = [
     "PurgeScopeType",
     "PurgeStatus",
     "PurgeTargetStatus",
+    "SubjectBarrierStatus",
     "AuditEvent",
     "PurgeOperation",
     "PurgeOperationTarget",
+    "SubjectWriteBarrier",
     "UserExportResult",
     "UserEraseResult",
 ]
@@ -87,6 +90,17 @@ class PurgeOperationTarget(BaseModel):
     error_detail: str | None = None
     started_at: int | None = None
     completed_at: int | None = None
+
+
+class SubjectWriteBarrier(BaseModel):
+    org_id: str
+    subject_ref: str
+    purge_id: str
+    status: SubjectBarrierStatus
+    error_code: str | None = None
+    error_detail: str | None = None
+    created_at: int = Field(default_factory=_now_epoch)
+    updated_at: int = Field(default_factory=_now_epoch)
 
 
 class UserExportResult(BaseModel):

--- a/reflexio/server/services/governance/config.py
+++ b/reflexio/server/services/governance/config.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from reflexio.server.env_utils import env_str, env_truthy
+from reflexio.server.services.governance.subject_refs import (
+    actor_ref,
+    request_ref,
+    subject_ref,
+)
+
+LOCAL_GOVERNANCE_REF_SECRET = "reflexio-local-governance-ref-secret"  # noqa: S105
+_PRODUCTION_DEPLOYMENT_MODES = {"platform", "self_host"}
+_PRODUCTION_ENVS = {"production", "staging"}
+
+
+def _is_local_dev_or_test() -> bool:
+    deployment_mode = env_str("DEPLOYMENT_MODE").lower()
+    reflexio_env = env_str("REFLEXIO_ENV", "development").lower()
+    if env_truthy(env_str("REFLEXIO_TEST_MODE")):
+        return True
+    return (
+        deployment_mode not in _PRODUCTION_DEPLOYMENT_MODES
+        and reflexio_env not in _PRODUCTION_ENVS
+    )
+
+
+def get_governance_ref_secret() -> str:
+    secret = env_str("REFLEXIO_GOVERNANCE_REF_SECRET")
+    if secret:
+        return secret
+    if _is_local_dev_or_test():
+        return LOCAL_GOVERNANCE_REF_SECRET
+    raise RuntimeError("REFLEXIO_GOVERNANCE_REF_SECRET is required")
+
+
+def governance_subject_ref(org_id: str, user_id: str, secret: str) -> str:
+    return subject_ref(f"{org_id}:subject:{user_id}", secret)
+
+
+def governance_request_ref(org_id: str, request_id: str, secret: str) -> str:
+    return request_ref(f"{org_id}:request:{request_id}", secret)
+
+
+def governance_actor_ref(
+    org_id: str,
+    credential_kind: str,
+    principal_or_fingerprint: str,
+    secret: str,
+) -> str:
+    return actor_ref(
+        f"{org_id}:actor:{credential_kind}:{principal_or_fingerprint}",
+        secret,
+    )

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -48,6 +48,7 @@ class GovernanceService:
         request_id: str,
         actor_context: GovernanceActorContext | None = None,
     ) -> UserExportResult:
+        self._assert_storage_ref_secret_matches()
         subref = governance_subject_ref(self.org_id, user_id, self.ref_secret)
         reqref = governance_request_ref(self.org_id, request_id, self.ref_secret)
         export_id = stable_id("export", f"{self.org_id}:export:{subref}:{reqref}")
@@ -184,7 +185,7 @@ class GovernanceService:
         if storage_secret != self.ref_secret:
             raise RuntimeError(
                 "GovernanceService ref_secret must match REFLEXIO_GOVERNANCE_REF_SECRET "
-                "for erasure"
+                "for governance operations"
             )
 
     def _completed_barrier_for_retry(

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -134,13 +134,11 @@ class GovernanceService:
                     user_id,
                 )
 
-            self.storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
-
             if not self._delete_targets_complete(purge_id):
                 self.storage.apply_governance_user_data_delete(purge_id, user_id)
             deleted_counts = self._deleted_counts_from_targets(purge_id)
 
-            rebuilt_agent_playbook_ids = self._rebuild_agent_playbooks(purge_id)
+            rebuilt_agent_playbook_ids: list[int] = []
             completed = self.storage.complete_subject_erasure_barrier_after_empty_check(
                 purge_id,
                 AuditEvent(

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -6,6 +6,7 @@ from typing import Any, Literal, TypedDict
 from reflexio.models.api_schema.domain.governance import (
     AuditEvent,
     PurgeOperationTarget,
+    SubjectWriteBarrier,
     UserEraseResult,
     UserExportResult,
 )
@@ -107,6 +108,11 @@ class GovernanceService:
             request_ref=reqref,
         )
         if purge.status == "complete":
+            barrier = self._completed_barrier_for_retry(subject_ref=subref, purge_id=purge_id)
+            if barrier.status != "erased":
+                raise ValueError(
+                    "Completed purge retry requires an erased subject barrier"
+                )
             return UserEraseResult(
                 subject_ref=subref,
                 purge_id=purge_id,
@@ -116,9 +122,8 @@ class GovernanceService:
                     self._rebuilt_agent_playbook_ids_from_targets(purge_id)
                 ),
             )
-        self.storage.begin_subject_erasure_barrier(subref, purge_id)
-
         try:
+            self.storage.begin_subject_erasure_barrier(subref, purge_id)
             if not self.storage.purge_targets_prepared(purge_id):
                 self.storage.prepare_governance_erase_targets(
                     purge_id,
@@ -171,6 +176,16 @@ class GovernanceService:
             deleted_counts=deleted_counts,
             rebuilt_agent_playbook_ids=rebuilt_agent_playbook_ids,
         )
+
+    def _completed_barrier_for_retry(
+        self, *, subject_ref: str, purge_id: str
+    ) -> SubjectWriteBarrier:
+        barrier = self.storage.get_subject_write_barrier(subject_ref)
+        if barrier is None or barrier.purge_id != purge_id:
+            raise ValueError(
+                "Completed purge retry requires the matching subject barrier"
+            )
+        return barrier
 
     def _load_user_requests_and_sessions(
         self, user_id: str

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -11,6 +11,7 @@ from reflexio.models.api_schema.domain.governance import (
     UserExportResult,
 )
 from reflexio.server.services.governance.config import (
+    get_governance_ref_secret,
     governance_request_ref,
     governance_subject_ref,
 )
@@ -90,6 +91,7 @@ class GovernanceService:
         request_id: str,
         actor_context: GovernanceActorContext | None = None,
     ) -> UserEraseResult:
+        self._assert_storage_ref_secret_matches()
         subref = governance_subject_ref(self.org_id, user_id, self.ref_secret)
         reqref = governance_request_ref(self.org_id, request_id, self.ref_secret)
         actor_type = actor_context["actor_type"] if actor_context else "system"
@@ -108,7 +110,9 @@ class GovernanceService:
             request_ref=reqref,
         )
         if purge.status == "complete":
-            barrier = self._completed_barrier_for_retry(subject_ref=subref, purge_id=purge_id)
+            barrier = self._completed_barrier_for_retry(
+                subject_ref=subref, purge_id=purge_id
+            )
             if barrier.status != "erased":
                 raise ValueError(
                     "Completed purge retry requires an erased subject barrier"
@@ -176,6 +180,14 @@ class GovernanceService:
             deleted_counts=deleted_counts,
             rebuilt_agent_playbook_ids=rebuilt_agent_playbook_ids,
         )
+
+    def _assert_storage_ref_secret_matches(self) -> None:
+        storage_secret = get_governance_ref_secret()
+        if storage_secret != self.ref_secret:
+            raise RuntimeError(
+                "GovernanceService ref_secret must match REFLEXIO_GOVERNANCE_REF_SECRET "
+                "for erasure"
+            )
 
     def _completed_barrier_for_retry(
         self, *, subject_ref: str, purge_id: str

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 from reflexio.models.api_schema.domain.governance import (
     AuditEvent,
@@ -28,16 +28,29 @@ _REQUIRED_DELETE_TARGET_NAMES = tuple(_DELETE_TARGET_NAME_TO_RESULT_KEY)
 _USER_PLAYBOOK_PAGE_SIZE = 1000
 
 
+class GovernanceActorContext(TypedDict):
+    actor_type: Literal["api_token", "jwt", "system"]
+    actor_ref: str | None
+
+
 class GovernanceService:
     def __init__(self, *, storage: Any, org_id: str, ref_secret: str) -> None:
         self.storage = storage
         self.org_id = org_id
         self.ref_secret = ref_secret
 
-    def export_user(self, *, user_id: str, request_id: str) -> UserExportResult:
+    def export_user(
+        self,
+        *,
+        user_id: str,
+        request_id: str,
+        actor_context: GovernanceActorContext | None = None,
+    ) -> UserExportResult:
         subref = governance_subject_ref(self.org_id, user_id, self.ref_secret)
         reqref = governance_request_ref(self.org_id, request_id, self.ref_secret)
         export_id = stable_id("export", f"{self.org_id}:export:{subref}:{reqref}")
+        actor_type = actor_context["actor_type"] if actor_context else "system"
+        actor_ref = actor_context["actor_ref"] if actor_context else None
         requests, sessions = self._load_user_requests_and_sessions(user_id)
         bundle: dict[str, Any] = {
             "profiles": [
@@ -57,6 +70,8 @@ class GovernanceService:
         self.storage.append_audit_event(
             AuditEvent(
                 org_id=self.org_id,
+                actor_type=actor_type,
+                actor_ref=actor_ref,
                 operation="EXPORT",
                 entity_type="request",
                 subject_ref=subref,
@@ -67,9 +82,17 @@ class GovernanceService:
         )
         return UserExportResult(subject_ref=subref, export_id=export_id, bundle=bundle)
 
-    def erase_user(self, *, user_id: str, request_id: str) -> UserEraseResult:
+    def erase_user(
+        self,
+        *,
+        user_id: str,
+        request_id: str,
+        actor_context: GovernanceActorContext | None = None,
+    ) -> UserEraseResult:
         subref = governance_subject_ref(self.org_id, user_id, self.ref_secret)
         reqref = governance_request_ref(self.org_id, request_id, self.ref_secret)
+        actor_type = actor_context["actor_type"] if actor_context else "system"
+        actor_ref = actor_context["actor_ref"] if actor_context else None
         idempotency_key = stable_id(
             "idem",
             f"{self.org_id}:user_erasure:{subref}:{reqref}",
@@ -85,8 +108,15 @@ class GovernanceService:
         )
         if purge.status == "complete":
             return UserEraseResult(
-                subject_ref=subref, purge_id=purge_id, status="complete"
+                subject_ref=subref,
+                purge_id=purge_id,
+                status="complete",
+                deleted_counts=self._deleted_counts_from_targets(purge_id),
+                rebuilt_agent_playbook_ids=(
+                    self._rebuilt_agent_playbook_ids_from_targets(purge_id)
+                ),
             )
+        self.storage.begin_subject_erasure_barrier(subref, purge_id)
 
         try:
             if not self.storage.purge_targets_prepared(purge_id):
@@ -102,10 +132,12 @@ class GovernanceService:
             deleted_counts = self._deleted_counts_from_targets(purge_id)
 
             rebuilt_agent_playbook_ids = self._rebuild_agent_playbooks(purge_id)
-            completed = self.storage.complete_purge_operation_with_audit(
+            completed = self.storage.complete_subject_erasure_barrier_after_empty_check(
                 purge_id,
                 AuditEvent(
                     org_id=self.org_id,
+                    actor_type=actor_type,
+                    actor_ref=actor_ref,
                     operation="ERASE",
                     entity_type="request",
                     subject_ref=subref,
@@ -118,6 +150,13 @@ class GovernanceService:
                 ),
             )
         except Exception as exc:
+            with suppress(Exception):
+                self.storage.fail_subject_erasure_barrier(
+                    subref,
+                    purge_id,
+                    error_code="governance_erase_failed",
+                    error_detail=type(exc).__name__,
+                )
             with suppress(Exception):
                 self.storage.fail_purge_operation(
                     purge_id,
@@ -200,6 +239,20 @@ class GovernanceService:
                 continue
             counts[result_key] = int(target.deleted_count)
         return counts
+
+    def _rebuilt_agent_playbook_ids_from_targets(self, purge_id: str) -> list[int]:
+        return [
+            int(target.target_ref)
+            for target in self.storage.list_purge_targets(
+                purge_id,
+                phase="rebuild_without_erased_sources",
+            )
+            if (
+                target.target_name == "agent_playbook"
+                and target.target_ref
+                and target.status == "complete"
+            )
+        ]
 
     def _rebuild_agent_playbooks(self, purge_id: str) -> list[int]:
         rebuilt_ids: list[int] = []

--- a/reflexio/server/services/governance/service.py
+++ b/reflexio/server/services/governance/service.py
@@ -9,11 +9,11 @@ from reflexio.models.api_schema.domain.governance import (
     UserEraseResult,
     UserExportResult,
 )
-from reflexio.server.services.governance.subject_refs import (
-    request_ref,
-    stable_id,
-    subject_ref,
+from reflexio.server.services.governance.config import (
+    governance_request_ref,
+    governance_subject_ref,
 )
+from reflexio.server.services.governance.subject_refs import stable_id
 
 _DELETE_TARGET_NAME_TO_RESULT_KEY = {
     "interaction": "interactions",
@@ -35,8 +35,8 @@ class GovernanceService:
         self.ref_secret = ref_secret
 
     def export_user(self, *, user_id: str, request_id: str) -> UserExportResult:
-        subref = subject_ref(user_id, self.ref_secret)
-        reqref = request_ref(request_id, self.ref_secret)
+        subref = governance_subject_ref(self.org_id, user_id, self.ref_secret)
+        reqref = governance_request_ref(self.org_id, request_id, self.ref_secret)
         export_id = stable_id("export", f"{self.org_id}:export:{subref}:{reqref}")
         requests, sessions = self._load_user_requests_and_sessions(user_id)
         bundle: dict[str, Any] = {
@@ -68,8 +68,8 @@ class GovernanceService:
         return UserExportResult(subject_ref=subref, export_id=export_id, bundle=bundle)
 
     def erase_user(self, *, user_id: str, request_id: str) -> UserEraseResult:
-        subref = subject_ref(user_id, self.ref_secret)
-        reqref = request_ref(request_id, self.ref_secret)
+        subref = governance_subject_ref(self.org_id, user_id, self.ref_secret)
+        reqref = governance_request_ref(self.org_id, request_id, self.ref_secret)
         idempotency_key = stable_id(
             "idem",
             f"{self.org_id}:user_erasure:{subref}:{reqref}",

--- a/reflexio/server/services/storage/error.py
+++ b/reflexio/server/services/storage/error.py
@@ -14,6 +14,10 @@ class StorageError(Exception):
         return f"StorageError: {self.message}"
 
 
+class SubjectWriteBarrierError(StorageError):
+    """Raised when a write targets a subject with an active erasure barrier."""
+
+
 def require_non_empty_session_id(value: Any) -> str:
     """Return a stripped, non-empty request ``session_id`` or raise ``StorageError``.
 

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -20,9 +20,15 @@ from reflexio.models.api_schema.domain.governance import (
     PurgeOperationType,
     PurgeScopeType,
     PurgeTargetStatus,
+    SubjectBarrierStatus,
     SubjectWriteBarrier,
 )
 from reflexio.models.config_schema import GovernanceRetentionConfig
+from reflexio.server.services.governance.config import (
+    get_governance_ref_secret,
+    governance_subject_ref,
+)
+from reflexio.server.services.storage.error import SubjectWriteBarrierError
 
 _LEGACY_AUDIT_REQUEST_REF = "reqref_v1_legacy_unknown"
 
@@ -90,6 +96,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_purge_operations_org_idem
 {_PURGE_OPERATION_TARGETS_TABLE_DDL}
 CREATE INDEX IF NOT EXISTS idx_purge_targets_purge_phase
     ON purge_operation_targets(org_id, purge_id, phase, status);
+
+CREATE TABLE IF NOT EXISTS subject_write_barriers (
+    org_id TEXT NOT NULL,
+    subject_ref TEXT NOT NULL,
+    purge_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    error_code TEXT,
+    error_detail TEXT,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (org_id, subject_ref),
+    CHECK (status IN ('erasing', 'erased', 'failed'))
+);
+CREATE INDEX IF NOT EXISTS idx_subject_write_barriers_org_purge
+    ON subject_write_barriers(org_id, purge_id);
 """
 
 _PREPARE_PHASE = "prepare_targets"
@@ -233,6 +254,21 @@ def init_governance_tables(conn: sqlite3.Connection) -> None:
     _upgrade_legacy_purge_operation_targets_table(conn)
     conn.executescript(GOVERNANCE_DDL)
     _enforce_audit_request_ref_not_null(conn)
+    _ensure_governance_subject_ref_columns(conn)
+
+
+def _ensure_governance_subject_ref_columns(conn: sqlite3.Connection) -> None:
+    for table in (
+        "requests",
+        "interactions",
+        "profiles",
+        "user_playbooks",
+        "agent_success_evaluation_result",
+    ):
+        columns = [row[1] for row in conn.execute(f"PRAGMA table_info({table})")]
+        if "governance_subject_ref" in columns:
+            continue
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN governance_subject_ref TEXT")
 
 
 def _epoch_now() -> int:
@@ -894,6 +930,19 @@ def _row_to_purge_target(row: sqlite3.Row) -> PurgeOperationTarget:
     )
 
 
+def _row_to_subject_write_barrier(row: sqlite3.Row) -> SubjectWriteBarrier:
+    return SubjectWriteBarrier(
+        org_id=str(row["org_id"]),
+        subject_ref=str(row["subject_ref"]),
+        purge_id=str(row["purge_id"]),
+        status=cast(SubjectBarrierStatus, str(row["status"])),
+        error_code=row["error_code"],
+        error_detail=row["error_detail"],
+        created_at=int(row["created_at"]),
+        updated_at=int(row["updated_at"]),
+    )
+
+
 class _SQLiteGovernanceDeps(Protocol):
     conn: sqlite3.Connection
     _lock: threading.RLock
@@ -960,7 +1009,7 @@ class SQLiteGovernanceMixin:
             raise ValueError(
                 "Purge operation subject_ref must match the barrier subject_ref"
             )
-        status_by_purge_status = {
+        status_by_purge_status: dict[str, SubjectBarrierStatus] = {
             "pending": "erasing",
             "running": "erasing",
             "complete": "erased",
@@ -976,6 +1025,45 @@ class SQLiteGovernanceMixin:
             created_at=purge_operation.created_at,
             updated_at=purge_operation.updated_at,
         )
+
+    def _active_subject_barrier_locked(self, subject_ref: str) -> sqlite3.Row | None:
+        return self.conn.execute(
+            """SELECT * FROM subject_write_barriers
+               WHERE org_id = ? AND subject_ref = ? AND status IN ('erasing', 'erased')""",
+            (self.org_id, subject_ref),
+        ).fetchone()
+
+    def _assert_subject_writable_locked(self, subject_ref: str) -> None:
+        row = self._active_subject_barrier_locked(subject_ref)
+        if row is not None:
+            raise SubjectWriteBarrierError(
+                f"subject {subject_ref} is blocked by erasure barrier {row['purge_id']}"
+            )
+
+    def _subject_ref_for_user_id(self, user_id: str) -> str:
+        return governance_subject_ref(
+            self.org_id,
+            user_id,
+            get_governance_ref_secret(),
+        )
+
+    def _same_subject_rows_remain_locked(self, subject_ref: str) -> bool:
+        for table in (
+            "requests",
+            "interactions",
+            "profiles",
+            "user_playbooks",
+            "agent_success_evaluation_result",
+        ):
+            row = self.conn.execute(
+                f"""SELECT 1 FROM {table}
+                    WHERE governance_subject_ref = ?
+                    LIMIT 1""",
+                (subject_ref,),
+            ).fetchone()
+            if row is not None:
+                return True
+        return False
 
     def _replace_agent_playbook_source_windows_locked(
         self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
@@ -2145,18 +2233,188 @@ class SQLiteGovernanceMixin:
         _validate_governance_prefixed_ref(
             "subject_ref", subject_ref, prefix="subref_v1_"
         )
-        purge_operation = self.get_purge_operation(purge_id)
-        return self._barrier_from_purge(purge_operation, subject_ref=subject_ref)
+        validated_purge_id = _validate_governance_purge_id("purge_id", purge_id)
+        now = _epoch_now()
+        with self._lock:
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                self.conn.execute(
+                    """INSERT INTO subject_write_barriers
+                       (org_id, subject_ref, purge_id, status, created_at, updated_at)
+                       VALUES (?, ?, ?, 'erasing', ?, ?)
+                       ON CONFLICT(org_id, subject_ref) DO UPDATE SET
+                         purge_id = excluded.purge_id,
+                         status = 'erasing',
+                         error_code = NULL,
+                         error_detail = NULL,
+                         updated_at = excluded.updated_at""",
+                    (self.org_id, subject_ref, validated_purge_id, now, now),
+                )
+                row = self.conn.execute(
+                    """SELECT * FROM subject_write_barriers
+                       WHERE org_id = ? AND subject_ref = ?""",
+                    (self.org_id, subject_ref),
+                ).fetchone()
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        if row is None:
+            raise ValueError("subject erasure barrier insert failed")
+        return _row_to_subject_write_barrier(row)
 
     def assert_subject_writable(self, subject_ref: str) -> None:
         _validate_governance_prefixed_ref(
             "subject_ref", subject_ref, prefix="subref_v1_"
         )
+        with self._lock:
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                self._assert_subject_writable_locked(subject_ref)
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     def complete_subject_erasure_barrier_after_empty_check(
         self, purge_id: str, audit_event: AuditEvent
     ) -> PurgeOperation:
-        return self.complete_purge_operation_with_audit(purge_id, audit_event)
+        purge_id = _validate_governance_purge_id("purge_id", purge_id)
+        if audit_event.org_id != self.org_id:
+            raise ValueError("Audit event org_id must match storage org_id")
+        if audit_event.idempotency_key != purge_id:
+            raise ValueError("Audit event idempotency key must match purge_id")
+        if not _is_successful_erase_event(audit_event, purge_id=purge_id):
+            raise ValueError(
+                "Completion requires a successful ERASE audit event for this purge"
+            )
+        audit_event = _canonicalize_audit_event_for_persistence(audit_event)
+        now = _epoch_now()
+        with self._lock:
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                row = self.conn.execute(
+                    "SELECT * FROM purge_operations WHERE purge_id = ? AND org_id = ?",
+                    (purge_id, self.org_id),
+                ).fetchone()
+                if row is None:
+                    raise ValueError(f"Purge operation {purge_id!r} not found")
+                purge_operation = _row_to_purge_operation(row)
+                if purge_operation.subject_ref != audit_event.subject_ref:
+                    raise ValueError(
+                        "Audit event subject_ref must match purge operation subject_ref"
+                    )
+                if purge_operation.request_ref != audit_event.request_ref:
+                    raise ValueError(
+                        "Audit event request_ref must match purge operation request_ref"
+                    )
+                snapshot = self.conn.execute(
+                    """SELECT 1 FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = 'all'
+                         AND phase = ? AND status = 'complete'""",
+                    (self.org_id, purge_id, _SNAPSHOT_TARGET_NAME, _PREPARE_PHASE),
+                ).fetchone()
+                if snapshot is None:
+                    raise ValueError(
+                        "Cannot complete purge without target snapshot marker"
+                    )
+                if self._same_subject_rows_remain_locked(audit_event.subject_ref or ""):
+                    raise ValueError("same-subject rows remain")
+                delete_rows = self.conn.execute(
+                    """SELECT target_name, status FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ? AND phase = 'delete'
+                         AND target_ref = 'all'""",
+                    (self.org_id, purge_id),
+                ).fetchall()
+                delete_statuses = {
+                    str(target_row["target_name"]): str(target_row["status"])
+                    for target_row in delete_rows
+                }
+                missing_delete_targets = [
+                    target_name
+                    for target_name in _CANONICAL_DELETE_TARGET_NAMES
+                    if delete_statuses.get(target_name) != "complete"
+                ]
+                if missing_delete_targets:
+                    raise ValueError(
+                        "Cannot complete purge without complete delete target matrix: "
+                        + ", ".join(missing_delete_targets)
+                    )
+                incomplete = self.conn.execute(
+                    """SELECT 1 FROM purge_operation_targets
+                       WHERE org_id = ? AND purge_id = ? AND status != 'complete'
+                       LIMIT 1""",
+                    (self.org_id, purge_id),
+                ).fetchone()
+                if incomplete is not None:
+                    raise ValueError("Cannot complete purge with incomplete targets")
+                existing_audit_row = self.conn.execute(
+                    """SELECT * FROM audit_events
+                       WHERE org_id = ? AND idempotency_key = ?""",
+                    (self.org_id, purge_id),
+                ).fetchone()
+                if existing_audit_row is not None:
+                    existing_event = _row_to_audit_event(existing_audit_row)
+                    if not _is_successful_erase_event(
+                        existing_event, purge_id=purge_id
+                    ):
+                        raise ValueError(
+                            "Existing audit row for purge_id must be the matching "
+                            "successful ERASE row"
+                        )
+                    if _successful_erase_identity(
+                        existing_event
+                    ) != _successful_erase_identity(audit_event):
+                        raise ValueError(
+                            "Existing audit row for purge_id must be the matching "
+                            "successful ERASE row"
+                        )
+                else:
+                    self._append_audit_event_with_cursor(self.conn, audit_event)
+                    existing_audit_row = self.conn.execute(
+                        """SELECT * FROM audit_events
+                           WHERE org_id = ? AND idempotency_key = ?""",
+                        (self.org_id, purge_id),
+                    ).fetchone()
+                if existing_audit_row is None:
+                    raise ValueError(
+                        "Completion requires exactly one successful ERASE audit row "
+                        "for the purge_id"
+                    )
+                existing_event = _row_to_audit_event(existing_audit_row)
+                if not _is_successful_erase_event(existing_event, purge_id=purge_id):
+                    raise ValueError(
+                        "Completion requires exactly one matching successful ERASE "
+                        "audit row for the purge_id"
+                    )
+                if _successful_erase_identity(
+                    existing_event
+                ) != _successful_erase_identity(audit_event):
+                    raise ValueError(
+                        "Completion requires exactly one matching successful ERASE "
+                        "audit row for the purge_id"
+                    )
+                self.conn.execute(
+                    """UPDATE subject_write_barriers
+                       SET status = 'erased', error_code = NULL, error_detail = NULL, updated_at = ?
+                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
+                    (now, self.org_id, audit_event.subject_ref, purge_id),
+                )
+                self.conn.execute(
+                    """UPDATE purge_operations
+                       SET status = 'complete',
+                           error_code = NULL,
+                           error_detail = NULL,
+                           updated_at = ?,
+                           completed_at = ?
+                       WHERE purge_id = ? AND org_id = ?""",
+                    (now, now, purge_id, self.org_id),
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        return self.get_purge_operation(purge_id)
 
     def fail_subject_erasure_barrier(
         self,
@@ -2168,8 +2426,64 @@ class SQLiteGovernanceMixin:
         _validate_governance_prefixed_ref(
             "subject_ref", subject_ref, prefix="subref_v1_"
         )
-        purge_operation = self.fail_purge_operation(purge_id, error_code, error_detail)
-        return self._barrier_from_purge(purge_operation, subject_ref=subject_ref)
+        validated_purge_id = _validate_governance_purge_id("purge_id", purge_id)
+        validated_error_code = _validate_governance_error_code(error_code)
+        validated_error_detail = _validate_governance_error_detail(error_detail)
+        now = _epoch_now()
+        with self._lock:
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                self.conn.execute(
+                    """INSERT INTO subject_write_barriers
+                       (org_id, subject_ref, purge_id, status, error_code, error_detail, created_at, updated_at)
+                       VALUES (?, ?, ?, 'failed', ?, ?, ?, ?)
+                       ON CONFLICT(org_id, subject_ref) DO UPDATE SET
+                         purge_id = excluded.purge_id,
+                         status = 'failed',
+                         error_code = excluded.error_code,
+                         error_detail = excluded.error_detail,
+                         updated_at = excluded.updated_at""",
+                    (
+                        self.org_id,
+                        subject_ref,
+                        validated_purge_id,
+                        validated_error_code,
+                        validated_error_detail,
+                        now,
+                        now,
+                    ),
+                )
+                purge_row = self.conn.execute(
+                    "SELECT 1 FROM purge_operations WHERE purge_id = ? AND org_id = ?",
+                    (validated_purge_id, self.org_id),
+                ).fetchone()
+                if purge_row is not None:
+                    self.conn.execute(
+                        """UPDATE purge_operations
+                           SET status = 'failed', error_code = ?, error_detail = ?,
+                               updated_at = ?, completed_at = ?
+                           WHERE purge_id = ? AND org_id = ?""",
+                        (
+                            validated_error_code,
+                            validated_error_detail,
+                            now,
+                            now,
+                            validated_purge_id,
+                            self.org_id,
+                        ),
+                    )
+                row = self.conn.execute(
+                    """SELECT * FROM subject_write_barriers
+                       WHERE org_id = ? AND subject_ref = ?""",
+                    (self.org_id, subject_ref),
+                ).fetchone()
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        if row is None:
+            raise ValueError("subject erasure barrier update failed")
+        return _row_to_subject_write_barrier(row)
 
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -267,8 +267,13 @@ def _ensure_governance_subject_ref_columns(conn: sqlite3.Connection) -> None:
     ):
         columns = [row[1] for row in conn.execute(f"PRAGMA table_info({table})")]
         if "governance_subject_ref" in columns:
-            continue
-        conn.execute(f"ALTER TABLE {table} ADD COLUMN governance_subject_ref TEXT")
+            pass
+        else:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN governance_subject_ref TEXT")
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{table}_governance_subject_ref "
+            f"ON {table}(governance_subject_ref)"
+        )
 
 
 def _epoch_now() -> int:
@@ -1053,7 +1058,7 @@ class SQLiteGovernanceMixin:
             """SELECT request_id, user_id
                FROM requests
                WHERE governance_subject_ref IS NULL"""
-        ).fetchall():
+        ):
             user_id = str(row["user_id"])
             if self._subject_ref_for_user_id(user_id) != subject_ref:
                 continue
@@ -1069,7 +1074,7 @@ class SQLiteGovernanceMixin:
         request_id_column: str | None = None,
     ) -> bool:
         sql = f"SELECT user_id{', ' + request_id_column if request_id_column else ''} FROM {table} WHERE governance_subject_ref IS NULL"  # noqa: S608
-        for row in self.conn.execute(sql).fetchall():
+        for row in self.conn.execute(sql):
             user_id = str(row["user_id"])
             if self._subject_ref_for_user_id(user_id) == subject_ref:
                 return True
@@ -2189,6 +2194,13 @@ class SQLiteGovernanceMixin:
                     raise ValueError(
                         "Audit event request_ref must match purge operation request_ref"
                     )
+                barrier_row = self.conn.execute(
+                    """SELECT status FROM subject_write_barriers
+                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
+                    (self.org_id, audit_event.subject_ref, purge_id),
+                ).fetchone()
+                if barrier_row is None or barrier_row["status"] != "erasing":
+                    raise ValueError("subject erasure barrier is missing")
                 snapshot = self.conn.execute(
                     """SELECT 1 FROM purge_operation_targets
                        WHERE org_id = ? AND purge_id = ? AND target_name = ? AND target_ref = 'all'
@@ -2481,12 +2493,14 @@ class SQLiteGovernanceMixin:
                         "Completion requires exactly one matching successful ERASE "
                         "audit row for the purge_id"
                     )
-                self.conn.execute(
+                barrier_update = self.conn.execute(
                     """UPDATE subject_write_barriers
                        SET status = 'erased', error_code = NULL, error_detail = NULL, updated_at = ?
                        WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
                     (now, self.org_id, audit_event.subject_ref, purge_id),
                 )
+                if barrier_update.rowcount != 1:
+                    raise ValueError("subject erasure barrier is missing")
                 self.conn.execute(
                     """UPDATE purge_operations
                        SET status = 'complete',

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -2572,6 +2572,19 @@ class SQLiteGovernanceMixin:
             raise ValueError("subject erasure barrier update failed")
         return _row_to_subject_write_barrier(row)
 
+    def get_subject_write_barrier(self, subject_ref: str) -> SubjectWriteBarrier | None:
+        _validate_governance_prefixed_ref(
+            "subject_ref", subject_ref, prefix="subref_v1_"
+        )
+        row = self.conn.execute(
+            """SELECT * FROM subject_write_barriers
+               WHERE org_id = ? AND subject_ref = ?""",
+            (self.org_id, subject_ref),
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_subject_write_barrier(row)
+
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str
     ) -> PurgeOperation:

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1047,7 +1047,42 @@ class SQLiteGovernanceMixin:
             get_governance_ref_secret(),
         )
 
+    def _legacy_request_ids_for_subject_locked(self, subject_ref: str) -> set[str]:
+        request_ids: set[str] = set()
+        for row in self.conn.execute(
+            """SELECT request_id, user_id
+               FROM requests
+               WHERE governance_subject_ref IS NULL"""
+        ).fetchall():
+            user_id = str(row["user_id"])
+            if self._subject_ref_for_user_id(user_id) != subject_ref:
+                continue
+            request_ids.add(str(row["request_id"]))
+        return request_ids
+
+    def _legacy_user_id_rows_remain_locked(
+        self,
+        *,
+        table: str,
+        subject_ref: str,
+        request_ids: set[str] | None = None,
+        request_id_column: str | None = None,
+    ) -> bool:
+        sql = f"SELECT user_id{', ' + request_id_column if request_id_column else ''} FROM {table} WHERE governance_subject_ref IS NULL"  # noqa: S608
+        for row in self.conn.execute(sql).fetchall():
+            user_id = str(row["user_id"])
+            if self._subject_ref_for_user_id(user_id) == subject_ref:
+                return True
+            if (
+                request_ids
+                and request_id_column is not None
+                and str(row[request_id_column]) in request_ids
+            ):
+                return True
+        return False
+
     def _same_subject_rows_remain_locked(self, subject_ref: str) -> bool:
+        legacy_request_ids = self._legacy_request_ids_for_subject_locked(subject_ref)
         for table in (
             "requests",
             "interactions",
@@ -1063,7 +1098,33 @@ class SQLiteGovernanceMixin:
             ).fetchone()
             if row is not None:
                 return True
-        return False
+        if legacy_request_ids:
+            return True
+        if self._legacy_user_id_rows_remain_locked(
+            table="interactions",
+            subject_ref=subject_ref,
+            request_ids=legacy_request_ids,
+            request_id_column="request_id",
+        ):
+            return True
+        if self._legacy_user_id_rows_remain_locked(
+            table="profiles",
+            subject_ref=subject_ref,
+            request_ids=legacy_request_ids,
+            request_id_column="generated_from_request_id",
+        ):
+            return True
+        if self._legacy_user_id_rows_remain_locked(
+            table="user_playbooks",
+            subject_ref=subject_ref,
+            request_ids=legacy_request_ids,
+            request_id_column="request_id",
+        ):
+            return True
+        return self._legacy_user_id_rows_remain_locked(
+            table="agent_success_evaluation_result",
+            subject_ref=subject_ref,
+        )
 
     def _replace_agent_playbook_source_windows_locked(
         self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
@@ -2238,6 +2299,32 @@ class SQLiteGovernanceMixin:
         with self._lock:
             try:
                 self.conn.execute("BEGIN IMMEDIATE")
+                purge_row = self.conn.execute(
+                    """SELECT * FROM purge_operations
+                       WHERE purge_id = ? AND org_id = ?""",
+                    (validated_purge_id, self.org_id),
+                ).fetchone()
+                if purge_row is None:
+                    raise ValueError(
+                        f"Purge operation {validated_purge_id!r} not found"
+                    )
+                purge_operation = _row_to_purge_operation(purge_row)
+                if purge_operation.subject_ref != subject_ref:
+                    raise ValueError(
+                        "Purge operation subject_ref must match the barrier subject_ref"
+                    )
+                existing_barrier = self.conn.execute(
+                    """SELECT purge_id FROM subject_write_barriers
+                       WHERE org_id = ? AND subject_ref = ?""",
+                    (self.org_id, subject_ref),
+                ).fetchone()
+                if (
+                    existing_barrier is not None
+                    and str(existing_barrier["purge_id"]) != validated_purge_id
+                ):
+                    raise ValueError(
+                        "Existing barrier purge_id must match the requested purge_id"
+                    )
                 self.conn.execute(
                     """INSERT INTO subject_write_barriers
                        (org_id, subject_ref, purge_id, status, created_at, updated_at)

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -266,6 +266,8 @@ def _ensure_governance_subject_ref_columns(conn: sqlite3.Connection) -> None:
         "agent_success_evaluation_result",
     ):
         columns = [row[1] for row in conn.execute(f"PRAGMA table_info({table})")]
+        if not columns:
+            continue
         if "governance_subject_ref" in columns:
             pass
         else:
@@ -1630,8 +1632,9 @@ class SQLiteGovernanceMixin:
             "DELETE FROM requests WHERE user_id = ?",
             (user_id,),
         )
+        if raw_upb_ids:
+            deps._delete_source_windows_for_user_playbook_ids(raw_upb_ids)
         if delete_upb_ids:
-            deps._delete_source_windows_for_user_playbook_ids(delete_upb_ids)
             deps._delete_in_chunks("user_playbooks", "user_playbook_id", delete_upb_ids)
         if delete_profile_ids:
             deps._delete_in_chunks("profiles", "profile_id", delete_profile_ids)
@@ -1827,64 +1830,6 @@ class SQLiteGovernanceMixin:
                     user_id,
                     owned_user_playbook_ids,
                 )
-                affected_agent_playbook_ids: list[int] = []
-                rebuild_details_by_agent_playbook_id: dict[int, dict[str, object]] = {}
-                if owned_user_playbook_ids:
-                    placeholders = ",".join("?" for _ in owned_user_playbook_ids)
-                    rows = self.conn.execute(
-                        f"""SELECT DISTINCT apsup.agent_playbook_id
-                            FROM agent_playbook_source_user_playbooks
-                            AS apsup
-                            JOIN agent_playbooks ap
-                              ON ap.agent_playbook_id = apsup.agent_playbook_id
-                            WHERE user_playbook_id IN ({placeholders})
-                            ORDER BY apsup.agent_playbook_id ASC""",
-                        sorted(owned_user_playbook_ids),
-                    ).fetchall()
-                    affected_agent_playbook_ids = [
-                        int(row["agent_playbook_id"]) for row in rows
-                    ]
-                    for agent_playbook_id in affected_agent_playbook_ids:
-                        status_row = self.conn.execute(
-                            """SELECT status
-                               FROM agent_playbooks
-                               WHERE agent_playbook_id = ?""",
-                            (agent_playbook_id,),
-                        ).fetchone()
-                        if status_row is None:
-                            raise ValueError(
-                                f"Agent playbook with ID {agent_playbook_id} not found"
-                            )
-                        window_rows = self.conn.execute(
-                            """SELECT user_playbook_id, source_interaction_ids
-                               FROM agent_playbook_source_user_playbooks
-                               WHERE agent_playbook_id = ?
-                               ORDER BY user_playbook_id ASC""",
-                            (agent_playbook_id,),
-                        ).fetchall()
-                        original_window_dicts = [
-                            {
-                                "user_playbook_id": int(row["user_playbook_id"]),
-                                "source_interaction_ids": [
-                                    int(source_id)
-                                    for source_id in (
-                                        _json_loads(row["source_interaction_ids"]) or []
-                                    )
-                                ],
-                            }
-                            for row in window_rows
-                        ]
-                        remaining_window_dicts = [
-                            window
-                            for window in original_window_dicts
-                            if int(window["user_playbook_id"])
-                            not in owned_user_playbook_ids
-                        ]
-                        rebuild_details_by_agent_playbook_id[agent_playbook_id] = {
-                            "original_source_windows": original_window_dicts,
-                            "previous_lifecycle_status": status_row["status"],
-                            "remaining_source_windows": remaining_window_dicts,
-                        }
                 for target_name, count in targets.items():
                     self._record_purge_target_locked(
                         purge_id=purge_id,
@@ -1896,17 +1841,6 @@ class SQLiteGovernanceMixin:
                         deleted_count=0,
                         error_detail=None,
                     )
-                for agent_playbook_id in affected_agent_playbook_ids:
-                    self._record_purge_target_locked(
-                        purge_id=purge_id,
-                        target_name="agent_playbook",
-                        target_ref=str(agent_playbook_id),
-                        phase="rebuild_without_erased_sources",
-                        status="pending",
-                        detail=rebuild_details_by_agent_playbook_id[agent_playbook_id],
-                        deleted_count=0,
-                        error_detail=None,
-                    )
                 self._record_purge_target_locked(
                     purge_id=purge_id,
                     target_name=_SNAPSHOT_TARGET_NAME,
@@ -1915,7 +1849,6 @@ class SQLiteGovernanceMixin:
                     status="complete",
                     detail={
                         "owned_user_playbook_ids": sorted(owned_user_playbook_ids),
-                        "affected_agent_playbook_ids": affected_agent_playbook_ids,
                     },
                     deleted_count=0,
                     error_detail=None,

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -20,6 +20,7 @@ from reflexio.models.api_schema.domain.governance import (
     PurgeOperationType,
     PurgeScopeType,
     PurgeTargetStatus,
+    SubjectWriteBarrier,
 )
 from reflexio.models.config_schema import GovernanceRetentionConfig
 
@@ -948,6 +949,33 @@ class SQLiteGovernanceMixin:
 
     def _deps(self) -> _SQLiteGovernanceDeps:
         return cast(_SQLiteGovernanceDeps, self)
+
+    def _barrier_from_purge(
+        self,
+        purge_operation: PurgeOperation,
+        *,
+        subject_ref: str,
+    ) -> SubjectWriteBarrier:
+        if purge_operation.subject_ref != subject_ref:
+            raise ValueError(
+                "Purge operation subject_ref must match the barrier subject_ref"
+            )
+        status_by_purge_status = {
+            "pending": "erasing",
+            "running": "erasing",
+            "complete": "erased",
+            "failed": "failed",
+        }
+        return SubjectWriteBarrier(
+            org_id=purge_operation.org_id,
+            subject_ref=subject_ref,
+            purge_id=purge_operation.purge_id,
+            status=status_by_purge_status[purge_operation.status],
+            error_code=purge_operation.error_code,
+            error_detail=purge_operation.error_detail,
+            created_at=purge_operation.created_at,
+            updated_at=purge_operation.updated_at,
+        )
 
     def _replace_agent_playbook_source_windows_locked(
         self, agent_playbook_id: int, windows: list[AgentPlaybookSourceWindow]
@@ -2110,6 +2138,38 @@ class SQLiteGovernanceMixin:
                 self.conn.rollback()
                 raise
         return self.get_purge_operation(purge_id)
+
+    def begin_subject_erasure_barrier(
+        self, subject_ref: str, purge_id: str
+    ) -> SubjectWriteBarrier:
+        _validate_governance_prefixed_ref(
+            "subject_ref", subject_ref, prefix="subref_v1_"
+        )
+        purge_operation = self.get_purge_operation(purge_id)
+        return self._barrier_from_purge(purge_operation, subject_ref=subject_ref)
+
+    def assert_subject_writable(self, subject_ref: str) -> None:
+        _validate_governance_prefixed_ref(
+            "subject_ref", subject_ref, prefix="subref_v1_"
+        )
+
+    def complete_subject_erasure_barrier_after_empty_check(
+        self, purge_id: str, audit_event: AuditEvent
+    ) -> PurgeOperation:
+        return self.complete_purge_operation_with_audit(purge_id, audit_event)
+
+    def fail_subject_erasure_barrier(
+        self,
+        subject_ref: str,
+        purge_id: str,
+        error_code: str,
+        error_detail: str,
+    ) -> SubjectWriteBarrier:
+        _validate_governance_prefixed_ref(
+            "subject_ref", subject_ref, prefix="subref_v1_"
+        )
+        purge_operation = self.fail_purge_operation(purge_id, error_code, error_detail)
+        return self._barrier_from_purge(purge_operation, subject_ref=subject_ref)
 
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -2520,26 +2520,26 @@ class SQLiteGovernanceMixin:
         with self._lock:
             try:
                 self.conn.execute("BEGIN IMMEDIATE")
-                self.conn.execute(
-                    """INSERT INTO subject_write_barriers
-                       (org_id, subject_ref, purge_id, status, error_code, error_detail, created_at, updated_at)
-                       VALUES (?, ?, ?, 'failed', ?, ?, ?, ?)
-                       ON CONFLICT(org_id, subject_ref) DO UPDATE SET
-                         purge_id = excluded.purge_id,
-                         status = 'failed',
-                         error_code = excluded.error_code,
-                         error_detail = excluded.error_detail,
-                         updated_at = excluded.updated_at""",
+                update_cursor = self.conn.execute(
+                    """UPDATE subject_write_barriers
+                       SET status = 'failed',
+                           error_code = ?,
+                           error_detail = ?,
+                           updated_at = ?
+                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
                     (
-                        self.org_id,
-                        subject_ref,
-                        validated_purge_id,
                         validated_error_code,
                         validated_error_detail,
                         now,
-                        now,
+                        self.org_id,
+                        subject_ref,
+                        validated_purge_id,
                     ),
                 )
+                if update_cursor.rowcount != 1:
+                    raise ValueError(
+                        "subject erasure barrier failure requires a matching barrier"
+                    )
                 purge_row = self.conn.execute(
                     "SELECT 1 FROM purge_operations WHERE purge_id = ? AND org_id = ?",
                     (validated_purge_id, self.org_id),
@@ -2561,8 +2561,8 @@ class SQLiteGovernanceMixin:
                     )
                 row = self.conn.execute(
                     """SELECT * FROM subject_write_barriers
-                       WHERE org_id = ? AND subject_ref = ?""",
-                    (self.org_id, subject_ref),
+                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
+                    (self.org_id, subject_ref, validated_purge_id),
                 ).fetchone()
                 self.conn.commit()
             except Exception:

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -2259,7 +2259,7 @@ class SQLiteGovernanceMixin:
                         "Purge operation subject_ref must match the barrier subject_ref"
                     )
                 existing_barrier = self.conn.execute(
-                    """SELECT purge_id FROM subject_write_barriers
+                    """SELECT * FROM subject_write_barriers
                        WHERE org_id = ? AND subject_ref = ?""",
                     (self.org_id, subject_ref),
                 ).fetchone()
@@ -2270,6 +2270,13 @@ class SQLiteGovernanceMixin:
                     raise ValueError(
                         "Existing barrier purge_id must match the requested purge_id"
                     )
+                if (
+                    existing_barrier is not None
+                    and str(existing_barrier["status"]) == "erased"
+                ):
+                    row = existing_barrier
+                    self.conn.commit()
+                    return _row_to_subject_write_barrier(row)
                 self.conn.execute(
                     """INSERT INTO subject_write_barriers
                        (org_id, subject_ref, purge_id, status, created_at, updated_at)
@@ -2473,7 +2480,8 @@ class SQLiteGovernanceMixin:
                            error_code = ?,
                            error_detail = ?,
                            updated_at = ?
-                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
+                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?
+                         AND status = 'erasing'""",
                     (
                         validated_error_code,
                         validated_error_detail,
@@ -2544,7 +2552,7 @@ class SQLiteGovernanceMixin:
                 """UPDATE purge_operations
                    SET status = 'failed', error_code = ?, error_detail = ?,
                    updated_at = ?, completed_at = ?
-                   WHERE purge_id = ? AND org_id = ?""",
+                   WHERE purge_id = ? AND org_id = ? AND status != 'complete'""",
                 (
                     validated_error_code,
                     validated_error_detail,
@@ -2555,6 +2563,12 @@ class SQLiteGovernanceMixin:
                 ),
             )
             if cur.rowcount == 0:
+                existing = self.conn.execute(
+                    "SELECT status FROM purge_operations WHERE purge_id = ? AND org_id = ?",
+                    (purge_id, self.org_id),
+                ).fetchone()
+                if existing is not None and str(existing["status"]) == "complete":
+                    raise ValueError("Purge operation is already complete")
                 raise ValueError(f"Purge operation {purge_id!r} not found")
             self.conn.commit()
         return self.get_purge_operation(purge_id)

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -2496,7 +2496,7 @@ class SQLiteGovernanceMixin:
                 barrier_update = self.conn.execute(
                     """UPDATE subject_write_barriers
                        SET status = 'erased', error_code = NULL, error_detail = NULL, updated_at = ?
-                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ?""",
+                       WHERE org_id = ? AND subject_ref = ? AND purge_id = ? AND status = 'erasing'""",
                     (now, self.org_id, audit_event.subject_ref, purge_id),
                 )
                 if barrier_update.rowcount != 1:

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -95,7 +95,8 @@ _PROFILE_PURGE_SQL = (
     "UPDATE profiles SET "
     "content='', user_id='', generated_from_request_id='', source='', "
     "embedding=NULL, extractor_names=NULL, expanded_terms=NULL, tags=NULL, "
-    "custom_features=NULL, notes=NULL, source_span=NULL, reader_angle=NULL "
+    "custom_features=NULL, notes=NULL, source_span=NULL, reader_angle=NULL, "
+    "governance_subject_ref=NULL "
     "WHERE profile_id=?"
 )
 _USER_PLAYBOOK_PURGE_SQL = (
@@ -103,7 +104,8 @@ _USER_PLAYBOOK_PURGE_SQL = (
     "content='', user_id=NULL, request_id='', source=NULL, "
     "trigger=NULL, rationale=NULL, blocking_issue=NULL, "
     "source_interaction_ids=NULL, embedding=NULL, expanded_terms=NULL, "
-    "tags=NULL, source_span=NULL, notes=NULL, reader_angle=NULL "
+    "tags=NULL, source_span=NULL, notes=NULL, reader_angle=NULL, "
+    "governance_subject_ref=NULL "
     "WHERE user_playbook_id=?"
 )
 # agent_playbook purge not yet required; added when Task 3/4 needs it.

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -208,11 +208,12 @@ class PlaybookMixin:
 
     def _subject_ref_from_user_playbook_row(self, row: sqlite3.Row) -> str:
         subject_ref = row["governance_subject_ref"]
-        return (
-            str(subject_ref)
-            if subject_ref
-            else self._subject_ref_for_user_id(row["user_id"])
-        )
+        if subject_ref:
+            return str(subject_ref)
+        user_id = row["user_id"]
+        if user_id is None or str(user_id) == "":
+            raise ValueError("User playbook subject identity is missing")
+        return self._subject_ref_for_user_id(str(user_id))
 
     def _assert_user_playbook_writable_locked(
         self,

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -199,6 +199,8 @@ class PlaybookMixin:
     _vec_delete: Any
     _delete_playbook_search_rows: Any
     _has_sqlite_vec: bool
+    _subject_ref_for_user_id: Any
+    _assert_subject_writable_locked: Any
 
     # ------------------------------------------------------------------
     # User Playbook methods
@@ -223,44 +225,52 @@ class PlaybookMixin:
                     up.embedding = self._get_embedding(embedding_text)
 
             created_at_iso = _epoch_to_iso(up.created_at)
+            subject_ref = self._subject_ref_for_user_id(up.user_id)
             with self._lock:
-                cur = self.conn.execute(
-                    """INSERT INTO user_playbooks
-                       (user_id, playbook_name, created_at, request_id, agent_version,
-                        content, trigger, rationale, blocking_issue,
-                        source_interaction_ids,
-                        status, source, embedding, expanded_terms,
-                        source_span, notes, reader_angle, tags,
-                        merged_into, superseded_by)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                    (
-                        up.user_id,
-                        up.playbook_name,
-                        created_at_iso,
-                        up.request_id,
-                        up.agent_version,
-                        up.content,
-                        up.trigger,
-                        up.rationale,
-                        json.dumps(up.blocking_issue.model_dump())
-                        if up.blocking_issue
-                        else None,
-                        _json_dumps(up.source_interaction_ids or None),
-                        up.status.value if up.status else None,
-                        up.source,
-                        _json_dumps(up.embedding),
-                        up.expanded_terms,
-                        up.source_span,
-                        up.notes,
-                        up.reader_angle,
-                        _json_dumps(up.tags),
-                        up.merged_into,
-                        up.superseded_by,
-                    ),
-                )
-                upid = cur.lastrowid or 0
-                up.user_playbook_id = upid
-                self.conn.commit()
+                try:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                    self._assert_subject_writable_locked(subject_ref)
+                    cur = self.conn.execute(
+                        """INSERT INTO user_playbooks
+                           (user_id, playbook_name, created_at, request_id, agent_version,
+                            content, trigger, rationale, blocking_issue,
+                            source_interaction_ids,
+                            status, source, embedding, expanded_terms,
+                            source_span, notes, reader_angle, tags,
+                            merged_into, superseded_by, governance_subject_ref)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        (
+                            up.user_id,
+                            up.playbook_name,
+                            created_at_iso,
+                            up.request_id,
+                            up.agent_version,
+                            up.content,
+                            up.trigger,
+                            up.rationale,
+                            json.dumps(up.blocking_issue.model_dump())
+                            if up.blocking_issue
+                            else None,
+                            _json_dumps(up.source_interaction_ids or None),
+                            up.status.value if up.status else None,
+                            up.source,
+                            _json_dumps(up.embedding),
+                            up.expanded_terms,
+                            up.source_span,
+                            up.notes,
+                            up.reader_angle,
+                            _json_dumps(up.tags),
+                            up.merged_into,
+                            up.superseded_by,
+                            subject_ref,
+                        ),
+                    )
+                    upid = cur.lastrowid or 0
+                    up.user_playbook_id = upid
+                    self.conn.commit()
+                except Exception:
+                    self.conn.rollback()
+                    raise
 
             fts_parts = [up.trigger or "", up.content or ""]
             if up.expanded_terms:
@@ -1658,24 +1668,42 @@ class PlaybookMixin:
                     ids.append(source_id)
                     seen.add(source_id)
         with self._lock:
-            self.conn.execute(
-                "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
-                (agent_playbook_id,),
-            )
-            self.conn.executemany(
-                """INSERT OR IGNORE INTO agent_playbook_source_user_playbooks
-                   (agent_playbook_id, user_playbook_id, source_interaction_ids)
-                   VALUES (?, ?, ?)""",
-                [
-                    (
-                        agent_playbook_id,
-                        upid,
-                        _json_dumps(source_interaction_ids) or "[]",
-                    )
-                    for upid, source_interaction_ids in by_id.items()
-                ],
-            )
-            self.conn.commit()
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                for user_playbook_id in by_id:
+                    row = self.conn.execute(
+                        """SELECT governance_subject_ref FROM user_playbooks
+                           WHERE user_playbook_id = ?""",
+                        (user_playbook_id,),
+                    ).fetchone()
+                    if row is None:
+                        raise ValueError(
+                            f"User playbook {user_playbook_id} not found for source window"
+                        )
+                    subject_ref = row["governance_subject_ref"]
+                    if isinstance(subject_ref, str) and subject_ref:
+                        self._assert_subject_writable_locked(subject_ref)
+                self.conn.execute(
+                    "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
+                    (agent_playbook_id,),
+                )
+                self.conn.executemany(
+                    """INSERT OR IGNORE INTO agent_playbook_source_user_playbooks
+                       (agent_playbook_id, user_playbook_id, source_interaction_ids)
+                       VALUES (?, ?, ?)""",
+                    [
+                        (
+                            agent_playbook_id,
+                            upid,
+                            _json_dumps(source_interaction_ids) or "[]",
+                        )
+                        for upid, source_interaction_ids in by_id.items()
+                    ],
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     @SQLiteStorageBase.handle_exceptions
     def get_source_windows_for_agent_playbook(
@@ -2044,31 +2072,41 @@ class PlaybookMixin:
                 result.embedding = []
 
             created_at_iso = _epoch_to_iso(result.created_at)
-            self._execute(
-                """INSERT INTO agent_success_evaluation_result
-                   (user_id, session_id, agent_version, evaluation_name, is_success,
-                    failure_type, failure_reason, regular_vs_shadow,
-                    number_of_correction_per_session, user_turns_to_resolution,
-                    is_escalated, embedding, created_at)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                (
-                    result.user_id,
-                    result.session_id,
-                    result.agent_version,
-                    result.evaluation_name,
-                    int(result.is_success),
-                    result.failure_type,
-                    result.failure_reason,
-                    result.regular_vs_shadow.value
-                    if result.regular_vs_shadow
-                    else None,
-                    result.number_of_correction_per_session,
-                    result.user_turns_to_resolution,
-                    int(result.is_escalated),
-                    _json_dumps(result.embedding) if result.embedding else None,
-                    created_at_iso,
-                ),
-            )
+            subject_ref = self._subject_ref_for_user_id(result.user_id)
+            with self._lock:
+                try:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                    self._assert_subject_writable_locked(subject_ref)
+                    self.conn.execute(
+                        """INSERT INTO agent_success_evaluation_result
+                           (user_id, session_id, agent_version, evaluation_name, is_success,
+                            failure_type, failure_reason, regular_vs_shadow,
+                            number_of_correction_per_session, user_turns_to_resolution,
+                            is_escalated, embedding, created_at, governance_subject_ref)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        (
+                            result.user_id,
+                            result.session_id,
+                            result.agent_version,
+                            result.evaluation_name,
+                            int(result.is_success),
+                            result.failure_type,
+                            result.failure_reason,
+                            result.regular_vs_shadow.value
+                            if result.regular_vs_shadow
+                            else None,
+                            result.number_of_correction_per_session,
+                            result.user_turns_to_resolution,
+                            int(result.is_escalated),
+                            _json_dumps(result.embedding) if result.embedding else None,
+                            created_at_iso,
+                            subject_ref,
+                        ),
+                    )
+                    self.conn.commit()
+                except Exception:
+                    self.conn.rollback()
+                    raise
 
     @SQLiteStorageBase.handle_exceptions
     def get_agent_success_evaluation_results(

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -645,11 +645,22 @@ class PlaybookMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def archive_user_playbook_by_id(self, user_id: str, user_playbook_id: int) -> bool:
-        cur = self._execute(
-            "UPDATE user_playbooks SET status = ?, retired_at = ? "
-            "WHERE user_playbook_id = ? AND user_id = ? AND status IS NULL",
-            (Status.ARCHIVED.value, _epoch_now(), user_playbook_id, user_id),
-        )
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT user_id, governance_subject_ref FROM user_playbooks WHERE user_playbook_id = ? AND user_id = ?",
+                (user_playbook_id, user_id),
+            ).fetchone()
+            if row is None:
+                return False
+            self._assert_subject_writable_locked(
+                self._subject_ref_from_user_playbook_row(row)
+            )
+            cur = self.conn.execute(
+                "UPDATE user_playbooks SET status = ?, retired_at = ? "
+                "WHERE user_playbook_id = ? AND user_id = ? AND status IS NULL",
+                (Status.ARCHIVED.value, _epoch_now(), user_playbook_id, user_id),
+            )
+            self.conn.commit()
         return cur.rowcount > 0
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -206,9 +206,35 @@ class PlaybookMixin:
     # User Playbook methods
     # ------------------------------------------------------------------
 
+    def _subject_ref_from_user_playbook_row(self, row: sqlite3.Row) -> str:
+        subject_ref = row["governance_subject_ref"]
+        return (
+            str(subject_ref)
+            if subject_ref
+            else self._subject_ref_for_user_id(row["user_id"])
+        )
+
+    def _assert_user_playbook_writable_locked(
+        self,
+        user_playbook_id: int,
+    ) -> sqlite3.Row | None:
+        row = self.conn.execute(
+            "SELECT user_id, governance_subject_ref FROM user_playbooks WHERE user_playbook_id = ?",
+            (user_playbook_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        self._assert_subject_writable_locked(
+            self._subject_ref_from_user_playbook_row(row)
+        )
+        return row
+
     @SQLiteStorageBase.handle_exceptions
     def save_user_playbooks(self, user_playbooks: list[UserPlaybook]) -> None:
         for up in user_playbooks:
+            subject_ref = self._subject_ref_for_user_id(up.user_id)
+            with self._lock:
+                self._assert_subject_writable_locked(subject_ref)
             embedding_text = up.trigger or up.content
             if embedding_text:
                 if self._should_expand_documents():
@@ -225,7 +251,6 @@ class PlaybookMixin:
                     up.embedding = self._get_embedding(embedding_text)
 
             created_at_iso = _epoch_to_iso(up.created_at)
-            subject_ref = self._subject_ref_for_user_id(up.user_id)
             with self._lock:
                 try:
                     self.conn.execute("BEGIN IMMEDIATE")
@@ -523,20 +548,24 @@ class PlaybookMixin:
 
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            affected = [
-                r["user_playbook_id"]
-                for r in self.conn.execute(
-                    f"SELECT user_playbook_id FROM user_playbooks WHERE {where}",
+            affected = list(
+                self.conn.execute(
+                    f"SELECT user_playbook_id, user_id, governance_subject_ref FROM user_playbooks WHERE {where}",
                     select_params + extra_params,
                 ).fetchall()
-            ]
+            )
+            for row in affected:
+                self._assert_subject_writable_locked(
+                    self._subject_ref_from_user_playbook_row(row)
+                )
             cur = self.conn.execute(
                 f"UPDATE user_playbooks SET status = ?, retired_at = ? WHERE {where}",
                 [new_val, retired_at_val] + select_params + extra_params,
             )
             from_val = old_status.value if old_status else None
             to_val = new_status.value if new_status else None
-            for upid in affected:
+            for row in affected:
+                upid = row["user_playbook_id"]
                 _append_event_stmt(
                     self.conn,
                     org_id=self.org_id,
@@ -1301,6 +1330,8 @@ class PlaybookMixin:
             op = "revise" if semantic_change else "status_change"
             prov = "wasRevisionOf" if op == "revise" else "wasInvalidatedBy"
             with self._lock:
+                if self._assert_user_playbook_writable_locked(user_playbook_id) is None:
+                    return
                 cur = self.conn.execute(
                     f"UPDATE user_playbooks SET {', '.join(updates)} WHERE user_playbook_id = ?",
                     tuple(params),
@@ -1342,11 +1373,14 @@ class PlaybookMixin:
         with self._lock:
             for upid in user_playbook_ids:
                 row = self.conn.execute(
-                    "SELECT status FROM user_playbooks WHERE user_playbook_id = ?",
+                    "SELECT status, user_id, governance_subject_ref FROM user_playbooks WHERE user_playbook_id = ?",
                     (upid,),
                 ).fetchone()
                 if row is None:
                     continue
+                self._assert_subject_writable_locked(
+                    self._subject_ref_from_user_playbook_row(row)
+                )
                 old_status = row["status"]
                 cur = self.conn.execute(
                     "UPDATE user_playbooks SET status = ?, retired_at = ?"

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -1672,7 +1672,7 @@ class PlaybookMixin:
                 self.conn.execute("BEGIN IMMEDIATE")
                 for user_playbook_id in by_id:
                     row = self.conn.execute(
-                        """SELECT governance_subject_ref FROM user_playbooks
+                        """SELECT user_id, governance_subject_ref FROM user_playbooks
                            WHERE user_playbook_id = ?""",
                         (user_playbook_id,),
                     ).fetchone()
@@ -1681,8 +1681,9 @@ class PlaybookMixin:
                             f"User playbook {user_playbook_id} not found for source window"
                         )
                     subject_ref = row["governance_subject_ref"]
-                    if isinstance(subject_ref, str) and subject_ref:
-                        self._assert_subject_writable_locked(subject_ref)
+                    if not isinstance(subject_ref, str) or not subject_ref:
+                        subject_ref = self._subject_ref_for_user_id(str(row["user_id"]))
+                    self._assert_subject_writable_locked(subject_ref)
                 self.conn.execute(
                     "DELETE FROM agent_playbook_source_user_playbooks WHERE agent_playbook_id = ?",
                     (agent_playbook_id,),

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -100,6 +100,8 @@ class ProfileMixin:
     llm_client: Any
     embedding_model_name: str
     embedding_dimensions: int
+    _subject_ref_for_user_id: Any
+    _assert_subject_writable_locked: Any
 
     # ------------------------------------------------------------------
     # CRUD — Profiles
@@ -151,39 +153,49 @@ class ProfileMixin:
             else:
                 profile.embedding = self._get_embedding(embedding_text)
             embedding = profile.embedding
-            self._execute(
-                """INSERT OR REPLACE INTO profiles
-                   (profile_id, user_id, content, last_modified_timestamp,
-                    generated_from_request_id, profile_time_to_live,
-                    expiration_timestamp, custom_features, embedding, source,
-                   status, extractor_names, expanded_terms,
-                    source_span, notes, reader_angle, tags, source_interaction_ids, created_at,
-                    merged_into, superseded_by)
-                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                (
-                    profile.profile_id,
-                    profile.user_id,
-                    profile.content,
-                    profile.last_modified_timestamp,
-                    profile.generated_from_request_id,
-                    profile.profile_time_to_live.value,
-                    profile.expiration_timestamp,
-                    _json_dumps(profile.custom_features),
-                    _json_dumps(profile.embedding),
-                    profile.source,
-                    profile.status.value if profile.status else None,
-                    _json_dumps(profile.extractor_names),
-                    profile.expanded_terms,
-                    profile.source_span,
-                    profile.notes,
-                    profile.reader_angle,
-                    _json_dumps(profile.tags),
-                    _json_dumps(profile.source_interaction_ids),
-                    _iso_now(),
-                    profile.merged_into,
-                    profile.superseded_by,
-                ),
-            )
+            subject_ref = self._subject_ref_for_user_id(profile.user_id)
+            with self._lock:
+                try:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                    self._assert_subject_writable_locked(subject_ref)
+                    self.conn.execute(
+                        """INSERT OR REPLACE INTO profiles
+                           (profile_id, user_id, content, last_modified_timestamp,
+                            generated_from_request_id, profile_time_to_live,
+                            expiration_timestamp, custom_features, embedding, source,
+                            status, extractor_names, expanded_terms,
+                            source_span, notes, reader_angle, tags, source_interaction_ids, created_at,
+                            merged_into, superseded_by, governance_subject_ref)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        (
+                            profile.profile_id,
+                            profile.user_id,
+                            profile.content,
+                            profile.last_modified_timestamp,
+                            profile.generated_from_request_id,
+                            profile.profile_time_to_live.value,
+                            profile.expiration_timestamp,
+                            _json_dumps(profile.custom_features),
+                            _json_dumps(profile.embedding),
+                            profile.source,
+                            profile.status.value if profile.status else None,
+                            _json_dumps(profile.extractor_names),
+                            profile.expanded_terms,
+                            profile.source_span,
+                            profile.notes,
+                            profile.reader_angle,
+                            _json_dumps(profile.tags),
+                            _json_dumps(profile.source_interaction_ids),
+                            _iso_now(),
+                            profile.merged_into,
+                            profile.superseded_by,
+                            subject_ref,
+                        ),
+                    )
+                    self.conn.commit()
+                except Exception:
+                    self.conn.rollback()
+                    raise
             fts_parts = [profile.content or ""]
             if profile.custom_features:
                 fts_parts.extend(str(v) for v in profile.custom_features.values() if v)
@@ -744,62 +756,71 @@ class ProfileMixin:
 
     def _insert_interaction(self, interaction: Interaction) -> int:
         created_at_iso = _epoch_to_iso(interaction.created_at)
+        subject_ref = self._subject_ref_for_user_id(interaction.user_id)
         with self._lock:
-            if interaction.interaction_id:
-                self.conn.execute(
-                    """INSERT OR REPLACE INTO interactions
-                       (interaction_id, user_id, content, request_id, created_at,
-                        role, user_action, user_action_description,
-                        interacted_image_url, image_encoding, shadow_content,
-                        expert_content, tools_used, citations, embedding)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                    (
-                        interaction.interaction_id,
-                        interaction.user_id,
-                        interaction.content,
-                        interaction.request_id,
-                        created_at_iso,
-                        interaction.role,
-                        interaction.user_action.value,
-                        interaction.user_action_description,
-                        interaction.interacted_image_url,
-                        interaction.image_encoding,
-                        interaction.shadow_content,
-                        interaction.expert_content,
-                        _json_dumps([t.model_dump() for t in interaction.tools_used]),
-                        _json_dumps([c.model_dump() for c in interaction.citations]),
-                        _json_dumps(interaction.embedding),
-                    ),
-                )
-                iid = interaction.interaction_id
-            else:
-                cur = self.conn.execute(
-                    """INSERT INTO interactions
-                       (user_id, content, request_id, created_at,
-                        role, user_action, user_action_description,
-                        interacted_image_url, image_encoding, shadow_content,
-                        expert_content, tools_used, citations, embedding)
-                       VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
-                    (
-                        interaction.user_id,
-                        interaction.content,
-                        interaction.request_id,
-                        created_at_iso,
-                        interaction.role,
-                        interaction.user_action.value,
-                        interaction.user_action_description,
-                        interaction.interacted_image_url,
-                        interaction.image_encoding,
-                        interaction.shadow_content,
-                        interaction.expert_content,
-                        _json_dumps([t.model_dump() for t in interaction.tools_used]),
-                        _json_dumps([c.model_dump() for c in interaction.citations]),
-                        _json_dumps(interaction.embedding),
-                    ),
-                )
-                iid = cur.lastrowid or 0
-                interaction.interaction_id = iid
-            self.conn.commit()
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                self._assert_subject_writable_locked(subject_ref)
+                if interaction.interaction_id:
+                    self.conn.execute(
+                        """INSERT OR REPLACE INTO interactions
+                           (interaction_id, user_id, content, request_id, created_at,
+                            role, user_action, user_action_description,
+                            interacted_image_url, image_encoding, shadow_content,
+                            expert_content, tools_used, citations, embedding, governance_subject_ref)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        (
+                            interaction.interaction_id,
+                            interaction.user_id,
+                            interaction.content,
+                            interaction.request_id,
+                            created_at_iso,
+                            interaction.role,
+                            interaction.user_action.value,
+                            interaction.user_action_description,
+                            interaction.interacted_image_url,
+                            interaction.image_encoding,
+                            interaction.shadow_content,
+                            interaction.expert_content,
+                            _json_dumps([t.model_dump() for t in interaction.tools_used]),
+                            _json_dumps([c.model_dump() for c in interaction.citations]),
+                            _json_dumps(interaction.embedding),
+                            subject_ref,
+                        ),
+                    )
+                    iid = interaction.interaction_id
+                else:
+                    cur = self.conn.execute(
+                        """INSERT INTO interactions
+                           (user_id, content, request_id, created_at,
+                            role, user_action, user_action_description,
+                            interacted_image_url, image_encoding, shadow_content,
+                            expert_content, tools_used, citations, embedding, governance_subject_ref)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                        (
+                            interaction.user_id,
+                            interaction.content,
+                            interaction.request_id,
+                            created_at_iso,
+                            interaction.role,
+                            interaction.user_action.value,
+                            interaction.user_action_description,
+                            interaction.interacted_image_url,
+                            interaction.image_encoding,
+                            interaction.shadow_content,
+                            interaction.expert_content,
+                            _json_dumps([t.model_dump() for t in interaction.tools_used]),
+                            _json_dumps([c.model_dump() for c in interaction.citations]),
+                            _json_dumps(interaction.embedding),
+                            subject_ref,
+                        ),
+                    )
+                    iid = cur.lastrowid or 0
+                    interaction.interaction_id = iid
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
         # Update FTS and vec
         self._fts_upsert(
             "interactions_fts",

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -107,6 +107,35 @@ class ProfileMixin:
     # CRUD — Profiles
     # ------------------------------------------------------------------
 
+    def _subject_ref_from_profile_row(self, row: sqlite3.Row) -> str:
+        subject_ref = row["governance_subject_ref"]
+        return (
+            str(subject_ref)
+            if subject_ref
+            else self._subject_ref_for_user_id(row["user_id"])
+        )
+
+    def _assert_profile_writable_locked(
+        self,
+        profile_id: str,
+        *,
+        user_id: str | None = None,
+    ) -> sqlite3.Row | None:
+        if user_id is None:
+            row = self.conn.execute(
+                "SELECT user_id, governance_subject_ref FROM profiles WHERE profile_id = ?",
+                (profile_id,),
+            ).fetchone()
+        else:
+            row = self.conn.execute(
+                "SELECT user_id, governance_subject_ref FROM profiles WHERE profile_id = ? AND user_id = ?",
+                (profile_id, user_id),
+            ).fetchone()
+        if row is None:
+            return None
+        self._assert_subject_writable_locked(self._subject_ref_from_profile_row(row))
+        return row
+
     @SQLiteStorageBase.handle_exceptions
     def get_all_profiles(
         self,
@@ -143,6 +172,9 @@ class ProfileMixin:
     @SQLiteStorageBase.handle_exceptions
     def add_user_profile(self, user_id: str, user_profiles: list[UserProfile]) -> None:  # noqa: ARG002
         for profile in user_profiles:
+            subject_ref = self._subject_ref_for_user_id(profile.user_id)
+            with self._lock:
+                self._assert_subject_writable_locked(subject_ref)
             embedding_text = "\n".join([profile.content, str(profile.custom_features)])
             if self._should_expand_documents():
                 with ThreadPoolExecutor(max_workers=2) as executor:
@@ -153,7 +185,6 @@ class ProfileMixin:
             else:
                 profile.embedding = self._get_embedding(embedding_text)
             embedding = profile.embedding
-            subject_ref = self._subject_ref_for_user_id(profile.user_id)
             with self._lock:
                 try:
                     self.conn.execute("BEGIN IMMEDIATE")
@@ -223,18 +254,28 @@ class ProfileMixin:
         that re-acquire it are safe.
         """
         current_ts = _epoch_now()
-        row = self._fetchone(
-            "SELECT profile_id FROM profiles WHERE user_id = ? AND profile_id = ? AND expiration_timestamp >= ?",
-            (user_id, profile_id, current_ts),
-        )
-        if not row:
-            logger.warning("User profile not found for user id: %s", user_id)
-            return
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT user_id, governance_subject_ref FROM profiles WHERE user_id = ? AND profile_id = ? AND expiration_timestamp >= ?",
+                (user_id, profile_id, current_ts),
+            ).fetchone()
+            if not row:
+                logger.warning("User profile not found for user id: %s", user_id)
+                return
+            self._assert_subject_writable_locked(
+                self._subject_ref_from_profile_row(row)
+            )
         embedding = self._get_embedding(
             "\n".join([new_profile.content, str(new_profile.custom_features)])
         )
         new_profile.embedding = embedding
         with self._lock:
+            if (
+                self._assert_profile_writable_locked(profile_id, user_id=user_id)
+                is None
+            ):
+                logger.warning("User profile not found for user id: %s", user_id)
+                return
             cur = self.conn.execute(
                 """UPDATE profiles SET content=?, last_modified_timestamp=?,
                    generated_from_request_id=?, profile_time_to_live=?,
@@ -294,10 +335,17 @@ class ProfileMixin:
     def update_user_profile_tags(
         self, user_id: str, profile_id: str, tags: list[str]
     ) -> None:
-        self._execute(
-            "UPDATE profiles SET tags=? WHERE user_id=? AND profile_id=?",
-            (_json_dumps(tags), user_id, profile_id),
-        )
+        with self._lock:
+            if (
+                self._assert_profile_writable_locked(profile_id, user_id=user_id)
+                is None
+            ):
+                return
+            self.conn.execute(
+                "UPDATE profiles SET tags=? WHERE user_id=? AND profile_id=?",
+                (_json_dumps(tags), user_id, profile_id),
+            )
+            self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_profile(self, request: DeleteUserProfileRequest) -> None:
@@ -420,20 +468,24 @@ class ProfileMixin:
 
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            affected = [
-                r["profile_id"]
-                for r in self.conn.execute(
-                    f"SELECT profile_id FROM profiles WHERE {where}",
+            affected = list(
+                self.conn.execute(
+                    f"SELECT profile_id, user_id, governance_subject_ref FROM profiles WHERE {where}",
                     select_params + extra_params,
                 ).fetchall()
-            ]
+            )
+            for row in affected:
+                self._assert_subject_writable_locked(
+                    self._subject_ref_from_profile_row(row)
+                )
             cur = self.conn.execute(
                 f"UPDATE profiles SET status = ?, last_modified_timestamp = ?, retired_at = ? WHERE {where}",
                 [new_val, now_ts, retired_at_val] + select_params + extra_params,
             )
             from_val = old_status.value if old_status else None
             to_val = new_status.value if new_status else None
-            for pid in affected:
+            for row in affected:
+                pid = row["profile_id"]
                 _append_event_stmt(
                     self.conn,
                     org_id=self.org_id,
@@ -542,6 +594,11 @@ class ProfileMixin:
     @SQLiteStorageBase.handle_exceptions
     def archive_profile_by_id(self, user_id: str, profile_id: str) -> bool:
         with self._lock:
+            if (
+                self._assert_profile_writable_locked(profile_id, user_id=user_id)
+                is None
+            ):
+                return False
             now_ts = _epoch_now()
             cur = self.conn.execute(
                 "UPDATE profiles SET status = ?, last_modified_timestamp = ?, retired_at = ? "
@@ -602,11 +659,14 @@ class ProfileMixin:
             for pid in profile_ids:
                 # Read current status for from_status derivation (user_id scoped)
                 row = self.conn.execute(
-                    "SELECT status FROM profiles WHERE profile_id = ? AND user_id = ?",
+                    "SELECT status, user_id, governance_subject_ref FROM profiles WHERE profile_id = ? AND user_id = ?",
                     (pid, user_id),
                 ).fetchone()
                 if row is None:
                     continue
+                self._assert_subject_writable_locked(
+                    self._subject_ref_from_profile_row(row)
+                )
                 old_status_val = (
                     row[0] if isinstance(row, (tuple, list)) else row["status"]
                 )
@@ -782,8 +842,12 @@ class ProfileMixin:
                             interaction.image_encoding,
                             interaction.shadow_content,
                             interaction.expert_content,
-                            _json_dumps([t.model_dump() for t in interaction.tools_used]),
-                            _json_dumps([c.model_dump() for c in interaction.citations]),
+                            _json_dumps(
+                                [t.model_dump() for t in interaction.tools_used]
+                            ),
+                            _json_dumps(
+                                [c.model_dump() for c in interaction.citations]
+                            ),
                             _json_dumps(interaction.embedding),
                             subject_ref,
                         ),
@@ -809,8 +873,12 @@ class ProfileMixin:
                             interaction.image_encoding,
                             interaction.shadow_content,
                             interaction.expert_content,
-                            _json_dumps([t.model_dump() for t in interaction.tools_used]),
-                            _json_dumps([c.model_dump() for c in interaction.citations]),
+                            _json_dumps(
+                                [t.model_dump() for t in interaction.tools_used]
+                            ),
+                            _json_dumps(
+                                [c.model_dump() for c in interaction.citations]
+                            ),
                             _json_dumps(interaction.embedding),
                             subject_ref,
                         ),

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -30,6 +30,8 @@ class RequestMixin:
     _execute: Any
     _fetchone: Any
     _fetchall: Any
+    _subject_ref_for_user_id: Any
+    _assert_subject_writable_locked: Any
 
     # ------------------------------------------------------------------
     # Request methods
@@ -38,20 +40,31 @@ class RequestMixin:
     @SQLiteStorageBase.handle_exceptions
     def add_request(self, request: Request) -> None:
         created_at_iso = _epoch_to_iso(request.created_at)
-        self._execute(
-            """INSERT OR REPLACE INTO requests
-               (request_id, user_id, created_at, source, agent_version, session_id, evaluation_only)
-               VALUES (?,?,?,?,?,?,?)""",
-            (
-                request.request_id,
-                request.user_id,
-                created_at_iso,
-                request.source,
-                request.agent_version,
-                request.session_id,
-                1 if request.evaluation_only else 0,
-            ),
-        )
+        subject_ref = self._subject_ref_for_user_id(request.user_id)
+        with self._lock:
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                self._assert_subject_writable_locked(subject_ref)
+                self.conn.execute(
+                    """INSERT OR REPLACE INTO requests
+                       (request_id, user_id, created_at, source, agent_version, session_id,
+                        evaluation_only, governance_subject_ref)
+                       VALUES (?,?,?,?,?,?,?,?)""",
+                    (
+                        request.request_id,
+                        request.user_id,
+                        created_at_iso,
+                        request.source,
+                        request.agent_version,
+                        request.session_id,
+                        1 if request.evaluation_only else 0,
+                        subject_ref,
+                    ),
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
 
     @SQLiteStorageBase.handle_exceptions
     def get_request(self, request_id: str) -> Request | None:

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Literal
 
 from reflexio.models.api_schema.domain.governance import (
@@ -12,7 +12,7 @@ from reflexio.models.api_schema.domain.governance import (
 from reflexio.models.config_schema import GovernanceRetentionConfig
 
 
-class GovernanceMixin:
+class GovernanceMixin(ABC):
     """Mixin for backend-neutral governance storage primitives."""
 
     @abstractmethod

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -128,6 +128,12 @@ class GovernanceMixin(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_subject_write_barrier(
+        self, subject_ref: str
+    ) -> SubjectWriteBarrier | None:
+        raise NotImplementedError
+
+    @abstractmethod
     def fail_purge_operation(
         self, purge_id: str, error_code: str, error_detail: str
     ) -> PurgeOperation:

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -7,6 +7,7 @@ from reflexio.models.api_schema.domain.governance import (
     AuditEvent,
     PurgeOperation,
     PurgeOperationTarget,
+    SubjectWriteBarrier,
 )
 from reflexio.models.config_schema import GovernanceRetentionConfig
 
@@ -98,6 +99,32 @@ class GovernanceMixin:
     def complete_purge_operation_with_audit(
         self, purge_id: str, audit_event: AuditEvent
     ) -> PurgeOperation:
+        raise NotImplementedError
+
+    @abstractmethod
+    def begin_subject_erasure_barrier(
+        self, subject_ref: str, purge_id: str
+    ) -> SubjectWriteBarrier:
+        raise NotImplementedError
+
+    @abstractmethod
+    def assert_subject_writable(self, subject_ref: str) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def complete_subject_erasure_barrier_after_empty_check(
+        self, purge_id: str, audit_event: AuditEvent
+    ) -> PurgeOperation:
+        raise NotImplementedError
+
+    @abstractmethod
+    def fail_subject_erasure_barrier(
+        self,
+        subject_ref: str,
+        purge_id: str,
+        error_code: str,
+        error_detail: str,
+    ) -> SubjectWriteBarrier:
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -421,14 +421,65 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
 
     assert retried.purge_id == erased.purge_id
     assert retried.status == "complete"
-    assert retried.deleted_counts == {}
-    assert retried.rebuilt_agent_playbook_ids == []
+    assert retried.deleted_counts == erased.deleted_counts
+    assert retried.rebuilt_agent_playbook_ids == erased.rebuilt_agent_playbook_ids
     erase_events_after_retry = [
         event
         for event in storage.list_audit_events(subject_ref=exported.subject_ref)
         if event.operation == "ERASE" and event.status == "ok"
     ]
     assert len(erase_events_after_retry) == 1
+
+
+def test_governance_service_persists_actor_context_in_audit(
+    storage: SQLiteStorage,
+) -> None:
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    service.export_user(
+        user_id="alice",
+        request_id="export-actor",
+        actor_context={
+            "actor_type": "jwt",
+            "actor_ref": "actref_v1_1234567890abcdef1234567890abcdef",
+        },
+    )
+
+    audit_events = storage.list_audit_events()
+    event = audit_events[-1]
+    assert event.actor_type == "jwt"
+    assert event.actor_ref == "actref_v1_1234567890abcdef1234567890abcdef"
+
+
+def test_completed_erase_retry_reconstructs_response(
+    storage: SQLiteStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
+    storage.add_request(
+        _request(request_id="retry-req", user_id="alice", session_id="retry-sess")
+    )
+    storage.add_user_interaction(
+        "alice",
+        _interaction(user_id="alice", request_id="retry-req", content="retry-token"),
+    )
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    first = service.erase_user(user_id="alice", request_id="erase-retry")
+    second = service.erase_user(user_id="alice", request_id="erase-retry")
+
+    assert second.status == "complete"
+    assert second.purge_id == first.purge_id
+    assert second.deleted_counts == first.deleted_counts
+    assert second.rebuilt_agent_playbook_ids == first.rebuilt_agent_playbook_ids
 
 
 def test_governance_erase_marks_purge_failed_when_workflow_raises(

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -21,8 +21,8 @@ from reflexio.models.api_schema.domain.enums import PlaybookStatus
 from reflexio.models.api_schema.retriever_schema import SearchAgentPlaybookRequest
 from reflexio.models.config_schema import SearchMode
 from reflexio.server.services.governance import service as governance_service_module
+from reflexio.server.services.governance.config import governance_subject_ref
 from reflexio.server.services.governance.service import GovernanceService
-from reflexio.server.services.governance.subject_refs import subject_ref
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -259,7 +259,11 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
 
     exported = service.export_user(user_id="alice", request_id="export-request-1")
 
-    assert exported.subject_ref == subject_ref("alice", "test-governance-secret")
+    assert exported.subject_ref == governance_subject_ref(
+        storage.org_id,
+        "alice",
+        "test-governance-secret",
+    )
     assert exported.export_id.startswith("export_")
     assert [profile["profile_id"] for profile in exported.bundle["profiles"]] == [
         "profile-alice"

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -118,7 +118,11 @@ def _eval_result(
 
 
 @pytest.fixture
-def storage(tmp_path: Path) -> Generator[SQLiteStorage, None, None]:
+def storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[SQLiteStorage, None, None]:
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
         yield SQLiteStorage(org_id="org-local", db_path=str(tmp_path / "governance.db"))
 

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -481,7 +481,9 @@ def test_governance_erase_persists_actor_context_in_audit(
         },
     )
 
-    erase_events = [event for event in storage.list_audit_events() if event.operation == "ERASE"]
+    erase_events = [
+        event for event in storage.list_audit_events() if event.operation == "ERASE"
+    ]
     assert len(erase_events) == 1
     assert erase_events[0].actor_type == "api_token"
     assert erase_events[0].actor_ref == "actref_v1_1234567890abcdef1234567890abcdef"
@@ -514,10 +516,26 @@ def test_completed_erase_retry_reconstructs_response(
     assert second.rebuilt_agent_playbook_ids == first.rebuilt_agent_playbook_ids
 
 
+def test_erase_fails_fast_when_service_and_storage_ref_secrets_differ(
+    storage: SQLiteStorage,
+) -> None:
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="different-service-secret",
+    )
+
+    with pytest.raises(RuntimeError, match="ref_secret must match"):
+        service.erase_user(user_id="alice", request_id="erase-mismatch")
+
+
 @pytest.mark.parametrize(
     ("barrier_sql", "match"),
     [
-        ("DELETE FROM subject_write_barriers WHERE subject_ref = ?", "matching subject barrier"),
+        (
+            "DELETE FROM subject_write_barriers WHERE subject_ref = ?",
+            "matching subject barrier",
+        ),
         (
             "UPDATE subject_write_barriers SET status = 'failed' WHERE subject_ref = ?",
             "erased subject barrier",
@@ -532,7 +550,11 @@ def test_completed_erase_retry_fails_closed_without_erased_barrier(
 ) -> None:
     monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
     storage.add_request(
-        _request(request_id="retry-closed-req", user_id="alice", session_id="retry-closed-sess")
+        _request(
+            request_id="retry-closed-req",
+            user_id="alice",
+            session_id="retry-closed-sess",
+        )
     )
     service = GovernanceService(
         storage=storage,

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -530,6 +530,19 @@ def test_erase_fails_fast_when_service_and_storage_ref_secrets_differ(
         service.erase_user(user_id="alice", request_id="erase-mismatch")
 
 
+def test_export_fails_fast_when_service_and_storage_ref_secrets_differ(
+    storage: SQLiteStorage,
+) -> None:
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="different-service-secret",
+    )
+
+    with pytest.raises(RuntimeError, match="ref_secret must match"):
+        service.export_user(user_id="alice", request_id="export-mismatch")
+
+
 @pytest.mark.parametrize(
     ("barrier_sql", "match"),
     [

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -23,6 +23,7 @@ from reflexio.models.config_schema import SearchMode
 from reflexio.server.services.governance import service as governance_service_module
 from reflexio.server.services.governance.config import governance_subject_ref
 from reflexio.server.services.governance.service import GovernanceService
+from reflexio.server.services.storage.error import SubjectWriteBarrierError
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
@@ -571,6 +572,59 @@ def test_barrier_acquisition_failure_marks_purge_failed_where_possible(
     assert len(failed_purges) == 1
     assert failed_purges[0]["error_code"] == "governance_erase_failed"
     assert failed_purges[0]["error_detail"] == "RuntimeError"
+
+
+def test_second_erase_conflict_preserves_original_barrier_and_write_block(
+    storage: SQLiteStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
+    subject_ref = governance_subject_ref(
+        storage.org_id,
+        "alice",
+        "test-governance-secret",
+    )
+    first_purge = storage.begin_purge_operation(
+        purge_id="purge_conflict_first",
+        idempotency_key="idem_conflict_first",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000061",
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, first_purge.purge_id)
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    with pytest.raises(
+        ValueError, match="Existing barrier purge_id must match the requested purge_id"
+    ):
+        service.erase_user(user_id="alice", request_id="erase-conflict-second")
+
+    barrier = storage.get_subject_write_barrier(subject_ref)
+    assert barrier is not None
+    assert barrier.purge_id == first_purge.purge_id
+    assert barrier.status == "erasing"
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.add_request(
+            _request(
+                request_id="req-after-conflict",
+                user_id="alice",
+                session_id="sess-after-conflict",
+            )
+        )
+
+    failed_purges = list(
+        storage.conn.execute(
+            "SELECT purge_id, status FROM purge_operations WHERE status = 'failed'"
+        ).fetchall()
+    )
+    assert len(failed_purges) == 1
+    assert failed_purges[0]["purge_id"] != first_purge.purge_id
+    assert failed_purges[0]["status"] == "failed"
 
 
 def test_governance_erase_marks_purge_failed_when_workflow_raises(

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -127,7 +127,7 @@ def storage(
         yield SQLiteStorage(org_id="org-local", db_path=str(tmp_path / "governance.db"))
 
 
-def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregate(
+def test_local_governance_e2e_erases_exports_audits_and_preserves_org_agent_playbooks(
     storage: SQLiteStorage,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -306,10 +306,7 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert erased.deleted_counts["requests"] == 1
     assert erased.deleted_counts["user_playbooks"] == 2
     assert erased.deleted_counts["agent_success_evaluation_results"] == 1
-    assert set(erased.rebuilt_agent_playbook_ids) == {
-        shared_playbook.agent_playbook_id,
-        orphan_playbook.agent_playbook_id,
-    }
+    assert erased.rebuilt_agent_playbook_ids == []
 
     assert storage.get_user_interaction("alice") == []
     assert storage.get_user_profile("alice") == []
@@ -345,14 +342,13 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
     assert delete_targets["agent_success_evaluation_result"].deleted_count == 1
     assert len(storage.get_user_playbooks(user_id="bob", limit=10)) == 1
 
-    rebuilt_playbook = storage.get_agent_playbook_by_id(
+    preserved_playbook = storage.get_agent_playbook_by_id(
         shared_playbook.agent_playbook_id
     )
-    assert rebuilt_playbook is not None
-    assert "aliceuniquesourcetoken" not in rebuilt_playbook.content
-    assert rebuilt_playbook.content == "bobuniquesourcetoken"
-    assert rebuilt_playbook.trigger == "bobtriggerunique"
-    assert rebuilt_playbook.rationale == "bobrationaleunique"
+    assert preserved_playbook is not None
+    assert preserved_playbook.content == shared_playbook.content
+    assert preserved_playbook.trigger == shared_playbook.trigger
+    assert preserved_playbook.rationale == shared_playbook.rationale
     assert storage.get_source_windows_for_agent_playbook(
         shared_playbook.agent_playbook_id
     ) == [
@@ -361,8 +357,14 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
             source_interaction_ids=[202],
         )
     ]
-    assert storage.get_agent_playbook_by_id(orphan_playbook.agent_playbook_id) is None
-    assert orphan_playbook.agent_playbook_id not in {
+    preserved_orphan_playbook = storage.get_agent_playbook_by_id(
+        orphan_playbook.agent_playbook_id
+    )
+    assert preserved_orphan_playbook is not None
+    assert preserved_orphan_playbook.content == orphan_playbook.content
+    assert preserved_orphan_playbook.trigger == orphan_playbook.trigger
+    assert preserved_orphan_playbook.rationale == orphan_playbook.rationale
+    assert orphan_playbook.agent_playbook_id in {
         playbook.agent_playbook_id for playbook in storage.get_agent_playbooks(limit=10)
     }
     assert (
@@ -377,29 +379,28 @@ def test_local_governance_e2e_erases_exports_audits_and_rebuilds_shared_aggregat
         )
         if event.op == "hard_delete"
     ]
-    assert len(hard_delete_events) == 1
-    assert hard_delete_events[0].request_id == erased.purge_id
+    assert hard_delete_events == []
 
-    assert (
-        storage.search_agent_playbooks(
-            SearchAgentPlaybookRequest(
-                query="aliceuniquesourcetoken",
-                top_k=10,
-                search_mode=SearchMode.FTS,
-            )
+    alice_search_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="aliceuniquesourcetoken",
+            top_k=10,
+            search_mode=SearchMode.FTS,
         )
-        == []
     )
-    assert (
-        storage.search_agent_playbooks(
-            SearchAgentPlaybookRequest(
-                query="aliceorphansourcetoken",
-                top_k=10,
-                search_mode=SearchMode.FTS,
-            )
+    assert [playbook.agent_playbook_id for playbook in alice_search_results] == [
+        shared_playbook.agent_playbook_id
+    ]
+    orphan_search_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(
+            query="aliceorphansourcetoken",
+            top_k=10,
+            search_mode=SearchMode.FTS,
         )
-        == []
     )
+    assert [playbook.agent_playbook_id for playbook in orphan_search_results] == [
+        orphan_playbook.agent_playbook_id
+    ]
     bob_search_results = storage.search_agent_playbooks(
         SearchAgentPlaybookRequest(
             query="bobuniquesourcetoken",

--- a/tests/server/services/governance/test_governance_local_e2e.py
+++ b/tests/server/services/governance/test_governance_local_e2e.py
@@ -455,6 +455,33 @@ def test_governance_service_persists_actor_context_in_audit(
     assert event.actor_ref == "actref_v1_1234567890abcdef1234567890abcdef"
 
 
+def test_governance_erase_persists_actor_context_in_audit(
+    storage: SQLiteStorage,
+) -> None:
+    storage.add_request(
+        _request(request_id="erase-actor-req", user_id="alice", session_id="sess-actor")
+    )
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    service.erase_user(
+        user_id="alice",
+        request_id="erase-actor",
+        actor_context={
+            "actor_type": "api_token",
+            "actor_ref": "actref_v1_1234567890abcdef1234567890abcdef",
+        },
+    )
+
+    erase_events = [event for event in storage.list_audit_events() if event.operation == "ERASE"]
+    assert len(erase_events) == 1
+    assert erase_events[0].actor_type == "api_token"
+    assert erase_events[0].actor_ref == "actref_v1_1234567890abcdef1234567890abcdef"
+
+
 def test_completed_erase_retry_reconstructs_response(
     storage: SQLiteStorage,
     monkeypatch: pytest.MonkeyPatch,
@@ -480,6 +507,70 @@ def test_completed_erase_retry_reconstructs_response(
     assert second.purge_id == first.purge_id
     assert second.deleted_counts == first.deleted_counts
     assert second.rebuilt_agent_playbook_ids == first.rebuilt_agent_playbook_ids
+
+
+@pytest.mark.parametrize(
+    ("barrier_sql", "match"),
+    [
+        ("DELETE FROM subject_write_barriers WHERE subject_ref = ?", "matching subject barrier"),
+        (
+            "UPDATE subject_write_barriers SET status = 'failed' WHERE subject_ref = ?",
+            "erased subject barrier",
+        ),
+    ],
+)
+def test_completed_erase_retry_fails_closed_without_erased_barrier(
+    storage: SQLiteStorage,
+    monkeypatch: pytest.MonkeyPatch,
+    barrier_sql: str,
+    match: str,
+) -> None:
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
+    storage.add_request(
+        _request(request_id="retry-closed-req", user_id="alice", session_id="retry-closed-sess")
+    )
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    first = service.erase_user(user_id="alice", request_id="erase-retry-closed")
+    storage.conn.execute(barrier_sql, (first.subject_ref,))
+    storage.conn.commit()
+
+    with pytest.raises(ValueError, match=match):
+        service.erase_user(user_id="alice", request_id="erase-retry-closed")
+
+
+def test_barrier_acquisition_failure_marks_purge_failed_where_possible(
+    storage: SQLiteStorage,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = GovernanceService(
+        storage=storage,
+        org_id=storage.org_id,
+        ref_secret="test-governance-secret",
+    )
+
+    def _raise_begin(*args, **kwargs):
+        raise RuntimeError("forced barrier begin failure")
+
+    monkeypatch.setattr(storage, "begin_subject_erasure_barrier", _raise_begin)
+
+    with pytest.raises(RuntimeError, match="forced barrier begin failure"):
+        service.erase_user(user_id="alice", request_id="erase-begin-failure")
+
+    failed_purges = [
+        row
+        for row in storage.conn.execute(
+            "SELECT status, error_code, error_detail FROM purge_operations"
+        ).fetchall()
+        if row["status"] == "failed"
+    ]
+    assert len(failed_purges) == 1
+    assert failed_purges[0]["error_code"] == "governance_erase_failed"
+    assert failed_purges[0]["error_detail"] == "RuntimeError"
 
 
 def test_governance_erase_marks_purge_failed_when_workflow_raises(
@@ -510,6 +601,16 @@ def test_governance_erase_marks_purge_failed_when_workflow_raises(
     assert len(failed_purges) == 1
     assert failed_purges[0]["error_code"] == "governance_erase_failed"
     assert failed_purges[0]["error_detail"] == "RuntimeError"
+    failed_barriers = [
+        row
+        for row in storage.conn.execute(
+            "SELECT status, error_code, error_detail FROM subject_write_barriers"
+        ).fetchall()
+        if row["status"] == "failed"
+    ]
+    assert len(failed_barriers) == 1
+    assert failed_barriers[0]["error_code"] == "governance_erase_failed"
+    assert failed_barriers[0]["error_detail"] == "RuntimeError"
 
 
 def test_session_export_paginates_by_returned_rows_when_requests_are_missing() -> None:

--- a/tests/server/services/governance/test_governance_refs.py
+++ b/tests/server/services/governance/test_governance_refs.py
@@ -40,6 +40,7 @@ def test_governance_mixin_tracks_new_barrier_methods_as_abstract() -> None:
         "assert_subject_writable",
         "complete_subject_erasure_barrier_after_empty_check",
         "fail_subject_erasure_barrier",
+        "get_subject_write_barrier",
     } <= GovernanceMixin.__abstractmethods__
 
 

--- a/tests/server/services/governance/test_governance_refs.py
+++ b/tests/server/services/governance/test_governance_refs.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from reflexio.server.services.governance.config import (
+    get_governance_ref_secret,
+    governance_actor_ref,
+    governance_request_ref,
+    governance_subject_ref,
+)
+
+
+def test_refs_are_domain_separated_by_org_and_kind() -> None:
+    secret = "test-secret"
+
+    assert governance_subject_ref("org-a", "alice", secret).startswith("subref_v1_")
+    assert governance_request_ref("org-a", "ticket-1", secret).startswith("reqref_v1_")
+    assert governance_actor_ref("org-a", "jwt", "principal-1", secret).startswith(
+        "actref_v1_"
+    )
+    assert governance_subject_ref("org-a", "alice", secret) != governance_subject_ref(
+        "org-b", "alice", secret
+    )
+    assert governance_request_ref("org-a", "same", secret) != governance_subject_ref(
+        "org-a", "same", secret
+    )
+    assert governance_actor_ref(
+        "org-a", "jwt", "principal-1", secret
+    ) != governance_actor_ref("org-a", "central_token", "principal-1", secret)
+
+
+def test_secret_defaults_only_in_local_dev_or_test(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REFLEXIO_GOVERNANCE_REF_SECRET", raising=False)
+    monkeypatch.delenv("DEPLOYMENT_MODE", raising=False)
+    monkeypatch.setenv("REFLEXIO_ENV", "development")
+
+    assert get_governance_ref_secret() == "reflexio-local-governance-ref-secret"
+
+
+def test_secret_fails_closed_in_platform_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REFLEXIO_GOVERNANCE_REF_SECRET", raising=False)
+    monkeypatch.setenv("DEPLOYMENT_MODE", "platform")
+    monkeypatch.setenv("REFLEXIO_ENV", "production")
+
+    with pytest.raises(RuntimeError, match="REFLEXIO_GOVERNANCE_REF_SECRET"):
+        get_governance_ref_secret()
+
+
+def test_blank_secret_is_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "   ")
+    monkeypatch.setenv("DEPLOYMENT_MODE", "self_host")
+    monkeypatch.setenv("REFLEXIO_ENV", "production")
+
+    with pytest.raises(RuntimeError, match="REFLEXIO_GOVERNANCE_REF_SECRET"):
+        get_governance_ref_secret()

--- a/tests/server/services/governance/test_governance_refs.py
+++ b/tests/server/services/governance/test_governance_refs.py
@@ -8,25 +8,39 @@ from reflexio.server.services.governance.config import (
     governance_request_ref,
     governance_subject_ref,
 )
+from reflexio.server.services.storage.storage_base._governance import GovernanceMixin
 
 
 def test_refs_are_domain_separated_by_org_and_kind() -> None:
     secret = "test-secret"
 
-    assert governance_subject_ref("org-a", "alice", secret).startswith("subref_v1_")
-    assert governance_request_ref("org-a", "ticket-1", secret).startswith("reqref_v1_")
-    assert governance_actor_ref("org-a", "jwt", "principal-1", secret).startswith(
-        "actref_v1_"
+    subject_ref_org_a = governance_subject_ref("org-a", "alice", secret)
+    subject_ref_org_b = governance_subject_ref("org-b", "alice", secret)
+    request_ref_org_a = governance_request_ref("org-a", "ticket-1", secret)
+    request_ref_org_b = governance_request_ref("org-b", "ticket-1", secret)
+    actor_ref_jwt_org_a = governance_actor_ref("org-a", "jwt", "principal-1", secret)
+    actor_ref_jwt_org_b = governance_actor_ref("org-b", "jwt", "principal-1", secret)
+    actor_ref_token_org_a = governance_actor_ref(
+        "org-a", "central_token", "principal-1", secret
     )
-    assert governance_subject_ref("org-a", "alice", secret) != governance_subject_ref(
-        "org-b", "alice", secret
-    )
-    assert governance_request_ref("org-a", "same", secret) != governance_subject_ref(
-        "org-a", "same", secret
-    )
-    assert governance_actor_ref(
-        "org-a", "jwt", "principal-1", secret
-    ) != governance_actor_ref("org-a", "central_token", "principal-1", secret)
+
+    assert subject_ref_org_a.startswith("subref_v1_")
+    assert request_ref_org_a.startswith("reqref_v1_")
+    assert actor_ref_jwt_org_a.startswith("actref_v1_")
+    assert subject_ref_org_a != subject_ref_org_b
+    assert request_ref_org_a != request_ref_org_b
+    assert actor_ref_jwt_org_a != actor_ref_jwt_org_b
+    assert request_ref_org_a != subject_ref_org_a
+    assert actor_ref_jwt_org_a != actor_ref_token_org_a
+
+
+def test_governance_mixin_tracks_new_barrier_methods_as_abstract() -> None:
+    assert {
+        "begin_subject_erasure_barrier",
+        "assert_subject_writable",
+        "complete_subject_erasure_barrier_after_empty_check",
+        "fail_subject_erasure_barrier",
+    } <= GovernanceMixin.__abstractmethods__
 
 
 def test_secret_defaults_only_in_local_dev_or_test(
@@ -34,7 +48,19 @@ def test_secret_defaults_only_in_local_dev_or_test(
 ) -> None:
     monkeypatch.delenv("REFLEXIO_GOVERNANCE_REF_SECRET", raising=False)
     monkeypatch.delenv("DEPLOYMENT_MODE", raising=False)
+    monkeypatch.delenv("REFLEXIO_TEST_MODE", raising=False)
     monkeypatch.setenv("REFLEXIO_ENV", "development")
+
+    assert get_governance_ref_secret() == "reflexio-local-governance-ref-secret"
+
+
+def test_secret_defaults_in_test_mode_even_for_platform_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("REFLEXIO_GOVERNANCE_REF_SECRET", raising=False)
+    monkeypatch.setenv("DEPLOYMENT_MODE", "platform")
+    monkeypatch.setenv("REFLEXIO_ENV", "production")
+    monkeypatch.setenv("REFLEXIO_TEST_MODE", "true")
 
     assert get_governance_ref_secret() == "reflexio-local-governance-ref-secret"
 
@@ -45,6 +71,7 @@ def test_secret_fails_closed_in_platform_production(
     monkeypatch.delenv("REFLEXIO_GOVERNANCE_REF_SECRET", raising=False)
     monkeypatch.setenv("DEPLOYMENT_MODE", "platform")
     monkeypatch.setenv("REFLEXIO_ENV", "production")
+    monkeypatch.delenv("REFLEXIO_TEST_MODE", raising=False)
 
     with pytest.raises(RuntimeError, match="REFLEXIO_GOVERNANCE_REF_SECRET"):
         get_governance_ref_secret()

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -193,6 +193,56 @@ def test_begin_subject_erasure_barrier_requires_matching_purge(
         )
 
 
+def test_fail_subject_erasure_barrier_requires_matching_barrier_row(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    first_purge = storage.begin_purge_operation(
+        purge_id="purge_barrier_first",
+        idempotency_key="idem_barrier_first",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000051",
+    )
+    second_purge = storage.begin_purge_operation(
+        purge_id="purge_barrier_second",
+        idempotency_key="idem_barrier_second",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000052",
+    )
+
+    storage.begin_subject_erasure_barrier(subject_ref, first_purge.purge_id)
+
+    with pytest.raises(ValueError, match="matching barrier"):
+        storage.fail_subject_erasure_barrier(
+            subject_ref,
+            second_purge.purge_id,
+            error_code="governance_erase_failed",
+            error_detail="ValueError",
+        )
+
+    barrier = storage.get_subject_write_barrier(subject_ref)
+    assert barrier is not None
+    assert barrier.purge_id == first_purge.purge_id
+    assert barrier.status == "erasing"
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.add_request(
+            Request(
+                request_id="req-still-blocked",
+                user_id="alice",
+                session_id="sess-still-blocked",
+                source="test",
+                agent_version="agent-v1",
+                created_at=_now(),
+            )
+        )
+
+
 def test_guarded_completion_requires_empty_subject_rows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -166,6 +166,33 @@ def test_barrier_blocks_playbook_eval_and_source_window_writes(
         )
 
 
+def test_begin_subject_erasure_barrier_requires_matching_purge(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    alice_subject_ref = governance_subject_ref(
+        "org-barrier", "alice", "barrier-secret"
+    )
+    bob_subject_ref = governance_subject_ref("org-barrier", "bob", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_barrier_match",
+        idempotency_key="idem_barrier_match",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=alice_subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000021",
+    )
+
+    with pytest.raises(ValueError, match="subject_ref must match"):
+        storage.begin_subject_erasure_barrier(bob_subject_ref, purge.purge_id)
+
+    with pytest.raises(ValueError, match="not found"):
+        storage.begin_subject_erasure_barrier(
+            alice_subject_ref, "purge_barrier_missing"
+        )
+
+
 def test_guarded_completion_requires_empty_subject_rows(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -212,4 +239,122 @@ def test_guarded_completion_requires_empty_subject_rows(
                 idempotency_key=purge.purge_id,
                 detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
             ),
+        )
+
+
+def test_guarded_completion_requires_empty_legacy_null_subject_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_guarded_legacy",
+        idempotency_key="idem_guarded_legacy",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000031",
+    )
+    storage.add_request(
+        Request(
+            request_id="req-legacy-before-barrier",
+            user_id="alice",
+            session_id="sess-legacy",
+            source="test",
+            agent_version="agent-v1",
+            created_at=_now(),
+        )
+    )
+    storage.conn.execute(
+        """UPDATE requests
+           SET governance_subject_ref = NULL
+           WHERE request_id = ?""",
+        ("req-legacy-before-barrier",),
+    )
+    storage.conn.commit()
+
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    storage.record_purge_target(
+        purge.purge_id,
+        target_name="target_snapshot",
+        phase="prepare_targets",
+        status="complete",
+        target_ref="all",
+        detail={"prepared": True},
+    )
+
+    with pytest.raises(ValueError, match="same-subject rows remain"):
+        storage.complete_subject_erasure_barrier_after_empty_check(
+            purge.purge_id,
+            AuditEvent(
+                org_id="org-barrier",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=subject_ref,
+                request_ref="reqref_v1_00000000000000000000000000000031",
+                idempotency_key=purge.purge_id,
+                detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
+            ),
+        )
+
+
+def test_source_window_write_blocks_legacy_null_subject_ref_user_playbook(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_source_window_legacy",
+        idempotency_key="idem_source_window_legacy",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000041",
+    )
+
+    user_playbook = UserPlaybook(
+        user_id="alice",
+        agent_version="agent-v1",
+        request_id="req-before-barrier",
+        playbook_name="legacy-source-window",
+        created_at=_now(),
+        content="legacy content",
+        trigger="legacy trigger",
+        rationale="legacy rationale",
+        source="test",
+    )
+    storage.save_user_playbooks([user_playbook])
+    storage.conn.execute(
+        """UPDATE user_playbooks
+           SET governance_subject_ref = NULL
+           WHERE user_playbook_id = ?""",
+        (user_playbook.user_playbook_id,),
+    )
+    storage.conn.commit()
+    agent_playbook = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="legacy-source-window",
+                agent_version="agent-v1",
+                created_at=_now(),
+                content="aggregate content",
+                trigger="aggregate trigger",
+                rationale="aggregate rationale",
+            )
+        ]
+    )[0]
+
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.set_source_windows_for_agent_playbook(
+            agent_playbook.agent_playbook_id,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=user_playbook.user_playbook_id,
+                    source_interaction_ids=[404],
+                )
+            ],
         )

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -16,7 +16,10 @@ from reflexio.models.api_schema.domain.entities import (
 )
 from reflexio.models.api_schema.domain.governance import AuditEvent
 from reflexio.server.services.governance.config import governance_subject_ref
-from reflexio.server.services.storage.error import SubjectWriteBarrierError
+from reflexio.server.services.storage.error import (
+    StorageError,
+    SubjectWriteBarrierError,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 
@@ -56,6 +59,28 @@ def _mark_all_completion_targets(storage: SQLiteStorage, purge_id: str) -> None:
             target_ref="all",
             detail={"count": 0},
         )
+
+
+def _complete_empty_purge(
+    storage: SQLiteStorage,
+    *,
+    purge_id: str,
+    subject_ref: str,
+    request_ref: str,
+) -> None:
+    _mark_all_completion_targets(storage, purge_id)
+    storage.complete_subject_erasure_barrier_after_empty_check(
+        purge_id,
+        AuditEvent(
+            org_id="org-barrier",
+            operation="ERASE",
+            entity_type="request",
+            subject_ref=subject_ref,
+            request_ref=request_ref,
+            idempotency_key=purge_id,
+            detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
+        ),
+    )
 
 
 def test_barrier_blocks_request_interaction_and_profile_writes(
@@ -266,6 +291,204 @@ def test_fail_subject_erasure_barrier_requires_matching_barrier_row(
                 agent_version="agent-v1",
                 created_at=_now(),
             )
+        )
+
+
+def test_begin_subject_erasure_barrier_preserves_terminal_erased_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    request_ref = "reqref_v1_00000000000000000000000000000053"
+    purge = storage.begin_purge_operation(
+        purge_id="purge_barrier_terminal_begin",
+        idempotency_key="idem_barrier_terminal_begin",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref=request_ref,
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    _complete_empty_purge(
+        storage,
+        purge_id=purge.purge_id,
+        subject_ref=subject_ref,
+        request_ref=request_ref,
+    )
+
+    barrier = storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    stored_barrier = storage.get_subject_write_barrier(subject_ref)
+    stored_purge = storage.get_purge_operation(purge.purge_id)
+
+    assert barrier.status == "erased"
+    assert stored_barrier is not None
+    assert stored_barrier.status == "erased"
+    assert stored_purge is not None
+    assert stored_purge.status == "complete"
+
+
+def test_fail_subject_erasure_barrier_rejects_terminal_erased_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    request_ref = "reqref_v1_00000000000000000000000000000054"
+    purge = storage.begin_purge_operation(
+        purge_id="purge_barrier_terminal_fail",
+        idempotency_key="idem_barrier_terminal_fail",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref=request_ref,
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    _complete_empty_purge(
+        storage,
+        purge_id=purge.purge_id,
+        subject_ref=subject_ref,
+        request_ref=request_ref,
+    )
+
+    with pytest.raises(ValueError, match="matching barrier"):
+        storage.fail_subject_erasure_barrier(
+            subject_ref,
+            purge.purge_id,
+            error_code="governance_erase_failed",
+            error_detail="late_failure",
+        )
+
+    barrier = storage.get_subject_write_barrier(subject_ref)
+    purge_after_failure = storage.get_purge_operation(purge.purge_id)
+    assert barrier is not None
+    assert barrier.status == "erased"
+    assert barrier.error_code is None
+    assert purge_after_failure is not None
+    assert purge_after_failure.status == "complete"
+    assert purge_after_failure.error_code is None
+
+
+def test_fail_purge_operation_rejects_terminal_complete_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    request_ref = "reqref_v1_00000000000000000000000000000055"
+    purge = storage.begin_purge_operation(
+        purge_id="purge_barrier_terminal_purge_fail",
+        idempotency_key="idem_barrier_terminal_purge_fail",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref=request_ref,
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    _complete_empty_purge(
+        storage,
+        purge_id=purge.purge_id,
+        subject_ref=subject_ref,
+        request_ref=request_ref,
+    )
+
+    with pytest.raises(ValueError, match="already complete"):
+        storage.fail_purge_operation(
+            purge.purge_id,
+            error_code="governance_erase_failed",
+            error_detail="late_failure",
+        )
+
+    barrier = storage.get_subject_write_barrier(subject_ref)
+    purge_after_failure = storage.get_purge_operation(purge.purge_id)
+    assert barrier is not None
+    assert barrier.status == "erased"
+    assert purge_after_failure.status == "complete"
+    assert purge_after_failure.error_code is None
+
+
+def test_guarded_completion_allows_purged_retained_skeletons(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    profile = UserProfile(
+        profile_id="profile-purged-skeleton",
+        user_id="alice",
+        content="profile pii",
+        generated_from_request_id="req-profile-purged-skeleton",
+        last_modified_timestamp=_now(),
+    )
+    user_playbook = UserPlaybook(
+        user_id="alice",
+        agent_version="agent-v1",
+        request_id="req-playbook-purged-skeleton",
+        playbook_name="purged-skeleton",
+        created_at=_now(),
+        content="playbook pii",
+        trigger="trigger pii",
+        rationale="rationale pii",
+        source="test",
+    )
+    storage.add_user_profile("alice", [profile])
+    storage.save_user_playbooks([user_playbook])
+    purge = storage.begin_purge_operation(
+        purge_id="purge_purged_skeletons",
+        idempotency_key="idem_purged_skeletons",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000061",
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    assert storage.purge_content(entity_type="profile", entity_id=profile.profile_id)
+    assert storage.purge_content(
+        entity_type="user_playbook",
+        entity_id=str(user_playbook.user_playbook_id),
+    )
+    _complete_empty_purge(
+        storage,
+        purge_id=purge.purge_id,
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000061",
+    )
+
+    barrier = storage.get_subject_write_barrier(subject_ref)
+    completed_purge = storage.get_purge_operation(purge.purge_id)
+    assert barrier is not None
+    assert barrier.status == "erased"
+    assert completed_purge is not None
+    assert completed_purge.status == "complete"
+
+
+def test_update_user_playbook_rejects_purged_retained_skeleton(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    user_playbook = UserPlaybook(
+        user_id="alice",
+        agent_version="agent-v1",
+        request_id="req-playbook-update-purged-skeleton",
+        playbook_name="purged-update",
+        created_at=_now(),
+        content="playbook pii",
+        trigger="trigger pii",
+        rationale="rationale pii",
+        source="test",
+    )
+    storage.save_user_playbooks([user_playbook])
+    assert storage.purge_content(
+        entity_type="user_playbook",
+        entity_id=str(user_playbook.user_playbook_id),
+    )
+
+    with pytest.raises(StorageError, match="subject identity is missing"):
+        storage.update_user_playbook(
+            user_playbook.user_playbook_id,
+            content="repopulated pii",
         )
 
 

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -406,6 +406,44 @@ def test_guarded_completion_requires_existing_erasing_subject_barrier(
         )
 
 
+def test_guarded_completion_rejects_failed_subject_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_failed_barrier",
+        idempotency_key="idem_failed_barrier",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000035",
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    storage.fail_subject_erasure_barrier(
+        subject_ref,
+        purge.purge_id,
+        error_code="test_failed_barrier",
+        error_detail="RuntimeError",
+    )
+    _mark_all_completion_targets(storage, purge.purge_id)
+
+    with pytest.raises(ValueError, match="subject erasure barrier is missing"):
+        storage.complete_subject_erasure_barrier_after_empty_check(
+            purge.purge_id,
+            AuditEvent(
+                org_id="org-barrier",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=subject_ref,
+                request_ref="reqref_v1_00000000000000000000000000000035",
+                idempotency_key=purge.purge_id,
+                detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
+            ),
+        )
+
+
 def test_barrier_blocks_profile_update_paths(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -470,6 +508,8 @@ def test_barrier_blocks_user_playbook_update_paths(
     )
     storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
 
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.archive_user_playbook_by_id("alice", playbook.user_playbook_id)
     with pytest.raises(SubjectWriteBarrierError):
         storage.update_user_playbook(playbook.user_playbook_id, tags=["blocked"])
     with pytest.raises(SubjectWriteBarrierError):

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    AgentPlaybookSourceWindow,
+    AgentSuccessEvaluationResult,
+    Interaction,
+    Request,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.domain.governance import AuditEvent
+from reflexio.server.services.governance.config import governance_subject_ref
+from reflexio.server.services.storage.error import SubjectWriteBarrierError
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+def _now() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+def _storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SQLiteStorage:
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "barrier-secret")
+    monkeypatch.setattr(SQLiteStorage, "_get_embedding", lambda *_args: [0.0] * 512)
+    return SQLiteStorage(org_id="org-barrier", db_path=str(tmp_path / "barrier.db"))
+
+
+def test_barrier_blocks_request_interaction_and_profile_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_barrier",
+        idempotency_key="idem_barrier",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_11111111111111111111111111111111",
+    )
+
+    barrier = storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    assert barrier.status == "erasing"
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.add_request(
+            Request(
+                request_id="req-after-barrier",
+                user_id="alice",
+                session_id="sess-1",
+                source="test",
+                agent_version="agent-v1",
+                created_at=_now(),
+            )
+        )
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.add_user_interaction(
+            "alice",
+            Interaction(
+                user_id="alice",
+                request_id="req-after-barrier",
+                content="blocked interaction",
+                created_at=_now(),
+            ),
+        )
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.add_user_profile(
+            "alice",
+            [
+                UserProfile(
+                    profile_id="profile-after-barrier",
+                    user_id="alice",
+                    content="blocked profile",
+                    generated_from_request_id="req-after-barrier",
+                    last_modified_timestamp=_now(),
+                )
+            ],
+        )
+
+
+def test_barrier_blocks_playbook_eval_and_source_window_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_barrier",
+        idempotency_key="idem_barrier",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_11111111111111111111111111111111",
+    )
+
+    user_playbook = UserPlaybook(
+        user_id="alice",
+        agent_version="agent-v1",
+        request_id="req-before-barrier",
+        playbook_name="barrier-test",
+        created_at=_now(),
+        content="initial content",
+        trigger="initial trigger",
+        rationale="initial rationale",
+        source="test",
+    )
+    storage.save_user_playbooks([user_playbook])
+    agent_playbook = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="barrier-test",
+                agent_version="agent-v1",
+                created_at=_now(),
+                content="aggregate content",
+                trigger="aggregate trigger",
+                rationale="aggregate rationale",
+            )
+        ]
+    )[0]
+
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.save_user_playbooks(
+            [
+                UserPlaybook(
+                    user_id="alice",
+                    agent_version="agent-v1",
+                    request_id="req-after-barrier",
+                    playbook_name="barrier-test",
+                    created_at=_now(),
+                    content="blocked content",
+                    trigger="blocked trigger",
+                    rationale="blocked rationale",
+                    source="test",
+                )
+            ]
+        )
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.save_agent_success_evaluation_results(
+            [
+                AgentSuccessEvaluationResult(
+                    user_id="alice",
+                    session_id="sess-1",
+                    agent_version="agent-v1",
+                    evaluation_name="barrier-test",
+                    is_success=False,
+                )
+            ]
+        )
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.set_source_windows_for_agent_playbook(
+            agent_playbook.agent_playbook_id,
+            [
+                AgentPlaybookSourceWindow(
+                    user_playbook_id=user_playbook.user_playbook_id,
+                    source_interaction_ids=[101],
+                )
+            ],
+        )
+
+
+def test_guarded_completion_requires_empty_subject_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_guarded_complete",
+        idempotency_key="idem_guarded_complete",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_0123456789abcdef0123456789abcdef",
+    )
+    storage.add_request(
+        Request(
+            request_id="req-before-barrier",
+            user_id="alice",
+            session_id="sess-1",
+            source="test",
+            agent_version="agent-v1",
+            created_at=_now(),
+        )
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+    storage.record_purge_target(
+        purge.purge_id,
+        target_name="target_snapshot",
+        phase="prepare_targets",
+        status="complete",
+        target_ref="all",
+        detail={"prepared": True},
+    )
+
+    with pytest.raises(ValueError, match="same-subject rows remain"):
+        storage.complete_subject_erasure_barrier_after_empty_check(
+            purge.purge_id,
+            AuditEvent(
+                org_id="org-barrier",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=subject_ref,
+                request_ref="reqref_v1_0123456789abcdef0123456789abcdef",
+                idempotency_key=purge.purge_id,
+                detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
+            ),
+        )

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -30,6 +30,34 @@ def _storage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SQLiteStorage:
     return SQLiteStorage(org_id="org-barrier", db_path=str(tmp_path / "barrier.db"))
 
 
+def _mark_all_completion_targets(storage: SQLiteStorage, purge_id: str) -> None:
+    storage.record_purge_target(
+        purge_id,
+        target_name="target_snapshot",
+        phase="prepare_targets",
+        status="complete",
+        target_ref="all",
+        detail={"prepared": True},
+    )
+    for target_name in (
+        "request",
+        "interaction",
+        "profile",
+        "user_playbook",
+        "agent_success_evaluation_result",
+        "profile_purge",
+        "user_playbook_purge",
+    ):
+        storage.record_purge_target(
+            purge_id,
+            target_name=target_name,
+            phase="delete",
+            status="complete",
+            target_ref="all",
+            detail={"count": 0},
+        )
+
+
 def test_barrier_blocks_request_interaction_and_profile_writes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -171,9 +199,7 @@ def test_begin_subject_erasure_barrier_requires_matching_purge(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     storage = _storage(tmp_path, monkeypatch)
-    alice_subject_ref = governance_subject_ref(
-        "org-barrier", "alice", "barrier-secret"
-    )
+    alice_subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
     bob_subject_ref = governance_subject_ref("org-barrier", "bob", "barrier-secret")
     purge = storage.begin_purge_operation(
         purge_id="purge_barrier_match",
@@ -346,6 +372,110 @@ def test_guarded_completion_requires_empty_legacy_null_subject_rows(
                 idempotency_key=purge.purge_id,
                 detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
             ),
+        )
+
+
+def test_guarded_completion_requires_existing_erasing_subject_barrier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    purge = storage.begin_purge_operation(
+        purge_id="purge_missing_barrier",
+        idempotency_key="idem_missing_barrier",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000032",
+    )
+    _mark_all_completion_targets(storage, purge.purge_id)
+
+    with pytest.raises(ValueError, match="subject erasure barrier is missing"):
+        storage.complete_subject_erasure_barrier_after_empty_check(
+            purge.purge_id,
+            AuditEvent(
+                org_id="org-barrier",
+                operation="ERASE",
+                entity_type="request",
+                subject_ref=subject_ref,
+                request_ref="reqref_v1_00000000000000000000000000000032",
+                idempotency_key=purge.purge_id,
+                detail={"deleted_counts": {}, "rebuilt_agent_playbook_ids": []},
+            ),
+        )
+
+
+def test_barrier_blocks_profile_update_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    profile = UserProfile(
+        profile_id="profile-before-barrier",
+        user_id="alice",
+        content="before",
+        generated_from_request_id="req-before-barrier",
+        last_modified_timestamp=_now(),
+    )
+    storage.add_user_profile("alice", [profile])
+    purge = storage.begin_purge_operation(
+        purge_id="purge_profile_update",
+        idempotency_key="idem_profile_update",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000033",
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.update_user_profile_tags("alice", profile.profile_id, ["blocked"])
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.archive_profile_by_id("alice", profile.profile_id)
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.supersede_profiles_by_ids(
+            "alice",
+            [profile.profile_id],
+            request_id="req-supersede-blocked",
+        )
+
+
+def test_barrier_blocks_user_playbook_update_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    playbook = UserPlaybook(
+        user_id="alice",
+        agent_version="agent-v1",
+        request_id="req-before-barrier",
+        playbook_name="barrier-update",
+        created_at=_now(),
+        content="before",
+        trigger="trigger",
+        rationale="rationale",
+        source="test",
+    )
+    storage.save_user_playbooks([playbook])
+    purge = storage.begin_purge_operation(
+        purge_id="purge_playbook_update",
+        idempotency_key="idem_playbook_update",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_00000000000000000000000000000034",
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.update_user_playbook(playbook.user_playbook_id, tags=["blocked"])
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.supersede_user_playbooks_by_ids(
+            [playbook.user_playbook_id],
+            request_id="req-supersede-playbook-blocked",
         )
 
 

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -48,13 +48,16 @@ CANONICAL_DELETE_TARGET_NAMES = (
 
 
 @pytest.fixture
-def storage(tmp_path):
+def storage(tmp_path, monkeypatch):
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
         yield SQLiteStorage(org_id="org1", db_path=str(tmp_path / "g.db"))
 
 
 @pytest.fixture
-def storage_factory(tmp_path):
+def storage_factory(tmp_path, monkeypatch):
+    monkeypatch.setenv("REFLEXIO_GOVERNANCE_REF_SECRET", "test-governance-secret")
+
     def _make_storage(org_id: str) -> SQLiteStorage:
         return SQLiteStorage(org_id=org_id, db_path=str(tmp_path / "shared-g.db"))
 
@@ -79,7 +82,6 @@ def _begin_purge(storage: SQLiteStorage, purge_id: str) -> str:
         status="complete",
         detail={
             "owned_user_playbook_ids": [11],
-            "affected_agent_playbook_ids": [22],
         },
     )
     return purge.purge_id
@@ -99,6 +101,7 @@ def _add_complete_delete_target_matrix(storage: SQLiteStorage, purge_id: str) ->
 def _begin_completeable_purge(storage: SQLiteStorage, purge_id: str) -> str:
     purge_id = _begin_purge(storage, purge_id)
     _add_complete_delete_target_matrix(storage, purge_id)
+    storage.begin_subject_erasure_barrier(SUBJECT_REF, purge_id)
     return purge_id
 
 
@@ -286,6 +289,24 @@ def _seed_agent_playbook(
     status: Status | None = Status.ARCHIVED,
     source_windows: list[AgentPlaybookSourceWindow] | None = None,
 ) -> int:
+    created_at = "2026-01-01T00:00:00.000Z"
+    for window in source_windows or [
+        AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])
+    ]:
+        storage.conn.execute(
+            """INSERT OR IGNORE INTO user_playbooks (
+                   user_playbook_id, user_id, playbook_name, created_at, request_id,
+                   agent_version, content, source_interaction_ids, embedding
+               ) VALUES (?, ?, '', ?, ?, '', ?, '[]', '[]')""",
+            (
+                window.user_playbook_id,
+                f"source-user-{window.user_playbook_id}",
+                created_at,
+                f"request-source-{window.user_playbook_id}",
+                f"source-playbook-{window.user_playbook_id}",
+            ),
+        )
+    storage.conn.commit()
     playbook = AgentPlaybook(
         playbook_name="governance-rebuild",
         agent_version="test-agent",
@@ -304,6 +325,35 @@ def _seed_agent_playbook(
         ],
     )
     return saved.agent_playbook_id
+
+
+def _record_agent_playbook_rebuild_target(
+    storage: SQLiteStorage,
+    *,
+    purge_id: str,
+    agent_playbook_id: int,
+    original_windows: list[dict[str, object]] | None = None,
+    remaining_windows: list[dict[str, object]] | None = None,
+    previous_lifecycle_status: str | None = Status.ARCHIVED.value,
+    status: Literal["pending", "running", "complete", "failed"] = "pending",
+) -> None:
+    storage.record_purge_target(
+        purge_id=purge_id,
+        target_name="agent_playbook",
+        target_ref=str(agent_playbook_id),
+        phase="rebuild_without_erased_sources",
+        status=status,
+        detail={
+            "original_source_windows": original_windows
+            or [
+                {"user_playbook_id": 7, "source_interaction_ids": [101]},
+                {"user_playbook_id": 9, "source_interaction_ids": [201]},
+            ],
+            "previous_lifecycle_status": previous_lifecycle_status,
+            "remaining_source_windows": remaining_windows
+            or [{"user_playbook_id": 9, "source_interaction_ids": [201]}],
+        },
+    )
 
 
 def test_audit_event_idempotency(storage):
@@ -452,6 +502,7 @@ def test_purge_targets_require_snapshot_marker(storage):
     )
 
     assert storage.purge_targets_prepared(purge.purge_id) is False
+    storage.begin_subject_erasure_barrier(SUBJECT_REF, purge.purge_id)
     with pytest.raises(ValueError, match="target snapshot"):
         storage.complete_purge_operation_with_audit(
             purge.purge_id,
@@ -820,6 +871,7 @@ def test_append_audit_event_rejects_successful_erase_without_idempotency_key(sto
 
 def test_complete_purge_operation_requires_full_delete_target_matrix(storage):
     purge_id = _begin_purge(storage, "purge_snapshot_only")
+    storage.begin_subject_erasure_barrier(SUBJECT_REF, purge_id)
 
     with pytest.raises(ValueError, match="delete target matrix"):
         storage.complete_purge_operation_with_audit(
@@ -873,10 +925,7 @@ def test_prepare_governance_erase_targets_sanitizes_snapshot_detail(storage):
         )
         if target.target_name == "target_snapshot"
     )
-    assert snapshot.detail == {
-        "owned_user_playbook_ids": [7],
-        "affected_agent_playbook_ids": [],
-    }
+    assert snapshot.detail == {"owned_user_playbook_ids": [7]}
 
 
 def test_apply_governance_user_data_delete_rejects_playbook_snapshot_drift(storage):
@@ -921,7 +970,9 @@ def test_apply_governance_user_data_delete_rejects_playbook_snapshot_drift(stora
     assert owned_user_playbook_ids < remaining_ids
 
 
-def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storage):
+def test_prepare_governance_erase_targets_does_not_plan_org_agent_playbook_rebuilds(
+    storage,
+):
     storage.begin_purge_operation(
         purge_id="purge_rebuild_windows",
         idempotency_key="idem_purge_rebuild_windows",
@@ -946,25 +997,13 @@ def test_prepare_governance_erase_targets_persists_rebuild_source_windows(storag
         owned_user_playbook_ids={7},
     )
 
-    rebuild_target = next(
-        target
-        for target in storage.list_purge_targets(
+    assert (
+        storage.list_purge_targets(
             "purge_rebuild_windows", phase="rebuild_without_erased_sources"
         )
-        if target.target_name == "agent_playbook"
-        and target.target_ref == str(agent_playbook_id)
+        == []
     )
-    assert rebuild_target.status == "pending"
-    assert rebuild_target.detail == {
-        "original_source_windows": [
-            {"user_playbook_id": 7, "source_interaction_ids": [101, 102]},
-            {"user_playbook_id": 9, "source_interaction_ids": [201]},
-        ],
-        "previous_lifecycle_status": Status.ARCHIVED.value,
-        "remaining_source_windows": [
-            {"user_playbook_id": 9, "source_interaction_ids": [201]},
-        ],
-    }
+    assert storage.get_agent_playbook_by_id(agent_playbook_id) is not None
 
 
 def test_prepare_governance_erase_targets_records_full_delete_matrix_counts(storage):
@@ -1042,10 +1081,11 @@ def test_hide_governance_agent_playbooks_for_rebuild_sets_archive_in_progress_an
             AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
         ],
     )
-    storage.prepare_governance_erase_targets(
+    _record_agent_playbook_rebuild_target(
+        storage,
         purge_id=purge_id,
-        user_id="user-hide-rebuild",
-        owned_user_playbook_ids={7},
+        agent_playbook_id=agent_playbook_id,
+        previous_lifecycle_status=None,
     )
     expected_detail = {
         "original_source_windows": [
@@ -1361,10 +1401,11 @@ def test_apply_governance_agent_playbook_rebuild_succeeds_after_prepare_and_hide
             AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
         ],
     )
-    storage.prepare_governance_erase_targets(
+    _record_agent_playbook_rebuild_target(
+        storage,
         purge_id=purge_id,
-        user_id="user-hide-rebuild",
-        owned_user_playbook_ids={7},
+        agent_playbook_id=agent_playbook_id,
+        previous_lifecycle_status=None,
     )
     storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
 
@@ -1706,10 +1747,11 @@ def test_apply_governance_agent_playbook_rebuild_rejects_second_call_after_compl
             AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
         ],
     )
-    storage.prepare_governance_erase_targets(
+    _record_agent_playbook_rebuild_target(
+        storage,
         purge_id=purge_id,
-        user_id="user-rebuild-second-call",
-        owned_user_playbook_ids={7},
+        agent_playbook_id=agent_playbook_id,
+        previous_lifecycle_status=Status.ARCHIVED.value,
     )
     storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
     storage.apply_governance_agent_playbook_rebuild(
@@ -1817,10 +1859,11 @@ def test_hide_governance_agent_playbooks_for_rebuild_is_idempotent_after_complet
             AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
         ],
     )
-    storage.prepare_governance_erase_targets(
+    _record_agent_playbook_rebuild_target(
+        storage,
         purge_id=purge_id,
-        user_id="user-hide-after-complete",
-        owned_user_playbook_ids={7},
+        agent_playbook_id=agent_playbook_id,
+        previous_lifecycle_status=Status.ARCHIVED.value,
     )
     storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
     storage.apply_governance_agent_playbook_rebuild(
@@ -1908,10 +1951,11 @@ def test_hide_governance_agent_playbooks_for_rebuild_does_not_reopen_complete_ta
             AgentPlaybookSourceWindow(user_playbook_id=9, source_interaction_ids=[201]),
         ],
     )
-    storage.prepare_governance_erase_targets(
+    _record_agent_playbook_rebuild_target(
+        storage,
         purge_id=purge_id,
-        user_id="user-hide-stale-prelock",
-        owned_user_playbook_ids={7},
+        agent_playbook_id=agent_playbook_id,
+        previous_lifecycle_status=Status.ARCHIVED.value,
     )
     storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
     storage.apply_governance_agent_playbook_rebuild(
@@ -1997,58 +2041,24 @@ def test_hide_governance_agent_playbooks_for_rebuild_does_not_reopen_complete_ta
     )
 
 
-def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot_and_rebuild(
+def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot(
     storage,
 ):
-    purge_id = "purge_prepare_idempotent_after_rebuild"
-    user_id = "user-prepare-idempotent-after-rebuild"
+    purge_id = "purge_prepare_idempotent_after_snapshot"
+    user_id = "user-prepare-idempotent-after-snapshot"
     storage.begin_purge_operation(
         purge_id=purge_id,
-        idempotency_key="idem_purge_prepare_idempotent_after_rebuild",
+        idempotency_key="idem_purge_prepare_idempotent_after_snapshot",
         operation_type="user_erasure",
         scope_type="user",
         subject_ref=SUBJECT_REF,
         request_ref=REQUEST_REF,
     )
     owned_user_playbook_ids = _seed_prepare_counts_user_data(storage, user_id=user_id)
-    _seed_eval_result(
-        storage,
-        user_id=user_id,
-        session_id="session-delete-hide-complete",
-        evaluation_name="governance_delete_hide_complete",
-    )
-    affected_user_playbook_id = min(owned_user_playbook_ids)
-    agent_playbook_id = _seed_agent_playbook(
-        storage,
-        status=Status.ARCHIVED,
-        source_windows=[
-            AgentPlaybookSourceWindow(
-                user_playbook_id=affected_user_playbook_id,
-                source_interaction_ids=[101],
-            ),
-            AgentPlaybookSourceWindow(
-                user_playbook_id=999999, source_interaction_ids=[201]
-            ),
-        ],
-    )
     storage.prepare_governance_erase_targets(
         purge_id=purge_id,
         user_id=user_id,
         owned_user_playbook_ids=owned_user_playbook_ids,
-    )
-    storage.hide_governance_agent_playbooks_for_rebuild(purge_id)
-    storage.apply_governance_agent_playbook_rebuild(
-        purge_id=purge_id,
-        agent_playbook_id=agent_playbook_id,
-        remaining_source_windows=[
-            {"user_playbook_id": 999999, "source_interaction_ids": [201]},
-        ],
-        content="rebuilt content",
-        trigger="rebuilt trigger",
-        rationale="rebuilt rationale",
-        blocking_issue=None,
-        expanded_terms="rebuilt terms",
-        tags=["rebuilt"],
     )
 
     before_targets = [
@@ -2061,16 +2071,8 @@ def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot
             target.deleted_count,
         )
         for target in storage.list_purge_targets(purge_id)
-        if target.target_name
-        in {*CANONICAL_DELETE_TARGET_NAMES, "agent_playbook", "target_snapshot"}
+        if target.target_name in {*CANONICAL_DELETE_TARGET_NAMES, "target_snapshot"}
     ]
-    before_playbook_row = storage.conn.execute(
-        """SELECT status, content, trigger, rationale, tags
-           FROM agent_playbooks
-           WHERE agent_playbook_id = ?""",
-        (agent_playbook_id,),
-    ).fetchone()
-    before_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
 
     storage.prepare_governance_erase_targets(
         purge_id=purge_id,
@@ -2088,20 +2090,10 @@ def test_prepare_governance_erase_targets_is_idempotent_after_completed_snapshot
             target.deleted_count,
         )
         for target in storage.list_purge_targets(purge_id)
-        if target.target_name
-        in {*CANONICAL_DELETE_TARGET_NAMES, "agent_playbook", "target_snapshot"}
+        if target.target_name in {*CANONICAL_DELETE_TARGET_NAMES, "target_snapshot"}
     ]
-    after_playbook_row = storage.conn.execute(
-        """SELECT status, content, trigger, rationale, tags
-           FROM agent_playbooks
-           WHERE agent_playbook_id = ?""",
-        (agent_playbook_id,),
-    ).fetchone()
-    after_windows = storage.get_source_windows_for_agent_playbook(agent_playbook_id)
 
     assert after_targets == before_targets
-    assert after_playbook_row == before_playbook_row
-    assert after_windows == before_windows
 
 
 def test_purge_targets_are_scoped_by_org_for_same_purge_id(storage_factory):
@@ -3163,7 +3155,7 @@ def test_apply_governance_user_data_delete_requires_complete_prepared_delete_mat
     }
 
 
-def test_apply_governance_user_data_delete_requires_hide_targets_for_planned_rebuilds(
+def test_apply_governance_user_data_delete_preserves_org_agent_playbooks_without_hide_targets(
     storage,
 ):
     purge_id = "purge_delete_requires_hide"
@@ -3184,7 +3176,7 @@ def test_apply_governance_user_data_delete_requires_hide_targets_for_planned_reb
         evaluation_name="governance_delete_hide_complete",
     )
     affected_user_playbook_id = min(owned_user_playbook_ids)
-    _seed_agent_playbook(
+    agent_playbook_id = _seed_agent_playbook(
         storage,
         status=None,
         source_windows=[
@@ -3200,21 +3192,20 @@ def test_apply_governance_user_data_delete_requires_hide_targets_for_planned_reb
         owned_user_playbook_ids=owned_user_playbook_ids,
     )
 
-    with pytest.raises(ValueError, match="hide_for_rebuild"):
-        storage.apply_governance_user_data_delete(
-            purge_id=purge_id,
-            user_id=user_id,
-        )
+    counts = storage.apply_governance_user_data_delete(
+        purge_id=purge_id,
+        user_id=user_id,
+    )
 
-    assert _user_scoped_row_counts(storage, user_id=user_id) == {
-        "requests": 1,
-        "interactions": 1,
-        "profiles": 2,
-        "user_playbooks": 2,
-    }
+    assert counts["user_playbooks"] == 1
+    remaining_counts = _user_scoped_row_counts(storage, user_id=user_id)
+    assert remaining_counts["requests"] == 0
+    assert remaining_counts["interactions"] == 0
+    assert storage.get_agent_playbook_by_id(agent_playbook_id) is not None
+    assert storage.get_source_windows_for_agent_playbook(agent_playbook_id) == []
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
     assert {(target.target_name, target.status) for target in delete_targets} == {
-        (target_name, "pending") for target_name in CANONICAL_DELETE_TARGET_NAMES
+        (target_name, "complete") for target_name in CANONICAL_DELETE_TARGET_NAMES
     }
 
 


### PR DESCRIPTION
## Summary
- Implements the OSS storage and service side of governance RTBF subject barriers so erased subjects cannot be rewritten by profile/playbook update paths.
- Adds deterministic governance subject references from deployment secret config and fail-fast validation for mismatched injected services.
- Extends the SQLite local proof with barrier lifecycle, rebuild exclusion, retry, and bypass regression coverage.
- Hardens terminal erasure behavior so completed purges/barriers cannot be regressed and purged retained skeleton rows no longer block completion or accept repopulation.

## Changes
- Governance models/config: add subject reference fields and deployment-secret based ref helpers.
- Governance service: begin/complete purge through the subject barrier, hide playbooks from rebuild, and reject mismatched ref secret injection for export and erase operations.
- SQLite storage: add governance barrier operations, guard profile/playbook writes, stream legacy null-subject scans, and fail closed for purged retained playbook skeletons without subject identity.
- Lineage purge: clear retained profile/user-playbook skeleton subject refs when content is purged so final same-subject checks can complete without leaving linkable lineage.
- Tests: add subject write barrier regressions plus expanded local RTBF e2e proof coverage, including terminal-state and purged-skeleton cases.

## Test Plan
- `uv run pytest --no-cov open_source/reflexio/tests/server/services/governance/test_governance_refs.py open_source/reflexio/tests/server/services/governance/test_governance_local_e2e.py open_source/reflexio/tests/server/services/governance/test_subject_write_barrier_sqlite.py reflexio_ext/tests/server/services/storage/test_subject_write_barrier_supabase.py reflexio_ext/tests/server/services/storage/test_subject_write_barrier_postgres.py -q` (`54 passed`)
- `uv run ruff check open_source/reflexio/reflexio/server/services/governance/service.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_governance.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_lineage.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_playbook.py open_source/reflexio/tests/server/services/governance/test_governance_refs.py open_source/reflexio/tests/server/services/governance/test_governance_local_e2e.py open_source/reflexio/tests/server/services/governance/test_subject_write_barrier_sqlite.py`
- `uv run ruff format --check open_source/reflexio/reflexio/server/services/governance/service.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_governance.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_lineage.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_playbook.py open_source/reflexio/tests/server/services/governance/test_governance_refs.py open_source/reflexio/tests/server/services/governance/test_governance_local_e2e.py open_source/reflexio/tests/server/services/governance/test_subject_write_barrier_sqlite.py`
- `uv run pyright open_source/reflexio/reflexio/server/services/governance/service.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_governance.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_lineage.py open_source/reflexio/reflexio/server/services/storage/sqlite_storage/_playbook.py open_source/reflexio/tests/server/services/governance/test_governance_refs.py open_source/reflexio/tests/server/services/governance/test_governance_local_e2e.py open_source/reflexio/tests/server/services/governance/test_subject_write_barrier_sqlite.py` (`0 errors`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added governance subject write barriers to block writes while an erasure is in progress.
  * Enhanced governance audit events to include actor details for better traceability.
  * Improved governance reference isolation for subjects, requests, and actors.
* **Bug Fixes**
  * Strengthened write-path authorization checks across requests, profiles, playbooks, and related data.
  * Made erase retries more deterministic and consistent when prior completion exists.
  * Improved failure handling, including safer “fail-closed” behavior when governance configuration is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
