### PR TITLE
refactor(playbook): decompose PlaybookAggregator into helper modules + a component (Tier 1b)

### DIFF
--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import logging
 import os
 import time
@@ -28,6 +27,13 @@ from reflexio.server.services.playbook.aggregation_prompt_processing import (
     AggregationPromptProcessingContext,
     AggregationPromptProcessor,
 )
+from reflexio.server.services.playbook.components import (
+    aggregator_clustering,
+    aggregator_prompt_formatting,
+)
+from reflexio.server.services.playbook.components.aggregator_clustering import (
+    CLUSTERING_ALGORITHM_THRESHOLD,
+)
 from reflexio.server.services.playbook.playbook_service_constants import (
     PlaybookServiceConstants,
 )
@@ -42,11 +48,6 @@ from reflexio.server.tracing import capture_anomaly, sentry_tags
 from reflexio.server.usage_metrics import record_usage_event
 
 logger = logging.getLogger(__name__)
-
-# Threshold for switching between clustering algorithms
-# Below this, use Agglomerative (works better with small datasets)
-# Above this, use HDBSCAN (scales better, handles noise)
-CLUSTERING_ALGORITHM_THRESHOLD = 50
 
 
 class PlaybookAggregator:
@@ -180,31 +181,6 @@ class PlaybookAggregator:
             last_processed_id=max_id,
         )
 
