### PR TITLE
fix: aggregate dashboard time series by day

### DIFF
--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -531,7 +531,8 @@ class TimeSeriesDataPoint(BaseModel):
     """A single data point in a time series."""
 
     timestamp: int = Field(gt=0)  # Unix timestamp
-    value: int = Field(ge=0)  # Count or metric value
+    value: float = Field(ge=0)  # Count or metric value
+    count: int | None = Field(default=None, ge=0)  # Optional weight for rate metrics
 
 
 class PeriodStats(BaseModel):

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -2,6 +2,7 @@
 
 import sqlite3
 from collections import defaultdict
+from datetime import UTC, datetime
 from typing import Any, Literal, cast
 
 from reflexio.models.api_schema.braintrust_schema import (
@@ -179,31 +180,60 @@ class ExtrasMixin:
             (current_start_iso, current_time_iso),
         )
 
+        def day_bucket(timestamp: int) -> int:
+            return int(
+                datetime.fromtimestamp(timestamp, tz=UTC)
+                .replace(hour=0, minute=0, second=0, microsecond=0)
+                .timestamp()
+            )
+
+        def count_series(timestamps: list[int]) -> list[dict[str, int]]:
+            buckets: dict[int, int] = defaultdict(int)
+            for timestamp in timestamps:
+                buckets[day_bucket(timestamp)] += 1
+            return [
+                {"timestamp": timestamp, "value": value}
+                for timestamp, value in sorted(buckets.items())
+            ]
+
+        def rate_series(rows: list[sqlite3.Row]) -> list[dict[str, int | float]]:
+            buckets: dict[int, dict[str, int]] = defaultdict(
+                lambda: {"success": 0, "count": 0}
+            )
+            for row in rows:
+                bucket = day_bucket(_iso_to_epoch(row["created_at"]))
+                buckets[bucket]["count"] += 1
+                if row["is_success"]:
+                    buckets[bucket]["success"] += 1
+            return [
+                {
+                    "timestamp": timestamp,
+                    "value": (
+                        100.0 * aggregate["success"] / aggregate["count"]
+                        if aggregate["count"]
+                        else 0.0
+                    ),
+                    "count": aggregate["count"],
+                }
+                for timestamp, aggregate in sorted(buckets.items())
+            ]
+
         return {
             "current_period": current_stats,
             "previous_period": previous_stats,
-            "interactions_time_series": [
-                {"timestamp": _iso_to_epoch(r["created_at"]), "value": 1}
-                for r in interactions_ts
-            ],
-            "profiles_time_series": [
-                {"timestamp": r["last_modified_timestamp"], "value": 1}
-                for r in profiles_ts
-            ],
-            "playbooks_time_series": sorted(
-                [
-                    {"timestamp": _iso_to_epoch(r["created_at"]), "value": 1}
-                    for r in (*user_playbooks_ts, *agent_playbooks_ts)
-                ],
-                key=lambda x: x["timestamp"],
+            "interactions_time_series": count_series(
+                [_iso_to_epoch(r["created_at"]) for r in interactions_ts]
             ),
-            "evaluations_time_series": [
-                {
-                    "timestamp": _iso_to_epoch(r["created_at"]),
-                    "value": 100 if r["is_success"] else 0,
-                }
-                for r in evals_ts
-            ],
+            "profiles_time_series": count_series(
+                [r["last_modified_timestamp"] for r in profiles_ts]
+            ),
+            "playbooks_time_series": count_series(
+                [
+                    _iso_to_epoch(r["created_at"])
+                    for r in (*user_playbooks_ts, *agent_playbooks_ts)
+                ]
+            ),
+            "evaluations_time_series": rate_series(evals_ts),
         }
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/storage_base/_extras.py
+++ b/reflexio/server/services/storage/storage_base/_extras.py
@@ -29,10 +29,10 @@ class ExtrasMixin:
             dict: Dictionary containing:
                 - current_period: Stats for the current period (days_back)
                 - previous_period: Stats for the previous period (for trend calculation)
-                - interactions_time_series: List of time series data points (raw, ungrouped)
-                - profiles_time_series: List of time series data points (raw, ungrouped)
-                - playbooks_time_series: List of time series data points (raw, ungrouped)
-                - evaluations_time_series: List of time series data points (raw, ungrouped)
+                - interactions_time_series: Daily bucketed interaction counts
+                - profiles_time_series: Daily bucketed profile counts
+                - playbooks_time_series: Daily bucketed playbook counts
+                - evaluations_time_series: Daily bucketed success rates with optional counts
         """
         raise NotImplementedError
 

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -524,6 +524,11 @@ class TestNumericConstraints:
         with pytest.raises(ValidationError):
             TimeSeriesDataPoint(timestamp=0, value=5)
 
+    def test_timeseries_count_non_negative(self):
+        """TimeSeriesDataPoint.count must be >= 0 when provided."""
+        with pytest.raises(ValidationError):
+            TimeSeriesDataPoint(timestamp=1000, value=5, count=-1)
+
     def test_playbook_aggregator_config_constraints(self):
         """PlaybookAggregatorConfig thresholds must be >= 1."""
         with pytest.raises(ValidationError):

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -490,9 +490,9 @@ class TestDashboardPlaybooksTimeSeries:
         stats = storage.get_dashboard_stats(days_back=30)
 
         assert stats["current_period"]["total_playbooks"] == 2
-        # The series must contain BOTH playbooks (regression: it previously
-        # queried only user_playbooks and would have length 1 here).
-        assert len(stats["playbooks_time_series"]) == 2
+        # The series must count BOTH playbooks (regression: it previously
+        # queried only user_playbooks and would undercount this bucket).
+        assert sum(point["value"] for point in stats["playbooks_time_series"]) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Move dashboard time-series contract toward pre-aggregated daily buckets so large interaction histories do not require raw event fanout.
- Add optional `count` metadata to time-series points so rate rollups can be weighted correctly.
- Keep the SQLite storage backend aligned with the new dashboard aggregation contract.

## Changes
- Updated `TimeSeriesDataPoint` with an optional non-negative `count` field.
- Aggregated SQLite dashboard count and eval series into UTC daily buckets.
- Updated storage contract tests and validators for the new bucketed shape.

## Test Plan
- `uv run ruff format reflexio/models/api_schema/retriever_schema.py reflexio/server/services/storage/sqlite_storage/_extras.py reflexio/server/services/storage/storage_base/_extras.py tests/models/test_validators.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run ruff check reflexio/models/api_schema/retriever_schema.py reflexio/server/services/storage/sqlite_storage/_extras.py reflexio/server/services/storage/storage_base/_extras.py tests/models/test_validators.py tests/server/services/storage/test_storage_contract_playbook.py`
- `uv run pyright reflexio/models/api_schema/retriever_schema.py reflexio/server/services/storage/sqlite_storage/_extras.py tests/models/test_validators.py tests/server/services/storage/test_storage_contract_playbook.py`
- `PYTEST_ADDOPTS=--no-cov REFLEXIO_GOVERNANCE_REF_SECRET=test-secret uv run pytest tests/models/test_validators.py tests/lib/test_config_unit.py tests/server/services/storage/test_storage_contract_playbook.py::TestDashboardPlaybooksTimeSeries`
