### PR TITLE
refactor(storage): decompose SQLiteStorageBase — peel deletion + fts/vec clusters

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -24,7 +24,7 @@ from ._stall_state import (
     mark_stall_notified,
     upsert_stall_state,
 )
-from .base import SQLiteDeletionMixin
+from .base import SQLiteDeletionMixin, SQLiteFtsVecMixin
 from .governance import (
     AuditEventStoreMixin,
     GovernanceEraseExecutionMixin,
@@ -66,6 +66,7 @@ class SQLiteStorage(
     SQLiteStallStateMixin,
     SQLiteShadowVerdictsMixin,
     SQLiteDeletionMixin,
+    SQLiteFtsVecMixin,
     SQLiteStorageBase,
 ):
     """SQLite-based storage with FTS5 and hybrid search."""

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -24,6 +24,7 @@ from ._stall_state import (
     mark_stall_notified,
     upsert_stall_state,
 )
+from .base import SQLiteDeletionMixin
 from .governance import (
     AuditEventStoreMixin,
     GovernanceEraseExecutionMixin,
@@ -64,6 +65,7 @@ class SQLiteStorage(
     SQLiteShareLinkMixin,
     SQLiteStallStateMixin,
     SQLiteShadowVerdictsMixin,
+    SQLiteDeletionMixin,
     SQLiteStorageBase,
 ):
     """SQLite-based storage with FTS5 and hybrid search."""

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -582,6 +582,10 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     _delete_in_chunks: Any
     _delete_source_windows_for_user_playbook_ids: Any
 
+    # FTS/vec index helpers provided by SQLiteFtsVecMixin via the composed
+    # SQLiteStorage MRO; declared here for _migrate_vec_tables's benefit.
+    _vec_upsert: Any
+
     @staticmethod
     def handle_exceptions(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)
@@ -1519,113 +1523,6 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
 
     def _current_timestamp(self) -> str:
         return datetime.now(UTC).isoformat()
-
-    # FTS helpers
-    def _fts_upsert(self, table: str, rowid: int, **text_fields: str | None) -> None:
-        """Insert or update an FTS row.  Deletes old entry first to avoid duplicates."""
-        with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
-            cols = list(text_fields.keys())
-            vals = [text_fields[c] or "" for c in cols]
-            placeholders = ",".join("?" for _ in cols)
-            col_str = ",".join(cols)
-            self.conn.execute(
-                f"INSERT INTO {table}(rowid, {col_str}) VALUES (?, {placeholders})",
-                [rowid, *vals],
-            )
-            self.conn.commit()
-
-    def _fts_delete(self, table: str, rowid: int) -> None:
-        with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
-            self.conn.commit()
-
-    def _fts_upsert_profile(self, profile_id: str, content: str) -> None:
-        """FTS for profiles uses profile_id TEXT as key column."""
-        with self._lock:
-            self.conn.execute(
-                "DELETE FROM profiles_fts WHERE profile_id = ?", (profile_id,)
-            )
-            self.conn.execute(
-                "INSERT INTO profiles_fts(profile_id, content) VALUES (?, ?)",
-                (profile_id, content),
-            )
-            self.conn.commit()
-
-    def _fts_delete_profile(self, profile_id: str) -> None:
-        with self._lock:
-            self.conn.execute(
-                "DELETE FROM profiles_fts WHERE profile_id = ?", (profile_id,)
-            )
-            self.conn.commit()
-
-    # Vec helpers (sqlite-vec)
-    def _vec_upsert(self, table: str, rowid: int, embedding: list[float]) -> None:
-        """Insert or update a vec table row. No-op when sqlite-vec is unavailable."""
-        if not self._has_sqlite_vec:
-            return
-        with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
-            self.conn.execute(
-                f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
-                (rowid, json.dumps(embedding)),
-            )
-            self.conn.commit()
-
-    def _vec_delete(self, table: str, rowid: int) -> None:
-        """Delete a vec table row. No-op when sqlite-vec is unavailable."""
-        if not self._has_sqlite_vec:
-            return
-        with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
-            self.conn.commit()
-
-    def _vec_knn_search(
-        self,
-        vec_table: str,
-        main_table: str,
-        query_embedding: list[float],
-        match_count: int,
-        conditions: list[str] | None = None,
-        params: list[Any] | None = None,
-    ) -> list[sqlite3.Row]:
-        """Run a native KNN search via sqlite-vec and join back to the main table.
-
-        Over-fetches from the KNN index (5x ``match_count``) so that post-filter
-        WHERE conditions (org, user, status, etc.) don't silently reduce the
-        result set below the requested count.
-
-        Args:
-            vec_table: Name of the vec0 virtual table.
-            main_table: Name of the main data table.
-            query_embedding: Query embedding vector.
-            match_count: Number of results to return.
-            conditions: Optional WHERE conditions for the main table.
-            params: Parameters for the conditions.
-
-        Returns:
-            Up to ``match_count`` rows from the main table, ordered by vector
-            distance (ascending).
-        """
-        knn_overfetch = match_count * 5
-        where_clause = " AND ".join(conditions) if conditions else "1=1"
-        sql = f"""SELECT m.* FROM {main_table} m
-                  JOIN (
-                      SELECT rowid, distance FROM {vec_table}
-                      WHERE embedding MATCH ?
-                      ORDER BY distance
-                      LIMIT ?
-                  ) v ON m.rowid = v.rowid
-                  WHERE {where_clause}
-                  ORDER BY v.distance
-                  LIMIT ?"""
-        all_params = [
-            json.dumps(query_embedding),
-            knn_overfetch,
-            *(params or []),
-            match_count,
-        ]
-        return self._fetchall(sql, all_params)
 
     # ------------------------------------------------------------------
     # Per-user data clear

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -53,12 +53,7 @@ from reflexio.server.services.storage.error import (
     StorageError,
     require_non_empty_session_id,
 )
-from reflexio.server.services.storage.retention import RetentionTarget
-from reflexio.server.services.storage.retention_mixin import (
-    RETENTION_DELETE_CHUNK,
-    RetentionMixin,
-    chunked,
-)
+from reflexio.server.services.storage.retention_mixin import RetentionMixin
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.site_var.site_var_manager import SiteVarManager
 
@@ -582,6 +577,11 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
 
     supports_embedding: ClassVar[bool] = True
 
+    # Chunked bulk-delete helpers provided by SQLiteDeletionMixin via the
+    # composed SQLiteStorage MRO; declared here for clear_user_data's benefit.
+    _delete_in_chunks: Any
+    _delete_source_windows_for_user_playbook_ids: Any
+
     @staticmethod
     def handle_exceptions(func: Callable[..., Any]) -> Callable[..., Any]:
         @functools.wraps(func)
@@ -706,239 +706,6 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_retire_playbook_aggregation_change_logs()
         init_stall_state_table(self.conn)
         return True
-
-    # -- Retention hooks (see RetentionMixin) --
-
-    @handle_exceptions
-    def _retention_table_exists(self, table_name: str) -> bool:
-        row = self._fetchone(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
-            (table_name,),
-        )
-        return row is not None
-
-    @handle_exceptions
-    def _retention_count_rows(self, target: RetentionTarget) -> int:
-        row = self._fetchone(f"SELECT COUNT(*) as cnt FROM {target.table_name}")  # noqa: S608
-        return int(row["cnt"]) if row else 0
-
-    @handle_exceptions
-    def _retention_select_oldest_keys(
-        self, target: RetentionTarget, count: int
-    ) -> list[tuple[Any, ...]]:
-        id_sql = ", ".join(target.id_columns)
-        tiebreak_sql = id_sql
-        rows = self._fetchall(
-            f"SELECT {id_sql} FROM {target.table_name} "  # noqa: S608
-            f"ORDER BY {target.order_column} ASC, {tiebreak_sql} ASC LIMIT ?",
-            (count,),
-        )
-        return [tuple(row[col] for col in target.id_columns) for row in rows]
-
-    @handle_exceptions
-    def _retention_perform_delete(
-        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
-    ) -> None:
-        # Wrap dependency + target deletes in a single critical section so
-        # concurrent writers see either both or neither.
-        with self._lock:
-            try:
-                self._retention_delete_dependencies(target, keys)
-                self._retention_delete_target_rows(target, keys)
-                self.conn.commit()
-            except Exception:
-                self.conn.rollback()
-                raise
-
-    def _retention_delete_dependencies(
-        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
-    ) -> None:
-        ids = [key[0] for key in keys]
-        target_name = target.name
-        if target_name == "requests":
-            self._delete_interactions_for_request_ids([str(v) for v in ids])
-        elif target_name == "interactions":
-            self._delete_interaction_search_rows([int(v) for v in ids])
-        elif target_name == "profiles":
-            self._delete_profile_search_rows([str(v) for v in ids])
-        elif target_name == "user_playbooks":
-            self._delete_source_windows_for_user_playbook_ids([int(v) for v in ids])
-            self._delete_playbook_search_rows(
-                "user", [int(v) for v in ids], commit=False
-            )
-        elif target_name == "agent_playbooks":
-            self._delete_source_windows_for_agent_playbook_ids([int(v) for v in ids])
-            self._delete_playbook_search_rows(
-                "agent", [int(v) for v in ids], commit=False
-            )
-        elif target_name == "playbook_optimization_jobs":
-            self._delete_optimizer_rows_for_job_ids([int(v) for v in ids])
-        elif target_name == "playbook_optimization_candidates":
-            self._delete_optimizer_evaluations_for_candidate_ids([int(v) for v in ids])
-
-    def _retention_delete_target_rows(
-        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
-    ) -> None:
-        if len(target.id_columns) == 1:
-            self._delete_in_chunks(
-                target.table_name,
-                target.id_columns[0],
-                [key[0] for key in keys],
-            )
-            return
-        # Composite-key delete: chunk by row to bound parameter count.
-        params_per_key = len(target.id_columns)
-        rows_per_chunk = max(1, RETENTION_DELETE_CHUNK // params_per_key)
-        for chunk in chunked(keys, rows_per_chunk):
-            where = " OR ".join(
-                "("
-                + " AND ".join(f"{column} = ?" for column in target.id_columns)
-                + ")"
-                for _ in chunk
-            )
-            params = [value for key in chunk for value in key]
-            self.conn.execute(
-                f"DELETE FROM {target.table_name} WHERE {where}",  # noqa: S608
-                params,
-            )
-
-    # -- Chunked-delete primitives shared by the cascade helpers --
-
-    def _delete_in_chunks(
-        self, table_name: str, column_name: str, values: list[Any]
-    ) -> None:
-        """Chunked ``DELETE FROM table WHERE col IN (...)``.
-
-        Chunking keeps parameter count under ``SQLITE_MAX_VARIABLE_NUMBER``
-        on older sqlite builds (default 999) and avoids degenerate plans
-        on very large IN lists.
-        """
-        if not values:
-            return
-        for chunk in chunked(values):
-            placeholders = ",".join("?" for _ in chunk)
-            self.conn.execute(
-                f"DELETE FROM {table_name} WHERE {column_name} IN ({placeholders})",  # noqa: S608
-                chunk,
-            )
-
-    def _select_in_chunks(self, sql_template: str, values: list[Any]) -> list[Any]:
-        """Run ``sql_template`` (containing ``{placeholders}``) over chunks of
-        ``values`` and aggregate the result rows."""
-        results: list[Any] = []
-        for chunk in chunked(values):
-            placeholders = ",".join("?" for _ in chunk)
-            stmt = sql_template.format(placeholders=placeholders)
-            results.extend(self.conn.execute(stmt, chunk).fetchall())
-        return results
-
-    def _delete_interactions_for_request_ids(self, request_ids: list[str]) -> None:
-        if not request_ids:
-            return
-        rows = self._select_in_chunks(
-            "SELECT interaction_id FROM interactions WHERE request_id IN ({placeholders})",
-            request_ids,
-        )
-        self._delete_interaction_search_rows(
-            [int(row["interaction_id"]) for row in rows]
-        )
-        self._delete_in_chunks("interactions", "request_id", request_ids)
-
-    def _delete_interaction_search_rows(self, interaction_ids: list[int]) -> None:
-        """Remove fts + vec index rows for the given interaction IDs.
-
-        Non-committing: participates in the caller's transaction.  Only called
-        from inside the retention atomic block (_retention_perform_delete).
-        """
-        if not interaction_ids:
-            return
-        self._delete_in_chunks("interactions_fts", "rowid", interaction_ids)
-        if self._has_sqlite_vec:
-            self._delete_in_chunks("interactions_vec", "rowid", interaction_ids)
-
-    def _delete_profile_search_rows(self, profile_ids: list[str]) -> None:
-        """Remove fts + vec index rows for the given profile IDs.
-
-        Non-committing: participates in the caller's transaction.  Only called
-        from inside the retention atomic block (_retention_perform_delete).
-        profiles_fts is keyed by profile_id (TEXT); profiles_vec by rowid (INT).
-        """
-        if not profile_ids:
-            return
-        self._delete_in_chunks("profiles_fts", "profile_id", profile_ids)
-        if self._has_sqlite_vec:
-            rows = self._select_in_chunks(
-                "SELECT rowid FROM profiles WHERE profile_id IN ({placeholders})",
-                profile_ids,
-            )
-            rowids = [row["rowid"] for row in rows]
-            if rowids:
-                self._delete_in_chunks("profiles_vec", "rowid", rowids)
-
-    def _delete_playbook_search_rows(
-        self, kind: str, ids: list[int], *, commit: bool = True
-    ) -> None:
-        """Remove fts + vec index rows for the given playbook IDs.
-
-        Args:
-            kind: ``"user"`` or ``"agent"``.
-            ids: Playbook row IDs to remove from the search indexes.
-            commit: When ``True`` (default) commits after the deletes so the
-                after-commit callers in ``_playbook.py`` get a clean, durable
-                cleanup.  Pass ``commit=False`` from inside the retention atomic
-                block so the deletes participate in the single block-level commit
-                (``_retention_perform_delete``).
-
-        Note: callers may already hold ``self._lock`` when calling this (the
-        ``commit=False`` retention/atomic-delete call sites do). The internal
-        ``with self._lock:`` re-acquire is safe ONLY because ``self._lock`` is a
-        reentrant ``threading.RLock``; a non-reentrant lock would deadlock here.
-        """
-        if not ids:
-            return
-        with self._lock:
-            self._delete_in_chunks(f"{kind}_playbooks_fts", "rowid", ids)
-            if self._has_sqlite_vec:
-                self._delete_in_chunks(f"{kind}_playbooks_vec", "rowid", ids)
-            if commit:
-                self.conn.commit()
-
-    def _delete_source_windows_for_agent_playbook_ids(
-        self, agent_playbook_ids: list[int]
-    ) -> None:
-        self._delete_in_chunks(
-            "agent_playbook_source_user_playbooks",
-            "agent_playbook_id",
-            agent_playbook_ids,
-        )
-
-    def _delete_source_windows_for_user_playbook_ids(
-        self, user_playbook_ids: list[int]
-    ) -> None:
-        self._delete_in_chunks(
-            "agent_playbook_source_user_playbooks",
-            "user_playbook_id",
-            user_playbook_ids,
-        )
-
-    def _delete_optimizer_rows_for_job_ids(self, job_ids: list[int]) -> None:
-        if not job_ids:
-            return
-        for table in (
-            "playbook_optimization_evaluations",
-            "playbook_optimization_events",
-            "playbook_optimization_candidates",
-        ):
-            self._delete_in_chunks(table, "job_id", job_ids)
-
-    def _delete_optimizer_evaluations_for_candidate_ids(
-        self, candidate_ids: list[int]
-    ) -> None:
-        self._delete_in_chunks(
-            "playbook_optimization_evaluations",
-            "candidate_id",
-            candidate_ids,
-        )
 
     def _try_load_sqlite_vec(self) -> bool:
         """Attempt to load the sqlite-vec extension for native KNN search.

--- a/reflexio/server/services/storage/sqlite_storage/base/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/__init__.py
@@ -1,0 +1,5 @@
+"""SQLite storage base sub-mixins (peeled from _base.py)."""
+
+from ._deletion import SQLiteDeletionMixin
+
+__all__ = ["SQLiteDeletionMixin"]

--- a/reflexio/server/services/storage/sqlite_storage/base/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/__init__.py
@@ -1,5 +1,6 @@
 """SQLite storage base sub-mixins (peeled from _base.py)."""
 
 from ._deletion import SQLiteDeletionMixin
+from ._fts_vec import SQLiteFtsVecMixin
 
-__all__ = ["SQLiteDeletionMixin"]
+__all__ = ["SQLiteDeletionMixin", "SQLiteFtsVecMixin"]

--- a/reflexio/server/services/storage/sqlite_storage/base/_deletion.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_deletion.py
@@ -1,0 +1,263 @@
+"""SQLite retention-hook + chunked bulk-delete helpers.
+
+Peeled verbatim from ``_base.py`` (Tier-1 storage decomposition). Composed into
+``SQLiteStorage`` ahead of ``SQLiteStorageBase`` so the atomic
+``_retention_perform_delete`` override wins over ``RetentionMixin``'s default.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+from reflexio.server.services.storage.retention import RetentionTarget
+from reflexio.server.services.storage.retention_mixin import (
+    RETENTION_DELETE_CHUNK,
+    chunked,
+)
+
+from .._base import SQLiteStorageBase
+
+
+class SQLiteDeletionMixin:
+    """Retention-hook impls + chunked bulk-delete helpers for SQLite storage."""
+
+    # Type hints for instance attributes/methods provided by SQLiteStorageBase via MRO
+    _lock: Any
+    conn: sqlite3.Connection
+    _fetchone: Any
+    _fetchall: Any
+    _has_sqlite_vec: bool
+
+    # -- Retention hooks (see RetentionMixin) --
+
+    @SQLiteStorageBase.handle_exceptions
+    def _retention_table_exists(self, table_name: str) -> bool:
+        row = self._fetchone(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        )
+        return row is not None
+
+    @SQLiteStorageBase.handle_exceptions
+    def _retention_count_rows(self, target: RetentionTarget) -> int:
+        row = self._fetchone(f"SELECT COUNT(*) as cnt FROM {target.table_name}")  # noqa: S608
+        return int(row["cnt"]) if row else 0
+
+    @SQLiteStorageBase.handle_exceptions
+    def _retention_select_oldest_keys(
+        self, target: RetentionTarget, count: int
+    ) -> list[tuple[Any, ...]]:
+        id_sql = ", ".join(target.id_columns)
+        tiebreak_sql = id_sql
+        rows = self._fetchall(
+            f"SELECT {id_sql} FROM {target.table_name} "  # noqa: S608
+            f"ORDER BY {target.order_column} ASC, {tiebreak_sql} ASC LIMIT ?",
+            (count,),
+        )
+        return [tuple(row[col] for col in target.id_columns) for row in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def _retention_perform_delete(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        # Wrap dependency + target deletes in a single critical section so
+        # concurrent writers see either both or neither.
+        with self._lock:
+            try:
+                self._retention_delete_dependencies(target, keys)
+                self._retention_delete_target_rows(target, keys)
+                self.conn.commit()
+            except Exception:
+                self.conn.rollback()
+                raise
+
+    def _retention_delete_dependencies(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        ids = [key[0] for key in keys]
+        target_name = target.name
+        if target_name == "requests":
+            self._delete_interactions_for_request_ids([str(v) for v in ids])
+        elif target_name == "interactions":
+            self._delete_interaction_search_rows([int(v) for v in ids])
+        elif target_name == "profiles":
+            self._delete_profile_search_rows([str(v) for v in ids])
+        elif target_name == "user_playbooks":
+            self._delete_source_windows_for_user_playbook_ids([int(v) for v in ids])
+            self._delete_playbook_search_rows(
+                "user", [int(v) for v in ids], commit=False
+            )
+        elif target_name == "agent_playbooks":
+            self._delete_source_windows_for_agent_playbook_ids([int(v) for v in ids])
+            self._delete_playbook_search_rows(
+                "agent", [int(v) for v in ids], commit=False
+            )
+        elif target_name == "playbook_optimization_jobs":
+            self._delete_optimizer_rows_for_job_ids([int(v) for v in ids])
+        elif target_name == "playbook_optimization_candidates":
+            self._delete_optimizer_evaluations_for_candidate_ids([int(v) for v in ids])
+
+    def _retention_delete_target_rows(
+        self, target: RetentionTarget, keys: list[tuple[Any, ...]]
+    ) -> None:
+        if len(target.id_columns) == 1:
+            self._delete_in_chunks(
+                target.table_name,
+                target.id_columns[0],
+                [key[0] for key in keys],
+            )
+            return
+        # Composite-key delete: chunk by row to bound parameter count.
+        params_per_key = len(target.id_columns)
+        rows_per_chunk = max(1, RETENTION_DELETE_CHUNK // params_per_key)
+        for chunk in chunked(keys, rows_per_chunk):
+            where = " OR ".join(
+                "("
+                + " AND ".join(f"{column} = ?" for column in target.id_columns)
+                + ")"
+                for _ in chunk
+            )
+            params = [value for key in chunk for value in key]
+            self.conn.execute(
+                f"DELETE FROM {target.table_name} WHERE {where}",  # noqa: S608
+                params,
+            )
+
+    # -- Chunked-delete primitives shared by the cascade helpers --
+
+    def _delete_in_chunks(
+        self, table_name: str, column_name: str, values: list[Any]
+    ) -> None:
+        """Chunked ``DELETE FROM table WHERE col IN (...)``.
+
+        Chunking keeps parameter count under ``SQLITE_MAX_VARIABLE_NUMBER``
+        on older sqlite builds (default 999) and avoids degenerate plans
+        on very large IN lists.
+        """
+        if not values:
+            return
+        for chunk in chunked(values):
+            placeholders = ",".join("?" for _ in chunk)
+            self.conn.execute(
+                f"DELETE FROM {table_name} WHERE {column_name} IN ({placeholders})",  # noqa: S608
+                chunk,
+            )
+
+    def _select_in_chunks(self, sql_template: str, values: list[Any]) -> list[Any]:
+        """Run ``sql_template`` (containing ``{placeholders}``) over chunks of
+        ``values`` and aggregate the result rows."""
+        results: list[Any] = []
+        for chunk in chunked(values):
+            placeholders = ",".join("?" for _ in chunk)
+            stmt = sql_template.format(placeholders=placeholders)
+            results.extend(self.conn.execute(stmt, chunk).fetchall())
+        return results
+
+    def _delete_interactions_for_request_ids(self, request_ids: list[str]) -> None:
+        if not request_ids:
+            return
+        rows = self._select_in_chunks(
+            "SELECT interaction_id FROM interactions WHERE request_id IN ({placeholders})",
+            request_ids,
+        )
+        self._delete_interaction_search_rows(
+            [int(row["interaction_id"]) for row in rows]
+        )
+        self._delete_in_chunks("interactions", "request_id", request_ids)
+
+    def _delete_interaction_search_rows(self, interaction_ids: list[int]) -> None:
+        """Remove fts + vec index rows for the given interaction IDs.
+
+        Non-committing: participates in the caller's transaction.  Only called
+        from inside the retention atomic block (_retention_perform_delete).
+        """
+        if not interaction_ids:
+            return
+        self._delete_in_chunks("interactions_fts", "rowid", interaction_ids)
+        if self._has_sqlite_vec:
+            self._delete_in_chunks("interactions_vec", "rowid", interaction_ids)
+
+    def _delete_profile_search_rows(self, profile_ids: list[str]) -> None:
+        """Remove fts + vec index rows for the given profile IDs.
+
+        Non-committing: participates in the caller's transaction.  Only called
+        from inside the retention atomic block (_retention_perform_delete).
+        profiles_fts is keyed by profile_id (TEXT); profiles_vec by rowid (INT).
+        """
+        if not profile_ids:
+            return
+        self._delete_in_chunks("profiles_fts", "profile_id", profile_ids)
+        if self._has_sqlite_vec:
+            rows = self._select_in_chunks(
+                "SELECT rowid FROM profiles WHERE profile_id IN ({placeholders})",
+                profile_ids,
+            )
+            rowids = [row["rowid"] for row in rows]
+            if rowids:
+                self._delete_in_chunks("profiles_vec", "rowid", rowids)
+
+    def _delete_playbook_search_rows(
+        self, kind: str, ids: list[int], *, commit: bool = True
+    ) -> None:
+        """Remove fts + vec index rows for the given playbook IDs.
+
+        Args:
+            kind: ``"user"`` or ``"agent"``.
+            ids: Playbook row IDs to remove from the search indexes.
+            commit: When ``True`` (default) commits after the deletes so the
+                after-commit callers in ``_playbook.py`` get a clean, durable
+                cleanup.  Pass ``commit=False`` from inside the retention atomic
+                block so the deletes participate in the single block-level commit
+                (``_retention_perform_delete``).
+
+        Note: callers may already hold ``self._lock`` when calling this (the
+        ``commit=False`` retention/atomic-delete call sites do). The internal
+        ``with self._lock:`` re-acquire is safe ONLY because ``self._lock`` is a
+        reentrant ``threading.RLock``; a non-reentrant lock would deadlock here.
+        """
+        if not ids:
+            return
+        with self._lock:
+            self._delete_in_chunks(f"{kind}_playbooks_fts", "rowid", ids)
+            if self._has_sqlite_vec:
+                self._delete_in_chunks(f"{kind}_playbooks_vec", "rowid", ids)
+            if commit:
+                self.conn.commit()
+
+    def _delete_source_windows_for_agent_playbook_ids(
+        self, agent_playbook_ids: list[int]
+    ) -> None:
+        self._delete_in_chunks(
+            "agent_playbook_source_user_playbooks",
+            "agent_playbook_id",
+            agent_playbook_ids,
+        )
+
+    def _delete_source_windows_for_user_playbook_ids(
+        self, user_playbook_ids: list[int]
+    ) -> None:
+        self._delete_in_chunks(
+            "agent_playbook_source_user_playbooks",
+            "user_playbook_id",
+            user_playbook_ids,
+        )
+
+    def _delete_optimizer_rows_for_job_ids(self, job_ids: list[int]) -> None:
+        if not job_ids:
+            return
+        for table in (
+            "playbook_optimization_evaluations",
+            "playbook_optimization_events",
+            "playbook_optimization_candidates",
+        ):
+            self._delete_in_chunks(table, "job_id", job_ids)
+
+    def _delete_optimizer_evaluations_for_candidate_ids(
+        self, candidate_ids: list[int]
+    ) -> None:
+        self._delete_in_chunks(
+            "playbook_optimization_evaluations",
+            "candidate_id",
+            candidate_ids,
+        )

--- a/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
@@ -1,0 +1,132 @@
+"""SQLite FTS5 + sqlite-vec index maintenance helpers.
+
+Peeled verbatim from ``_base.py`` (Tier-1 storage decomposition). These helpers
+are **self-committing**: each calls ``self.conn.commit()`` internally so the
+index sidecar update is durable. They are sqlite-only — there is no
+supabase/postgres counterpart. Composed into ``SQLiteStorage`` ahead of
+``SQLiteStorageBase``; the boot-time ``_migrate_vec_tables`` (residual in
+``_base.py``) resolves ``self._vec_upsert`` through the composed MRO.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any
+
+
+class SQLiteFtsVecMixin:
+    """FTS5 + sqlite-vec index-maintenance helpers for SQLite storage."""
+
+    # Type hints for instance attributes/methods provided by SQLiteStorageBase via MRO
+    _lock: Any
+    conn: sqlite3.Connection
+    _fetchall: Any
+    _has_sqlite_vec: bool
+
+    # FTS helpers
+    def _fts_upsert(self, table: str, rowid: int, **text_fields: str | None) -> None:
+        """Insert or update an FTS row.  Deletes old entry first to avoid duplicates."""
+        with self._lock:
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            cols = list(text_fields.keys())
+            vals = [text_fields[c] or "" for c in cols]
+            placeholders = ",".join("?" for _ in cols)
+            col_str = ",".join(cols)
+            self.conn.execute(
+                f"INSERT INTO {table}(rowid, {col_str}) VALUES (?, {placeholders})",
+                [rowid, *vals],
+            )
+            self.conn.commit()
+
+    def _fts_delete(self, table: str, rowid: int) -> None:
+        with self._lock:
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.commit()
+
+    def _fts_upsert_profile(self, profile_id: str, content: str) -> None:
+        """FTS for profiles uses profile_id TEXT as key column."""
+        with self._lock:
+            self.conn.execute(
+                "DELETE FROM profiles_fts WHERE profile_id = ?", (profile_id,)
+            )
+            self.conn.execute(
+                "INSERT INTO profiles_fts(profile_id, content) VALUES (?, ?)",
+                (profile_id, content),
+            )
+            self.conn.commit()
+
+    def _fts_delete_profile(self, profile_id: str) -> None:
+        with self._lock:
+            self.conn.execute(
+                "DELETE FROM profiles_fts WHERE profile_id = ?", (profile_id,)
+            )
+            self.conn.commit()
+
+    # Vec helpers (sqlite-vec)
+    def _vec_upsert(self, table: str, rowid: int, embedding: list[float]) -> None:
+        """Insert or update a vec table row. No-op when sqlite-vec is unavailable."""
+        if not self._has_sqlite_vec:
+            return
+        with self._lock:
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.execute(
+                f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
+                (rowid, json.dumps(embedding)),
+            )
+            self.conn.commit()
+
+    def _vec_delete(self, table: str, rowid: int) -> None:
+        """Delete a vec table row. No-op when sqlite-vec is unavailable."""
+        if not self._has_sqlite_vec:
+            return
+        with self._lock:
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.commit()
+
+    def _vec_knn_search(
+        self,
+        vec_table: str,
+        main_table: str,
+        query_embedding: list[float],
+        match_count: int,
+        conditions: list[str] | None = None,
+        params: list[Any] | None = None,
+    ) -> list[sqlite3.Row]:
+        """Run a native KNN search via sqlite-vec and join back to the main table.
+
+        Over-fetches from the KNN index (5x ``match_count``) so that post-filter
+        WHERE conditions (org, user, status, etc.) don't silently reduce the
+        result set below the requested count.
+
+        Args:
+            vec_table: Name of the vec0 virtual table.
+            main_table: Name of the main data table.
+            query_embedding: Query embedding vector.
+            match_count: Number of results to return.
+            conditions: Optional WHERE conditions for the main table.
+            params: Parameters for the conditions.
+
+        Returns:
+            Up to ``match_count`` rows from the main table, ordered by vector
+            distance (ascending).
+        """
+        knn_overfetch = match_count * 5
+        where_clause = " AND ".join(conditions) if conditions else "1=1"
+        sql = f"""SELECT m.* FROM {main_table} m
+                  JOIN (
+                      SELECT rowid, distance FROM {vec_table}
+                      WHERE embedding MATCH ?
+                      ORDER BY distance
+                      LIMIT ?
+                  ) v ON m.rowid = v.rowid
+                  WHERE {where_clause}
+                  ORDER BY v.distance
+                  LIMIT ?"""
+        all_params = [
+            json.dumps(query_embedding),
+            knn_overfetch,
+            *(params or []),
+            match_count,
+        ]
+        return self._fetchall(sql, all_params)

--- a/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
@@ -28,20 +28,20 @@ class SQLiteFtsVecMixin:
     def _fts_upsert(self, table: str, rowid: int, **text_fields: str | None) -> None:
         """Insert or update an FTS row.  Deletes old entry first to avoid duplicates."""
         with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))  # noqa: S608
             cols = list(text_fields.keys())
             vals = [text_fields[c] or "" for c in cols]
             placeholders = ",".join("?" for _ in cols)
             col_str = ",".join(cols)
             self.conn.execute(
-                f"INSERT INTO {table}(rowid, {col_str}) VALUES (?, {placeholders})",
+                f"INSERT INTO {table}(rowid, {col_str}) VALUES (?, {placeholders})",  # noqa: S608
                 [rowid, *vals],
             )
             self.conn.commit()
 
     def _fts_delete(self, table: str, rowid: int) -> None:
         with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))  # noqa: S608
             self.conn.commit()
 
     def _fts_upsert_profile(self, profile_id: str, content: str) -> None:
@@ -69,9 +69,9 @@ class SQLiteFtsVecMixin:
         if not self._has_sqlite_vec:
             return
         with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))  # noqa: S608
             self.conn.execute(
-                f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
+                f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",  # noqa: S608
                 (rowid, json.dumps(embedding)),
             )
             self.conn.commit()
@@ -81,7 +81,7 @@ class SQLiteFtsVecMixin:
         if not self._has_sqlite_vec:
             return
         with self._lock:
-            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))
+            self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))  # noqa: S608
             self.conn.commit()
 
     def _vec_knn_search(
@@ -122,7 +122,7 @@ class SQLiteFtsVecMixin:
                   ) v ON m.rowid = v.rowid
                   WHERE {where_clause}
                   ORDER BY v.distance
-                  LIMIT ?"""
+                  LIMIT ?"""  # noqa: S608
         all_params = [
             json.dumps(query_embedding),
             knn_overfetch,

--- a/tests/server/services/storage/sqlite_storage/test_delete_in_chunks_boundary_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_delete_in_chunks_boundary_integration.py
@@ -1,0 +1,120 @@
+"""Characterization test: ``_delete_in_chunks`` batches its ``IN (...)`` deletes.
+
+Pins the chunk-boundary behavior a later verbatim move (peeling
+``SQLiteDeletionMixin`` out of ``sqlite_storage/_base.py``) must preserve.
+
+Modern sqlite raises ``SQLITE_LIMIT_VARIABLE_NUMBER`` to 32766, so a naive
+single-statement ``IN`` over ~1200 ids would NOT overflow here and the chunk
+guard would look vacuous. To keep the test falsifiable across builds, the
+fixture caps the connection's variable limit to 999 (the classic old-build
+default). Chunking uses ``RETENTION_DELETE_CHUNK`` (500) params per statement,
+so it stays under the cap while any un-chunked collapse would exceed it.
+
+Falsifiability: if a later move collapses the batching into a single
+``DELETE ... WHERE col IN (<all ids>)``, the >999-id cases raise
+``sqlite3.OperationalError: too many SQL variables`` and the "keep" assertion
+catches an over-broad delete. A stub that no-ops fails the deletion assertion.
+"""
+
+import sqlite3
+
+import pytest
+
+from reflexio.server.services.storage.retention_mixin import RETENTION_DELETE_CHUNK
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+# Classic pre-3.32 default; below any un-chunked collapse of the id lists used
+# here, but above the per-chunk parameter count (RETENTION_DELETE_CHUNK).
+_OLD_SQLITE_VARIABLE_LIMIT = 999
+
+
+def _store(tmp_path) -> SQLiteStorage:
+    storage = SQLiteStorage(org_id="org-chunk", db_path=str(tmp_path / "chunk.db"))
+    storage.conn.setlimit(
+        sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, _OLD_SQLITE_VARIABLE_LIMIT
+    )
+    return storage
+
+
+def _make_scratch_table(storage: SQLiteStorage) -> None:
+    storage.conn.execute(
+        "CREATE TABLE chunk_scratch (id INTEGER PRIMARY KEY, tag TEXT)"
+    )
+    storage.conn.commit()
+
+
+def _insert_ids(storage: SQLiteStorage, ids: list[int], tag: str) -> None:
+    storage.conn.executemany(
+        "INSERT INTO chunk_scratch (id, tag) VALUES (?, ?)",
+        [(i, tag) for i in ids],
+    )
+    storage.conn.commit()
+
+
+@pytest.mark.parametrize(
+    "delete_count",
+    [
+        RETENTION_DELETE_CHUNK - 1,  # under one chunk
+        RETENTION_DELETE_CHUNK,  # exactly one chunk boundary
+        RETENTION_DELETE_CHUNK + 1,  # one past the boundary (2 chunks)
+        RETENTION_DELETE_CHUNK * 2 + 200,  # 3 chunks, > the capped variable limit
+    ],
+)
+def test_delete_in_chunks_deletes_all_across_chunk_boundaries(
+    tmp_path, delete_count: int
+) -> None:
+    storage = _store(tmp_path)
+    _make_scratch_table(storage)
+
+    # Ids to delete plus a disjoint "keep" set that must survive.
+    delete_ids = list(range(1, delete_count + 1))
+    keep_ids = list(range(1_000_000, 1_000_000 + 50))
+    _insert_ids(storage, delete_ids, "del")
+    _insert_ids(storage, keep_ids, "keep")
+
+    # Must not raise "too many SQL variables" even for id lists > the cap.
+    storage._delete_in_chunks("chunk_scratch", "id", delete_ids)  # type: ignore[attr-defined]
+
+    remaining = storage.conn.execute("SELECT id FROM chunk_scratch").fetchall()
+    remaining_ids = {row["id"] for row in remaining}
+
+    assert remaining_ids == set(keep_ids), (
+        "all target ids must be deleted and only the keep set may remain"
+    )
+
+
+def test_delete_in_chunks_empty_values_is_noop(tmp_path) -> None:
+    storage = _store(tmp_path)
+    _make_scratch_table(storage)
+    _insert_ids(storage, [1, 2, 3], "keep")
+
+    storage._delete_in_chunks("chunk_scratch", "id", [])  # type: ignore[attr-defined]
+
+    count = storage.conn.execute("SELECT COUNT(*) AS c FROM chunk_scratch").fetchone()
+    assert count["c"] == 3
+
+
+def test_delete_in_chunks_survives_where_single_statement_overflows(
+    tmp_path,
+) -> None:
+    """A single un-chunked ``IN`` over these ids overflows the cap; chunking must not."""
+    storage = _store(tmp_path)
+    _make_scratch_table(storage)
+    ids = list(range(1, 1500))
+    _insert_ids(storage, ids, "del")
+
+    # Sanity: a single-statement IN over the same ids DOES overflow the cap, so
+    # the chunked helper's success below is a real guard, not a vacuous pass.
+    placeholders = ",".join("?" for _ in ids)
+    with pytest.raises(sqlite3.OperationalError, match="too many SQL variables"):
+        storage.conn.execute(
+            f"DELETE FROM chunk_scratch WHERE id IN ({placeholders})",  # noqa: S608
+            ids,
+        )
+    storage.conn.rollback()
+
+    storage._delete_in_chunks("chunk_scratch", "id", ids)  # type: ignore[attr-defined]
+    count = storage.conn.execute("SELECT COUNT(*) AS c FROM chunk_scratch").fetchone()
+    assert count["c"] == 0

--- a/tests/server/services/storage/sqlite_storage/test_fts_vec_self_commit_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_fts_vec_self_commit_integration.py
@@ -1,0 +1,74 @@
+"""Characterization test: ``_fts_upsert`` / ``_vec_upsert`` self-commit.
+
+Pins the FtsVec day-one guard a later verbatim move (peeling
+``SQLiteFtsVecMixin`` out of ``sqlite_storage/_base.py``) must preserve: these
+helpers commit internally, so a write is immediately durable and visible from a
+SECOND connection with no outer commit from the caller.
+
+Falsifiability: if the move drops the helper's internal ``self.conn.commit()``,
+the write stays in the first connection's uncommitted transaction and a fresh
+second connection sees zero rows — the "visible" assertions below fail.
+"""
+
+import sqlite3
+
+import pytest
+
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+_ROWID = 987654
+
+
+def _store(tmp_path) -> tuple[SQLiteStorage, str]:
+    db_path = str(tmp_path / "ftsvec.db")
+    return SQLiteStorage(org_id="org-ftsvec", db_path=db_path), db_path
+
+
+def test_fts_upsert_is_visible_from_second_connection(tmp_path) -> None:
+    storage, db_path = _store(tmp_path)
+
+    # No outer transaction/commit from the test — the helper must self-commit.
+    storage._fts_upsert(  # type: ignore[attr-defined]
+        "user_playbooks_fts", _ROWID, search_text="self committing row"
+    )
+
+    probe = sqlite3.connect(db_path)
+    try:
+        found = probe.execute(
+            "SELECT rowid FROM user_playbooks_fts WHERE rowid = ?", (_ROWID,)
+        ).fetchall()
+    finally:
+        probe.close()
+
+    assert len(found) == 1, (
+        "_fts_upsert must self-commit so the row is visible from a second connection"
+    )
+
+
+def test_vec_upsert_is_visible_from_second_connection(tmp_path) -> None:
+    storage, db_path = _store(tmp_path)
+    if not storage._has_sqlite_vec:  # type: ignore[attr-defined]
+        pytest.skip("sqlite-vec extension not loaded in this environment")
+
+    embedding = [0.0] * storage.embedding_dimensions
+    storage._vec_upsert("user_playbooks_vec", _ROWID, embedding)  # type: ignore[attr-defined]
+
+    # A vec0 virtual table can only be queried with the extension loaded.
+    import sqlite_vec  # type: ignore[import-untyped]
+
+    probe = sqlite3.connect(db_path)
+    try:
+        probe.enable_load_extension(True)
+        sqlite_vec.load(probe)
+        probe.enable_load_extension(False)
+        found = probe.execute(
+            "SELECT rowid FROM user_playbooks_vec WHERE rowid = ?", (_ROWID,)
+        ).fetchall()
+    finally:
+        probe.close()
+
+    assert len(found) == 1, (
+        "_vec_upsert must self-commit so the row is visible from a second connection"
+    )

--- a/tests/server/services/storage/sqlite_storage/test_playbook_search_rows_commit_participation_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_playbook_search_rows_commit_participation_integration.py
@@ -1,0 +1,96 @@
+"""Characterization test: ``_delete_playbook_search_rows``'s ``commit=`` contract.
+
+Pins the exact behavior a later verbatim move (peeling ``SQLiteDeletionMixin``
+out of ``sqlite_storage/_base.py``) must preserve: ``commit=False`` participates
+in the caller's outer transaction (so a rollback discards the deletes), while
+the default ``commit=True`` durably persists them.
+
+Falsifiability:
+- If the move drops the ``commit=False`` path (i.e. always self-commits), the
+  ``commit=False`` test's rollback would no longer restore the FTS rows and the
+  "still present" assertion fails.
+- If the move drops the ``commit=True`` self-commit, the default test's rows
+  would reappear after the rollback and the "deleted" assertion fails.
+"""
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _store(tmp_path, name: str) -> SQLiteStorage:
+    return SQLiteStorage(org_id=f"org-{name}", db_path=str(tmp_path / f"{name}.db"))
+
+
+def _make_user_playbook(uid: int) -> UserPlaybook:
+    return UserPlaybook(
+        user_playbook_id=uid,
+        user_id="u1",
+        playbook_name="pb",
+        agent_version="v1",
+        request_id=f"req-{uid}",
+        content=f"content-{uid}",
+        created_at=uid,
+        source="test",
+        source_interaction_ids=[],
+    )
+
+
+def _seed_playbooks_with_fts(storage: SQLiteStorage) -> list[int]:
+    """Save two user playbooks via the real write path (which indexes FTS)."""
+    storage.save_user_playbooks([_make_user_playbook(1), _make_user_playbook(2)])
+    rows = storage.conn.execute(
+        "SELECT user_playbook_id FROM user_playbooks ORDER BY user_playbook_id"
+    ).fetchall()
+    ids = [row["user_playbook_id"] for row in rows]
+    assert len(ids) == 2
+    return ids
+
+
+def _fts_rowids_present(storage: SQLiteStorage, ids: list[int]) -> int:
+    ph = ",".join("?" for _ in ids)
+    rows = storage.conn.execute(
+        f"SELECT rowid FROM user_playbooks_fts WHERE rowid IN ({ph})",  # noqa: S608
+        ids,
+    ).fetchall()
+    return len(rows)
+
+
+def test_delete_playbook_search_rows_commit_false_participates_in_txn(
+    tmp_path,
+) -> None:
+    storage = _store(tmp_path, "commit-false")
+    ids = _seed_playbooks_with_fts(storage)
+    assert _fts_rowids_present(storage, ids) == 2
+
+    # commit=False: the deletes join the caller's open transaction and must NOT
+    # self-commit. Rolling back the outer transaction therefore restores them.
+    storage._delete_playbook_search_rows("user", ids, commit=False)  # type: ignore[attr-defined]
+    assert _fts_rowids_present(storage, ids) == 0  # pending within the txn
+
+    storage.conn.rollback()
+
+    assert _fts_rowids_present(storage, ids) == 2, (
+        "commit=False must not self-commit; the outer rollback must restore the rows"
+    )
+
+
+def test_delete_playbook_search_rows_default_commit_persists_across_rollback(
+    tmp_path,
+) -> None:
+    storage = _store(tmp_path, "commit-true")
+    ids = _seed_playbooks_with_fts(storage)
+    assert _fts_rowids_present(storage, ids) == 2
+
+    # Default commit=True self-commits, so a subsequent rollback is a no-op.
+    storage._delete_playbook_search_rows("user", ids)  # type: ignore[attr-defined]
+    assert _fts_rowids_present(storage, ids) == 0
+
+    storage.conn.rollback()
+
+    assert _fts_rowids_present(storage, ids) == 0, (
+        "default commit=True must durably persist the deletes past a rollback"
+    )

--- a/tests/server/services/storage/sqlite_storage/test_purge_content.py
+++ b/tests/server/services/storage/sqlite_storage/test_purge_content.py
@@ -477,13 +477,13 @@ def test_clear_user_data_chunk_boundary(tmp_path, monkeypatch):
     a chunk size of 2, then seeds 5 profiles so the delete-set crosses the chunk
     boundary. All rows must be deleted/purged without error.
     """
-    import reflexio.server.services.storage.sqlite_storage._base as _base_mod
+    import reflexio.server.services.storage.sqlite_storage.base._deletion as _deletion_mod
     from reflexio.server.services.storage.retention_mixin import chunked as real_chunked
 
     def chunked_size2(values, chunk_size=500):  # type: ignore[misc]
         return real_chunked(values, chunk_size=2)
 
-    monkeypatch.setattr(_base_mod, "chunked", chunked_size2)
+    monkeypatch.setattr(_deletion_mod, "chunked", chunked_size2)
 
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
         s = SQLiteStorage(org_id="0", db_path=str(tmp_path / "t.db"))


### PR DESCRIPTION
## Summary

Decompose the oversized `SQLiteStorageBase` god-class (2428 lines) by peeling two cohesive, runtime-independent helper clusters into sub-mixins, a behavior-preserving **verbatim** refactor with zero public-surface or behavior change. Fourth in the Tier-1 storage-decomposition series (after playbook, profiles, governance).

The load-bearing boot/schema block and the shared module-level utilities are deliberately **kept in place** — only the two genuinely-separable clusters move.

## Changes

Two sub-mixins under `sqlite_storage/base/`, composed via MRO ahead of the residual `SQLiteStorageBase`:

- **`SQLiteDeletionMixin`** (`base/_deletion.py`) — the `_retention_*` hook implementations (incl. the atomic `_retention_perform_delete` override) + the bulk-delete helpers (`_delete_in_chunks`, `_delete_*_search_rows`, `_delete_source_windows_*`, `_delete_optimizer_*`). Retention and bulk-delete are merged because retention cascades directly into bulk-delete — one cohesive deletion cluster.
- **`SQLiteFtsVecMixin`** (`base/_fts_vec.py`) — the 7 self-committing FTS5/`sqlite-vec` index helpers (`_fts_*`/`_vec_*`).

**Kept in residual `_base.py`:** the whole BootSchema block (`__init__` → `migrate()` → the `_migrate_*` cluster → `_DDL` — its ordering is load-bearing: `_migrate_eval_result_user_id` must run before `_DDL` or a legacy DB wedges permanently); the 20 module-level utilities (`_json_*`, `_row_to_*`, `_epoch_*`, etc.) imported by name across 15+ sibling files; the connection primitives; and `clear_user_data` (which calls the moved helpers via MRO). Residual: 2428 → 2092 lines (BootSchema is irreducible — this extracts the maximum safely-separable surface).

Method bodies moved **byte-for-byte** (AST-verified), preserving every `commit=`/`commit=False`, the `_delete_playbook_search_rows` RLock reentrancy, and the self-committing FTS/vec behaviour.

## Test plan

- 3 new characterization tests pin the behaviour a verbatim move must preserve: `_delete_in_chunks` chunk-boundary (caps the sqlite variable limit to force multi-chunk iteration), `_delete_playbook_search_rows(commit=False)` transaction participation, and FTS/vec self-commit (durable from a second connection). All empirically confirmed falsifiable.
- Full OSS storage suite: **909 passed**, incl. the retention contract + rollback-integration tests and the boot→runtime `_migrate_vec_tables → _vec_upsert` MRO edge.
- `ruff` + `pyright` clean; whole-branch `/review-loop` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended SQLite storage with improved deletion handling and enhanced FTS/text and vector index maintenance to strengthen content cleanup and retrieval.

* **Bug Fixes**
  * Improved retention-style cleanup to delete data in chunks safely, including related index records, and to execute consistently within a single durable operation.
  * Refined commit behavior for search/index updates so changes become visible immediately only when intended.

* **Tests**
  * Added integration tests covering chunk boundary deletes, self-committing FTS/vector upserts, and playbook search row deletion commit participation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->