-    def _format_cluster_input(self, cluster_playbooks: list[UserPlaybook]) -> str:
-        """
-        Format a cluster of playbooks for the aggregation prompt using per-item format.
-
-        Each playbook is shown as a self-contained unit with content as the
-        primary content, followed by optional structured fields as supplementary metadata.
-
-        Args:
-            cluster_playbooks: List of raw playbooks in this cluster
-
-        Returns:
-            str: Formatted input for the aggregation prompt
-        """
-        blocks = []
-        for idx, fb in enumerate(cluster_playbooks, 1):
-            lines = [f"[{idx}]"]
-            if fb.content:
-                lines.append(f'Content: "{fb.content}"')
-            if fb.trigger:
-                lines.append(f'Trigger: "{fb.trigger}"')
-            if fb.rationale:
-                lines.append(f'Rationale: "{fb.rationale}"')
-            blocks.append("\n".join(lines))
-        return "\n\n".join(blocks) if blocks else "(No playbook items)"
-
     def _preprocess_prompt_field(
         self,
         text: str | None,
@@ -299,211 +275,30 @@ class PlaybookAggregator:
 
     @staticmethod
     def _get_direction_key(fb: UserPlaybook) -> str:
-        """
-        Extract a similarity key from a user playbook for grouping.
-
-        Returns the raw content used for token-overlap comparison. Grouping is
-        purely content-similarity based: under Option B a skill may legitimately
-        hold mixed-orientation rules (do-rules and avoid-rules for different
-        sub-aspects of one task), so whole-content polarity is NOT derived or
-        gated here. Preserving distinct do/avoid rules when similar items are
-        merged is the aggregation prompt's responsibility.
-
-        Args:
-            fb: A user playbook item
-
-        Returns:
-            str: Content used as the similarity key for grouping
-        """
-        return fb.content or ""
+        return aggregator_prompt_formatting.get_direction_key(fb)
 
     @staticmethod
     def _token_overlap(str1: str, str2: str, threshold: float = 0.6) -> bool:
-        """
-        Check if two strings have significant token overlap using asymmetric containment.
-
-        Computes the ratio of shared tokens to the smaller set, so a short string
-        contained in a longer one still counts as a match.
-
-        Args:
-            str1: First string
-            str2: Second string
-            threshold: Minimum overlap ratio
-
-        Returns:
-            bool: True if overlap ratio >= threshold
-        """
-        tokens1 = set(str1.lower().split())
-        tokens2 = set(str2.lower().split())
-        if not tokens1 or not tokens2:
-            return False
-        intersection = len(tokens1 & tokens2)
-        overlap_ratio = max(intersection / len(tokens1), intersection / len(tokens2))
-        return overlap_ratio >= threshold
+        return aggregator_prompt_formatting.token_overlap(str1, str2, threshold)
 
     @staticmethod
     def _group_playbooks_by_direction(
         cluster_playbooks: list[UserPlaybook],
         threshold: float = 0.6,
     ) -> list[list[UserPlaybook]]:
-        """
-        Group playbooks by similarity of their content.
-
-        Uses greedy single-linkage: each playbook is assigned to the first
-        existing group that has any member with sufficient token overlap.
-        Groups are returned sorted by size descending (largest first).
-
-        Grouping is purely content-similarity based and does NOT gate on a
-        derived whole-content polarity. Under Option B a skill may hold
-        mixed-orientation rules (do-rules and avoid-rules for different
-        sub-aspects), and whole-content polarity is undefined for such a skill.
-        Keeping a do-rule and an avoid-rule as distinct rules when similar items
-        are merged into one skill is the aggregation prompt's responsibility,
-        not a mechanical split here.
-
-        Args:
-            cluster_playbooks: List of raw playbooks to group
-            threshold: Token overlap threshold for grouping
-
-        Returns:
-            list[list[UserPlaybook]]: Groups sorted by size descending
-        """
-        groups: list[list[UserPlaybook]] = []
-
-        for fb in cluster_playbooks:
-            key = PlaybookAggregator._get_direction_key(fb)
-            matched = False
-            for group in groups:
-                if any(
-                    PlaybookAggregator._token_overlap(
-                        key,
-                        PlaybookAggregator._get_direction_key(group_fb),
-                        threshold,
-                    )
-                    for group_fb in group
-                ):
-                    group.append(fb)
-                    matched = True
-                    break
-            if not matched:
-                groups.append([fb])
-
-        # Sort by group size descending (largest first)
-        groups.sort(key=len, reverse=True)
-        return groups
+        return aggregator_prompt_formatting.group_playbooks_by_direction(
+            cluster_playbooks, threshold
+        )
 
     def _format_structured_cluster_input(
         self,
         cluster_playbooks: list[UserPlaybook],
         direction_overlap_threshold: float = 0.6,
     ) -> str:
-        """
-        Format a cluster of playbooks for structured aggregation prompt.
-
-        When the cluster forms a single similarity group, uses the flat-list
-        format. When distinct similarity groups are detected (multiple groups),
-        uses a grouped format so the LLM can see which items are similar and
-        preserve distinct rules (e.g. a do-rule and an avoid-rule) as separate
-        rules in the merged skill rather than collapsing them.
-
-        Args:
-            cluster_playbooks: List of raw playbooks in this cluster
-            direction_overlap_threshold: Token overlap threshold for grouping by direction
-
-        Returns:
-            str: Formatted input for the aggregation prompt
-        """
-        groups = self._group_playbooks_by_direction(
-            cluster_playbooks, threshold=direction_overlap_threshold
+        return aggregator_prompt_formatting.format_structured_cluster_input(
+            cluster_playbooks,
+            direction_overlap_threshold=direction_overlap_threshold,
         )
-
-        if len(groups) <= 1:
-            return self._format_flat(cluster_playbooks)
-        return self._format_grouped(groups)
-
-    def _format_flat(self, cluster_playbooks: list[UserPlaybook]) -> str:
-        """
-        Format playbooks as flat bullet lists (original format, used when no conflict).
-
-        Args:
-            cluster_playbooks: List of raw playbooks in this cluster
-
-        Returns:
-            str: Formatted input with separate field lists
-        """
-        triggers = []
-        rationales = []
-
-        for fb in cluster_playbooks:
-            if fb.trigger:
-                triggers.append(fb.trigger)
-            if fb.rationale:
-                rationales.append(fb.rationale)
-
-        lines: list[str] = []
-
-        if triggers:
-            lines.append("TRIGGER conditions (to be consolidated):")
-            lines.extend(f"- {trigger}" for trigger in triggers)
-        else:
-            lines.append("TRIGGER conditions: (none specified)")
-
-        if rationales:
-            lines.append("RATIONALE summaries:")
-            lines.extend(f"- {r}" for r in rationales)
-
-        self._append_freeform_observations(lines, cluster_playbooks)
-
-        return "\n".join(lines)
-
-    def _format_grouped(
-        self,
-        groups: list[list[UserPlaybook]],
-    ) -> str:
-        """
-        Format playbooks in grouped layout (used when conflicting directions are detected).
-
-        Args:
-            groups: AgentPlaybook groups sorted by size descending
-
-        Returns:
-            str: Formatted input with group headers and per-playbook fields
-        """
-        lines: list[str] = [
-            "The following playbook items are grouped by similarity. "
-            "Groups are ordered by size (largest first).",
-            "",
-        ]
-
-        for idx, group in enumerate(groups, start=1):
-            count_label = "playbook" if len(group) == 1 else "playbooks"
-            lines.append(f"Group {idx} ({len(group)} {count_label}):")
-            for fb in group:
-                parts: list[str] = []
-                if fb.trigger:
-                    parts.append(f'Trigger: "{fb.trigger}"')
-                if fb.rationale:
-                    parts.append(f'Rationale: "{fb.rationale}"')
-                if not parts and fb.content:
-                    parts.append(f'AgentPlaybook: "{fb.content}"')
-                if parts:
-                    lines.append(f"  - {parts[0]}")
-                    lines.extend(f"    {p}" for p in parts[1:])
-            lines.append("")
-
-        return "\n".join(lines)
-
-    @staticmethod
-    def _append_freeform_observations(
-        lines: list[str], cluster_playbooks: list[UserPlaybook]
-    ) -> None:
-        """Append freeform observations from cluster playbooks to output lines."""
-        freeform_observations = [
-            fb.content for fb in cluster_playbooks if not fb.trigger and fb.content
-        ]
-        if freeform_observations:
-            lines.append("Freeform observations (from freeform cluster members):")
-            lines.extend(f"- {obs}" for obs in freeform_observations)
 
     # ===============================
     # private methods - cluster change detection
@@ -511,62 +306,16 @@ class PlaybookAggregator:
 
     @staticmethod
     def _compute_cluster_fingerprint(cluster_playbooks: list[UserPlaybook]) -> str:
-        """
-        Compute a fingerprint for a cluster based on its user_playbook_ids.
-        The fingerprint is deterministic and order-independent.
-
-        Args:
-            cluster_playbooks: List of raw playbooks in this cluster
-
-        Returns:
-            str: SHA-256 hash (truncated to 16 hex chars) of sorted user_playbook_ids
-        """
-        sorted_ids = sorted(fb.user_playbook_id for fb in cluster_playbooks)
-        id_str = ",".join(str(id) for id in sorted_ids)
-        return hashlib.sha256(id_str.encode()).hexdigest()[:16]
+        return aggregator_clustering.compute_cluster_fingerprint(cluster_playbooks)
 
     def _determine_cluster_changes(
         self,
         clusters: dict[int, list[UserPlaybook]],
         prev_fingerprints: dict,
     ) -> tuple[dict[int, list[UserPlaybook]], list[int]]:
-        """
-        Compare current cluster fingerprints against stored fingerprints to determine changes.
-
-        Args:
-            clusters: Current clusters (cluster_id -> list of UserPlaybook)
-            prev_fingerprints: Previous fingerprint state
-                (fingerprint_hash -> {"agent_playbook_id": int, "user_playbook_ids": list})
-
-        Returns:
-            tuple of:
-                - changed_clusters: Only clusters needing new LLM calls
-                - playbook_ids_to_archive: Old playbook_ids from changed/disappeared clusters
-        """
-        # Compute fingerprints for current clusters
-        current_fingerprints = {}
-        for cluster_id, cluster_playbooks in clusters.items():
-            fp = self._compute_cluster_fingerprint(cluster_playbooks)
-            current_fingerprints[cluster_id] = fp
-
-        current_fp_set = set(current_fingerprints.values())
-        prev_fp_set = set(prev_fingerprints.keys())
-
-        # Changed clusters: fingerprints that are new (not in previous state)
-        changed_clusters = {}
-        for cluster_id, fp in current_fingerprints.items():
-            if fp not in prev_fp_set:
-                changed_clusters[cluster_id] = clusters[cluster_id]
-
-        # Playbook IDs to archive: from fingerprints that disappeared or changed
-        playbook_ids_to_archive = []
-        for fp, fp_data in prev_fingerprints.items():
-            if fp not in current_fp_set:
-                playbook_id = fp_data.get("agent_playbook_id")
-                if playbook_id is not None:
-                    playbook_ids_to_archive.append(playbook_id)
-
-        return changed_clusters, playbook_ids_to_archive
+        return aggregator_clustering.determine_cluster_changes(
+            clusters, prev_fingerprints
+        )
 
     # ===============================
     # public methods
@@ -1108,7 +857,9 @@ class PlaybookAggregator:
         # Mock mode: cluster by trigger
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
             logger.info("Mock mode: clustering by trigger")
-            return self._cluster_by_trigger_mock(user_playbooks, min_cluster_size)
+            return aggregator_clustering.cluster_by_trigger_mock(
+                user_playbooks, min_cluster_size
+            )
 
         # Extract embeddings from user playbooks
         import numpy as np
@@ -1163,77 +914,15 @@ class PlaybookAggregator:
 
         return clusters
 
-    def _cluster_by_trigger_mock(
-        self, user_playbooks: list[UserPlaybook], min_cluster_size: int
-    ) -> dict[int, list[UserPlaybook]]:
-        """
-        Simple mock clustering by exact trigger match.
-
-        Args:
-            user_playbooks: List of user playbooks with trigger field
-            min_cluster_size: Minimum number of playbooks per cluster
-
-        Returns:
-            dict[int, list[UserPlaybook]]: Clusters grouped by trigger
-        """
-        # Group by trigger
-        condition_groups: dict[str, list[UserPlaybook]] = {}
-        for fb in user_playbooks:
-            condition = fb.trigger or ""
-            if condition not in condition_groups:
-                condition_groups[condition] = []
-            condition_groups[condition].append(fb)
-
-        # Convert to cluster format, filtering by min_cluster_size
-        clusters: dict[int, list[UserPlaybook]] = {}
-        cluster_id = 0
-        for playbooks_group in condition_groups.values():
-            if len(playbooks_group) >= min_cluster_size:
-                clusters[cluster_id] = playbooks_group
-                cluster_id += 1
-
-        logger.info(
-            "Mock mode: created %d trigger clusters from %d playbooks",
-            len(clusters),
-            len(user_playbooks),
-        )
-        return clusters
-
     def _cluster_with_agglomerative(
         self,
         distance_matrix: np.ndarray,
-        min_cluster_size: int,  # noqa: ARG002
+        min_cluster_size: int,
         distance_threshold: float,
     ) -> np.ndarray:
-        """
-        Cluster using Agglomerative Clustering - best for small datasets.
-
-        Args:
-            distance_matrix: Precomputed cosine distance matrix
-            min_cluster_size: Minimum cluster size (used for logging only,
-                              filtering happens in get_clusters)
-            distance_threshold: Maximum cosine distance to merge clusters (1 - similarity_threshold)
-
-        Returns:
-            np.ndarray: Cluster labels for each point
-        """
-        from sklearn.cluster import AgglomerativeClustering
-
-        logger.info(
-            "Using Agglomerative Clustering for %d playbooks (< %d threshold), distance_threshold=%.2f",
-            len(distance_matrix),
-            CLUSTERING_ALGORITHM_THRESHOLD,
-            distance_threshold,
+        return aggregator_clustering.cluster_with_agglomerative(
+            distance_matrix, min_cluster_size, distance_threshold
         )
-
-        clusterer = AgglomerativeClustering(
-            n_clusters=None,  # type: ignore[reportArgumentType]
-            distance_threshold=distance_threshold,
-            metric="precomputed",
-            linkage="average",
-        )
-
-        return clusterer.fit_predict(distance_matrix)
 
     def _cluster_with_hdbscan(
         self,
@@ -1241,60 +930,9 @@ class PlaybookAggregator:
         min_cluster_size: int,
         distance_threshold: float,
     ) -> np.ndarray:
-        """
-        Cluster using HDBSCAN - best for large datasets with potential noise.
-
-        Args:
-            distance_matrix: Precomputed cosine distance matrix
-            min_cluster_size: Minimum number of points to form a cluster
-            distance_threshold: Maximum cosine distance for cluster merging (1 - similarity_threshold)
-
-        Returns:
-            np.ndarray: Cluster labels for each point (-1 indicates noise)
-        """
-        import hdbscan
-
-        logger.info(
-            "Using HDBSCAN for %d playbooks (>= %d threshold), distance_threshold=%.2f",
-            len(distance_matrix),
-            CLUSTERING_ALGORITHM_THRESHOLD,
-            distance_threshold,
+        return aggregator_clustering.cluster_with_hdbscan(
+            distance_matrix, min_cluster_size, distance_threshold
         )
-
-        clusterer = hdbscan.HDBSCAN(
-            min_cluster_size=min_cluster_size,
-            min_samples=1,
-            metric="precomputed",
-            cluster_selection_epsilon=distance_threshold,
-        )
-
-        return clusterer.fit_predict(distance_matrix)
-
-    def _generate_playbooks_from_clusters(
-        self,
-        clusters: dict[int, list[UserPlaybook]],
-        existing_approved_playbooks: list[AgentPlaybook],
-        direction_overlap_threshold: float = 0.6,
-    ) -> list[AgentPlaybook]:
-        """
-        Generate playbooks from clusters, considering existing approved playbooks.
-
-        Args:
-            clusters: Dictionary mapping cluster IDs to lists of raw playbooks
-            existing_approved_playbooks: List of existing approved playbooks to avoid duplication
-            direction_overlap_threshold: Token overlap threshold for grouping by direction
-
-        Returns:
-            list[AgentPlaybook]: List of newly generated playbooks (excludes duplicates)
-        """
-        return [
-            playbook
-            for playbook, _ in self._generate_playbooks_with_source_clusters(
-                clusters,
-                existing_approved_playbooks,
-                direction_overlap_threshold=direction_overlap_threshold,
-            )
-        ]
 
     def _generate_playbooks_with_source_clusters(
         self,

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -34,6 +34,9 @@ from reflexio.server.services.playbook.components import (
 from reflexio.server.services.playbook.components.aggregator_clustering import (
     CLUSTERING_ALGORITHM_THRESHOLD,
 )
+from reflexio.server.services.playbook.components.aggregator_postprocessing import (
+    AggregationPostProcessing,
+)
 from reflexio.server.services.playbook.playbook_service_constants import (
     PlaybookServiceConstants,
 )
@@ -64,16 +67,14 @@ class PlaybookAggregator:
         self.request_context = request_context
         self.agent_version = agent_version
         self.aggregation_prompt_processor = aggregation_prompt_processor
+        # Cohesive pre/post-processing component (the enterprise redaction
+        # Protocol seam). Constructed from the SAME injected instance stored
+        # above — do NOT re-resolve the AGGREGATION_PROMPT_PROCESSOR ServiceKey.
+        self._postproc = AggregationPostProcessing(aggregation_prompt_processor)
 
     # ===============================
     # private methods - operation state
     # ===============================
-
-    @staticmethod
-    def _format_prompt_extra_instructions(instructions: str | None) -> str:
-        if not instructions or not instructions.strip():
-            return ""
-        return f"{instructions.strip()}\n"
 
     def _create_state_manager(self) -> OperationStateManager:
         """
@@ -181,97 +182,30 @@ class PlaybookAggregator:
             last_processed_id=max_id,
         )
 
-    def _preprocess_prompt_field(
-        self,
-        text: str | None,
-        shared_state: dict[str, object],
-        processing_context: AggregationPromptProcessingContext | None = None,
-    ) -> str | None:
-        if text is None or self.aggregation_prompt_processor is None:
-            return text
-        result = self.aggregation_prompt_processor.preprocess_prompt_text(
-            text,
-            shared_state=shared_state,
-            context=processing_context,
-        )
-        if processing_context is not None and (result.changed or result.text != text):
-            processing_context.changed = True
-        return result.text
-
-    def _preprocess_user_playbook_for_prompt(
-        self,
-        playbook: UserPlaybook,
-        shared_state: dict[str, object],
-        processing_context: AggregationPromptProcessingContext | None = None,
-    ) -> UserPlaybook:
-        if self.aggregation_prompt_processor is None:
-            return playbook
-        return playbook.model_copy(
-            update={
-                "content": self._preprocess_prompt_field(
-                    playbook.content, shared_state, processing_context
-                )
-                or "",
-                "trigger": self._preprocess_prompt_field(
-                    playbook.trigger, shared_state, processing_context
-                ),
-                "rationale": self._preprocess_prompt_field(
-                    playbook.rationale, shared_state, processing_context
-                ),
-            }
-        )
-
-    def _aggregation_prompt_extra_instructions_for_context(
-        self,
-        processing_context: AggregationPromptProcessingContext | None,
-    ) -> str:
-        if (
-            processing_context is None
-            or not processing_context.changed
-            or self.aggregation_prompt_processor is None
-        ):
-            return ""
-
-        context_instructions = self.aggregation_prompt_processor.prompt_instructions(
-            processing_context
-        )
-        if not isinstance(context_instructions, str):
-            context_instructions = None
-        return self._format_prompt_extra_instructions(context_instructions)
+    # ===============================
+    # private methods - aggregation pre/post-processing
+    # ===============================
+    # Bodies live on the AggregationPostProcessing component (self._postproc).
+    # These thin delegators are kept for OSS test call-sites that invoke them by
+    # name (test_playbook_aggregator.py). Internal callers use self._postproc.
 
     def _postprocess_aggregation_output(
         self,
         value: object,
         processing_context: AggregationPromptProcessingContext | None = None,
     ) -> tuple[object, int]:
-        if self.aggregation_prompt_processor is None:
-            return value, 0
-        result = self.aggregation_prompt_processor.postprocess_aggregation_output(
-            value,
-            context=processing_context,
-        )
-        return result.value, result.artifacts_removed
+        return self._postproc._postprocess_aggregation_output(value, processing_context)
 
-    def _postprocess_aggregation_response(
+    def _aggregation_prompt_extra_instructions_for_context(
         self,
-        response: PlaybookAggregationOutput,
-        processing_context: AggregationPromptProcessingContext | None = None,
-    ) -> tuple[PlaybookAggregationOutput, int]:
-        processed, artifact_count = self._postprocess_aggregation_output(
-            response,
-            processing_context,
+        processing_context: AggregationPromptProcessingContext | None,
+    ) -> str:
+        return self._postproc._aggregation_prompt_extra_instructions_for_context(
+            processing_context
         )
-        if not isinstance(processed, PlaybookAggregationOutput):
-            return response, 0
-        return processed, artifact_count
 
     def _record_postprocessing_artifacts(self, artifact_count: int) -> None:
-        if artifact_count <= 0:
-            return
-        logger.warning(
-            "Post-processed %d residual artifacts in aggregated playbook output",
-            artifact_count,
-        )
+        self._postproc._record_postprocessing_artifacts(artifact_count)
 
     @staticmethod
     def _get_direction_key(fb: UserPlaybook) -> str:
@@ -959,7 +893,7 @@ class PlaybookAggregator:
                 prompt_cluster_playbooks = cluster_playbooks
             else:
                 prompt_cluster_playbooks = [
-                    self._preprocess_user_playbook_for_prompt(
+                    self._postproc._preprocess_user_playbook_for_prompt(
                         playbook, shared_state, processing_context
                     )
                     for playbook in cluster_playbooks
@@ -1056,11 +990,11 @@ class PlaybookAggregator:
                     trigger=trigger,
                 )
             )
-            response, artifact_count = self._postprocess_aggregation_response(
+            response, artifact_count = self._postproc._postprocess_aggregation_response(
                 response,
                 processing_context,
             )
-            self._record_postprocessing_artifacts(artifact_count)
+            self._postproc._record_postprocessing_artifacts(artifact_count)
             playbook = self._process_aggregation_response(response, cluster_playbooks)
             if playbook is None:
                 return None
@@ -1080,7 +1014,7 @@ class PlaybookAggregator:
                     {
                         "user_playbooks": raw_playbooks_str,
                         "existing_approved_playbooks": existing_approved_playbooks_str,
-                        "aggregation_prompt_extra_instructions": self._aggregation_prompt_extra_instructions_for_context(
+                        "aggregation_prompt_extra_instructions": self._postproc._aggregation_prompt_extra_instructions_for_context(
                             processing_context
                         ),
                     },
@@ -1096,17 +1030,21 @@ class PlaybookAggregator:
                 parse_structured_output=True,
             )
             if isinstance(response, PlaybookAggregationOutput):
-                response, artifact_count = self._postprocess_aggregation_response(
-                    response,
-                    processing_context,
+                response, artifact_count = (
+                    self._postproc._postprocess_aggregation_response(
+                        response,
+                        processing_context,
+                    )
                 )
-                self._record_postprocessing_artifacts(artifact_count)
+                self._postproc._record_postprocessing_artifacts(artifact_count)
             else:
-                response, artifact_count = self._postprocess_aggregation_output(
-                    response,
-                    processing_context,
+                response, artifact_count = (
+                    self._postproc._postprocess_aggregation_output(
+                        response,
+                        processing_context,
+                    )
                 )
-                self._record_postprocessing_artifacts(artifact_count)
+                self._postproc._record_postprocessing_artifacts(artifact_count)
             log_model_response(logger, "Aggregation structured response", response)
 
             if not isinstance(response, PlaybookAggregationOutput):
@@ -1118,11 +1056,13 @@ class PlaybookAggregator:
 
             return self._process_aggregation_response(response, cluster_playbooks)
         except Exception as exc:
-            processed_error, artifact_count = self._postprocess_aggregation_output(
-                str(exc),
-                processing_context,
+            processed_error, artifact_count = (
+                self._postproc._postprocess_aggregation_output(
+                    str(exc),
+                    processing_context,
+                )
             )
-            self._record_postprocessing_artifacts(artifact_count)
+            self._postproc._record_postprocessing_artifacts(artifact_count)
             logger.error(
                 "AgentPlaybook aggregation failed due to %s, returning None.",
                 processed_error,

--- a/reflexio/server/services/playbook/components/aggregator_clustering.py
+++ b/reflexio/server/services/playbook/components/aggregator_clustering.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import numpy as np
+
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+
+logger = logging.getLogger(__name__)
+
+# Threshold for switching between clustering algorithms
+# Below this, use Agglomerative (works better with small datasets)
+# Above this, use HDBSCAN (scales better, handles noise)
+CLUSTERING_ALGORITHM_THRESHOLD = 50
+
+
+def compute_cluster_fingerprint(cluster_playbooks: list[UserPlaybook]) -> str:
+    """
+    Compute a fingerprint for a cluster based on its user_playbook_ids.
+    The fingerprint is deterministic and order-independent.
+
+    Args:
+        cluster_playbooks: List of raw playbooks in this cluster
+
+    Returns:
+        str: SHA-256 hash (truncated to 16 hex chars) of sorted user_playbook_ids
+    """
+    sorted_ids = sorted(fb.user_playbook_id for fb in cluster_playbooks)
+    id_str = ",".join(str(id) for id in sorted_ids)
+    return hashlib.sha256(id_str.encode()).hexdigest()[:16]
+
+
+def determine_cluster_changes(
+    clusters: dict[int, list[UserPlaybook]],
+    prev_fingerprints: dict,
+) -> tuple[dict[int, list[UserPlaybook]], list[int]]:
+    """
+    Compare current cluster fingerprints against stored fingerprints to determine changes.
+
+    Args:
+        clusters: Current clusters (cluster_id -> list of UserPlaybook)
+        prev_fingerprints: Previous fingerprint state
+            (fingerprint_hash -> {"agent_playbook_id": int, "user_playbook_ids": list})
+
+    Returns:
+        tuple of:
+            - changed_clusters: Only clusters needing new LLM calls
+            - playbook_ids_to_archive: Old playbook_ids from changed/disappeared clusters
+    """
+    # Compute fingerprints for current clusters
+    current_fingerprints = {}
+    for cluster_id, cluster_playbooks in clusters.items():
+        fp = compute_cluster_fingerprint(cluster_playbooks)
+        current_fingerprints[cluster_id] = fp
+
+    current_fp_set = set(current_fingerprints.values())
+    prev_fp_set = set(prev_fingerprints.keys())
+
+    # Changed clusters: fingerprints that are new (not in previous state)
+    changed_clusters = {}
+    for cluster_id, fp in current_fingerprints.items():
+        if fp not in prev_fp_set:
+            changed_clusters[cluster_id] = clusters[cluster_id]
+
+    # Playbook IDs to archive: from fingerprints that disappeared or changed
+    playbook_ids_to_archive = []
+    for fp, fp_data in prev_fingerprints.items():
+        if fp not in current_fp_set:
+            playbook_id = fp_data.get("agent_playbook_id")
+            if playbook_id is not None:
+                playbook_ids_to_archive.append(playbook_id)
+
+    return changed_clusters, playbook_ids_to_archive
+
+
+def cluster_by_trigger_mock(
+    user_playbooks: list[UserPlaybook], min_cluster_size: int
+) -> dict[int, list[UserPlaybook]]:
+    """
+    Simple mock clustering by exact trigger match.
+
+    Args:
+        user_playbooks: List of user playbooks with trigger field
+        min_cluster_size: Minimum number of playbooks per cluster
+
+    Returns:
+        dict[int, list[UserPlaybook]]: Clusters grouped by trigger
+    """
+    # Group by trigger
+    condition_groups: dict[str, list[UserPlaybook]] = {}
+    for fb in user_playbooks:
+        condition = fb.trigger or ""
+        if condition not in condition_groups:
+            condition_groups[condition] = []
+        condition_groups[condition].append(fb)
+
+    # Convert to cluster format, filtering by min_cluster_size
+    clusters: dict[int, list[UserPlaybook]] = {}
+    cluster_id = 0
+    for playbooks_group in condition_groups.values():
+        if len(playbooks_group) >= min_cluster_size:
+            clusters[cluster_id] = playbooks_group
+            cluster_id += 1
+
+    logger.info(
+        "Mock mode: created %d trigger clusters from %d playbooks",
+        len(clusters),
+        len(user_playbooks),
+    )
+    return clusters
+
+
+def cluster_with_agglomerative(
+    distance_matrix: np.ndarray,
+    min_cluster_size: int,  # noqa: ARG001
+    distance_threshold: float,
+) -> np.ndarray:
+    """
+    Cluster using Agglomerative Clustering - best for small datasets.
+
+    Args:
+        distance_matrix: Precomputed cosine distance matrix
+        min_cluster_size: Minimum cluster size (used for logging only,
+                          filtering happens in get_clusters)
+        distance_threshold: Maximum cosine distance to merge clusters (1 - similarity_threshold)
+
+    Returns:
+        np.ndarray: Cluster labels for each point
+    """
+    from sklearn.cluster import AgglomerativeClustering
+
+    logger.info(
+        "Using Agglomerative Clustering for %d playbooks (< %d threshold), distance_threshold=%.2f",
+        len(distance_matrix),
+        CLUSTERING_ALGORITHM_THRESHOLD,
+        distance_threshold,
+    )
+
+    clusterer = AgglomerativeClustering(
+        n_clusters=None,  # type: ignore[reportArgumentType]
+        distance_threshold=distance_threshold,
+        metric="precomputed",
+        linkage="average",
+    )
+
+    return clusterer.fit_predict(distance_matrix)
+
+
+def cluster_with_hdbscan(
+    distance_matrix: np.ndarray,
+    min_cluster_size: int,
+    distance_threshold: float,
+) -> np.ndarray:
+    """
+    Cluster using HDBSCAN - best for large datasets with potential noise.
+
+    Args:
+        distance_matrix: Precomputed cosine distance matrix
+        min_cluster_size: Minimum number of points to form a cluster
+        distance_threshold: Maximum cosine distance for cluster merging (1 - similarity_threshold)
+
+    Returns:
+        np.ndarray: Cluster labels for each point (-1 indicates noise)
+    """
+    import hdbscan
+
+    logger.info(
+        "Using HDBSCAN for %d playbooks (>= %d threshold), distance_threshold=%.2f",
+        len(distance_matrix),
+        CLUSTERING_ALGORITHM_THRESHOLD,
+        distance_threshold,
+    )
+
+    clusterer = hdbscan.HDBSCAN(
+        min_cluster_size=min_cluster_size,
+        min_samples=1,
+        metric="precomputed",
+        cluster_selection_epsilon=distance_threshold,
+    )
+
+    return clusterer.fit_predict(distance_matrix)

--- a/reflexio/server/services/playbook/components/aggregator_postprocessing.py
+++ b/reflexio/server/services/playbook/components/aggregator_postprocessing.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import logging
+
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AggregationPromptProcessingContext,
+    AggregationPromptProcessor,
+)
+from reflexio.server.services.playbook.playbook_service_utils import (
+    PlaybookAggregationOutput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AggregationPostProcessing:
+    """Pre/post-processing for playbook aggregation prompts and LLM output.
+
+    Groups the aggregation prompt-processor seam (the enterprise redaction
+    Protocol integration point). Holds the single injected collaborator,
+    ``aggregation_prompt_processor``, by shared reference from the owning
+    ``PlaybookAggregator`` — the SAME object resolved from the
+    ``AGGREGATION_PROMPT_PROCESSOR`` ServiceKey — so the enterprise
+    ``EnterpriseAggregationPromptProcessor`` injection is preserved unchanged.
+    """
+
+    def __init__(
+        self,
+        aggregation_prompt_processor: AggregationPromptProcessor | None,
+    ) -> None:
+        self.aggregation_prompt_processor = aggregation_prompt_processor
+
+    @staticmethod
+    def _format_prompt_extra_instructions(instructions: str | None) -> str:
+        if not instructions or not instructions.strip():
+            return ""
+        return f"{instructions.strip()}\n"
+
+    def _preprocess_prompt_field(
+        self,
+        text: str | None,
+        shared_state: dict[str, object],
+        processing_context: AggregationPromptProcessingContext | None = None,
+    ) -> str | None:
+        if text is None or self.aggregation_prompt_processor is None:
+            return text
+        result = self.aggregation_prompt_processor.preprocess_prompt_text(
+            text,
+            shared_state=shared_state,
+            context=processing_context,
+        )
+        if processing_context is not None and (result.changed or result.text != text):
+            processing_context.changed = True
+        return result.text
+
+    def _preprocess_user_playbook_for_prompt(
+        self,
+        playbook: UserPlaybook,
+        shared_state: dict[str, object],
+        processing_context: AggregationPromptProcessingContext | None = None,
+    ) -> UserPlaybook:
+        if self.aggregation_prompt_processor is None:
+            return playbook
+        return playbook.model_copy(
+            update={
+                "content": self._preprocess_prompt_field(
+                    playbook.content, shared_state, processing_context
+                )
+                or "",
+                "trigger": self._preprocess_prompt_field(
+                    playbook.trigger, shared_state, processing_context
+                ),
+                "rationale": self._preprocess_prompt_field(
+                    playbook.rationale, shared_state, processing_context
+                ),
+            }
+        )
+
+    def _aggregation_prompt_extra_instructions_for_context(
+        self,
+        processing_context: AggregationPromptProcessingContext | None,
+    ) -> str:
+        if (
+            processing_context is None
+            or not processing_context.changed
+            or self.aggregation_prompt_processor is None
+        ):
+            return ""
+
+        context_instructions = self.aggregation_prompt_processor.prompt_instructions(
+            processing_context
+        )
+        if not isinstance(context_instructions, str):
+            context_instructions = None
+        return self._format_prompt_extra_instructions(context_instructions)
+
+    def _postprocess_aggregation_output(
+        self,
+        value: object,
+        processing_context: AggregationPromptProcessingContext | None = None,
+    ) -> tuple[object, int]:
+        if self.aggregation_prompt_processor is None:
+            return value, 0
+        result = self.aggregation_prompt_processor.postprocess_aggregation_output(
+            value,
+            context=processing_context,
+        )
+        return result.value, result.artifacts_removed
+
+    def _postprocess_aggregation_response(
+        self,
+        response: PlaybookAggregationOutput,
+        processing_context: AggregationPromptProcessingContext | None = None,
+    ) -> tuple[PlaybookAggregationOutput, int]:
+        processed, artifact_count = self._postprocess_aggregation_output(
+            response,
+            processing_context,
+        )
+        if not isinstance(processed, PlaybookAggregationOutput):
+            return response, 0
+        return processed, artifact_count
+
+    def _record_postprocessing_artifacts(self, artifact_count: int) -> None:
+        if artifact_count <= 0:
+            return
+        logger.warning(
+            "Post-processed %d residual artifacts in aggregated playbook output",
+            artifact_count,
+        )

--- a/reflexio/server/services/playbook/components/aggregator_prompt_formatting.py
+++ b/reflexio/server/services/playbook/components/aggregator_prompt_formatting.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+
+
+def get_direction_key(fb: UserPlaybook) -> str:
+    """
+    Extract a similarity key from a user playbook for grouping.
+
+    Returns the raw content used for token-overlap comparison. Grouping is
+    purely content-similarity based: under Option B a skill may legitimately
+    hold mixed-orientation rules (do-rules and avoid-rules for different
+    sub-aspects of one task), so whole-content polarity is NOT derived or
+    gated here. Preserving distinct do/avoid rules when similar items are
+    merged is the aggregation prompt's responsibility.
+
+    Args:
+        fb: A user playbook item
+
+    Returns:
+        str: Content used as the similarity key for grouping
+    """
+    return fb.content or ""
+
+
+def token_overlap(str1: str, str2: str, threshold: float = 0.6) -> bool:
+    """
+    Check if two strings have significant token overlap using asymmetric containment.
+
+    Computes the ratio of shared tokens to the smaller set, so a short string
+    contained in a longer one still counts as a match.
+
+    Args:
+        str1: First string
+        str2: Second string
+        threshold: Minimum overlap ratio
+
+    Returns:
+        bool: True if overlap ratio >= threshold
+    """
+    tokens1 = set(str1.lower().split())
+    tokens2 = set(str2.lower().split())
+    if not tokens1 or not tokens2:
+        return False
+    intersection = len(tokens1 & tokens2)
+    overlap_ratio = max(intersection / len(tokens1), intersection / len(tokens2))
+    return overlap_ratio >= threshold
+
+
+def group_playbooks_by_direction(
+    cluster_playbooks: list[UserPlaybook],
+    threshold: float = 0.6,
+) -> list[list[UserPlaybook]]:
+    """
+    Group playbooks by similarity of their content.
+
+    Uses greedy single-linkage: each playbook is assigned to the first
+    existing group that has any member with sufficient token overlap.
+    Groups are returned sorted by size descending (largest first).
+
+    Grouping is purely content-similarity based and does NOT gate on a
+    derived whole-content polarity. Under Option B a skill may hold
+    mixed-orientation rules (do-rules and avoid-rules for different
+    sub-aspects), and whole-content polarity is undefined for such a skill.
+    Keeping a do-rule and an avoid-rule as distinct rules when similar items
+    are merged into one skill is the aggregation prompt's responsibility,
+    not a mechanical split here.
+
+    Args:
+        cluster_playbooks: List of raw playbooks to group
+        threshold: Token overlap threshold for grouping
+
+    Returns:
+        list[list[UserPlaybook]]: Groups sorted by size descending
+    """
+    groups: list[list[UserPlaybook]] = []
+
+    for fb in cluster_playbooks:
+        key = get_direction_key(fb)
+        matched = False
+        for group in groups:
+            if any(
+                token_overlap(
+                    key,
+                    get_direction_key(group_fb),
+                    threshold,
+                )
+                for group_fb in group
+            ):
+                group.append(fb)
+                matched = True
+                break
+        if not matched:
+            groups.append([fb])
+
+    # Sort by group size descending (largest first)
+    groups.sort(key=len, reverse=True)
+    return groups
+
+
+def format_structured_cluster_input(
+    cluster_playbooks: list[UserPlaybook],
+    direction_overlap_threshold: float = 0.6,
+) -> str:
+    """
+    Format a cluster of playbooks for structured aggregation prompt.
+
+    When the cluster forms a single similarity group, uses the flat-list
+    format. When distinct similarity groups are detected (multiple groups),
+    uses a grouped format so the LLM can see which items are similar and
+    preserve distinct rules (e.g. a do-rule and an avoid-rule) as separate
+    rules in the merged skill rather than collapsing them.
+
+    Args:
+        cluster_playbooks: List of raw playbooks in this cluster
+        direction_overlap_threshold: Token overlap threshold for grouping by direction
+
+    Returns:
+        str: Formatted input for the aggregation prompt
+    """
+    groups = group_playbooks_by_direction(
+        cluster_playbooks, threshold=direction_overlap_threshold
+    )
+
+    if len(groups) <= 1:
+        return format_flat(cluster_playbooks)
+    return format_grouped(groups)
+
+
+def format_flat(cluster_playbooks: list[UserPlaybook]) -> str:
+    """
+    Format playbooks as flat bullet lists (original format, used when no conflict).
+
+    Args:
+        cluster_playbooks: List of raw playbooks in this cluster
+
+    Returns:
+        str: Formatted input with separate field lists
+    """
+    triggers = []
+    rationales = []
+
+    for fb in cluster_playbooks:
+        if fb.trigger:
+            triggers.append(fb.trigger)
+        if fb.rationale:
+            rationales.append(fb.rationale)
+
+    lines: list[str] = []
+
+    if triggers:
+        lines.append("TRIGGER conditions (to be consolidated):")
+        lines.extend(f"- {trigger}" for trigger in triggers)
+    else:
+        lines.append("TRIGGER conditions: (none specified)")
+
+    if rationales:
+        lines.append("RATIONALE summaries:")
+        lines.extend(f"- {r}" for r in rationales)
+
+    append_freeform_observations(lines, cluster_playbooks)
+
+    return "\n".join(lines)
+
+
+def format_grouped(
+    groups: list[list[UserPlaybook]],
+) -> str:
+    """
+    Format playbooks in grouped layout (used when conflicting directions are detected).
+
+    Args:
+        groups: AgentPlaybook groups sorted by size descending
+
+    Returns:
+        str: Formatted input with group headers and per-playbook fields
+    """
+    lines: list[str] = [
+        "The following playbook items are grouped by similarity. "
+        "Groups are ordered by size (largest first).",
+        "",
+    ]
+
+    for idx, group in enumerate(groups, start=1):
+        count_label = "playbook" if len(group) == 1 else "playbooks"
+        lines.append(f"Group {idx} ({len(group)} {count_label}):")
+        for fb in group:
+            parts: list[str] = []
+            if fb.trigger:
+                parts.append(f'Trigger: "{fb.trigger}"')
+            if fb.rationale:
+                parts.append(f'Rationale: "{fb.rationale}"')
+            if not parts and fb.content:
+                parts.append(f'AgentPlaybook: "{fb.content}"')
+            if parts:
+                lines.append(f"  - {parts[0]}")
+                lines.extend(f"    {p}" for p in parts[1:])
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def append_freeform_observations(
+    lines: list[str], cluster_playbooks: list[UserPlaybook]
+) -> None:
+    """Append freeform observations from cluster playbooks to output lines."""
+    freeform_observations = [
+        fb.content for fb in cluster_playbooks if not fb.trigger and fb.content
+    ]
+    if freeform_observations:
+        lines.append("Freeform observations (from freeform cluster members):")
+        lines.extend(f"- {obs}" for obs in freeform_observations)

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1437,16 +1437,41 @@ class TestRun:
 # ---------------------------------------------------------------------------
 
 
+def _format_cluster_input(cluster_playbooks: list[UserPlaybook]) -> str:
+    """
+    Format a cluster of playbooks for the aggregation prompt using per-item format.
+
+    Each playbook is shown as a self-contained unit with content as the
+    primary content, followed by optional structured fields as supplementary metadata.
+
+    Args:
+        cluster_playbooks: List of raw playbooks in this cluster
+
+    Returns:
+        str: Formatted input for the aggregation prompt
+    """
+    blocks = []
+    for idx, fb in enumerate(cluster_playbooks, 1):
+        lines = [f"[{idx}]"]
+        if fb.content:
+            lines.append(f'Content: "{fb.content}"')
+        if fb.trigger:
+            lines.append(f'Trigger: "{fb.trigger}"')
+        if fb.rationale:
+            lines.append(f'Rationale: "{fb.rationale}"')
+        blocks.append("\n".join(lines))
+    return "\n\n".join(blocks) if blocks else "(No playbook items)"
+
+
 class TestFormatClusterInput:
     def test_all_fields_present(self):
         """Each playbook becomes a numbered block with Content and Trigger."""
-        agg = _make_aggregator()
         raws = [
             _raw(rid=1, when="cond1"),
             _raw(rid=2, when="cond2"),
         ]
 
-        result = agg._format_cluster_input(raws)
+        result = _format_cluster_input(raws)
 
         assert "[1]" in result
         assert "[2]" in result
@@ -1456,25 +1481,22 @@ class TestFormatClusterInput:
         assert 'Trigger: "cond2"' in result
 
     def test_no_trigger_omits_trigger_line(self):
-        agg = _make_aggregator()
         raws = [_raw(rid=1, when=None)]
 
-        result = agg._format_cluster_input(raws)
+        result = _format_cluster_input(raws)
 
         assert "Trigger:" not in result
 
     def test_empty_list_returns_placeholder(self):
         """Empty input returns a placeholder string."""
-        agg = _make_aggregator()
-        result = agg._format_cluster_input([])
+        result = _format_cluster_input([])
         assert result == "(No playbook items)"
 
     def test_content_is_first_field_after_number(self):
         """Content line appears immediately after the numbered header."""
-        agg = _make_aggregator()
         raws = [_raw(rid=1, when="cond")]
 
-        result = agg._format_cluster_input(raws)
+        result = _format_cluster_input(raws)
 
         lines = result.strip().split("\n")
         assert lines[0] == "[1]"
@@ -1482,10 +1504,9 @@ class TestFormatClusterInput:
 
     def test_multiple_playbooks_separated_by_blank_lines(self):
         """Multiple playbooks are separated by blank lines."""
-        agg = _make_aggregator()
         raws = [_raw(rid=1, when="cond1"), _raw(rid=2, when="cond2")]
 
-        result = agg._format_cluster_input(raws)
+        result = _format_cluster_input(raws)
 
         # Two blocks separated by double newline
         assert "\n\n" in result

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -13,6 +13,7 @@ Targets coverage gaps in:
 
 import logging
 import re
+from contextlib import ExitStack, contextmanager
 from typing import Any
 from unittest.mock import ANY, MagicMock, call, patch
 
@@ -27,6 +28,7 @@ from reflexio.models.config_schema import (
     SINGLETON_USER_PLAYBOOK_NAME,
     PlaybookAggregatorConfig,
     PlaybookConfig,
+    PlaybookOptimizerConfig,
 )
 from reflexio.server.services.playbook.aggregation_prompt_processing import (
     AggregationPromptProcessingContext,
@@ -2061,3 +2063,332 @@ def test_playbook_aggregation_prompt_preserves_distinct_orientations():
     assert 'never collapse a "do" rule and an "avoid" rule into one' in normalized
     # Mixed-orientation rules for different sub-aspects are allowed in one skill.
     assert "separate bullets" in normalized
+
+
+# ---------------------------------------------------------------------------
+# run() side-effect ORDER characterization — the SOLE order guard.
+#
+# e2e tests assert final DB/output but physically cannot observe the internal
+# call ORDER, so a reordered-but-eventually-consistent refactor of run() would
+# stay e2e-green. This suite records EVERY observable side effect on ONE ordered
+# ``call_log`` (a single MagicMock storage + patched module-level
+# ``record_usage_event`` / ``capture_anomaly`` + the optimization scheduler),
+# then asserts the exact interleaving the aggregation lineage invariant depends
+# on. Each assertion is written to FAIL if that specific ordering/guard breaks.
+# ---------------------------------------------------------------------------
+
+_AGG_MODULE = "reflexio.server.services.playbook.components.aggregator"
+_SCHEDULER_GET_INSTANCE = (
+    "reflexio.server.services.playbook_optimizer."
+    "PlaybookOptimizationScheduler.get_instance"
+)
+
+
+class _EmptyStrUUID:
+    """A uuid4 stand-in whose ``str()`` is empty (to drive the falsy ``_run_id``
+    supersede guard) but whose ``.hex`` remains valid for any downstream use."""
+
+    hex = "0" * 32
+
+    def __str__(self) -> str:
+        return ""
+
+
+def _make_ordered_aggregator(call_log: list[tuple[str, Any]]) -> Any:
+    """Build a run()-ready aggregator whose storage records every relevant
+    side effect (in call order) onto the shared ``call_log``."""
+    agg = _make_aggregator()
+
+    fac = PlaybookAggregatorConfig(min_cluster_size=2, reaggregation_trigger_count=2)
+    afc = PlaybookConfig(
+        extractor_name="fb",
+        extraction_definition_prompt="prompt",
+        aggregation_config=fac,
+    )
+    cfg = agg.configurator.get_config.return_value
+    cfg.user_playbook_extractor_config = afc
+    # A real optimizer config (not a MagicMock) so the enqueue gate — which uses
+    # ``is not True`` identity checks — actually passes and the scheduler fires.
+    cfg.playbook_optimizer_config = PlaybookOptimizerConfig(
+        enabled=True, optimize_agent_playbooks=True
+    )
+
+    agg.storage.count_user_playbooks.return_value = 5
+    agg.storage.get_agent_playbooks.return_value = []
+    agg.storage.get_user_playbooks.return_value = [_raw(rid=1), _raw(rid=2)]
+
+    def _save(playbook: AgentPlaybook, **_kwargs: Any) -> AgentPlaybook:
+        call_log.append(("save", playbook.agent_playbook_id))
+        return playbook
+
+    agg.storage.save_agent_playbook_with_aggregate_event.side_effect = _save
+
+    def _set_source_windows(agent_playbook_id: int, _windows: Any) -> None:
+        call_log.append(("set_source_windows", agent_playbook_id))
+
+    agg.storage.set_source_windows_for_agent_playbook.side_effect = _set_source_windows
+
+    def _archive(name: str, **_kwargs: Any) -> None:
+        call_log.append(("archive", name))
+
+    agg.storage.archive_agent_playbooks_by_playbook_name.side_effect = _archive
+
+    def _supersede_by_name(name: str, **_kwargs: Any) -> None:
+        call_log.append(("supersede_by_name", name))
+
+    agg.storage.supersede_agent_playbooks_by_playbook_name.side_effect = (
+        _supersede_by_name
+    )
+
+    def _supersede_by_ids(ids: Any, **_kwargs: Any) -> None:
+        call_log.append(("supersede_by_ids", tuple(ids)))
+
+    agg.storage.supersede_agent_playbooks_by_ids.side_effect = _supersede_by_ids
+
+    def _restore_by_name(name: str, **_kwargs: Any) -> None:
+        call_log.append(("restore", name))
+
+    agg.storage.restore_archived_agent_playbooks_by_playbook_name.side_effect = (
+        _restore_by_name
+    )
+
+    return agg
+
+
+@contextmanager
+def _instrument_run(
+    call_log: list[tuple[str, Any]],
+    clusters: dict[int, list[UserPlaybook]],
+    generated_pairs: list[tuple[AgentPlaybook, list[UserPlaybook]]],
+    *,
+    uuid_side_effect: Any | None = None,
+):
+    """Patch the module-level collaborators (usage events, anomaly capture,
+    optimization scheduler) and the LLM-generation / clustering / state-manager
+    seams so every side effect lands on ``call_log`` in call order.
+
+    Yields (capture_anomaly_mock, scheduler_mock).
+    """
+    with ExitStack() as stack:
+        record = stack.enter_context(patch(f"{_AGG_MODULE}.record_usage_event"))
+        record.side_effect = lambda **kw: call_log.append(("usage", kw["event_name"]))
+
+        anomaly = stack.enter_context(patch(f"{_AGG_MODULE}.capture_anomaly"))
+        anomaly.side_effect = lambda *a, **_k: call_log.append(
+            ("anomaly", a[0] if a else None)
+        )
+
+        scheduler = MagicMock()
+        scheduler.enqueue.side_effect = lambda **kw: call_log.append(
+            ("enqueue", kw["target"].target_id)
+        )
+        stack.enter_context(patch(_SCHEDULER_GET_INSTANCE, return_value=scheduler))
+
+        stack.enter_context(
+            patch.object(PlaybookAggregator, "get_clusters", return_value=clusters)
+        )
+
+        def _generate(*_a: Any, **_k: Any):
+            call_log.append(("generate", None))
+            return generated_pairs
+
+        gen = stack.enter_context(
+            patch.object(PlaybookAggregator, "_generate_playbooks_with_source_clusters")
+        )
+        gen.side_effect = _generate
+
+        mgr = MagicMock()
+        mgr.get_cluster_fingerprints.return_value = {}
+        stack.enter_context(
+            patch.object(PlaybookAggregator, "_create_state_manager", return_value=mgr)
+        )
+
+        if uuid_side_effect is not None:
+            stack.enter_context(
+                patch(f"{_AGG_MODULE}.uuid.uuid4", side_effect=uuid_side_effect)
+            )
+
+        yield anomaly, scheduler
+
+
+def _first_index(call_log: list[tuple[str, Any]], name: str) -> int:
+    return next(i for i, (n, _) in enumerate(call_log) if n == name)
+
+
+def _last_index(call_log: list[tuple[str, Any]], *names: str) -> int:
+    return max(i for i, (n, _) in enumerate(call_log) if n in names)
+
+
+class TestRunSideEffectOrder:
+    """The falsifiable order guard for run(). Each test drives run() with two
+    generated playbooks (distinct ids 100/200) so interleaving is observable."""
+
+    def _two_pairs(
+        self,
+    ) -> tuple[dict[int, list[UserPlaybook]], list]:
+        cluster_a = [_raw(rid=1)]
+        cluster_b = [_raw(rid=2)]
+        clusters = {0: cluster_a, 1: cluster_b}
+        pb_a = _agent_playbook(fid=100)
+        pb_a.agent_playbook_id = 100
+        pb_b = _agent_playbook(fid=200)
+        pb_b.agent_playbook_id = 200
+        generated_pairs = [(pb_a, cluster_a), (pb_b, cluster_b)]
+        return clusters, generated_pairs
+
+    def test_archive_between_generate_and_first_save(self):
+        """(a) The deferred full-archive fires AFTER generation produced
+        playbooks and BEFORE the first save — never before generation (which
+        would drop existing PENDING/APPROVED on a null LLM result) and never
+        after the first save (which would archive freshly-saved rows)."""
+        call_log: list[tuple[str, Any]] = []
+        agg = _make_ordered_aggregator(call_log)
+        clusters, generated_pairs = self._two_pairs()
+
+        with _instrument_run(call_log, clusters, generated_pairs):
+            agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+        i_generate = _first_index(call_log, "generate")
+        i_archive = _first_index(call_log, "archive")
+        i_save = _first_index(call_log, "save")
+        assert i_generate < i_archive < i_save, call_log
+
+    def test_per_playbook_save_then_source_windows_interleaved(self):
+        """(b) Each save is IMMEDIATELY followed by set_source_windows for THAT
+        iteration's agent_playbook_id — the writes are interleaved per playbook,
+        not batched (all saves then all windows)."""
+        call_log: list[tuple[str, Any]] = []
+        agg = _make_ordered_aggregator(call_log)
+        clusters, generated_pairs = self._two_pairs()
+
+        with _instrument_run(call_log, clusters, generated_pairs):
+            agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+        saved_ids = [detail for name, detail in call_log if name == "save"]
+        assert saved_ids == [100, 200], call_log
+        for idx, (name, detail) in enumerate(call_log):
+            if name == "save":
+                nxt_name, nxt_detail = call_log[idx + 1]
+                assert nxt_name == "set_source_windows", call_log
+                assert nxt_detail == detail, (
+                    f"set_source_windows must use this iteration's id {detail!r}, "
+                    f"got {nxt_detail!r}"
+                )
+
+    def test_enqueue_after_last_supersede_before_succeeded(self):
+        """(c) _enqueue_playbook_optimization fires AFTER the last supersede and
+        BEFORE the aggregation_succeeded usage event."""
+        call_log: list[tuple[str, Any]] = []
+        agg = _make_ordered_aggregator(call_log)
+        clusters, generated_pairs = self._two_pairs()
+
+        with _instrument_run(call_log, clusters, generated_pairs) as (_a, scheduler):
+            agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+        assert scheduler.enqueue.call_count == 2, call_log
+        i_last_supersede = _last_index(
+            call_log, "supersede_by_name", "supersede_by_ids"
+        )
+        i_enqueue = _first_index(call_log, "enqueue")
+        i_succeeded = next(
+            i
+            for i, (n, d) in enumerate(call_log)
+            if n == "usage" and d == "aggregation_succeeded"
+        )
+        assert i_last_supersede < i_enqueue < i_succeeded, call_log
+
+    def test_empty_run_id_takes_capture_anomaly_guard_branch(self):
+        """(d) When _run_id is falsy the supersede-guard captures an anomaly and
+        SKIPS the (unreconstructable) soft-supersede — never silently removes.
+        Without the empty-uuid injection this branch is dead (uuid4 is always
+        non-empty in practice), so it must be forced here to be exercised."""
+        call_log: list[tuple[str, Any]] = []
+        agg = _make_ordered_aggregator(call_log)
+        clusters, generated_pairs = self._two_pairs()
+
+        with _instrument_run(
+            call_log,
+            clusters,
+            generated_pairs,
+            uuid_side_effect=lambda: _EmptyStrUUID(),
+        ) as (anomaly, _scheduler):
+            agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+        anomaly.assert_called_once()
+        assert anomaly.call_args.args[0] == "lineage.aggregation.missing_request_id"
+        # The soft-supersede must be skipped entirely on the empty-run_id branch.
+        supersede_calls = [
+            name
+            for name, _ in call_log
+            if name in ("supersede_by_name", "supersede_by_ids")
+        ]
+        assert supersede_calls == [], call_log
+        agg.storage.supersede_agent_playbooks_by_playbook_name.assert_not_called()
+        agg.storage.supersede_agent_playbooks_by_ids.assert_not_called()
+
+    def test_mid_run_failure_emits_failed_restores_and_skips_enqueue(self):
+        """(e) A failure mid-run (here: set_source_windows raises, after archive
+        and the first save, before supersede/enqueue) emits aggregation_failed,
+        restores the archived state, re-raises — and NEVER enqueues optimization
+        or emits aggregation_succeeded."""
+        call_log: list[tuple[str, Any]] = []
+        agg = _make_ordered_aggregator(call_log)
+        clusters, generated_pairs = self._two_pairs()
+
+        def _set_source_windows_boom(agent_playbook_id: int, _windows: Any) -> None:
+            call_log.append(("set_source_windows", agent_playbook_id))
+            raise RuntimeError("boom in set_source_windows")
+
+        agg.storage.set_source_windows_for_agent_playbook.side_effect = (
+            _set_source_windows_boom
+        )
+
+        with (
+            _instrument_run(call_log, clusters, generated_pairs) as (_a, scheduler),
+            pytest.raises(RuntimeError, match="boom in set_source_windows"),
+        ):
+            agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+        names = [name for name, _ in call_log]
+        assert ("usage", "aggregation_failed") in call_log, call_log
+        assert ("usage", "aggregation_succeeded") not in call_log, call_log
+        # Full-archive restore ran; optimization never enqueued.
+        assert "restore" in names, call_log
+        assert "enqueue" not in names, call_log
+        scheduler.enqueue.assert_not_called()
+        # The failure was reached only after archive + at least one save.
+        assert names.index("archive") < names.index("save"), call_log
+
+
+class TestLazyArchivePreservesExisting:
+    """The deferred/lazy full-archive (aggregator.py ~:832-844): when a
+    full-archive run's LLM produces ZERO new playbooks, the archive is SKIPPED
+    (full_archive flips False) so existing PENDING/APPROVED playbooks survive —
+    and no supersede/restore fires.
+
+    Verified-before-adding: test_aggregation_soft_delete_integration.py (27
+    tests) covers the supersede/empty-run_id/from-status paths but NOT this
+    "0 new playbooks -> archive skipped" branch, so it is added here rather than
+    folded into that file.
+    """
+
+    def test_zero_new_playbooks_skips_full_archive(self):
+        call_log: list[tuple[str, Any]] = []
+        agg = _make_ordered_aggregator(call_log)
+        clusters = {0: [_raw(rid=1)]}
+
+        with _instrument_run(call_log, clusters, generated_pairs=[]) as (
+            _a,
+            scheduler,
+        ):
+            agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+        # Archive skipped because the LLM produced no replacements.
+        agg.storage.archive_agent_playbooks_by_playbook_name.assert_not_called()
+        assert "archive" not in [name for name, _ in call_log], call_log
+        # full_archive flipped False -> no supersede-by-name, existing preserved.
+        agg.storage.supersede_agent_playbooks_by_playbook_name.assert_not_called()
+        agg.storage.supersede_agent_playbooks_by_ids.assert_not_called()
+        agg.storage.restore_archived_agent_playbooks_by_playbook_name.assert_not_called()
+        # Nothing saved -> nothing enqueued.
+        scheduler.enqueue.assert_not_called()


### PR DESCRIPTION
## Summary

Decompose the `PlaybookAggregator` service god-class (`playbook/components/aggregator.py`, 1545 lines) into two stateless helper modules + one cohesive component, keeping the `run`/orchestration facade intact. Behavior-preserving with **zero public-surface or behavior change**. First **Tier-1b** (service-class) decomposition — a different shape from the Tier-1 storage mixins: this is **composition, not mixins** (the aggregator has zero shared-mutable `self`-state).

## Changes

- **`aggregator_clustering.py`** (new) — stateless clustering helpers (agglomerative/hdbscan/mock, fingerprint, change-detection).
- **`aggregator_prompt_formatting.py`** (new) — stateless prompt-formatting helpers (flat/grouped/structured cluster input, direction grouping).
- **`aggregator_postprocessing.py`** (new) — `AggregationPostProcessing` component (7 pre/post methods; holds the single `aggregation_prompt_processor` collaborator — the enterprise redaction Protocol seam, constructed from the injected instance).
- **`aggregator.py`** (facade, 1545 → 1122 lines) — keeps `run` + `get_clusters` + generation orchestration (the full side-effect chain, verbatim) + config/operation-state, and thin one-line delegators for the by-name-tested helpers so external call-sites are unaffected.

The ~760-line orchestration core (`run` + generation) is irreducible and stays whole. Moved bodies are byte-identical (AST-verified) modulo the mechanical `self.<collab>`→param rebinding.

## Weak-gate characterization (no contract suite covers this path; e2e can't observe internal call order)

Added a **`run` side-effect ORDER characterization test** — the sole falsifiable guard for the central invariant: archive-after-generate-before-first-save; per-playbook save→set_source_windows interleaving; enqueue-after-last-supersede-before-`aggregation_succeeded`; the empty-`_run_id` `capture_anomaly` guard branch; and mid-run-failure → `aggregation_failed` + restore + re-raise + no enqueue. Each assertion was empirically confirmed to fail under a targeted reorder mutation. Plus a lazy-archive "0-new → existing preserved" assertion.

## Dead code
- Deleted `_generate_playbooks_from_clusters` (zero callers).
- Relocated the test-only `_format_cluster_input` (dead in production) + its 5 tests into the test module.

## Test plan
- OSS `test_playbook_aggregator.py` + clustering + soft-delete + the new order guard → all pass; OSS e2e `test_playbook_workflows.py` aggregation path green (credential-gated skips are skips, not failures).
- `ruff` + `pyright` (0 errors) clean; whole-branch `/review-loop` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked playbook aggregation to use dedicated clustering, prompt-formatting, and postprocessing components for more consistent behavior.
  * Improved how clusters are grouped and formatted, including better handling of similar playbooks and freeform content.

* **Tests**
  * Expanded aggregation test coverage for formatted output, ordering, error handling, and side-effect sequencing during run operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->