### PR TITLE
feat: support DB-backed list filters

### DIFF
--- a/reflexio/cli/utils.py
+++ b/reflexio/cli/utils.py
@@ -44,7 +44,7 @@ def find_pids_on_port(port: int) -> list[int]:
     """Find process IDs listening on the given port using lsof."""
     try:
         result = subprocess.run(
-            ["lsof", "-t", f"-i:{port}"],
+            ["lsof", "-nP", "-t", f"-iTCP:{port}", "-sTCP:LISTEN"],
             capture_output=True,
             text=True,
             check=False,
@@ -74,6 +74,47 @@ def find_pids_by_pattern(pattern: str) -> list[int]:
     except FileNotFoundError:
         pass
     return []
+
+
+def get_requested_port_conflicts(ports: dict[str, int]) -> list[str]:
+    """Return startup-blocking conflicts for requested service ports."""
+    conflicts: list[str] = []
+    services_by_port: dict[int, list[str]] = {}
+    for name, port in ports.items():
+        services_by_port.setdefault(port, []).append(name)
+
+    for port, names in sorted(services_by_port.items()):
+        if len(names) > 1:
+            conflicts.append(
+                f"port {port} is assigned to multiple services: {', '.join(sorted(names))}"
+            )
+
+    for name, port in sorted(ports.items()):
+        pids = find_pids_on_port(port)
+        if pids:
+            pid_list = ", ".join(str(pid) for pid in sorted(set(pids)))
+            conflicts.append(
+                f"{name} port {port} is already in use by PID(s): {pid_list}"
+            )
+
+    return conflicts
+
+
+def ensure_requested_ports_available(ports: dict[str, int]) -> None:
+    """Exit with a clear message when requested service ports are unavailable."""
+    conflicts = get_requested_port_conflicts(ports)
+    if not conflicts:
+        return
+
+    sys.stdout.write("Error: cannot start Reflexio services because ports conflict.\n")
+    for conflict in conflicts:
+        sys.stdout.write(f"  - {conflict}\n")
+    sys.stdout.write(
+        "Stop the existing service with `uv run reflexio services stop` or choose "
+        "different BACKEND_PORT/FRONTEND_PORT/DOCS_PORT values.\n"
+    )
+    sys.stdout.flush()
+    sys.exit(1)
 
 
 def kill_processes(
@@ -232,6 +273,8 @@ def run_services(
 
     signal.signal(signal.SIGINT, shutdown)
     signal.signal(signal.SIGTERM, shutdown)
+
+    ensure_requested_ports_available(ports)
 
     for svc in services:
         noise_env = _NOISE_SUPPRESSION_ENV.get(svc.name, {})

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -1154,9 +1154,13 @@ class ReflexioClient:
         force_refresh: bool = False,
         *,
         user_id: str | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         top_k: int | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
         status_filter: list[Status | str | None] | None = None,
         tags: list[str] | None = None,
     ) -> GetProfilesViewResponse:
@@ -1166,9 +1170,13 @@ class ReflexioClient:
             request (Optional[GetUserProfilesRequest]): The list request object (alternative to kwargs)
             force_refresh (bool, optional): If True, bypass cache and fetch fresh data. Defaults to False.
             user_id (str): The user ID to get profiles for
+            profile_id (Optional[str]): Exact profile ID filter.
+            query (Optional[str]): Case-insensitive text filter across visible fields.
             start_time (Optional[datetime]): Filter by start time
             end_time (Optional[datetime]): Filter by end time
             top_k (Optional[int]): Maximum number of results to return (default: 30)
+            source (Optional[str]): Filter by profile source.
+            profile_time_to_live (Optional[str]): Filter by profile TTL value.
             status_filter (Optional[list[Optional[Union[Status, str]]]]): Filter by profile status. Accepts Status enum or string values (e.g., "archived", "pending").
             tags (Optional[list[str]]): Match profiles having any of these tags.
 
@@ -1191,9 +1199,13 @@ class ReflexioClient:
             request,
             GetUserProfilesRequest,
             user_id=user_id,
+            profile_id=profile_id,
+            query=query,
             start_time=start_time,
             end_time=end_time,
             top_k=top_k,
+            source=source,
+            profile_time_to_live=profile_time_to_live,
             status_filter=converted_status_filter,
             tags=tags,
         )
@@ -1203,9 +1215,13 @@ class ReflexioClient:
             cached_result = self._cache.get(
                 "get_profiles",
                 user_id=req.user_id,
+                profile_id=req.profile_id,
+                query=req.query,
                 start_time=req.start_time,
                 end_time=req.end_time,
                 top_k=req.top_k,
+                source=req.source,
+                profile_time_to_live=req.profile_time_to_live,
                 status_filter=req.status_filter,
                 tags=req.tags,
             )
@@ -1225,9 +1241,13 @@ class ReflexioClient:
             "get_profiles",
             result,
             user_id=req.user_id,
+            profile_id=req.profile_id,
+            query=req.query,
             start_time=req.start_time,
             end_time=req.end_time,
             top_k=req.top_k,
+            source=req.source,
+            profile_time_to_live=req.profile_time_to_live,
             status_filter=req.status_filter,
             tags=req.tags,
         )
@@ -1256,6 +1276,13 @@ class ReflexioClient:
         self,
         limit: int = 100,
         status_filter: str | None = None,
