### PR TITLE
fix: paginate get_sessions by session, not request rows

### DIFF
--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -119,10 +119,11 @@ class SearchMixin(ReflexioBase):
                     Session(session_id=group_name, requests=request_data_list)
                 )
 
-            # Determine has_more: count total requests returned across all groups
+            # Pagination is session-based (top_k counts sessions): there may be
+            # more pages when this page filled the session limit.
             total_returned = sum(len(s.requests) for s in sessions)
             effective_limit = request.top_k or 100
-            has_more = total_returned >= effective_limit
+            has_more = len(sessions) >= effective_limit
 
             return GetRequestsResponse(
                 success=True,

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -440,8 +440,15 @@ class GetRequestsRequest(BaseModel):
     source: str | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
-    top_k: int | None = Field(default=30, gt=0)
-    offset: int | None = Field(default=0, ge=0)
+    top_k: int | None = Field(
+        default=30,
+        gt=0,
+        description="Maximum number of sessions to return. Pagination is "
+        "per-session: every returned session includes all of its requests.",
+    )
+    offset: int | None = Field(
+        default=0, ge=0, description="Number of sessions to skip for pagination."
+    )
 
     @model_validator(mode="after")
     def check_time_range(self) -> Self:

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -486,7 +486,7 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 
 **Key Methods**:
 - CRUD: profiles, interactions, playbooks, results, requests, playbook aggregation change logs
-- `get_sessions(offset, top_k, session_id)` → `dict[str, list[RequestInteractionDataModel]]` (groups by session_id, supports offset/limit pagination)
+- `get_sessions(offset, top_k, session_id)` → `dict[str, list[RequestInteractionDataModel]]` (groups by session_id; paginates per-session — `top_k`/`offset` count sessions, and each returned session includes all of its requests)
 - `get_rerun_user_ids(user_id, start_time, end_time, source, agent_version)` → `list[str]` - Get distinct user IDs matching filters for rerun workflows (pushes filtering to storage layer)
 - `get_feedbacks(status_filter, feedback_status_filter)` - Filter by playbook status and approval status
 - `save_feedbacks()` → returns `list[Feedback]` with `feedback_id` populated (callers can ignore return)

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -170,37 +170,60 @@ class RequestMixin:
         offset: int = 0,
         source: str | None = None,
     ) -> dict[str, list[RequestInteractionDataModel]]:
-        sql = "SELECT * FROM requests WHERE 1=1"
-        params: list[Any] = []
-
+        # Request-level filters shared by both the session-page query and the
+        # request-fetch query. Pagination is applied at the SESSION level
+        # (top_k/offset count sessions, not request rows) so a session with many
+        # requests is never truncated to a subset of its rows.
+        filter_sql = ""
+        filter_params: list[Any] = []
         if user_id:
-            sql += " AND user_id = ?"
-            params.append(user_id)
+            filter_sql += " AND user_id = ?"
+            filter_params.append(user_id)
         if request_id:
-            sql += " AND request_id = ?"
-            params.append(request_id)
+            filter_sql += " AND request_id = ?"
+            filter_params.append(request_id)
         if session_id:
-            sql += " AND session_id = ?"
-            params.append(session_id)
+            filter_sql += " AND session_id = ?"
+            filter_params.append(session_id)
         if source is not None:
-            sql += " AND source = ?"
-            params.append(source)
+            filter_sql += " AND source = ?"
+            filter_params.append(source)
         if start_time:
-            sql += " AND created_at >= ?"
-            params.append(_epoch_to_iso(start_time))
+            filter_sql += " AND created_at >= ?"
+            filter_params.append(_epoch_to_iso(start_time))
         if end_time:
-            sql += " AND created_at <= ?"
-            params.append(_epoch_to_iso(end_time))
+            filter_sql += " AND created_at <= ?"
+            filter_params.append(_epoch_to_iso(end_time))
 
+        # Step 1: select the page of session_ids, ordered by each session's most
+        # recent matching request (latest-first), with session_id as a stable
+        # tiebreak so pages don't overlap or skip.
         effective_limit = top_k or 100
-        sql += " ORDER BY created_at DESC LIMIT ? OFFSET ?"
-        params.extend([effective_limit, offset])
+        page_rows = self._fetchall(
+            f"SELECT session_id, MAX(created_at) AS latest FROM requests "
+            f"WHERE 1=1{filter_sql} "
+            f"GROUP BY session_id ORDER BY latest DESC, session_id DESC "
+            f"LIMIT ? OFFSET ?",
+            [*filter_params, effective_limit, offset],
+        )
+        if not page_rows:
+            return {}
+        page_session_ids = [r["session_id"] for r in page_rows]
 
-        req_rows = self._fetchall(sql, params)
+        # Step 2: fetch ALL matching requests for the sessions in this page.
+        placeholders = ",".join("?" for _ in page_session_ids)
+        req_rows = self._fetchall(
+            f"SELECT * FROM requests WHERE 1=1{filter_sql} "
+            f"AND session_id IN ({placeholders}) ORDER BY created_at DESC",
+            [*filter_params, *page_session_ids],
+        )
         if not req_rows:
             return {}
 
