### PR TITLE
fix: preserve durable async publish writes

### DIFF
--- a/reflexio/lib/_interactions.py
+++ b/reflexio/lib/_interactions.py
@@ -53,11 +53,18 @@ class InteractionsMixin(ReflexioBase):
     def publish_interaction(
         self,
         request: PublishUserInteractionRequest | dict,
+        *,
+        use_publish_limiter: bool = True,
+        publish_limiter_wait_forever: bool = True,
     ) -> PublishUserInteractionResponse:
         """Publish user interactions.
 
         Args:
             request (Union[PublishUserInteractionRequest, dict]): The publish user interaction request
+            use_publish_limiter: Whether GenerationService should throttle the
+                post-write learning pipeline.
+            publish_limiter_wait_forever: Whether GenerationService should queue
+                indefinitely for that post-write learning limiter.
 
         Returns:
             PublishUserInteractionResponse: Response containing success status and message
@@ -87,7 +94,11 @@ class InteractionsMixin(ReflexioBase):
             # Convert dict to PublishUserInteractionRequest if needed
             if isinstance(request, dict):
                 request = PublishUserInteractionRequest(**request)
-            result = generation_service.run(request)
+            result = generation_service.run(
+                request,
+                use_publish_limiter=use_publish_limiter,
+                publish_limiter_wait_forever=publish_limiter_wait_forever,
+            )
             after_profiles = _safe_count(storage.count_all_profiles)
             after_playbooks = _safe_count(storage.count_user_playbooks)
             # Don't concatenate warnings into the message field — they

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -701,7 +701,12 @@ def publish_user_interaction(
 
     def _publish_task() -> None:
         try:
-            publisher_api.add_user_interaction(org_id=org_id, request=payload)
+            publisher_api.add_user_interaction(
+                org_id=org_id,
+                request=payload,
+                use_publish_limiter=True,
+                publish_limiter_wait_forever=False,
+            )
         except Exception:
             logger.exception("Background publish failed for org %s", org_id)
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -686,31 +686,27 @@ def publish_user_interaction(
     _gate: None = Depends(default_billing_gate("learnings_generated")),  # noqa: B008
 ) -> PublishUserInteractionResponse:
     if wait_for_response:
-        # Process synchronously so the caller gets the real result
+        # Sync callers wait for the real result, so preserve bounded backpressure
+        # before any storage side effects. The inner service limiter is disabled
+        # because this route already owns the publish slot.
         return _run_limited_api(
             org_id,
             "publish",
-            lambda: publisher_api.add_user_interaction(org_id=org_id, request=payload),
+            lambda: publisher_api.add_user_interaction(
+                org_id=org_id,
+                request=payload,
+                use_publish_limiter=False,
+            ),
         )
 
-    def _limited_publish_task() -> None:
+    def _publish_task() -> None:
         try:
-            run_with_operation_limit(
-                org_id=org_id,
-                operation="publish",
-                fn=lambda: publisher_api.add_user_interaction(
-                    org_id=org_id, request=payload
-                ),
-                wait_forever=False,
-            )
-        except TimeoutError:
-            logger.warning(
-                "Dropped queued publish for org %s because publish limiter is saturated",
-                org_id,
-            )
+            publisher_api.add_user_interaction(org_id=org_id, request=payload)
+        except Exception:
+            logger.exception("Background publish failed for org %s", org_id)
 
     # Run in background — caller gets immediate acknowledgement
-    background_tasks.add_task(_limited_publish_task)
+    background_tasks.add_task(_publish_task)
     return PublishUserInteractionResponse(
         success=True, message="Interaction queued for processing"
     )

--- a/reflexio/server/api_endpoints/publisher_api.py
+++ b/reflexio/server/api_endpoints/publisher_api.py
@@ -62,12 +62,19 @@ logger = logging.getLogger(__name__)
 def add_user_interaction(
     org_id: str,
     request: PublishUserInteractionRequest,
+    *,
+    use_publish_limiter: bool = True,
+    publish_limiter_wait_forever: bool = True,
 ) -> PublishUserInteractionResponse:
     """Add user interaction
 
     Args:
         org_id (str): Organization ID
         request (PublishUserInteractionRequest): The request containing interaction data