+        user_id: str | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> GetProfilesViewResponse:
         """Get all user profiles across all users.
 
@@ -1264,6 +1291,13 @@ class ReflexioClient:
             status_filter (str, optional): Filter by profile status. Accepts
                 ``"current"``, ``"pending"``, or ``"archived"``. If ``None``
                 (the default), profiles with any status are returned.
+            user_id (str, optional): Filter by exact user ID.
+            profile_id (str, optional): Filter by exact profile ID.
+            query (str, optional): Case-insensitive text filter across visible fields.
+            source (str, optional): Filter by exact profile source.
+            profile_time_to_live (str, optional): Filter by profile TTL value.
+            start_time (int, optional): Minimum last-modified epoch seconds.
+            end_time (int, optional): Maximum last-modified epoch seconds.
 
         Returns:
             GetProfilesViewResponse: Response containing all user profiles
@@ -1273,6 +1307,21 @@ class ReflexioClient:
         params: dict[str, str | int] = {"limit": limit}
         if status_filter:
             params["status_filter"] = status_filter
+        params.update(
+            {
+                key: value
+                for key, value in {
+                    "user_id": user_id,
+                    "profile_id": profile_id,
+                    "query": query,
+                    "source": source,
+                    "profile_time_to_live": profile_time_to_live,
+                    "start_time": start_time,
+                    "end_time": end_time,
+                }.items()
+                if value is not None
+            }
+        )
         response = self._make_request(
             "GET",
             f"/api/get_all_profiles?{urlencode(params)}",
@@ -1375,9 +1424,14 @@ class ReflexioClient:
         request: GetUserPlaybooksRequest | dict | None = None,
         *,
         limit: int | None = None,
+        user_playbook_id: int | None = None,
         user_id: str | None = None,
+        request_id: str | None = None,
+        query: str | None = None,
         playbook_name: str | None = None,
         agent_version: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
         status_filter: list[Status | None] | None = None,
         tags: list[str] | None = None,
     ) -> GetUserPlaybooksViewResponse:
@@ -1386,9 +1440,14 @@ class ReflexioClient:
         Args:
             request (Optional[GetUserPlaybooksRequest]): The get request object (alternative to kwargs)
             limit (Optional[int]): Maximum number of results to return (default: 100)
+            user_playbook_id (Optional[int]): Exact user playbook ID filter.
             user_id (Optional[str]): Filter by user ID
+            request_id (Optional[str]): Filter by generating request ID.
+            query (Optional[str]): Case-insensitive text filter across visible fields.
             playbook_name (Optional[str]): Filter by playbook name
             agent_version (Optional[str]): Filter by agent version
+            start_time (Optional[datetime]): Filter by start time.
+            end_time (Optional[datetime]): Filter by end time.
             status_filter (Optional[list[Optional[Status]]]): Filter by status
             tags (Optional[list[str]]): Match playbooks having any of these tags.
 
@@ -1399,9 +1458,14 @@ class ReflexioClient:
             request,
             GetUserPlaybooksRequest,
             limit=limit,
+            user_playbook_id=user_playbook_id,
             user_id=user_id,
+            request_id=request_id,
+            query=query,
             playbook_name=playbook_name,
             agent_version=agent_version,
+            start_time=start_time,
+            end_time=end_time,
             status_filter=status_filter,
             tags=tags,
         )
@@ -1653,8 +1717,12 @@ class ReflexioClient:
         force_refresh: bool = False,
         *,
         limit: int | None = None,
+        agent_playbook_id: int | None = None,
+        query: str | None = None,
         playbook_name: str | None = None,
         agent_version: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: PlaybookStatus | None = None,
         tags: list[str] | None = None,
@@ -1665,8 +1733,12 @@ class ReflexioClient:
             request (Optional[GetAgentPlaybooksRequest]): The get request object (alternative to kwargs)
             force_refresh (bool, optional): If True, bypass cache and fetch fresh data. Defaults to False.
             limit (Optional[int]): Maximum number of results to return (default: 100)
+            agent_playbook_id (Optional[int]): Exact agent playbook ID filter.
+            query (Optional[str]): Case-insensitive text filter across visible fields.
             playbook_name (Optional[str]): Filter by playbook name
             agent_version (Optional[str]): Filter by agent version
+            start_time (Optional[datetime]): Filter by start time.
+            end_time (Optional[datetime]): Filter by end time.
             status_filter (Optional[list[Optional[Status]]]): Filter by status
             playbook_status_filter (Optional[PlaybookStatus]): Filter by playbook status (default: APPROVED)
             tags (Optional[list[str]]): Match playbooks having any of these tags.
@@ -1678,8 +1750,12 @@ class ReflexioClient:
             request,
             GetAgentPlaybooksRequest,
             limit=limit,
+            agent_playbook_id=agent_playbook_id,
+            query=query,
             playbook_name=playbook_name,
             agent_version=agent_version,
+            start_time=start_time,
+            end_time=end_time,
             status_filter=status_filter,
             playbook_status_filter=playbook_status_filter,
             tags=tags,
@@ -1690,8 +1766,12 @@ class ReflexioClient:
             cached_result = self._cache.get(
                 "get_agent_playbooks",
                 limit=req.limit,
+                agent_playbook_id=req.agent_playbook_id,
+                query=req.query,
                 playbook_name=req.playbook_name,
                 agent_version=req.agent_version,
+                start_time=req.start_time,
+                end_time=req.end_time,
                 status_filter=req.status_filter,
                 playbook_status_filter=req.playbook_status_filter,
                 tags=req.tags,
@@ -1712,8 +1792,12 @@ class ReflexioClient:
             "get_agent_playbooks",
             result,
             limit=req.limit,
+            agent_playbook_id=req.agent_playbook_id,
+            query=req.query,
             playbook_name=req.playbook_name,
             agent_version=req.agent_version,
+            start_time=req.start_time,
+            end_time=req.end_time,
             status_filter=req.status_filter,
             playbook_status_filter=req.playbook_status_filter,
             tags=req.tags,
@@ -1727,6 +1811,8 @@ class ReflexioClient:
         *,
         user_id: str | None = None,
         request_id: str | None = None,
+        session_id: str | None = None,
+        source: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         top_k: int | None = None,
@@ -1737,6 +1823,8 @@ class ReflexioClient:
             request (Optional[GetRequestsRequest]): The get request object (alternative to kwargs)
             user_id (Optional[str]): Filter by user ID
             request_id (Optional[str]): Filter by request ID
+            session_id (Optional[str]): Filter by session ID
+            source (Optional[str]): Filter by request source
             start_time (Optional[datetime]): Filter by start time
             end_time (Optional[datetime]): Filter by end time
             top_k (Optional[int]): Maximum number of results to return (default: 30)
@@ -1749,6 +1837,8 @@ class ReflexioClient:
             GetRequestsRequest,
             user_id=user_id,
             request_id=request_id,
+            session_id=session_id,
+            source=source,
             start_time=start_time,
             end_time=end_time,
             top_k=top_k,
@@ -1766,6 +1856,8 @@ class ReflexioClient:
         *,
         limit: int | None = None,
         agent_version: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
     ) -> GetEvaluationResultsViewResponse:
         """Get agent success evaluation results.
 