-        grouped: dict[str, list[RequestInteractionDataModel]] = {}
+        # Preserve the latest-first session ordering from step 1.
+        grouped: dict[str, list[RequestInteractionDataModel]] = {
+            (sid or ""): [] for sid in page_session_ids
+        }
         for rr in req_rows:
             req = _row_to_request(rr)
             group_name = req.session_id or ""

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -188,10 +188,10 @@ class RequestMixin:
         if source is not None:
             filter_sql += " AND source = ?"
             filter_params.append(source)
-        if start_time:
+        if start_time is not None:
             filter_sql += " AND created_at >= ?"
             filter_params.append(_epoch_to_iso(start_time))
-        if end_time:
+        if end_time is not None:
             filter_sql += " AND created_at <= ?"
             filter_params.append(_epoch_to_iso(end_time))
 

--- a/tests/lib/test_search_unit.py
+++ b/tests/lib/test_search_unit.py
@@ -144,10 +144,16 @@ class TestGetRequests:
         assert "session_b" in session_ids
 
     def test_has_more_flag_true(self):
-        """has_more is True when total returned equals top_k."""
+        """has_more is True when the number of sessions returned equals top_k.
+
+        Pagination is session-based: a single busy session (many requests) must
+        not flip has_more on; only filling the session limit does.
+        """
         mixin = _make_mixin()
-        items = [_make_request_interaction("s", f"req_{i}") for i in range(5)]
-        _get_storage(mixin).get_sessions.return_value = {"s": items}
+        # 5 sessions, each with one request, fills a top_k=5 session page.
+        _get_storage(mixin).get_sessions.return_value = {
+            f"s{i}": [_make_request_interaction(f"s{i}", f"req_{i}")] for i in range(5)
+        }
 
         request = GetRequestsRequest(top_k=5)
         response = mixin.get_requests(request)
@@ -155,8 +161,20 @@ class TestGetRequests:
         assert response.success is True
         assert response.has_more is True
 
+    def test_has_more_flag_false_for_single_busy_session(self):
+        """A single session with many requests does not set has_more (top_k counts sessions)."""
+        mixin = _make_mixin()
+        items = [_make_request_interaction("s", f"req_{i}") for i in range(20)]
+        _get_storage(mixin).get_sessions.return_value = {"s": items}
+
+        request = GetRequestsRequest(top_k=5)
+        response = mixin.get_requests(request)
+
+        assert response.success is True
+        assert response.has_more is False
+
     def test_has_more_flag_false(self):
-        """has_more is False when total returned is less than top_k."""
+        """has_more is False when fewer sessions than top_k are returned."""
         mixin = _make_mixin()
         items = [_make_request_interaction("s", "req_1")]
         _get_storage(mixin).get_sessions.return_value = {"s": items}


### PR DESCRIPTION
## Summary

`get_sessions` paginated **request rows** with `LIMIT/OFFSET` and only grouped them into sessions afterward. As a result a session with more requests than `top_k` was truncated to a subset of its rows on a page, and a busy session could split across pages. Downstream (the interactions view) this surfaced as "some interactions for a session aren't showing" and inconsistent session counts.

This switches pagination to the **session** level: `top_k`/`offset` now count sessions, and every returned session includes **all** of its matching requests.

## Changes

- `sqlite_storage/_requests.py` — `get_sessions` is now a two-step query: (1) select the page of `session_id`s ordered by each session's latest request (`GROUP BY ... ORDER BY MAX(created_at) DESC LIMIT/OFFSET`), (2) fetch **all** requests for those sessions and attach interactions. `request_id` keeps its exact single-request early path.
- `lib/_search.py` — `has_more` is derived from the number of sessions returned, so a single busy session no longer flips it on.
- `models/api_schema/retriever_schema.py` — `GetRequestsRequest.top_k`/`offset` documented as session-paged.
- `server/README.md` — updated `get_sessions` description.
- `tests/lib/test_search_unit.py` — updated `has_more` cases to session semantics; added a "single busy session does not set has_more" case.

## Test Plan

- Updated unit tests pass (`tests/lib/test_search_unit.py`).
- Storage contract tests pass (`tests/server/services/storage/test_storage_contract_requests.py`, `test_session_window_contract.py`).
- Governance local e2e (which pages sessions via `get_sessions`) passes.
- Manual repro: a 50-request session now returns all 50 requests/interactions in page 0 (previously truncated to `top_k`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pagination now operates at the session level, ensuring sessions with multiple requests are returned without truncation.
  - `has_more` now indicates whether additional sessions are available (based on session counts).

- **Documentation**
  - Updated pagination field descriptions and storage docs to clarify that `top_k` and `offset` apply to sessions, not individual requests.

- **Tests**
  - Revised and added pagination test cases to validate the new session-based `has_more` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->