### PR TITLE
fix: serialize Reflexio cold initialization

### DIFF
--- a/reflexio/lib/_config.py
+++ b/reflexio/lib/_config.py
@@ -29,32 +29,37 @@ class ConfigMixin(ReflexioBase):
             # security). Without this, the marker reaches the readiness check as
             # an unfillable StorageConfigManagedSupabase and fails with
             # "Storage configuration is incomplete".
+            current_storage_config = configurator.get_current_storage_configuration()
             storage_config = config.storage_config
             if storage_config is None or isinstance(
                 storage_config, StorageConfigManagedSupabase
             ):
-                storage_config = configurator.get_current_storage_configuration()
+                storage_config = current_storage_config
                 config.storage_config = storage_config
 
-            # Check if storage config is ready to test
-            if not configurator.is_storage_config_ready_to_test(
-                storage_config=storage_config
-            ):
-                return SetConfigResponse(
-                    success=False, msg="Storage configuration is incomplete"
+            storage_config_changed = storage_config != current_storage_config
+            if storage_config_changed or current_storage_config is None:
+                # Storage validation initializes the backend and may run
+                # migrations, so only do it when the storage target changes.
+                if not configurator.is_storage_config_ready_to_test(
+                    storage_config=storage_config
+                ):
+                    return SetConfigResponse(
+                        success=False, msg="Storage configuration is incomplete"
+                    )
+
+                (
+                    success,
+                    error_msg,
+                ) = configurator.test_and_init_storage_config(
+                    storage_config=storage_config
                 )
 
-            # Test and initialize storage connection
-            (
-                success,
-                error_msg,
-            ) = configurator.test_and_init_storage_config(storage_config=storage_config)
-
-            if not success:
-                return SetConfigResponse(
-                    success=False,
-                    msg=f"Failed to validate storage connection: {error_msg}",
-                )
+                if not success:
+                    return SetConfigResponse(
+                        success=False,
+                        msg=f"Failed to validate storage connection: {error_msg}",
+                    )
 
             # Only set config if validation passed
             configurator.set_config(config)

--- a/reflexio/server/cache/reflexio_cache.py
+++ b/reflexio/server/cache/reflexio_cache.py
@@ -65,6 +65,17 @@ _reflexio_cache: TTLCache = TTLCache(
     maxsize=REFLEXIO_CACHE_MAX_SIZE, ttl=REFLEXIO_CACHE_TTL_SECONDS
 )
 _reflexio_cache_lock = threading.Lock()
+_REFLEXIO_CONSTRUCTION_LOCK_STRIPES = 64
+_reflexio_construction_locks = tuple(
+    threading.Lock() for _ in range(_REFLEXIO_CONSTRUCTION_LOCK_STRIPES)
+)
+
+
+def _get_construction_lock(cache_key: CacheKey) -> threading.Lock:
+    """Return a bounded striped lock for cold Reflexio construction."""
+    return _reflexio_construction_locks[
+        hash(cache_key) % _REFLEXIO_CONSTRUCTION_LOCK_STRIPES
+    ]
 
 
 def _probe_version_safe(reflexio: Reflexio) -> _ProbeResult:
@@ -157,45 +168,60 @@ def get_reflexio(org_id: str, storage_base_dir: str | None = None) -> Reflexio:
                     del _reflexio_cache[cache_key]
             span.set_data("evicted", evicted)
 
-    # Cache miss (or just-evicted stale entry) - create a new instance
-    # outside the lock to avoid blocking concurrent requests for other orgs.
-    with profile_step("reflexio.cache.construct"):
-        reflexio = Reflexio(org_id=org_id, storage_base_dir=storage_base_dir)
-    with profile_step("reflexio.cache.version_probe", cache_state="miss") as span:
-        new_version = _probe_version_safe(reflexio)
-        span.set_data("probe_failed", new_version is _PROBE_FAILED)
-        span.set_data(
-            "probe_supported",
-            new_version is not None and new_version is not _PROBE_FAILED,
+    # Cache miss (or just-evicted stale entry). Only one request per cache
+    # key may construct at a time; construction can initialize storage and
+    # run migrations, so parallel cold starts for the same org are not safe.
+    construction_lock = _get_construction_lock(cache_key)
+    with construction_lock:
+        with _reflexio_cache_lock:
+            entry = _reflexio_cache.get(cache_key)
+        if entry is not None:
+            return entry.reflexio
+
+        logger.info(
+            "Constructing Reflexio instance for org %s storage_base_dir=%s",
+            org_id,
+            storage_base_dir,
+        )
+        with profile_step("reflexio.cache.construct"):
+            reflexio = Reflexio(org_id=org_id, storage_base_dir=storage_base_dir)
+        with profile_step("reflexio.cache.version_probe", cache_state="miss") as span:
+            new_version = _probe_version_safe(reflexio)
+            span.set_data("probe_failed", new_version is _PROBE_FAILED)
+            span.set_data(
+                "probe_supported",
+                new_version is not None and new_version is not _PROBE_FAILED,
+            )
+
+        # Construction-time probe failure: serve this request from the
+        # newly-built instance but DON'T cache it. Caching with
+        # ``cached_version=None`` would conflate the entry with a
+        # legitimately-unprobeable backend and permanently disable
+        # auto-eviction. Skipping the cache means the next request pays a
+        # construction cost, but version-based eviction is preserved as
+        # soon as the backend recovers.
+        if new_version is _PROBE_FAILED:
+            logger.warning(
+                "Constructed uncached Reflexio instance for org %s because config version probe failed",
+                org_id,
+            )
+            return reflexio
+
+        new_entry = _CacheEntry(
+            reflexio=reflexio,
+            cached_version=new_version,  # type: ignore[arg-type]
         )
 
-    # Construction-time probe failure: serve this request from the
-    # newly-built instance but DON'T cache it. Caching with
-    # ``cached_version=None`` would conflate the entry with a
-    # legitimately-unprobeable backend and permanently disable
-    # auto-eviction. Skipping the cache means the next request pays a
-    # construction cost, but version-based eviction is preserved as
-    # soon as the backend recovers.
-    if new_version is _PROBE_FAILED:
-        return reflexio
-
-    new_entry = _CacheEntry(
-        reflexio=reflexio,
-        cached_version=new_version,  # type: ignore[arg-type]
-    )
-
-    with profile_step("reflexio.cache.store") as span:
-        with _reflexio_cache_lock:
-            # Double-check in case another thread populated while we were constructing.
-            existing = _reflexio_cache.get(cache_key)
-            stored = existing is None
-            if stored:
+        with profile_step("reflexio.cache.store") as span:
+            with _reflexio_cache_lock:
                 _reflexio_cache[cache_key] = new_entry
-                result = reflexio
-            else:
-                result = existing.reflexio
-        span.set_data("stored", stored)
-        return result
+            span.set_data("stored", True)
+            logger.info(
+                "Stored Reflexio instance for org %s storage_base_dir=%s",
+                org_id,
+                storage_base_dir,
+            )
+            return reflexio
 
 
 def invalidate_reflexio_cache(org_id: str, storage_base_dir: str | None = None) -> bool:

--- a/reflexio/server/routes/config.py
+++ b/reflexio/server/routes/config.py
@@ -156,9 +156,8 @@ def update_config(
     from pydantic import ValidationError
 
     reflexio = reflexio_cache.get_reflexio(org_id=org_id)
-    existing = reflexio.request_context.configurator.get_config().model_dump(
-        mode="python"
-    )
+    existing_config = reflexio.request_context.configurator.get_config()
+    existing = existing_config.model_dump(mode="python")
     merged = {**existing, **partial}
     # Pydantic validates the merged shape and rejects unknown / malformed
     # fields here, before storage validation in reflexio.set_config.
@@ -183,6 +182,10 @@ def update_config(
                 "validation_errors": exc.errors(),
             },
         ) from exc
+    if merged_config.model_dump(mode="python") == existing:
+        logger.info("Skipping no-op config update for org %s", org_id)
+        return SetConfigResponse(success=True, msg="Configuration unchanged")
+
     response = reflexio.set_config(merged_config)
     if response.success:
         reflexio_cache.invalidate_reflexio_cache(org_id=org_id)

--- a/tests/lib/test_config_unit.py
+++ b/tests/lib/test_config_unit.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 from reflexio.lib._config import ConfigMixin
 from reflexio.lib._dashboard import DashboardMixin
 from reflexio.models.api_schema.retriever_schema import GetDashboardStatsRequest
-from reflexio.models.config_schema import Config
+from reflexio.models.config_schema import Config, StorageConfigSQLite
 
 # ---------------------------------------------------------------------------
 # ConfigMixin helpers
@@ -105,6 +105,50 @@ class TestSetConfig:
 
         assert response.success is False
         assert "Connection refused" in (response.msg or "")
+
+    def test_set_config_skips_storage_init_when_storage_unchanged(self):
+        """Saving non-storage config changes should not run migrations."""
+        mixin = _make_config_mixin()
+        storage_config = StorageConfigSQLite(db_path="/var/data/current.db")
+        config = Config(storage_config=storage_config, window_size=25)
+
+        _get_configurator(
+            mixin
+        ).get_current_storage_configuration.return_value = storage_config
+
+        response = mixin.set_config(config)
+
+        assert response.success is True
+        _get_configurator(mixin).is_storage_config_ready_to_test.assert_not_called()
+        _get_configurator(mixin).test_and_init_storage_config.assert_not_called()
+        _get_configurator(mixin).set_config.assert_called_once_with(config)
+
+    def test_set_config_initializes_storage_when_storage_changed(self):
+        """Changing storage still validates and initializes the new target."""
+        mixin = _make_config_mixin()
+        existing_storage_config = StorageConfigSQLite(db_path="/var/data/current.db")
+        new_storage_config = StorageConfigSQLite(db_path="/var/data/new.db")
+        config = Config(storage_config=new_storage_config)
+
+        _get_configurator(
+            mixin
+        ).get_current_storage_configuration.return_value = existing_storage_config
+        _get_configurator(mixin).is_storage_config_ready_to_test.return_value = True
+        _get_configurator(mixin).test_and_init_storage_config.return_value = (
+            True,
+            None,
+        )
+
+        response = mixin.set_config(config)
+
+        assert response.success is True
+        _get_configurator(mixin).is_storage_config_ready_to_test.assert_called_once_with(
+            storage_config=new_storage_config
+        )
+        _get_configurator(mixin).test_and_init_storage_config.assert_called_once_with(
+            storage_config=new_storage_config
+        )
+        _get_configurator(mixin).set_config.assert_called_once_with(config)
 
     def test_set_config_storage_not_ready(self):
         """Returns failure when storage config is incomplete."""

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -337,6 +337,28 @@ class TestUpdateConfigRoute:
         # Cache invalidated on success.
         mock_invalidate.assert_called_once_with(org_id="test-org")
 
+    def test_no_op_patch_skips_set_config_and_cache_invalidation(
+        self, client, patched_reflexio, mock_reflexio
+    ):
+        existing = self._existing_config()
+        self._wire_mock(mock_reflexio, existing)
+
+        with patch(
+            "reflexio.server.cache.reflexio_cache.invalidate_reflexio_cache"
+        ) as mock_invalidate:
+            response = client.post(
+                "/api/update_config",
+                json={"window_size": existing.window_size},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "success": True,
+            "msg": "Configuration unchanged",
+        }
+        mock_reflexio.set_config.assert_not_called()
+        mock_invalidate.assert_not_called()
+
     def test_unknown_field_returns_422_before_set_config(
         self, client, patched_reflexio, mock_reflexio
     ):

--- a/tests/server/cache/test_reflexio_cache.py
+++ b/tests/server/cache/test_reflexio_cache.py
@@ -11,6 +11,8 @@ Covers:
 7. Version-based auto-invalidation: stale entries are evicted on next get
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
@@ -173,6 +175,35 @@ class TestGetReflexio:
             "has_cached_version": True,
         }
         assert tracer.started[5][1] == {"cache_state": "hit"}
+
+    @patch("reflexio.server.cache.reflexio_cache.Reflexio")
+    def test_concurrent_cache_miss_constructs_once_per_key(
+        self, mock_reflexio_cls: MagicMock
+    ):
+        """Concurrent misses for one org share one construction path."""
+        first_constructor_entered = threading.Event()
+        release_constructor = threading.Event()
+        constructed = _stub_reflexio(("db", 1))
+
+        def construct(**_kwargs):
+            first_constructor_entered.set()
+            assert release_constructor.wait(timeout=2)
+            return constructed
+
+        mock_reflexio_cls.side_effect = construct
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(get_reflexio, "org-1")
+            assert first_constructor_entered.wait(timeout=2)
+            second = executor.submit(get_reflexio, "org-1")
+            release_constructor.set()
+
+            assert first.result(timeout=2) is constructed
+            assert second.result(timeout=2) is constructed
+
+        mock_reflexio_cls.assert_called_once_with(
+            org_id="org-1", storage_base_dir=None
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Serialize cold Reflexio construction per cache-key stripe so concurrent requests for the same org do not race through storage initialization/migration.
- Short-circuit true no-op `update_config` requests before storage validation, preserving warm cache entries for config round-trip tests.
- Skip storage validation/init during `set_config` when the effective storage target is unchanged, so non-storage config saves no longer run migrations.
- Add focused regressions for concurrent cache misses, no-op config updates, and storage-change-only initialization.

## Changes
- Cache
  - Added bounded striped construction locks around `get_reflexio` cache misses.
  - Kept version probing and cache storage behavior unchanged after construction.
- Config API and library
  - Detect unchanged merged config payloads and return success without calling `set_config`.
  - Compare the effective storage config against the current storage config before calling the migration-bearing `test_and_init_storage_config` path.
- Tests
  - Added a concurrent cache miss regression test.
  - Added a no-op `update_config` regression test.
  - Added `set_config` tests for unchanged storage skip and changed storage initialization.

## Test Plan
- `uv run ruff check reflexio/server/cache/reflexio_cache.py reflexio/server/routes/config.py reflexio/lib/_config.py tests/server/cache/test_reflexio_cache.py tests/server/api_endpoints/test_api_routes.py tests/lib/test_config_unit.py`
- `uv run pyright reflexio/server/cache/reflexio_cache.py reflexio/server/routes/config.py reflexio/lib/_config.py tests/lib/test_config_unit.py`
- `uv run pytest tests/server/cache/test_reflexio_cache.py tests/server/api_endpoints/test_api_routes.py tests/lib/test_config_unit.py -q --no-cov`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance caching so concurrent requests for the same cache key reuse a single constructed instance.
  * Configuration updates now detect when settings haven’t changed and skip applying updates and cache invalidation.
  * Storage configuration handling now avoids re-initialization/validation when the effective storage settings are unchanged.

* **Tests**
  * Added concurrency coverage to ensure cache-miss construction happens once per key.
  * Added tests confirming unchanged configuration updates are treated as no-ops.
  * Added unit tests for storage configuration skip vs re-initialize behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->