### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -101,9 +101,10 @@ Description: FastAPI backend server that processes user interactions to generate
 **Detailed Documentation**: See [`reflexio/server/README.md`](server/README.md) for component details, including the [Prompt Bank](server/prompt/prompt_bank/README.md), [Playbook Service](server/services/playbook/README.md), and [Site Variables](server/site_var/README.md)
 
 ### Main Entry Points
-- **API**: `api.py` - FastAPI routes
+- **API composer**: `api.py` - `create_app()` factory, middleware/capability wiring, and `core_router` aggregation
+- **Domain routes**: `server/routes/` - FastAPI route modules grouped by system, interactions, profiles, playbooks, search, provenance, evaluation, Braintrust, and config
 - **Extension Registry**: `extensions.py` - optional capability/service registration for OSS and enterprise integrations
-- **Endpoint Helpers**: `api_endpoints/` - Request handlers calling `Reflexio` (reflexio_lib)
+- **Endpoint Helpers**: `api_endpoints/` - Shared handler/helper functions and `RequestContext` used by route modules
 - **Core Service**: `services/generation_service.py` - Main orchestrator
 
 ### Purpose
@@ -115,8 +116,9 @@ Receives user interactions from clients and processes them to:
 ### Component Relationships
 ```
 client (Python SDK)
-  -> api.py (FastAPI routes)
-    -> api_endpoints/ (request handlers)
+  -> api.py (create_app + core_router)
+    -> routes/ (domain FastAPI routers)
+    -> api_endpoints/ (shared handlers + RequestContext)
       -> reflexio_lib.Reflexio (main entry)
         -> services/generation_service.py (orchestrator)
           ├─> services/profile/ -> storage (BaseStorage)
@@ -126,12 +128,13 @@ client (Python SDK)
 
 ### Key Components
 - **`api_endpoints/`**: Request handling, `RequestContext` (bundles storage/config/prompts), auth
+- **`routes/`**: Domain route modules (`system.py`, `interactions.py`, `profiles.py`, `playbooks.py`, `search.py`, `provenance.py`, `evaluation.py`, `braintrust.py`, `config.py`) included into `api.py`'s `core_router`
 - **`db/`**: Auth & config storage only (SQLite) - NOT for profiles/interactions
 - **`llm/`**: Unified LLM client (auto-detects OpenAI/Claude from model name)
 - **`prompt/`**: Versioned prompt templates in `prompt_bank/`
 - **`services/`**: Core business logic
   - `generation_service.py` - Orchestrator (runs profile/playbook/success services)
-  - `base_generation_service.py` - Abstract base for parallel actor execution
+  - `base_generation_service.py` + `base_generation/` - Abstract base plus mixins for parallel actor execution, batch progress, should-run prechecks, status transitions, and usage billing
   - `profile/` - Profile extraction & updates
   - `playbook/` - Playbook extraction, consolidation, and aggregation
   - `agent_success_evaluation/` - Success evaluation

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -33,8 +33,9 @@ Description: FastAPI backend server that processes user interactions to generate
 
 ## Main Entry Points
 
-- **API**: `api.py` - FastAPI routes (only place to expose endpoints)
-- **Endpoint Helpers**: `api_endpoints/` - Bridge between routes and business logic
+- **API composer**: `api.py` - `create_app()` factory, middleware/capability wiring, OpenAPI auth decoration, and `core_router` aggregation
+- **Domain routes**: `routes/` - FastAPI route modules; add new public API surfaces here and include their routers in `api.py`
+- **Endpoint Helpers**: `api_endpoints/` - Shared handlers/helpers plus `RequestContext` used by route modules
 - **Extension Registry**: `extensions.py` - Capability and service registry for optional OSS/enterprise integrations
 - **Core Service**: `services/generation_service.py` - Main orchestrator
 
@@ -57,7 +58,19 @@ Description: FastAPI backend server that processes user interactions to generate
 
 **Directory**: `api_endpoints/`
 
-**Detailed Documentation**: See [`api_endpoints/README.md`](api_endpoints/README.md) for the `RequestContext` contract and per-file handler map.
+**Route modules** live in `routes/` and are grouped by domain. `api.py` remains the composition root: it creates `core_router`, includes each domain router, and mounts the aggregate router into the FastAPI app. **Detailed handler documentation**: See [`api_endpoints/README.md`](api_endpoints/README.md) for the `RequestContext` contract and helper map.
+
+| Route file | Purpose |
+|------|---------|
+| `routes/system.py` | Root/health/version and operation status/cancel surfaces. |
+| `routes/interactions.py` | Publish, request/session/interaction retrieval, direct interaction writes, and clear-data operations. |
+| `routes/profiles.py` | Profile retrieval, statistics, rerun/manual generation, upgrade/downgrade, update/delete lifecycle routes. |
+| `routes/playbooks.py` | User/agent playbook retrieval, aggregation, lifecycle, status/update/delete, and application stats routes. |
+| `routes/search.py` | Unified search and entity-specific search/rerank routes. |
+| `routes/provenance.py` | Learning provenance and approval routes. |
+| `routes/evaluation.py` | Evaluation overview, regenerate jobs, grade-on-demand, shadow comparisons, pending tool calls, and stall-state routes. |
+| `routes/braintrust.py` | Braintrust connection/project/status/sync routes. |
+| `routes/config.py` | Config read/write and account identity routes. |
 
 | File | Purpose |
 |------|---------|
@@ -97,10 +110,13 @@ Description: FastAPI backend server that processes user interactions to generate
 ## LLM Client
 
 **Directory**: `llm/`
-**Entry Point**: `litellm_client.py` - `LiteLLMClient`
+**Entry Point**: `litellm_client.py` - `LiteLLMClient` facade composed from focused mixins
 
 Key files:
-- `litellm_client.py`: Unified LiteLLMClient using LiteLLM for multi-provider support
+- `litellm_client.py`: Stable import surface, client config/credential resolution, and `LiteLLMClient` facade
+- `_litellm_text_generation.py`, `_litellm_embedding.py`, `_litellm_structured_output.py`: Completion/tool-call, embedding, and structured-output mixins
+- `_litellm_json_extraction.py`, `_litellm_subprocess.py`, `_litellm_types.py`: JSON parsing, hard-timeout subprocess snapshots/workers, and shared public types/errors
+- `providers/`: Optional local/provider adapters (`claude-code/`, OpenClaw, local embedding, Nomic embedding); registration is opt-in via environment/config
 - `openai_client.py`: OpenAI implementation (legacy, do not use directly)
 - `claude_client.py`: Claude implementation (legacy, do not use directly)
 - `llm_utils.py`: Helper functions for Pydantic model conversion
@@ -230,7 +246,8 @@ Called by API endpoints via `Reflexio`
 
 ### Base Infrastructure
 
-- `base_generation_service.py`: Abstract base for all services (parallel extractor execution via ThreadPoolExecutor, `EXTRACTOR_TIMEOUT_SECONDS = 300` per-extractor safety timeout)
+- `base_generation_service.py`: Stable `BaseGenerationService` import surface plus service-specific orchestration hooks (parallel extractor execution via ThreadPoolExecutor, `EXTRACTOR_TIMEOUT_SECONDS = 300` per-extractor safety timeout)
+- `base_generation/`: Mixins for batch progress, config filtering, extraction lifecycle, should-run prechecks, status transitions, and usage billing that keep `base_generation_service.py` navigable without changing caller imports
 - `extractor_config_utils.py`: Shared utility for filtering extractor configs by source, `allow_manual_trigger`, and extractor names
 - `extractor_interaction_utils.py`: Per-extractor utilities for stride_size checking and source filtering
 - `operation_state_utils.py`: Centralized `OperationStateManager` for all `_operation_state` table interactions (progress tracking, concurrency locks, extractor/aggregator bookmarks, simple locks)
@@ -488,8 +505,8 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 
 | File | Purpose |
 |------|---------|
-| `storage_base/` | BaseStorage interface split by domain (`_profiles.py`, `_playbook.py`, `_requests.py`, `_operations.py`, `_agent_run.py`, `_lineage.py`, `_shadow_verdicts.py`, `_stall_state.py`, `_share_links.py`) |
-| `sqlite_storage/` | SQLite-backed implementation split across the same domains, including governance-aware retention/barrier handling and lineage/tombstone support in `_governance.py` / `_lineage.py` |
+| `storage_base/` | BaseStorage interface split by domain. Legacy facades (`_profiles.py`, `_playbook.py`, `_agent_run.py`, etc.) preserve imports while subpackages (`profiles/`, `playbook/`, `agent_run/`, `governance/`) hold focused abstract store contracts. |
+| `sqlite_storage/` | SQLite-backed implementation split across matching facades and subpackages (`profiles/`, `playbook/`, `agent_run/`, `governance/`, `base/`), including governance-aware retention/barrier handling and lineage/tombstone support. |
 | `governance_validation.py` | Shared validation helpers for subject references and governance contracts before storage writes. |
 | `retention.py`, `retention_mixin.py` | Data retention and cleanup helpers |
 | `constants.py`, `error.py` | Storage constants and shared errors |

--- a/reflexio/server/api_endpoints/README.md
+++ b/reflexio/server/api_endpoints/README.md
@@ -1,5 +1,5 @@
 # server/api_endpoints
-Description: Bridge between FastAPI routes and business logic — builds `RequestContext`, validates requests, and delegates into `Reflexio`. Most endpoints are registered on the `core_router` in `../api.py`; the files here are the handlers/helpers it calls.
+Description: Shared helpers between FastAPI domain routes and business logic — builds `RequestContext`, validates requests, and delegates into `Reflexio`. Public route declarations live in `../routes/` and are aggregated by `core_router` in `../api.py`; the files here are reusable handlers/helpers those routes call.
 
 > For the complete endpoint list (publish, retrieval, search, profile/playbook lifecycle, evaluation, Braintrust, operations), see the parent [server README](../README.md#api-endpoints).
 
@@ -18,8 +18,9 @@ Description: Bridge between FastAPI routes and business logic — builds `Reques
 ## Architecture Pattern
 
 ```
-api.py (core_router + sub-routers)
-  -> Depends(get_request_context) -> RequestContext(org_id, storage, configurator, prompt_manager)
+api.py (create_app + core_router)
+  -> routes/<domain>.py (FastAPI routers)
+    -> Depends(get_request_context) -> RequestContext(org_id, storage, configurator, prompt_manager)
     -> get_reflexio(org_id) -> Reflexio (reflexio_lib) -> services/
 ```
 

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -24,7 +24,7 @@ strings before deleting old import paths in the same PR.
 |------|---------|
 | `generation_service.py` | `GenerationService` — saves interactions, runs profile + playbook generation in parallel (ThreadPoolExecutor), schedules deferred evaluation when `session_id` is present. |
 | `publish_learning_worker.py` | Deferred post-persist publish learning worker — queues async publish learning after durable interaction writes and requeues under publish limiter pressure. |
