### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -102,6 +102,7 @@ Description: FastAPI backend server that processes user interactions to generate
 
 ### Main Entry Points
 - **API**: `api.py` - FastAPI routes
+- **Extension Registry**: `extensions.py` - optional capability/service registration for OSS and enterprise integrations
 - **Endpoint Helpers**: `api_endpoints/` - Request handlers calling `Reflexio` (reflexio_lib)
 - **Core Service**: `services/generation_service.py` - Main orchestrator
 
@@ -141,7 +142,8 @@ client (Python SDK)
   - `playbook_optimizer/` - Scenario-based playbook optimization experiments
   - `braintrust/` - Braintrust eval export/sync support
   - `lineage/` - Resolve current records and schedule tombstone garbage collection for superseded profile/playbook rows
-  - `storage/` - Abstract layer (SQLite prod, LocalJSON test)
+  - `governance/` - Subject-reference contracts and retention/barrier helpers used by storage and lineage
+  - `storage/` - Abstract layer (SQLite prod, LocalJSON test) with governance-aware write validation
   - `pre_retrieval/` - Query rewriting and document expansion helpers
   - `configurator/` - YAML config loader
 - **`site_var/`**: Global settings singleton

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -6,6 +6,7 @@ Description: FastAPI backend server that processes user interactions to generate
 - [Main Entry Points](#main-entry-points)
 - [Cache](#cache)
 - [API Endpoints](#api-endpoints)
+- [Extension Registry](#extension-registry)
 - [LLM Client](#llm-client)
 - [Prompts](#prompts)
 - [Site Variables](#site-variables)
@@ -34,6 +35,7 @@ Description: FastAPI backend server that processes user interactions to generate
 
 - **API**: `api.py` - FastAPI routes (only place to expose endpoints)
 - **Endpoint Helpers**: `api_endpoints/` - Bridge between routes and business logic
+- **Extension Registry**: `extensions.py` - Capability and service registry for optional OSS/enterprise integrations
 - **Core Service**: `services/generation_service.py` - Main orchestrator
 
 ## Cache
@@ -83,6 +85,14 @@ Description: FastAPI backend server that processes user interactions to generate
 **Authentication Pattern**: The open-source app uses `default_get_org_id` and `DEFAULT_ORG_ID` for local/no-auth starts. The enterprise extension wraps `create_app()` with authenticated org resolution, login/OAuth/account/share/waitlist routers, admin checks, Sentry tracing, and usage metrics.
 
 **Pattern**: Core route handlers call `Reflexio` through `get_reflexio(org_id)`; endpoint helper files should not instantiate `Reflexio` directly.
+
+## Extension Registry
+
+**File**: `extensions.py`
+
+`CapabilityRegistry` lets deployments register optional routers, startup/shutdown hooks, and cross-cutting services without hardcoding enterprise-only imports into the OSS app. `create_app()` builds the active registry, stores it on `app.state.capability_registry`, installs capability routers/startup/shutdown hooks, and exposes typed service lookup through `ServiceKey`.
+
+**Pattern**: Optional integrations should register capabilities/services at app construction time and consume them through the registry; avoid importing enterprise implementations directly in OSS modules.
 
 ## LLM Client
 
@@ -188,6 +198,7 @@ python -m reflexio.server.scripts.manage_invitation_codes list --show-used
 - **Search preparation**: `pre_retrieval/` and `unified_search_service.py` handle query reformulation, document expansion, embeddings, and cross-entity search orchestration.
 - **Optimization/integrations**: `playbook_optimizer/` and `braintrust/` run candidate playbook optimization, rollout support, and Braintrust export/sync.
 - **Lineage**: `lineage/` resolves active records across superseded chains and schedules tombstone garbage collection for profile/playbook storage.
+- **Governance**: `governance/` defines subject-reference contracts and retention/barrier policy helpers used by storage and lineage paths.
 - **Persistence/config**: `storage/`, `configurator/`, and `operation_state_utils.py` provide storage abstractions, config loading, locks, bookmarks, progress, and cancellation.
 
 ### Orchestrator
@@ -478,7 +489,8 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 | File | Purpose |
 |------|---------|
 | `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_lineage.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
-| `sqlite_storage/` | SQLite-backed implementation split across the same domains, including lineage/tombstone support in `_lineage.py` |
+| `sqlite_storage/` | SQLite-backed implementation split across the same domains, including governance-aware retention/barrier handling and lineage/tombstone support in `_governance.py` / `_lineage.py` |
+| `governance_validation.py` | Shared validation helpers for subject references and governance contracts before storage writes. |
 | `retention.py`, `retention_mixin.py` | Data retention and cleanup helpers |
 | `constants.py`, `error.py` | Storage constants and shared errors |
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -52,6 +52,7 @@ strings before deleting old import paths in the same PR.
 | `playbook_optimizer/` | Scenario-based playbook optimization: mature flat package with `optimizer.py`, `scheduler.py`, `rollout.py`, `judge.py`, `models.py`, `scenario_resolver.py`, `gepa_adapter.py`, and `assistant_webhook.py`. See [README](playbook_optimizer/README.md). |
 | `braintrust/` | Braintrust export/sync: `service.py`, `client.py`, `_cron.py`, `_encryption.py`. |
 | `lineage/` | Current-record resolution and tombstone GC: `resolve.py`, `gc_scheduler.py`. |
+| `governance/` | Subject-reference and retention/barrier policy contracts: `config.py`, `service.py`, `subject_refs.py`. Storage and lineage code use these helpers to preserve governance constraints during writes, supersedes, and cleanup. |
 | `pre_retrieval/` | `QueryReformulator` (`_query_reformulator.py`) + `DocumentExpander` (`_document_expander.py`) - query rewrite and doc expansion for recall. Compact by design; see [README](pre_retrieval/README.md). |
 | `tagging/` | `TaggingService` (`service.py`) + deferred `tagging_scheduler.py` - post-generation profile/playbook tagging. Compact by design; see [README](tagging/README.md). |
 | `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks. |
@@ -61,7 +62,7 @@ strings before deleting old import paths in the same PR.
 
 | Path | Purpose |
 |------|---------|
-| `storage/` | `storage_base/` (`BaseStorage` split by domain, including `_lineage.py`) + `sqlite_storage/` (including lineage/tombstones) + `retention*.py`. Access via `request_context.storage` only. |
+| `storage/` | `storage_base/` (`BaseStorage` split by domain, including `_governance.py` and `_lineage.py`) + `sqlite_storage/` (governance validation, retention barriers, lineage/tombstones) + `governance_validation.py` + `retention*.py`. Access via `request_context.storage` only. |
 | `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
 
 ## Key Rules
@@ -71,3 +72,4 @@ strings before deleting old import paths in the same PR.
 - **ALWAYS use `LiteLLMClient`** for completions/embeddings and `request_context.prompt_manager.render_prompt(...)` for prompts — no hardcoded prompts, no direct OpenAI/Claude clients.
 - **All `_operation_state` writes go through `OperationStateManager`** — don't touch the table directly (it backs locks, bookmarks, progress, and cancellation).
 - **`tool_can_use` lives at root `Config`** — shared by playbook extraction and success evaluation, not per-service.
+- **Preserve governance subject refs/barriers** — route validation through `services/governance/` and `storage/governance_validation.py`; do not bypass retention or subject-write checks in storage implementations.


### PR DESCRIPTION
## Summary
- Updates model-facing code-map READMEs to reflect the current extension registry and governance/storage structure.
- Adds navigation pointers for `extensions.py`, `services/governance/`, and governance-aware storage validation.
- Follows the parent repository policy in `how_to_write_readme.md`: concise, path-oriented, navigation-focused README updates only.

## Repositories/submodules reviewed
- Parent repository: `ReflexioAI/reflexio-enterprise`
- Submodules: `ReflexioAI/reflexio`, `ReflexioAI/claude-smart`

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/README.md reflexio/server/README.md reflexio/server/services/README.md`

## Notes/Risks
- Documentation-only change.
- Parent repository submodule pointer should not be committed until this submodule PR is merged and a pointer update is explicitly desired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the server and services documentation to reflect new extension registration and governance guidance.
  * Added clearer descriptions of storage behavior, including governance-aware validation, retention, and lineage handling.
  * Expanded architecture references so it’s easier to understand how integrations and policy-related components fit together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->