@@ -1773,6 +1865,8 @@ class ReflexioClient:
             request (Optional[GetAgentSuccessEvaluationResultsRequest]): The get request object (alternative to kwargs)
             limit (Optional[int]): Maximum number of results to return (default: 100)
             agent_version (Optional[str]): Filter by agent version
+            start_time (Optional[datetime]): Filter by start time
+            end_time (Optional[datetime]): Filter by end time
 
         Returns:
             GetEvaluationResultsViewResponse: Response containing agent success evaluation results
@@ -1782,6 +1876,8 @@ class ReflexioClient:
             GetAgentSuccessEvaluationResultsRequest,
             limit=limit,
             agent_version=agent_version,
+            start_time=start_time,
+            end_time=end_time,
         )
         response = self._make_request(
             "POST",

--- a/reflexio/lib/_agent_playbook.py
+++ b/reflexio/lib/_agent_playbook.py
@@ -213,8 +213,16 @@ class AgentPlaybookMixin(ReflexioBase):
         try:
             agent_playbooks = self._get_storage().get_agent_playbooks(
                 limit=request.limit or 100,
+                agent_playbook_id=request.agent_playbook_id,
+                query=request.query,
                 playbook_name=request.playbook_name,
                 agent_version=request.agent_version,
+                start_time=(
+                    int(request.start_time.timestamp()) if request.start_time else None
+                ),
+                end_time=(
+                    int(request.end_time.timestamp()) if request.end_time else None
+                ),
                 status_filter=request.status_filter,
                 playbook_status_filter=[request.playbook_status_filter]
                 if request.playbook_status_filter

--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -414,25 +414,21 @@ class ProfilesMixin(ReflexioBase):
                 status_filter = [None]  # Default to current profiles
 
         profiles = self._get_storage().get_user_profile(
-            request.user_id, status_filter=status_filter, tags=request.tags
+            request.user_id,
+            status_filter=status_filter,
+            tags=request.tags,
+            profile_id=request.profile_id,
+            query=request.query,
+            source=request.source,
+            profile_time_to_live=request.profile_time_to_live,
+            start_time=(
+                int(request.start_time.timestamp()) if request.start_time else None
+            ),
+            end_time=int(request.end_time.timestamp()) if request.end_time else None,
         )
         profiles = sorted(
             profiles, key=lambda x: x.last_modified_timestamp, reverse=True
         )
-
-        # Apply time filters
-        if request.start_time:
-            profiles = [
-                p
-                for p in profiles
-                if p.last_modified_timestamp >= int(request.start_time.timestamp())
-            ]
-        if request.end_time:
-            profiles = [
-                p
-                for p in profiles
-                if p.last_modified_timestamp <= int(request.end_time.timestamp())
-            ]
 
         # Apply top_k limit
         if request.top_k:
@@ -450,6 +446,13 @@ class ProfilesMixin(ReflexioBase):
         self,
         limit: int = 100,
         status_filter: list[Status | None] | None = None,
+        user_id: str | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> GetUserProfilesResponse:
         """Get all user profiles across all users.
 
@@ -467,7 +470,15 @@ class ProfilesMixin(ReflexioBase):
         if status_filter is None:
             status_filter = [None]  # Default to current profiles
         profiles = self._get_storage().get_all_profiles(
-            limit=limit, status_filter=status_filter
+            limit=limit,
+            status_filter=status_filter,
+            user_id=user_id,
+            profile_id=profile_id,
+            query=query,
+            source=source,
+            profile_time_to_live=profile_time_to_live,
+            start_time=start_time,
+            end_time=end_time,
         )
         profiles = sorted(
             profiles, key=lambda x: x.last_modified_timestamp, reverse=True

--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -41,9 +41,23 @@ class SearchMixin(ReflexioBase):
             request = GetAgentSuccessEvaluationResultsRequest(**request)
 
         try:
-            results = self._get_storage().get_agent_success_evaluation_results(
-                limit=request.limit or 100, agent_version=request.agent_version
-            )
+            if request.start_time or request.end_time:
+                results = self._get_storage().get_agent_success_evaluation_results_in_window(
+                    from_ts=(
+                        int(request.start_time.timestamp()) if request.start_time else 0
+                    ),
+                    to_ts=(
+                        int(request.end_time.timestamp())
+                        if request.end_time
+                        else 2**31 - 1
+                    ),
+                    limit=request.limit or 100,
+                    agent_version=request.agent_version,
+                )
+            else:
+                results = self._get_storage().get_agent_success_evaluation_results(
+                    limit=request.limit or 100, agent_version=request.agent_version
+                )
             return GetAgentSuccessEvaluationResultsResponse(
                 success=True,
                 agent_success_evaluation_results=results,
@@ -79,6 +93,7 @@ class SearchMixin(ReflexioBase):
                 user_id=request.user_id,
                 request_id=request.request_id,
                 session_id=request.session_id,
+                source=request.source,
                 start_time=(
                     int(request.start_time.timestamp()) if request.start_time else None
                 ),

--- a/reflexio/lib/_user_playbook.py
+++ b/reflexio/lib/_user_playbook.py
@@ -53,10 +53,19 @@ class UserPlaybookMixin(ReflexioBase):
         try:
             user_playbooks = self._get_storage().get_user_playbooks(
                 limit=request.limit or 100,
+                user_playbook_id=request.user_playbook_id,
                 user_id=request.user_id,
+                request_id=request.request_id,
+                query=request.query,
                 playbook_name=request.playbook_name,
                 agent_version=request.agent_version,
                 status_filter=request.status_filter,
+                start_time=(
+                    int(request.start_time.timestamp()) if request.start_time else None
+                ),
+                end_time=(
+                    int(request.end_time.timestamp()) if request.end_time else None
+                ),
                 tags=request.tags,
             )
             return GetUserPlaybooksResponse(

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -187,9 +187,13 @@ class GetInteractionsResponse(BaseModel):
 
 class GetUserProfilesRequest(BaseModel):
     user_id: NonEmptyStr
+    profile_id: str | None = None
+    query: str | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
     top_k: int | None = Field(default=30, gt=0)
+    source: str | None = None
+    profile_time_to_live: str | None = None
     status_filter: list[Status | None] | None = None
     tags: list[str] | None = None
 
@@ -222,11 +226,22 @@ class SetConfigResponse(BaseModel):
 
 class GetUserPlaybooksRequest(BaseModel):
     limit: int | None = Field(default=100, gt=0)
+    user_playbook_id: int | None = Field(default=None, gt=0)
     user_id: str | None = None
+    request_id: str | None = None
+    query: str | None = None
     playbook_name: str | None = None
     agent_version: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
     tags: list[str] | None = None
+
+    @model_validator(mode="after")
+    def check_time_range(self) -> Self:
+        """Validate that end_time is after start_time."""
+        TimeRangeValidatorMixin.validate_time_range(self.start_time, self.end_time)
+        return self
 
 
 class GetUserPlaybooksResponse(BaseModel):
@@ -237,8 +252,12 @@ class GetUserPlaybooksResponse(BaseModel):
 
 class GetAgentPlaybooksRequest(BaseModel):
     limit: int | None = Field(default=100, gt=0)
+    agent_playbook_id: int | None = Field(default=None, gt=0)
+    query: str | None = None
     playbook_name: str | None = None
     agent_version: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
     playbook_status_filter: PlaybookStatus | None = None
     tags: list[str] | None = None
@@ -246,6 +265,12 @@ class GetAgentPlaybooksRequest(BaseModel):
     # Optional; consumed by _meter_applied_learnings in server/api.py.
     request_id: str | None = None
     session_id: str | None = None
+
+    @model_validator(mode="after")
+    def check_time_range(self) -> Self:
+        """Validate that end_time is after start_time."""
+        TimeRangeValidatorMixin.validate_time_range(self.start_time, self.end_time)
+        return self
 
 
 class GetAgentPlaybooksResponse(BaseModel):
@@ -392,6 +417,14 @@ class SearchAgentPlaybookResponse(BaseModel):
 class GetAgentSuccessEvaluationResultsRequest(BaseModel):
     limit: int | None = Field(default=100, gt=0)
     agent_version: str | None = None
+    start_time: datetime | None = None
+    end_time: datetime | None = None
+
+    @model_validator(mode="after")
+    def check_time_range(self) -> Self:
+        """Validate that end_time is after start_time."""
+        TimeRangeValidatorMixin.validate_time_range(self.start_time, self.end_time)
+        return self
 
 
 class GetAgentSuccessEvaluationResultsResponse(BaseModel):
@@ -404,6 +437,7 @@ class GetRequestsRequest(BaseModel):
     user_id: str | None = None
     request_id: str | None = None
     session_id: str | None = None
+    source: str | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
     top_k: int | None = Field(default=30, gt=0)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -1845,6 +1845,12 @@ def get_all_profiles(
     limit: int = 100,
     status_filter: str | None = None,
     profile_id: str | None = None,
+    user_id: str | None = None,
+    query: str | None = None,
+    source: str | None = None,
+    profile_time_to_live: str | None = None,
+    start_time: int | None = None,
+    end_time: int | None = None,
     include_tombstones: bool = False,
     org_id: str = Depends(default_get_org_id),
 ) -> GetProfilesViewResponse:
@@ -1854,6 +1860,12 @@ def get_all_profiles(
         limit (int, optional): Maximum number of profiles to return. Defaults to 100.
         status_filter (str, optional): Filter by profile status. Can be "current", "pending", or "archived".
         profile_id (str, optional): Exact profile ID to retrieve.
+        user_id (str, optional): Exact user ID to filter by.
+        query (str, optional): Case-insensitive text filter across visible fields.
+        source (str, optional): Exact profile source to filter by.
+        profile_time_to_live (str, optional): Exact TTL value to filter by.
+        start_time (int, optional): Minimum last-modified epoch seconds.
+        end_time (int, optional): Maximum last-modified epoch seconds.
         include_tombstones (bool, optional): Include merged/superseded rows when
             looking up a specific profile_id.
         org_id (str): Organization ID
@@ -1863,7 +1875,7 @@ def get_all_profiles(
     """
     reflexio = get_reflexio(org_id=org_id)
 
-    if profile_id:
+    if profile_id and include_tombstones:
         storage = reflexio.request_context.storage
         if storage is None:
             return GetProfilesViewResponse(
@@ -1890,7 +1902,17 @@ def get_all_profiles(
     elif status_filter == "archived":
         status_filter_list = [Status.ARCHIVED]
 
-    response = reflexio.get_all_profiles(limit=limit, status_filter=status_filter_list)  # type: ignore[reportArgumentType]
+    response = reflexio.get_all_profiles(
+        limit=limit,
+        status_filter=status_filter_list,  # type: ignore[reportArgumentType]
+        user_id=user_id,
+        profile_id=profile_id,
+        query=query,
+        source=source,
+        profile_time_to_live=profile_time_to_live,
+        start_time=start_time,
+        end_time=end_time,
+    )
     return GetProfilesViewResponse(
         success=response.success,
         user_profiles=[to_profile_view(p) for p in response.user_profiles],

--- a/reflexio/server/services/storage/sqlite_storage/_playbook.py
+++ b/reflexio/server/services/storage/sqlite_storage/_playbook.py
@@ -322,13 +322,30 @@ class PlaybookMixin:
         include_embedding: bool = False,
         tags: list[str] | None = None,
         offset: int = 0,
+        user_playbook_id: int | None = None,
+        request_id: str | None = None,
+        query: str | None = None,
     ) -> list[UserPlaybook]:
         sql = "SELECT * FROM user_playbooks WHERE 1=1"
         params: list[Any] = []
 
+        if user_playbook_id is not None:
+            sql += " AND user_playbook_id = ?"
+            params.append(user_playbook_id)
         if user_id is not None:
             sql += " AND user_id = ?"
             params.append(user_id)
+        if request_id is not None:
+            sql += " AND request_id = ?"
+            params.append(request_id)
+        if query:
+            like = f"%{query.lower()}%"
+            sql += (
+                " AND (LOWER(content) LIKE ? OR LOWER(trigger) LIKE ? "
+                "OR LOWER(rationale) LIKE ? OR LOWER(request_id) LIKE ? "
+                "OR LOWER(playbook_name) LIKE ? OR LOWER(user_id) LIKE ?)"
+            )
+            params.extend([like, like, like, like, like, like])
         if playbook_name:
             sql += " AND playbook_name = ?"
             params.append(playbook_name)
@@ -1025,10 +1042,25 @@ class PlaybookMixin:
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
         tags: list[str] | None = None,
+        agent_playbook_id: int | None = None,
+        query: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> list[AgentPlaybook]:
         sql = "SELECT * FROM agent_playbooks WHERE 1=1"
         params: list[Any] = []
 
+        if agent_playbook_id is not None:
+            sql += " AND agent_playbook_id = ?"
+            params.append(agent_playbook_id)
+        if query:
+            like = f"%{query.lower()}%"
+            sql += (
+                " AND (LOWER(content) LIKE ? OR LOWER(trigger) LIKE ? "
+                "OR LOWER(rationale) LIKE ? OR LOWER(playbook_name) LIKE ? "
+                "OR LOWER(playbook_metadata) LIKE ?)"
+            )
+            params.extend([like, like, like, like, like])
         if playbook_name:
             sql += " AND playbook_name = ?"
             params.append(playbook_name)
@@ -1036,6 +1068,12 @@ class PlaybookMixin:
         if agent_version is not None:
             sql += " AND agent_version = ?"
             params.append(agent_version)
+        if start_time is not None:
+            sql += " AND created_at >= ?"
+            params.append(_epoch_to_iso(start_time))
+        if end_time is not None:
+            sql += " AND created_at <= ?"
+            params.append(_epoch_to_iso(end_time))
 
         if status_filter is not None:
             frag, sparams = _build_status_sql(status_filter)

--- a/reflexio/server/services/storage/sqlite_storage/_profiles.py
+++ b/reflexio/server/services/storage/sqlite_storage/_profiles.py
@@ -75,6 +75,10 @@ def _build_tags_sql(alias: str, tags: list[str] | None) -> tuple[str, list[Any]]
     )
 
 
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 class ProfileMixin:
     """Mixin providing profile and interaction CRUD + search."""
 
@@ -141,11 +145,46 @@ class ProfileMixin:
         self,
         limit: int = 100,
         status_filter: list[Status | None] | None = None,
+        user_id: str | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> list[UserProfile]:
         if status_filter is None:
             status_filter = [None]
         frag, params = _build_status_sql(status_filter)
-        sql = f"SELECT * FROM profiles WHERE {frag} ORDER BY last_modified_timestamp DESC LIMIT ?"
+        conditions = [frag]
+        if user_id:
+            conditions.append("user_id = ?")
+            params.append(user_id)
+        if profile_id:
+            conditions.append("LOWER(profile_id) = LOWER(?)")
+            params.append(profile_id)
+        if query:
+            like = f"%{_escape_like_pattern(query.lower())}%"
+            conditions.append(
+                "(LOWER(content) LIKE ? ESCAPE '\\' OR LOWER(profile_id) LIKE ? ESCAPE '\\' OR LOWER(user_id) LIKE ? ESCAPE '\\')"
+            )
+            params.extend([like, like, like])
+        if source is not None:
+            conditions.append("source = ?")
+            params.append(source)
+        if profile_time_to_live:
+            conditions.append("profile_time_to_live = ?")
+            params.append(profile_time_to_live)
+        if start_time is not None:
+            conditions.append("last_modified_timestamp >= ?")
+            params.append(start_time)
+        if end_time is not None:
+            conditions.append("last_modified_timestamp <= ?")
+            params.append(end_time)
+        sql = (
+            f"SELECT * FROM profiles WHERE {' AND '.join(conditions)} "
+            "ORDER BY last_modified_timestamp DESC LIMIT ?"
+        )
         params.append(limit)
         return [_row_to_profile(r) for r in self._fetchall(sql, params)]
 
@@ -155,6 +194,12 @@ class ProfileMixin:
         user_id: str,
         status_filter: list[Status | None] | None = None,
         tags: list[str] | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> list[UserProfile]:
         if status_filter is None:
             status_filter = [None]
@@ -162,6 +207,27 @@ class ProfileMixin:
         frag, params = _build_status_sql(status_filter)
         conditions = ["user_id = ?", "expiration_timestamp >= ?", frag]
         all_params: list[Any] = [user_id, current_ts, *params]
+        if profile_id:
+            conditions.append("LOWER(profile_id) = LOWER(?)")
+            all_params.append(profile_id)
+        if query:
+            like = f"%{_escape_like_pattern(query.lower())}%"
+            conditions.append(
+                "(LOWER(content) LIKE ? ESCAPE '\\' OR LOWER(profile_id) LIKE ? ESCAPE '\\' OR LOWER(user_id) LIKE ? ESCAPE '\\')"
+            )
+            all_params.extend([like, like, like])
+        if source is not None:
+            conditions.append("source = ?")
+            all_params.append(source)
+        if profile_time_to_live:
+            conditions.append("profile_time_to_live = ?")
+            all_params.append(profile_time_to_live)
+        if start_time is not None:
+            conditions.append("last_modified_timestamp >= ?")
+            all_params.append(start_time)
+        if end_time is not None:
+            conditions.append("last_modified_timestamp <= ?")
+            all_params.append(end_time)
         tag_frag, tag_params = _build_tags_sql("profiles", tags)
         if tag_frag:
             conditions.append(tag_frag)

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -168,6 +168,7 @@ class RequestMixin:
         end_time: int | None = None,
         top_k: int | None = 30,
         offset: int = 0,
+        source: str | None = None,
     ) -> dict[str, list[RequestInteractionDataModel]]:
         sql = "SELECT * FROM requests WHERE 1=1"
         params: list[Any] = []
@@ -181,6 +182,9 @@ class RequestMixin:
         if session_id:
             sql += " AND session_id = ?"
             params.append(session_id)
+        if source is not None:
+            sql += " AND source = ?"
+            params.append(source)
         if start_time:
             sql += " AND created_at >= ?"
             params.append(_epoch_to_iso(start_time))

--- a/reflexio/server/services/storage/storage_base/_playbook.py
+++ b/reflexio/server/services/storage/storage_base/_playbook.py
@@ -57,12 +57,18 @@ class PlaybookMixin:
         include_embedding: bool = False,
         tags: list[str] | None = None,
         offset: int = 0,
+        user_playbook_id: int | None = None,
+        request_id: str | None = None,
+        query: str | None = None,
     ) -> list[UserPlaybook]:
         """Get user playbooks from storage.
 
         Args:
             limit (int): Maximum number of playbooks to return
+            user_playbook_id (int, optional): Exact user playbook ID to retrieve.
             user_id (str, optional): The user ID to filter by. If None, returns playbooks for all users.
+            request_id (str, optional): Request ID that generated the playbook.
+            query (str, optional): Case-insensitive text filter across visible fields.
             playbook_name (str, optional): The playbook name to filter by. If None, returns all user playbooks.
             agent_version (str, optional): The agent version to filter by. If None, returns all agent versions.
             status_filter (list[Optional[Status]], optional): List of status values to filter by.
@@ -388,13 +394,21 @@ class PlaybookMixin:
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
         tags: list[str] | None = None,
+        agent_playbook_id: int | None = None,
+        query: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> list[AgentPlaybook]:
         """Get agent playbooks from storage.
 
         Args:
             limit (int): Maximum number of agent playbooks to return
+            agent_playbook_id (int, optional): Exact agent playbook ID to retrieve.
+            query (str, optional): Case-insensitive text filter across visible fields.
             playbook_name (str, optional): The playbook name to filter by. If None, returns all agent playbooks.
             agent_version (str, optional): The agent version to filter by. If None, returns all versions.
+            start_time (int, optional): Unix timestamp. Only return playbooks created at or after this time.
+            end_time (int, optional): Unix timestamp. Only return playbooks created at or before this time.
             status_filter (list[Optional[Status]], optional): List of Status values to filter by. None in the list means CURRENT status.
             playbook_status_filter (Optional[list[PlaybookStatus]]): List of PlaybookStatus values to filter by.
                 If None, returns all playbook statuses.

--- a/reflexio/server/services/storage/storage_base/_profiles.py
+++ b/reflexio/server/services/storage/storage_base/_profiles.py
@@ -22,6 +22,13 @@ class ProfileMixin:
         self,
         limit: int = 100,
         status_filter: list[Status | None] | None = None,
+        user_id: str | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> list[UserProfile]:
         raise NotImplementedError
 
@@ -35,6 +42,12 @@ class ProfileMixin:
         user_id: str,
         status_filter: list[Status | None] | None = None,
         tags: list[str] | None = None,
+        profile_id: str | None = None,
+        query: str | None = None,
+        source: str | None = None,
+        profile_time_to_live: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
     ) -> list[UserProfile]:
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -80,6 +80,7 @@ class RequestMixin:
         end_time: int | None = None,
         top_k: int | None = 30,
         offset: int = 0,