-| `base_generation_service.py` | `BaseGenerationService` — abstract base; the **Service Pattern** (load configs → create actors → run in parallel → save results). Per-extractor timeout `EXTRACTOR_TIMEOUT_SECONDS = 300`. |
+| `base_generation_service.py` + `base_generation/` | `BaseGenerationService` stable import surface plus mixins for batch progress, config filtering, extraction lifecycle, should-run prechecks, status transitions, and usage billing. Per-extractor timeout `EXTRACTOR_TIMEOUT_SECONDS = 300`. |
 | `operation_state_utils.py` | `OperationStateManager` — all `_operation_state` access (progress, concurrency locks, extractor/aggregator bookmarks, cluster fingerprints, cancellation). |
 | `extractor_config_utils.py`, `extractor_interaction_utils.py` | Filter extractors by source / `allow_manual_trigger` / names; per-extractor stride + window + bookmark handling. |
 | `deduplication_utils.py`, `service_utils.py`, `embedding_text.py` | LLM dedup helpers (used by `ProfileConsolidator` + `PlaybookConsolidator`), message construction / JSON extraction / response logging, embedding text builders. |
@@ -63,7 +63,7 @@ strings before deleting old import paths in the same PR.
 
 | Path | Purpose |
 |------|---------|
-| `storage/` | `storage_base/` (`BaseStorage` split by domain, including `_governance.py` and `_lineage.py`) + `sqlite_storage/` (governance validation, retention barriers, lineage/tombstones) + `governance_validation.py` + `retention*.py`. Access via `request_context.storage` only. |
+| `storage/` | `storage_base/` and `sqlite_storage/` keep legacy domain facades while focused subpackages own `profiles/`, `playbook/`, `agent_run/`, `governance/`, and SQLite `base/` helpers; plus `governance_validation.py` and `retention*.py`. Access via `request_context.storage` only. |
 | `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
 
 ## Key Rules


### PR DESCRIPTION
## Summary
- Syncs model-facing Reflexio code-map READMEs with the latest OSS server decomposition.
- Documents the new `server/routes/` domain-router layer, the LiteLLM facade/mixin split, `base_generation/` mixins, and focused storage subpackages.
- Updates follow `/root/reflexio-enterprise/how_to_write_readme.md` by keeping changes navigation-focused and avoiding the public `open_source/reflexio/README.md` landing page.

## Repositories/submodules reviewed
- Parent: `ReflexioAI/reflexio-enterprise`
- Submodules: `ReflexioAI/reflexio`, `ReflexioAI/claude-smart`

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`
- `reflexio/server/api_endpoints/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py . reflexio/README.md reflexio/server/README.md reflexio/server/services/README.md reflexio/server/api_endpoints/README.md`
- `markdownlint` skipped: command not installed in this runtime

## Notes/Risks
- Documentation-only changes.
- Parent repository submodule pointer is not committed; this PR is scoped to the `ReflexioAI/reflexio` submodule repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the server architecture, including how the main app entry point, domain routes, and shared endpoint helpers fit together.
  * Expanded the API, service, and storage guides with clearer directory boundaries, component roles, and integration flow.
  * Updated diagrams and component maps to better reflect current request handling and dependency injection patterns.
  * Added more precise descriptions for core service infrastructure and client-facing architecture references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->