### PR TITLE
feat(lineage): register_global_sweep seam for once-per-tick global reclamation

### DIFF
--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -71,6 +71,28 @@ def set_org_id_provider(provider: Callable[[], list[str]] | None) -> None:
     _org_id_provider_hook = provider
 
 
+# Global sweeps run once per tick (for GLOBAL tables like invitation_codes),
+# gated on expiry_reclamation.enabled. Each fn takes `now` (unix epoch) and
+# returns a deleted-row count. Enterprise registers its sweeps here at startup;
+# empty (OSS default) keeps behavior byte-for-byte identical to before.
+_global_sweep_hooks: list[Callable[[int], int]] = []
+
+
+def register_global_sweep(fn: Callable[[int], int]) -> None:
+    """Register a global (once-per-tick) reclamation sweep.
+
+    Args:
+        fn (Callable[[int], int]): Called with the current unix epoch; returns
+            the number of rows it deleted.
+    """
+    _global_sweep_hooks.append(fn)
+
+
+def clear_global_sweeps() -> None:
+    """Clear all registered global sweeps (tests restore OSS defaults)."""
+    _global_sweep_hooks.clear()
+
+
 class LineageGCScheduler(ThreadedScheduler):
     """Polling daemon that hard-deletes expired tombstones per org."""
 
@@ -248,6 +270,29 @@ class LineageGCScheduler(ThreadedScheduler):
                             method_name,
                         )
 
+    def _run_global_sweeps(self, cfg: object) -> None:
+        """Invoke each registered global sweep once, gated on expiry_reclamation.
+
+        Per-sweep failure isolation: one sweep raising does not skip the others.
+        The specific per-entity anomaly is emitted inside each registered sweep;
+        this is a generic backstop.
+
+        Args:
+            cfg: The bootstrap-org config read for this tick.
+        """
+        expiry = getattr(cfg, "expiry_reclamation", None)
+        if expiry is None or not expiry.enabled:
+            return
+        now = int(time.time())
+        for sweep in _global_sweep_hooks:
+            try:
+                deleted = sweep(now)
+                if deleted:
+                    logger.info("event=global_sweep deleted=%d", deleted)
+            except Exception:
+                capture_anomaly("lineage.global_sweep.failed")
+                logger.exception("event=global_sweep_failed")
+
     def _run_once(self) -> float:
         poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
         try:
@@ -256,6 +301,7 @@ class LineageGCScheduler(ThreadedScheduler):
             poll_interval = cfg.lineage_gc.poll_interval_seconds
             org_ids = self._discover_org_ids(bootstrap_ctx)
             self._gc_tick(org_ids)