+        source: str | None = None,
     ) -> dict[str, list[RequestInteractionDataModel]]:
         """Get requests with their associated interactions, grouped by session_id.
 
@@ -87,6 +88,7 @@ class RequestMixin:
             user_id (str, optional): User ID to filter requests.
             request_id (str, optional): Specific request ID to retrieve
             session_id (str, optional): Specific session ID to retrieve
+            source (str, optional): Request source to match exactly.
             start_time (int, optional): Start timestamp for filtering
             end_time (int, optional): End timestamp for filtering
             top_k (int, optional): Maximum number of requests to return

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from subprocess import CompletedProcess
 
 from reflexio.cli import utils
 
@@ -14,3 +15,49 @@ def test_pidfile_path_uses_platform_temp_dir() -> None:
     assert path.parent == Path(tempfile.gettempdir())
     assert str(path).startswith(tempfile.gettempdir())
     assert path.name.startswith("reflexio_services_")
+
+
+def test_find_pids_on_port_queries_tcp_listeners_only(monkeypatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> CompletedProcess[str]:
+        calls.append(cmd)
+        assert capture_output is True
+        assert text is True
+        assert check is False
+        return CompletedProcess(cmd, 0, stdout="123\nnot-a-pid\n456\n")
+
+    monkeypatch.setattr(utils.subprocess, "run", fake_run)
+
+    assert utils.find_pids_on_port(8090) == [123, 456]
+    assert calls == [["lsof", "-nP", "-t", "-iTCP:8090", "-sTCP:LISTEN"]]
+
+
+def test_requested_port_conflicts_detect_duplicate_service_ports(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(utils, "find_pids_on_port", lambda _port: [])
+
+    conflicts = utils.get_requested_port_conflicts(
+        {"frontend": 8090, "docs": 8090, "backend": 8091}
+    )
+
+    assert conflicts == ["port 8090 is assigned to multiple services: docs, frontend"]
+
+
+def test_requested_port_conflicts_detect_occupied_ports(monkeypatch) -> None:
+    monkeypatch.setattr(
+        utils,
+        "find_pids_on_port",
+        lambda port: [123, 456] if port == 8090 else [],
+    )
+
+    conflicts = utils.get_requested_port_conflicts({"frontend": 8090, "docs": 8092})
+
+    assert conflicts == ["frontend port 8090 is already in use by PID(s): 123, 456"]

--- a/tests/lib/test_agent_playbook_unit.py
+++ b/tests/lib/test_agent_playbook_unit.py
@@ -4,6 +4,7 @@ Tests get_agent_playbooks, add_agent_playbook, delete_agent_playbook, search_age
 delete_all_agent_playbooks_bulk, and update_agent_playbook_status with mocked storage.
 """
 
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from reflexio.lib._agent_playbook import AgentPlaybookMixin
@@ -40,11 +41,11 @@ def _make_mixin(*, storage_configured: bool = True) -> AgentPlaybookMixin:
 
 
 def _get_storage(mixin: AgentPlaybookMixin) -> MagicMock:
-    return mixin.request_context.storage
+    return cast(MagicMock, mixin.request_context.storage)
 
 
-def _sample_agent_playbook(**overrides) -> AgentPlaybook:
-    defaults = {
+def _sample_agent_playbook(**overrides: Any) -> AgentPlaybook:
+    defaults: dict[str, Any] = {
         "agent_version": "v1",
         "playbook_name": "test_fb",
         "content": "test playbook content",
@@ -577,8 +578,12 @@ class TestGetAgentPlaybooksError:
         assert response.success is True
         _get_storage(mixin).get_agent_playbooks.assert_called_once_with(
             limit=10,
+            agent_playbook_id=None,
+            query=None,
             playbook_name=None,
             agent_version=None,
+            start_time=None,
+            end_time=None,
             status_filter=None,
             playbook_status_filter=[PlaybookStatus.APPROVED],
             tags=None,

--- a/tests/lib/test_profiles_unit.py
+++ b/tests/lib/test_profiles_unit.py
@@ -7,6 +7,7 @@ with mocked storage and services.
 """
 
 import time
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 from reflexio.lib._base import STORAGE_NOT_CONFIGURED_MSG
@@ -52,7 +53,7 @@ def _make_mixin(*, storage_configured: bool = True) -> ProfilesMixin:
 
 
 def _get_storage(mixin: ProfilesMixin) -> MagicMock:
-    return mixin.request_context.storage
+    return cast(MagicMock, mixin.request_context.storage)
 
 
 def _sample_profile(**overrides) -> UserProfile:
@@ -193,7 +194,15 @@ class TestGetAllProfiles:
         assert response.success is True
         assert len(response.user_profiles) == 1
         _get_storage(mixin).get_all_profiles.assert_called_once_with(
-            limit=50, status_filter=[None]
+            limit=50,
+            status_filter=[None],
+            user_id=None,
+            profile_id=None,
+            query=None,
+            source=None,
+            profile_time_to_live=None,
+            start_time=None,
+            end_time=None,
         )
 
     def test_storage_not_configured(self):

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -149,6 +149,19 @@ class TestUserPlaybookCRUD:
         assert all(rf.playbook_name == "alpha" for rf in alpha)
         assert beta[0].playbook_name == "beta"
 
+    def test_get_user_playbooks_filters_query_before_limit(self, storage):
+        newer = _make_user_playbook(1, "u1", "alpha", "v1")
+        newer.content = "newer nonmatch"
+        newer.created_at = 1_700_000_200
+        older_match = _make_user_playbook(2, "u2", "beta", "v1")
+        older_match.content = "older needle"
+        older_match.created_at = 1_700_000_100
+        storage.save_user_playbooks([newer, older_match])
+
+        result = storage.get_user_playbooks(limit=1, query="needle")
+
+        assert [p.content for p in result] == ["older needle"]
+
     def test_delete_all_user_playbooks_by_playbook_name(self, storage):
         storage.save_user_playbooks(
             [
@@ -271,6 +284,13 @@ class TestArchiveUserPlaybookById:
 
 class TestAgentPlaybookSourceWindows:
     def test_source_windows_round_trip_and_legacy_ids(self, storage):
+        storage.save_user_playbooks(
+            [
+                _make_user_playbook(1, "u1", "fb", "v1"),
+                _make_user_playbook(2, "u1", "fb", "v1"),
+                _make_user_playbook(3, "u1", "fb", "v1"),
+            ]
+        )
         storage.set_source_windows_for_agent_playbook(
             10,
             [
@@ -289,6 +309,13 @@ class TestAgentPlaybookSourceWindows:
         assert [w.source_interaction_ids for w in windows] == [[20, 21], [30]]
 
     def test_legacy_id_writer_creates_empty_source_windows(self, storage):
+        storage.save_user_playbooks(
+            [
+                _make_user_playbook(1, "u1", "fb", "v1"),
+                _make_user_playbook(2, "u1", "fb", "v1"),
+                _make_user_playbook(3, "u1", "fb", "v1"),
+            ]
+        )
         storage.set_source_user_playbook_ids_for_agent_playbook(10, [2, 3, 2])
 
         assert storage.get_source_user_playbook_ids_for_agent_playbook(10) == [2, 3]
@@ -320,6 +347,13 @@ class TestAgentPlaybookSourceWindows:
         ]
 
     def test_batch_source_user_playbook_ids_round_trip(self, storage):
+        storage.save_user_playbooks(
+            [
+                _make_user_playbook(1, "u1", "fb", "v1"),
+                _make_user_playbook(2, "u1", "fb", "v1"),
+                _make_user_playbook(3, "u1", "fb", "v1"),
+            ]
+        )
         storage.set_source_windows_for_agent_playbook(
             10,
             [
@@ -368,6 +402,19 @@ class TestAgentPlaybookCRUD:
 
         result = storage.get_agent_playbooks(playbook_name="fb")
         assert len(result) == 2
+
+    def test_get_agent_playbooks_filters_query_before_limit(self, storage):
+        newer = _make_agent_playbook(1, "alpha", "v1")
+        newer.content = "newer nonmatch"
+        newer.created_at = 1_700_000_200
+        older_match = _make_agent_playbook(2, "beta", "v1")
+        older_match.content = "older needle"
+        older_match.created_at = 1_700_000_100
+        storage.save_agent_playbooks([newer, older_match])
+
+        result = storage.get_agent_playbooks(limit=1, query="needle")
+
+        assert [p.content for p in result] == ["older needle"]
 
     def test_update_agent_playbook_tags_round_trip(self, storage):
         storage.save_agent_playbooks([_make_agent_playbook(1, "fb", "v1")])

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -134,6 +134,41 @@ class TestProfileCRUD:
         profiles = storage.get_all_profiles(limit=2)
         assert len(profiles) == 2
 
+    def test_get_all_profiles_filters_before_limit(self, storage: BaseStorage) -> None:
+        newer = _make_profile("u-new", "p-new", "newer nonmatch")
+        newer.last_modified_timestamp = 1_700_000_200
+        older_match = _make_profile("u-old", "p-old", "older needle")
+        older_match.last_modified_timestamp = 1_700_000_100
+        storage.add_user_profile("u-new", [newer])
+        storage.add_user_profile("u-old", [older_match])
+
+        profiles = storage.get_all_profiles(limit=1, query="needle")
+
+        assert [p.profile_id for p in profiles] == ["p-old"]
+
+    def test_profile_query_treats_like_metacharacters_as_literals(
+        self, storage: BaseStorage
+    ) -> None:
+        storage.add_user_profile(
+            "u-like",
+            [
+                _make_profile("u-like", "p-percent-literal", "progress is 100%"),
+                _make_profile("u-like", "p-percent-word", "progress is 100 percent"),
+                _make_profile("u-like", "p-underscore-literal", "uses _tmp files"),
+                _make_profile("u-like", "p-underscore-word", "uses xtmp files"),
+            ],
+        )
+
+        all_percent = storage.get_all_profiles(query="100%")
+        user_percent = storage.get_user_profile("u-like", query="100%")
+        all_underscore = storage.get_all_profiles(query="_tmp")
+        user_underscore = storage.get_user_profile("u-like", query="_tmp")
+
+        assert {p.profile_id for p in all_percent} == {"p-percent-literal"}
+        assert {p.profile_id for p in user_percent} == {"p-percent-literal"}
+        assert {p.profile_id for p in all_underscore} == {"p-underscore-literal"}
+        assert {p.profile_id for p in user_underscore} == {"p-underscore-literal"}
+
     def test_delete_profile(self, storage: BaseStorage) -> None:
         storage.add_user_profile("u1", [_make_profile("u1", "p1", "likes sushi")])
         assert len(storage.get_user_profile("u1")) == 1

--- a/tests/server/services/storage/test_storage_contract_requests.py
+++ b/tests/server/services/storage/test_storage_contract_requests.py
@@ -18,12 +18,13 @@ def _make_request(
     request_id: str,
     user_id: str,
     session_id: str = "s-default",
+    source: str = "test",
 ) -> Request:
     return Request(
         request_id=request_id,
         user_id=user_id,
         created_at=int(datetime.now(UTC).timestamp()),
-        source="test",
+        source=source,
         agent_version="v1",
         session_id=session_id,
     )
@@ -94,6 +95,23 @@ class TestSessionQueries:
         assert len(items) == 1
         assert items[0].request.request_id == "r1"
         assert items[0].session_id == "s1"
+
+    def test_get_sessions_filters_source_before_limit(
+        self, storage: BaseStorage
+    ) -> None:
+        newer = _make_request("r-new", "u1", source="web")
+        newer.created_at = 1_700_000_200
+        older_match = _make_request("r-old", "u1", source="cli")
+        older_match.created_at = 1_700_000_100
+        storage.add_request(newer)
+        storage.add_request(older_match)
+
+        sessions = storage.get_sessions(source="cli", top_k=1)
+        request_ids = [
+            item.request.request_id for items in sessions.values() for item in items
+        ]
+
+        assert request_ids == ["r-old"]
 
     def test_get_requests_by_session(self, storage: BaseStorage) -> None:
         storage.add_request(_make_request("r1", "u1", session_id="s1"))


### PR DESCRIPTION
## Summary
- Adds DB-backed filters for profile, playbook, request, and evaluation list APIs so callers can avoid overfetching and frontend-only filtering.
- Extends client request schemas and storage contracts with exact IDs, free-text query, source, TTL, and time-window filters where applicable.
- Adds startup port-conflict detection for requested service ports.

## Changes
- API/client: exposes new list filter fields for profiles, playbooks, requests, and evaluation results.
- Storage: implements the new filters in SQLite storage and shared storage contracts.
- Tests: adds storage contract and lib tests for the new filters, plus service port conflict helper coverage.

## Test Plan
- `uv run ruff check ...`
- `uv run pyright ...`
- `REFLEXIO_TEST_MODE=1 uv run pytest --no-cov open_source/reflexio/tests/cli/test_utils.py open_source/reflexio/tests/lib/test_agent_playbook_unit.py open_source/reflexio/tests/lib/test_profiles_unit.py open_source/reflexio/tests/server/services/storage/test_storage_contract_playbook.py open_source/reflexio/tests/server/services/storage/test_storage_contract_profiles.py open_source/reflexio/tests/server/services/storage/test_storage_contract_requests.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded profile/playbook/request/evaluation retrieval with additional filters: IDs, free-text query, source, and start/end time ranges.
  * Added time-range validation for playbook and evaluation requests.
  * Enhanced the server-side API for profile listing with the same new filter options.

* **Bug Fixes**
  * Improved port conflict detection and blocked service startup when requested ports are duplicated or already listening.
  * Ensured query/source/time filtering is applied before pagination/limits.

* **Tests**
  * Added/updated coverage for port conflict detection and filtering precedence (including source filtering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->