### PR TITLE
fix(llm): subprocess hard-timeout deadlock + caller message-dict mutation

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -230,10 +230,15 @@ class TextGenerationMixin:
         if system_message:
             # Check if first message is already a system message
             if final_messages and final_messages[0].get("role") == "system":
-                # Merge with existing system message
-                final_messages[0]["content"] = (
-                    f"{system_message}\n\n{final_messages[0]['content']}"
-                )
+                # Merge with existing system message. Replace the slot with a NEW
+                # dict rather than mutating in place — ``list(messages)`` is a
+                # shallow copy that shares the caller's dict objects, so an
+                # in-place edit would corrupt the caller's list (and re-prepend on
+                # reuse/retry).
+                final_messages[0] = {
+                    **final_messages[0],
+                    "content": f"{system_message}\n\n{final_messages[0]['content']}",
+                }
             else:
                 final_messages.insert(0, {"role": "system", "content": system_message})
 

--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -468,25 +468,64 @@ class TextGenerationMixin:
         )
         process.start()
         try:
-            process.join(timeout=hard_timeout)
+            # Drain the result queue BEFORE joining the child. A large completion
+            # payload overflows the OS pipe buffer, so the child's queue-feeder
+            # thread blocks on ``put`` until a reader drains it — and the child
+            # cannot exit while that thread is blocked. Joining first would then
+            # deadlock the parent against a child that finished but is wedged on a
+            # full pipe, tripping a *false* hard timeout (a large-but-successful
+            # result reported as a wall-clock kill). Reading here unblocks the
+            # feeder so the child can exit. The read is bounded by the same
+            # ``hard_timeout`` budget the join used to enforce.
+            deadline = time.monotonic() + hard_timeout
+            result: tuple[str, Any] | None = None
+            while result is None:
+                remaining = deadline - time.monotonic()
+                try:
+                    result = result_queue.get(timeout=max(0.0, min(0.1, remaining)))
+                    break
+                except queue.Empty as exc:
+                    if remaining <= 0:
+                        # True wall-clock timeout: the child ran past the hard
+                        # bound without producing a result. Kill it (if still
+                        # alive) and surface the timeout; a child that exited
+                        # without a result is a distinct failure.
+                        if process.is_alive():
+                            process.terminate()
+                            process.join(timeout=1.0)
+                            if process.is_alive():
+                                process.kill()
+                                process.join(timeout=1.0)
+                            raise LLMHardTimeoutError(
+                                f"LLM request exceeded hard timeout of {hard_timeout:.3f}s "
+                                f"(provider timeout={provider_timeout!r})"
+                            ) from exc
+                        raise LiteLLMClientError(
+                            "LLM request process exited without returning a result "
+                            f"(exitcode={process.exitcode})"
+                        ) from exc
+                    if not process.is_alive():
+                        # The child exited before the deadline. Give the queue one
+                        # last read in case the feeder flushed the payload just
+                        # before exit; otherwise it died without a result.
+                        try:
+                            result = result_queue.get(timeout=1.0)
+                        except queue.Empty as exc2:
+                            raise LiteLLMClientError(
+                                "LLM request process exited without returning a result "
+                                f"(exitcode={process.exitcode})"
+                            ) from exc2
+
+            # The loop only exits with a drained result (every no-result path
+            # above raises); the assert makes that invariant explicit for pyright.
+            assert result is not None
+            status, payload = result
+            # The payload is drained, so the feeder is unblocked and the child can
+            # exit. Reap it (terminating if it lingers) to avoid a zombie.
+            process.join(timeout=1.0)
             if process.is_alive():
                 process.terminate()
                 process.join(timeout=1.0)
-                if process.is_alive():
-                    process.kill()
-                    process.join(timeout=1.0)
-                raise LLMHardTimeoutError(
-                    f"LLM request exceeded hard timeout of {hard_timeout:.3f}s "
-                    f"(provider timeout={provider_timeout!r})"
-                )
-
-            try:
-                status, payload = result_queue.get(timeout=1.0)
-            except queue.Empty as exc:
-                raise LiteLLMClientError(
-                    "LLM request process exited without returning a result "
-                    f"(exitcode={process.exitcode})"
-                ) from exc
 
             if status == "ok":
                 return payload

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2779,3 +2779,32 @@ class TestEmbeddingRetries:
         )
         client.get_embedding("hi")
         assert "fallbacks" not in captured
+
+
+def test_generate_chat_response_does_not_mutate_caller_messages() -> None:
+    """Merging a ``system_message`` must not mutate the caller's message dicts.
+
+    ``final_messages = list(messages)`` is a shallow copy that shares the caller's
+    dict objects, so merging into ``final_messages[0]`` in place used to corrupt
+    the caller's list and re-prepend the system message on reuse/retry.
+    """
+    client = _build_client()
+    original = [
+        {"role": "system", "content": "orig-system"},
+        {"role": "user", "content": "hi"},
+    ]
+
+    with patch.object(client, "_make_request", return_value="ok") as mock_req:
+        client.generate_chat_response(original, system_message="injected")
+
+    # The caller's first dict is untouched...
+    assert original[0]["content"] == "orig-system"
+    # ...while _make_request received a NEW merged system dict.
+    sent = mock_req.call_args[0][0]
+    assert sent[0] is not original[0]
+    assert sent[0]["content"] == "injected\n\norig-system"
+
+    # A second call must not double-prepend onto the caller's data.
+    with patch.object(client, "_make_request", return_value="ok"):
+        client.generate_chat_response(original, system_message="injected")
+    assert original[0]["content"] == "orig-system"

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1183,7 +1183,9 @@ class TestStrictStructuredOutputRequest:
             patch.object(
                 LiteLLMClient, "_supports_response_schema", return_value=False
             ),