+            self._run_global_sweeps(cfg)
         except Exception:
             logger.exception("event=lineage_gc_scheduler_tick_failed")
         return max(poll_interval, _MIN_POLL_SECONDS)

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -81,6 +81,10 @@ _global_sweep_hooks: list[Callable[[int], int]] = []
 def register_global_sweep(fn: Callable[[int], int]) -> None:
     """Register a global (once-per-tick) reclamation sweep.
 
+    Note: a registered sweep that absorbs its own exceptions (returns instead
+    of raising) will NOT trigger the generic ``lineage.global_sweep.failed``
+    backstop; such a sweep must emit its own failure anomaly.
+
     Args:
         fn (Callable[[int], int]): Called with the current unix epoch; returns
             the number of rows it deleted.
@@ -290,8 +294,9 @@ class LineageGCScheduler(ThreadedScheduler):
                 if deleted:
                     logger.info("event=global_sweep deleted=%d", deleted)
             except Exception:
-                capture_anomaly("lineage.global_sweep.failed")
-                logger.exception("event=global_sweep_failed")
+                sweep_id = getattr(sweep, "__qualname__", repr(sweep))
+                capture_anomaly("lineage.global_sweep.failed", sweep=sweep_id)
+                logger.exception("event=global_sweep_failed sweep=%s", sweep_id)
 
     def _run_once(self) -> float:
         poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS

--- a/tests/server/services/lineage/test_gc_scheduler_global_sweep.py
+++ b/tests/server/services/lineage/test_gc_scheduler_global_sweep.py
@@ -44,9 +44,21 @@ def test_global_sweep_skipped_when_disabled():
     assert calls == []
 
 
+def test_global_sweep_skipped_when_no_expiry_field():
+    """_run_global_sweeps must gate on expiry_reclamation; cfg without the field skips sweeps."""
+    calls: list[int] = []
+    register_global_sweep(lambda now: calls.append(now) or 1)
+    # SimpleNamespace() with NO expiry_reclamation attribute at all
+    _scheduler()._run_global_sweeps(types.SimpleNamespace())
+    assert calls == []
+
+
 def test_global_sweep_failure_isolated(monkeypatch):
     ran: list[int] = []
-    monkeypatch.setattr(gc_scheduler, "capture_anomaly", lambda *_a, **_k: None)
+    anomaly_calls: list[tuple] = []
+    monkeypatch.setattr(
+        gc_scheduler, "capture_anomaly", lambda *a, **k: anomaly_calls.append((a, k))
+    )
 
     def boom(now: int) -> int:
         raise RuntimeError("sweep failed")
@@ -55,3 +67,29 @@ def test_global_sweep_failure_isolated(monkeypatch):
     register_global_sweep(lambda now: ran.append(now) or 1)
     _scheduler()._run_global_sweeps(_cfg(True))
     assert len(ran) == 1  # second sweep still ran despite the first raising
+    assert len(anomaly_calls) == 1
+    assert anomaly_calls[0][0][0] == "lineage.global_sweep.failed"
+
+
+def test_run_once_invokes_global_sweeps(monkeypatch):
+    """Deleting the _run_global_sweeps() call from _run_once() must break this test."""
+    calls: list[int] = []
+    register_global_sweep(lambda now: calls.append(now) or 1)
+
+    cfg = types.SimpleNamespace(
+        lineage_gc=types.SimpleNamespace(poll_interval_seconds=10),
+        expiry_reclamation=types.SimpleNamespace(enabled=True),
+    )
+    ctx = types.SimpleNamespace(
+        configurator=types.SimpleNamespace(get_config=lambda: cfg),
+    )
+    scheduler = LineageGCScheduler(
+        request_context_factory=lambda _org_id: ctx,  # type: ignore[arg-type]
+        bootstrap_org_id="org-boot",
+    )
+    monkeypatch.setattr(scheduler, "_discover_org_ids", lambda _ctx: [])
+    monkeypatch.setattr(scheduler, "_gc_tick", lambda _org_ids: None)
+
+    scheduler._run_once()
+
+    assert len(calls) == 1

--- a/tests/server/services/lineage/test_gc_scheduler_global_sweep.py
+++ b/tests/server/services/lineage/test_gc_scheduler_global_sweep.py
@@ -1,0 +1,57 @@
+import types
+
+import pytest
+
+from reflexio.server.services.lineage import gc_scheduler
+from reflexio.server.services.lineage.gc_scheduler import (
+    LineageGCScheduler,
+    clear_global_sweeps,
+    register_global_sweep,
+)
+
+
+def _scheduler() -> LineageGCScheduler:
+    return LineageGCScheduler(
+        request_context_factory=lambda _org_id: types.SimpleNamespace(),  # type: ignore[arg-type]
+        bootstrap_org_id="org-boot",
+    )
+
+
+def _cfg(enabled: bool):
+    return types.SimpleNamespace(
+        expiry_reclamation=types.SimpleNamespace(enabled=enabled)
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hooks():
+    clear_global_sweeps()
+    yield
+    clear_global_sweeps()
+
+
+def test_global_sweep_runs_once_when_enabled():
+    calls: list[int] = []
+    register_global_sweep(lambda now: calls.append(now) or 3)
+    _scheduler()._run_global_sweeps(_cfg(True))
+    assert len(calls) == 1
+
+
+def test_global_sweep_skipped_when_disabled():
+    calls: list[int] = []
+    register_global_sweep(lambda now: calls.append(now) or 0)
+    _scheduler()._run_global_sweeps(_cfg(False))
+    assert calls == []
+
+
+def test_global_sweep_failure_isolated(monkeypatch):
+    ran: list[int] = []
+    monkeypatch.setattr(gc_scheduler, "capture_anomaly", lambda *_a, **_k: None)
+
+    def boom(now: int) -> int:
+        raise RuntimeError("sweep failed")
+
+    register_global_sweep(boom)
+    register_global_sweep(lambda now: ran.append(now) or 1)
+    _scheduler()._run_global_sweeps(_cfg(True))
+    assert len(ran) == 1  # second sweep still ran despite the first raising


### PR DESCRIPTION
## Summary

Adds a small `register_global_sweep` seam to the lineage GC scheduler so a deployment can register **global** (once-per-tick) reclamation sweeps — for tables that are not per-org — that run inside the single existing `LineageGCScheduler` tick, gated live on `expiry_reclamation.enabled`. This mirrors the existing `set_org_id_provider` injection pattern and keeps the OSS scheduler free of any enterprise dependency.

The enterprise side consumes this to fold its `invitation_codes` reclamation into the shared scheduler and delete a standalone daemon (see the enterprise PR below).

## Changes

- `gc_scheduler.py`:
  - `_global_sweep_hooks` list + `register_global_sweep(fn: Callable[[int], int])` + `clear_global_sweeps()` (test hook), mirroring the `set_org_id_provider` module-hook pattern.
  - `LineageGCScheduler._run_global_sweeps(cfg)`: invokes each registered sweep once per tick, gated on `expiry_reclamation.enabled` (getattr-guarded for legacy configs), with per-sweep failure isolation. The `lineage.global_sweep.failed` backstop anomaly carries a `sweep=` identity for Sentry grouping.
  - Call site added to `_run_once` after `_gc_tick(org_ids)`.
  - Docstring on `register_global_sweep` documents that a sweep which absorbs its own exceptions bypasses the generic backstop and must emit its own failure anomaly.

## Tests

`test_gc_scheduler_global_sweep.py` (new): runs-once-when-enabled, skipped-when-disabled, skipped-when-`expiry_reclamation`-absent, failure-isolation (asserts the backstop anomaly fires), and `_run_once`→`_run_global_sweeps` wiring. Existing lineage suites stay green (43 passed).

Behavior with no registered sweeps (OSS default) is byte-for-byte identical to before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running scheduled global cleanup sweeps alongside existing lineage maintenance.
  * Global sweeps can now be registered and cleared dynamically.
* **Bug Fixes**
  * Global sweep failures no longer stop other sweeps from running.
  * Sweeps only run when the relevant cleanup setting is enabled, helping avoid unexpected work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->