### PR TITLE
fix(server): defer async publish learning safely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,13 @@ REFLEXIO_DEFAULT_ORG_ID=self-host-org
 # elided. (optional; default 512; set <= 0 to disable slicing and pass full
 # content)
 REFLEXIO_MAX_INTERACTION_CONTENT_TOKENS=512
+# Warn when queued post-persist async publish learning jobs reach this depth.
+# The queue is unbounded so acknowledged publishes do not drop learning due to
+# transient limiter pressure. (optional; default 1000)
+REFLEXIO_PUBLISH_LEARNING_QUEUE_WARN_SIZE=1000
+# Worker threads for post-persist async publish learning. (optional; default
+# matches the configured publish concurrency limit, currently 4)
+REFLEXIO_PUBLISH_LEARNING_WORKERS=
 # Inactivity delay in seconds before a quiet session is evaluated by agent-success
 # evaluation. (optional; default 600 = 10 minutes)
 GROUP_EVALUATION_DELAY_SECONDS=600

--- a/reflexio/lib/_interactions.py
+++ b/reflexio/lib/_interactions.py
@@ -56,6 +56,7 @@ class InteractionsMixin(ReflexioBase):
         *,
         use_publish_limiter: bool = True,
         publish_limiter_wait_forever: bool = True,
+        defer_learning: bool = False,
     ) -> PublishUserInteractionResponse:
         """Publish user interactions.
 
@@ -65,6 +66,8 @@ class InteractionsMixin(ReflexioBase):
                 post-write learning pipeline.
             publish_limiter_wait_forever: Whether GenerationService should queue
                 indefinitely for that post-write learning limiter.
+            defer_learning: Whether to enqueue post-persist learning instead of
+                running it inline.
 
         Returns:
             PublishUserInteractionResponse: Response containing success status and message
@@ -98,6 +101,7 @@ class InteractionsMixin(ReflexioBase):
                 request,
                 use_publish_limiter=use_publish_limiter,
                 publish_limiter_wait_forever=publish_limiter_wait_forever,
+                defer_learning=defer_learning,
             )
             after_profiles = _safe_count(storage.count_all_profiles)
             after_playbooks = _safe_count(storage.count_user_playbooks)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -401,6 +401,11 @@ def create_app(
                 scheduler.stop()
             if gc_scheduler is not None:
                 gc_scheduler.stop()
+            from reflexio.server.services.publish_learning_worker import (
+                stop_publish_learning_worker,
+            )
+
+            stop_publish_learning_worker(timeout=5.0)
 
     app = FastAPI(docs_url="/docs", lifespan=lifespan)
 

--- a/reflexio/server/api_endpoints/publisher_api.py
+++ b/reflexio/server/api_endpoints/publisher_api.py
@@ -65,6 +65,7 @@ def add_user_interaction(
     *,
     use_publish_limiter: bool = True,
     publish_limiter_wait_forever: bool = True,
+    defer_learning: bool = False,
 ) -> PublishUserInteractionResponse:
     """Add user interaction
 