-            patch("reflexio.server.llm._litellm_structured_output.assert_provider_safe_schema"),
+            patch(
+                "reflexio.server.llm._litellm_structured_output.assert_provider_safe_schema"
+            ),
         ):
             params, _, _, _, _ = client._build_completion_params(
                 [{"role": "user", "content": "test"}],
@@ -1208,7 +1210,9 @@ class TestStrictStructuredOutputRequest:
         # Non-base double exercises the make_strict backstop; patch the
         # by-construction guard (it would raise under pytest) — see the sibling
         # test above for why.
-        with patch("reflexio.server.llm._litellm_structured_output.assert_provider_safe_schema"):
+        with patch(
+            "reflexio.server.llm._litellm_structured_output.assert_provider_safe_schema"
+        ):
             params, _, _, _, _ = client._build_completion_params(
                 [{"role": "user", "content": "test"}],
                 response_format=_DiscriminatedOutput,
@@ -2392,6 +2396,44 @@ class TestLitellmIntegration:
         # A single subprocess spawn/kill cycle (the blind same-model hard-timeout
         # retry was removed) — still far below the 1s the blocked call would take.
         assert time.perf_counter() - start < 1.0
+
+    def test_large_result_does_not_deadlock_hard_timeout(self, monkeypatch):
+        """A large completion payload overflows the OS pipe buffer feeding the
+        result queue. If the parent joined the child before draining the queue,
+        the child's queue-feeder thread would block on the full pipe, the child
+        could not exit, and a finished-but-large result would trip a *false*
+        hard timeout. The queue must be drained before join."""
+        monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "0")
+        client = LiteLLMClient(LiteLLMConfig(model="x"))
+
+        big = "x" * (2 * 1024 * 1024)  # 2 MB, far exceeds the ~64KB pipe buffer
+
+        def _big(**_params):
+            choice = MagicMock()
+            choice.message.content = big
+            choice.message.tool_calls = None
+            choice.finish_reason = "stop"
+            resp = MagicMock()
+            resp.choices = [choice]
+            resp.usage = None
+            resp._hidden_params = {}
+            resp.model = "x"
+            return resp
+
+        monkeypatch.setattr("litellm.completion", _big)
+        params = {"model": "x", "messages": self._messages(), "timeout": 0.5}
+        # Force the subprocess path (a monkeypatched completion is not module
+        # "litellm", so isolation falls to the short-timeout branch).
+        assert client._should_process_isolate_completion(0.5, 0.0)
+
+        start = time.perf_counter()
+        payload = client._completion_with_hard_timeout(params, hard_timeout=10.0)
+        elapsed = time.perf_counter() - start
+
+        assert payload.choices[0].message.content == big
+        # Draining-before-join returns immediately; the pre-fix deadlock would
+        # instead burn the full hard_timeout and raise LLMHardTimeoutError.
+        assert elapsed < 8.0
 
     def test_worker_snapshots_litellm_api_connection_error(self, monkeypatch):
         """LiteLLM exceptions can dump but fail to load across process queues."""


### PR DESCRIPTION
## Summary

Two latent robustness fixes in the litellm client (both confirmed with a repro test that fails pre-fix / passes post-fix). A third CodeRabbit-flagged item (`_build_completion_params`/`_apply_prompt_caching` mutation) was investigated and found to be a **false positive** — those already copy-on-write — so it's not touched.

### 1. Subprocess hard-timeout deadlock → false timeout (availability)
`_completion_with_hard_timeout` joined the child process **before** draining the `mp.Queue` result. A large completion payload (>~64KB) fills the OS pipe buffer, so the child blocks on `queue.put(...)` while the parent blocks on `join(...)` — the parent then hits its timeout and raises `LLMHardTimeoutError` for a call that **actually succeeded**. Fix: drain the queue (bounded by the same `hard_timeout` budget) before join; kill/terminate + ok/error snapshot semantics preserved. Regression test uses a 2 MB payload.

### 2. Caller message-dict mutation on `system_message` merge (correctness)
`generate_chat_response` did `final_messages = list(messages)` (a shallow copy sharing the caller's dict objects) then merged the system message into `final_messages[0]` **in place**, corrupting the caller's list and re-prepending on reuse/retry. Fix: replace the list slot with a new dict instead of mutating the shared one.

## Test plan
- Both regression tests proven fail-pre (via `git stash` of the fix) / pass-post.
- `tests/server/llm/` 490 passed / 60 skipped, **no mock snapshot churn**; ruff clean; pyright 0 errors on changed files.

## Note
- Out of scope (deferred, distinct): the litellm cleartext image-URL "SSRF" is a security-*policy* question (inherent to the vision feature), left for a separate decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented chat request system messages from being modified in place, keeping caller-provided message data unchanged.
  * Improved handling of long-running AI responses so large outputs no longer trigger false hard timeouts or deadlocks.
  * Made result collection more reliable when processing large payloads, helping requests complete successfully and on time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->