### PR TITLE
chore: drop dead type-stubs + fix citation test transaction nesting

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -85,13 +85,8 @@ class AgentPlaybookStoreMixin:
     _should_expand_documents: Any
     _expand_document: Any
     _fts_upsert: Any
-    _fts_delete: Any
     _vec_upsert: Any
-    _vec_delete: Any
     _delete_playbook_search_rows: Any
-    _has_sqlite_vec: bool
-    _subject_ref_for_user_id: Any
-    _assert_subject_writable_locked: Any
 
     def _index_agent_playbook_fts_vec(self, ap: AgentPlaybook) -> None:
         """Update the FTS and vector indexes for a single agent playbook row.

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -61,18 +61,14 @@ class UserPlaybookStoreMixin:
     _lock: Any
     conn: sqlite3.Connection
     org_id: str
-    _execute: Any
     _fetchone: Any
     _fetchall: Any
     _get_embedding: Any
     _should_expand_documents: Any
     _expand_document: Any
     _fts_upsert: Any
-    _fts_delete: Any
     _vec_upsert: Any
-    _vec_delete: Any
     _delete_playbook_search_rows: Any
-    _has_sqlite_vec: bool
     _subject_ref_for_user_id: Any
     _assert_subject_writable_locked: Any
 

--- a/tests/server/services/storage/test_sqlite_storage_bc_extras.py
+++ b/tests/server/services/storage/test_sqlite_storage_bc_extras.py
@@ -203,6 +203,10 @@ def test_get_citations_by_session_ids_extracts_cited_rows(
         "UPDATE interactions SET citations = NULL WHERE request_id = ? AND role = ?",
         (null_request_id, "Assistant"),
     )
+    # Commit the raw UPDATE so the shared connection isn't left mid-transaction —
+    # otherwise the next add_request()'s `BEGIN IMMEDIATE` raises
+    # "cannot start a transaction within a transaction".
+    storage.conn.commit()
     blank_request_id = _add_request_with_interactions(
         storage,
         session_id="blank",
@@ -213,6 +217,7 @@ def test_get_citations_by_session_ids_extracts_cited_rows(
         "UPDATE interactions SET citations = '' WHERE request_id = ? AND role = ?",
         (blank_request_id, "Assistant"),
     )
+    storage.conn.commit()
 
     out = storage.get_citations_by_session_ids(
         ["s1", "s2", "empty", "nullish", "blank", "missing"]


### PR DESCRIPTION
## Post-decomposition cleanup: dead type-stubs + a brittle-test fix

Small follow-up to the playbook decomposition (#262).

- **Remove orphaned MRO type-stub attributes** that the mixin split left unused in their sub-mixin (`sqlite_storage/playbook/_agent.py`, `_user.py`). Type-only annotations with zero runtime effect; each removed stub was verified unused in its file and pyright stays clean. (Surfaced by the whole-branch review.)
- **Fix `test_get_citations_by_session_ids_extracts_cited_rows`** (pre-existing brittle test): it ran a raw `storage.conn.execute("UPDATE ...")` on the shared connection without committing, leaving an implicit transaction open, so the next `add_request()`'s `BEGIN IMMEDIATE` raised *"cannot start a transaction within a transaction."* Commit the raw UPDATEs.

Full OSS storage suite: **844 passed, 0 failures** (this was the last remaining red). pyright + ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQLite data handling so updates are reliably saved before citation lookups run, reducing inconsistent results in edge cases.
  * Kept playbook storage behavior aligned with current SQLite capabilities, helping avoid unexpected issues during search and delete operations.
* **Tests**
  * Updated test coverage to reflect committed database changes before citation retrieval checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->