@@ -75,6 +76,8 @@ def add_user_interaction(
             post-write learning pipeline.
         publish_limiter_wait_forever (bool): Whether GenerationService should queue
             indefinitely for that post-write learning limiter.
+        defer_learning (bool): Whether to enqueue post-persist learning instead
+            of running it inline.
 
     Returns:
         PublishUserInteractionResponse: Response containing success status and message
@@ -88,6 +91,7 @@ def add_user_interaction(
         request=request,
         use_publish_limiter=use_publish_limiter,
         publish_limiter_wait_forever=publish_limiter_wait_forever,
+        defer_learning=defer_learning,
     )
 
 

--- a/reflexio/server/operation_limiter.py
+++ b/reflexio/server/operation_limiter.py
@@ -62,6 +62,11 @@ def _limit_for(operation: OperationName) -> int:
     return _DEFAULT_LIMITS[operation]
 
 
+def operation_limit_value(operation: OperationName) -> int:
+    """Return the configured concurrency limit for an operation."""
+    return _limit_for(operation)
+
+
 def _timeout_for(operation: OperationName) -> float:
     raw = os.getenv(_env_key(operation, "TIMEOUT_SECONDS"), "").strip()
     if raw:
@@ -403,6 +408,7 @@ def operation_limit(
     *,
     timeout_seconds: float | None = None,
     wait_forever: bool = False,
+    log_timeout: bool = True,
 ) -> Any:
     """Acquire the per-org limiter for an operation, recording wait metrics."""
     state = _state_for(org_id, operation)
@@ -448,7 +454,7 @@ def operation_limit(
                 limit=state.limit,
                 active=active,
             )
-            if operation == "publish":
+            if operation == "publish" and log_timeout:
                 logger.warning(
                     "publish_limiter_timeout org_id=%s limit=%s active=%s "
                     "waiting=%s wait_ms=%s timeout_seconds=%s hardware=%s",
@@ -504,12 +510,14 @@ def run_with_operation_limit[T](
     fn: Callable[[], T],
     timeout_seconds: float | None = None,
     wait_forever: bool = False,
+    log_timeout: bool = True,
 ) -> T:
     with operation_limit(
         org_id,
         operation,
         timeout_seconds=timeout_seconds,
         wait_forever=wait_forever,
+        log_timeout=log_timeout,
     ):
         return fn()
 

--- a/reflexio/server/routes/interactions.py
+++ b/reflexio/server/routes/interactions.py
@@ -84,8 +84,7 @@ def publish_user_interaction(
             publisher_api.add_user_interaction(
                 org_id=org_id,
                 request=payload,
-                use_publish_limiter=True,
-                publish_limiter_wait_forever=False,
+                defer_learning=True,
             )
         except Exception:
             logger.exception("Background publish failed for org %s", org_id)

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -23,6 +23,7 @@ strings before deleting old import paths in the same PR.
 | File | Purpose |
 |------|---------|
 | `generation_service.py` | `GenerationService` — saves interactions, runs profile + playbook generation in parallel (ThreadPoolExecutor), schedules deferred evaluation when `session_id` is present. |
+| `publish_learning_worker.py` | Deferred post-persist publish learning worker — queues async publish learning after durable interaction writes and requeues under publish limiter pressure. |
 | `base_generation_service.py` | `BaseGenerationService` — abstract base; the **Service Pattern** (load configs → create actors → run in parallel → save results). Per-extractor timeout `EXTRACTOR_TIMEOUT_SECONDS = 300`. |
 | `operation_state_utils.py` | `OperationStateManager` — all `_operation_state` access (progress, concurrency locks, extractor/aggregator bookmarks, cluster fingerprints, cancellation). |
 | `extractor_config_utils.py`, `extractor_interaction_utils.py` | Filter extractors by source / `allow_manual_trigger` / names; per-extractor stride + window + bookmark handling. |

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -147,6 +147,7 @@ class GenerationService:
         *,
         use_publish_limiter: bool = True,
         publish_limiter_wait_forever: bool = True,
+        defer_learning: bool = False,
     ) -> GenerationServiceResult:
         """
         Process a user interaction request by storing interactions and triggering generation services.
@@ -168,6 +169,8 @@ class GenerationService:
                 limiter to avoid waiting after storage side effects.
             publish_limiter_wait_forever: Whether to queue indefinitely for the
                 post-write learning limiter when ``use_publish_limiter`` is true.
+            defer_learning: Whether to persist the publish and enqueue learning
+                for a process-local worker instead of running it inline.
 
         Returns:
             GenerationServiceResult: The request_id assigned to this publish call
@@ -305,6 +308,51 @@ class GenerationService:
                 )
                 return result
 
+            if defer_learning:
+                from reflexio.server.services.publish_learning_worker import (
+                    PublishLearningJob,
+                    enqueue_publish_learning,
+                )
+
+                self._schedule_group_evaluation_if_needed(
+                    new_request=new_request,
+                    user_id=user_id,
+                    agent_version=agent_version,
+                    source=source,
+                )
+                learning_queued = enqueue_publish_learning(
+                    PublishLearningJob(
+                        org_id=self.org_id,
+                        user_id=user_id,
+                        request_id=request_id,
+                        session_id=new_request.session_id,
+                        source=source,
+                        agent_version=agent_version,
+                        force_extraction=publish_user_interaction_request.force_extraction,
+                        skip_aggregation=publish_user_interaction_request.skip_aggregation,
+                    )
+                )
+                record_usage_event(
+                    org_id=self.org_id,
+                    user_id=user_id,
+                    request_id=request_id,
+                    session_id=new_request.session_id,
+                    source=source,
+                    agent_version=agent_version,
+                    backend="classic",
+                    event_name="publish_request_succeeded",
+                    event_category="publish",
+                    outcome="success",
+                    count_value=len(new_interactions),
+                    duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                    metadata={
+                        "defer_learning": True,
+                        "learning_queued": learning_queued,
+                        "warning_count": len(result.warnings),
+                    },
+                )
+                return result
+
             # The durable write above must not sit behind the publish limiter:
             # async API callers have already received success=True. Throttle only
             # the post-write learning pipeline so a hung LLM cannot silently drop
@@ -319,114 +367,15 @@ class GenerationService:
                 else nullcontext()
             )
             with learning_limit:
-                # Reflection runs as its own sliding-window step BEFORE the
-                # extractor pool spins up, so any replacements it makes are
-                # visible to the extractors when they retrieve existing
-                # profile/playbook context. Wrapped in a broad except so a
-                # reflection bug never breaks the publish.
-                self._maybe_run_reflection(
+                self._run_learning_steps(
                     user_id=user_id,
                     request_id=request_id,
                     agent_version=agent_version,
-                    source=source,
-                )
-
-                # Create generation services and requests
-                # Each service writes to separate storage tables and has no dependencies on others
-                profile_generation_service = ProfileGenerationService(
-                    llm_client=self.client, request_context=self.request_context
-                )
-                profile_generation_request = ProfileGenerationRequest(
-                    user_id=user_id,
-                    request_id=request_id,
-                    source=source,
                     force_extraction=publish_user_interaction_request.force_extraction,
-                )
-
-                playbook_generation_service = PlaybookGenerationService(
-                    llm_client=self.client,
-                    request_context=self.request_context,
                     skip_aggregation=publish_user_interaction_request.skip_aggregation,
-                )
-                playbook_generation_request = PlaybookGenerationRequest(
-                    request_id=request_id,
-                    agent_version=agent_version,
-                    user_id=user_id,
                     source=source,
-                    force_extraction=publish_user_interaction_request.force_extraction,
+                    result=result,
                 )
-
-                # Run profile and playbook generation services in parallel
-                # Each service creates its own internal ThreadPoolExecutor for extractors
-                # This is safe because we create separate, independent pool instances
-                # Uses manual executor management to avoid blocking on shutdown(wait=True)
-                # when threads are hung on LLM calls
-                executor = ThreadPoolExecutor(max_workers=2)
-                try:
-                    # Each thread needs its own context copy — Context.run() is non-reentrant
-                    futures = [
-                        executor.submit(
-                            contextvars.copy_context().run,
-                            profile_generation_service.run,
-                            profile_generation_request,
-                        ),
-                        executor.submit(
-                            contextvars.copy_context().run,
-                            playbook_generation_service.run,
-                            playbook_generation_request,
-                        ),
-                    ]
-
-                    # Collect results and handle any exceptions
-                    # Each service failure is logged but doesn't block others
-                    service_names = ["profile_generation", "playbook_generation"]
-                    for future, service_name in zip(
-                        futures, service_names, strict=True
-                    ):
-                        try:
-                            future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
-                        except FuturesTimeoutError:  # noqa: PERF203
-                            msg = f"{service_name} timed out after {GENERATION_SERVICE_TIMEOUT_SECONDS}s"
-                            with sentry_tags(
-                                subsystem="generation",
-                                service=service_name,
-                                request_id=request_id,
-                                error_type="timeout",
-                            ):
-                                logger.error("%s for request %s", msg, request_id)
-                            result.warnings.append(msg)
-                        except Exception as e:
-                            msg = f"{service_name} failed: {e}"
-                            with sentry_tags(
-                                subsystem="generation",
-                                service=service_name,
-                                request_id=request_id,
-                                error_type=type(e).__name__,
-                            ):
-                                logger.exception(
-                                    "Generation service failed for request %s",
-                                    request_id,
-                                )
-                            result.warnings.append(msg)
-                finally:
-                    executor.shutdown(wait=False, cancel_futures=True)
-
-                # Tagging runs an LLM call per newly generated entity, so defer it off
-                # the publish path. The scheduler debounces bursts and is idempotent
-                # (already-tagged entities are skipped).
-                try:
-                    schedule_tagging(
-                        org_id=self.org_id,
-                        user_id=user_id,
-                        agent_version=agent_version,
-                        request_context=self.request_context,
-                        llm_client=self.client,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to schedule tagging for publish request %s",
-                        request_id,
-                    )
 
                 # Schedule delayed group evaluation for the required session.
                 self._schedule_group_evaluation_if_needed(
@@ -482,8 +431,140 @@ class GenerationService:
             raise
 
     # ===============================
+    # deferred learning
+    # ===============================
+
+    def run_deferred_learning(
+        self,
+        *,
+        user_id: str,
+        request_id: str,
+        session_id: str | None,  # noqa: ARG002 - kept for worker telemetry symmetry
+        source: str | None,
+        agent_version: str,
+        force_extraction: bool,
+        skip_aggregation: bool,
+    ) -> GenerationServiceResult:
+        result = GenerationServiceResult(request_id=request_id)
+        self._run_learning_steps(
+            user_id=user_id,
+            request_id=request_id,
+            agent_version=agent_version,
+            force_extraction=force_extraction,
+            skip_aggregation=skip_aggregation,
+            source=source,
+            result=result,
+        )
+        return result
+
+    # ===============================
     # private methods
     # ===============================
+
+    def _run_learning_steps(
+        self,
+        *,
+        user_id: str,
+        request_id: str,
+        agent_version: str,
+        force_extraction: bool,
+        skip_aggregation: bool,
+        source: str | None,
+        result: GenerationServiceResult,
+    ) -> None:
+        # Reflection runs as its own sliding-window step BEFORE the extractor
+        # pool spins up, so replacements are visible to extractors.
+        self._maybe_run_reflection(
+            user_id=user_id,
+            request_id=request_id,
+            agent_version=agent_version,
+            source=source,
+        )
+
+        profile_generation_service = ProfileGenerationService(
+            llm_client=self.client, request_context=self.request_context
+        )
+        profile_generation_request = ProfileGenerationRequest(
+            user_id=user_id,
+            request_id=request_id,
+            source=source,
+            force_extraction=force_extraction,
+        )
+
+        playbook_generation_service = PlaybookGenerationService(
+            llm_client=self.client,
+            request_context=self.request_context,
+            skip_aggregation=skip_aggregation,
+        )
+        playbook_generation_request = PlaybookGenerationRequest(
+            request_id=request_id,
+            agent_version=agent_version,
+            user_id=user_id,
+            source=source,
+            force_extraction=force_extraction,
+        )
+
+        executor = ThreadPoolExecutor(max_workers=2)
+        try:
+            futures = [
+                executor.submit(
+                    contextvars.copy_context().run,
+                    profile_generation_service.run,
+                    profile_generation_request,
+                ),
+                executor.submit(
+                    contextvars.copy_context().run,
+                    playbook_generation_service.run,
+                    playbook_generation_request,
+                ),
+            ]
+
+            service_names = ["profile_generation", "playbook_generation"]
+            for future, service_name in zip(futures, service_names, strict=True):
+                try:
+                    future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
+                except FuturesTimeoutError:  # noqa: PERF203
+                    msg = (
+                        f"{service_name} timed out after "
+                        f"{GENERATION_SERVICE_TIMEOUT_SECONDS}s"
+                    )
+                    with sentry_tags(
+                        subsystem="generation",
+                        service=service_name,
+                        request_id=request_id,
+                        error_type="timeout",
+                    ):
+                        logger.error("%s for request %s", msg, request_id)
+                    result.warnings.append(msg)
+                except Exception as e:
+                    msg = f"{service_name} failed: {e}"
+                    with sentry_tags(
+                        subsystem="generation",
+                        service=service_name,
+                        request_id=request_id,
+                        error_type=type(e).__name__,
+                    ):
+                        logger.exception(
+                            "Generation service failed for request %s",
+                            request_id,
+                        )
+                    result.warnings.append(msg)
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+
+        try:
+            schedule_tagging(
+                org_id=self.org_id,
+                user_id=user_id,
+                agent_version=agent_version,
+                request_context=self.request_context,
+                llm_client=self.client,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to schedule tagging for publish request %s",
+                request_id,
+            )
 
     def _schedule_group_evaluation_if_needed(
         self,

--- a/reflexio/server/services/publish_learning_worker.py
+++ b/reflexio/server/services/publish_learning_worker.py
@@ -1,0 +1,288 @@
+"""Process-local queue for learning work after async publish persistence."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+import time
+from dataclasses import dataclass, field
+
+from reflexio.server.cache.reflexio_cache import get_reflexio
+from reflexio.server.env_utils import env_str
+from reflexio.server.operation_limiter import operation_limit, operation_limit_value
+from reflexio.server.services.generation_service import GenerationService
+from reflexio.server.usage_metrics import record_usage_event
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_QUEUE_WARN_SIZE = 1000
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = env_str(name, str(default))
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        logger.warning("Invalid %s=%r; using %s", name, raw, default)
+        return max(minimum, default)
+
+
+@dataclass(frozen=True)
+class PublishLearningJob:
+    """Metadata needed to run post-persist publish learning."""
+
+    org_id: str
+    user_id: str
+    request_id: str
+    session_id: str | None
+    source: str | None
+    agent_version: str
+    force_extraction: bool
+    skip_aggregation: bool
+    enqueued_at: float = field(default_factory=time.monotonic)
+
+
+class PublishLearningWorker:
+    """Process-local worker pool for deferred publish learning."""
+
+    def __init__(
+        self,
+        *,
+        queue_warn_size: int | None = None,
+        worker_count: int | None = None,
+    ) -> None:
+        default_workers = operation_limit_value("publish")
+        self.queue_warn_size = (
+            queue_warn_size
+            if queue_warn_size is not None
+            else _env_int(
+                "REFLEXIO_PUBLISH_LEARNING_QUEUE_WARN_SIZE",
+                _DEFAULT_QUEUE_WARN_SIZE,
+            )
+        )
+        self.worker_count = (
+            worker_count
+            if worker_count is not None
+            else _env_int("REFLEXIO_PUBLISH_LEARNING_WORKERS", default_workers)
+        )
+        self._queue: queue.Queue[PublishLearningJob] = queue.Queue()
+        self._stop_event = threading.Event()
+        self._threads: list[threading.Thread] = []
+        self._started = False
+        self._start_lock = threading.Lock()
+
+    def start(self) -> None:
+        with self._start_lock:
+            if self._started:
+                return
+            self._stop_event.clear()
+            self._threads = [
+                threading.Thread(
+                    target=self._worker_loop,
+                    name=f"publish-learning-worker-{idx}",
+                    daemon=True,
+                )
+                for idx in range(self.worker_count)
+            ]
+            for thread in self._threads:
+                thread.start()
+            self._started = True
+            logger.info(
+                "event=publish_learning_worker_started workers=%d queue_warn_size=%d",
+                self.worker_count,
+                self.queue_warn_size,
+            )
+
+    def enqueue(self, job: PublishLearningJob) -> bool:
+        self.start()
+        self._queue.put_nowait(job)
+        queue_depth = self._queue.qsize()
+        if queue_depth >= self.queue_warn_size:
+            record_usage_event(
+                org_id=job.org_id,
+                user_id=job.user_id,
+                request_id=job.request_id,
+                session_id=job.session_id,
+                source=job.source,
+                agent_version=job.agent_version,
+                event_name="learning_queue_pressure",
+                event_category="publish_learning",
+                outcome="queued",
+                metadata={
+                    "queue_depth": queue_depth,
+                    "queue_warn_size": self.queue_warn_size,
+                },
+            )
+            logger.warning(
+                "event=publish_learning_queue_pressure org_id=%s user_id=%s "
+                "request_id=%s queue_depth=%d queue_warn_size=%d",
+                job.org_id,
+                job.user_id,
+                job.request_id,
+                queue_depth,
+                self.queue_warn_size,
+            )
+        logger.info(
+            "event=publish_learning_enqueued org_id=%s user_id=%s request_id=%s "
+            "queue_depth=%d queue_warn_size=%d",
+            job.org_id,
+            job.user_id,
+            job.request_id,
+            queue_depth,
+            self.queue_warn_size,
+        )
+        return True
+
+    def stop(self, timeout: float | None = 5.0) -> None:
+        self._stop_event.set()
+        deadline = None if timeout is None else time.monotonic() + timeout
+        for thread in list(self._threads):
+            remaining = (
+                None if deadline is None else max(0.0, deadline - time.monotonic())
+            )
+            thread.join(timeout=remaining)
+        if all(not thread.is_alive() for thread in self._threads):
+            self._threads = []
+            self._started = False
+        logger.info("event=publish_learning_worker_stopped")
+
+    def _worker_loop(self) -> None:
+        while not self._stop_event.is_set() or not self._queue.empty():
+            try:
+                job = self._queue.get(timeout=0.25)
+            except queue.Empty:
+                continue
+            try:
+                self._process_job(job)
+            finally:
+                self._queue.task_done()
+
+    def _process_job(self, job: PublishLearningJob) -> None:
+        try:
+            with operation_limit(
+                job.org_id,
+                "publish",
+                wait_forever=False,
+                log_timeout=False,
+            ):
+                reflexio = get_reflexio(org_id=job.org_id)
+                GenerationService(
+                    llm_client=reflexio.llm_client,
+                    request_context=reflexio.request_context,
+                ).run_deferred_learning(
+                    user_id=job.user_id,
+                    request_id=job.request_id,
+                    session_id=job.session_id,
+                    source=job.source,
+                    agent_version=job.agent_version,
+                    force_extraction=job.force_extraction,
+                    skip_aggregation=job.skip_aggregation,
+                )
+        except TimeoutError:
+            self._requeue_after_limiter_timeout(job)
+            return
+        except Exception as exc:
+            record_usage_event(
+                org_id=job.org_id,
+                user_id=job.user_id,
+                request_id=job.request_id,
+                session_id=job.session_id,
+                source=job.source,
+                agent_version=job.agent_version,
+                event_name="learning_failed",
+                event_category="publish_learning",
+                outcome="failed",
+                error_kind=type(exc).__name__,
+            )
+            logger.exception(
+                "event=publish_learning_failed org_id=%s user_id=%s request_id=%s",
+                job.org_id,
+                job.user_id,
+                job.request_id,
+            )
+            return
+
+        record_usage_event(
+            org_id=job.org_id,
+            user_id=job.user_id,
+            request_id=job.request_id,
+            session_id=job.session_id,
+            source=job.source,
+            agent_version=job.agent_version,
+            event_name="learning_succeeded",
+            event_category="publish_learning",
+            outcome="success",
+        )
+        logger.info(
+            "event=publish_learning_done org_id=%s user_id=%s request_id=%s "
+            "queue_depth=%d",
+            job.org_id,
+            job.user_id,
+            job.request_id,
+            self._queue.qsize(),
+        )
+
+    def _requeue_after_limiter_timeout(self, job: PublishLearningJob) -> None:
+        self._queue.put_nowait(job)
+
+        record_usage_event(
+            org_id=job.org_id,
+            user_id=job.user_id,
+            request_id=job.request_id,
+            session_id=job.session_id,
+            source=job.source,
+            agent_version=job.agent_version,
+            event_name="learning_requeued_limiter_busy",
+            event_category="publish_learning",
+            outcome="requeued",
+            metadata={
+                "age_seconds": self._job_age_seconds(job),
+                "queue_depth": self._queue.qsize(),
+            },
+        )
+        logger.info(
+            "event=publish_learning_requeued_limiter_busy org_id=%s user_id=%s "
+            "request_id=%s queue_depth=%d age_seconds=%.3f",
+            job.org_id,
+            job.user_id,
+            job.request_id,
+            self._queue.qsize(),
+            self._job_age_seconds(job),
+        )
+
+    @staticmethod
+    def _job_age_seconds(job: PublishLearningJob) -> float:
+        return time.monotonic() - job.enqueued_at
+
+
+_worker: PublishLearningWorker | None = None
+_worker_lock = threading.Lock()
+
+
+def get_publish_learning_worker() -> PublishLearningWorker:
+    global _worker  # noqa: PLW0603
+    if _worker is None:
+        with _worker_lock:
+            if _worker is None:
+                _worker = PublishLearningWorker()
+    return _worker
+
+
+def enqueue_publish_learning(job: PublishLearningJob) -> bool:
+    return get_publish_learning_worker().enqueue(job)
+
+
+def stop_publish_learning_worker(timeout: float | None = 5.0) -> None:
+    global _worker  # noqa: PLW0603
+    worker = _worker
+    if worker is not None:
+        worker.stop(timeout=timeout)
+
+
+def reset_publish_learning_worker_for_tests() -> None:
+    global _worker  # noqa: PLW0603
+    worker = _worker
+    if worker is not None:
+        worker.stop(timeout=0.1)
+    _worker = None

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -128,11 +128,7 @@ class TestPublishInteraction:
 
         assert response.status_code == 200
         add_user_interaction.assert_called_once()
-        assert add_user_interaction.call_args.kwargs["use_publish_limiter"] is True
-        assert (
-            add_user_interaction.call_args.kwargs["publish_limiter_wait_forever"]
-            is False
-        )
+        assert add_user_interaction.call_args.kwargs["defer_learning"] is True
 
     def test_publish_missing_body_returns_422(self, client):
         response = client.post("/api/publish_interaction")
@@ -318,7 +314,9 @@ class TestUpdateConfigRoute:
         existing = self._existing_config()
         self._wire_mock(mock_reflexio, existing)
 
-        with patch("reflexio.server.cache.reflexio_cache.invalidate_reflexio_cache") as mock_invalidate:
+        with patch(
+            "reflexio.server.cache.reflexio_cache.invalidate_reflexio_cache"
+        ) as mock_invalidate:
             response = client.post(
                 "/api/update_config",
                 json={"window_size": 25},
@@ -383,7 +381,9 @@ class TestUpdateConfigRoute:
             success=False, msg="storage validation failed"
         )
 
-        with patch("reflexio.server.cache.reflexio_cache.invalidate_reflexio_cache") as mock_invalidate:
+        with patch(
+            "reflexio.server.cache.reflexio_cache.invalidate_reflexio_cache"
+        ) as mock_invalidate:
             response = client.post(
                 "/api/update_config",
                 json={"window_size": 25},

--- a/tests/server/api_endpoints/test_publisher_api.py
+++ b/tests/server/api_endpoints/test_publisher_api.py
@@ -62,6 +62,7 @@ class TestAddUserInteraction:
             request=request,
             use_publish_limiter=True,
             publish_limiter_wait_forever=True,
+            defer_learning=False,
         )
         assert result is expected
 

--- a/tests/server/services/test_generation_service.py
+++ b/tests/server/services/test_generation_service.py
@@ -1,7 +1,7 @@
 import datetime
 import tempfile
 from datetime import UTC
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -140,6 +140,105 @@ def test_publish_request_tagging_schedule_failure_is_best_effort(mock_llm_respon
         assert result.request_id == request_id
         assert generation_service.storage is not None
         assert generation_service.storage.get_request(request_id) is not None
+
+
+def test_defer_learning_persists_and_enqueues_without_inline_extractors(
+    mock_llm_responses,
+):
+    user_id = "test_user_id"
+    org_id = "test_org"
+    session_id = "test_session_id"
+    request_id = "deferred-request-id"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        generation_service = GenerationService(
+            llm_client=LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini")),
+            request_context=RequestContext(org_id=org_id, storage_base_dir=temp_dir),
+        )
+        request = PublishUserInteractionRequest(
+            request_id=request_id,
+            user_id=user_id,
+            interaction_data_list=[
+                InteractionData(
+                    content="test interaction",
+                    created_at=int(datetime.datetime.now(UTC).timestamp()),
+                )
+            ],
+            session_id=session_id,
+        )
+        usage_events = []
+
+        with (
+            patch.object(
+                generation_service, "_schedule_group_evaluation_if_needed"
+            ) as schedule_eval,
+            patch(
+                "reflexio.server.services.publish_learning_worker.enqueue_publish_learning",
+                return_value=True,
+            ) as enqueue_learning,
+            patch(
+                "reflexio.server.services.generation_service.ProfileGenerationService",
+                side_effect=AssertionError("profile extraction should be deferred"),
+            ),
+            patch(
+                "reflexio.server.services.generation_service.PlaybookGenerationService",
+                side_effect=AssertionError("playbook extraction should be deferred"),
+            ),
+            patch(
+                "reflexio.server.services.generation_service.record_usage_event",
+                side_effect=lambda **kwargs: usage_events.append(kwargs),
+            ),
+        ):
+            result = generation_service.run(request, defer_learning=True)
+
+        assert result.request_id == request_id
+        assert generation_service.storage is not None
+        assert generation_service.storage.get_request(request_id) is not None
+        assert enqueue_learning.call_count == 1
+        assert schedule_eval.call_count == 1
+        success_event = next(
+            event
+            for event in usage_events
+            if event["event_name"] == "publish_request_succeeded"
+        )
+        assert success_event["metadata"]["defer_learning"] is True
+        assert success_event["metadata"]["learning_queued"] is True
+
+
+def test_defer_learning_stall_skips_learning_enqueue(mock_llm_responses):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        generation_service = GenerationService(
+            llm_client=LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini")),
+            request_context=RequestContext(
+                org_id="test_org", storage_base_dir=temp_dir
+            ),
+        )
+        request = PublishUserInteractionRequest(
+            user_id="user-1",
+            interaction_data_list=[
+                InteractionData(
+                    content="test interaction",
+                    created_at=int(datetime.datetime.now(UTC).timestamp()),
+                )
+            ],
+            session_id="session-1",
+        )
+
+        with (
+            patch.object(
+                generation_service,
+                "_active_learning_stall_warning",
+                return_value="learning paused",
+            ),
+            patch(
+                "reflexio.server.services.publish_learning_worker.enqueue_publish_learning",
+                MagicMock(side_effect=AssertionError("should not enqueue")),
+            ),
+        ):
+            result = generation_service.run(request, defer_learning=True)
+
+    assert result.request_id is not None
+    assert result.warnings == ["learning paused"]
 
 
 def test_publish_request_rejects_empty_caller_request_id():

--- a/tests/server/services/test_publish_learning_worker.py
+++ b/tests/server/services/test_publish_learning_worker.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.server.operation_limiter import (
+    operation_limit,
+    reset_operation_limiters_for_tests,
+)
+from reflexio.server.services.publish_learning_worker import (
+    PublishLearningJob,
+    PublishLearningWorker,
+    reset_publish_learning_worker_for_tests,
+)
+from reflexio.server.tracing import configure_tracer
+from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
+
+
+@pytest.fixture(autouse=True)
+def _reset_worker_limiters_and_metrics():
+    reset_publish_learning_worker_for_tests()
+    reset_operation_limiters_for_tests()
+    configure_tracer(None)
+    configure_usage_event_recorder(None)
+    yield
+    reset_publish_learning_worker_for_tests()
+    reset_operation_limiters_for_tests()
+    configure_tracer(None)
+    configure_usage_event_recorder(None)
+
+
+def _job(
+    *,
+    org_id: str = "org_1",
+    request_id: str = "req_1",
+    enqueued_at: float | None = None,
+) -> PublishLearningJob:
+    return PublishLearningJob(
+        org_id=org_id,
+        user_id="user_1",
+        request_id=request_id,
+        session_id="sess_1",
+        source="test",
+        agent_version="v1",
+        force_extraction=False,
+        skip_aggregation=False,
+        **({} if enqueued_at is None else {"enqueued_at": enqueued_at}),
+    )
+
+
+def test_enqueue_over_warning_threshold_keeps_job_and_records_pressure():
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = PublishLearningWorker(queue_warn_size=1, worker_count=0)
+
+    assert worker.enqueue(_job(request_id="req_1")) is True
+    assert worker.enqueue(_job(request_id="req_2")) is True
+
+    assert worker._queue.qsize() == 2
+    assert any(event.event_name == "learning_queue_pressure" for event in events)
+
+
+def test_limiter_timeout_requeues_without_publish_timeout_warning(monkeypatch, caplog):
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "1")
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_TIMEOUT_SECONDS", "0.01")
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = PublishLearningWorker(queue_warn_size=10, worker_count=0)
+    job = _job()
+
+    with (
+        operation_limit("org_1", "publish", timeout_seconds=0.1),
+        caplog.at_level(logging.WARNING, logger="reflexio.server.operation_limiter"),
+    ):
+        worker._process_job(job)
+
+    assert "publish_limiter_timeout" not in caplog.text
+    assert worker._queue.get_nowait() == job
+    assert any(event.event_name == "limiter_acquire_timeout" for event in events)
+    assert any(event.event_name == "learning_requeued_limiter_busy" for event in events)
+
+
+def test_requeued_learning_runs_after_limiter_capacity_opens(monkeypatch):
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "1")
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_TIMEOUT_SECONDS", "0.01")
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = PublishLearningWorker(queue_warn_size=10, worker_count=0)
+    job = _job()
+
+    with operation_limit("org_1", "publish", timeout_seconds=0.1):
+        worker._process_job(job)
+
+    assert worker._queue.get_nowait() == job
+
+    mock_reflexio = MagicMock()
+    mock_reflexio.llm_client = MagicMock()
+    mock_reflexio.request_context = MagicMock()
+    with (
+        patch(
+            "reflexio.server.services.publish_learning_worker.get_reflexio",
+            return_value=mock_reflexio,
+        ),
+        patch(
+            "reflexio.server.services.publish_learning_worker.GenerationService"
+        ) as generation_service_cls,
+    ):
+        worker._process_job(job)
+
+    generation_service_cls.return_value.run_deferred_learning.assert_called_once()
+    assert any(event.event_name == "learning_requeued_limiter_busy" for event in events)
+    assert any(event.event_name == "learning_succeeded" for event in events)

--- a/tests/server/test_operation_limiter.py
+++ b/tests/server/test_operation_limiter.py
@@ -140,6 +140,43 @@ def test_operation_limiter_wait_forever_queues_until_slot_available(monkeypatch)
     )
 
 
