### PR TITLE
fix: grade-on-demand cache-key collision + batch-mode flag leak + provenance 503

### DIFF
--- a/reflexio/server/routes/evaluation.py
+++ b/reflexio/server/routes/evaluation.py
@@ -86,10 +86,14 @@ def _grade_on_demand_cache_key(
     Returns:
         str: A namespaced key suitable for ``storage.upsert_operation_state``.
     """
-    return (
-        f"{_GRADE_ON_DEMAND_CACHE_KEY_PREFIX}::{org_id}::{session_id}"
-        f"::{agent_version}::{evaluation_name}"
+    # Length-prefix each free-form component (``f"{len(s)}:{s}"``) so the join is
+    # injective: distinct component tuples can never collapse to the same key even
+    # when a component itself contains the ``::`` delimiter. Keeps the prefix intact
+    # for prefix-based filtering and the key human-readable for inspection.
+    parts = "::".join(
+        f"{len(s)}:{s}" for s in (org_id, session_id, agent_version, evaluation_name)
     )
+    return f"{_GRADE_ON_DEMAND_CACHE_KEY_PREFIX}::{parts}"
 
 
 def _read_grade_on_demand_cache(
@@ -441,8 +445,9 @@ def grade_on_demand(
     )
 
     # Two operation_state rows are intentionally written for this session:
-    #   1) `grade_on_demand::{org_id}::{session_id}::{agent_version}::{evaluation_name}`
-    #      — our 24h cache, set below after the result_id is resolved.
+    #   1) `grade_on_demand::{len:org}::{len:session}::{len:version}::{len:eval}`
+    #      (each component length-prefixed by `_grade_on_demand_cache_key` so the
+    #      key is injective) — our 24h cache, set below after result_id resolves.
     #   2) `agent_success_group_eval::{org_id}::{user_id}::{session_id}`
     #      — the runner's own "evaluated" marker, written by
     #      run_group_evaluation. Future background runs without

--- a/reflexio/server/routes/provenance.py
+++ b/reflexio/server/routes/provenance.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 from fastapi import (
     APIRouter,
     Depends,
+    HTTPException,
 )
 
 from reflexio.models.api_schema.retriever_schema import (
@@ -328,8 +329,15 @@ def get_learning_provenance(
     payload: GetLearningProvenanceRequest,
     org_id: str = Depends(default_get_org_id),
 ) -> LearningProvenanceViewResponse:
-    """Return read-only learning provenance for a generated learning row."""
+    """Return read-only learning provenance for a generated learning row.
+
+    Raises:
+        HTTPException: 503 when storage is not configured (matches the sibling
+            route convention, e.g. evaluation.py / stall_state_api.py).
+    """
     reflexio = reflexio_cache.get_reflexio(org_id=org_id)
+    if reflexio.request_context.storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
     if payload.kind == "profile":
         return _get_profile_learning_provenance(payload, reflexio)
     if payload.kind == "user_playbook":

--- a/reflexio/server/services/base_generation/_batch_progress.py
+++ b/reflexio/server/services/base_generation/_batch_progress.py
@@ -80,13 +80,14 @@ class BatchProgressMixin(Generic[TRequest]):  # noqa: UP046
         total_users = len(user_ids)
         self._is_batch_mode = True
 
-        # Initialize progress
-        state_manager.initialize_progress(
-            total_users=total_users,
-            request_params=request_params,
-        )
-
         try:
+            # Initialize progress. Kept inside the try so a raise here still
+            # resets _is_batch_mode via the finally (no leak into the next op).
+            state_manager.initialize_progress(
+                total_users=total_users,
+                request_params=request_params,
+            )
+
             # Process each user
             users_processed = 0
             processed_user_ids: list[str] = []

--- a/tests/server/services/test_batch_progress_flag.py
+++ b/tests/server/services/test_batch_progress_flag.py
@@ -1,0 +1,43 @@
+"""Regression test for the batch-mode flag leak in ``_run_batch_with_progress``.
+
+``_is_batch_mode`` is read by the base ``run`` to alter behavior. If the batch
+setup (``initialize_progress``) raises, the flag must NOT be left ``True`` — a
+leak would spuriously put the NEXT operation on the same service instance into
+batch mode.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.server.services.base_generation._batch_progress import (
+    BatchProgressMixin,
+)
+
+
+class _MinimalBatchService(BatchProgressMixin[dict]):
+    """Smallest concrete host for the batch driver under test."""
+
+    def __init__(self) -> None:
+        self._is_batch_mode = False
+
+    def _get_base_service_name(self) -> str:
+        return "minimal"
+
+
+def test_batch_mode_flag_reset_when_initialize_progress_raises() -> None:
+    svc = _MinimalBatchService()
+    state_manager = MagicMock()
+    state_manager.initialize_progress.side_effect = RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        svc._run_batch_with_progress(
+            user_ids=["u1"],
+            request={},
+            request_params={},
+            state_manager=state_manager,
+        )
+
+    assert svc._is_batch_mode is False

--- a/tests/server/test_grade_on_demand_cache_key.py
+++ b/tests/server/test_grade_on_demand_cache_key.py
@@ -1,0 +1,50 @@
+"""Unit tests for the grade-on-demand cache key builder.
+
+The key namespaces the on-demand grading cache in ``operation_state``. It MUST
+be injective across its four components (org_id, session_id, agent_version,
+evaluation_name) — a collision serves a cached verdict for one input against a
+DIFFERENT input.
+"""
+
+from __future__ import annotations
+
+from reflexio.server.routes.evaluation import (
+    _GRADE_ON_DEMAND_CACHE_KEY_PREFIX,
+    _grade_on_demand_cache_key,
+)
+
+
+def test_cache_key_is_injective_across_delimiter_boundaries() -> None:
+    """Distinct component tuples must never collapse to the same key.
+
+    ``session_id="a::b", agent_version="c"`` and
+    ``session_id="a", agent_version="b::c"`` are DIFFERENT inputs; with a naive
+    ``::`` join they produce an identical key and cross-serve verdicts.
+    """
+    key_a = _grade_on_demand_cache_key("org", "a::b", "c", "eval")
+    key_b = _grade_on_demand_cache_key("org", "a", "b::c", "eval")
+    assert key_a != key_b
+
+
+def test_cache_key_injective_org_vs_session_boundary() -> None:
+    """The org/session boundary must not be forgeable either."""
+    key_a = _grade_on_demand_cache_key("o::x", "s", "v", "e")
+    key_b = _grade_on_demand_cache_key("o", "x::s", "v", "e")
+    assert key_a != key_b
+
+
+def test_cache_key_injective_version_vs_eval_boundary() -> None:
+    key_a = _grade_on_demand_cache_key("o", "s", "v::x", "e")
+    key_b = _grade_on_demand_cache_key("o", "s", "v", "x::e")
+    assert key_a != key_b
+
+
+def test_cache_key_keeps_prefix_for_filtering() -> None:
+    key = _grade_on_demand_cache_key("org", "sess", "v1", "eval")
+    assert key.startswith(f"{_GRADE_ON_DEMAND_CACHE_KEY_PREFIX}::")
+
+
+def test_cache_key_stable_for_identical_inputs() -> None:
+    assert _grade_on_demand_cache_key("o", "s", "v", "e") == (
+        _grade_on_demand_cache_key("o", "s", "v", "e")
+    )

--- a/tests/server/test_learning_provenance_api.py
+++ b/tests/server/test_learning_provenance_api.py
@@ -1,4 +1,8 @@
 from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
 
 from reflexio.models.api_schema.domain import (
     AgentPlaybook,
@@ -13,6 +17,7 @@ from reflexio.server.routes.provenance import (
     _get_agent_playbook_learning_provenance,
     _get_profile_learning_provenance,
     _get_user_playbook_learning_provenance,
+    get_learning_provenance,
 )
 
 
@@ -291,3 +296,25 @@ def test_missing_learning_target_returns_structured_failure() -> None:
     assert response.success is False
     assert response.provenance_status == "unavailable"
     assert response.msg == "Profile not found"
+
+
+def test_unconfigured_storage_returns_503() -> None:
+    """When storage is not configured, the endpoint returns a controlled 503.
+
+    Matches the sibling route convention (evaluation.py, stall_state_api.py)
+    that surfaces 503 "Storage not configured" instead of an uncontrolled 500
+    from dereferencing ``None`` storage.
+    """
+    reflexio = SimpleNamespace(request_context=SimpleNamespace(storage=None))
+    with (
+        patch(
+            "reflexio.server.routes.provenance.reflexio_cache.get_reflexio",
+            return_value=reflexio,
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        get_learning_provenance(
+            GetLearningProvenanceRequest(kind="profile", id="1"),
+            org_id="org-1",
+        )
+    assert exc_info.value.status_code == 503


### PR DESCRIPTION
## Summary

Three latent correctness/robustness fixes, each confirmed with a repro test that fails pre-fix / passes post-fix (no false positives). One commit each.

### 1. Grade-on-demand cache-key collision (wrong cached grades)
`_grade_on_demand_cache_key` joined `org_id`/`session_id`/`agent_version`/`evaluation_name` with `::`. Since `session_id`/`evaluation_name` are free-form, distinct inputs collided — e.g. `session_id="a::b", agent_version="c"` forged the same key as `session_id="a", agent_version="b::c"` — serving a **cached grade from a different input**. Fixed with length-prefixed components (`{len(s)}:{s}`), injective and still inspectable; prefix retained. (Changes the key format → existing cached rows are one-time misses that re-grade once and expire via the 24h TTL; nothing parses the key.)

### 2. Batch-mode flag leak on setup failure
`_run_batch_with_progress` set `_is_batch_mode=True` before the try, with the raisable `initialize_progress()` between it and the try/finally reset — so a raise there **leaked `_is_batch_mode=True`** into the next operation on the same service. Fixed by moving `initialize_progress()` inside the try; happy path unchanged. (The in-progress-guard TOCTOU is not reachable single-threaded-per-request and was intentionally left alone.)

### 3. Provenance 503 on unavailable storage
`get_learning_provenance` was the lone route missing the repo's `storage is None` → "Storage not configured" 503 guard (present in evaluation / stall_state / pending_tool_call), so it 500'd with an `AttributeError`. Added the matching guard — maps only the storage-unavailable class, consistent with the existing convention.

## Test plan
- 3 repro tests proven fail-pre (via `git stash`) / pass-post; combined suites 105 passed; ruff + pyright clean; no mock snapshot churn.
