### PR TITLE
refactor(storage): promote _parse_status to public parse_status

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -5,6 +5,7 @@ from ._base import (
     _sanitize_fts_query,
     _true_rrf_merge,
     _vector_rank_rows,
+    parse_status,
 )
 from ._extras import ExtrasMixin
 from ._governance import SQLiteGovernanceMixin
@@ -87,6 +88,7 @@ __all__ = [
     "_sanitize_fts_query",
     "_true_rrf_merge",
     "_vector_rank_rows",
+    "parse_status",
     "StallReason",
     "StallState",
     "clear_stall_state",

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -293,7 +293,7 @@ _PROFILE_TOMBSTONE_STATUS_VALUES = (
 )
 
 
-def _parse_status(value: str | None) -> Status | None:
+def parse_status(value: str | None) -> Status | None:
     """Parse a stored status string into a Status, tolerating unknown values.
 
     Unknown non-null values (e.g. a status written by a newer build after a
@@ -423,7 +423,7 @@ def _row_to_profile(row: sqlite3.Row) -> UserProfile:
         expiration_timestamp=d["expiration_timestamp"],
         custom_features=_json_loads(d.get("custom_features")),
         source=d.get("source") or "",
-        status=_parse_status(d.get("status")),
+        status=parse_status(d.get("status")),
         extractor_names=_json_loads(d.get("extractor_names")),
         expanded_terms=d.get("expanded_terms"),
         source_span=d.get("source_span"),
@@ -503,7 +503,7 @@ def _row_to_user_playbook(
         blocking_issue=BlockingIssue(**json.loads(d["blocking_issue"]))
         if d.get("blocking_issue")
         else None,
-        status=_parse_status(d.get("status")),
+        status=parse_status(d.get("status")),
         source=d.get("source"),
         source_interaction_ids=_json_loads(d.get("source_interaction_ids")) or [],
         tags=_json_loads(d.get("tags")),
@@ -536,7 +536,7 @@ def _row_to_agent_playbook(row: sqlite3.Row) -> AgentPlaybook:
         playbook_metadata=d.get("playbook_metadata") or "",
         tags=_json_loads(d.get("tags")),
         embedding=[],
-        status=_parse_status(d.get("status")),
+        status=parse_status(d.get("status")),
         expanded_terms=d.get("expanded_terms"),
         merged_into=d.get("merged_into"),
         superseded_by=d.get("superseded_by"),

--- a/tests/server/services/storage/sqlite_storage/test_status_tolerance_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_status_tolerance_integration.py
@@ -1,19 +1,20 @@
 import pytest
+
 from reflexio.models.api_schema.domain.enums import Status
-from reflexio.server.services.storage.sqlite_storage._base import _parse_status
+from reflexio.server.services.storage.sqlite_storage import parse_status
 
 pytestmark = pytest.mark.integration
 
 
 def test_parse_status_known_and_null():
-    assert _parse_status(None) is None
-    assert _parse_status("") is None
-    assert _parse_status("merged") == Status.MERGED
+    assert parse_status(None) is None
+    assert parse_status("") is None
+    assert parse_status("merged") == Status.MERGED
 
 
 def test_parse_status_unknown_maps_to_tombstone_not_current():
     # An unknown status (e.g. a future 'expired' seen by an older build) must NOT
     # raise and must NOT be treated as CURRENT (None) — else it would leak as live.
-    result = _parse_status("some_future_status")
+    result = parse_status("some_future_status")
     assert result is not None
     assert result in (Status.MERGED, Status.SUPERSEDED)


### PR DESCRIPTION
## Summary

Promote the storage status-string parser `_parse_status` → public `parse_status`. It parses a stored status string into a `Status` (tolerating unknown values as a tombstone sentinel) and is legitimately needed by the enterprise storage layer — which currently imports the **private** symbol, tripping the enterprise↔OSS boundary guard (`test_enterprise_imports_only_oss_public_modules`, red on main). That guard's allowlist only shrinks, so the correct fix is to make the symbol public rather than allowlist the violation.

## Changes
- `sqlite_storage/_base.py`: rename `_parse_status` → `parse_status`; update its 3 in-file callers.
- `sqlite_storage/__init__.py`: re-export `parse_status` on the public package surface (`__all__` + import list) so consumers import it via a public path.

## Test plan
- OSS sqlite storage suites + `import reflexio` green; ruff + pyright clean. Behavior-identical (pure rename + public re-export).

## Related
- Enterprise repoints its two import sites to the public path (restoring the boundary guard green): ReflexioAI/reflexio-enterprise (companion PR).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made status parsing available through the storage package’s public interface.

* **Bug Fixes**
  * Preserved existing status handling for stored records, including support for unknown values and empty statuses.
  * Updated coverage to validate the public status parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->