### PR TITLE
refactor: public OSS surface + Capability registry foundation (Phase 0 + 1A)

### DIFF
--- a/reflexio/cli/bootstrap_config.py
+++ b/reflexio/cli/bootstrap_config.py
@@ -24,7 +24,7 @@ _DEFAULT_STORAGE = "sqlite"
 def default_org_id() -> str:
     """Resolve the default org id, honoring ``REFLEXIO_DEFAULT_ORG_ID``.
 
-    Mirrors :func:`reflexio.server._auth.default_get_org_id` so the local CLI
+    Mirrors :func:`reflexio.server.auth.default_get_org_id` so the local CLI
     helpers (``setup``, ``config show`` / ``config local``) resolve the same
     ``config_<org>.json`` the running no-auth server reads. Uses ``os.environ``
     directly (not ``env_utils``) to keep this module's import lightweight — see

--- a/reflexio/lib/_base.py
+++ b/reflexio/lib/_base.py
@@ -127,6 +127,21 @@ class ReflexioBase:
             raise RuntimeError(STORAGE_NOT_CONFIGURED_MSG)
         return storage
 
+    def get_storage(self) -> BaseStorage:
+        """Return the configured storage backend.
+
+        Public accessor for consumers (including enterprise) that need the
+        underlying ``BaseStorage``. Prefer ``request_context.storage`` inside
+        OSS pipeline code; this exists for callers that hold a ``Reflexio``.
+
+        Returns:
+            BaseStorage: The configured storage backend.
+
+        Raises:
+            RuntimeError: If storage is not configured.
+        """
+        return self._get_storage()
+
     def _get_query_reformulator(self) -> QueryReformulator:
         """Lazily create and cache a QueryReformulator instance.
 

--- a/reflexio/lib/_generation.py
+++ b/reflexio/lib/_generation.py
@@ -38,6 +38,10 @@ class GenerationMixin(ReflexioBase):
         """
         if not self._is_storage_configured():
             raise ValueError(STORAGE_NOT_CONFIGURED_MSG)
+        from reflexio.server.extensions import get_service
+        from reflexio.server.services.playbook.aggregation_prompt_processing import (
+            AGGREGATION_PROMPT_PROCESSOR,
+        )
         from reflexio.server.services.playbook.components.aggregator import (
             PlaybookAggregator,
         )
@@ -45,9 +49,7 @@ class GenerationMixin(ReflexioBase):
             PlaybookAggregatorRequest,
         )
 
-        aggregation_prompt_processor = (
-            self.request_context.configurator.create_aggregation_prompt_processor()
-        )
+        aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
         aggregator_kwargs = {}
         if aggregation_prompt_processor is not None:
             aggregator_kwargs["aggregation_prompt_processor"] = (

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -3368,7 +3368,7 @@ def _wire_capabilities(
     sourced from ``capabilities.role`` when set (threaded in by the enterprise
     composition root via ``build_registry(deployment_role())``).  When
     ``capabilities.role`` is ``None`` the role falls back to the
-    ``mount_data_plane`` derivation (``"all"`` when True, ``"data-plane"``
+    ``mount_data_plane`` derivation (``"all"`` when True, ``"control-plane"``
     when False), preserving the existing OSS-only behaviour.
 
     Args:
@@ -3390,7 +3390,7 @@ def _wire_capabilities(
     if capabilities.role is not None:
         role = capabilities.role
     else:
-        role = "all" if mount_data_plane else "data-plane"
+        role = "all" if mount_data_plane else "control-plane"
     if capabilities.configurator_class is not None:
         from reflexio.server.services.configurator.configurator import (
             set_configurator_class,
@@ -3512,13 +3512,14 @@ def create_app(
             # drives a per-org worker with org-scoped claims, so it is not limited
             # to the bootstrap org. The bootstrap org is only used to read config
             # and to seed cross-org discovery.
+            bootstrap_org_id = _resolve_lifespan_org_id(get_org_id)
             scheduler = maybe_start_resume_scheduler(
                 lambda org_id: RequestContext(org_id=org_id),
-                bootstrap_org_id=_resolve_lifespan_org_id(get_org_id),
+                bootstrap_org_id=bootstrap_org_id,
             )
             gc_scheduler = maybe_start_lineage_gc(
                 lambda org_id: RequestContext(org_id=org_id),
-                bootstrap_org_id=_resolve_lifespan_org_id(get_org_id),
+                bootstrap_org_id=bootstrap_org_id,
             )
         try:
             if capabilities is not None:

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from reflexio.server.extensions import CapabilityRegistry
+    from reflexio.server.extensions import AppContext, CapabilityRegistry
 
 from anyio.to_thread import current_default_thread_limiter
 from fastapi import (
@@ -3414,6 +3414,7 @@ def create_app(
     get_billing_gate: Callable[[str], Callable[..., None]] | None = None,
     mount_data_plane: bool = True,
     capabilities: "CapabilityRegistry | None" = None,
+    app_context_factory: "Callable[[], AppContext] | None" = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -3445,6 +3446,10 @@ def create_app(
             each capability's routers, services, hooks, and lifecycle methods are
             wired into the app at construction time. Behavior is unchanged when
             ``None``.
+        app_context_factory: Optional callable returning the AppContext passed to
+            each capability's on_startup. When None, an empty AppContext() is used
+            (local OSS / tests). Enterprise binds this to supply self_host_org_id /
+            activated computed during its own startup.
 
     Returns:
         Configured FastAPI application.
@@ -3504,7 +3509,11 @@ def create_app(
             )
         try:
             if capabilities is not None:
-                ctx = AppContext()
+                ctx = (
+                    app_context_factory()
+                    if app_context_factory is not None
+                    else AppContext()
+                )
                 for cap in capabilities.capabilities:
                     await cap.on_startup(ctx)
                     started_caps.append(cap)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -162,18 +162,18 @@ from reflexio.models.config_schema import (
     SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
     Config,
 )
-from reflexio.server._auth import (
-    DEFAULT_ORG_ID,
-    default_billing_gate,
-    default_get_caller_type,
-    default_get_org_id,
-)
 from reflexio.server.api_endpoints import (
     account_api,
     health_api,
     pending_tool_call_api,
     publisher_api,
     stall_state_api,
+)
+from reflexio.server.auth import (
+    DEFAULT_ORG_ID,
+    default_billing_gate,
+    default_get_caller_type,
+    default_get_org_id,
 )
 from reflexio.server.cache.reflexio_cache import (
     get_reflexio,
@@ -3366,12 +3366,12 @@ def create_app(
     from collections.abc import AsyncIterator
     from contextlib import asynccontextmanager
 
-    from reflexio.server._auth import (
+    from reflexio.server.api_endpoints.request_context import RequestContext
+    from reflexio.server.auth import (
         default_billing_gate,
         default_get_caller_type,
         default_get_org_id,
     )
-    from reflexio.server.api_endpoints.request_context import RequestContext
     from reflexio.server.llm.model_defaults import validate_llm_availability
     from reflexio.server.services.extraction.resume_scheduler import (
         maybe_start_resume_scheduler,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -3363,6 +3363,13 @@ def _wire_capabilities(
 
     No-op when ``capabilities`` is None.
 
+    The deployment role passed to each capability's ``routers(role)`` is
+    sourced from ``capabilities.role`` when set (threaded in by the enterprise
+    composition root via ``build_registry(deployment_role())``).  When
+    ``capabilities.role`` is ``None`` the role falls back to the
+    ``mount_data_plane`` derivation (``"all"`` when True, ``"data-plane"``
+    when False), preserving the existing OSS-only behaviour.
+
     Args:
         app (FastAPI): The application instance to wire into.
         capabilities (CapabilityRegistry | None): Capabilities to install, or None.
@@ -3373,7 +3380,10 @@ def _wire_capabilities(
     from reflexio.server.auth import default_billing_gate
     from reflexio.server.extensions import HookRegistry
 
-    role = "all" if mount_data_plane else "data-plane"
+    if capabilities.role is not None:
+        role = capabilities.role
+    else:
+        role = "all" if mount_data_plane else "data-plane"
     if capabilities.configurator_class is not None:
         from reflexio.server.services.configurator.configurator import (
             set_configurator_class,

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -3358,6 +3358,7 @@ def _wire_capabilities(
     app: FastAPI,
     capabilities: "CapabilityRegistry | None",
     mount_data_plane: bool,
+    additional_routers: list[APIRouter] | None = None,
 ) -> None:
     """Wire capability routers, services, and hooks into the app at construction time.
 