+        use_publish_limiter (bool): Whether GenerationService should throttle the
+            post-write learning pipeline.
+        publish_limiter_wait_forever (bool): Whether GenerationService should queue
+            indefinitely for that post-write learning limiter.
 
     Returns:
         PublishUserInteractionResponse: Response containing success status and message
@@ -77,7 +84,11 @@ def add_user_interaction(
         return PublishUserInteractionResponse(success=False, message=message)
 
     reflexio = get_reflexio(org_id=org_id)
-    return reflexio.publish_interaction(request=request)
+    return reflexio.publish_interaction(
+        request=request,
+        use_publish_limiter=use_publish_limiter,
+        publish_limiter_wait_forever=publish_limiter_wait_forever,
+    )
 
 
 def add_user_playbook(

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -10,6 +10,7 @@ import uuid
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from contextlib import nullcontext
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,7 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.models.config_schema import Config
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.operation_limiter import operation_limit
 from reflexio.server.services.agent_success_evaluation.runner import (
     run_group_evaluation,
 )
@@ -140,7 +142,11 @@ class GenerationService:
     # ===============================
 
     def run(
-        self, publish_user_interaction_request: PublishUserInteractionRequest
+        self,
+        publish_user_interaction_request: PublishUserInteractionRequest,
+        *,
+        use_publish_limiter: bool = True,
+        publish_limiter_wait_forever: bool = True,
     ) -> GenerationServiceResult:
         """
         Process a user interaction request by storing interactions and triggering generation services.
@@ -156,6 +162,12 @@ class GenerationService:
 
         Args:
             publish_user_interaction_request: The incoming user interaction request
+            use_publish_limiter: Whether this service should throttle the post-write
+                learning pipeline. Server sync calls acquire the bounded API
+                limiter before invoking this service, so they disable the inner
+                limiter to avoid waiting after storage side effects.
+            publish_limiter_wait_forever: Whether to queue indefinitely for the
+                post-write learning limiter when ``use_publish_limiter`` is true.
 
         Returns:
             GenerationServiceResult: The request_id assigned to this publish call
@@ -293,137 +305,153 @@ class GenerationService:
                 )
                 return result
 
-            # Reflection runs as its own sliding-window step BEFORE the
-            # extractor pool spins up, so any replacements it makes are
-            # visible to the extractors when they retrieve existing
-            # profile/playbook context. Wrapped in a broad except so a
-            # reflection bug never breaks the publish.
-            self._maybe_run_reflection(
-                user_id=user_id,
-                request_id=request_id,
-                agent_version=agent_version,
-                source=source,
+            # The durable write above must not sit behind the publish limiter:
+            # async API callers have already received success=True. Throttle only
+            # the post-write learning pipeline so a hung LLM cannot silently drop
+            # later acknowledged publishes before they reach storage.
+            learning_limit = (
+                operation_limit(
+                    self.org_id,
+                    "publish",
+                    wait_forever=publish_limiter_wait_forever,
+                )
+                if use_publish_limiter
+                else nullcontext()
             )
+            with learning_limit:
+                # Reflection runs as its own sliding-window step BEFORE the
+                # extractor pool spins up, so any replacements it makes are
+                # visible to the extractors when they retrieve existing
+                # profile/playbook context. Wrapped in a broad except so a
+                # reflection bug never breaks the publish.
+                self._maybe_run_reflection(
+                    user_id=user_id,
+                    request_id=request_id,
+                    agent_version=agent_version,
+                    source=source,
+                )
 
-            # Create generation services and requests
-            # Each service writes to separate storage tables and has no dependencies on others
-            profile_generation_service = ProfileGenerationService(
-                llm_client=self.client, request_context=self.request_context
-            )
-            profile_generation_request = ProfileGenerationRequest(
-                user_id=user_id,
-                request_id=request_id,
-                source=source,
-                force_extraction=publish_user_interaction_request.force_extraction,
-            )
+                # Create generation services and requests
+                # Each service writes to separate storage tables and has no dependencies on others
+                profile_generation_service = ProfileGenerationService(
+                    llm_client=self.client, request_context=self.request_context
+                )
+                profile_generation_request = ProfileGenerationRequest(
+                    user_id=user_id,
+                    request_id=request_id,
+                    source=source,
+                    force_extraction=publish_user_interaction_request.force_extraction,
+                )
 
-            playbook_generation_service = PlaybookGenerationService(
-                llm_client=self.client,
-                request_context=self.request_context,
-                skip_aggregation=publish_user_interaction_request.skip_aggregation,
-            )
-            playbook_generation_request = PlaybookGenerationRequest(
-                request_id=request_id,
-                agent_version=agent_version,
-                user_id=user_id,
-                source=source,
-                force_extraction=publish_user_interaction_request.force_extraction,
-            )
+                playbook_generation_service = PlaybookGenerationService(
+                    llm_client=self.client,
+                    request_context=self.request_context,
+                    skip_aggregation=publish_user_interaction_request.skip_aggregation,
+                )
+                playbook_generation_request = PlaybookGenerationRequest(
+                    request_id=request_id,
+                    agent_version=agent_version,
+                    user_id=user_id,
+                    source=source,
+                    force_extraction=publish_user_interaction_request.force_extraction,
+                )
 
-            # Run profile and playbook generation services in parallel
-            # Each service creates its own internal ThreadPoolExecutor for extractors
-            # This is safe because we create separate, independent pool instances
-            # Uses manual executor management to avoid blocking on shutdown(wait=True)
-            # when threads are hung on LLM calls
-            executor = ThreadPoolExecutor(max_workers=2)
-            try:
-                # Each thread needs its own context copy — Context.run() is non-reentrant
-                futures = [
-                    executor.submit(
-                        contextvars.copy_context().run,
-                        profile_generation_service.run,
-                        profile_generation_request,
-                    ),
-                    executor.submit(
-                        contextvars.copy_context().run,
-                        playbook_generation_service.run,
-                        playbook_generation_request,
-                    ),
-                ]
+                # Run profile and playbook generation services in parallel
+                # Each service creates its own internal ThreadPoolExecutor for extractors
+                # This is safe because we create separate, independent pool instances
+                # Uses manual executor management to avoid blocking on shutdown(wait=True)
+                # when threads are hung on LLM calls
+                executor = ThreadPoolExecutor(max_workers=2)
+                try:
+                    # Each thread needs its own context copy — Context.run() is non-reentrant
+                    futures = [
+                        executor.submit(
+                            contextvars.copy_context().run,
+                            profile_generation_service.run,
+                            profile_generation_request,
+                        ),
+                        executor.submit(
+                            contextvars.copy_context().run,
+                            playbook_generation_service.run,
+                            playbook_generation_request,
+                        ),
+                    ]
 
-                # Collect results and handle any exceptions
-                # Each service failure is logged but doesn't block others
-                service_names = ["profile_generation", "playbook_generation"]
-                for future, service_name in zip(futures, service_names, strict=True):
-                    try:
-                        future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
-                    except FuturesTimeoutError:  # noqa: PERF203
-                        msg = f"{service_name} timed out after {GENERATION_SERVICE_TIMEOUT_SECONDS}s"
-                        with sentry_tags(
-                            subsystem="generation",
-                            service=service_name,
-                            request_id=request_id,
-                            error_type="timeout",
-                        ):
-                            logger.error("%s for request %s", msg, request_id)
-                        result.warnings.append(msg)
-                    except Exception as e:
-                        msg = f"{service_name} failed: {e}"
-                        with sentry_tags(
-                            subsystem="generation",
-                            service=service_name,
-                            request_id=request_id,
-                            error_type=type(e).__name__,
-                        ):
-                            logger.exception(
-                                "Generation service failed for request %s",
-                                request_id,
-                            )
-                        result.warnings.append(msg)
-            finally:
-                executor.shutdown(wait=False, cancel_futures=True)
+                    # Collect results and handle any exceptions
+                    # Each service failure is logged but doesn't block others
+                    service_names = ["profile_generation", "playbook_generation"]
+                    for future, service_name in zip(
+                        futures, service_names, strict=True
+                    ):
+                        try:
+                            future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
+                        except FuturesTimeoutError:  # noqa: PERF203
+                            msg = f"{service_name} timed out after {GENERATION_SERVICE_TIMEOUT_SECONDS}s"
+                            with sentry_tags(
+                                subsystem="generation",
+                                service=service_name,
+                                request_id=request_id,
+                                error_type="timeout",
+                            ):
+                                logger.error("%s for request %s", msg, request_id)
+                            result.warnings.append(msg)
+                        except Exception as e:
+                            msg = f"{service_name} failed: {e}"
+                            with sentry_tags(
+                                subsystem="generation",
+                                service=service_name,
+                                request_id=request_id,
+                                error_type=type(e).__name__,
+                            ):
+                                logger.exception(
+                                    "Generation service failed for request %s",
+                                    request_id,
+                                )
+                            result.warnings.append(msg)
+                finally:
+                    executor.shutdown(wait=False, cancel_futures=True)
 
-            # Tagging runs an LLM call per newly generated entity, so defer it off
-            # the publish path. The scheduler debounces bursts and is idempotent
-            # (already-tagged entities are skipped).
-            try:
-                schedule_tagging(
-                    org_id=self.org_id,
+                # Tagging runs an LLM call per newly generated entity, so defer it off
+                # the publish path. The scheduler debounces bursts and is idempotent
+                # (already-tagged entities are skipped).
+                try:
+                    schedule_tagging(
+                        org_id=self.org_id,
+                        user_id=user_id,
+                        agent_version=agent_version,
+                        request_context=self.request_context,
+                        llm_client=self.client,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to schedule tagging for publish request %s",
+                        request_id,
+                    )
+
+                # Schedule delayed group evaluation for the required session.
+                self._schedule_group_evaluation_if_needed(
+                    new_request=new_request,
                     user_id=user_id,
                     agent_version=agent_version,
-                    request_context=self.request_context,
-                    llm_client=self.client,
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to schedule tagging for publish request %s",
-                    request_id,
+                    source=source,
                 )
 
-            # Schedule delayed group evaluation for the required session.
-            self._schedule_group_evaluation_if_needed(
-                new_request=new_request,
-                user_id=user_id,
-                agent_version=agent_version,
-                source=source,
-            )
-
-            record_usage_event(
-                org_id=self.org_id,
-                user_id=user_id,
-                request_id=request_id,
-                session_id=new_request.session_id,
-                source=source,
-                agent_version=agent_version,
-                backend="classic",
-                event_name="publish_request_succeeded",
-                event_category="publish",
-                outcome="success",
-                count_value=len(new_interactions),
-                duration_ms=int((time.perf_counter() - publish_start) * 1000),
-                metadata={"warning_count": len(result.warnings)},
-            )
-            return result
+                record_usage_event(
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    session_id=new_request.session_id,
+                    source=source,
+                    agent_version=agent_version,
+                    backend="classic",
+                    event_name="publish_request_succeeded",
+                    event_category="publish",
+                    outcome="success",
+                    count_value=len(new_interactions),
+                    duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                    metadata={"warning_count": len(result.warnings)},
+                )
+                return result
 
         except Exception as e:
             record_usage_event(

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -70,9 +70,18 @@ class TestPublishInteraction:
             success=True, message="Interaction processed"
         )
 
-        with patch(
-            "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
-            return_value=mock_response,
+        def run_immediately(**kwargs):
+            return kwargs["fn"]()
+
+        with (
+            patch(
+                "reflexio.server.api.run_with_operation_limit",
+                side_effect=run_immediately,
+            ) as run_with_operation_limit,
+            patch(
+                "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
+                return_value=mock_response,
+            ) as add_user_interaction,
         ):
             response = client.post(
                 "/api/publish_interaction",
@@ -82,6 +91,9 @@ class TestPublishInteraction:
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
+        assert run_with_operation_limit.call_args.kwargs["operation"] == "publish"
+        add_user_interaction.assert_called_once()
+        assert add_user_interaction.call_args.kwargs["use_publish_limiter"] is False
 
     def test_async_publish_returns_queued(self, client, patched_reflexio):
         """Async mode returns immediate acknowledgement without calling publisher."""
@@ -94,26 +106,20 @@ class TestPublishInteraction:
         assert data["success"] is True
         assert "queued" in data["message"].lower()
 
-    def test_async_publish_does_not_wait_forever_for_limiter_capacity(
+    def test_async_publish_does_not_gate_durable_write_on_limiter(
         self, client, patched_reflexio
     ):
-        captured: dict[str, bool] = {}
-
-        def _fake_run_with_limit(**kwargs):
-            captured["wait_forever"] = kwargs["wait_forever"]
-            return kwargs["fn"]()
-
         with (
             patch(
                 "reflexio.server.api.run_with_operation_limit",
-                side_effect=_fake_run_with_limit,
+                side_effect=AssertionError("publish limiter should not wrap storage"),
             ),
             patch(
                 "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
                 return_value=PublishUserInteractionResponse(
                     success=True, message="Interaction processed"
                 ),
-            ),
+            ) as add_user_interaction,
         ):
             response = client.post(
                 "/api/publish_interaction",
@@ -121,7 +127,7 @@ class TestPublishInteraction:
             )
 
         assert response.status_code == 200
-        assert captured["wait_forever"] is False
+        add_user_interaction.assert_called_once()
 
     def test_publish_missing_body_returns_422(self, client):
         response = client.post("/api/publish_interaction")

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -128,6 +128,11 @@ class TestPublishInteraction:
 
         assert response.status_code == 200
         add_user_interaction.assert_called_once()
+        assert add_user_interaction.call_args.kwargs["use_publish_limiter"] is True
+        assert (
+            add_user_interaction.call_args.kwargs["publish_limiter_wait_forever"]
+            is False
+        )
 
     def test_publish_missing_body_returns_422(self, client):
         response = client.post("/api/publish_interaction")

--- a/tests/server/api_endpoints/test_publisher_api.py
+++ b/tests/server/api_endpoints/test_publisher_api.py
@@ -58,7 +58,11 @@ class TestAddUserInteraction:
 
         result = add_user_interaction(ORG_ID, request)
 
-        mock_reflexio.publish_interaction.assert_called_once_with(request=request)
+        mock_reflexio.publish_interaction.assert_called_once_with(
+            request=request,
+            use_publish_limiter=True,
+            publish_limiter_wait_forever=True,
+        )
         assert result is expected
 
     @patch(f"{MODULE}.validate_publish_user_interaction_request")

--- a/tests/server/services/reflection/test_generation_service_wiring.py
+++ b/tests/server/services/reflection/test_generation_service_wiring.py
@@ -9,6 +9,7 @@ wiring check.
 from __future__ import annotations
 
 import tempfile
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -84,6 +85,40 @@ def test_run_invokes_maybe_run_reflection(request_context, llm_client, publish_r
     # agent_version must be threaded through so reflected playbooks
     # inherit the publish's resolved version, not "".
     assert kwargs.get("agent_version") == "v1"
+
+
+def test_run_writes_request_and_interactions_before_publish_limiter(
+    request_context, llm_client, publish_request
+):
+    """The post-write limiter must not block acknowledged async publishes from storage."""
+    request_id = "req-before-learning-limiter"
+    request = publish_request.model_copy(update={"request_id": request_id})
+    service = GenerationService(llm_client=llm_client, request_context=request_context)
+    limiter_calls = []
+
+    @contextmanager
+    def saturated_publish_limit(org_id, operation, **kwargs):
+        limiter_calls.append((org_id, operation, kwargs))
+        raise TimeoutError("publish limiter saturated")
+        yield
+
+    with (
+        patch(
+            "reflexio.server.services.generation_service.operation_limit",
+            saturated_publish_limit,
+        ),
+        patch("reflexio.server.services.generation_service.record_usage_event"),
+        pytest.raises(TimeoutError, match="publish limiter saturated"),
+    ):
+        service.run(request)
+
+    storage = request_context.storage
+    assert storage is not None
+    assert storage.get_request(request_id) is not None
+    assert len(storage.get_interactions_by_request_ids([request_id])) == 2
+    assert limiter_calls == [
+        ("test_org", "publish", {"wait_forever": True}),
+    ]
 
 
 def test_reflection_failure_does_not_break_publish(


### PR DESCRIPTION
## Summary
- Preserve durable async publish writes before any publish limiter backpressure can interrupt post-write learning.
- Keep synchronous publishes bounded at the API route while disabling the inner service limiter for that path.
- Ensure async background publishes still use the post-write learning limiter, but do not queue indefinitely when limiter capacity is saturated.
- Add wiring tests that prove async storage is not wrapped by the route limiter and that stored interactions exist before post-write limiter saturation.

## Changes
- Threads `use_publish_limiter` and `publish_limiter_wait_forever` through `publish_interaction` and publisher API calls.
- Moves the generation service publish limiter to wrap reflection/profile/playbook/tagging/evaluation work after request and interaction storage.
- Passes `publish_limiter_wait_forever=False` from the async API background task so acknowledged writes remain durable while background learning backpressure stays bounded.
- Updates route tests and generation-service wiring coverage for sync and async publish behavior.

## Test Plan
- `uv run ruff check --fix reflexio/lib/_interactions.py reflexio/server/api.py reflexio/server/api_endpoints/publisher_api.py reflexio/server/services/generation_service.py tests/server/api_endpoints/test_api_routes.py tests/server/api_endpoints/test_publisher_api.py tests/server/services/reflection/test_generation_service_wiring.py`
- `uv run ruff format reflexio/lib/_interactions.py reflexio/server/api.py reflexio/server/api_endpoints/publisher_api.py reflexio/server/services/generation_service.py tests/server/api_endpoints/test_api_routes.py tests/server/api_endpoints/test_publisher_api.py tests/server/services/reflection/test_generation_service_wiring.py`
- `uv run ruff check reflexio/lib/_interactions.py reflexio/server/api.py reflexio/server/api_endpoints/publisher_api.py reflexio/server/services/generation_service.py tests/server/api_endpoints/test_api_routes.py tests/server/api_endpoints/test_publisher_api.py tests/server/services/reflection/test_generation_service_wiring.py`
- `uv run pyright reflexio/lib/_interactions.py reflexio/server/api.py reflexio/server/api_endpoints/publisher_api.py reflexio/server/services/generation_service.py tests/server/api_endpoints/test_api_routes.py tests/server/api_endpoints/test_publisher_api.py tests/server/services/reflection/test_generation_service_wiring.py`
- `uv run pytest tests/server/api_endpoints/test_api_routes.py tests/server/api_endpoints/test_publisher_api.py tests/server/services/reflection/test_generation_service_wiring.py --no-cov`
- Follow-up: `uv run ruff check --fix reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- Follow-up: `uv run ruff format reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- Follow-up: `uv run ruff check reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- Follow-up: `uv run pyright reflexio/server/api.py tests/server/api_endpoints/test_api_routes.py`
- Follow-up: `uv run pytest tests/server/api_endpoints/test_api_routes.py --no-cov`

Note: the same focused pytest command without `--no-cov` had all 57 tests pass, then failed the global coverage threshold because it was a subset run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable publish throttling controls for user interaction submission, including options to wait indefinitely or skip the limiter.
  * Updated the publish flow so synchronous requests keep bounded backpressure, while background publishing is handled more directly.

* **Bug Fixes**
  * Preserved storage and response behavior while improving how publish work is queued and handled under load.
  * Improved failure logging for background publish processing.

* **Tests**
  * Expanded endpoint and service tests to cover the new publish control behavior and storage-before-throttling flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
