### PR TITLE
refactor(server): ThreadedScheduler base + DeploymentProfile (Tier 3 B+C)

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from reflexio.server.deployment_profile import DeploymentProfile
     from reflexio.server.extensions import AppContext, CapabilityRegistry
 
 from fastapi import APIRouter, FastAPI
@@ -234,6 +235,29 @@ def _wire_capabilities(
             app.include_router(r)
 
 
+def _resolve_app_profile(
+    profile: "DeploymentProfile | None",
+    *,
+    mount_data_plane: bool,
+    require_auth: bool,
+) -> "DeploymentProfile":
+    """Return the caller's profile, or derive one from the legacy knobs.
+
+    Args:
+        profile (DeploymentProfile | None): Explicit profile, or None to derive.
+        mount_data_plane (bool): Legacy knob — whether data-plane routers/lifespan run.
+        require_auth (bool): Legacy knob — whether auth is declared.
+
+    Returns:
+        DeploymentProfile: ``profile`` when provided, else the derived profile.
+    """
+    from reflexio.server.deployment_profile import resolve_profile
+
+    if profile is not None:
+        return profile
+    return resolve_profile(mount_data_plane=mount_data_plane, require_auth=require_auth)
+
+
 def create_app(
     get_org_id: Callable[..., str] | None = None,
     additional_routers: list[APIRouter] | None = None,
@@ -244,6 +268,7 @@ def create_app(
     mount_data_plane: bool = True,
     capabilities: "CapabilityRegistry | None" = None,
     app_context_factory: "Callable[[], AppContext] | None" = None,
+    profile: "DeploymentProfile | None" = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -279,6 +304,12 @@ def create_app(
             each capability's on_startup. When None, an empty AppContext() is used
             (local OSS / tests). Enterprise binds this to supply self_host_org_id /
             activated computed during its own startup.
+        profile: Optional declarative :class:`DeploymentProfile`. When None
+            (default), it is DERIVED from the ``mount_data_plane`` / ``require_auth``
+            knobs so behaviour is identical to before this parameter existed. When
+            provided it is the single source for router-group mounting, auth, and
+            data-plane lifespan gating (the legacy knobs still populate the derived
+            profile, so callers may pass either — they express the same thing).
 
     Returns:
         Configured FastAPI application.
@@ -295,6 +326,14 @@ def create_app(
         raise ValueError(
             "pass billing_gate via either get_billing_gate or capabilities, not both"
         )
+    # The profile is a cleaner representation of the two existing knobs. When the
+    # caller does not pass one, derive it from ``mount_data_plane`` / ``require_auth``
+    # so behaviour is byte-identical to before this parameter existed.
+    profile = _resolve_app_profile(
+        profile, mount_data_plane=mount_data_plane, require_auth=require_auth
+    )
+    mounts_data_plane = profile.mounts_data_plane
+    auth_required = profile.auth_required
     from collections.abc import AsyncIterator
     from contextlib import asynccontextmanager
 
@@ -318,7 +357,7 @@ def create_app(
         scheduler = None
         gc_scheduler = None
         started_caps: list = []
-        if mount_data_plane:
+        if mounts_data_plane:
             log_publish_hardware_capacity()
             validate_llm_availability()
             from reflexio.server.llm.rerank import prewarm as _prewarm_cross_encoder
@@ -365,7 +404,7 @@ def create_app(
 
     app = FastAPI(docs_url="/docs", lifespan=lifespan)
 
-    if require_auth:
+    if auth_required:
         _add_openapi_security(app)
 
     @app.get("/meta/version")
@@ -391,7 +430,7 @@ def create_app(
     # hosts that wire in auth (``require_auth=True``) restrict browser origins.
     # OSS/local runs have no auth and bundle their own docs playground on a
     # separate port, so they allow any origin (no credentials needed).
-    if require_auth:
+    if auth_required:
         app.add_middleware(
             CORSMiddleware,
             allow_origins=_resolve_cors_origins(),
@@ -448,12 +487,12 @@ def create_app(
     # ``app.state`` instead of a module-level global keeps the gate
     # scoped to this FastAPI instance, so multiple apps (e.g. tests,
     # multi-tenant embeddings) can coexist without leaking state.
-    app.state.my_config_enabled = bool(get_org_id is not None and require_auth)
+    app.state.my_config_enabled = bool(get_org_id is not None and auth_required)
 
     # Include data-plane routes (core, stall-state, pending-tool-call). A
     # control-plane host sets mount_data_plane=False to skip these while
     # keeping every other piece of scaffolding below.
-    if mount_data_plane:
+    if mounts_data_plane:
         # Include core routes
         app.include_router(core_router)
 
@@ -468,7 +507,7 @@ def create_app(
         app.include_router(router)
 
     # Wire capability routers, services, and hooks (composition-root only)
-    _wire_capabilities(app, capabilities, mount_data_plane, additional_routers)
+    _wire_capabilities(app, capabilities, mounts_data_plane, additional_routers)
 
     # Health/observability endpoint (per-worker metrics for recycling)
     health_api.install(app)

--- a/reflexio/server/deployment_profile.py
+++ b/reflexio/server/deployment_profile.py
@@ -1,0 +1,69 @@
+"""Declarative deployment profile (Tier-3 Phase C).
+
+A ``DeploymentProfile`` is a minimal, frozen description of *what a running app
+serves*: its deployment ``role``, the set of ``router_groups`` it mounts, and
+whether auth is required. It is a cleaner internal representation of the knobs
+``create_app`` already accepts (``mount_data_plane`` / ``require_auth``) — the
+profile changes nothing observable; it just gives the composition root a single
+value to thread instead of scattered booleans.
+
+This module is an OSS public seam: it imports nothing from ``reflexio_ext`` and
+carries no enterprise backend knowledge (string/stdlib only). The enterprise
+composition defines its own profiles (self-host / platform) on top of this type.
+
+``mounts_data_plane`` is DERIVED from ``router_groups`` (membership of the
+``DATA_PLANE_GROUP``), not stored — so the two can never disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The single OSS router group: the data-plane surface (core product endpoints,
+# stall-state, pending-tool-call) that ``create_app`` mounts when data-plane is
+# active. Enterprise adds its own group names on top of this type.
+DATA_PLANE_GROUP = "data-plane"
+
+
+@dataclass(frozen=True)
+class DeploymentProfile:
+    """What a running app serves: role, mounted router groups, auth requirement.
+
+    Attributes:
+        role (str): Deployment role label (e.g. ``"all"``, ``"data-plane"``,
+            ``"control-plane"``). Informational for the OSS factory; enterprise
+            uses it to select its router set.
+        router_groups (frozenset[str]): Router-group names this app mounts.
+        auth_required (bool): Whether the app declares/enforces auth.
+    """
+
+    role: str
+    router_groups: frozenset[str]
+    auth_required: bool
+
+    @property
+    def mounts_data_plane(self) -> bool:
+        """Whether this profile mounts the data-plane router group."""
+        return DATA_PLANE_GROUP in self.router_groups
+
+
+def resolve_profile(*, mount_data_plane: bool, require_auth: bool) -> DeploymentProfile:
+    """Derive the OSS profile from the legacy ``create_app`` knobs.
+
+    Behaviour-preserving: this is the identity mapping from the two booleans
+    ``create_app`` has always accepted onto the profile representation.
+
+    Args:
+        mount_data_plane (bool): Whether the data-plane routers/lifespan run.
+        require_auth (bool): Whether auth (Bearer security scheme) is declared.
+
+    Returns:
+        DeploymentProfile: ``role="all"`` + the data-plane group when
+        ``mount_data_plane`` is True, otherwise ``role="control-plane"`` with no
+        router groups. ``auth_required`` mirrors ``require_auth``.
+    """
+    router_groups = frozenset({DATA_PLANE_GROUP}) if mount_data_plane else frozenset()
+    role = "all" if mount_data_plane else "control-plane"
+    return DeploymentProfile(
+        role=role, router_groups=router_groups, auth_required=require_auth
+    )

--- a/reflexio/server/scheduling.py
+++ b/reflexio/server/scheduling.py
@@ -1,0 +1,127 @@
+"""Shared thread-lifecycle base for the process-local polling schedulers.
+
+Reflexio runs a family of background daemons — extraction resume, lineage GC,
+and (in the enterprise layer) billing ship / lease / period-close / integrity /
+audit / offline-tuner / governance-retention / invitation-reclamation. Every one
+of them hand-rolled the SAME thread mechanics: a :class:`threading.Event`
+stop-signal, a daemon :class:`threading.Thread` running a ``while not
+stop.is_set()`` loop, and a ``.join(timeout)`` graceful stop.
+
+:class:`ThreadedScheduler` captures ONLY those mechanics. Each scheduler keeps
+its own poll interval, work body, gating, and log lines — supplied via a small
+set of hooks so no observable behaviour changes:
+
+- :meth:`_run_once` performs one tick (catching its own errors) and returns the
+  number of seconds to wait before the next tick. A scheduler that reads its
+  interval from config each tick keeps doing exactly that by returning the fresh
+  value.
+- :meth:`_should_start` can veto startup (the enterprise schedulers whose
+  ``start`` is a logged no-op when a feature gate is off).
+- :meth:`_on_started` / :meth:`_on_stopped` emit each scheduler's own start/stop
+  log line (through its own module logger, so output is byte-identical).
+
+A scheduler whose loop is materially different (e.g. a bounded-attempt retrier
+that waits *before* each attempt and exits on first success) may override
+:meth:`_run_loop` wholesale and still reuse :meth:`start` / :meth:`stop` /
+:meth:`is_running`.
+
+This module is an OSS public seam: it imports only the standard library and
+nothing from ``reflexio_ext``.
+"""
+
+from __future__ import annotations
+
+import threading
+
+
+class ThreadedScheduler:
+    """Base for a process-local daemon that ticks on a background thread.
+
+    Owns the shared thread mechanics only: a stop :class:`threading.Event`, a
+    daemon thread, an idempotent :meth:`start`, and a join-with-timeout
+    :meth:`stop`. Subclasses supply the per-tick work + cadence via
+    :meth:`_run_once` (or override :meth:`_run_loop` for a bespoke loop shape).
+
+    Args:
+        thread_name (str): OS thread name for the daemon (aids debugging / logs).
+    """
+
+    def __init__(self, *, thread_name: str) -> None:
+        self._thread_name = thread_name
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start the daemon thread, unless it is gated off or already running.
+
+        Calls :meth:`_should_start` first (a subclass gate that can log + veto),
+        then the idempotent alive-check, then spawns the thread and calls
+        :meth:`_on_started`.
+        """
+        if not self._should_start():
+            return
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name=self._thread_name,
+            daemon=True,
+        )
+        self._thread.start()
+        self._on_started()
+
+    def stop(self, *, timeout_seconds: float = 5.0) -> None:
+        """Signal the loop to stop and join the thread.
+
+        Args:
+            timeout_seconds (float): Max seconds to wait for the thread to exit.
+        """
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout_seconds)
+        self._thread = None
+        self._on_stopped()
+
+    def is_running(self) -> bool:
+        """Return whether the background thread exists and is alive.
+
+        Returns:
+            bool: True when the loop thread is running.
+        """
+        return self._thread is not None and self._thread.is_alive()
+
+    # -- Overridable hooks ---------------------------------------------------
+
+    def _should_start(self) -> bool:
+        """Return whether :meth:`start` should spawn the thread (default True).
+
+        Override to gate startup behind a feature flag; the override owns any
+        "not starting" log line.
+        """
+        return True
+
+    def _on_started(self) -> None:
+        """Hook run after the thread starts (default no-op); override to log."""
+
+    def _on_stopped(self) -> None:
+        """Hook run after the thread joins (default no-op); override to log."""
+
+    def _run_once(self) -> float:
+        """Run one tick and return the seconds to wait before the next.
+
+        Implementations MUST catch their own per-tick errors — a raise here would
+        kill the daemon thread. The returned value is passed straight to
+        ``stop_event.wait`` as the inter-tick delay, so a subclass may compute a
+        fresh interval each tick (e.g. from config).
+
+        Returns:
+            float: Seconds to wait before the next tick.
+        """
+        raise NotImplementedError
+
+    def _run_loop(self) -> None:
+        """Drive :meth:`_run_once` until stopped, waiting its returned interval."""
+        while not self._stop_event.is_set():
+            interval = self._run_once()
+            self._stop_event.wait(interval)

--- a/reflexio/server/scheduling.py
+++ b/reflexio/server/scheduling.py
@@ -80,7 +80,12 @@ class ThreadedScheduler:
         self._stop_event.set()
         if self._thread is not None:
             self._thread.join(timeout=timeout_seconds)
-        self._thread = None
+            # Only drop the reference once the thread has actually exited. If the
+            # join timed out (a slow ``_run_once`` still running), keep it so
+            # ``is_running()`` stays true and a subsequent ``start()`` refuses to
+            # spawn a second loop while the first is alive.
+            if not self._thread.is_alive():
+                self._thread = None
         self._on_stopped()
 
     def is_running(self) -> bool:

--- a/reflexio/server/services/extraction/resume_scheduler.py
+++ b/reflexio/server/services/extraction/resume_scheduler.py
@@ -11,11 +11,11 @@ with — never another tenant's runs.
 from __future__ import annotations
 
 import logging
-import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.scheduling import ThreadedScheduler
 from reflexio.server.services.extraction.resumable_agent import (
     pending_tool_calls_enabled,
 )
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_POLL_INTERVAL_SECONDS = 5.0
 
 
-class ExtractionResumeScheduler:
+class ExtractionResumeScheduler(ThreadedScheduler):
     """Small polling wrapper that drives :class:`ExtractionResumeWorker` per org."""
 
     def __init__(
@@ -37,29 +37,15 @@ class ExtractionResumeScheduler:
         bootstrap_org_id: str,
         max_runs_per_tick: int = 10,
     ) -> None:
+        super().__init__(thread_name="reflexio-extraction-resume-scheduler")
         self.request_context_factory = request_context_factory
         self.bootstrap_org_id = bootstrap_org_id
         self.max_runs_per_tick = max_runs_per_tick
-        self._stop_event = threading.Event()
-        self._thread: threading.Thread | None = None
 
-    def start(self) -> None:
-        if self._thread is not None and self._thread.is_alive():
-            return
-        self._stop_event.clear()
-        self._thread = threading.Thread(
-            target=self._run_loop,
-            name="reflexio-extraction-resume-scheduler",
-            daemon=True,
-        )
-        self._thread.start()
+    def _on_started(self) -> None:
         logger.info("event=extraction_resume_scheduler_started")
 
-    def stop(self, *, timeout_seconds: float = 5.0) -> None:
-        self._stop_event.set()
-        if self._thread is not None:
-            self._thread.join(timeout=timeout_seconds)
-        self._thread = None
+    def _on_stopped(self) -> None:
         logger.info("event=extraction_resume_scheduler_stopped")
 
     def _discover_org_ids(self, bootstrap_ctx: RequestContext) -> list[str]:
@@ -116,28 +102,27 @@ class ExtractionResumeScheduler:
                     org_id,
                 )
 
-    def _run_loop(self) -> None:
-        while not self._stop_event.is_set():
-            poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
-            try:
-                bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
-                config = bootstrap_ctx.configurator.get_config()
-                poll_interval = (
-                    config.pending_tool_call_config.resume_poll_interval_seconds
-                )
-                self._expire_pending_tool_calls(bootstrap_ctx)
-                for org_id in self._discover_org_ids(bootstrap_ctx):
-                    if self._stop_event.is_set():
-                        break
-                    self._drain_org(org_id)
-            except Exception as exc:
-                with sentry_tags(
-                    subsystem="extraction",
-                    op="scheduler_tick",
-                    error_type=type(exc).__name__,
-                ):
-                    logger.exception("event=extraction_resume_scheduler_tick_failed")
-            self._stop_event.wait(poll_interval)
+    def _run_once(self) -> float:
+        poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
+        try:
+            bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
+            config = bootstrap_ctx.configurator.get_config()
+            poll_interval = (
+                config.pending_tool_call_config.resume_poll_interval_seconds
+            )
+            self._expire_pending_tool_calls(bootstrap_ctx)
+            for org_id in self._discover_org_ids(bootstrap_ctx):
+                if self._stop_event.is_set():
+                    break
+                self._drain_org(org_id)
+        except Exception as exc:
+            with sentry_tags(
+                subsystem="extraction",
+                op="scheduler_tick",
+                error_type=type(exc).__name__,
+            ):
+                logger.exception("event=extraction_resume_scheduler_tick_failed")
+        return poll_interval
 
 
 def maybe_start_resume_scheduler(

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -22,11 +22,11 @@ GovernanceRetentionCapability (reflexio_ext), not here.
 from __future__ import annotations
 
 import logging
-import threading
 import time
 from collections.abc import Callable
 
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.scheduling import ThreadedScheduler
 from reflexio.server.tracing import capture_anomaly
 
 logger = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ def set_org_id_provider(provider: Callable[[], list[str]] | None) -> None:
     _org_id_provider_hook = provider
 
 
-class LineageGCScheduler:
+class LineageGCScheduler(ThreadedScheduler):
     """Polling daemon that hard-deletes expired tombstones per org."""
 
     def __init__(
@@ -81,6 +81,7 @@ class LineageGCScheduler:
         bootstrap_org_id: str,
         org_id_provider: Callable[[], list[str]] | None = None,
     ) -> None:
+        super().__init__(thread_name="reflexio-lineage-gc-scheduler")
         self.request_context_factory = request_context_factory
         self.bootstrap_org_id = bootstrap_org_id
         # Optional injectable org-id source. When set (managed/multi-tenant mode),
@@ -90,28 +91,11 @@ class LineageGCScheduler:
         # raises NotImplementedError on Supabase. When None (OSS default),
         # discovery falls back to storage.list_org_ids() exactly as before.
         self.org_id_provider = org_id_provider
-        self._stop_event = threading.Event()
-        self._thread: threading.Thread | None = None
 
-    def start(self) -> None:
-        """Start the daemon thread (idempotent if already running)."""
-        if self._thread is not None and self._thread.is_alive():
-            return
-        self._stop_event.clear()
-        self._thread = threading.Thread(
-            target=self._run_loop,
-            name="reflexio-lineage-gc-scheduler",
-            daemon=True,
-        )
-        self._thread.start()
+    def _on_started(self) -> None:
         logger.info("event=lineage_gc_scheduler_started")
 
-    def stop(self, *, timeout_seconds: float = 5.0) -> None:
-        """Signal the daemon to stop and wait for it to finish."""
-        self._stop_event.set()
-        if self._thread is not None:
-            self._thread.join(timeout=timeout_seconds)
-        self._thread = None
+    def _on_stopped(self) -> None:
         logger.info("event=lineage_gc_scheduler_stopped")
 
     def _discover_org_ids(self, bootstrap_ctx: RequestContext) -> list[str]:
@@ -264,18 +248,17 @@ class LineageGCScheduler:
                             method_name,
                         )
 
-    def _run_loop(self) -> None:
-        while not self._stop_event.is_set():
-            poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
-            try:
-                bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
-                cfg = bootstrap_ctx.configurator.get_config()
-                poll_interval = cfg.lineage_gc.poll_interval_seconds
-                org_ids = self._discover_org_ids(bootstrap_ctx)
-                self._gc_tick(org_ids)
-            except Exception:
-                logger.exception("event=lineage_gc_scheduler_tick_failed")
-            self._stop_event.wait(max(poll_interval, _MIN_POLL_SECONDS))
+    def _run_once(self) -> float:
+        poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
+        try:
+            bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
+            cfg = bootstrap_ctx.configurator.get_config()
+            poll_interval = cfg.lineage_gc.poll_interval_seconds
+            org_ids = self._discover_org_ids(bootstrap_ctx)
+            self._gc_tick(org_ids)
+        except Exception:
+            logger.exception("event=lineage_gc_scheduler_tick_failed")
+        return max(poll_interval, _MIN_POLL_SECONDS)
 
 
 def maybe_start_lineage_gc(

--- a/tests/server/test_scheduling.py
+++ b/tests/server/test_scheduling.py
@@ -131,3 +131,44 @@ def test_run_once_return_value_drives_wait_interval() -> None:
     sched._run_loop()
 
     assert waits == [42.0]
+
+
+def test_stop_timeout_keeps_thread_reference_and_blocks_double_start() -> None:
+    """A join timeout must not orphan the live thread nor allow a second start.
+
+    If ``stop()`` cleared ``_thread`` unconditionally, a slow ``_run_once`` still
+    running after the join timeout would leave ``is_running()`` false while the
+    old loop is alive, and the next ``start()`` would spawn a SECOND thread.
+    """
+    release = threading.Event()
+
+    class _SlowScheduler(ThreadedScheduler):
+        def __init__(self) -> None:
+            super().__init__(thread_name="test-slow-scheduler")
+            self.entered = threading.Event()
+
+        def _run_once(self) -> float:
+            self.entered.set()
+            release.wait(timeout=5.0)  # block past the stop() timeout
+            return 0.001
+
+    sched = _SlowScheduler()
+    try:
+        sched.start()
+        assert sched.entered.wait(timeout=2.0)
+        first_thread = sched._thread
+
+        # join times out because the tick is still blocked
+        sched.stop(timeout_seconds=0.05)
+        assert sched.is_running() is True  # reference kept; thread still alive
+        assert sched._thread is first_thread
+
+        # a second start must NOT spawn another thread
+        sched.start()
+        assert sched._thread is first_thread
+    finally:
+        release.set()
+        sched.stop(timeout_seconds=2.0)
+
+    assert sched.is_running() is False
+    assert sched._thread is None

--- a/tests/server/test_scheduling.py
+++ b/tests/server/test_scheduling.py
@@ -1,0 +1,133 @@
+"""Unit tests for the shared :class:`ThreadedScheduler` base.
+
+Exercise the thread mechanics in isolation (no real scheduler, no I/O): start /
+stop / join / idempotent-start / idempotent-stop, the ``_run_once`` interval
+seam, and the ``_should_start`` / ``_on_started`` / ``_on_stopped`` hooks.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from reflexio.server.scheduling import ThreadedScheduler
+
+
+class _CountingScheduler(ThreadedScheduler):
+    """Ticks as fast as it can, counting ticks; records lifecycle hook calls."""
+
+    def __init__(self, *, should_start: bool = True) -> None:
+        super().__init__(thread_name="test-counting-scheduler")
+        self._should_start_flag = should_start
+        self.ticks = 0
+        self.started_calls = 0
+        self.stopped_calls = 0
+        self._first_tick = threading.Event()
+
+    def _should_start(self) -> bool:
+        return self._should_start_flag
+
+    def _on_started(self) -> None:
+        self.started_calls += 1
+
+    def _on_stopped(self) -> None:
+        self.stopped_calls += 1
+
+    def _run_once(self) -> float:
+        self.ticks += 1
+        self._first_tick.set()
+        return 0.001
+
+
+def _wait_until(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+def test_start_spawns_running_thread_and_ticks() -> None:
+    sched = _CountingScheduler()
+    assert sched.is_running() is False
+
+    sched.start()
+    try:
+        assert sched._first_tick.wait(timeout=2.0), "loop never ticked"
+        assert sched.is_running() is True
+        assert sched.started_calls == 1
+        assert _wait_until(lambda: sched.ticks >= 2), "loop did not keep ticking"
+    finally:
+        sched.stop(timeout_seconds=2.0)
+
+    assert sched.is_running() is False
+    assert sched._thread is None
+    assert sched.stopped_calls == 1
+
+
+def test_stop_joins_and_halts_ticking() -> None:
+    sched = _CountingScheduler()
+    sched.start()
+    assert sched._first_tick.wait(timeout=2.0)
+
+    sched.stop(timeout_seconds=2.0)
+    assert sched.is_running() is False
+    ticks_after_stop = sched.ticks
+    time.sleep(0.05)
+    assert sched.ticks == ticks_after_stop, "loop kept ticking after stop"
+
+
+def test_start_is_idempotent_while_running() -> None:
+    sched = _CountingScheduler()
+    sched.start()
+    try:
+        assert sched._first_tick.wait(timeout=2.0)
+        first_thread = sched._thread
+        sched.start()  # second start must be a no-op
+        assert sched._thread is first_thread
+        assert sched.started_calls == 1
+    finally:
+        sched.stop(timeout_seconds=2.0)
+
+
+def test_stop_is_idempotent_when_not_running() -> None:
+    sched = _CountingScheduler()
+    # Stopping a never-started scheduler is safe and still fires the hook.
+    sched.stop(timeout_seconds=1.0)
+    assert sched.is_running() is False
+    assert sched._thread is None
+    assert sched.stopped_calls == 1
+
+
+def test_should_start_false_vetoes_startup() -> None:
+    sched = _CountingScheduler(should_start=False)
+    sched.start()
+    assert sched.is_running() is False
+    assert sched._thread is None
+    assert sched.started_calls == 0
+
+
+def test_run_once_return_value_drives_wait_interval() -> None:
+    """The value returned by ``_run_once`` is passed to ``stop_event.wait``."""
+    waits: list[float] = []
+
+    class _IntervalScheduler(ThreadedScheduler):
+        def __init__(self) -> None:
+            super().__init__(thread_name="test-interval-scheduler")
+
+        def _run_once(self) -> float:
+            return 42.0
+
+    sched = _IntervalScheduler()
+    original_wait = sched._stop_event.wait
+
+    def capturing_wait(timeout: float | None = None) -> bool:
+        waits.append(timeout)  # type: ignore[arg-type]
+        sched._stop_event.set()  # exit after one iteration
+        return original_wait(0)
+
+    sched._stop_event.wait = capturing_wait  # type: ignore[method-assign]
+    sched._run_loop()
+
+    assert waits == [42.0]


### PR DESCRIPTION
## Summary

Phases **B + C** of the create_app re-architecture (Tier 3), OSS side. Behavior-preserving; the settled Capability/lifespan seam is untouched.

- **B — `ThreadedScheduler` base** (`server/scheduling.py`, stdlib-only): DRYs the duplicated `threading.Thread`+`Event`+`join` mechanics the ~11 schedulers each hand-rolled. The 2 OSS schedulers (`ExtractionResumeScheduler`, `LineageGCScheduler`) subclass it with their poll interval/work/logging kept verbatim (via `_run_once`/`_on_started`/`_on_stopped` hooks). Public API (`start`/`stop`/`is_running`) identical. New daemon = subclass the base.
- **C — `DeploymentProfile`** (`server/deployment_profile.py`, 3 fields `role`/`router_groups`/`auth_required` + derived `mounts_data_plane`): a minimal declarative spec so new deployment modes become one profile entry. `create_app` gains an **additive** `profile: DeploymentProfile | None = None` (derives from the existing `mount_data_plane`/`require_auth` knobs when `None` — `mount_data_plane` kept, all call sites unchanged). The route+app golden is **byte-identical** — the profile is just a cleaner internal representation of the same booleans.

## Test plan
- `test_scheduling.py` (base start/stop/join/idempotent) + `test_app_route_inventory.py` golden (byte-identical) — green; ruff + pyright clean; whole-branch `/review-loop` APPROVE.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a declarative deployment profile option to control app routing behavior (data-plane vs control-plane) and whether authentication is required for API/OpenAPI and CORS behavior.
  * Improved background task handling by unifying scheduled maintenance under a shared threaded scheduler model.
* **Bug Fixes**
  * Preserved legacy behavior when the new profile option isn’t provided.
  * Improved scheduler start/stop reliability, shutdown safety, and predictability for maintenance tasks.
* **Tests**
  * Added unit coverage for scheduler lifecycle, idempotency, and timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->