### PR TITLE
feat: expiry reclamation — reclaim TTL-expired rows (profiles, share_links, pending_tool_calls)

### DIFF
--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -42,17 +42,21 @@ class SearchMixin(ReflexioBase):
 
         try:
             if request.start_time or request.end_time:
-                results = self._get_storage().get_agent_success_evaluation_results_in_window(
-                    from_ts=(
-                        int(request.start_time.timestamp()) if request.start_time else 0
-                    ),
-                    to_ts=(
-                        int(request.end_time.timestamp())
-                        if request.end_time
-                        else 2**31 - 1
-                    ),
-                    limit=request.limit or 100,
-                    agent_version=request.agent_version,
+                results = (
+                    self._get_storage().get_agent_success_evaluation_results_in_window(
+                        from_ts=(
+                            int(request.start_time.timestamp())
+                            if request.start_time
+                            else 0
+                        ),
+                        to_ts=(
+                            int(request.end_time.timestamp())
+                            if request.end_time
+                            else 2**31 - 1
+                        ),
+                        limit=request.limit or 100,
+                        agent_version=request.agent_version,
+                    )
                 )
             else:
                 results = self._get_storage().get_agent_success_evaluation_results(

--- a/reflexio/models/api_schema/domain/enums.py
+++ b/reflexio/models/api_schema/domain/enums.py
@@ -46,6 +46,7 @@ class Status(str, Enum):  # noqa: UP042 - CURRENT=None is not compatible with St
     SUPERSEDED = (
         "superseded"  # tombstone: replaced by a new version (superseded_by set)
     )
+    EXPIRED = "expired"  # tombstone: TTL elapsed while active (see expiry reclamation)
 
 
 class OperationStatus(StrEnum):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -712,10 +712,15 @@ class ExpiryReclamationConfig(BaseModel):
     """Direct-delete reclamation of expired plain rows (non-audited).
 
     Independent of ``lineage_gc``: these rows carry no PII/audit/grace obligation,
-    so they are reclaimed whenever this is enabled even if tombstone GC is off.
+    so they can be reclaimed whenever this is enabled even if tombstone GC is off.
+
+    Opt-in by default (``enabled=False``) so operators control a staged rollout
+    of the direct-delete Class B sweeps and are not surprised by deletions on
+    upgrade.  ``lineage_gc.enabled`` (which defaults to True) is unaffected and
+    continues to drive the Class A profile-expiry and tombstone-GC paths.
     """
 
-    enabled: bool = True
+    enabled: bool = False
 
 
 class GovernanceRetentionConfig(BaseModel):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -708,6 +708,16 @@ class LineageGCConfig(BaseModel):
     poll_interval_seconds: int = Field(default=86400, gt=0)
 
 
+class ExpiryReclamationConfig(BaseModel):
+    """Direct-delete reclamation of expired plain rows (non-audited).
+
+    Independent of ``lineage_gc``: these rows carry no PII/audit/grace obligation,
+    so they are reclaimed whenever this is enabled even if tombstone GC is off.
+    """
+
+    enabled: bool = True
+
+
 class GovernanceRetentionConfig(BaseModel):
     """Audit-event retention policy. **Enterprise-only:** reclamation is performed
     by the reflexio_ext GovernanceRetentionCapability. In an OSS-only deployment
@@ -859,6 +869,10 @@ class Config(BaseModel):
     )
     # Tombstone GC job gate (opt-in, off by default — see LineageGCConfig)
     lineage_gc: LineageGCConfig = Field(default_factory=LineageGCConfig)
+    # Direct-delete reclamation of expired plain rows (share links, pending tool calls)
+    expiry_reclamation: ExpiryReclamationConfig = Field(
+        default_factory=ExpiryReclamationConfig
+    )
     governance_retention: GovernanceRetentionConfig = Field(
         default_factory=GovernanceRetentionConfig
     )
@@ -920,6 +934,7 @@ class Config(BaseModel):
                 "reflection_config",
                 "playbook_optimizer_config",
                 "lineage_gc",
+                "expiry_reclamation",
                 "governance_retention",
                 "pending_tool_call_config",
                 "retrieval_floor",

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -103,6 +103,21 @@ class LineageGCScheduler:
                 cfg = ctx.configurator.get_config()
                 if not cfg.lineage_gc.enabled:
                     continue
+                # Class A: tombstone TTL-expired active profiles so the existing
+                # tombstone GC can reclaim them after the grace window.
+                expired_tombstoned = ctx.storage.expire_active_profiles(
+                    now=int(time.time())
+                )
+                if expired_tombstoned:
+                    logger.info(
+                        "event=expiry_sweep org_id=%s profiles_tombstoned=%d",
+                        org_id, expired_tombstoned,
+                    )
+                if expired_tombstoned > _HIGH_VOLUME_THRESHOLD:
+                    capture_anomaly(
+                        "lineage.expiry_sweep.high_volume",
+                        org_id=org_id, count=expired_tombstoned,
+                    )
                 older_than_epoch = (
                     int(time.time())
                     - cfg.lineage_gc.tombstone_grace_window_days * 86400

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -124,7 +124,19 @@ class LineageGCScheduler:
         The bootstrap org is always unioned in either way.
         """
         if self.org_id_provider is not None:
-            org_ids = list(self.org_id_provider())
+            try:
+                org_ids = list(self.org_id_provider())
+            except Exception:
+                capture_anomaly(
+                    "lineage.gc.org_id_provider_failed",
+                    bootstrap_org_id=self.bootstrap_org_id,
+                )
+                logger.exception(
+                    "event=lineage_gc_org_id_provider_failed bootstrap_org_id=%s "
+                    "— falling back to bootstrap org only",
+                    self.bootstrap_org_id,
+                )
+                org_ids = []
         else:
             storage = getattr(bootstrap_ctx, "storage", None)
             org_ids = []

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -171,10 +171,15 @@ class LineageGCScheduler:
                 if ctx.storage is None:
                     continue
                 cfg = ctx.configurator.get_config()
+            except Exception:
+                capture_anomaly("lineage.gc.run_failed", org_id=org_id)
+                logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
+                continue
 
-                # Class A: profile expiry sweep + tombstone GC (requires PII/grace
-                # sign-off; gated on lineage_gc.enabled independently of Class B).
-                if cfg.lineage_gc.enabled:
+            # Class A: profile expiry sweep (requires PII/grace sign-off; gated on
+            # lineage_gc.enabled independently of Class B).
+            if cfg.lineage_gc.enabled:
+                try:
                     expired_tombstoned = ctx.storage.expire_active_profiles(
                         now=int(time.time())
                     )
@@ -190,6 +195,14 @@ class LineageGCScheduler:
                             org_id=org_id,
                             count=expired_tombstoned,
                         )
+                except Exception:
+                    capture_anomaly("lineage.expiry_sweep.failed", org_id=org_id)
+                    logger.exception(
+                        "event=lineage_expiry_sweep_failed org_id=%s", org_id
+                    )
+
+                # Tombstone GC: each entity type is independent within the loop.
+                try:
                     older_than_epoch = (
                         int(time.time())
                         - cfg.lineage_gc.tombstone_grace_window_days * 86400
@@ -212,18 +225,25 @@ class LineageGCScheduler:
                             org_id=org_id,
                             count=tombstone_deleted,
                         )
+                except Exception:
+                    capture_anomaly("lineage.gc.tombstone_gc_failed", org_id=org_id)
+                    logger.exception(
+                        "event=lineage_gc_tombstone_gc_failed org_id=%s", org_id
+                    )
 
-                # Class B: direct-delete of expired plain rows (no audit/grace
-                # obligation; independent of lineage_gc).
-                if (
-                    getattr(cfg, "expiry_reclamation", None) is not None
-                    and cfg.expiry_reclamation.enabled
-                ):
-                    now = int(time.time())
-                    for method_name, grace, limit in _CLASS_B_SWEEPS:
-                        method = getattr(ctx.storage, method_name, None)
-                        if method is None:
-                            continue
+            # Class B: direct-delete of expired plain rows (no audit/grace
+            # obligation; independent of lineage_gc).  Each sweep is isolated so
+            # one failing method does not skip the rest.
+            if (
+                getattr(cfg, "expiry_reclamation", None) is not None
+                and cfg.expiry_reclamation.enabled
+            ):
+                now = int(time.time())
+                for method_name, grace, limit in _CLASS_B_SWEEPS:
+                    method = getattr(ctx.storage, method_name, None)
+                    if method is None:
+                        continue
+                    try:
                         deleted = method(now=now, grace_seconds=grace, limit=limit)
                         if deleted:
                             logger.info(
@@ -232,9 +252,17 @@ class LineageGCScheduler:
                                 method_name,
                                 deleted,
                             )
-            except Exception:
-                capture_anomaly("lineage.gc.run_failed", org_id=org_id)
-                logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
+                    except Exception:
+                        capture_anomaly(
+                            "lineage.class_b_reclaim.failed",
+                            org_id=org_id,
+                            method=method_name,
+                        )
+                        logger.exception(
+                            "event=class_b_reclaim_failed org_id=%s method=%s",
+                            org_id,
+                            method_name,
+                        )
 
     def _run_loop(self) -> None:
         while not self._stop_event.is_set():

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -30,6 +30,14 @@ _HIGH_VOLUME_THRESHOLD = 1000
 
 _ENTITY_TYPES = ("user_playbook", "agent_playbook", "profile")
 
+# Class B: direct-delete sweeps for expired plain rows (no PII/audit obligation).
+# Each entry is (storage_method_name, grace_seconds, batch_limit).
+# Methods added in Tasks 2.2 / 2.3; getattr-guarded so missing impls are skipped.
+_CLASS_B_SWEEPS: tuple[tuple[str, int, int], ...] = (
+    ("delete_expired_share_links", 7 * 86400, 1000),
+    ("delete_expired_pending_tool_calls", 1 * 86400, 1000),
+)
+
 
 class LineageGCScheduler:
     """Polling daemon that hard-deletes expired tombstones per org."""
@@ -101,45 +109,67 @@ class LineageGCScheduler:
                 if ctx.storage is None:
                     continue
                 cfg = ctx.configurator.get_config()
-                if not cfg.lineage_gc.enabled:
-                    continue
-                # Class A: tombstone TTL-expired active profiles so the existing
-                # tombstone GC can reclaim them after the grace window.
-                expired_tombstoned = ctx.storage.expire_active_profiles(
-                    now=int(time.time())
-                )
-                if expired_tombstoned:
-                    logger.info(
-                        "event=expiry_sweep org_id=%s profiles_tombstoned=%d",
-                        org_id, expired_tombstoned,
+
+                # Class A: profile expiry sweep + tombstone GC (requires PII/grace
+                # sign-off; gated on lineage_gc.enabled independently of Class B).
+                if cfg.lineage_gc.enabled:
+                    expired_tombstoned = ctx.storage.expire_active_profiles(
+                        now=int(time.time())
                     )
-                if expired_tombstoned > _HIGH_VOLUME_THRESHOLD:
-                    capture_anomaly(
-                        "lineage.expiry_sweep.high_volume",
-                        org_id=org_id, count=expired_tombstoned,
+                    if expired_tombstoned:
+                        logger.info(
+                            "event=expiry_sweep org_id=%s profiles_tombstoned=%d",
+                            org_id,
+                            expired_tombstoned,
+                        )
+                    if expired_tombstoned > _HIGH_VOLUME_THRESHOLD:
+                        capture_anomaly(
+                            "lineage.expiry_sweep.high_volume",
+                            org_id=org_id,
+                            count=expired_tombstoned,
+                        )
+                    older_than_epoch = (
+                        int(time.time())
+                        - cfg.lineage_gc.tombstone_grace_window_days * 86400
                     )
-                older_than_epoch = (
-                    int(time.time())
-                    - cfg.lineage_gc.tombstone_grace_window_days * 86400
-                )
-                tombstone_deleted = 0
-                for entity_type in _ENTITY_TYPES:
-                    tombstone_deleted += ctx.storage.gc_expired_tombstones(
-                        entity_type=entity_type,
-                        older_than_epoch=older_than_epoch,
-                    )
-                if tombstone_deleted:
-                    logger.info(
-                        "event=lineage_gc_tick org_id=%s tombstone_deleted=%d",
-                        org_id,
-                        tombstone_deleted,
-                    )
-                if tombstone_deleted > _HIGH_VOLUME_THRESHOLD:
-                    capture_anomaly(
-                        "lineage.gc.high_volume",
-                        org_id=org_id,
-                        count=tombstone_deleted,
-                    )
+                    tombstone_deleted = 0
+                    for entity_type in _ENTITY_TYPES:
+                        tombstone_deleted += ctx.storage.gc_expired_tombstones(
+                            entity_type=entity_type,
+                            older_than_epoch=older_than_epoch,
+                        )
+                    if tombstone_deleted:
+                        logger.info(
+                            "event=lineage_gc_tick org_id=%s tombstone_deleted=%d",
+                            org_id,
+                            tombstone_deleted,
+                        )
+                    if tombstone_deleted > _HIGH_VOLUME_THRESHOLD:
+                        capture_anomaly(
+                            "lineage.gc.high_volume",
+                            org_id=org_id,
+                            count=tombstone_deleted,
+                        )
+
+                # Class B: direct-delete of expired plain rows (no audit/grace
+                # obligation; independent of lineage_gc).
+                if (
+                    getattr(cfg, "expiry_reclamation", None) is not None
+                    and cfg.expiry_reclamation.enabled
+                ):
+                    now = int(time.time())
+                    for method_name, grace, limit in _CLASS_B_SWEEPS:
+                        method = getattr(ctx.storage, method_name, None)
+                        if method is None:
+                            continue
+                        deleted = method(now=now, grace_seconds=grace, limit=limit)
+                        if deleted:
+                            logger.info(
+                                "event=class_b_reclaim org_id=%s method=%s deleted=%d",
+                                org_id,
+                                method_name,
+                                deleted,
+                            )
             except Exception:
                 capture_anomaly("lineage.gc.run_failed", org_id=org_id)
                 logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
@@ -216,7 +246,10 @@ def maybe_start_lineage_gc(
                 "and will NOT run here."
             )
 
-        if not cfg.lineage_gc.enabled:
+        expiry_reclamation_enabled = getattr(
+            getattr(cfg, "expiry_reclamation", None), "enabled", False
+        )
+        if not (cfg.lineage_gc.enabled or expiry_reclamation_enabled):
             return None
     except Exception as exc:
         logger.warning(

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -48,6 +48,28 @@ _CLASS_B_SWEEPS: tuple[tuple[str, int, int], ...] = (
     ("delete_expired_pending_tool_calls", 1 * 86400, 1000),
 )
 
+# Injection seam: a deployment (e.g. enterprise/managed) sets a tenant-enumerating
+# provider here at startup so the single OSS-started scheduler sweeps ALL tenant
+# orgs. maybe_start_lineage_gc reads this when no explicit provider is passed.
+# None (OSS default) keeps behavior byte-for-byte identical to before.
+_org_id_provider_hook: Callable[[], list[str]] | None = None
+
+
+def set_org_id_provider(provider: Callable[[], list[str]] | None) -> None:
+    """Register the org-id provider consulted by ``maybe_start_lineage_gc``.
+
+    Managed multi-tenant deployments call this at app-construction time so the
+    lineage GC / expiry sweep reaches every tenant org (``storage.list_org_ids()``
+    raises ``NotImplementedError`` on Supabase, degrading to bootstrap-only).
+    Pass ``None`` to clear the hook (used by tests to restore OSS defaults).
+
+    Args:
+        provider (Callable[[], list[str]] | None): Callable returning the tenant
+            org ids to sweep, or ``None`` to clear.
+    """
+    global _org_id_provider_hook  # noqa: PLW0603
+    _org_id_provider_hook = provider
+
 
 class LineageGCScheduler:
     """Polling daemon that hard-deletes expired tombstones per org."""
@@ -57,9 +79,17 @@ class LineageGCScheduler:
         *,
         request_context_factory: Callable[[str], RequestContext],
         bootstrap_org_id: str,
+        org_id_provider: Callable[[], list[str]] | None = None,
     ) -> None:
         self.request_context_factory = request_context_factory
         self.bootstrap_org_id = bootstrap_org_id
+        # Optional injectable org-id source. When set (managed/multi-tenant mode),
+        # it is the authoritative enumeration seam; enterprise supplies a
+        # provider that lists tenant orgs via the control-plane repository — the
+        # only seam that surfaces managed tenants where storage.list_org_ids()
+        # raises NotImplementedError on Supabase. When None (OSS default),
+        # discovery falls back to storage.list_org_ids() exactly as before.
+        self.org_id_provider = org_id_provider
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -85,20 +115,30 @@ class LineageGCScheduler:
         logger.info("event=lineage_gc_scheduler_stopped")
 
     def _discover_org_ids(self, bootstrap_ctx: RequestContext) -> list[str]:
-        """Return every known org, always including the bootstrap org."""
-        storage = getattr(bootstrap_ctx, "storage", None)
-        org_ids: list[str] = []
-        if storage is not None:
-            try:
-                org_ids = storage.list_org_ids()
-            except NotImplementedError:
-                logger.warning(
-                    "event=lineage_gc_list_org_ids_not_implemented "
-                    "backend=%s bootstrap_org_id=%s — GC will only process bootstrap org",
-                    type(storage).__name__,
-                    bootstrap_ctx.org_id,
-                )
-                org_ids = []
+        """Return every known org, always including the bootstrap org.
+
+        When an ``org_id_provider`` was injected (managed/multi-tenant mode), it
+        is the authoritative org-id source and ``storage.list_org_ids()`` is not
+        consulted. Otherwise the OSS single-tenant path is used unchanged
+        (``storage.list_org_ids()`` with a visible NotImplementedError fallback).
+        The bootstrap org is always unioned in either way.
+        """
+        if self.org_id_provider is not None:
+            org_ids = list(self.org_id_provider())
+        else:
+            storage = getattr(bootstrap_ctx, "storage", None)
+            org_ids = []
+            if storage is not None:
+                try:
+                    org_ids = storage.list_org_ids()
+                except NotImplementedError:
+                    logger.warning(
+                        "event=lineage_gc_list_org_ids_not_implemented "
+                        "backend=%s bootstrap_org_id=%s — GC will only process bootstrap org",
+                        type(storage).__name__,
+                        bootstrap_ctx.org_id,
+                    )
+                    org_ids = []
         if bootstrap_ctx.org_id not in org_ids:
             org_ids = [bootstrap_ctx.org_id, *org_ids]
         return org_ids
@@ -202,6 +242,7 @@ def maybe_start_lineage_gc(
     request_context_factory: Callable[[str], RequestContext],
     *,
     bootstrap_org_id: str,
+    org_id_provider: Callable[[], list[str]] | None = None,
 ) -> LineageGCScheduler | None:
     """Start the scheduler when bootstrap config enables tombstone GC or expiry reclamation.
 
@@ -232,6 +273,10 @@ def maybe_start_lineage_gc(
     Args:
         request_context_factory: Builds an org-scoped :class:`RequestContext`.
         bootstrap_org_id: Org used to read config and seed cross-org discovery.
+        org_id_provider: Optional tenant-enumerating org-id source. When ``None``
+            (OSS default), falls back to the module-level provider hook set via
+            :func:`set_org_id_provider`; when both are ``None`` discovery uses
+            ``storage.list_org_ids()`` exactly as before.
 
     Returns:
         LineageGCScheduler: The started scheduler, or ``None`` if neither flag is set.
@@ -279,6 +324,9 @@ def maybe_start_lineage_gc(
     scheduler = LineageGCScheduler(
         request_context_factory=request_context_factory,
         bootstrap_org_id=bootstrap_org_id,
+        org_id_provider=(
+            org_id_provider if org_id_provider is not None else _org_id_provider_hook
+        ),
     )
     scheduler.start()
     return scheduler

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -1,9 +1,19 @@
-"""Process-local scheduler for lineage tombstone garbage collection.
+"""Process-local scheduler for lineage tombstone garbage collection and expiry reclamation.
 
-Startup is gated on ``lineage_gc.enabled`` (default on). Each tick evaluates
-every org independently and hard-deletes expired tombstones per that org's
-``lineage_gc`` config. One org's failure never stalls the loop; errors are
-captured as Sentry anomalies and the loop continues to the next org.
+Startup runs when EITHER ``lineage_gc.enabled`` OR ``expiry_reclamation.enabled``
+is set in the bootstrap org's config. Each tick evaluates every org independently.
+
+- **Class A** (profile expiry sweep + tombstone GC): gated on ``lineage_gc.enabled``.
+  Hard-deletes expired tombstones per that org's ``lineage_gc`` config.
+- **Class B** (plain-row direct-delete sweeps, no PII/audit obligation): gated on
+  ``expiry_reclamation.enabled``. Currently sweeps expired share links and expired
+  pending tool calls.
+
+One org's failure never stalls the loop; errors are captured as Sentry anomalies
+and the loop continues to the next org.
+
+Note: the poll interval is always taken from ``lineage_gc.poll_interval_seconds``
+even when only ``expiry_reclamation`` is enabled; Class B currently shares that cadence.
 
 Governance-retention reclamation is a premium concern handled by the enterprise
 GovernanceRetentionCapability (reflexio_ext), not here.
@@ -193,11 +203,15 @@ def maybe_start_lineage_gc(
     *,
     bootstrap_org_id: str,
 ) -> LineageGCScheduler | None:
-    """Start the scheduler only when bootstrap config enables tombstone GC.
+    """Start the scheduler when bootstrap config enables tombstone GC or expiry reclamation.
 
-    Startup requires bootstrap-org config to enable tombstone GC via
-    ``lineage_gc.enabled``. Tombstone-GC enablement criteria (must
-    ALL hold before enabling for a production org):
+    Startup runs when bootstrap-org config sets EITHER ``lineage_gc.enabled``
+    (Class A: profile expiry + tombstone GC) OR ``expiry_reclamation.enabled``
+    (Class B: plain-row direct-delete sweeps). Returns ``None`` if neither flag
+    is set.
+
+    Tombstone-GC enablement criteria (must ALL hold before enabling ``lineage_gc``
+    for a production org):
 
     1. **Mechanism**: GC ages tombstones by ``retired_at`` (the INTEGER epoch
        written at every tombstone write-path).  Rows with ``retired_at = NULL``
@@ -212,12 +226,15 @@ def maybe_start_lineage_gc(
     4. **DPO sign-off**: obtain sign-off on the PII-lifetime and audit-depth
        implications before enabling in any deployment that processes personal data.
 
+    Note: the poll cadence is always controlled by ``lineage_gc.poll_interval_seconds``
+    even when only ``expiry_reclamation`` is enabled; Class B shares that interval.
+
     Args:
         request_context_factory: Builds an org-scoped :class:`RequestContext`.
         bootstrap_org_id: Org used to read config and seed cross-org discovery.
 
     Returns:
-        LineageGCScheduler: The started scheduler, or ``None`` if not enabled.
+        LineageGCScheduler: The started scheduler, or ``None`` if neither flag is set.
     """
     try:
         ctx = request_context_factory(bootstrap_org_id)

--- a/reflexio/server/services/storage/sqlite_storage/_agent_run.py
+++ b/reflexio/server/services/storage/sqlite_storage/_agent_run.py
@@ -715,9 +715,9 @@ class SQLiteAgentRunMixin:
             try:
                 rows = self.conn.execute(
                     "SELECT id FROM _pending_tool_calls "
-                    "WHERE status = 'expired' AND expires_at IS NOT NULL AND expires_at < ? "
+                    "WHERE org_id = ? AND status = 'expired' AND expires_at IS NOT NULL AND expires_at < ? "
                     "ORDER BY expires_at ASC LIMIT ?",
-                    (cutoff_iso, bounded_limit),
+                    (self.org_id, cutoff_iso, bounded_limit),
                 ).fetchall()
                 if not rows:
                     self.conn.commit()

--- a/reflexio/server/services/storage/sqlite_storage/_agent_run.py
+++ b/reflexio/server/services/storage/sqlite_storage/_agent_run.py
@@ -691,6 +691,49 @@ class SQLiteAgentRunMixin:
         return len(call_ids)
 
     @SQLiteStorageBase.handle_exceptions
+    def delete_expired_pending_tool_calls(
+        self, *, now: int, grace_seconds: int, limit: int = 1000
+    ) -> int:
+        """Delete terminal 'expired'-status rows whose expires_at is past the grace window.
+
+        Only rows with status='expired' are deleted. RESOLVED rows are never
+        touched even if their expires_at is in the past, preserving live cached
+        results for resumable extraction.
+
+        Args:
+            now: Current Unix epoch seconds.
+            grace_seconds: Grace buffer; cutoff = now - grace_seconds.
+            limit: Max rows to delete per call.
+
+        Returns:
+            Number of rows deleted.
+        """
+        cutoff_iso = datetime.fromtimestamp(now - grace_seconds, UTC).isoformat()
+        bounded_limit = max(1, min(limit, 10_000))
+        with self._lock:
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                rows = self.conn.execute(
+                    "SELECT id FROM _pending_tool_calls "
+                    "WHERE status = 'expired' AND expires_at IS NOT NULL AND expires_at < ? "
+                    "ORDER BY expires_at ASC LIMIT ?",
+                    (cutoff_iso, bounded_limit),
+                ).fetchall()
+                if not rows:
+                    self.conn.commit()
+                    return 0
+                ids = [r["id"] for r in rows]
+                ph = ",".join("?" * len(ids))
+                cur = self.conn.execute(
+                    f"DELETE FROM _pending_tool_calls WHERE id IN ({ph})", ids
+                )
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+        return cur.rowcount
+
+    @SQLiteStorageBase.handle_exceptions
     def find_active_pending_tool_call(
         self,
         *,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -288,6 +288,15 @@ def _true_rrf_merge(
 # explicit status_filter on list/count methods.
 _TOMBSTONE_STATUS_VALUES = (Status.MERGED.value, Status.SUPERSEDED.value)
 
+# Profile reads also treat EXPIRED (TTL-expired tombstone) as non-current. Kept
+# separate from _TOMBSTONE_STATUS_VALUES because that tuple is shared with playbook
+# queries (which never carry EXPIRED) via hardcoded placeholders.
+_PROFILE_TOMBSTONE_STATUS_VALUES = (
+    Status.MERGED.value,
+    Status.SUPERSEDED.value,
+    Status.EXPIRED.value,
+)
+
 
 def _parse_status(value: str | None) -> Status | None:
     """Parse a stored status string into a Status, tolerating unknown values.

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -289,6 +289,33 @@ def _true_rrf_merge(
 _TOMBSTONE_STATUS_VALUES = (Status.MERGED.value, Status.SUPERSEDED.value)
 
 
+def _parse_status(value: str | None) -> Status | None:
+    """Parse a stored status string into a Status, tolerating unknown values.
+
+    Unknown non-null values (e.g. a status written by a newer build after a
+    rollback) map to a non-current tombstone sentinel and log an anomaly, rather
+    than raising ValueError. Never maps to None (which models CURRENT/live).
+
+    Args:
+        value: Raw status string from the database, or None/empty for CURRENT.
+
+    Returns:
+        The matching Status enum member, Status.SUPERSEDED for unknown values,
+        or None for falsy input (representing the CURRENT/live state).
+    """
+    if not value:
+        return None
+    try:
+        return Status(value)
+    except ValueError:
+        from reflexio.server.tracing import capture_anomaly
+
+        capture_anomaly(
+            "storage.status.unknown_value", level="warning", status_value=value
+        )
+        return Status.SUPERSEDED
+
+
 def _status_value(status: Status | None) -> str | None:
     """Convert a Status enum (or None) to its DB string value."""
     if status is None:
@@ -392,7 +419,7 @@ def _row_to_profile(row: sqlite3.Row) -> UserProfile:
         expiration_timestamp=d["expiration_timestamp"],
         custom_features=_json_loads(d.get("custom_features")),
         source=d.get("source") or "",
-        status=Status(d["status"]) if d.get("status") else None,
+        status=_parse_status(d.get("status")),
         extractor_names=_json_loads(d.get("extractor_names")),
         expanded_terms=d.get("expanded_terms"),
         source_span=d.get("source_span"),
@@ -472,7 +499,7 @@ def _row_to_user_playbook(
         blocking_issue=BlockingIssue(**json.loads(d["blocking_issue"]))
         if d.get("blocking_issue")
         else None,
-        status=Status(d["status"]) if d.get("status") else None,
+        status=_parse_status(d.get("status")),
         source=d.get("source"),
         source_interaction_ids=_json_loads(d.get("source_interaction_ids")) or [],
         tags=_json_loads(d.get("tags")),
@@ -505,7 +532,7 @@ def _row_to_agent_playbook(row: sqlite3.Row) -> AgentPlaybook:
         playbook_metadata=d.get("playbook_metadata") or "",
         tags=_json_loads(d.get("tags")),
         embedding=[],
-        status=Status(d["status"]) if d.get("status") else None,
+        status=_parse_status(d.get("status")),
         expanded_terms=d.get("expanded_terms"),
         merged_into=d.get("merged_into"),
         superseded_by=d.get("superseded_by"),

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -17,7 +17,12 @@ EntityType = Literal["user_playbook", "agent_playbook", "profile"]
 # Also used as the merge guard: a source that already carries any of these
 # statuses is skipped (no re-tombstone, no clock reset).
 _GC_ELIGIBLE_STATUSES: frozenset[str] = frozenset(
-    {Status.MERGED.value, Status.SUPERSEDED.value, Status.ARCHIVED.value}
+    {
+        Status.MERGED.value,
+        Status.SUPERSEDED.value,
+        Status.ARCHIVED.value,
+        Status.EXPIRED.value,
+    }
 )
 
 # Mapping from entity_type string to (table_name, primary_key_column).

--- a/reflexio/server/services/storage/sqlite_storage/_share_links.py
+++ b/reflexio/server/services/storage/sqlite_storage/_share_links.py
@@ -164,3 +164,32 @@ class SQLiteShareLinkMixin:
             (self.org_id,),
         )
         return cur.rowcount
+
+    @SQLiteStorageBase.handle_exceptions
+    def delete_expired_share_links(
+        self, *, now: int, grace_seconds: int, limit: int = 1000
+    ) -> int:
+        """Physically delete share links whose expires_at < now - grace_seconds.
+
+        Args:
+            now (int): Current Unix epoch timestamp.
+            grace_seconds (int): Additional grace window; only rows with
+                expires_at < (now - grace_seconds) are deleted.
+            limit (int): Maximum number of rows to delete in one call.
+                Rows are processed in expires_at ASC order (oldest first).
+
+        Returns:
+            int: Number of rows physically deleted.
+        """
+        cutoff = now - grace_seconds
+        rows = self._fetchall(
+            "SELECT id FROM share_links WHERE org_id = ? AND expires_at IS NOT NULL "
+            "AND expires_at < ? ORDER BY expires_at ASC LIMIT ?",
+            (self.org_id, cutoff, limit),
+        )
+        if not rows:
+            return 0
+        ids = [r["id"] for r in rows]
+        ph = ",".join("?" * len(ids))
+        cur = self._execute(f"DELETE FROM share_links WHERE id IN ({ph})", ids)  # noqa: S608
+        return cur.rowcount

--- a/reflexio/server/services/storage/sqlite_storage/_share_links.py
+++ b/reflexio/server/services/storage/sqlite_storage/_share_links.py
@@ -182,14 +182,15 @@ class SQLiteShareLinkMixin:
             int: Number of rows physically deleted.
         """
         cutoff = now - grace_seconds
-        rows = self._fetchall(
-            "SELECT id FROM share_links WHERE org_id = ? AND expires_at IS NOT NULL "
-            "AND expires_at < ? ORDER BY expires_at ASC LIMIT ?",
+        # Re-assert the expiry condition inside the DELETE via a subquery so
+        # the predicate cannot race between the SELECT and the DELETE (TOCTOU).
+        # Matches the Supabase RPC sibling which re-asserts expires_at in a single
+        # atomic statement.
+        cur = self._execute(
+            "DELETE FROM share_links WHERE id IN ("
+            "  SELECT id FROM share_links WHERE org_id = ? AND expires_at IS NOT NULL"
+            "  AND expires_at < ? ORDER BY expires_at ASC LIMIT ?"
+            ")",
             (self.org_id, cutoff, limit),
         )
-        if not rows:
-            return 0
-        ids = [r["id"] for r in rows]
-        ph = ",".join("?" * len(ids))
-        cur = self._execute(f"DELETE FROM share_links WHERE id IN ({ph})", ids)  # noqa: S608
         return cur.rowcount

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -329,7 +329,8 @@ class AgentPlaybookStoreMixin:
     ) -> AgentPlaybook | None:
         sql = "SELECT * FROM agent_playbooks WHERE agent_playbook_id = ?"
         if not include_tombstones:
-            sql += " AND (status IS NULL OR status NOT IN (?, ?, ?))"
+            _ph = ",".join("?" * len(_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES))
+            sql += f" AND (status IS NULL OR status NOT IN ({_ph}))"
             row = self._fetchone(
                 sql,
                 (agent_playbook_id, *_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES),
@@ -689,10 +690,11 @@ class AgentPlaybookStoreMixin:
                 # would require adding playbook_status to the SELECT. The UPDATE WHERE
                 # clause already excludes those rows atomically; the extra continue here
                 # would be a no-op and not worth the added complexity.
+                _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
                 cur = self.conn.execute(
                     "UPDATE agent_playbooks SET status = ?, retired_at = ?"
                     " WHERE agent_playbook_id = ? AND playbook_status != ?"
-                    " AND (status IS NULL OR status NOT IN (?, ?))",
+                    f" AND (status IS NULL OR status NOT IN ({_ph}))",
                     (
                         Status.SUPERSEDED.value,
                         now_ts,
@@ -882,7 +884,8 @@ class AgentPlaybookStoreMixin:
             conditions.append(frag)
             params.extend(sparams)
         else:
-            conditions.append("(ap.status IS NULL OR ap.status NOT IN (?, ?, ?))")
+            _ph = ",".join("?" * len(_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES))
+            conditions.append(f"(ap.status IS NULL OR ap.status NOT IN ({_ph}))")
             params.extend(_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES)
         tag_frag, tag_params = _build_tags_sql("ap", request.tags)
         if tag_frag:

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -230,7 +230,8 @@ class UserPlaybookStoreMixin:
             params.extend(sparams)
         else:
             # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
-            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
+            sql += f" AND (status IS NULL OR status NOT IN ({_ph}))"
             params.extend(_TOMBSTONE_STATUS_VALUES)
         tag_frag, tag_params = _build_tags_sql("user_playbooks", tags)
         if tag_frag:
@@ -274,7 +275,8 @@ class UserPlaybookStoreMixin:
             params.extend(sparams)
         else:
             # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
-            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
+            sql += f" AND (status IS NULL OR status NOT IN ({_ph}))"
             params.extend(_TOMBSTONE_STATUS_VALUES)
 
         row = self._fetchone(sql, params)
@@ -282,11 +284,12 @@ class UserPlaybookStoreMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def count_user_playbooks_by_session(self, session_id: str) -> int:
+        _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
         row = self._fetchone(
-            """SELECT COUNT(*) as cnt FROM user_playbooks up
+            f"""SELECT COUNT(*) as cnt FROM user_playbooks up
                JOIN requests r ON up.request_id = r.request_id
                WHERE r.session_id = ?
-                 AND (up.status IS NULL OR up.status NOT IN (?, ?))""",
+                 AND (up.status IS NULL OR up.status NOT IN ({_ph}))""",  # noqa: S608
             (session_id, *_TOMBSTONE_STATUS_VALUES),
         )
         return row["cnt"] if row else 0
@@ -620,7 +623,8 @@ class UserPlaybookStoreMixin:
             params.extend(sparams)
         else:
             # Default: exclude tombstone statuses (MERGED/SUPERSEDED)
-            conditions.append("(up.status IS NULL OR up.status NOT IN (?, ?))")
+            _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
+            conditions.append(f"(up.status IS NULL OR up.status NOT IN ({_ph}))")
             params.extend(_TOMBSTONE_STATUS_VALUES)
         tag_frag, tag_params = _build_tags_sql("up", request.tags)
         if tag_frag:
@@ -695,7 +699,8 @@ class UserPlaybookStoreMixin:
     ) -> UserPlaybook | None:
         sql = "SELECT * FROM user_playbooks WHERE user_playbook_id = ?"
         if not include_tombstones:
-            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
+            _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
+            sql += f" AND (status IS NULL OR status NOT IN ({_ph}))"
             row = self._fetchone(sql, (user_playbook_id, *_TOMBSTONE_STATUS_VALUES))
         else:
             row = self._fetchone(sql, (user_playbook_id,))
@@ -814,10 +819,11 @@ class UserPlaybookStoreMixin:
                     self._subject_ref_from_user_playbook_row(row)
                 )
                 old_status = row["status"]
+                _ph = ",".join("?" * len(_TOMBSTONE_STATUS_VALUES))
                 cur = self.conn.execute(
                     "UPDATE user_playbooks SET status = ?, retired_at = ?"
                     " WHERE user_playbook_id = ?"
-                    " AND (status IS NULL OR status NOT IN (?, ?))",
+                    f" AND (status IS NULL OR status NOT IN ({_ph}))",
                     (
                         Status.SUPERSEDED.value,
                         now_ts,

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
@@ -558,44 +558,56 @@ class ProfileStoreMixin:
             return 0
         batch_request_id = uuid.uuid4().hex
         with self._lock:
-            affected = list(
-                self.conn.execute(
-                    "SELECT profile_id, user_id, governance_subject_ref FROM profiles "
-                    "WHERE status IS NULL AND expiration_timestamp < ? "
-                    "ORDER BY expiration_timestamp ASC LIMIT ?",
-                    (now, limit),
-                ).fetchall()
-            )
-            if not affected:
-                return 0
-            for row in affected:
-                self._assert_subject_writable_locked(
-                    self._subject_ref_from_profile_row(row)
+            # BEGIN IMMEDIATE acquires a write lock immediately so no other
+            # connection can write between the SELECT and the UPDATE.  This
+            # ensures the affected-id list == the actually-updated set, making
+            # the emitted status_change events correct.  Matches the pattern
+            # used by expire_pending_tool_calls in sqlite_storage/_agent_run.py.
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                affected = list(
+                    self.conn.execute(
+                        "SELECT profile_id, user_id, governance_subject_ref FROM profiles "
+                        "WHERE status IS NULL AND expiration_timestamp < ? "
+                        "ORDER BY expiration_timestamp ASC LIMIT ?",
+                        (now, limit),
+                    ).fetchall()
                 )
-            ids = [r["profile_id"] for r in affected]
-            ph = ",".join("?" * len(ids))
-            cur = self.conn.execute(
-                f"UPDATE profiles SET status = ?, retired_at = ?, last_modified_timestamp = ? "  # noqa: S608
-                f"WHERE profile_id IN ({ph}) AND status IS NULL",
-                [Status.EXPIRED.value, now, now, *ids],
-            )
-            for row in affected:
-                _append_event_stmt(
-                    self.conn,
-                    org_id=self.org_id,
-                    entity_type="profile",
-                    entity_id=str(row["profile_id"]),
-                    op="status_change",
-                    prov="wasInvalidatedBy",
-                    source_ids=[],
-                    actor="system",
-                    request_id=batch_request_id,
-                    reason="ttl-expired",
-                    from_status=None,
-                    to_status=Status.EXPIRED.value,
-                    status_namespace="lifecycle_status",
+                if not affected:
+                    self.conn.commit()
+                    return 0
+                for row in affected:
+                    self._assert_subject_writable_locked(
+                        self._subject_ref_from_profile_row(row)
+                    )
+                ids = [r["profile_id"] for r in affected]
+                ph = ",".join("?" * len(ids))
+                cur = self.conn.execute(
+                    f"UPDATE profiles SET status = ?, retired_at = ?, last_modified_timestamp = ? "  # noqa: S608
+                    f"WHERE profile_id IN ({ph}) AND status IS NULL",
+                    [Status.EXPIRED.value, now, now, *ids],
                 )
-            self.conn.commit()
+                for row in affected:
+                    _append_event_stmt(
+                        self.conn,
+                        org_id=self.org_id,
+                        entity_type="profile",
+                        entity_id=str(row["profile_id"]),
+                        op="status_change",
+                        prov="wasInvalidatedBy",
+                        source_ids=[],
+                        actor="system",
+                        request_id=batch_request_id,
+                        reason="ttl-expired",
+                        from_status=None,
+                        to_status=Status.EXPIRED.value,
+                        status_namespace="lifecycle_status",
+                    )
+            except Exception:
+                self.conn.rollback()
+                raise
+            else:
+                self.conn.commit()
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
@@ -18,7 +18,7 @@ from reflexio.models.api_schema.service_schemas import (
 )
 
 from .._base import (
-    _TOMBSTONE_STATUS_VALUES,
+    _PROFILE_TOMBSTONE_STATUS_VALUES,
     SQLiteStorageBase,
     _build_status_sql,
     _epoch_now,
@@ -167,13 +167,18 @@ class ProfileStoreMixin:
         profile_time_to_live: str | None = None,
         start_time: int | None = None,
         end_time: int | None = None,
+        include_expired: bool = False,
     ) -> list[UserProfile]:
         if status_filter is None:
             status_filter = [None]
-        current_ts = _epoch_now()
         frag, params = _build_status_sql(status_filter)
-        conditions = ["user_id = ?", "expiration_timestamp >= ?", frag]
-        all_params: list[Any] = [user_id, current_ts, *params]
+        conditions: list[str] = ["user_id = ?"]
+        all_params: list[Any] = [user_id]
+        if not include_expired:
+            conditions.append("expiration_timestamp >= ?")
+            all_params.append(_epoch_now())
+        conditions.append(frag)
+        all_params.extend(params)
         if profile_id:
             conditions.append("LOWER(profile_id) = LOWER(?)")
             all_params.append(profile_id)
@@ -538,6 +543,62 @@ class ProfileStoreMixin:
         return cur.rowcount
 
     @SQLiteStorageBase.handle_exceptions
+    def expire_active_profiles(self, *, now: int, limit: int = 1000) -> int:
+        """Tombstone active profiles whose TTL has elapsed.
+
+        Args:
+            now: Current epoch timestamp (seconds). Profiles with
+                ``expiration_timestamp < now`` are tombstoned.
+            limit: Maximum number of profiles to tombstone in one call (default 1000).
+
+        Returns:
+            int: Number of profiles tombstoned.
+        """
+        if limit <= 0:
+            return 0
+        batch_request_id = uuid.uuid4().hex
+        with self._lock:
+            affected = list(
+                self.conn.execute(
+                    "SELECT profile_id, user_id, governance_subject_ref FROM profiles "
+                    "WHERE status IS NULL AND expiration_timestamp < ? "
+                    "ORDER BY expiration_timestamp ASC LIMIT ?",
+                    (now, limit),
+                ).fetchall()
+            )
+            if not affected:
+                return 0
+            for row in affected:
+                self._assert_subject_writable_locked(
+                    self._subject_ref_from_profile_row(row)
+                )
+            ids = [r["profile_id"] for r in affected]
+            ph = ",".join("?" * len(ids))
+            cur = self.conn.execute(
+                f"UPDATE profiles SET status = ?, retired_at = ?, last_modified_timestamp = ? "  # noqa: S608
+                f"WHERE profile_id IN ({ph}) AND status IS NULL",
+                [Status.EXPIRED.value, now, now, *ids],
+            )
+            for row in affected:
+                _append_event_stmt(
+                    self.conn,
+                    org_id=self.org_id,
+                    entity_type="profile",
+                    entity_id=str(row["profile_id"]),
+                    op="status_change",
+                    prov="wasInvalidatedBy",
+                    source_ids=[],
+                    actor="system",
+                    request_id=batch_request_id,
+                    reason="ttl-expired",
+                    from_status=None,
+                    to_status=Status.EXPIRED.value,
+                    status_namespace="lifecycle_status",
+                )
+            self.conn.commit()
+        return cur.rowcount
+
+    @SQLiteStorageBase.handle_exceptions
     def get_profiles_by_ids(
         self,
         user_id: str,
@@ -567,7 +628,7 @@ class ProfileStoreMixin:
 
         Args:
             profile_id: The profile's primary key.
-            include_tombstones: When False (default), MERGED/SUPERSEDED profiles
+            include_tombstones: When False (default), MERGED/SUPERSEDED/EXPIRED profiles
                 return None. Set to True for lineage resolution (resolve_current).
 
         Returns:
@@ -575,8 +636,9 @@ class ProfileStoreMixin:
         """
         sql = "SELECT * FROM profiles WHERE profile_id = ?"
         if not include_tombstones:
-            sql += " AND (status IS NULL OR status NOT IN (?, ?))"
-            row = self._fetchone(sql, (profile_id, *_TOMBSTONE_STATUS_VALUES))
+            ph = ",".join("?" * len(_PROFILE_TOMBSTONE_STATUS_VALUES))
+            sql += f" AND (status IS NULL OR status NOT IN ({ph}))"
+            row = self._fetchone(sql, (profile_id, *_PROFILE_TOMBSTONE_STATUS_VALUES))
         else:
             row = self._fetchone(sql, (profile_id,))
         return _row_to_profile(row) if row else None

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -164,8 +164,8 @@ class BaseStorage(
         interaction_count = len(self.get_user_interaction(user_id))
 
         # All statuses a user's row can have — including tombstones (SUPERSEDED,
-        # MERGED). Erasure MUST reach every row the user owns regardless of
-        # status; the old filter excluded tombstones, leaving them in the DB
+        # MERGED, EXPIRED). Erasure MUST reach every row the user owns regardless
+        # of status; the old filter excluded tombstones, leaving them in the DB
         # after clear_user_data (GDPR regression).
         _all_statuses: list[Status | None] = [
             None,  # CURRENT
@@ -174,6 +174,7 @@ class BaseStorage(
             Status.ARCHIVE_IN_PROGRESS,
             Status.SUPERSEDED,
             Status.MERGED,
+            Status.EXPIRED,
         ]
 
         # Snapshot user_playbook ids for the user and partition into
@@ -192,10 +193,14 @@ class BaseStorage(
         )
 
         # Snapshot profile ids for the user and partition into
-        # purge vs delete sets.
+        # purge vs delete sets. include_expired=True drops the
+        # expiration_timestamp >= now guard so EXPIRED tombstones (expiry in
+        # the past) are enumerated and reached by the erasure path.
         raw_profile_ids = [
             p.profile_id
-            for p in self.get_user_profile(user_id, status_filter=_all_statuses)
+            for p in self.get_user_profile(
+                user_id, status_filter=_all_statuses, include_expired=True
+            )
             if p.profile_id is not None
         ]
         purge_profile_ids, delete_profile_ids = self._partition_purge_vs_delete(

--- a/reflexio/server/services/storage/storage_base/_agent_run.py
+++ b/reflexio/server/services/storage/storage_base/_agent_run.py
@@ -270,6 +270,36 @@ class AgentRunMixin:
     ) -> int:
         raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
 
+    def delete_expired_pending_tool_calls(
+        self,
+        *,
+        now: int,
+        grace_seconds: int,
+        limit: int = 1000,
+    ) -> int:
+        """Physically delete terminal 'expired'-status rows past the grace window.
+
+        Only rows with ``status = 'expired'`` (the terminal marker set by
+        ``expire_pending_tool_calls``) are candidates. RESOLVED rows are never
+        deleted — even if their ``expires_at`` is in the past — because their
+        ``valid_until`` may still be live and their cached result is needed by
+        resumable extraction resume paths.
+
+        The deletion cutoff is ``now - grace_seconds`` expressed as an ISO-8601
+        string (``expires_at`` is stored as TEXT/ISO in SQLite and as
+        ``timestamp with time zone`` in Postgres).
+
+        Args:
+            now: Current Unix epoch seconds.
+            grace_seconds: Extra TTL buffer; a row is only deleted if its
+                ``expires_at < datetime(now - grace_seconds)``.
+            limit: Maximum rows to delete in one call (default 1000).
+
+        Returns:
+            Number of rows actually deleted.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
+
     def find_active_pending_tool_call(
         self,
         *,

--- a/reflexio/server/services/storage/storage_base/_governance.py
+++ b/reflexio/server/services/storage/storage_base/_governance.py
@@ -128,9 +128,7 @@ class GovernanceMixin(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_subject_write_barrier(
-        self, subject_ref: str
-    ) -> SubjectWriteBarrier | None:
+    def get_subject_write_barrier(self, subject_ref: str) -> SubjectWriteBarrier | None:
         raise NotImplementedError
 
     @abstractmethod

--- a/reflexio/server/services/storage/storage_base/_share_links.py
+++ b/reflexio/server/services/storage/storage_base/_share_links.py
@@ -91,3 +91,23 @@ class ShareLinkMixin:
             int: Number of links deleted.
         """
         raise NotImplementedError
+
+    @abstractmethod
+    def delete_expired_share_links(
+        self, *, now: int, grace_seconds: int, limit: int = 1000
+    ) -> int:
+        """Physically delete share links whose expires_at < now - grace_seconds.
+
+        Rows where expires_at IS NULL (never expire) are always preserved.
+
+        Args:
+            now (int): Current Unix epoch timestamp.
+            grace_seconds (int): Additional grace window; only rows with
+                expires_at < (now - grace_seconds) are deleted.
+            limit (int): Maximum number of rows to delete in one call.
+                Rows are processed in expires_at ASC order (oldest first).
+
+        Returns:
+            int: Number of rows physically deleted.
+        """
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
@@ -37,7 +37,32 @@ class ProfileStoreMixin:
         profile_time_to_live: str | None = None,
         start_time: int | None = None,
         end_time: int | None = None,
+        include_expired: bool = False,
     ) -> list[UserProfile]:
+        """Return profiles for a user, optionally including expired rows.
+
+        Args:
+            user_id: The user whose profiles to return.
+            status_filter: Statuses to include (``None`` element = CURRENT).
+                Defaults to ``[None]`` (CURRENT only) when not supplied.
+            tags: If provided, only return profiles whose ``tags`` overlap.
+            profile_id: If provided, filter to this exact profile id.
+            query: Free-text substring match across content, profile_id, user_id.
+            source: If provided, filter to this exact source value.
+            profile_time_to_live: If provided, filter to this TTL value.
+            start_time: If provided, lower bound on last_modified_timestamp.
+            end_time: If provided, upper bound on last_modified_timestamp.
+            include_expired: When ``False`` (default), rows whose
+                ``expiration_timestamp`` is in the past are excluded
+                (byte-for-byte prior behaviour — every existing caller is
+                unaffected).  Pass ``True`` to omit the expiry filter so
+                EXPIRED tombstones (``expiration_timestamp < now``) are
+                returned.  Required by ``clear_user_data`` to reach every
+                profile a user owns regardless of TTL state.
+
+        Returns:
+            list[UserProfile]: Matching profiles in unspecified order.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
@@ -105,6 +105,24 @@ class ProfileStoreMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def expire_active_profiles(self, *, now: int, limit: int = 1000) -> int:
+        """Tombstone active profiles whose TTL has elapsed.
+
+        Selects ``status IS NULL AND expiration_timestamp < now`` and transitions
+        each to ``status=EXPIRED, retired_at=now``, emitting a ``status_change``
+        lineage event (reason ``ttl-expired``). Returns the number tombstoned.
+
+        Args:
+            now: Current epoch timestamp (seconds). Profiles with
+                ``expiration_timestamp < now`` are tombstoned.
+            limit: Maximum number of profiles to tombstone in one call (default 1000).
+
+        Returns:
+            int: Number of profiles tombstoned.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def get_profiles_by_ids(
         self,
         user_id: str,

--- a/tests/models/test_status_enum.py
+++ b/tests/models/test_status_enum.py
@@ -1,0 +1,6 @@
+from reflexio.models.api_schema.domain.enums import Status
+
+
+def test_expired_status_value():
+    assert Status.EXPIRED.value == "expired"
+    assert Status("expired") is Status.EXPIRED

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -28,6 +28,9 @@ def _make_storage(*, gc_return: int = 0) -> MagicMock:
     """Return a mock storage whose gc_expired_tombstones returns ``gc_return``."""
     storage = MagicMock()
     storage.gc_expired_tombstones.return_value = gc_return
+    # expire_active_profiles is now called at the start of each tick; default to 0
+    # so existing tests that don't exercise the sweep see a clean integer return.
+    storage.expire_active_profiles.return_value = 0
     return storage
 
 

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -288,6 +288,31 @@ def test_discover_org_ids_not_implemented_warns_and_falls_back_to_bootstrap(
     ), "Expected a warning with event=lineage_gc_list_org_ids_not_implemented"
 
 
+def test_discover_org_ids_provider_raises_falls_back_to_bootstrap():
+    """When org_id_provider raises, _discover_org_ids falls back to bootstrap-only.
+
+    Regression guard for Task 3.5 fix 1: a provider exception must NOT propagate
+    to _run_loop (which would skip the entire tick). The old NotImplementedError
+    fallback behaviour is restored — bootstrap is always swept.
+    """
+    bootstrap_ctx = _make_ctx("org_bootstrap", lineage_gc=LineageGCConfig(enabled=True))
+
+    def exploding_provider() -> list[str]:
+        raise RuntimeError("provider blown up")
+
+    sched = LineageGCScheduler(
+        request_context_factory=lambda _: bootstrap_ctx,  # type: ignore[arg-type]
+        bootstrap_org_id="org_bootstrap",
+        org_id_provider=exploding_provider,
+    )
+
+    # Must not raise — provider failure is isolated; bootstrap still included.
+    org_ids = sched._discover_org_ids(bootstrap_ctx)  # type: ignore[arg-type]
+    assert org_ids == ["org_bootstrap"], (
+        "bootstrap org must be present even when provider raises"
+    )
+
+
 # ---------------------------------------------------------------------------
 # list_org_ids — SQLite single-tenant implementation
 # ---------------------------------------------------------------------------

--- a/tests/server/services/lineage/test_gc_scheduler_expiry_integration.py
+++ b/tests/server/services/lineage/test_gc_scheduler_expiry_integration.py
@@ -1,0 +1,90 @@
+"""Integration test: _gc_tick tombstones TTL-expired active profiles (Task 1.4).
+
+Verifies that the expiry sweep step is wired into _gc_tick BEFORE the tombstone
+GC so that profiles past their TTL are tombstoned in the same tick that would
+then reclaim them (after the grace window).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.models.config_schema import LineageGCConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.lineage.gc_scheduler import LineageGCScheduler
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+_ORG_ID = "expiry_gc_test_org"
+
+
+@pytest.fixture()
+def org_id() -> str:
+    return _ORG_ID
+
+
+@pytest.fixture()
+def real_ctx_factory(tmp_path):
+    """Return a factory that builds a RequestContext over a real SQLiteStorage.
+
+    Config has lineage_gc.enabled=True and tombstone_grace_window_days=1 (minimum
+    valid value, gt=0 constraint) so the sweep tombstones expired profiles in the
+    tick while the GC step does not hard-delete them (retired_at=now is not older
+    than now-1day).
+    """
+    storage = SQLiteStorage(org_id=_ORG_ID, db_path=str(tmp_path / "gc_test.db"))
+    cfg = SimpleNamespace(
+        lineage_gc=LineageGCConfig(enabled=True, tombstone_grace_window_days=1)
+    )
+
+    def factory(org_id: str) -> RequestContext:
+        ctx = RequestContext.__new__(RequestContext)
+        ctx.org_id = org_id
+        ctx.storage = storage
+        ctx.storage_base_dir = None
+        configurator = MagicMock()
+        configurator.get_config.return_value = cfg
+        ctx.configurator = configurator
+        return ctx
+
+    return factory
+
+
+def test_tick_tombstones_then_gc_reclaims_expired(real_ctx_factory, org_id):
+    """_gc_tick must tombstone TTL-expired active profiles via expire_active_profiles
+    before running the tombstone GC step.
+
+    With a grace window of 1 day the freshly-tombstoned row is not yet eligible
+    for hard-deletion in the same tick, so the profile must be visible as status
+    EXPIRED via include_tombstones=True rather than hard-deleted.
+    """
+    ctx = real_ctx_factory(org_id)
+    # Seed an expired active profile (expiration_timestamp=100 << now).
+    ctx.storage.add_user_profile(
+        "u1",
+        [
+            UserProfile(
+                profile_id="e1",
+                user_id="u1",
+                content="c",
+                last_modified_timestamp=1,
+                generated_from_request_id="r1",
+                expiration_timestamp=100,
+            )
+        ],
+    )
+
+    sched = LineageGCScheduler(
+        request_context_factory=real_ctx_factory, bootstrap_org_id=org_id
+    )
+    sched._gc_tick([org_id])
+
+    row = ctx.storage.get_profile_by_id("e1", include_tombstones=True)
+    # Either hard-deleted (None) or tombstoned as EXPIRED — either satisfies the contract.
+    assert row is None or row.status == Status.EXPIRED

--- a/tests/server/services/lineage/test_gc_scheduler_expiry_integration.py
+++ b/tests/server/services/lineage/test_gc_scheduler_expiry_integration.py
@@ -86,5 +86,6 @@ def test_tick_tombstones_then_gc_reclaims_expired(real_ctx_factory, org_id):
     sched._gc_tick([org_id])
 
     row = ctx.storage.get_profile_by_id("e1", include_tombstones=True)
-    # Either hard-deleted (None) or tombstoned as EXPIRED — either satisfies the contract.
-    assert row is None or row.status == Status.EXPIRED
+    # The tombstone_grace_window_days=1 ensures a freshly-tombstoned row is NOT
+    # hard-deleted in the same tick.  The row must exist and be EXPIRED.
+    assert row is not None and row.status == Status.EXPIRED

--- a/tests/server/services/lineage/test_gc_scheduler_multitenant_integration.py
+++ b/tests/server/services/lineage/test_gc_scheduler_multitenant_integration.py
@@ -1,0 +1,264 @@
+"""Integration tests: managed-tenant reclamation via org_id_provider (Task 3.4).
+
+In managed multi-tenant mode ``storage.list_org_ids()`` raises
+``NotImplementedError`` on Supabase, so ``_discover_org_ids`` degrades to the
+bootstrap org only and tenant orgs' expired rows leak. Task 3.4 makes org
+discovery injectable: when an ``org_id_provider`` is supplied (the enterprise
+supplies a tenant-enumerating one), the profile expiry sweep (Class A) and the
+plain-row sweeps (Class B: share links + pending tool calls) reach EVERY tenant.
+
+These tests prove:
+1. Multi-tenant reclamation: with a provider returning two tenant orgs and a
+   per-org SQLite factory, one tick reclaims BOTH orgs' rows (not just bootstrap).
+2. The provider is actually consulted (the enterprise enumeration path), and
+   ``storage.list_org_ids()`` is NOT used when a provider is present.
+3. Per-org failure isolation still holds under the provider path.
+4. The default (no provider) path is unchanged: ``storage.list_org_ids()`` is used.
+5. ``maybe_start_lineage_gc`` picks up a module-level provider hook.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.config_schema import ExpiryReclamationConfig, LineageGCConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.lineage import gc_scheduler as gc_module
+from reflexio.server.services.lineage.gc_scheduler import (
+    LineageGCScheduler,
+    maybe_start_lineage_gc,
+    set_org_id_provider,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.storage_base import (
+    PendingToolCallRecord,
+    PendingToolCallStatus,
+    build_pending_tool_call_dedup_key,
+    build_scope_hash,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _both_enabled_config() -> SimpleNamespace:
+    """Config with Class A (lineage_gc) and Class B (expiry_reclamation) enabled."""
+    return SimpleNamespace(
+        lineage_gc=LineageGCConfig(enabled=True, tombstone_grace_window_days=1),
+        expiry_reclamation=ExpiryReclamationConfig(enabled=True),
+    )
+
+
+def _seed_org(storage: SQLiteStorage, org_id: str) -> str:
+    """Seed one org with a TTL-expired profile, expired share link, expired call.
+
+    Returns:
+        str: The profile_id seeded (for tombstone assertions).
+    """
+    profile_id = f"p_{org_id}"
+    storage.add_user_profile(
+        f"u_{org_id}",
+        [
+            UserProfile(
+                profile_id=profile_id,
+                user_id=f"u_{org_id}",
+                content="tenant profile",
+                last_modified_timestamp=1,
+                generated_from_request_id=f"r_{org_id}",
+                expiration_timestamp=100,  # far in the past → eligible for expiry sweep
+            )
+        ],
+    )
+    storage.create_share_link(
+        token=f"shr_{org_id}",
+        resource_type="profile",
+        resource_id=f"res_{org_id}",
+        expires_at=1,  # long expired
+        created_by_email=None,
+    )
+    now = datetime.now(UTC)
+    scope = {"org_id": org_id, "scope_kind": "org"}
+    storage.create_pending_tool_call(
+        PendingToolCallRecord(
+            id=f"call_{org_id}",
+            org_id=org_id,
+            scope=scope,
+            scope_hash=build_scope_hash(scope),
+            tool_name="ask_human",
+            dedup_key=build_pending_tool_call_dedup_key(
+                tool_name="ask_human", question_text=f"q_{org_id}"
+            ),
+            status=PendingToolCallStatus("expired"),
+            question_text=f"q_{org_id}",
+            expires_at=now - timedelta(days=2),  # past the 1-day Class B grace
+            cache_until=now - timedelta(days=2),
+        )
+    )
+    return profile_id
+
+
+def _assert_reclaimed(storage: SQLiteStorage, org_id: str, profile_id: str) -> None:
+    """Assert Class A + Class B reclaimed every seeded row for this org."""
+    row = storage.get_profile_by_id(profile_id, include_tombstones=True)
+    assert row is not None, f"{org_id}: profile row should still exist (tombstoned)"
+    assert row.status is not None, (
+        f"{org_id}: Class A must tombstone the TTL-expired active profile"
+    )
+    assert storage.get_share_links() == [], (
+        f"{org_id}: Class B must delete the expired share link"
+    )
+    assert storage.get_pending_tool_call(f"call_{org_id}") is None, (
+        f"{org_id}: Class B must delete the expired pending tool call"
+    )
+
+
+@pytest.fixture
+def multitenant(tmp_path):
+    """Two tenant orgs, each backed by its own SQLite storage + shared config."""
+    storages = {
+        org: SQLiteStorage(org_id=org, db_path=str(tmp_path / f"{org}.db"))
+        for org in ("org_a", "org_b")
+    }
+    profile_ids = {org: _seed_org(s, org) for org, s in storages.items()}
+    cfg = _both_enabled_config()
+
+    def factory(org_id: str) -> RequestContext:
+        ctx = RequestContext.__new__(RequestContext)
+        ctx.org_id = org_id
+        ctx.storage = storages[org_id]
+        ctx.storage_base_dir = None
+        configurator = MagicMock()
+        configurator.get_config.return_value = cfg
+        ctx.configurator = configurator
+        return ctx
+
+    return storages, profile_ids, factory
+
+
+def test_provider_sweeps_all_tenant_orgs(multitenant):
+    """With a provider returning both tenants, one tick reclaims BOTH orgs' rows."""
+    storages, profile_ids, factory = multitenant
+
+    provider_calls: list[int] = []
+
+    def provider() -> list[str]:
+        provider_calls.append(1)
+        return ["org_a", "org_b"]
+
+    sched = LineageGCScheduler(
+        request_context_factory=factory,
+        bootstrap_org_id="org_a",
+        org_id_provider=provider,
+    )
+
+    bootstrap_ctx = factory("org_a")
+    org_ids = sched._discover_org_ids(bootstrap_ctx)
+    assert provider_calls, "provider must be consulted (enterprise enumeration path)"
+    assert set(org_ids) == {"org_a", "org_b"}
+
+    sched._gc_tick(org_ids)
+
+    for org, storage in storages.items():
+        _assert_reclaimed(storage, org, profile_ids[org])
+
+
+def test_provider_short_circuits_storage_list_org_ids(multitenant):
+    """When a provider is set, storage.list_org_ids() is NOT consulted."""
+    storages, _profile_ids, factory = multitenant
+    # Make list_org_ids explode so any accidental use is caught.
+    for storage in storages.values():
+        storage.list_org_ids = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("list_org_ids must not be called with a provider")
+        )
+
+    sched = LineageGCScheduler(
+        request_context_factory=factory,
+        bootstrap_org_id="org_a",
+        org_id_provider=lambda: ["org_a", "org_b"],
+    )
+    org_ids = sched._discover_org_ids(factory("org_a"))
+    assert set(org_ids) == {"org_a", "org_b"}
+
+
+def test_provider_path_isolates_per_org_failure(tmp_path):
+    """One org raising in the tick does not stop the other org's reclamation."""
+    good = SQLiteStorage(org_id="org_good", db_path=str(tmp_path / "good.db"))
+    good_profile = _seed_org(good, "org_good")
+    cfg = _both_enabled_config()
+
+    def factory(org_id: str) -> RequestContext:
+        ctx = RequestContext.__new__(RequestContext)
+        ctx.org_id = org_id
+        if org_id == "org_bad":
+            ctx.storage = MagicMock()
+            ctx.storage.expire_active_profiles.side_effect = RuntimeError("boom")
+        else:
+            ctx.storage = good
+        ctx.storage_base_dir = None
+        configurator = MagicMock()
+        configurator.get_config.return_value = cfg
+        ctx.configurator = configurator
+        return ctx
+
+    sched = LineageGCScheduler(
+        request_context_factory=factory,
+        bootstrap_org_id="org_bad",
+        org_id_provider=lambda: ["org_bad", "org_good"],
+    )
+    # Must not raise — per-org failure is isolated.
+    sched._gc_tick(sched._discover_org_ids(factory("org_bad")))
+    _assert_reclaimed(good, "org_good", good_profile)
+
+
+def test_default_path_uses_storage_list_org_ids():
+    """Without a provider, _discover_org_ids consults storage.list_org_ids()."""
+    storage = MagicMock()
+    storage.list_org_ids.return_value = ["org_bootstrap", "org_tenant"]
+    bootstrap_ctx = RequestContext.__new__(RequestContext)
+    bootstrap_ctx.org_id = "org_bootstrap"
+    bootstrap_ctx.storage = storage
+
+    sched = LineageGCScheduler(
+        request_context_factory=lambda _org_id: bootstrap_ctx,
+        bootstrap_org_id="org_bootstrap",
+    )
+    assert sched.org_id_provider is None
+    org_ids = sched._discover_org_ids(bootstrap_ctx)
+    storage.list_org_ids.assert_called_once()
+    assert set(org_ids) == {"org_bootstrap", "org_tenant"}
+
+
+def test_maybe_start_lineage_gc_reads_module_provider_hook(tmp_path):
+    """maybe_start_lineage_gc picks up a provider set via set_org_id_provider."""
+    storage = SQLiteStorage(org_id="org_a", db_path=str(tmp_path / "hook.db"))
+    cfg = _both_enabled_config()
+
+    def factory(org_id: str) -> RequestContext:
+        ctx = RequestContext.__new__(RequestContext)
+        ctx.org_id = org_id
+        ctx.storage = storage
+        ctx.storage_base_dir = None
+        configurator = MagicMock()
+        configurator.get_config.return_value = SimpleNamespace(
+            lineage_gc=SimpleNamespace(
+                enabled=True, poll_interval_seconds=3600, tombstone_grace_window_days=1
+            ),
+            expiry_reclamation=cfg.expiry_reclamation,
+        )
+        ctx.configurator = configurator
+        return ctx
+
+    hook = lambda: ["org_a", "org_b"]  # noqa: E731
+    set_org_id_provider(hook)
+    try:
+        sched = maybe_start_lineage_gc(factory, bootstrap_org_id="org_a")  # type: ignore[arg-type]
+        assert sched is not None
+        assert sched.org_id_provider is hook
+        sched.stop(timeout_seconds=1.0)
+    finally:
+        set_org_id_provider(None)
+    assert gc_module._org_id_provider_hook is None

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -43,7 +43,9 @@ from reflexio.server.services.configurator.configurator import DefaultConfigurat
 pytestmark = pytest.mark.integration
 
 # Patch target for the expiry filter used inside get_user_profile
-_EPOCH_NOW_PATH = "reflexio.server.services.storage.sqlite_storage._profiles._epoch_now"
+_EPOCH_NOW_PATH = (
+    "reflexio.server.services.storage.sqlite_storage.profiles._profile_store._epoch_now"
+)
 
 
 @pytest.fixture()

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -23,12 +23,14 @@ Time control:
 
 from __future__ import annotations
 
+import pathlib
 from unittest.mock import patch
 
 import pytest
 
 from reflexio.lib.reflexio_lib import Reflexio
 from reflexio.models.api_schema.common import NEVER_EXPIRES_TIMESTAMP
+from reflexio.models.api_schema.domain.entities import UserProfile
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.service_schemas import InteractionData
 from reflexio.models.config_schema import (
@@ -45,7 +47,7 @@ _EPOCH_NOW_PATH = "reflexio.server.services.storage.sqlite_storage._profiles._ep
 
 
 @pytest.fixture()
-def reflexio_instance(tmp_path: pytest.TempPathFactory, worker_id: str) -> Reflexio:
+def reflexio_instance(tmp_path: pathlib.Path, worker_id: str) -> Reflexio:
     """Create a Reflexio instance with real SQLite storage and a profile-only config.
 
     ``stride_size=1`` ensures the extractor runs after a single published interaction
@@ -164,6 +166,10 @@ def test_ttl_expired_active_profile_is_physically_reclaimed(
     assert "status_change" in ops, (
         "Expected a status_change lineage event (reason=ttl-expired) from the sweep"
     )
+    sc_events = [e for e in events if e.op == "status_change"]
+    assert any(getattr(e, "reason", None) == "ttl-expired" for e in sc_events), (
+        "Expected a status_change event with reason='ttl-expired' from expire_active_profiles"
+    )
     assert "hard_delete" in ops, (
         "Expected a hard_delete lineage event from gc_expired_tombstones"
     )
@@ -215,6 +221,15 @@ def test_pre_fix_pathology_active_expired_is_not_gc_eligible_until_swept(
     assert raw.status is None, (
         "Profile status must be None (CURRENT) before the expiry sweep; "
         "it is NOT yet a tombstone"
+    )
+    # retired_at is storage-internal (not on the domain model) — read via direct SQL.
+    raw_retired_at = storage.conn.execute(
+        "SELECT retired_at FROM profiles WHERE profile_id = ?",
+        (profile.profile_id,),
+    ).fetchone()["retired_at"]
+    assert raw_retired_at is None, (
+        "Profile retired_at must be None before the expiry sweep; "
+        "the un-reclaimable state requires BOTH status None and retired_at None"
     )
 
     # GC without sweep skips it — status=None is not in the eligible set.
@@ -283,4 +298,33 @@ def test_expiry_sweep_does_not_break_concurrent_supersede(
     assert not supersede_events, (
         "No SUPERSEDED status_change event must be emitted after the sweep already "
         "tombstoned the profile to EXPIRED"
+    )
+
+    # -- Lineage-consistency check: the sweep must not break a concurrent survivor --
+    # Create a second profile as the survivor (NEVER_EXPIRES; not touched by the sweep).
+    survivor = UserProfile(
+        profile_id="survivor_profile_race_test",
+        user_id=profile.user_id,
+        content="survivor profile for race-consistency check",
+        last_modified_timestamp=profile.last_modified_timestamp + 1,
+        generated_from_request_id="race_test_survivor_req",
+        expiration_timestamp=NEVER_EXPIRES_TIMESTAMP,
+    )
+    storage.add_user_profile(profile.user_id, [survivor])
+
+    # A supersede call "in favor of" the survivor (source = the EXPIRED profile) must
+    # remain a no-op and must NOT corrupt the survivor.
+    storage.supersede_profiles_by_ids(
+        profile.user_id,
+        [profile.profile_id],
+        "race_test_request_id_survivor",
+    )
+
+    # The survivor must be resolvable after the no-op supersede on the EXPIRED source.
+    assert (
+        storage.get_profile_by_id(survivor.profile_id, include_tombstones=False)
+        is not None
+    ), (
+        "Survivor profile must remain resolvable (status=NULL) after a no-op "
+        "supersede_profiles_by_ids call on the already-EXPIRED source"
     )

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -1,0 +1,286 @@
+"""Integration tests: TTL-expiry reclamation regression guard (Task 1.6).
+
+Three tests guard the specific pathology where an active (status=NULL) profile
+whose ``expiration_timestamp`` has elapsed was invisible to both the read filter
+AND the tombstone GC — so it leaked indefinitely until the ``expire_active_profiles``
+sweep was added.
+
+Why integration (not e2e):
+    The e2e test conftest bypasses the global LLM mock so historical e2e tests can
+    hit real APIs.  Under ``tests/server/`` the global mock IS active (no paid key
+    needed).  The LLM mock returns ``time_to_live: "one_month"`` for every profile
+    extraction call, so ``calculate_expiration_timestamp`` runs in the real extractor
+    code-path and stores a non-NEVER expiration_timestamp — the real computation path
+    is exercised without any hand-crafted literal on the row.
+
+Time control:
+    ``expire_active_profiles`` and ``gc_expired_tombstones`` accept explicit ``now``
+    / ``older_than_epoch`` parameters, so we pass ``profile.expiration_timestamp + N``
+    to simulate being past expiry without touching the wall clock.  For the
+    ``get_user_profile`` read-filter assertion (which uses ``_epoch_now()`` internally)
+    we monkeypatch ``_epoch_now`` in the profiles module for the duration of the check.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.models.api_schema.common import NEVER_EXPIRES_TIMESTAMP
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.models.api_schema.service_schemas import InteractionData
+from reflexio.models.config_schema import (
+    Config,
+    ProfileExtractorConfig,
+    StorageConfigSQLite,
+)
+from reflexio.server.services.configurator.configurator import DefaultConfigurator
+
+pytestmark = pytest.mark.integration
+
+# Patch target for the expiry filter used inside get_user_profile
+_EPOCH_NOW_PATH = "reflexio.server.services.storage.sqlite_storage._profiles._epoch_now"
+
+
+@pytest.fixture()
+def reflexio_instance(tmp_path: pytest.TempPathFactory, worker_id: str) -> Reflexio:
+    """Create a Reflexio instance with real SQLite storage and a profile-only config.
+
+    ``stride_size=1`` ensures the extractor runs after a single published interaction
+    without requiring the default stride of 8.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory, unique per test.
+        worker_id: Pytest-xdist worker id for org isolation under parallel runs.
+
+    Returns:
+        Reflexio: A fully configured instance backed by an isolated SQLite DB.
+    """
+    org_id = f"expiry_regression_{worker_id}"
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "expiry_test.db")),
+        agent_context_prompt="test agent for expiry regression",
+        stride_size=1,
+        profile_extractor_config=ProfileExtractorConfig(
+            extractor_name="expiry_test_extractor",
+            context_prompt="extract user facts",
+            extraction_definition_prompt="name, intent",
+            tagging_definition_prompt="choice of ['fact']",
+        ),
+    )
+    configurator = DefaultConfigurator(org_id=org_id, config=config)
+    return Reflexio(org_id=org_id, configurator=configurator)
+
+
+def _publish_and_get_profile(reflexio: Reflexio) -> object:
+    """Publish one interaction through the real extraction path and return the profile.
+
+    The mock LLM returns ``time_to_live: "one_month"`` for profile extraction,
+    so ``calculate_expiration_timestamp`` runs in the extractor and stores a real
+    (non-NEVER) ``expiration_timestamp`` on the persisted row.
+
+    Args:
+        reflexio: A configured Reflexio instance.
+
+    Returns:
+        UserProfile: The first profile created by ``publish_interaction``.
+
+    Raises:
+        AssertionError: If publication fails or no profile is created.
+    """
+    user_id = "u_expiry_test"
+    response = reflexio.publish_interaction(
+        {
+            "user_id": user_id,
+            "session_id": "sess_expiry_regression",
+            "interaction_data_list": [
+                InteractionData(content="User shared their preferences.", role="user"),
+            ],
+            "source": "expiry_regression_test",
+        }
+    )
+    assert response.success, f"publish_interaction failed: {response.message}"
+    storage = reflexio.request_context.storage
+    profiles = storage.get_user_profile(user_id)
+    assert profiles, (
+        "publish_interaction must produce at least one profile via the real "
+        "calculate_expiration_timestamp path"
+    )
+    return profiles[0]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: faithful path — profile minted with real TTL is swept and GC'd away
+# ---------------------------------------------------------------------------
+
+
+def test_ttl_expired_active_profile_is_physically_reclaimed(
+    reflexio_instance: Reflexio,
+) -> None:
+    """Faithful path: a profile created with a real TTL is swept to EXPIRED then hard-deleted.
+
+    Guards the full reclamation pipeline:
+      1. publish_interaction → mock LLM emits one_month TTL → calculate_expiration_timestamp
+         stores a non-NEVER expiration_timestamp.
+      2. expire_active_profiles(now=past_expiry) tombstones the row (status → EXPIRED).
+      3. gc_expired_tombstones(older_than_epoch=past_expiry+1) hard-deletes the tombstone.
+      4. get_profile_by_id(include_tombstones=True) → None (row is gone).
+      5. Lineage events contain both ``status_change`` (reason ttl-expired) and ``hard_delete``.
+    """
+    storage = reflexio_instance.request_context.storage
+    profile = _publish_and_get_profile(reflexio_instance)
+
+    # The mock LLM returns one_month TTL → real expiration_timestamp, not the sentinel.
+    assert profile.expiration_timestamp != NEVER_EXPIRES_TIMESTAMP, (
+        "expiration_timestamp must be a real finite value produced by "
+        "calculate_expiration_timestamp, not the NEVER_EXPIRES sentinel"
+    )
+
+    past_expiry = profile.expiration_timestamp + 1
+
+    # Step 1: sweep tombstones the TTL-expired active profile.
+    swept = storage.expire_active_profiles(now=past_expiry)
+    assert swept == 1, "expire_active_profiles must tombstone exactly 1 profile"
+
+    # Step 2: GC hard-deletes the tombstone (retired_at == past_expiry < older_than_epoch).
+    deleted = storage.gc_expired_tombstones(
+        entity_type="profile",
+        older_than_epoch=past_expiry + 1,
+    )
+    assert deleted == 1, (
+        "gc_expired_tombstones must physically delete exactly 1 tombstone"
+    )
+
+    # Profile row is physically gone.
+    assert (
+        storage.get_profile_by_id(profile.profile_id, include_tombstones=True) is None
+    ), "profile must be gone after GC (include_tombstones=True must return None)"
+
+    # Lineage log contains both the TTL-expiry status_change and the hard_delete.
+    events = storage.get_lineage_events(entity_id=profile.profile_id)
+    ops = {e.op for e in events}
+    assert "status_change" in ops, (
+        "Expected a status_change lineage event (reason=ttl-expired) from the sweep"
+    )
+    assert "hard_delete" in ops, (
+        "Expected a hard_delete lineage event from gc_expired_tombstones"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: pre-fix negative — before the sweep the bug is demonstrable
+# ---------------------------------------------------------------------------
+
+
+def test_pre_fix_pathology_active_expired_is_not_gc_eligible_until_swept(
+    reflexio_instance: Reflexio,
+) -> None:
+    """Pre-fix negative: an active-but-expired profile is invisible to reads and GC until swept.
+
+    This test pins the exact bug that ``expire_active_profiles`` was introduced to fix:
+      - A profile past its ``expiration_timestamp`` has status=NULL (CURRENT).
+      - Normal reads filter ``expiration_timestamp >= now`` → the row is invisible.
+      - The tombstone GC filters ``status IN (MERGED, SUPERSEDED, ARCHIVED, EXPIRED)``
+        → the row is NOT eligible for hard-deletion.
+      - Only ``expire_active_profiles`` (the sweep) transitions it to status=EXPIRED,
+        making it eligible for GC.
+
+    We monkeypatch ``_epoch_now`` — used by ``get_user_profile``'s expiry filter —
+    to simulate being past the profile's expiration, without touching the wall clock.
+    """
+    storage = reflexio_instance.request_context.storage
+    profile = _publish_and_get_profile(reflexio_instance)
+
+    assert profile.expiration_timestamp != NEVER_EXPIRES_TIMESTAMP
+
+    past_expiry = profile.expiration_timestamp + 10
+
+    # Simulate being past expiry: get_user_profile filters expiration_timestamp >= _epoch_now().
+    with patch(_EPOCH_NOW_PATH, return_value=past_expiry):
+        visible = storage.get_user_profile(profile.user_id)
+
+    # The expired profile is invisible to normal reads (filtered by expiry timestamp).
+    assert not any(p.profile_id == profile.profile_id for p in visible), (
+        "An active-but-expired profile must be invisible to get_user_profile "
+        "at simulated post-expiry time"
+    )
+
+    # But the row still exists in storage with status=None (CURRENT) — not yet a tombstone.
+    raw = storage.get_profile_by_id(profile.profile_id, include_tombstones=True)
+    assert raw is not None, (
+        "Profile must still exist in storage — it has not been swept yet"
+    )
+    assert raw.status is None, (
+        "Profile status must be None (CURRENT) before the expiry sweep; "
+        "it is NOT yet a tombstone"
+    )
+
+    # GC without sweep skips it — status=None is not in the eligible set.
+    gc_before_sweep = storage.gc_expired_tombstones(
+        entity_type="profile",
+        older_than_epoch=past_expiry + 1,
+    )
+    assert gc_before_sweep == 0, (
+        "gc_expired_tombstones must return 0 for a status=None profile: "
+        "only tombstones (MERGED/SUPERSEDED/ARCHIVED/EXPIRED) are eligible"
+    )
+
+    # The sweep is the fix: transitions the row from active to EXPIRED.
+    swept = storage.expire_active_profiles(now=past_expiry)
+    assert swept == 1, (
+        "expire_active_profiles must tombstone the active-but-expired profile"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: race — supersede on a sweep-EXPIRED source is a clean no-op
+# ---------------------------------------------------------------------------
+
+
+def test_expiry_sweep_does_not_break_concurrent_supersede(
+    reflexio_instance: Reflexio,
+) -> None:
+    """Race: a supersede attempt on a sweep-tombstoned profile is a clean no-op.
+
+    After ``expire_active_profiles`` transitions a profile to status=EXPIRED, a
+    concurrent ``supersede_profiles_by_ids`` on that id must silently skip it
+    (returns [] — an empty committed set), produce no crash, and emit no phantom
+    ``status_change`` lineage event for the SUPERSEDED transition.
+
+    Guards spec RD-ADV-005: the sweep must not corrupt dedup lineage.
+    """
+    storage = reflexio_instance.request_context.storage
+    profile = _publish_and_get_profile(reflexio_instance)
+
+    assert profile.expiration_timestamp != NEVER_EXPIRES_TIMESTAMP
+
+    past_expiry = profile.expiration_timestamp + 10
+
+    # Sweep tombstones the profile to EXPIRED.
+    swept = storage.expire_active_profiles(now=past_expiry)
+    assert swept == 1
+
+    # A supersede attempt on the now-EXPIRED source must be a clean no-op.
+    actually_superseded = storage.supersede_profiles_by_ids(
+        profile.user_id,
+        [profile.profile_id],
+        "race_test_request_id",
+    )
+    assert actually_superseded == [], (
+        "supersede_profiles_by_ids must return [] when the target is already EXPIRED; "
+        "EXPIRED is not in the eligible set {NULL, PENDING}"
+    )
+
+    # No phantom SUPERSEDED status_change must be emitted for the already-EXPIRED row.
+    events = storage.get_lineage_events(entity_id=profile.profile_id)
+    supersede_events = [
+        e
+        for e in events
+        if e.op == "status_change" and e.to_status == Status.SUPERSEDED.value
+    ]
+    assert not supersede_events, (
+        "No SUPERSEDED status_change event must be emitted after the sweep already "
+        "tombstoned the profile to EXPIRED"
+    )

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -108,9 +108,9 @@ def _publish_and_get_profile(reflexio: Reflexio) -> object:
     assert response.success, f"publish_interaction failed: {response.message}"
     storage = reflexio.request_context.storage
     profiles = storage.get_user_profile(user_id)
-    assert profiles, (
-        "publish_interaction must produce at least one profile via the real "
-        "calculate_expiration_timestamp path"
+    assert len(profiles) == 1, (
+        "publish_interaction must produce exactly one profile via the real "
+        "calculate_expiration_timestamp path; got %d" % len(profiles)
     )
     return profiles[0]
 

--- a/tests/server/services/lineage/test_reclamation_class_b_integration.py
+++ b/tests/server/services/lineage/test_reclamation_class_b_integration.py
@@ -1,0 +1,202 @@
+"""Integration tests: Class B direct-delete sweep in _gc_tick (Task 2.1).
+
+Key invariant: Class B (share-link + pending-tool-call reclamation) runs even
+when ``lineage_gc.enabled=False``.  Class A (profile expiry sweep + tombstone GC)
+must NOT run when ``lineage_gc.enabled=False``.
+
+Both are gated independently:
+  - Class A runs under ``if cfg.lineage_gc.enabled``
+  - Class B runs under ``if cfg.expiry_reclamation.enabled``
+  - The scheduler STARTS when EITHER flag is True.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.config_schema import ExpiryReclamationConfig, LineageGCConfig
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.lineage.gc_scheduler import (
+    LineageGCScheduler,
+    maybe_start_lineage_gc,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+_ORG_ID = "class_b_gc_test_org"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def org_id() -> str:
+    return _ORG_ID
+
+
+def _make_ctx_factory(
+    tmp_path,
+    *,
+    lineage_gc_enabled: bool,
+    expiry_reclamation_enabled: bool,
+) -> tuple[SQLiteStorage, object]:
+    """Build (storage, factory) pair for the given flag combination."""
+    storage = SQLiteStorage(org_id=_ORG_ID, db_path=str(tmp_path / "gc_b_test.db"))
+    cfg = SimpleNamespace(
+        lineage_gc=LineageGCConfig(enabled=lineage_gc_enabled, tombstone_grace_window_days=1),
+        expiry_reclamation=ExpiryReclamationConfig(enabled=expiry_reclamation_enabled),
+    )
+
+    def factory(org_id: str) -> RequestContext:
+        ctx = RequestContext.__new__(RequestContext)
+        ctx.org_id = org_id
+        ctx.storage = storage
+        ctx.storage_base_dir = None
+        configurator = MagicMock()
+        configurator.get_config.return_value = cfg
+        ctx.configurator = configurator
+        return ctx
+
+    return storage, factory
+
+
+def _seed_expired_share_link(storage: SQLiteStorage, expires_at: int) -> None:
+    """Create a share link with the given expiration epoch."""
+    storage.create_share_link(
+        token="shr_class_b_test",
+        resource_type="profile",
+        resource_id="r_class_b",
+        expires_at=expires_at,
+        created_by_email=None,
+    )
+
+
+def _share_link_count(storage: SQLiteStorage) -> int:
+    """Return the number of share links in storage."""
+    return len(storage.get_share_links())
+
+
+def _seed_active_profile(storage: SQLiteStorage) -> UserProfile:
+    """Seed an active profile with a far-past expiration (eligible for expiry sweep)."""
+    p = UserProfile(
+        profile_id="p_class_b_active",
+        user_id="u_class_b",
+        content="test profile",
+        last_modified_timestamp=1,
+        generated_from_request_id="r_class_b_profile",
+        expiration_timestamp=100,  # far in the past
+    )
+    storage.add_user_profile("u_class_b", [p])
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Class B reclaims even when lineage_gc is DISABLED
+# ---------------------------------------------------------------------------
+
+
+def test_class_b_runs_when_lineage_gc_disabled(tmp_path, org_id):
+    """Class B sweep deletes expired share links when lineage_gc.enabled=False.
+
+    Also asserts that Class A (profile expiry sweep) does NOT run, confirming
+    that the two guards are independent.
+    """
+    storage, factory = _make_ctx_factory(
+        tmp_path,
+        lineage_gc_enabled=False,
+        expiry_reclamation_enabled=True,
+    )
+
+    # Seed a long-expired share link.
+    _seed_expired_share_link(storage, expires_at=1)
+    assert _share_link_count(storage) == 1
+
+    # Seed an active profile with a past expiration — if Class A ran it would
+    # be tombstoned.
+    profile = _seed_active_profile(storage)
+
+    sched = LineageGCScheduler(request_context_factory=factory, bootstrap_org_id=org_id)
+    sched._gc_tick([org_id])
+
+    # Class B: share link must be reclaimed.
+    assert _share_link_count(storage) == 0, (
+        "Class B must delete the expired share link even when lineage_gc is disabled"
+    )
+
+    # Class A must NOT have run: the active profile must still be active (not tombstoned).
+    row = storage.get_profile_by_id(profile.profile_id, include_tombstones=True)
+    assert row is not None, "Profile must still exist — Class A must not have run"
+    assert row.status is None, (
+        "Profile status must remain None (CURRENT); expire_active_profiles must not "
+        "have been called (lineage_gc.enabled=False gates Class A)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Both disabled → scheduler does not start
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_does_not_start_when_both_disabled(tmp_path, org_id):
+    """maybe_start_lineage_gc returns None when both flags are False."""
+    _, factory = _make_ctx_factory(
+        tmp_path,
+        lineage_gc_enabled=False,
+        expiry_reclamation_enabled=False,
+    )
+    result = maybe_start_lineage_gc(factory, bootstrap_org_id=org_id)  # type: ignore[arg-type]
+    assert result is None, (
+        "Scheduler must not start when lineage_gc.enabled=False and "
+        "expiry_reclamation.enabled=False"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Scheduler starts when only expiry_reclamation is enabled
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_starts_when_only_expiry_reclamation_enabled(tmp_path, org_id):
+    """maybe_start_lineage_gc starts when expiry_reclamation.enabled=True even
+    with lineage_gc.enabled=False."""
+    _, factory = _make_ctx_factory(
+        tmp_path,
+        lineage_gc_enabled=False,
+        expiry_reclamation_enabled=True,
+    )
+    sched = maybe_start_lineage_gc(factory, bootstrap_org_id=org_id)  # type: ignore[arg-type]
+    assert sched is not None, (
+        "Scheduler must start when expiry_reclamation.enabled=True "
+        "(even with lineage_gc.enabled=False)"
+    )
+    sched.stop(timeout_seconds=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Class B tick is a no-op when expiry_reclamation is disabled
+# ---------------------------------------------------------------------------
+
+
+def test_class_b_does_not_run_when_disabled(tmp_path, org_id):
+    """When expiry_reclamation.enabled=False the share link is NOT deleted."""
+    storage, factory = _make_ctx_factory(
+        tmp_path,
+        lineage_gc_enabled=False,
+        expiry_reclamation_enabled=False,
+    )
+    _seed_expired_share_link(storage, expires_at=1)
+    assert _share_link_count(storage) == 1
+
+    sched = LineageGCScheduler(request_context_factory=factory, bootstrap_org_id=org_id)
+    sched._gc_tick([org_id])
+
+    assert _share_link_count(storage) == 1, (
+        "Class B must not run when expiry_reclamation.enabled=False"
+    )

--- a/tests/server/services/storage/sqlite_storage/test_clear_user_data_expired_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_clear_user_data_expired_integration.py
@@ -1,0 +1,144 @@
+"""Task 1.8: clear_user_data must reach EXPIRED and expired profile rows.
+
+Before the fix, BaseStorage.clear_user_data used get_user_profile with
+``_all_statuses`` that omitted Status.EXPIRED and the unconditional
+``expiration_timestamp >= now`` filter hid any profile with a past expiry.
+EXPIRED tombstones (expiration_timestamp in the past) were silently skipped
+by the GDPR erasure path.
+
+Note: SQLiteStorage has its own clear_user_data override that reads profiles
+directly via ``SELECT … WHERE user_id = ?`` (no status/expiry filter), so
+the SQLite override already handles EXPIRED profiles.  The bug lives in
+BaseStorage.clear_user_data (used by the Supabase/Postgres backends).
+We call BaseStorage.clear_user_data(s, …) directly here so the failing
+assertion targets the broken base-class code path.
+
+Two test bodies:
+  * test_base_clear_user_data_erases_expired_profile — the bug: EXPIRED
+    profile survives BaseStorage.clear_user_data (FAILS before fix, PASSES
+    after).
+  * test_get_user_profile_include_expired_param — the new param:
+    include_expired=True surfaces the EXPIRED row; False (default) hides it
+    (fails BEFORE fix with TypeError on unknown kwarg, PASSES after).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+pytestmark = pytest.mark.integration
+
+_USER = "u_erasure_1_8"
+_PAST_EXP = 1  # epoch timestamp well in the past
+_FAR_FUTURE = 10_000_000_000  # far future so profile won't expire naturally
+
+
+def _mk_profile(pid: str, *, exp: int) -> UserProfile:
+    return UserProfile(
+        profile_id=pid,
+        user_id=_USER,
+        content=f"pii-{pid}",
+        last_modified_timestamp=1,
+        generated_from_request_id="req1",
+        expiration_timestamp=exp,
+    )
+
+
+def test_base_clear_user_data_erases_expired_profile(tmp_path):
+    """EXPIRED profile must be physically absent after BaseStorage.clear_user_data.
+
+    We call BaseStorage.clear_user_data(s, …) directly (bypassing the
+    SQLiteStorage override) to exercise the base-class code path shared
+    with Supabase/Postgres.
+
+    Before the fix, BaseStorage.clear_user_data calls
+    get_user_profile(status_filter=_all_statuses) which (a) omits
+    Status.EXPIRED from the list and (b) applies expiration_timestamp >= now
+    unconditionally, so the EXPIRED row is never enumerated and survives
+    erasure.  After the fix, Status.EXPIRED is in _all_statuses and
+    include_expired=True is passed, so the row is enumerated and deleted.
+    """
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test_1_8")
+
+        # Add two profiles: one that will become EXPIRED, one that stays CURRENT.
+        s.add_user_profile(_USER, [_mk_profile("p_expired", exp=_PAST_EXP)])
+        s.add_user_profile(_USER, [_mk_profile("p_current", exp=_FAR_FUTURE)])
+
+        # Transition p_expired → status=EXPIRED via the expiry sweep.
+        swept = s.expire_active_profiles(now=1_000_000)
+        assert swept == 1, f"Expected 1 profile tombstoned, got {swept}"
+
+        # Sanity: EXPIRED profile is hidden from default get_user_profile.
+        live = s.get_user_profile(_USER)
+        assert all(p.profile_id != "p_expired" for p in live), (
+            "EXPIRED profile should not appear in default get_user_profile"
+        )
+
+        # Run on-demand GDPR erasure using the BASE CLASS implementation.
+        # (SQLiteStorage overrides clear_user_data with raw SQL that already
+        # catches EXPIRED rows; we call the base class to target the broken path.)
+        counts = BaseStorage.clear_user_data(s, _USER)
+
+        # The combined profile count (hard-deleted + purged) must cover both rows.
+        total = counts.get("profiles", 0) + counts.get("purged_profiles", 0)
+        assert total >= 2, (
+            f"Expected at least 2 profiles processed by BaseStorage.clear_user_data, "
+            f"got counts={counts}"
+        )
+
+        # p_expired must no longer exist — even with include_tombstones=True.
+        gone = s.get_profile_by_id("p_expired", include_tombstones=True)
+        assert gone is None, (
+            "EXPIRED profile must be physically absent after BaseStorage.clear_user_data; "
+            f"got status={gone.status if gone else None!r}"
+        )
+
+        # p_current must also be erased (no regression on normal profiles).
+        current_gone = s.get_profile_by_id("p_current", include_tombstones=True)
+        assert current_gone is None, (
+            "CURRENT profile must also be absent after BaseStorage.clear_user_data; "
+            f"got {current_gone!r}"
+        )
+
+
+def test_get_user_profile_include_expired_param(tmp_path):
+    """include_expired=True returns the EXPIRED row; False (default) does not.
+
+    Directly tests the new keyword on get_user_profile.  Before the fix,
+    the kwarg doesn't exist, so this test raises TypeError (wrapped in
+    StorageError by the handle_exceptions decorator).
+    """
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_param_test")
+
+        s.add_user_profile(_USER, [_mk_profile("px", exp=_PAST_EXP)])
+        s.expire_active_profiles(now=1_000_000)
+
+        # include_expired=True with EXPIRED status_filter must surface the row.
+        with_expired = s.get_user_profile(
+            _USER,
+            status_filter=[Status.EXPIRED],
+            include_expired=True,
+        )
+        assert any(p.profile_id == "px" for p in with_expired), (
+            "get_user_profile(include_expired=True) must return the EXPIRED row"
+        )
+
+        # include_expired=False (default) must not return the EXPIRED row even
+        # when the status_filter explicitly includes EXPIRED.
+        without_expired = s.get_user_profile(
+            _USER,
+            status_filter=[Status.EXPIRED],
+            include_expired=False,
+        )
+        assert all(p.profile_id != "px" for p in without_expired), (
+            "get_user_profile(include_expired=False) must not return the EXPIRED row"
+        )

--- a/tests/server/services/storage/sqlite_storage/test_expired_tombstone_filtering_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_expired_tombstone_filtering_integration.py
@@ -1,0 +1,38 @@
+"""Task 1.2: get_profile_by_id hides EXPIRED profiles by default."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _mk_profile(pid: str) -> UserProfile:
+    return UserProfile(
+        profile_id=pid,
+        user_id="u1",
+        content="c",
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id="r1",
+        status=None,
+    )
+
+
+def test_get_profile_by_id_hides_expired(tmp_path):
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage = SQLiteStorage(org_id="org_test", db_path=str(tmp_path / "t.db"))
+        storage.add_user_profile("u1", [_mk_profile("p1")])
+        # A freshly-added profile is stored with a NULL status (live/CURRENT), so
+        # the CURRENT->EXPIRED transition is driven from old_status=None. Passing
+        # Status.CURRENT here would query `status = 'None'` (the enum's literal
+        # value) and match zero NULL-status rows.
+        storage.update_all_profiles_status(None, Status.EXPIRED, user_ids=["u1"])
+        assert storage.get_profile_by_id("p1", include_tombstones=False) is None
+        assert storage.get_profile_by_id("p1", include_tombstones=True) is not None

--- a/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.integration
 def _seed_call(
     s: SQLiteStorage,
     *,
-    id: str,
+    call_id: str,
     status: str,
     expires_at: str | None = None,
     valid_until: str | None = None,
@@ -35,16 +35,16 @@ def _seed_call(
     now = datetime.now(UTC)
     scope: dict[str, str] = {"org_id": org_id, "scope_kind": "org"}
     record = PendingToolCallRecord(
-        id=id,
+        id=call_id,
         org_id=org_id,
         scope=scope,
         scope_hash=build_scope_hash(scope),
         tool_name="ask_human",
         dedup_key=build_pending_tool_call_dedup_key(
-            tool_name="ask_human", question_text=f"q_{id}"
+            tool_name="ask_human", question_text=f"q_{call_id}"
         ),
         status=PendingToolCallStatus(status),
-        question_text=f"q_{id}",
+        question_text=f"q_{call_id}",
         expires_at=(
             datetime.fromisoformat(expires_at).replace(tzinfo=UTC)
             if expires_at
@@ -66,13 +66,13 @@ def test_delete_expired_pending_tool_calls_spares_resolved(tmp_path):
     now = datetime.now(UTC)
     _seed_call(
         s,
-        id="a",
+        call_id="a",
         status="expired",
         expires_at=(now - timedelta(days=2)).isoformat(),
     )
     _seed_call(
         s,
-        id="b",
+        call_id="b",
         status="resolved",
         valid_until=(now + timedelta(days=5)).isoformat(),
         expires_at=(now - timedelta(days=2)).isoformat(),  # past expires_at but RESOLVED
@@ -92,7 +92,7 @@ def test_delete_expired_within_grace_not_deleted(tmp_path):
     # expires_at 30 min ago, grace = 1 h → cutoff 1 h ago → not past cutoff
     _seed_call(
         s,
-        id="c",
+        call_id="c",
         status="expired",
         expires_at=(now - timedelta(minutes=30)).isoformat(),
     )
@@ -116,7 +116,7 @@ def test_delete_expired_pending_tool_calls_ignores_pending_status(tmp_path):
     # PENDING row whose expires_at is in the past — must NOT be deleted
     _seed_call(
         s,
-        id="d",
+        call_id="d",
         status="pending",
         expires_at=(now - timedelta(days=3)).isoformat(),
     )
@@ -141,14 +141,14 @@ def test_delete_expired_pending_tool_calls_scopes_to_own_org(tmp_path):
 
     _seed_call(
         s_a,
-        id="row-a",
+        call_id="row-a",
         status="expired",
         expires_at=(now - timedelta(days=1)).isoformat(),
         org_id="org_a",
     )
     _seed_call(
         s_b,
-        id="row-b",
+        call_id="row-b",
         status="expired",
         expires_at=(now - timedelta(days=1)).isoformat(),
         org_id="org_b",

--- a/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
@@ -1,0 +1,127 @@
+"""Task 2.3: delete_expired_pending_tool_calls deletes only terminal 'expired' rows.
+
+RESOLVED rows (with live valid_until) are never deleted, even if their
+expires_at is in the past — they hold cached results used by resumable
+extraction resume paths.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.storage_base import (
+    PendingToolCallRecord,
+    PendingToolCallStatus,
+    build_pending_tool_call_dedup_key,
+    build_scope_hash,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_call(
+    s: SQLiteStorage,
+    *,
+    id: str,
+    status: str,
+    expires_at: str | None = None,
+    valid_until: str | None = None,
+    org_id: str = "org_test",
+) -> PendingToolCallRecord:
+    """Insert a _pending_tool_calls row with arbitrary status for test setup."""
+    now = datetime.now(UTC)
+    scope: dict[str, str] = {"org_id": org_id, "scope_kind": "org"}
+    record = PendingToolCallRecord(
+        id=id,
+        org_id=org_id,
+        scope=scope,
+        scope_hash=build_scope_hash(scope),
+        tool_name="ask_human",
+        dedup_key=build_pending_tool_call_dedup_key(
+            tool_name="ask_human", question_text=f"q_{id}"
+        ),
+        status=PendingToolCallStatus(status),
+        question_text=f"q_{id}",
+        expires_at=(
+            datetime.fromisoformat(expires_at).replace(tzinfo=UTC)
+            if expires_at
+            else now + timedelta(hours=1)
+        ),
+        cache_until=now + timedelta(hours=1),
+        valid_until=(
+            datetime.fromisoformat(valid_until).replace(tzinfo=UTC)
+            if valid_until
+            else None
+        ),
+    )
+    return s.create_pending_tool_call(record)
+
+
+def test_delete_expired_pending_tool_calls_spares_resolved(tmp_path):
+    """Expired row is deleted; RESOLVED row with live valid_until is preserved."""
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    now = datetime.now(UTC)
+    _seed_call(
+        s,
+        id="a",
+        status="expired",
+        expires_at=(now - timedelta(days=2)).isoformat(),
+    )
+    _seed_call(
+        s,
+        id="b",
+        status="resolved",
+        valid_until=(now + timedelta(days=5)).isoformat(),
+        expires_at=(now - timedelta(days=2)).isoformat(),  # past expires_at but RESOLVED
+    )
+    deleted = s.delete_expired_pending_tool_calls(
+        now=int(now.timestamp()), grace_seconds=86400
+    )
+    assert deleted == 1
+    assert s.get_pending_tool_call("a") is None
+    assert s.get_pending_tool_call("b") is not None  # live cached result preserved
+
+
+def test_delete_expired_within_grace_not_deleted(tmp_path):
+    """Expired row inside the grace window is not deleted yet."""
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    now = datetime.now(UTC)
+    # expires_at 30 min ago, grace = 1 h → cutoff 1 h ago → not past cutoff
+    _seed_call(
+        s,
+        id="c",
+        status="expired",
+        expires_at=(now - timedelta(minutes=30)).isoformat(),
+    )
+    deleted = s.delete_expired_pending_tool_calls(
+        now=int(now.timestamp()), grace_seconds=3600
+    )
+    assert deleted == 0
+    assert s.get_pending_tool_call("c") is not None
+
+
+def test_delete_expired_pending_tool_calls_empty(tmp_path):
+    """Returns 0 on an empty table."""
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    assert s.delete_expired_pending_tool_calls(now=1_000_000, grace_seconds=0) == 0
+
+
+def test_delete_expired_pending_tool_calls_ignores_pending_status(tmp_path):
+    """Pending rows (not yet expired) are never physically deleted."""
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    now = datetime.now(UTC)
+    # PENDING row whose expires_at is in the past — must NOT be deleted
+    _seed_call(
+        s,
+        id="d",
+        status="pending",
+        expires_at=(now - timedelta(days=3)).isoformat(),
+    )
+    deleted = s.delete_expired_pending_tool_calls(
+        now=int(now.timestamp()), grace_seconds=0
+    )
+    assert deleted == 0
+    assert s.get_pending_tool_call("d") is not None

--- a/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
@@ -125,3 +125,42 @@ def test_delete_expired_pending_tool_calls_ignores_pending_status(tmp_path):
     )
     assert deleted == 0
     assert s.get_pending_tool_call("d") is not None
+
+
+def test_delete_expired_pending_tool_calls_scopes_to_own_org(tmp_path):
+    """Cross-org isolation: org A's sweep must not delete org B's expired rows.
+
+    Two SQLiteStorage instances share the same db_path (shared-file deployment).
+    Only the row belonging to org A must be deleted when org A runs the sweep.
+    Org B's row must survive.
+    """
+    db = str(tmp_path / "shared.db")
+    now = datetime.now(UTC)
+    s_a = SQLiteStorage(db_path=db, org_id="org_a")
+    s_b = SQLiteStorage(db_path=db, org_id="org_b")
+
+    _seed_call(
+        s_a,
+        id="row-a",
+        status="expired",
+        expires_at=(now - timedelta(days=1)).isoformat(),
+        org_id="org_a",
+    )
+    _seed_call(
+        s_b,
+        id="row-b",
+        status="expired",
+        expires_at=(now - timedelta(days=1)).isoformat(),
+        org_id="org_b",
+    )
+
+    # Only sweep org A
+    deleted = s_a.delete_expired_pending_tool_calls(
+        now=int(now.timestamp()), grace_seconds=0
+    )
+
+    assert deleted == 1, "org A's row must be deleted"
+    assert s_a.get_pending_tool_call("row-a") is None, "org A row must be gone"
+    assert s_b.get_pending_tool_call("row-b") is not None, (
+        "org B row must survive — cross-tenant deletion detected"
+    )

--- a/tests/server/services/storage/sqlite_storage/test_profile_expiry_sweep_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_profile_expiry_sweep_integration.py
@@ -1,0 +1,45 @@
+"""Task 1.3: expire_active_profiles tombstones TTL-expired active profiles."""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import UserProfile
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _p(pid: str, exp: int) -> UserProfile:
+    return UserProfile(
+        profile_id=pid,
+        user_id="u1",
+        content="c",
+        last_modified_timestamp=1,
+        generated_from_request_id="r1",
+        expiration_timestamp=exp,
+    )
+
+
+def test_expire_active_profiles_tombstones_only_expired(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    s.add_user_profile("u1", [_p("old", exp=100)])  # expired
+    s.add_user_profile("u1", [_p("fresh", exp=10_000)])  # not expired
+    n = s.expire_active_profiles(now=1000)
+    assert n == 1
+    # expired profile is hidden from normal reads
+    assert s.get_profile_by_id("old", include_tombstones=False) is None
+    # but visible when tombstones included, with EXPIRED status
+    row = s.get_profile_by_id("old", include_tombstones=True)
+    assert row is not None
+    assert row.status == Status.EXPIRED
+    # fresh profile is unaffected
+    assert s.get_profile_by_id("fresh", include_tombstones=False) is not None
+
+
+def test_expire_active_profiles_idempotent(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    s.add_user_profile("u1", [_p("old", exp=100)])
+    assert s.expire_active_profiles(now=1000) == 1
+    assert s.expire_active_profiles(now=1000) == 0  # already tombstoned

--- a/tests/server/services/storage/sqlite_storage/test_share_link_expiry_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_share_link_expiry_integration.py
@@ -1,0 +1,60 @@
+"""Task 2.2: delete_expired_share_links physically deletes expired share links."""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _link(n: int, expires_at: int | None) -> dict:
+    return {
+        "token": f"shr_test.{n}",
+        "resource_type": "profile",
+        "resource_id": f"r{n}",
+        "expires_at": expires_at,
+        "created_by_email": None,
+    }
+
+
+def test_delete_expired_share_links(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    s.create_share_link(**_link(1, expires_at=1))        # long expired
+    s.create_share_link(**_link(2, expires_at=10_000))   # fresh
+    s.create_share_link(**_link(3, expires_at=None))     # never expires
+    assert s.delete_expired_share_links(now=1000, grace_seconds=0) == 1
+    assert {lnk.id for lnk in s.get_share_links()} == {2, 3}
+
+
+def test_delete_expired_share_links_respects_grace(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    s.create_share_link(**_link(1, expires_at=900))   # expired_at=900, now=1000, grace=200 → cutoff=800 → not past grace
+    s.create_share_link(**_link(2, expires_at=700))   # expired_at=700, cutoff=800 → past grace, deleted
+    assert s.delete_expired_share_links(now=1000, grace_seconds=200) == 1
+    remaining = {lnk.id for lnk in s.get_share_links()}
+    assert len(remaining) == 1  # only expires_at=900 row survives
+
+
+def test_delete_expired_share_links_preserves_null(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    s.create_share_link(**_link(1, expires_at=None))
+    s.create_share_link(**_link(2, expires_at=None))
+    assert s.delete_expired_share_links(now=999_999_999, grace_seconds=0) == 0
+    assert len(s.get_share_links()) == 2
+
+
+def test_delete_expired_share_links_empty(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    assert s.delete_expired_share_links(now=1000, grace_seconds=0) == 0
+
+
+def test_delete_expired_share_links_respects_limit(tmp_path):
+    s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
+    for i in range(5):
+        s.create_share_link(**_link(i, expires_at=i + 1))
+    # All 5 are expired (now=1000), but limit=3
+    deleted = s.delete_expired_share_links(now=1000, grace_seconds=0, limit=3)
+    assert deleted == 3
+    assert len(s.get_share_links()) == 2

--- a/tests/server/services/storage/sqlite_storage/test_status_tolerance_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_status_tolerance_integration.py
@@ -1,0 +1,19 @@
+import pytest
+from reflexio.models.api_schema.domain.enums import Status
+from reflexio.server.services.storage.sqlite_storage._base import _parse_status
+
+pytestmark = pytest.mark.integration
+
+
+def test_parse_status_known_and_null():
+    assert _parse_status(None) is None
+    assert _parse_status("") is None
+    assert _parse_status("merged") == Status.MERGED
+
+
+def test_parse_status_unknown_maps_to_tombstone_not_current():
+    # An unknown status (e.g. a future 'expired' seen by an older build) must NOT
+    # raise and must NOT be treated as CURRENT (None) — else it would leak as live.
+    result = _parse_status("some_future_status")
+    assert result is not None
+    assert result in (Status.MERGED, Status.SUPERSEDED)

--- a/tests/server/services/storage/test_sqlite_share_links.py
+++ b/tests/server/services/storage/test_sqlite_share_links.py
@@ -132,3 +132,53 @@ class TestDeleteAllShareLinks:
             )
         assert storage.delete_all_share_links() == 3
         assert storage.get_share_links() == []
+
+
+class TestDeleteExpiredShareLinks:
+    def test_deletes_expired_beyond_grace(self, storage):
+        """Links whose expires_at < now - grace_seconds are deleted."""
+        now = 2_000_000_000
+        grace = 7 * 86400
+        # Expired beyond grace
+        storage.create_share_link(
+            token="shr_old", resource_type="profile", resource_id="p1",
+            expires_at=1, created_by_email=None,
+        )
+        count = storage.delete_expired_share_links(now=now, grace_seconds=grace)
+        assert count == 1
+        assert storage.get_share_link_by_token("shr_old") is None
+
+    def test_preserves_link_within_grace(self, storage):
+        """Links still within the grace window are left untouched."""
+        now = 2_000_000_000
+        grace = 7 * 86400
+        # Expired just 1 second ago (within 7-day grace)
+        storage.create_share_link(
+            token="shr_recent", resource_type="profile", resource_id="p2",
+            expires_at=now - 1, created_by_email=None,
+        )
+        count = storage.delete_expired_share_links(now=now, grace_seconds=grace)
+        assert count == 0
+        assert storage.get_share_link_by_token("shr_recent") is not None
+
+    def test_preserves_link_without_expires_at(self, storage):
+        """Links with expires_at=None (never-expire) must never be deleted."""
+        storage.create_share_link(
+            token="shr_noexp", resource_type="profile", resource_id="p3",
+            expires_at=None, created_by_email=None,
+        )
+        count = storage.delete_expired_share_links(now=2_000_000_000, grace_seconds=0)
+        assert count == 0
+        assert storage.get_share_link_by_token("shr_noexp") is not None
+
+    def test_limit_respected(self, storage):
+        """limit parameter caps rows deleted per call."""
+        now = 2_000_000_000
+        for i in range(5):
+            storage.create_share_link(
+                token=f"shr_exp_{i}", resource_type="profile", resource_id=f"p{i}",
+                expires_at=1, created_by_email=None,
+            )
+        count = storage.delete_expired_share_links(now=now, grace_seconds=0, limit=3)
+        assert count == 3
+        assert len(storage.get_share_links()) == 2

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -487,7 +487,11 @@ class TestInteractionCRUD:
 
 
 def test_expire_active_profiles_contract(storage: BaseStorage) -> None:
-    """Contract: expire_active_profiles tombstones TTL-expired active profiles."""
+    """Contract: expire_active_profiles tombstones TTL-expired active profiles.
+
+    Enforces that the backend TOMBSTONES (status → EXPIRED), not hard-deletes,
+    so that the tombstone GC can later reclaim the row after the grace window.
+    """
     storage.add_user_profile(
         "u1",
         [
@@ -502,4 +506,13 @@ def test_expire_active_profiles_contract(storage: BaseStorage) -> None:
         ],
     )
     assert storage.expire_active_profiles(now=1000) == 1
+    # Hidden from default reads (expiry-filtered).
     assert storage.get_profile_by_id("c1", include_tombstones=False) is None
+    # But the tombstone must still exist with status EXPIRED — not hard-deleted.
+    tombstone = storage.get_profile_by_id("c1", include_tombstones=True)
+    assert tombstone is not None, (
+        "expire_active_profiles must TOMBSTONE the row (status=EXPIRED), not hard-delete it"
+    )
+    assert tombstone.status == Status.EXPIRED, (
+        f"expected status=EXPIRED after sweep, got {tombstone.status!r}"
+    )

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -484,3 +484,22 @@ class TestInteractionCRUD:
             sources=["api"],
         )
         assert new_groups[0].interactions[0].image_encoding == "base64-image-data"
+
+
+def test_expire_active_profiles_contract(storage: BaseStorage) -> None:
+    """Contract: expire_active_profiles tombstones TTL-expired active profiles."""
+    storage.add_user_profile(
+        "u1",
+        [
+            UserProfile(
+                profile_id="c1",
+                user_id="u1",
+                content="c",
+                last_modified_timestamp=1,
+                generated_from_request_id="r1",
+                expiration_timestamp=100,
+            )
+        ],
+    )
+    assert storage.expire_active_profiles(now=1000) == 1
+    assert storage.get_profile_by_id("c1", include_tombstones=False) is None


### PR DESCRIPTION
## Summary

Reclaims TTL/expiry rows that were filtered out of reads but never physically deleted, so dead rows (including PII-bearing expired profiles) no longer accumulate forever. This is the shared/OSS half of the "expiry reclamation" feature; the enterprise (Supabase/Postgres) half is a companion PR.

### The bug
An **active** profile whose TTL elapses gets `status = CURRENT (NULL)` and `retired_at = NULL`. It matches neither the read filters (`expiration_timestamp >= now`) nor the tombstone-only GC predicate — so it becomes a permanent invisible row. The same "filter-on-read, never reclaim" shape also affected `share_links` and `pending_tool_calls`.

## What changed

**Profiles (lineage path)**
- New `Status.EXPIRED` tombstone status (GC-eligible via `_GC_ELIGIBLE_STATUSES`).
- `expire_active_profiles(now, limit)` sweep: `status IS NULL AND expiration_timestamp < now` → `status=EXPIRED, retired_at=now`, emitting a `status_change` lineage event (`reason="ttl-expired"`) — atomically, guarded on the updated rows. The existing `gc_expired_tombstones` + `purge_content` then reclaim after the grace window.
- EXPIRED hidden from `get_profile_by_id` (profile-only tombstone set + dynamic placeholders — playbook queries untouched).
- Reader status-tolerance: `_parse_status` maps an unknown status to a non-current tombstone sentinel (never `None`) so a rolled-back build can't crash on a future `'expired'`.
- GDPR: `clear_user_data` gains `include_expired` so on-demand erasure reaches expired/EXPIRED rows.

**Plain rows (direct-delete sweeps)**
- `delete_expired_share_links` and `delete_expired_pending_tool_calls` (the latter scoped to terminal `status='expired'` + `org_id`, TEXT/ISO-aware — never reaps live RESOLVED results).
- `ExpiryReclamationConfig` + a Class B loop in the daily scheduler, gated by `expiry_reclamation.enabled` independently of `lineage_gc.enabled`; scheduler starts on either flag.
- `org_id_provider` injection so the enterprise can drive per-tenant reclamation in managed mode (default None = unchanged).

## Testing
Integration-first (real storage, mocked LLM): the profile sweep + GC reclamation, a pre-fix pathology regression guard (proves the exact bug), cross-org isolation for the pending-tool-call delete, dynamic-placeholder playbook regression, and scheduler wiring. Full OSS suite green (pre-existing unrelated `BEGIN IMMEDIATE` failures excluded).

## Deploy note
The sweep writes a new `'expired'` status. Roll out the enum + `_parse_status` reader-tolerance **before** enabling the sweep (two-stage), so a rollback to a pre-EXPIRED build can't crash on `Status('expired')`. See `docs_for_coding_agent/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for expiring active profiles and reclaiming expired records.
  * Share links and pending tool calls can now be cleaned up after expiry, with configurable grace periods and limits.
  * Multi-tenant background cleanup can now run across all discovered orgs.

* **Bug Fixes**
  * Expired items are now handled more consistently in reads, cleanup, and user-data deletion.
  * Improved handling for unknown stored status values to avoid read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