+def test_operation_limiter_can_suppress_publish_timeout_log(monkeypatch, caplog):
+    monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "1")
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    ready = threading.Event()
+    release = threading.Event()
+
+    def _hold_limit() -> None:
+        with operation_limit("org_1", "publish", timeout_seconds=0.1):
+            ready.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=_hold_limit)
+    holder.start()
+    try:
+        assert ready.wait(timeout=5)
+        with (
+            caplog.at_level(
+                logging.WARNING, logger="reflexio.server.operation_limiter"
+            ),
+            pytest.raises(TimeoutError),
+            operation_limit(
+                "org_1",
+                "publish",
+                timeout_seconds=0.01,
+                log_timeout=False,
+            ),
+        ):
+            pass
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert "publish_limiter_timeout" not in caplog.text
+    assert any(event.event_name == "limiter_acquire_timeout" for event in events)
+
+
 def test_publish_hardware_capacity_snapshot_reports_hardware_guidance(monkeypatch):
     monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_LIMIT", "7")
     monkeypatch.setenv("REFLEXIO_PUBLISH_CONCURRENCY_TIMEOUT_SECONDS", "2.5")


### PR DESCRIPTION
## Summary
- Decouple async publish responses from post-persist learning work so clients are not held behind profile/playbook extraction.
- Add a dedicated deferred publish learning worker that retries when the publish limiter is saturated instead of dropping jobs.
- Preserve foreground publish behavior while routing BackgroundTasks through the deferred learning path.