@@ -3374,6 +3375,12 @@ def _wire_capabilities(
         app (FastAPI): The application instance to wire into.
         capabilities (CapabilityRegistry | None): Capabilities to install, or None.
         mount_data_plane (bool): Whether the data-plane role is active.
+        additional_routers (list[APIRouter] | None): Routers already mounted via
+            ``additional_routers``; used to detect and reject double-mounts at boot.
+
+    Raises:
+        ValueError: If a capability's router object is also present in
+            ``additional_routers`` — each router must be mounted exactly once.
     """
     if capabilities is None:
         return
@@ -3398,10 +3405,16 @@ def _wire_capabilities(
     # HookRegistry is a stateless facade: its methods configure process-global
     # tracer/usage-recorder/retrieval-capture singletons; the object needn't be stored.
     hooks = HookRegistry()
+    additional = additional_routers or []
     for cap in capabilities.capabilities:
         cap.install_services()
         cap.install_hooks(hooks)
         for r in cap.routers(role):
+            if r in additional:
+                raise ValueError(
+                    f"router for capability {cap.name!r} is mounted both via the "
+                    f"registry and additional_routers; mount it exactly once"
+                )
             app.include_router(r)
 
 
@@ -3638,7 +3651,7 @@ def create_app(
         app.include_router(router)
 
     # Wire capability routers, services, and hooks (composition-root only)
-    _wire_capabilities(app, capabilities, mount_data_plane)
+    _wire_capabilities(app, capabilities, mount_data_plane, additional_routers)
 
     # Health/observability endpoint (per-worker metrics for recycling)
     health_api.install(app)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -3410,7 +3410,7 @@ def _wire_capabilities(
         cap.install_services()
         cap.install_hooks(hooks)
         for r in cap.routers(role):
-            if r in additional:
+            if any(r is a for a in additional):
                 raise ValueError(
                     f"router for capability {cap.name!r} is mounted both via the "
                     f"registry and additional_routers; mount it exactly once"

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -6,7 +6,10 @@ import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from reflexio.server.extensions import CapabilityRegistry
 
 from anyio.to_thread import current_default_thread_limiter
 from fastapi import (
@@ -3324,6 +3327,74 @@ def _add_openapi_security(app: FastAPI) -> None:
     app.openapi = custom_openapi  # type: ignore[method-assign]
 
 
+def _resolve_lifespan_org_id(get_org_id: Callable[..., str] | None) -> str:
+    """Resolve the bootstrap org ID for lifespan schedulers without a request context.
+
+    Args:
+        get_org_id (Callable[..., str] | None): Custom org-ID dependency, or None for
+            the default single-tenant mode.
+
+    Returns:
+        str: The resolved org ID string.
+    """
+    from reflexio.server.auth import default_get_org_id
+
+    if get_org_id is None:
+        return default_get_org_id()
+    try:
+        signature = inspect.signature(get_org_id)
+    except (TypeError, ValueError):
+        return default_get_org_id()
+    if signature.parameters:
+        return default_get_org_id()
+    try:
+        return str(get_org_id())
+    except Exception:
+        logger.exception("Failed to resolve lifespan org_id; using default org")
+        return default_get_org_id()
+
+
+def _wire_capabilities(
+    app: FastAPI,
+    capabilities: "CapabilityRegistry | None",
+    mount_data_plane: bool,
+) -> None:
+    """Wire capability routers, services, and hooks into the app at construction time.
+
+    No-op when ``capabilities`` is None.
+
+    Args:
+        app (FastAPI): The application instance to wire into.
+        capabilities (CapabilityRegistry | None): Capabilities to install, or None.
+        mount_data_plane (bool): Whether the data-plane role is active.
+    """
+    if capabilities is None:
+        return
+    from reflexio.server.auth import default_billing_gate
+    from reflexio.server.extensions import HookRegistry
+
+    role = "all" if mount_data_plane else "data-plane"
+    if capabilities.configurator_class is not None:
+        from reflexio.server.services.configurator.configurator import (
+            set_configurator_class,
+        )
+
+        set_configurator_class(capabilities.configurator_class)
+    if capabilities.billing_gate is not None:
+        for line in ("application", "learnings_generated"):
+            app.dependency_overrides[default_billing_gate(line)] = (
+                capabilities.billing_gate(line)
+            )
+    # HookRegistry is a stateless facade: its methods configure process-global
+    # tracer/usage-recorder/retrieval-capture singletons; the object needn't be stored.
+    hooks = HookRegistry()
+    for cap in capabilities.capabilities:
+        cap.install_services()
+        cap.install_hooks(hooks)
+        for r in cap.routers(role):
+            app.include_router(r)
+
+
 def create_app(
     get_org_id: Callable[..., str] | None = None,
     additional_routers: list[APIRouter] | None = None,
@@ -3332,6 +3403,7 @@ def create_app(
     get_caller_type: Callable[..., str] | None = None,
     get_billing_gate: Callable[[str], Callable[..., None]] | None = None,
     mount_data_plane: bool = True,
+    capabilities: "CapabilityRegistry | None" = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -3359,10 +3431,26 @@ def create_app(
             scheduler, while keeping all other scaffolding (middleware, CORS,
             auth overrides, OpenAPI security, health, ``/meta/version``,
             ``additional_routers``).
+        capabilities: Optional registry of enterprise capabilities. When provided,
+            each capability's routers, services, hooks, and lifecycle methods are
+            wired into the app at construction time. Behavior is unchanged when
+            ``None``.
 
     Returns:
         Configured FastAPI application.
+
+    Raises:
+        ValueError: If both ``get_billing_gate`` and ``capabilities.billing_gate``
+            are provided — pass billing_gate through exactly one path.
     """
+    if (
+        get_billing_gate is not None
+        and capabilities is not None
+        and capabilities.billing_gate is not None
+    ):
+        raise ValueError(
+            "pass billing_gate via either get_billing_gate or capabilities, not both"
+        )
     from collections.abc import AsyncIterator
     from contextlib import asynccontextmanager
 
@@ -3372,6 +3460,7 @@ def create_app(
         default_get_caller_type,
         default_get_org_id,
     )
+    from reflexio.server.extensions import AppContext
     from reflexio.server.llm.model_defaults import validate_llm_availability
     from reflexio.server.services.extraction.resume_scheduler import (
         maybe_start_resume_scheduler,
@@ -3380,25 +3469,11 @@ def create_app(
         maybe_start_lineage_gc,
     )
 
-    def _lifespan_org_id() -> str:
-        if get_org_id is None:
-            return default_get_org_id()
-        try:
-            signature = inspect.signature(get_org_id)
-        except (TypeError, ValueError):
-            return default_get_org_id()
-        if signature.parameters:
-            return default_get_org_id()
-        try:
-            return str(get_org_id())
-        except Exception:
-            logger.exception("Failed to resolve lifespan org_id; using default org")
-            return default_get_org_id()
-
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         scheduler = None
         gc_scheduler = None
+        started_caps: list = []
         if mount_data_plane:
             log_publish_hardware_capacity()
             validate_llm_availability()
@@ -3411,15 +3486,29 @@ def create_app(
             # and to seed cross-org discovery.
             scheduler = maybe_start_resume_scheduler(
                 lambda org_id: RequestContext(org_id=org_id),
-                bootstrap_org_id=_lifespan_org_id(),
+                bootstrap_org_id=_resolve_lifespan_org_id(get_org_id),
             )
             gc_scheduler = maybe_start_lineage_gc(
                 lambda org_id: RequestContext(org_id=org_id),
-                bootstrap_org_id=_lifespan_org_id(),
+                bootstrap_org_id=_resolve_lifespan_org_id(get_org_id),
             )
         try:
+            if capabilities is not None:
+                ctx = AppContext()
+                for cap in capabilities.capabilities:
+                    await cap.on_startup(ctx)
+                    started_caps.append(cap)
             yield
         finally:
+            for cap in reversed(started_caps):
+                try:
+                    await cap.on_shutdown()
+                except Exception:
+                    logger.warning(
+                        "capability %r on_shutdown raised; continuing cleanup",
+                        cap,
+                        exc_info=True,
+                    )
             if scheduler is not None:
                 scheduler.stop()
             if gc_scheduler is not None:
@@ -3528,6 +3617,9 @@ def create_app(
     # Include additional routers
     for router in additional_routers or []:
         app.include_router(router)
+
+    # Wire capability routers, services, and hooks (composition-root only)
+    _wire_capabilities(app, capabilities, mount_data_plane)
 
     # Health/observability endpoint (per-worker metrics for recycling)
     health_api.install(app)

--- a/reflexio/server/api_endpoints/request_context.py
+++ b/reflexio/server/api_endpoints/request_context.py
@@ -1,6 +1,6 @@
 from fastapi import Depends
 
-from reflexio.server._auth import default_get_org_id
+from reflexio.server.auth import default_get_org_id
 from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.configurator.base_configurator import BaseConfigurator
 from reflexio.server.services.configurator.configurator import get_configurator_class

--- a/reflexio/server/auth.py
+++ b/reflexio/server/auth.py
@@ -5,6 +5,8 @@ Lives in its own module to avoid an import cycle: api endpoints reference
 :func:`default_get_org_id` (e.g. via FastAPI ``Depends``) and are themselves
 imported by :mod:`reflexio.server.api`. Putting the dependency here keeps the
 import graph acyclic.
+
+Public module path: :mod:`reflexio.server.auth`.
 """
 
 from __future__ import annotations

--- a/reflexio/server/extensions.py
+++ b/reflexio/server/extensions.py
@@ -9,6 +9,23 @@ reachable from every RequestContext construction site — HTTP, library
 
 from __future__ import annotations
 
+from abc import ABC
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import ClassVar
+
+from fastapi import APIRouter
+
+from reflexio.server.services.unified_search_service import (
+    RetrievalCaptureHook,
+    configure_retrieval_capture_hook,
+)
+from reflexio.server.tracing import Tracer, configure_tracer
+from reflexio.server.usage_metrics import (
+    UsageEventRecorder,
+    configure_usage_event_recorder,
+)
+
 
 class ServiceKey[T]:
     """Typed handle into the runtime-service registry.
@@ -53,6 +70,12 @@ def get_service[T](key: ServiceKey[T]) -> T | None:
 def require_service[T](key: ServiceKey[T]) -> T:
     """Return the provider for ``key``, raising if unset (required providers).
 
+    Args:
+        key (ServiceKey[T]): The typed key whose provider to retrieve.
+
+    Returns:
+        T: The registered provider value.
+
     Raises:
         LookupError: If no provider is registered for ``key``.
     """
@@ -64,3 +87,134 @@ def require_service[T](key: ServiceKey[T]) -> T:
 def reset_services() -> None:
     """Clear all registered services. Test-only."""
     _services.clear()
+
+
+# ---------------------------------------------------------------------------
+# Hook registry, app context, and capability lifecycle primitives
+# ---------------------------------------------------------------------------
+
+
+class HookRegistry:
+    """Facade over OSS process-global hook setters; capabilities install through it."""
+
+    def set_tracer(self, tracer: Tracer | None) -> None:
+        """Install (or clear) the process-global request tracer.
+
+        Args:
+            tracer (Tracer | None): Tracer implementation, or None to disable.
+        """
+        configure_tracer(tracer)
+
+    def set_usage_recorder(self, recorder: UsageEventRecorder | None) -> None:
+        """Install (or clear) the process-global usage-event recorder.
+
+        Args:
+            recorder (UsageEventRecorder | None): Recorder callable, or None to disable.
+        """
+        configure_usage_event_recorder(recorder)
+
+    def set_retrieval_capture(self, hook: RetrievalCaptureHook | None) -> None:
+        """Install (or clear) the process-global retrieval-capture hook.
+
+        Args:
+            hook (RetrievalCaptureHook | None): Hook callable, or None to disable.
+        """
+        configure_retrieval_capture_hook(hook)
+
+
+@dataclass(frozen=True)
+class AppContext:
+    """Inter-step startup data passed to Capability.on_startup.
+
+    Mirrors the values that thread through reflexio_ext lifespan locals
+    (prepare_enterprise_startup output).
+
+    Attributes:
+        self_host_org_id (str | None): Org ID for self-hosted deployments, or None for platform.
+        activated (bool): Whether the enterprise activation check passed.
+    """
+
+    self_host_org_id: str | None = None
+    activated: bool = False
+
+
+class Capability(ABC):
+    """An enterprise feature plugged into the app at its composition root.
+
+    All methods are no-op defaults so the registry can drive every capability
+    through the same phases without hasattr checks. The provider owns this
+    lifecycle shape (ABC); runtime-feature *contracts* are Protocols defined by OSS.
+    """
+
+    name: ClassVar[str]
+
+    def install_services(self) -> None:  # noqa: B027
+        """Register runtime-service providers (process-global). Default: none."""
+
+    def install_hooks(self, hooks: HookRegistry) -> None:  # noqa: B027
+        """Install pipeline hooks (tracer/usage-recorder/retrieval-capture). Default: none.
+
+        Args:
+            hooks (HookRegistry): Registry to install hooks through.
+        """
+
+    def routers(self, role: str) -> list[APIRouter]:  # noqa: ARG002
+        """Return routers to mount for this deployment role. Default: none.
+
+        Args:
+            role (str): Deployment role (e.g. "all", "data-plane").
+
+        Returns:
+            list[APIRouter]: Routers to mount; empty list by default.
+        """
+        return []
+
+    async def on_startup(self, ctx: AppContext) -> None:  # noqa: B027
+        """Start daemons/schedulers. Raising aborts boot (fail-loud). Default: none.
+
+        Args:
+            ctx (AppContext): Startup context produced by prepare_enterprise_startup.
+        """
+
+    async def on_shutdown(self) -> None:  # noqa: B027
+        """Stop what on_startup started. Default: none."""
+
+
+class CapabilityRegistry:
+    """Holds additive capabilities plus the two singular construction-time concerns.
+
+    Args:
+        capabilities (list[Capability]): Capability instances; names must be unique.
+        configurator_class (type | None): Single configurator class, or None.
+        billing_gate (Callable | None): Billing gate factory, or None.
+
+    Raises:
+        RuntimeError: If two capabilities share the same name.
+    """
+
+    def __init__(
+        self,
+        capabilities: list[Capability],
+        *,
+        configurator_class: type | None = None,
+        billing_gate: Callable[[str], Callable[..., None]] | None = None,
+    ) -> None:
+        names = [c.name for c in capabilities]
+        dupes = {n for n in names if names.count(n) > 1}
+        if dupes:
+            raise RuntimeError(f"duplicate capability names: {sorted(dupes)}")
+        self.capabilities = capabilities
+        self.configurator_class = configurator_class
+        self.billing_gate = billing_gate
+
+    def router_names(self) -> set[str]:
+        """Names of capabilities that contribute at least one router (for dual-path de-dup).
+
+        Returns:
+            set[str]: Names of capabilities returning non-empty router lists.
+        """
+        return {
+            c.name
+            for c in self.capabilities
+            if c.routers("all") or c.routers("data-plane")
+        }

--- a/reflexio/server/extensions.py
+++ b/reflexio/server/extensions.py
@@ -187,6 +187,9 @@ class CapabilityRegistry:
         capabilities (list[Capability]): Capability instances; names must be unique.
         configurator_class (type | None): Single configurator class, or None.
         billing_gate (Callable | None): Billing gate factory, or None.
+        role (str | None): Deployment role to thread into ``_wire_capabilities``
+            (e.g. ``"all"``, ``"data-plane"``). When ``None``, ``create_app``
+            derives the role from ``mount_data_plane``.
 
     Raises:
         RuntimeError: If two capabilities share the same name.
@@ -198,6 +201,7 @@ class CapabilityRegistry:
         *,
         configurator_class: type | None = None,
         billing_gate: Callable[[str], Callable[..., None]] | None = None,
+        role: str | None = None,
     ) -> None:
         names = [c.name for c in capabilities]
         dupes = {n for n in names if names.count(n) > 1}
@@ -206,15 +210,4 @@ class CapabilityRegistry:
         self.capabilities = capabilities
         self.configurator_class = configurator_class
         self.billing_gate = billing_gate
-
-    def router_names(self) -> set[str]:
-        """Names of capabilities that contribute at least one router (for dual-path de-dup).
-
-        Returns:
-            set[str]: Names of capabilities returning non-empty router lists.
-        """
-        return {
-            c.name
-            for c in self.capabilities
-            if c.routers("all") or c.routers("data-plane")
-        }
+        self.role = role

--- a/reflexio/server/extensions.py
+++ b/reflexio/server/extensions.py
@@ -1,0 +1,66 @@
+"""OSS extension primitives: the process-global capability/service registry.
+
+OSS defines these seams; enterprise registers implementations at its composition
+root. OSS never imports reflexio_ext. The service registry is process-global (a
+module dict), mirroring set_configurator_class/get_configurator_class, so it is
+reachable from every RequestContext construction site — HTTP, library
+(lib/_base.py), and background workers — not just app-scoped ones.
+"""
+
+from __future__ import annotations
+
+
+class ServiceKey[T]:
+    """Typed handle into the runtime-service registry.
+
+    Args:
+        name (str): Stable identifier, used in error messages and as the dict key.
+    """
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"ServiceKey({self.name!r})"
+
+
+_services: dict[str, object] = {}
+
+
+def register_service[T](
+    key: ServiceKey[T], value: T, *, override: bool = False
+) -> None:
+    """Register a runtime-service provider under ``key`` (composition root only).
+
+    Args:
+        key (ServiceKey[T]): The typed key.
+        value (T): The provider/value.
+        override (bool): Allow replacing an existing registration. Default False.
+
+    Raises:
+        RuntimeError: If ``key`` is already registered and ``override`` is False.
+    """
+    if not override and key.name in _services:
+        raise RuntimeError(f"service already registered for key {key.name!r}")
+    _services[key.name] = value
+
+
+def get_service[T](key: ServiceKey[T]) -> T | None:
+    """Return the provider for ``key``, or None if unset (optional providers)."""
+    return _services.get(key.name)  # type: ignore[return-value]
+
+
+def require_service[T](key: ServiceKey[T]) -> T:
+    """Return the provider for ``key``, raising if unset (required providers).
+
+    Raises:
+        LookupError: If no provider is registered for ``key``.
+    """
+    if key.name not in _services:
+        raise LookupError(f"required service not registered for key {key.name!r}")
+    return _services[key.name]  # type: ignore[return-value]
+
+
+def reset_services() -> None:
+    """Clear all registered services. Test-only."""
+    _services.clear()

--- a/reflexio/server/services/configurator/base_configurator.py
+++ b/reflexio/server/services/configurator/base_configurator.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import Any, ClassVar
 
 from pydantic import BaseModel
 
@@ -12,11 +12,6 @@ from reflexio.models.config_schema import Config, StorageConfig, StorageConfigTe
 from reflexio.server.services.configurator.config_storage import ConfigStorage
 from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.storage_base import BaseStorage
-
-if TYPE_CHECKING:
-    from reflexio.server.services.playbook.aggregation_prompt_processing import (
-        AggregationPromptProcessor,
-    )
 
 logger = logging.getLogger(__name__)
 
@@ -90,12 +85,6 @@ class BaseConfigurator(ABC):
     def get_prompt_bank_paths(self) -> list[Path]:
         """Return additional prompt banks this configurator contributes."""
         return []
-
-    def create_aggregation_prompt_processor(
-        self,
-    ) -> AggregationPromptProcessor | None:
-        """Return a deployment-specific aggregation prompt processor, if any."""
-        return None
 
     def get_agent_context(self) -> str:
         context = self.get_config().agent_context_prompt

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -50,9 +50,9 @@ Triggered manually via `/api/run_playbook_aggregation`. Clusters user playbooks 
 - `get_clusters(user_playbooks, config)` - HDBSCAN/Agglomerative clustering on embeddings
 - `aggregate()` - Full aggregation pipeline with LLM-based consolidation
 
-**Optional prompt processing**: deployments can override
-`BaseConfigurator.create_aggregation_prompt_processor()` to supply an
-`AggregationPromptProcessor`. The aggregator applies the processor only at the
+**Optional prompt processing**: deployments can register an
+`AggregationPromptProcessor` via the `AGGREGATION_PROMPT_PROCESSOR` ServiceKey
+(`register_service`). The aggregator applies the processor only at the
 aggregation prompt boundary, carries an opaque per-cluster processing context,
 injects extra prompt guidance only when preprocessing changed prompt input, and
 post-processes generated outputs before storage or model-response logging.

--- a/reflexio/server/services/playbook/aggregation_prompt_processing.py
+++ b/reflexio/server/services/playbook/aggregation_prompt_processing.py
@@ -37,8 +37,8 @@ class AggregationPromptProcessor(Protocol):
     Implementations may transform prompt text before the aggregation LLM call,
     provide contextual prompt instructions when preprocessing changed prompt
     input, and post-process aggregation output before storage or response
-    logging. Deployments supply one by overriding
-    ``BaseConfigurator.create_aggregation_prompt_processor()``.
+    logging. Deployments supply one by registering it via the
+    ``AGGREGATION_PROMPT_PROCESSOR`` ServiceKey (``register_service``).
     """
 
     def preprocess_prompt_text(

--- a/reflexio/server/services/playbook/aggregation_prompt_processing.py
+++ b/reflexio/server/services/playbook/aggregation_prompt_processing.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Protocol
 
+from reflexio.server.extensions import ServiceKey
+
 
 @dataclass
 class AggregationPromptProcessingContext:
@@ -89,3 +91,10 @@ class PassthroughPromptProcessor:
         context: AggregationPromptProcessingContext | None = None,  # noqa: ARG002
     ) -> PromptPostprocessResult:
         return PromptPostprocessResult(value=value)
+
+
+# Singleton runtime-service key (round-5 RD-NEC-002): one processor registered at
+# the enterprise composition root; None in local OSS (passthrough, no redaction).
+AGGREGATION_PROMPT_PROCESSOR: ServiceKey[AggregationPromptProcessor] = ServiceKey(
+    "aggregation_prompt_processor"
+)

--- a/reflexio/server/services/playbook/service.py
+++ b/reflexio/server/services/playbook/service.py
@@ -22,10 +22,14 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
 )
 from reflexio.models.config_schema import PlaybookConfig
+from reflexio.server.extensions import get_service
 from reflexio.server.operation_limiter import run_with_operation_limit
 from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     StatusChangeOperation,
+)
+from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
 )
 from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
 from reflexio.server.services.playbook.components.extractor import PlaybookExtractor
@@ -537,9 +541,7 @@ class PlaybookGenerationService(
         )
 
         # Initialize and run aggregator (synchronous)
-        aggregation_prompt_processor = (
-            self.request_context.configurator.create_aggregation_prompt_processor()
-        )
+        aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
         aggregator_kwargs = {}
         if aggregation_prompt_processor is not None:
             aggregator_kwargs["aggregation_prompt_processor"] = (

--- a/reflexio/server/services/storage/governance_validation.py
+++ b/reflexio/server/services/storage/governance_validation.py
@@ -1,0 +1,688 @@
+"""Pure governance validation and canonicalization helpers.
+
+These are stateless functions and constants (no sqlite3/storage-class dependency)
+that validate and canonicalize governance schema objects.  Both the SQLite and
+Supabase storage backends import from this module so that neither needs to reach
+into a private sibling package.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from typing import Any, NoReturn, cast, get_args
+
+from reflexio.models.api_schema.domain import AgentPlaybookSourceWindow
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.models.api_schema.domain.governance import (
+    AuditActorType,
+    AuditEntityType,
+    AuditEvent,
+    AuditOperation,
+    AuditStatus,
+    PurgeOperationType,
+    PurgeScopeType,
+    PurgeTargetStatus,
+)
+
+_PREPARE_PHASE = "prepare_targets"
+_SNAPSHOT_TARGET_NAME = "target_snapshot"
+_CANONICAL_DELETE_TARGET_NAMES = (
+    "request",
+    "interaction",
+    "profile",
+    "user_playbook",
+    "agent_success_evaluation_result",
+    "profile_purge",
+    "user_playbook_purge",
+)
+_ALLOWED_AUDIT_ACTOR_TYPES = frozenset(get_args(AuditActorType))
+_ALLOWED_AUDIT_OPERATIONS = frozenset(get_args(AuditOperation))
+_ALLOWED_AUDIT_ENTITY_TYPES = frozenset(get_args(AuditEntityType))
+_ALLOWED_AUDIT_STATUSES = frozenset(get_args(AuditStatus))
+_ALLOWED_PURGE_OPERATION_TYPES = frozenset(get_args(PurgeOperationType))
+_ALLOWED_PURGE_SCOPE_TYPES = frozenset(get_args(PurgeScopeType))
+_ALLOWED_PURGE_TARGET_STATUSES = frozenset(get_args(PurgeTargetStatus))
+_ALLOWED_PURGE_TARGET_NAMES = frozenset(
+    {
+        _SNAPSHOT_TARGET_NAME,
+        "request",
+        "interaction",
+        "profile",
+        "user_playbook",
+        "agent_success_evaluation_result",
+        "agent_playbook",
+        "profile_purge",
+        "user_playbook_purge",
+    }
+)
+_ALLOWED_PURGE_TARGET_PHASES = frozenset(
+    {
+        _PREPARE_PHASE,
+        "delete",
+        "hide_for_rebuild",
+        "rebuild_without_erased_sources",
+    }
+)
+_ALLOWED_AUDIT_DETAIL_KEYS = frozenset(
+    {
+        "agent_playbook_id",
+        "count",
+        "deleted_counts",
+        "deleted_count",
+        "rebuilt_agent_playbook_ids",
+        "route",
+        "status",
+    }
+)
+_ALLOWED_PURGE_TARGET_DETAIL_KEYS = frozenset(
+    {
+        "affected_agent_playbook_ids",
+        "agent_playbook_id",
+        "count",
+        "deleted_counts",
+        "deleted_count",
+        "erased_source_ids",
+        "owned_user_playbook_ids",
+        "original_source_windows",
+        "previous_lifecycle_status",
+        "prepared",
+        "rebuilt_agent_playbook_ids",
+        "remaining_source_windows",
+        "route",
+        "source_interaction_ids",
+        "status",
+        "user_playbook_id",
+    }
+)
+_DISALLOWED_DETAIL_KEYS = frozenset(
+    {
+        "content",
+        "email",
+        "prompt",
+        "request_id",
+        "request_ref",
+        "user_id",
+    }
+)
+_EMAIL_RE = re.compile(r"\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
+_REQUEST_ID_RE = re.compile(
+    r"\b(?:reqref_(?!v1_)|request[_-]|req[_-])[A-Za-z0-9_-]*\b",
+    re.IGNORECASE,
+)
+_TOKEN_NAME_RE = re.compile(
+    r"\b(?:api[-_ ]?token|token[-_ ]?name|bearer|secret[-_ ]?key)\b",
+    re.IGNORECASE,
+)
+_RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
+_SAFE_INTERNAL_ID_RE = re.compile(r"^[0-9]+$")
+_USER_LIKE_TARGET_REF_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
+_CODE_SHAPED_VALUE_RE = re.compile(r"^[A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)+$")
+_IDENTIFIERISH_CODE_VALUE_RE = re.compile(
+    r"^(?:user|subject|actor)[_.:-][A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)*$",
+    re.IGNORECASE,
+)
+_SAFE_ERROR_CODE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,127}$")
+_IDENTIFIERISH_ERROR_CODE_RE = re.compile(
+    r"^(?:user|subject|request|req|actor|email)[-_.:]?[A-Za-z0-9_.:-]+$",
+    re.IGNORECASE,
+)
+_ALLOWED_DETAIL_STATUS_VALUES = frozenset(
+    {
+        "archive_in_progress",
+        "complete",
+        "error",
+        "failed",
+        "ok",
+        "pending",
+        "running",
+    }
+)
+_ALLOWED_PREVIOUS_LIFECYCLE_STATUS_VALUES = frozenset(
+    status.value for status in Status if status.value is not None
+)
+_ALLOWED_DETAIL_ROUTE_VALUES = frozenset(
+    {
+        "prepare_targets",
+        "delete",
+        "hide_for_rebuild",
+        "rebuild_without_erased_sources",
+    }
+)
+_ALLOWED_DELETED_COUNTS_KEYS = frozenset(
+    {
+        "interactions",
+        "user_playbooks",
+        "profiles",
+        "requests",
+        "agent_success_evaluation_results",
+        "purged_profiles",
+        "purged_user_playbooks",
+    }
+)
+
+
+def _epoch_now() -> int:
+    return int(datetime.now(UTC).timestamp())
+
+
+def _raise_governance_validation_error(field_name: str, reason: str) -> NoReturn:
+    raise ValueError(f"Unsafe governance {field_name}: {reason}")
+
+
+def _validate_governance_string(field_name: str, value: str) -> None:
+    if _EMAIL_RE.search(value):
+        _raise_governance_validation_error(field_name, "email")
+    if _REQUEST_ID_RE.search(value):
+        _raise_governance_validation_error(field_name, "request_id")
+    if _TOKEN_NAME_RE.search(value):
+        _raise_governance_validation_error(field_name, "token")
+    if _RAW_EXCEPTION_RE.search(value):
+        _raise_governance_validation_error(field_name, "raw exception text")
+
+
+def _validate_governance_prose_string(field_name: str, value: str) -> None:
+    _validate_governance_string(field_name, value)
+    lowered = value.lower()
+    if "prompt" in lowered or "content" in lowered:
+        _raise_governance_validation_error(field_name, "prompt/content")
+
+
+def _validate_governance_prefixed_ref(
+    field_name: str, value: str | None, *, prefix: str
+) -> None:
+    if value is None:
+        return
+    if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", value) is None:
+        _raise_governance_validation_error(
+            field_name, f"must match {prefix}<32 lowercase hex chars>"
+        )
+
+
+def _validate_governance_code_shaped(
+    field_name: str,
+    value: str,
+    *,
+    allow_minimized_ref: bool,
+) -> str:
+    if not value:
+        _raise_governance_validation_error(field_name, "required")
+    _validate_governance_string(field_name, value)
+    if allow_minimized_ref and any(
+        re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", value)
+        for prefix in ("subref_v1_", "reqref_v1_", "actref_v1_")
+    ):
+        return value
+    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error(field_name, "identifier")
+    if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "identifier")
+    if _SAFE_INTERNAL_ID_RE.fullmatch(value):
+        return value
+    if _CODE_SHAPED_VALUE_RE.fullmatch(value):
+        return value
+    if _USER_LIKE_TARGET_REF_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "user-like identifier")
+    _raise_governance_validation_error(
+        field_name, "must be minimized, internal, or code-shaped"
+    )
+    raise AssertionError("unreachable")
+
+
+def _validate_governance_idempotency_key(
+    field_name: str, value: str | None
+) -> str | None:
+    if value is None:
+        return None
+    if _SAFE_INTERNAL_ID_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "numeric identifier")
+    return _validate_governance_code_shaped(
+        field_name,
+        value,
+        allow_minimized_ref=False,
+    )
+
+
+def _validate_governance_detail_enum(
+    field_name: str, value: Any, *, allowed_values: frozenset[str]
+) -> str:
+    if not isinstance(value, str):
+        _raise_governance_validation_error(field_name, "expected str")
+    _validate_governance_prose_string(field_name, value)
+    if value not in allowed_values:
+        _raise_governance_validation_error(field_name, "must be canonical")
+    return value
+
+
+def _validate_governance_purge_id(field_name: str, value: str) -> str:
+    if not value:
+        _raise_governance_validation_error(field_name, "required")
+    _validate_governance_string(field_name, value)
+    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error(field_name, "identifier")
+    if not value.startswith("purge_"):
+        _raise_governance_validation_error(field_name, "must start with purge_")
+    if _CODE_SHAPED_VALUE_RE.fullmatch(value) is None:
+        _raise_governance_validation_error(field_name, "must be code-shaped")
+    suffix = value[len("purge_") :]
+    if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(suffix):
+        _raise_governance_validation_error(field_name, "identifier")
+    if suffix.isdecimal():
+        _raise_governance_validation_error(field_name, "numeric identifier")
+    return value
+
+
+def _validate_governance_int(field_name: str, value: Any) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        _raise_governance_validation_error(field_name, "expected int")
+
+
+def _validate_governance_nonnegative_int(field_name: str, value: Any) -> int:
+    _validate_governance_int(field_name, value)
+    if value < 0:
+        _raise_governance_validation_error(field_name, "must be nonnegative")
+    return cast(int, value)
+
+
+def _validate_governance_deleted_count(value: Any) -> int:
+    return _validate_governance_nonnegative_int("deleted_count", value)
+
+
+def _validate_governance_int_list(field_name: str, value: Any) -> list[int]:
+    if not isinstance(value, list):
+        _raise_governance_validation_error(field_name, "expected list[int]")
+    normalized_items: list[int] = []
+    for item in value:
+        _validate_governance_int(field_name, item)
+        normalized_items.append(cast(int, item))
+    return normalized_items
+
+
+def _validate_governance_deleted_counts(field_name: str, value: Any) -> dict[str, int]:
+    if not isinstance(value, dict):
+        _raise_governance_validation_error(field_name, "expected dict[str, int]")
+    normalized_counts: dict[str, int] = {}
+    for raw_key, raw_value in value.items():
+        key = str(raw_key).strip().lower()
+        if key in normalized_counts:
+            _raise_governance_validation_error(field_name, f"duplicate key {key}")
+        if key not in _ALLOWED_DELETED_COUNTS_KEYS:
+            _raise_governance_validation_error(field_name, key)
+        normalized_counts[key] = _validate_governance_deleted_count(raw_value)
+    return normalized_counts
+
+
+def _normalize_governance_window_item(
+    field_name: str, index: int, item: object
+) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        _raise_governance_validation_error(
+            f"{field_name}[{index}]", "expected window dict"
+        )
+    window_item = cast(dict[Any, Any], item)
+    normalized_item: dict[str, Any] = {}
+    for raw_key, raw_value in window_item.items():
+        normalized_key = str(raw_key).strip().lower()
+        if normalized_key in normalized_item:
+            _raise_governance_validation_error(
+                f"{field_name}[{index}]", f"duplicate key {normalized_key}"
+            )
+        normalized_item[normalized_key] = raw_value
+    return normalized_item
+
+
+def _validate_governance_window_list(
+    field_name: str, value: Any
+) -> list[dict[str, object]]:
+    if not isinstance(value, list):
+        _raise_governance_validation_error(field_name, "expected list[window]")
+    normalized_windows: list[dict[str, object]] = []
+    for index, item in enumerate(value):
+        normalized_item = _normalize_governance_window_item(field_name, index, item)
+        normalized_keys = set(normalized_item)
+        unexpected_keys = normalized_keys - {
+            "user_playbook_id",
+            "source_interaction_ids",
+        }
+        if unexpected_keys:
+            _raise_governance_validation_error(
+                f"{field_name}[{index}]", sorted(unexpected_keys)[0]
+            )
+        if "user_playbook_id" not in normalized_item:
+            _raise_governance_validation_error(
+                f"{field_name}[{index}].user_playbook_id", "required"
+            )
+        _validate_governance_int(
+            f"{field_name}[{index}].user_playbook_id",
+            normalized_item["user_playbook_id"],
+        )
+        canonical_item: dict[str, object] = {
+            "user_playbook_id": cast(int, normalized_item["user_playbook_id"])
+        }
+        if "source_interaction_ids" in normalized_item:
+            canonical_item["source_interaction_ids"] = _validate_governance_int_list(
+                f"{field_name}[{index}].source_interaction_ids",
+                normalized_item["source_interaction_ids"],
+            )
+        normalized_windows.append(canonical_item)
+    return normalized_windows
+
+
+def _parse_governance_window_list(
+    field_name: str, value: list[dict[str, object]]
+) -> list[AgentPlaybookSourceWindow]:
+    windows: list[AgentPlaybookSourceWindow] = []
+    for normalized_item in _validate_governance_window_list(field_name, value):
+        user_playbook_id = cast(int, normalized_item["user_playbook_id"])
+        source_ids = cast(
+            list[int], normalized_item.get("source_interaction_ids") or []
+        )
+        windows.append(
+            AgentPlaybookSourceWindow(
+                user_playbook_id=user_playbook_id,
+                source_interaction_ids=[int(source_id) for source_id in source_ids],
+            )
+        )
+    return windows
+
+
+def _canonicalize_governance_windows(
+    field_name: str, value: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    return [
+        window.model_dump()
+        for window in _parse_governance_window_list(field_name, value)
+    ]
+
+
+def _validate_governance_target_ref(
+    *, target_name: str, phase: str, target_ref: str
+) -> str:
+    if target_name == _SNAPSHOT_TARGET_NAME:
+        if phase != _PREPARE_PHASE:
+            _raise_governance_validation_error(
+                _SNAPSHOT_TARGET_NAME, "must use prepare_targets phase"
+            )
+        if target_ref != "all":
+            _raise_governance_validation_error("target_ref", "must be all")
+        return target_ref
+    if target_name in {
+        "request",
+        "interaction",
+        "profile",
+        "user_playbook",
+        "profile_purge",
+        "user_playbook_purge",
+    }:
+        if phase != "delete":
+            _raise_governance_validation_error(
+                phase,
+                f"{target_name} targets must use delete phase",
+            )
+        if target_ref != "all":
+            _raise_governance_validation_error("target_ref", "must be all")
+        return target_ref
+    if target_name == "agent_playbook":
+        if phase not in {"hide_for_rebuild", "rebuild_without_erased_sources"}:
+            _raise_governance_validation_error(
+                phase,
+                "agent_playbook targets must use hide_for_rebuild or "
+                "rebuild_without_erased_sources",
+            )
+        if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
+            return target_ref
+        _raise_governance_validation_error(
+            "target_ref", "must be a numeric internal id"
+        )
+    if target_ref in {"", "all"}:
+        return target_ref
+    if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
+        return target_ref
+    for prefix in ("reqref_v1_", "subref_v1_", "actref_v1_"):
+        if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", target_ref):
+            return target_ref
+        if target_ref.startswith(prefix):
+            _raise_governance_validation_error(
+                "target_ref", f"must match {prefix}<32 lowercase hex chars>"
+            )
+    _validate_governance_string("target_ref", target_ref)
+    if _USER_LIKE_TARGET_REF_RE.fullmatch(target_ref):
+        _raise_governance_validation_error("target_ref", "user-like identifier")
+    _raise_governance_validation_error("target_ref", "must be minimized or internal")
+    raise AssertionError("unreachable")
+
+
+def _validate_governance_detail_entry(
+    field_name: str,
+    key: str,
+    value: Any,
+    *,
+    allowed_keys: frozenset[str],
+) -> object:
+    if key in _DISALLOWED_DETAIL_KEYS:
+        _raise_governance_validation_error(field_name, key)
+    if key not in allowed_keys:
+        _raise_governance_validation_error(field_name, key)
+    if key in {"count", "deleted_count"}:
+        return _validate_governance_nonnegative_int(field_name, value)
+    if key in {"agent_playbook_id", "user_playbook_id"}:
+        _validate_governance_int(field_name, value)
+        return cast(int, value)
+    if key == "deleted_counts":
+        return _validate_governance_deleted_counts(field_name, value)
+    if key in {
+        "affected_agent_playbook_ids",
+        "erased_source_ids",
+        "owned_user_playbook_ids",
+        "rebuilt_agent_playbook_ids",
+        "source_interaction_ids",
+    }:
+        return _validate_governance_int_list(field_name, value)
+    if key in {"original_source_windows", "remaining_source_windows"}:
+        return _validate_governance_window_list(field_name, value)
+    if key == "previous_lifecycle_status":
+        if value is None:
+            return None
+        return _validate_governance_detail_enum(
+            field_name,
+            value,
+            allowed_values=_ALLOWED_PREVIOUS_LIFECYCLE_STATUS_VALUES,
+        )
+    if key == "prepared":
+        if not isinstance(value, bool):
+            _raise_governance_validation_error(field_name, "expected bool")
+        return value
+    if key == "route":
+        return _validate_governance_detail_enum(
+            field_name,
+            value,
+            allowed_values=_ALLOWED_DETAIL_ROUTE_VALUES,
+        )
+    if key == "status":
+        return _validate_governance_detail_enum(
+            field_name,
+            value,
+            allowed_values=_ALLOWED_DETAIL_STATUS_VALUES,
+        )
+    _raise_governance_validation_error(field_name, key)
+
+
+def _validate_governance_detail(
+    field_name: str,
+    detail: dict[str, object] | None,
+    *,
+    allowed_keys: frozenset[str],
+) -> dict[str, object] | None:
+    if detail is None:
+        return None
+    if not isinstance(detail, dict):
+        _raise_governance_validation_error(field_name, "expected dict")
+    normalized_detail: dict[str, object] = {}
+    for key, value in detail.items():
+        normalized_key = str(key).strip().lower()
+        if normalized_key in normalized_detail:
+            _raise_governance_validation_error(
+                field_name, f"duplicate key {normalized_key}"
+            )
+        normalized_detail[normalized_key] = _validate_governance_detail_entry(
+            f"{field_name}.{normalized_key}",
+            normalized_key,
+            value,
+            allowed_keys=allowed_keys,
+        )
+    return normalized_detail
+
+
+def _validate_governance_code_like(field_name: str, value: str) -> str:
+    if not value:
+        _raise_governance_validation_error(field_name, "required")
+    _validate_governance_string(field_name, value)
+    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
+        _raise_governance_validation_error(field_name, "identifier")
+    if _IDENTIFIERISH_ERROR_CODE_RE.fullmatch(value):
+        _raise_governance_validation_error(field_name, "identifier")
+    if not _SAFE_ERROR_CODE_RE.fullmatch(value):
+        _raise_governance_validation_error(
+            field_name, "must be a stable diagnostic code"
+        )
+    return value
+
+
+def _validate_governance_error_detail(error_detail: str | None) -> str | None:
+    if error_detail is None:
+        return None
+    return _validate_governance_code_like("error_detail", error_detail)
+
+
+def _validate_governance_error_code(error_code: str) -> str:
+    return _validate_governance_code_like("error_code", error_code)
+
+
+def _validate_governance_enum(
+    field_name: str, value: str, *, allowed: frozenset[str]
+) -> str:
+    if value not in allowed:
+        _raise_governance_validation_error(
+            field_name,
+            f"must be one of {', '.join(sorted(allowed))}",
+        )
+    return value
+
+
+def _normalize_governance_detail_for_identity(
+    detail: dict[str, object] | None,
+) -> str | None:
+    if detail is None:
+        return None
+    normalized_detail: dict[str, object] = {}
+    for key, value in detail.items():
+        normalized_key = str(key).strip().lower()
+        if normalized_key in {"original_source_windows", "remaining_source_windows"}:
+            normalized_windows = [
+                _normalize_governance_window_item(normalized_key, index, item)
+                for index, item in enumerate(cast(list[object], value))
+            ]
+            normalized_detail[normalized_key] = normalized_windows
+            continue
+        normalized_detail[normalized_key] = value
+    return json.dumps(normalized_detail, sort_keys=True, separators=(",", ":"))
+
+
+def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
+    _validate_governance_enum(
+        "actor_type",
+        event.actor_type,
+        allowed=_ALLOWED_AUDIT_ACTOR_TYPES,
+    )
+    _validate_governance_enum(
+        "operation",
+        event.operation,
+        allowed=_ALLOWED_AUDIT_OPERATIONS,
+    )
+    _validate_governance_enum(
+        "entity_type",
+        event.entity_type,
+        allowed=_ALLOWED_AUDIT_ENTITY_TYPES,
+    )
+    _validate_governance_enum(
+        "status",
+        event.status,
+        allowed=_ALLOWED_AUDIT_STATUSES,
+    )
+    _validate_governance_prefixed_ref("actor_ref", event.actor_ref, prefix="actref_v1_")
+    _validate_governance_prefixed_ref(
+        "subject_ref", event.subject_ref, prefix="subref_v1_"
+    )
+    if event.request_ref is None:
+        _raise_governance_validation_error("request_ref", "required")
+    _validate_governance_prefixed_ref(
+        "request_ref", event.request_ref, prefix="reqref_v1_"
+    )
+    if event.entity_id is not None:
+        _validate_governance_code_shaped(
+            "entity_id",
+            event.entity_id,
+            allow_minimized_ref=True,
+        )
+    _validate_governance_idempotency_key("idempotency_key", event.idempotency_key)
+    _validate_governance_detail(
+        "audit_event.detail",
+        event.detail,
+        allowed_keys=_ALLOWED_AUDIT_DETAIL_KEYS,
+    )
+
+
+def _canonicalize_audit_event_for_persistence(event: AuditEvent) -> AuditEvent:
+    _validate_audit_event_for_persistence(event)
+    return event.model_copy(
+        update={
+            "detail": _validate_governance_detail(
+                "audit_event.detail",
+                event.detail,
+                allowed_keys=_ALLOWED_AUDIT_DETAIL_KEYS,
+            )
+        }
+    )
+
+
+def _is_successful_erase_event(
+    event: AuditEvent, *, purge_id: str | None = None
+) -> bool:
+    if event.operation != "ERASE" or event.status != "ok":
+        return False
+    if purge_id is not None:
+        return event.idempotency_key == purge_id
+    return True
+
+
+def _successful_erase_identity(
+    event: AuditEvent,
+) -> tuple[
+    str,
+    str,
+    str | None,
+    str,
+    str,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    str | None,
+    str | None,
+]:
+    return (
+        event.org_id,
+        event.actor_type,
+        event.actor_ref,
+        event.operation,
+        event.entity_type,
+        event.entity_id,
+        event.subject_ref,
+        event.request_ref,
+        event.status,
+        event.idempotency_key,
+        _normalize_governance_detail_for_identity(
+            cast(dict[str, object] | None, event.detail)
+        ),
+    )

--- a/reflexio/server/services/storage/governance_validation.py
+++ b/reflexio/server/services/storage/governance_validation.py
@@ -412,6 +412,7 @@ def _validate_governance_target_ref(
         "interaction",
         "profile",
         "user_playbook",
+        "agent_success_evaluation_result",
         "profile_purge",
         "user_playbook_purge",
     }:

--- a/reflexio/server/services/storage/governance_validation.py
+++ b/reflexio/server/services/storage/governance_validation.py
@@ -407,15 +407,7 @@ def _validate_governance_target_ref(
         if target_ref != "all":
             _raise_governance_validation_error("target_ref", "must be all")
         return target_ref
-    if target_name in {
-        "request",
-        "interaction",
-        "profile",
-        "user_playbook",
-        "agent_success_evaluation_result",
-        "profile_purge",
-        "user_playbook_purge",
-    }:
+    if target_name in _CANONICAL_DELETE_TARGET_NAMES:
         if phase != "delete":
             _raise_governance_validation_error(
                 phase,

--- a/reflexio/server/services/storage/sqlite_storage/_governance.py
+++ b/reflexio/server/services/storage/sqlite_storage/_governance.py
@@ -1,25 +1,16 @@
 from __future__ import annotations
 
 import json
-import re
 import sqlite3
 import threading
-from datetime import UTC, datetime
-from typing import Any, Literal, NoReturn, Protocol, cast, get_args
+from typing import Any, Literal, Protocol, cast
 
 from reflexio.models.api_schema.domain import AgentPlaybook, AgentPlaybookSourceWindow
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.domain.governance import (
-    AuditActorType,
-    AuditEntityType,
     AuditEvent,
-    AuditOperation,
-    AuditStatus,
     PurgeOperation,
     PurgeOperationTarget,
-    PurgeOperationType,
-    PurgeScopeType,
-    PurgeTargetStatus,
     SubjectBarrierStatus,
     SubjectWriteBarrier,
 )
@@ -29,6 +20,33 @@ from reflexio.server.services.governance.config import (
     governance_subject_ref,
 )
 from reflexio.server.services.storage.error import SubjectWriteBarrierError
+from reflexio.server.services.storage.governance_validation import (
+    _ALLOWED_PURGE_OPERATION_TYPES,
+    _ALLOWED_PURGE_SCOPE_TYPES,
+    _ALLOWED_PURGE_TARGET_DETAIL_KEYS,
+    _ALLOWED_PURGE_TARGET_NAMES,
+    _ALLOWED_PURGE_TARGET_PHASES,
+    _ALLOWED_PURGE_TARGET_STATUSES,
+    _CANONICAL_DELETE_TARGET_NAMES,
+    _PREPARE_PHASE,
+    _SNAPSHOT_TARGET_NAME,
+    _canonicalize_audit_event_for_persistence,
+    _canonicalize_governance_windows,
+    _epoch_now,
+    _is_successful_erase_event,
+    _parse_governance_window_list,
+    _successful_erase_identity,
+    _validate_governance_deleted_count,
+    _validate_governance_detail,
+    _validate_governance_enum,
+    _validate_governance_error_code,
+    _validate_governance_error_detail,
+    _validate_governance_idempotency_key,
+    _validate_governance_int_list,
+    _validate_governance_prefixed_ref,
+    _validate_governance_purge_id,
+    _validate_governance_target_ref,
+)
 
 _LEGACY_AUDIT_REQUEST_REF = "reqref_v1_legacy_unknown"
 
@@ -113,142 +131,6 @@ CREATE INDEX IF NOT EXISTS idx_subject_write_barriers_org_purge
     ON subject_write_barriers(org_id, purge_id);
 """
 
-_PREPARE_PHASE = "prepare_targets"
-_SNAPSHOT_TARGET_NAME = "target_snapshot"
-_CANONICAL_DELETE_TARGET_NAMES = (
-    "request",
-    "interaction",
-    "profile",
-    "user_playbook",
-    "agent_success_evaluation_result",
-    "profile_purge",
-    "user_playbook_purge",
-)
-_ALLOWED_AUDIT_ACTOR_TYPES = frozenset(get_args(AuditActorType))
-_ALLOWED_AUDIT_OPERATIONS = frozenset(get_args(AuditOperation))
-_ALLOWED_AUDIT_ENTITY_TYPES = frozenset(get_args(AuditEntityType))
-_ALLOWED_AUDIT_STATUSES = frozenset(get_args(AuditStatus))
-_ALLOWED_PURGE_OPERATION_TYPES = frozenset(get_args(PurgeOperationType))
-_ALLOWED_PURGE_SCOPE_TYPES = frozenset(get_args(PurgeScopeType))
-_ALLOWED_PURGE_TARGET_STATUSES = frozenset(get_args(PurgeTargetStatus))
-_ALLOWED_PURGE_TARGET_NAMES = frozenset(
-    {
-        _SNAPSHOT_TARGET_NAME,
-        "request",
-        "interaction",
-        "profile",
-        "user_playbook",
-        "agent_success_evaluation_result",
-        "agent_playbook",
-        "profile_purge",
-        "user_playbook_purge",
-    }
-)
-_ALLOWED_PURGE_TARGET_PHASES = frozenset(
-    {
-        _PREPARE_PHASE,
-        "delete",
-        "hide_for_rebuild",
-        "rebuild_without_erased_sources",
-    }
-)
-_ALLOWED_AUDIT_DETAIL_KEYS = frozenset(
-    {
-        "agent_playbook_id",
-        "count",
-        "deleted_counts",
-        "deleted_count",
-        "rebuilt_agent_playbook_ids",
-        "route",
-        "status",
-    }
-)
-_ALLOWED_PURGE_TARGET_DETAIL_KEYS = frozenset(
-    {
-        "affected_agent_playbook_ids",
-        "agent_playbook_id",
-        "count",
-        "deleted_counts",
-        "deleted_count",
-        "erased_source_ids",
-        "owned_user_playbook_ids",
-        "original_source_windows",
-        "previous_lifecycle_status",
-        "prepared",
-        "rebuilt_agent_playbook_ids",
-        "remaining_source_windows",
-        "route",
-        "source_interaction_ids",
-        "status",
-        "user_playbook_id",
-    }
-)
-_DISALLOWED_DETAIL_KEYS = frozenset(
-    {
-        "content",
-        "email",
-        "prompt",
-        "request_id",
-        "request_ref",
-        "user_id",
-    }
-)
-_EMAIL_RE = re.compile(r"\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
-_REQUEST_ID_RE = re.compile(
-    r"\b(?:reqref_(?!v1_)|request[_-]|req[_-])[A-Za-z0-9_-]*\b",
-    re.IGNORECASE,
-)
-_TOKEN_NAME_RE = re.compile(
-    r"\b(?:api[-_ ]?token|token[-_ ]?name|bearer|secret[-_ ]?key)\b",
-    re.IGNORECASE,
-)
-_RAW_EXCEPTION_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception)\s*:")
-_SAFE_INTERNAL_ID_RE = re.compile(r"^[0-9]+$")
-_USER_LIKE_TARGET_REF_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_-]{0,63}$")
-_CODE_SHAPED_VALUE_RE = re.compile(r"^[A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)+$")
-_IDENTIFIERISH_CODE_VALUE_RE = re.compile(
-    r"^(?:user|subject|actor)[_.:-][A-Za-z0-9]+(?:[_.:-][A-Za-z0-9]+)*$",
-    re.IGNORECASE,
-)
-_SAFE_ERROR_CODE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,127}$")
-_IDENTIFIERISH_ERROR_CODE_RE = re.compile(
-    r"^(?:user|subject|request|req|actor|email)[-_.:]?[A-Za-z0-9_.:-]+$",
-    re.IGNORECASE,
-)
-_ALLOWED_DETAIL_STATUS_VALUES = frozenset(
-    {
-        "archive_in_progress",
-        "complete",
-        "error",
-        "failed",
-        "ok",
-        "pending",
-        "running",
-    }
-)
-_ALLOWED_PREVIOUS_LIFECYCLE_STATUS_VALUES = frozenset(
-    status.value for status in Status if status.value is not None
-)
-_ALLOWED_DETAIL_ROUTE_VALUES = frozenset(
-    {
-        "prepare_targets",
-        "delete",
-        "hide_for_rebuild",
-        "rebuild_without_erased_sources",
-    }
-)
-_ALLOWED_DELETED_COUNTS_KEYS = frozenset(
-    {
-        "interactions",
-        "user_playbooks",
-        "profiles",
-        "requests",
-        "agent_success_evaluation_results",
-        "purged_profiles",
-        "purged_user_playbooks",
-    }
-)
-
 
 def init_governance_tables(conn: sqlite3.Connection) -> None:
     _upgrade_legacy_purge_operation_targets_table(conn)
@@ -278,10 +160,6 @@ def _ensure_governance_subject_ref_columns(conn: sqlite3.Connection) -> None:
         )
 
 
-def _epoch_now() -> int:
-    return int(datetime.now(UTC).timestamp())
-
-
 def _json_dumps(obj: Any) -> str | None:
     if obj is None:
         return None
@@ -292,235 +170,6 @@ def _json_loads(text: str | None) -> Any:
     if not text:
         return None
     return json.loads(text)
-
-
-def _raise_governance_validation_error(field_name: str, reason: str) -> NoReturn:
-    raise ValueError(f"Unsafe governance {field_name}: {reason}")
-
-
-def _validate_governance_string(field_name: str, value: str) -> None:
-    if _EMAIL_RE.search(value):
-        _raise_governance_validation_error(field_name, "email")
-    if _REQUEST_ID_RE.search(value):
-        _raise_governance_validation_error(field_name, "request_id")
-    if _TOKEN_NAME_RE.search(value):
-        _raise_governance_validation_error(field_name, "token")
-    if _RAW_EXCEPTION_RE.search(value):
-        _raise_governance_validation_error(field_name, "raw exception text")
-
-
-def _validate_governance_prose_string(field_name: str, value: str) -> None:
-    _validate_governance_string(field_name, value)
-    lowered = value.lower()
-    if "prompt" in lowered or "content" in lowered:
-        _raise_governance_validation_error(field_name, "prompt/content")
-
-
-def _validate_governance_prefixed_ref(
-    field_name: str, value: str | None, *, prefix: str
-) -> None:
-    if value is None:
-        return
-    if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", value) is None:
-        _raise_governance_validation_error(
-            field_name, f"must match {prefix}<32 lowercase hex chars>"
-        )
-
-
-def _validate_governance_code_shaped(
-    field_name: str,
-    value: str,
-    *,
-    allow_minimized_ref: bool,
-) -> str:
-    if not value:
-        _raise_governance_validation_error(field_name, "required")
-    _validate_governance_string(field_name, value)
-    if allow_minimized_ref and any(
-        re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", value)
-        for prefix in ("subref_v1_", "reqref_v1_", "actref_v1_")
-    ):
-        return value
-    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
-        _raise_governance_validation_error(field_name, "identifier")
-    if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(value):
-        _raise_governance_validation_error(field_name, "identifier")
-    if _SAFE_INTERNAL_ID_RE.fullmatch(value):
-        return value
-    if _CODE_SHAPED_VALUE_RE.fullmatch(value):
-        return value
-    if _USER_LIKE_TARGET_REF_RE.fullmatch(value):
-        _raise_governance_validation_error(field_name, "user-like identifier")
-    _raise_governance_validation_error(
-        field_name, "must be minimized, internal, or code-shaped"
-    )
-    raise AssertionError("unreachable")
-
-
-def _validate_governance_idempotency_key(
-    field_name: str, value: str | None
-) -> str | None:
-    if value is None:
-        return None
-    if _SAFE_INTERNAL_ID_RE.fullmatch(value):
-        _raise_governance_validation_error(field_name, "numeric identifier")
-    return _validate_governance_code_shaped(
-        field_name,
-        value,
-        allow_minimized_ref=False,
-    )
-
-
-def _validate_governance_detail_enum(
-    field_name: str, value: Any, *, allowed_values: frozenset[str]
-) -> str:
-    if not isinstance(value, str):
-        _raise_governance_validation_error(field_name, "expected str")
-    _validate_governance_prose_string(field_name, value)
-    if value not in allowed_values:
-        _raise_governance_validation_error(field_name, "must be canonical")
-    return value
-
-
-def _validate_governance_purge_id(field_name: str, value: str) -> str:
-    if not value:
-        _raise_governance_validation_error(field_name, "required")
-    _validate_governance_string(field_name, value)
-    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
-        _raise_governance_validation_error(field_name, "identifier")
-    if not value.startswith("purge_"):
-        _raise_governance_validation_error(field_name, "must start with purge_")
-    if _CODE_SHAPED_VALUE_RE.fullmatch(value) is None:
-        _raise_governance_validation_error(field_name, "must be code-shaped")
-    suffix = value[len("purge_") :]
-    if _IDENTIFIERISH_CODE_VALUE_RE.fullmatch(suffix):
-        _raise_governance_validation_error(field_name, "identifier")
-    if suffix.isdecimal():
-        _raise_governance_validation_error(field_name, "numeric identifier")
-    return value
-
-
-def _validate_governance_int(field_name: str, value: Any) -> None:
-    if isinstance(value, bool) or not isinstance(value, int):
-        _raise_governance_validation_error(field_name, "expected int")
-
-
-def _validate_governance_nonnegative_int(field_name: str, value: Any) -> int:
-    _validate_governance_int(field_name, value)
-    if value < 0:
-        _raise_governance_validation_error(field_name, "must be nonnegative")
-    return cast(int, value)
-
-
-def _validate_governance_deleted_count(value: Any) -> int:
-    return _validate_governance_nonnegative_int("deleted_count", value)
-
-
-def _validate_governance_int_list(field_name: str, value: Any) -> list[int]:
-    if not isinstance(value, list):
-        _raise_governance_validation_error(field_name, "expected list[int]")
-    normalized_items: list[int] = []
-    for item in value:
-        _validate_governance_int(field_name, item)
-        normalized_items.append(cast(int, item))
-    return normalized_items
-
-
-def _validate_governance_deleted_counts(field_name: str, value: Any) -> dict[str, int]:
-    if not isinstance(value, dict):
-        _raise_governance_validation_error(field_name, "expected dict[str, int]")
-    normalized_counts: dict[str, int] = {}
-    for raw_key, raw_value in value.items():
-        key = str(raw_key).strip().lower()
-        if key in normalized_counts:
-            _raise_governance_validation_error(field_name, f"duplicate key {key}")
-        if key not in _ALLOWED_DELETED_COUNTS_KEYS:
-            _raise_governance_validation_error(field_name, key)
-        normalized_counts[key] = _validate_governance_deleted_count(raw_value)
-    return normalized_counts
-
-
-def _normalize_governance_window_item(
-    field_name: str, index: int, item: object
-) -> dict[str, Any]:
-    if not isinstance(item, dict):
-        _raise_governance_validation_error(
-            f"{field_name}[{index}]", "expected window dict"
-        )
-    window_item = cast(dict[Any, Any], item)
-    normalized_item: dict[str, Any] = {}
-    for raw_key, raw_value in window_item.items():
-        normalized_key = str(raw_key).strip().lower()
-        if normalized_key in normalized_item:
-            _raise_governance_validation_error(
-                f"{field_name}[{index}]", f"duplicate key {normalized_key}"
-            )
-        normalized_item[normalized_key] = raw_value
-    return normalized_item
-
-
-def _validate_governance_window_list(
-    field_name: str, value: Any
-) -> list[dict[str, object]]:
-    if not isinstance(value, list):
-        _raise_governance_validation_error(field_name, "expected list[window]")
-    normalized_windows: list[dict[str, object]] = []
-    for index, item in enumerate(value):
-        normalized_item = _normalize_governance_window_item(field_name, index, item)
-        normalized_keys = set(normalized_item)
-        unexpected_keys = normalized_keys - {
-            "user_playbook_id",
-            "source_interaction_ids",
-        }
-        if unexpected_keys:
-            _raise_governance_validation_error(
-                f"{field_name}[{index}]", sorted(unexpected_keys)[0]
-            )
-        if "user_playbook_id" not in normalized_item:
-            _raise_governance_validation_error(
-                f"{field_name}[{index}].user_playbook_id", "required"
-            )
-        _validate_governance_int(
-            f"{field_name}[{index}].user_playbook_id",
-            normalized_item["user_playbook_id"],
-        )
-        canonical_item: dict[str, object] = {
-            "user_playbook_id": cast(int, normalized_item["user_playbook_id"])
-        }
-        if "source_interaction_ids" in normalized_item:
-            canonical_item["source_interaction_ids"] = _validate_governance_int_list(
-                f"{field_name}[{index}].source_interaction_ids",
-                normalized_item["source_interaction_ids"],
-            )
-        normalized_windows.append(canonical_item)
-    return normalized_windows
-
-
-def _parse_governance_window_list(
-    field_name: str, value: list[dict[str, object]]
-) -> list[AgentPlaybookSourceWindow]:
-    windows: list[AgentPlaybookSourceWindow] = []
-    for normalized_item in _validate_governance_window_list(field_name, value):
-        user_playbook_id = cast(int, normalized_item["user_playbook_id"])
-        source_ids = cast(
-            list[int], normalized_item.get("source_interaction_ids") or []
-        )
-        windows.append(
-            AgentPlaybookSourceWindow(
-                user_playbook_id=user_playbook_id,
-                source_interaction_ids=[int(source_id) for source_id in source_ids],
-            )
-        )
-    return windows
-
-
-def _canonicalize_governance_windows(
-    field_name: str, value: list[dict[str, object]]
-) -> list[dict[str, object]]:
-    return [
-        window.model_dump()
-        for window in _parse_governance_window_list(field_name, value)
-    ]
 
 
 def _build_agent_playbook_source_window_rows(
@@ -542,256 +191,6 @@ def _build_agent_playbook_source_window_rows(
         )
         for user_playbook_id, source_interaction_ids in by_id.items()
     ]
-
-
-def _validate_governance_target_ref(
-    *, target_name: str, phase: str, target_ref: str
-) -> str:
-    if target_name == _SNAPSHOT_TARGET_NAME:
-        if phase != _PREPARE_PHASE:
-            _raise_governance_validation_error(
-                _SNAPSHOT_TARGET_NAME, "must use prepare_targets phase"
-            )
-        if target_ref != "all":
-            _raise_governance_validation_error("target_ref", "must be all")
-        return target_ref
-    if target_name in {
-        "request",
-        "interaction",
-        "profile",
-        "user_playbook",
-        "profile_purge",
-        "user_playbook_purge",
-    }:
-        if phase != "delete":
-            _raise_governance_validation_error(
-                phase,
-                f"{target_name} targets must use delete phase",
-            )
-        if target_ref != "all":
-            _raise_governance_validation_error("target_ref", "must be all")
-        return target_ref
-    if target_name == "agent_playbook":
-        if phase not in {"hide_for_rebuild", "rebuild_without_erased_sources"}:
-            _raise_governance_validation_error(
-                phase,
-                "agent_playbook targets must use hide_for_rebuild or "
-                "rebuild_without_erased_sources",
-            )
-        if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
-            return target_ref
-        _raise_governance_validation_error(
-            "target_ref", "must be a numeric internal id"
-        )
-    if target_ref in {"", "all"}:
-        return target_ref
-    if _SAFE_INTERNAL_ID_RE.fullmatch(target_ref):
-        return target_ref
-    for prefix in ("reqref_v1_", "subref_v1_", "actref_v1_"):
-        if re.fullmatch(rf"{re.escape(prefix)}[0-9a-f]{{32}}", target_ref):
-            return target_ref
-        if target_ref.startswith(prefix):
-            _raise_governance_validation_error(
-                "target_ref", f"must match {prefix}<32 lowercase hex chars>"
-            )
-    _validate_governance_string("target_ref", target_ref)
-    if _USER_LIKE_TARGET_REF_RE.fullmatch(target_ref):
-        _raise_governance_validation_error("target_ref", "user-like identifier")
-    _raise_governance_validation_error("target_ref", "must be minimized or internal")
-    raise AssertionError("unreachable")
-
-
-def _validate_governance_detail_entry(
-    field_name: str,
-    key: str,
-    value: Any,
-    *,
-    allowed_keys: frozenset[str],
-) -> object:
-    if key in _DISALLOWED_DETAIL_KEYS:
-        _raise_governance_validation_error(field_name, key)
-    if key not in allowed_keys:
-        _raise_governance_validation_error(field_name, key)
-    if key in {"count", "deleted_count"}:
-        return _validate_governance_nonnegative_int(field_name, value)
-    if key in {"agent_playbook_id", "user_playbook_id"}:
-        _validate_governance_int(field_name, value)
-        return cast(int, value)
-    if key == "deleted_counts":
-        return _validate_governance_deleted_counts(field_name, value)
-    if key in {
-        "affected_agent_playbook_ids",
-        "erased_source_ids",
-        "owned_user_playbook_ids",
-        "rebuilt_agent_playbook_ids",
-        "source_interaction_ids",
-    }:
-        return _validate_governance_int_list(field_name, value)
-    if key in {"original_source_windows", "remaining_source_windows"}:
-        return _validate_governance_window_list(field_name, value)
-    if key == "previous_lifecycle_status":
-        if value is None:
-            return None
-        return _validate_governance_detail_enum(
-            field_name,
-            value,
-            allowed_values=_ALLOWED_PREVIOUS_LIFECYCLE_STATUS_VALUES,
-        )
-    if key == "prepared":
-        if not isinstance(value, bool):
-            _raise_governance_validation_error(field_name, "expected bool")
-        return value
-    if key == "route":
-        return _validate_governance_detail_enum(
-            field_name,
-            value,
-            allowed_values=_ALLOWED_DETAIL_ROUTE_VALUES,
-        )
-    if key == "status":
-        return _validate_governance_detail_enum(
-            field_name,
-            value,
-            allowed_values=_ALLOWED_DETAIL_STATUS_VALUES,
-        )
-    _raise_governance_validation_error(field_name, key)
-
-
-def _validate_governance_detail(
-    field_name: str,
-    detail: dict[str, object] | None,
-    *,
-    allowed_keys: frozenset[str],
-) -> dict[str, object] | None:
-    if detail is None:
-        return None
-    if not isinstance(detail, dict):
-        _raise_governance_validation_error(field_name, "expected dict")
-    normalized_detail: dict[str, object] = {}
-    for key, value in detail.items():
-        normalized_key = str(key).strip().lower()
-        if normalized_key in normalized_detail:
-            _raise_governance_validation_error(
-                field_name, f"duplicate key {normalized_key}"
-            )
-        normalized_detail[normalized_key] = _validate_governance_detail_entry(
-            f"{field_name}.{normalized_key}",
-            normalized_key,
-            value,
-            allowed_keys=allowed_keys,
-        )
-    return normalized_detail
-
-
-def _validate_governance_code_like(field_name: str, value: str) -> str:
-    if not value:
-        _raise_governance_validation_error(field_name, "required")
-    _validate_governance_string(field_name, value)
-    if value.startswith(("subref_v1_", "reqref_v1_", "actref_v1_")):
-        _raise_governance_validation_error(field_name, "identifier")
-    if _IDENTIFIERISH_ERROR_CODE_RE.fullmatch(value):
-        _raise_governance_validation_error(field_name, "identifier")
-    if not _SAFE_ERROR_CODE_RE.fullmatch(value):
-        _raise_governance_validation_error(
-            field_name, "must be a stable diagnostic code"
-        )
-    return value
-
-
-def _validate_governance_error_detail(error_detail: str | None) -> str | None:
-    if error_detail is None:
-        return None
-    return _validate_governance_code_like("error_detail", error_detail)
-
-
-def _validate_governance_error_code(error_code: str) -> str:
-    return _validate_governance_code_like("error_code", error_code)
-
-
-def _validate_governance_enum(
-    field_name: str, value: str, *, allowed: frozenset[str]
-) -> str:
-    if value not in allowed:
-        _raise_governance_validation_error(
-            field_name,
-            f"must be one of {', '.join(sorted(allowed))}",
-        )
-    return value
-
-
-def _normalize_governance_detail_for_identity(
-    detail: dict[str, object] | None,
-) -> str | None:
-    if detail is None:
-        return None
-    normalized_detail: dict[str, object] = {}
-    for key, value in detail.items():
-        normalized_key = str(key).strip().lower()
-        if normalized_key in {"original_source_windows", "remaining_source_windows"}:
-            normalized_windows = [
-                _normalize_governance_window_item(normalized_key, index, item)
-                for index, item in enumerate(cast(list[object], value))
-            ]
-            normalized_detail[normalized_key] = normalized_windows
-            continue
-        normalized_detail[normalized_key] = value
-    return json.dumps(normalized_detail, sort_keys=True, separators=(",", ":"))
-
-
-def _validate_audit_event_for_persistence(event: AuditEvent) -> None:
-    _validate_governance_enum(
-        "actor_type",
-        event.actor_type,
-        allowed=_ALLOWED_AUDIT_ACTOR_TYPES,
-    )
-    _validate_governance_enum(
-        "operation",
-        event.operation,
-        allowed=_ALLOWED_AUDIT_OPERATIONS,
-    )
-    _validate_governance_enum(
-        "entity_type",
-        event.entity_type,
-        allowed=_ALLOWED_AUDIT_ENTITY_TYPES,
-    )
-    _validate_governance_enum(
-        "status",
-        event.status,
-        allowed=_ALLOWED_AUDIT_STATUSES,
-    )
-    _validate_governance_prefixed_ref("actor_ref", event.actor_ref, prefix="actref_v1_")
-    _validate_governance_prefixed_ref(
-        "subject_ref", event.subject_ref, prefix="subref_v1_"
-    )
-    if event.request_ref is None:
-        _raise_governance_validation_error("request_ref", "required")
-    _validate_governance_prefixed_ref(
-        "request_ref", event.request_ref, prefix="reqref_v1_"
-    )
-    if event.entity_id is not None:
-        _validate_governance_code_shaped(
-            "entity_id",
-            event.entity_id,
-            allow_minimized_ref=True,
-        )
-    _validate_governance_idempotency_key("idempotency_key", event.idempotency_key)
-    _validate_governance_detail(
-        "audit_event.detail",
-        event.detail,
-        allowed_keys=_ALLOWED_AUDIT_DETAIL_KEYS,
-    )
-
-
-def _canonicalize_audit_event_for_persistence(event: AuditEvent) -> AuditEvent:
-    _validate_audit_event_for_persistence(event)
-    return event.model_copy(
-        update={
-            "detail": _validate_governance_detail(
-                "audit_event.detail",
-                event.detail,
-                allowed_keys=_ALLOWED_AUDIT_DETAIL_KEYS,
-            )
-        }
-    )
 
 
 def _upgrade_legacy_purge_operation_targets_table(conn: sqlite3.Connection) -> None:
@@ -842,48 +241,6 @@ def _enforce_audit_request_ref_not_null(conn: sqlite3.Connection) -> None:
             SELECT RAISE(ABORT, 'audit_events.request_ref is required');
         END
         """
-    )
-
-
-def _is_successful_erase_event(
-    event: AuditEvent, *, purge_id: str | None = None
-) -> bool:
-    if event.operation != "ERASE" or event.status != "ok":
-        return False
-    if purge_id is not None:
-        return event.idempotency_key == purge_id
-    return True
-
-
-def _successful_erase_identity(
-    event: AuditEvent,
-) -> tuple[
-    str,
-    str,
-    str | None,
-    str,
-    str,
-    str | None,
-    str | None,
-    str | None,
-    str,
-    str | None,
-    str | None,
-]:
-    return (
-        event.org_id,
-        event.actor_type,
-        event.actor_ref,
-        event.operation,
-        event.entity_type,
-        event.entity_id,
-        event.subject_ref,
-        event.request_ref,
-        event.status,
-        event.idempotency_key,
-        _normalize_governance_detail_for_identity(
-            cast(dict[str, object] | None, event.detail)
-        ),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from reflexio.server.extensions import reset_services
 
 _THIS_DIR = Path(__file__).resolve().parent  # tests/
 PROJECT_ROOT = _THIS_DIR.parent.parent  # repo root
@@ -49,6 +50,14 @@ def pytest_configure(config):
 
 def pytest_unconfigure(config):
     cleanup_llm_mock(config)
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_services() -> None:
+    """Clear the process-global service registry before and after each test."""
+    reset_services()
+    yield
+    reset_services()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -53,7 +54,7 @@ def pytest_unconfigure(config):
 
 
 @pytest.fixture(autouse=True)
-def _reset_runtime_services() -> None:
+def _reset_runtime_services() -> Iterator[None]:
     """Clear the process-global service registry before and after each test."""
     reset_services()
     yield

--- a/tests/lib/test_generation_unit.py
+++ b/tests/lib/test_generation_unit.py
@@ -5,7 +5,7 @@ rerun_profile_generation, manual_profile_generation, rerun_playbook_generation,
 manual_playbook_generation, and storage-not-configured error handling.
 """
 
-from typing import Any, cast
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -22,7 +22,9 @@ from reflexio.models.api_schema.service_schemas import (
     RerunProfileGenerationRequest,
     RerunProfileGenerationResponse,
 )
+from reflexio.server.extensions import register_service
 from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
     PassthroughPromptProcessor,
 )
 
@@ -40,8 +42,6 @@ def _make_mixin(*, storage_configured: bool = True) -> GenerationMixin:
     mock_request_context.org_id = "test_org"
     mock_request_context.storage = mock_storage if storage_configured else None
     mock_request_context.is_storage_configured.return_value = storage_configured
-    mock_configurator = cast(Any, mock_request_context.configurator)
-    mock_configurator.create_aggregation_prompt_processor.return_value = None
 
     mixin.request_context = mock_request_context
     mixin.llm_client = MagicMock()
@@ -71,23 +71,20 @@ class TestRunPlaybookAggregation:
             request_context=mixin.request_context,
             agent_version="v2",
         )
-        configurator = cast(Any, mixin.request_context.configurator)
-        configurator.create_aggregation_prompt_processor.assert_called_once_with()
         mock_agg_instance.run.assert_called_once()
         request_arg = mock_agg_instance.run.call_args[0][0]
         assert request_arg.agent_version == "v2"
         assert request_arg.rerun is True
 
     @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
-    def test_injects_configurator_processor(self, mock_agg_cls):
-        """Passes a configured prompt processor to manual aggregation."""
+    def test_injects_registered_processor(self, mock_agg_cls):
+        """Passes a registered prompt processor to manual aggregation."""
         processor: Any = PassthroughPromptProcessor()
+        register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
         mixin = _make_mixin()
 
         mock_agg_instance = MagicMock()
         mock_agg_cls.return_value = mock_agg_instance
-        configurator = cast(Any, mixin.request_context.configurator)
-        configurator.create_aggregation_prompt_processor.return_value = processor
 
         mixin.run_playbook_aggregation(agent_version="v2")
 
@@ -97,20 +94,18 @@ class TestRunPlaybookAggregation:
             agent_version="v2",
             aggregation_prompt_processor=processor,
         )
-        configurator.create_aggregation_prompt_processor.assert_called_once_with()
         mock_agg_instance.run.assert_called_once()
 
     @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
     def test_does_not_thread_processor_prompt_text_as_separate_kwarg(
         self, mock_agg_cls
     ):
-        mixin = _make_mixin()
         processor: Any = PassthroughPromptProcessor()
         processor.prompt_extra_instructions = "Extra aggregation instruction."
+        register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
+        mixin = _make_mixin()
         mock_agg_instance = MagicMock()
         mock_agg_cls.return_value = mock_agg_instance
-        configurator = cast(Any, mixin.request_context.configurator)
-        configurator.create_aggregation_prompt_processor.return_value = processor
 
         mixin.run_playbook_aggregation(agent_version="v2")
 

--- a/tests/server/services/governance/test_governance_refs.py
+++ b/tests/server/services/governance/test_governance_refs.py
@@ -8,6 +8,10 @@ from reflexio.server.services.governance.config import (
     governance_request_ref,
     governance_subject_ref,
 )
+from reflexio.server.services.storage.governance_validation import (
+    _CANONICAL_DELETE_TARGET_NAMES,
+    _validate_governance_target_ref,
+)
 from reflexio.server.services.storage.storage_base._governance import GovernanceMixin
 
 
@@ -42,6 +46,36 @@ def test_governance_mixin_tracks_new_barrier_methods_as_abstract() -> None:
         "fail_subject_erasure_barrier",
         "get_subject_write_barrier",
     } <= GovernanceMixin.__abstractmethods__
+
+
+def test_agent_success_eval_result_is_delete_only_target() -> None:
+    """``agent_success_evaluation_result`` is a canonical delete target, so its
+    target_ref validation must enforce the delete-only contract (phase=='delete',
+    target_ref=='all') — not fall through to the permissive generic path that
+    would accept e.g. ``hide_for_rebuild``.
+    """
+    target = "agent_success_evaluation_result"
+    assert target in _CANONICAL_DELETE_TARGET_NAMES
+
+    # Valid canonical delete shape is accepted.
+    assert (
+        _validate_governance_target_ref(
+            target_name=target, phase="delete", target_ref="all"
+        )
+        == "all"
+    )
+
+    # Previously accepted (fell through to generic path); must now be rejected.
+    with pytest.raises(ValueError, match="must use delete phase"):
+        _validate_governance_target_ref(
+            target_name=target, phase="hide_for_rebuild", target_ref="all"
+        )
+
+    # delete phase but non-"all" ref must also be rejected.
+    with pytest.raises(ValueError, match="must be all"):
+        _validate_governance_target_ref(
+            target_name=target, phase="delete", target_ref="123"
+        )
 
 
 def test_secret_defaults_only_in_local_dev_or_test(

--- a/tests/server/services/playbook/test_aggregation_service_key.py
+++ b/tests/server/services/playbook/test_aggregation_service_key.py
@@ -1,0 +1,12 @@
+from reflexio.server.extensions import get_service, register_service, reset_services
+from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
+)
+
+
+def test_unset_is_none_then_resolves_after_register() -> None:
+    reset_services()
+    assert get_service(AGGREGATION_PROMPT_PROCESSOR) is None
+    sentinel = object()
+    register_service(AGGREGATION_PROMPT_PROCESSOR, sentinel)  # type: ignore[arg-type]
+    assert get_service(AGGREGATION_PROMPT_PROCESSOR) is sentinel

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -206,7 +206,6 @@ class _MappingAwareProcessor:
 
 
 def test_aggregation_prompt_processing_protocol_types_importable():
-    from reflexio.server.services.configurator.configurator import DefaultConfigurator
     from reflexio.server.services.playbook.aggregation_prompt_processing import (
         PassthroughPromptProcessor,
         PromptPostprocessResult,
@@ -228,10 +227,6 @@ def test_aggregation_prompt_processing_protocol_types_importable():
     assert preprocess_result == PromptPreprocessResult(text="keep this")
     assert postprocess_result == PromptPostprocessResult(value={"content": "keep this"})
     assert context.changed is False
-    assert (
-        DefaultConfigurator(org_id="test-org").create_aggregation_prompt_processor()
-        is None
-    )
 
 
 def test_aggregation_prompt_processor_preprocesses_cluster_playbooks_but_not_existing_agent_playbooks():

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -19,8 +19,10 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.extensions import register_service
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
     PassthroughPromptProcessor,
 )
 from reflexio.server.services.playbook.playbook_service_utils import (
@@ -82,7 +84,6 @@ def _service_for_inline_aggregation(configurator: Any) -> PlaybookGenerationServ
 def test_inline_aggregation_default_path_does_not_inject_processor():
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
-    configurator.create_aggregation_prompt_processor.return_value = None
     service = _service_for_inline_aggregation(configurator)
     created_kwargs: list[dict[str, Any]] = []
 
@@ -107,20 +108,15 @@ def test_inline_aggregation_default_path_does_not_inject_processor():
 
     assert len(created_kwargs) == 1
     assert "aggregation_prompt_processor" not in created_kwargs[0]
-    configurator.create_aggregation_prompt_processor.assert_called_once_with()
 
 
-def test_inline_aggregation_injects_configured_processor():
+def test_inline_aggregation_injects_registered_processor():
     processor = PassthroughPromptProcessor()
+    register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
 
-    class ConfiguratorWithProcessor:
-        def get_config(self) -> Config:
-            return _aggregation_enabled_config()
-
-        def create_aggregation_prompt_processor(self) -> PassthroughPromptProcessor:
-            return processor
-
-    service = _service_for_inline_aggregation(ConfiguratorWithProcessor())
+    configurator = MagicMock()
+    configurator.get_config.return_value = _aggregation_enabled_config()
+    service = _service_for_inline_aggregation(configurator)
     created_kwargs: list[dict[str, Any]] = []
 
     class FakeAggregator:
@@ -149,15 +145,11 @@ def test_inline_aggregation_injects_configured_processor():
 def test_inline_aggregation_does_not_thread_processor_prompt_text_separately():
     processor: Any = PassthroughPromptProcessor()
     processor.prompt_extra_instructions = "Extra aggregation instruction."
+    register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
 
-    class ConfiguratorWithExtraInstructions:
-        def get_config(self) -> Config:
-            return _aggregation_enabled_config()
-
-        def create_aggregation_prompt_processor(self) -> PassthroughPromptProcessor:
-            return processor
-
-    service = _service_for_inline_aggregation(ConfiguratorWithExtraInstructions())
+    configurator = MagicMock()
+    configurator.get_config.return_value = _aggregation_enabled_config()
+    service = _service_for_inline_aggregation(configurator)
     created_kwargs: list[dict[str, Any]] = []
 
     class FakeAggregator:

--- a/tests/server/test_auth_default_org.py
+++ b/tests/server/test_auth_default_org.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from reflexio.server._auth import DEFAULT_ORG_ID, default_get_org_id
+from reflexio.server.auth import DEFAULT_ORG_ID, default_get_org_id
 
 _ENV = "REFLEXIO_DEFAULT_ORG_ID"
 

--- a/tests/server/test_create_app_capabilities.py
+++ b/tests/server/test_create_app_capabilities.py
@@ -118,3 +118,39 @@ def test_billing_gate_double_wire_raises() -> None:
     cap_registry = CapabilityRegistry([], billing_gate=my_gate)
     with pytest.raises(ValueError, match="billing_gate"):
         create_app(get_billing_gate=my_gate, capabilities=cap_registry)
+
+
+class RoleCaptureCap(Capability):
+    """Records the role passed to routers() so tests can inspect it."""
+
+    name = "role_capture"
+    seen_role: str | None = None
+
+    def routers(self, role: str) -> list[APIRouter]:
+        RoleCaptureCap.seen_role = role
+        return []
+
+
+def test_capabilities_role_overrides_mount_data_plane_derivation() -> None:
+    """When capabilities.role is set, create_app must use it, not mount_data_plane."""
+    RoleCaptureCap.seen_role = None
+    reg = CapabilityRegistry([RoleCaptureCap()], role="data-plane")
+    # mount_data_plane=True would normally yield "all" — but capabilities.role wins.
+    create_app(capabilities=reg, mount_data_plane=True)
+    assert RoleCaptureCap.seen_role == "data-plane", (
+        "capabilities.role must override mount_data_plane derivation"
+    )
+
+
+def test_capabilities_role_none_falls_back_to_mount_data_plane() -> None:
+    """When capabilities.role is None, create_app falls back to mount_data_plane derivation."""
+    RoleCaptureCap.seen_role = None
+    # role=None → fallback: mount_data_plane=True → "all"
+    reg = CapabilityRegistry([RoleCaptureCap()])
+    create_app(capabilities=reg, mount_data_plane=True)
+    assert RoleCaptureCap.seen_role == "all"
+
+    RoleCaptureCap.seen_role = None
+    reg2 = CapabilityRegistry([RoleCaptureCap()])
+    create_app(capabilities=reg2, mount_data_plane=False)
+    assert RoleCaptureCap.seen_role == "data-plane"

--- a/tests/server/test_create_app_capabilities.py
+++ b/tests/server/test_create_app_capabilities.py
@@ -1,0 +1,120 @@
+"""Tests for create_app(capabilities=CapabilityRegistry(...)) wiring.
+
+Covers:
+- capability routers are mounted and reachable
+- on_startup / on_shutdown lifecycle runs
+- on_startup raise is fail-loud (propagates out of the lifespan)
+- partial-cleanup invariant: already-started caps shut down; never-started caps skipped
+- billing-gate double-wire raises ValueError at construction time
+- capabilities=None leaves behavior unchanged (smoke)
+"""
+
+from collections.abc import Callable
+
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+from reflexio.server.extensions import AppContext, Capability, CapabilityRegistry
+
+
+class RouterCap(Capability):
+    name = "rc"
+
+    def routers(self, role: str) -> list[APIRouter]:
+        r = APIRouter()
+
+        @r.get("/api/_cap_probe")
+        def probe() -> dict:
+            return {"ok": True}
+
+        return [r]
+
+
+class LifecycleCap(Capability):
+    name = "lc"
+    started = False
+    stopped = False
+
+    async def on_startup(self, ctx: AppContext) -> None:
+        LifecycleCap.started = True
+
+    async def on_shutdown(self) -> None:
+        LifecycleCap.stopped = True
+
+
+class BoomCap(Capability):
+    name = "boom"
+
+    async def on_startup(self, ctx: AppContext) -> None:
+        raise RuntimeError("startup failed")
+
+
+class NeverStartedCap(Capability):
+    """A cap positioned after BoomCap; its on_startup is never reached."""
+
+    name = "never"
+    shutdown_called = False
+
+    async def on_shutdown(self) -> None:
+        NeverStartedCap.shutdown_called = True
+
+
+def test_capability_routers_are_mounted() -> None:
+    app = create_app(capabilities=CapabilityRegistry([RouterCap()]))
+    with TestClient(app) as c:
+        assert c.get("/api/_cap_probe").json() == {"ok": True}
+
+
+def test_on_startup_and_shutdown_run() -> None:
+    LifecycleCap.started = LifecycleCap.stopped = False
+    app = create_app(capabilities=CapabilityRegistry([LifecycleCap()]))
+    with TestClient(app):
+        assert LifecycleCap.started is True
+    assert LifecycleCap.stopped is True
+
+
+def test_on_startup_raise_is_fail_loud() -> None:
+    app = create_app(capabilities=CapabilityRegistry([BoomCap()]))
+    with pytest.raises(RuntimeError, match="startup failed"), TestClient(app):
+        pass
+
+
+def test_capabilities_none_is_unchanged() -> None:
+    app = create_app()  # legacy path, no capabilities
+    assert app is not None
+
+
+def test_partial_cleanup_invariant() -> None:
+    """Already-started caps must be shut down; caps that never started must not be."""
+    LifecycleCap.started = LifecycleCap.stopped = False
+    NeverStartedCap.shutdown_called = False
+
+    # Order: LifecycleCap starts successfully, BoomCap raises, NeverStartedCap never runs.
+    app = create_app(
+        capabilities=CapabilityRegistry([LifecycleCap(), BoomCap(), NeverStartedCap()])
+    )
+    with pytest.raises(RuntimeError, match="startup failed"), TestClient(app):
+        pass
+
+    assert LifecycleCap.stopped is True, (
+        "already-started cap must be shut down on partial failure"
+    )
+    assert NeverStartedCap.shutdown_called is False, (
+        "cap whose on_startup never ran must NOT be shut down"
+    )
+
+
+def test_billing_gate_double_wire_raises() -> None:
+    """Passing billing_gate via both get_billing_gate and capabilities must raise."""
+
+    def my_gate(line: str) -> Callable[..., None]:
+        def dep() -> None:
+            pass
+
+        return dep
+
+    cap_registry = CapabilityRegistry([], billing_gate=my_gate)
+    with pytest.raises(ValueError, match="billing_gate"):
+        create_app(get_billing_gate=my_gate, capabilities=cap_registry)

--- a/tests/server/test_create_app_capabilities.py
+++ b/tests/server/test_create_app_capabilities.py
@@ -62,21 +62,27 @@ class NeverStartedCap(Capability):
 
 
 def test_capability_routers_are_mounted() -> None:
-    app = create_app(capabilities=CapabilityRegistry([RouterCap()]))
+    app = create_app(
+        capabilities=CapabilityRegistry([RouterCap()]), mount_data_plane=False
+    )
     with TestClient(app) as c:
         assert c.get("/api/_cap_probe").json() == {"ok": True}
 
 
 def test_on_startup_and_shutdown_run() -> None:
     LifecycleCap.started = LifecycleCap.stopped = False
-    app = create_app(capabilities=CapabilityRegistry([LifecycleCap()]))
+    app = create_app(
+        capabilities=CapabilityRegistry([LifecycleCap()]), mount_data_plane=False
+    )
     with TestClient(app):
         assert LifecycleCap.started is True
     assert LifecycleCap.stopped is True
 
 
 def test_on_startup_raise_is_fail_loud() -> None:
-    app = create_app(capabilities=CapabilityRegistry([BoomCap()]))
+    app = create_app(
+        capabilities=CapabilityRegistry([BoomCap()]), mount_data_plane=False
+    )
     with pytest.raises(RuntimeError, match="startup failed"), TestClient(app):
         pass
 
@@ -93,7 +99,8 @@ def test_partial_cleanup_invariant() -> None:
 
     # Order: LifecycleCap starts successfully, BoomCap raises, NeverStartedCap never runs.
     app = create_app(
-        capabilities=CapabilityRegistry([LifecycleCap(), BoomCap(), NeverStartedCap()])
+        capabilities=CapabilityRegistry([LifecycleCap(), BoomCap(), NeverStartedCap()]),
+        mount_data_plane=False,
     )
     with pytest.raises(RuntimeError, match="startup failed"), TestClient(app):
         pass
@@ -153,7 +160,7 @@ def test_capabilities_role_none_falls_back_to_mount_data_plane() -> None:
     RoleCaptureCap.seen_role = None
     reg2 = CapabilityRegistry([RoleCaptureCap()])
     create_app(capabilities=reg2, mount_data_plane=False)
-    assert RoleCaptureCap.seen_role == "data-plane"
+    assert RoleCaptureCap.seen_role == "control-plane"
 
 
 def test_router_double_mount_is_boot_error() -> None:

--- a/tests/server/test_create_app_capabilities.py
+++ b/tests/server/test_create_app_capabilities.py
@@ -169,3 +169,23 @@ def test_router_double_mount_is_boot_error() -> None:
     reg = CapabilityRegistry([_Dup()], role="all")
     with pytest.raises(ValueError, match="dup"):
         create_app(capabilities=reg, additional_routers=[shared])
+
+
+def test_router_double_mount_guard_uses_identity_not_equality() -> None:
+    """Guard must use 'is' (identity), not '==' (equality).
+
+    Two distinct empty APIRouter() instances compare equal via __eq__ (same routes list),
+    so the guard must NOT fire when a capability returns a fresh router that happens to be
+    route-identical to one in additional_routers.
+    """
+
+    class _FreshRouter(Capability):
+        name = "fresh"
+
+        def routers(self, role: str) -> list[APIRouter]:
+            return [APIRouter()]  # distinct object every call
+
+    extra = APIRouter()  # also empty — equal to the one above via __eq__
+    reg = CapabilityRegistry([_FreshRouter()], role="all")
+    # Must NOT raise; the two routers are equal but not the same object.
+    create_app(capabilities=reg, additional_routers=[extra])

--- a/tests/server/test_create_app_capabilities.py
+++ b/tests/server/test_create_app_capabilities.py
@@ -154,3 +154,18 @@ def test_capabilities_role_none_falls_back_to_mount_data_plane() -> None:
     reg2 = CapabilityRegistry([RoleCaptureCap()])
     create_app(capabilities=reg2, mount_data_plane=False)
     assert RoleCaptureCap.seen_role == "data-plane"
+
+
+def test_router_double_mount_is_boot_error() -> None:
+    """A capability router also passed via additional_routers must raise ValueError at boot."""
+    shared = APIRouter()
+
+    class _Dup(Capability):
+        name = "dup"
+
+        def routers(self, role: str) -> list[APIRouter]:
+            return [shared]
+
+    reg = CapabilityRegistry([_Dup()], role="all")
+    with pytest.raises(ValueError, match="dup"):
+        create_app(capabilities=reg, additional_routers=[shared])

--- a/tests/server/test_extensions_registry.py
+++ b/tests/server/test_extensions_registry.py
@@ -1,6 +1,18 @@
+import asyncio
+
 import pytest
+from fastapi import APIRouter
+
 from reflexio.server.extensions import (
-    ServiceKey, register_service, get_service, require_service, reset_services,
+    AppContext,
+    Capability,
+    CapabilityRegistry,
+    HookRegistry,
+    ServiceKey,
+    get_service,
+    register_service,
+    require_service,
+    reset_services,
 )
 
 KEY: ServiceKey[str] = ServiceKey("demo")
@@ -31,3 +43,53 @@ def test_double_register_is_error_unless_override() -> None:
         register_service(KEY, "y")
     register_service(KEY, "y", override=True)
     assert get_service(KEY) == "y"
+
+
+def test_key_isolation() -> None:
+    """Distinct ServiceKey instances are independent — registering under "a" does not affect "b"."""
+    key_a: ServiceKey[str] = ServiceKey("a")
+    key_b: ServiceKey[str] = ServiceKey("b")
+    register_service(key_a, "val_a")
+    assert get_service(key_b) is None
+
+
+# ---------------------------------------------------------------------------
+# Task-2 capability / hook / context tests
+# ---------------------------------------------------------------------------
+
+
+class _Cap(Capability):
+    name = "demo_cap"
+
+    def routers(self, role: str) -> list[APIRouter]:
+        return [APIRouter()]
+
+
+def test_capability_defaults_are_noops() -> None:
+    cap = _Cap()
+    cap.install_services()            # no raise
+    cap.install_hooks(HookRegistry())  # no raise
+    assert isinstance(cap.routers("all"), list)
+    asyncio.run(cap.on_startup(AppContext()))  # no raise
+    asyncio.run(cap.on_shutdown())             # no raise
+
+
+def test_registry_dedup_on_duplicate_name() -> None:
+    with pytest.raises(RuntimeError):
+        CapabilityRegistry([_Cap(), _Cap()])
+
+
+def test_registry_carries_singular_concerns() -> None:
+    reg = CapabilityRegistry(
+        [_Cap()],
+        configurator_class=object,
+        billing_gate=lambda line: (lambda: None),
+    )
+    assert reg.configurator_class is object
+    assert reg.billing_gate is not None
+    assert "demo_cap" in reg.router_names()
+
+
+def test_appcontext_defaults() -> None:
+    ctx = AppContext()
+    assert ctx.self_host_org_id is None and ctx.activated is False

--- a/tests/server/test_extensions_registry.py
+++ b/tests/server/test_extensions_registry.py
@@ -67,11 +67,11 @@ class _Cap(Capability):
 
 def test_capability_defaults_are_noops() -> None:
     cap = _Cap()
-    cap.install_services()            # no raise
+    cap.install_services()  # no raise
     cap.install_hooks(HookRegistry())  # no raise
     assert isinstance(cap.routers("all"), list)
     asyncio.run(cap.on_startup(AppContext()))  # no raise
-    asyncio.run(cap.on_shutdown())             # no raise
+    asyncio.run(cap.on_shutdown())  # no raise
 
 
 def test_registry_dedup_on_duplicate_name() -> None:
@@ -83,11 +83,10 @@ def test_registry_carries_singular_concerns() -> None:
     reg = CapabilityRegistry(
         [_Cap()],
         configurator_class=object,
-        billing_gate=lambda line: (lambda: None),
+        billing_gate=lambda _: lambda: None,
     )
     assert reg.configurator_class is object
     assert reg.billing_gate is not None
-    assert "demo_cap" in reg.router_names()
 
 
 def test_appcontext_defaults() -> None:

--- a/tests/server/test_extensions_registry.py
+++ b/tests/server/test_extensions_registry.py
@@ -1,0 +1,33 @@
+import pytest
+from reflexio.server.extensions import (
+    ServiceKey, register_service, get_service, require_service, reset_services,
+)
+
+KEY: ServiceKey[str] = ServiceKey("demo")
+
+
+def setup_function() -> None:
+    reset_services()
+
+
+def test_get_returns_none_when_unset() -> None:
+    assert get_service(KEY) is None
+
+
+def test_register_then_get_and_require() -> None:
+    register_service(KEY, "x")
+    assert get_service(KEY) == "x"
+    assert require_service(KEY) == "x"
+
+
+def test_require_raises_when_unset() -> None:
+    with pytest.raises(LookupError):
+        require_service(KEY)
+
+
+def test_double_register_is_error_unless_override() -> None:
+    register_service(KEY, "x")
+    with pytest.raises(RuntimeError):
+        register_service(KEY, "y")
+    register_service(KEY, "y", override=True)
+    assert get_service(KEY) == "y"


### PR DESCRIPTION
## What

OSS-side of the boundary refactor, now covering **Phase 0 + Plan 1A** (paired with enterprise PR ReflexioAI/reflexio-enterprise#474).

### Phase 0 — public surface (shipped earlier)
- Promote `reflexio.server._auth` → public `reflexio.server.auth`.
- Extract governance validation helpers → public `reflexio.server.services.storage.governance_validation` (imported by SQLite + Supabase backends).
- Add public `Reflexio.get_storage()`.
Pure seam-hardening; no behavior change; no public client/API-schema change.

### Plan 1A — Capability registry foundation (new)
- New `reflexio.server.extensions`: process-global typed `ServiceKey` registry (`register_service`/`get_service`/`require_service`, de-dup); `Capability` ABC (no-op defaults); `HookRegistry` (facade over the existing hook setters); `AppContext`; `CapabilityRegistry`.
- `create_app(capabilities=)`: dual-path with the legacy params; **fail-loud** capability lifecycle (a raising `on_startup` aborts boot, cleaning up exactly the already-started capabilities); applies the configurator swap + billing-gate DI; threads the deployment role to `routers(role)`.

## Verification
- 15 OSS foundation tests (registry contract incl. de-dup/require; `create_app` dual-path, fail-loud partial-cleanup invariant, legacy-path unchanged); 203 existing server tests pass; `import reflexio` standalone (boundary guard). ruff + pyright clean.

## Scope
Phase 0 + Plan 1A foundation. Runtime-service consumers (redaction) land in a later phase. Client surface, API schemas, and the core learning loop are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enterprise app “capabilities” for capability-provided routing plus async startup/shutdown lifecycle hooks.
  * Introduced a new public `get_storage()` method to retrieve the configured storage backend.
  * Enabled aggregation prompt processing via service-key registration.
* **Bug Fixes**
  * Centralized and strengthened governance validation/canonicalization for storage audit/erase handling.
  * Improved capability lifecycle handling so shutdown continues even if a capability’s shutdown fails.
* **Tests**
  * Expanded coverage for capabilities wiring (including router mount guard), runtime service registry, aggregation prompt processor injection, storage getter behavior, and governance ref validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->