## Changes
- Added `publish_learning_worker.py` with process-local worker threads, limiter-busy requeueing, shutdown handling, and usage/log events.
- Split `GenerationService` so durable interaction persistence can enqueue learning separately from inline learning execution.
- Added `defer_learning` plumbing through publish helpers and async route handling.
- Added limiter log suppression for worker retry timeouts while preserving usage events.
- Documented the new worker and env tuning knobs in `.env.example`.

## Test Plan
- `uv run pytest -q -o addopts='' reflexio_ext/tests/test_env_file_validation.py::test_every_env_read_is_documented_in_template open_source/reflexio/tests/server/api_endpoints/test_api_routes.py::TestPublishInteraction open_source/reflexio/tests/server/api_endpoints/test_publisher_api.py open_source/reflexio/tests/server/test_operation_limiter.py open_source/reflexio/tests/server/services/test_publish_learning_worker.py open_source/reflexio/tests/server/services/test_generation_service.py open_source/reflexio/tests/server/services/reflection/test_generation_service_wiring.py`
- `uv run ruff check <touched python files>`
- `uv run pyright <touched python files>`
- Manual local stress verification with `REFLEXIO_PUBLISH_CONCURRENCY_LIMIT=1`, `REFLEXIO_PUBLISH_CONCURRENCY_TIMEOUT_SECONDS=0.05`, and 16 concurrent publishes:
  - 16/16 publish calls returned 200
  - 16/16 users had all 8 interactions persisted
  - 16/16 users had learned profiles
  - 16/16 users had learned playbooks
  - log counters for run `727b8343`: `16 publish_learning_done`, `147 publish_learning_requeued_limiter_busy`, `0` drops/failures/publish limiter timeout errors
