### PR TITLE
feat(lineage): register_per_org_sweep seam for per-org reclamation

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -725,9 +725,10 @@ class ExpiryReclamationConfig(BaseModel):
 
 class GovernanceRetentionConfig(BaseModel):
     """Audit-event retention policy. **Enterprise-only:** reclamation is performed
-    by the reflexio_ext GovernanceRetentionCapability. In an OSS-only deployment
-    these knobs are accepted but inert (the OSS lineage scheduler does not reclaim
-    audit events) and the server logs a startup warning when retention is enabled.
+    by an enterprise per-org reclamation sweep registered via
+    ``register_per_org_sweep``. In an OSS-only deployment these knobs are accepted
+    but inert (the OSS lineage scheduler does not reclaim audit events) and the
+    server logs a startup warning when retention is enabled.
     """
 
     audit_events_retention_enabled: bool = False

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -411,10 +411,11 @@ def maybe_start_lineage_gc(
         cfg = ctx.configurator.get_config()
 
         # Dead-knob warning: audit-event retention is an ENTERPRISE-only feature
-        # (handled by reflexio_ext GovernanceRetentionCapability). In an OSS-only
-        # deployment the knob is accepted but does nothing — warn loudly. Detected
-        # via the configurator class: enterprise swaps in EnterpriseConfigurator at
-        # construction, so the OSS DefaultConfigurator means "no enterprise here".
+        # (handled by an enterprise per-org reclamation sweep registered via
+        # register_per_org_sweep). In an OSS-only deployment the knob is accepted
+        # but does nothing — warn loudly. Detected via the configurator class:
+        # enterprise swaps in EnterpriseConfigurator at construction, so the OSS
+        # DefaultConfigurator means "no enterprise here".
         from reflexio.server.services.configurator.configurator import (  # noqa: PLC0415
             DefaultConfigurator,
             get_configurator_class,
@@ -439,10 +440,17 @@ def maybe_start_lineage_gc(
         governance_retention_enabled = getattr(
             gr, "audit_events_retention_enabled", False
         )
+        # Also start when any reclamation sweep has been registered — registered
+        # hooks carry their own per-org gates (in the enterprise closure), so the
+        # scheduler must run even if the bootstrap org's config has all flags off.
+        # This preserves the "start unconditionally, gate per-org" invariant of
+        # the deleted GovernanceRetentionScheduler.
         if not (
             cfg.lineage_gc.enabled
             or expiry_reclamation_enabled
             or governance_retention_enabled
+            or bool(_per_org_sweep_hooks)
+            or bool(_global_sweep_hooks)
         ):
             return None
     except Exception as exc:

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -1,22 +1,24 @@
 """Process-local scheduler for lineage tombstone garbage collection and expiry reclamation.
 
 Startup runs when EITHER ``lineage_gc.enabled`` OR ``expiry_reclamation.enabled``
-is set in the bootstrap org's config. Each tick evaluates every org independently.
+OR ``governance_retention.audit_events_retention_enabled`` is set in the bootstrap
+org's config. Each tick evaluates every org independently.
 
 - **Class A** (profile expiry sweep + tombstone GC): gated on ``lineage_gc.enabled``.
   Hard-deletes expired tombstones per that org's ``lineage_gc`` config.
 - **Class B** (plain-row direct-delete sweeps, no PII/audit obligation): gated on
   ``expiry_reclamation.enabled``. Currently sweeps expired share links and expired
   pending tool calls.
+- **Per-org sweeps**: registered via :func:`register_per_org_sweep`; invoked
+  unconditionally once per org after the Class-B block. Enterprise registers a
+  governance-retention closure here at startup (see ``reflexio_ext``).
 
 One org's failure never stalls the loop; errors are captured as Sentry anomalies
 and the loop continues to the next org.
 
 Note: the poll interval is always taken from ``lineage_gc.poll_interval_seconds``
-even when only ``expiry_reclamation`` is enabled; Class B currently shares that cadence.
-
-Governance-retention reclamation is a premium concern handled by the enterprise
-GovernanceRetentionCapability (reflexio_ext), not here.
+even when only ``expiry_reclamation`` or ``governance_retention`` is enabled;
+all sweep classes share that cadence.
 """
 
 from __future__ import annotations
@@ -95,6 +97,36 @@ def register_global_sweep(fn: Callable[[int], int]) -> None:
 def clear_global_sweeps() -> None:
     """Clear all registered global sweeps (tests restore OSS defaults)."""
     _global_sweep_hooks.clear()
+
+
+# Per-org sweeps run once per org per tick (for per-org reclamation concerns).
+# Each fn takes (org_id, now) and returns a deleted-row count. Enterprise
+# registers its closure here at startup so governance retention folds into the
+# shared scheduler loop; empty (OSS default) keeps behavior identical to before.
+_per_org_sweep_hooks: list[Callable[[str, int], int]] = []
+
+
+def register_per_org_sweep(fn: Callable[[str, int], int]) -> None:
+    """Register a per-org reclamation sweep.
+
+    The sweep is invoked once per org inside ``_gc_tick``'s org loop, after
+    the Class-B block, unconditionally (not gated on ``lineage_gc`` or
+    ``expiry_reclamation`` — the real gate lives in the enterprise closure).
+
+    Note: a registered sweep that absorbs its own exceptions (returns instead
+    of raising) will NOT trigger the generic ``lineage.per_org_sweep.failed``
+    backstop; such a sweep must emit its own failure anomaly.
+
+    Args:
+        fn (Callable[[str, int], int]): Called with ``(org_id, now)`` where
+            ``now`` is the current unix epoch; returns the number of rows deleted.
+    """
+    _per_org_sweep_hooks.append(fn)
+
+
+def clear_per_org_sweeps() -> None:
+    """Clear all registered per-org sweeps (tests restore OSS defaults)."""
+    _per_org_sweep_hooks.clear()
 
 
 class LineageGCScheduler(ThreadedScheduler):
@@ -274,6 +306,25 @@ class LineageGCScheduler(ThreadedScheduler):
                             method_name,
                         )
 
+            # Per-org sweeps: invoked unconditionally (not gated on lineage_gc or
+            # expiry_reclamation — the real gate lives in each enterprise closure).
+            # Each sweep is isolated so one failure does not skip the rest.
+            for sweep in _per_org_sweep_hooks:
+                try:
+                    sweep(org_id, int(time.time()))
+                except Exception:
+                    sweep_id = getattr(sweep, "__qualname__", repr(sweep))
+                    capture_anomaly(
+                        "lineage.per_org_sweep.failed",
+                        org_id=org_id,
+                        sweep=sweep_id,
+                    )
+                    logger.exception(
+                        "event=per_org_sweep_failed org_id=%s sweep=%s",
+                        org_id,
+                        sweep_id,
+                    )
+
     def _run_global_sweeps(self, cfg: object) -> None:
         """Invoke each registered global sweep once, gated on expiry_reclamation.
 
@@ -385,7 +436,14 @@ def maybe_start_lineage_gc(
         expiry_reclamation_enabled = getattr(
             getattr(cfg, "expiry_reclamation", None), "enabled", False
         )
-        if not (cfg.lineage_gc.enabled or expiry_reclamation_enabled):
+        governance_retention_enabled = getattr(
+            gr, "audit_events_retention_enabled", False
+        )
+        if not (
+            cfg.lineage_gc.enabled
+            or expiry_reclamation_enabled
+            or governance_retention_enabled
+        ):
             return None
     except Exception as exc:
         logger.warning(

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -306,24 +306,46 @@ class LineageGCScheduler(ThreadedScheduler):
                             method_name,
                         )
 
-            # Per-org sweeps: invoked unconditionally (not gated on lineage_gc or
-            # expiry_reclamation — the real gate lives in each enterprise closure).
-            # Each sweep is isolated so one failure does not skip the rest.
-            for sweep in _per_org_sweep_hooks:
-                try:
-                    sweep(org_id, int(time.time()))
-                except Exception:
-                    sweep_id = getattr(sweep, "__qualname__", repr(sweep))
-                    capture_anomaly(
-                        "lineage.per_org_sweep.failed",
-                        org_id=org_id,
-                        sweep=sweep_id,
-                    )
-                    logger.exception(
-                        "event=per_org_sweep_failed org_id=%s sweep=%s",
+            # Per-org sweeps: invoked unconditionally once per org (the real gate
+            # lives in each enterprise closure). Extracted to keep _gc_tick's
+            # cyclomatic complexity in check and to mirror _run_global_sweeps.
+            self._run_per_org_sweeps(org_id)
+
+    def _run_per_org_sweeps(self, org_id: str) -> None:
+        """Invoke each registered per-org sweep once for this org.
+
+        Invoked unconditionally (not gated on ``lineage_gc``/``expiry_reclamation``
+        — the real gate lives in each enterprise closure). Per-sweep failure
+        isolation: one sweep raising does not skip the others; a sweep that
+        absorbs its own exceptions bypasses the ``lineage.per_org_sweep.failed``
+        backstop and must emit its own anomaly.
+
+        Args:
+            org_id: The org being swept this tick.
+        """
+        now = int(time.time())
+        for sweep in _per_org_sweep_hooks:
+            sweep_id = getattr(sweep, "__qualname__", repr(sweep))
+            try:
+                deleted = sweep(org_id, now)
+                if deleted:
+                    logger.info(
+                        "event=per_org_sweep org_id=%s sweep=%s deleted=%d",
                         org_id,
                         sweep_id,
+                        deleted,
                     )
+            except Exception:
+                capture_anomaly(
+                    "lineage.per_org_sweep.failed",
+                    org_id=org_id,
+                    sweep=sweep_id,
+                )
+                logger.exception(
+                    "event=per_org_sweep_failed org_id=%s sweep=%s",
+                    org_id,
+                    sweep_id,
+                )
 
     def _run_global_sweeps(self, cfg: object) -> None:
         """Invoke each registered global sweep once, gated on expiry_reclamation.
@@ -371,10 +393,15 @@ def maybe_start_lineage_gc(
 ) -> LineageGCScheduler | None:
     """Start the scheduler when bootstrap config enables tombstone GC or expiry reclamation.
 
-    Startup runs when bootstrap-org config sets EITHER ``lineage_gc.enabled``
-    (Class A: profile expiry + tombstone GC) OR ``expiry_reclamation.enabled``
-    (Class B: plain-row direct-delete sweeps). Returns ``None`` if neither flag
-    is set.
+    Startup runs when the bootstrap-org config sets ``lineage_gc.enabled``
+    (Class A: profile expiry + tombstone GC), ``expiry_reclamation.enabled``
+    (Class B: plain-row direct-delete sweeps), or
+    ``governance_retention.audit_events_retention_enabled`` — OR when any sweep
+    hook has been registered via :func:`register_per_org_sweep` /
+    :func:`register_global_sweep`. Registered hooks carry their own per-org gate
+    in the enterprise closure, so the scheduler must start to evaluate them even
+    when none of the bootstrap-org flags are set. Returns ``None`` only if none
+    of these conditions hold.
 
     Tombstone-GC enablement criteria (must ALL hold before enabling ``lineage_gc``
     for a production org):
@@ -404,7 +431,8 @@ def maybe_start_lineage_gc(
             ``storage.list_org_ids()`` exactly as before.
 
     Returns:
-        LineageGCScheduler: The started scheduler, or ``None`` if neither flag is set.
+        LineageGCScheduler: The started scheduler, or ``None`` if no start
+        condition holds (see the startup criteria above).
     """
     try:
         ctx = request_context_factory(bootstrap_org_id)

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -16,7 +16,9 @@ from reflexio.server.services.lineage.gc_scheduler import (
     _HIGH_VOLUME_THRESHOLD,
     _MIN_POLL_SECONDS,
     LineageGCScheduler,
+    clear_per_org_sweeps,
     maybe_start_lineage_gc,
+    register_per_org_sweep,
 )
 
 # ---------------------------------------------------------------------------
@@ -190,8 +192,9 @@ def test_gc_tick_no_high_volume_anomaly_below_threshold():
 def test_gc_tick_never_runs_governance_retention():
     """Invariant: the reduced OSS scheduler sheds the premium concern. Even when
     a governance_retention config with audit_events_retention_enabled=True is
-    present, _gc_tick must NEVER call gc_governance_retention (that behavior
-    moved to the enterprise GovernanceRetentionCapability)."""
+    present, _gc_tick must NEVER call gc_governance_retention directly — that
+    behavior is only invoked if an enterprise per-org sweep is registered via
+    register_per_org_sweep (Task 1 seam)."""
     cfg = LineageGCConfig(enabled=True, tombstone_grace_window_days=10)
     storage = _make_storage(gc_return=0)
     ctx = _make_ctx("org_gov", lineage_gc=cfg, storage=storage)
@@ -539,3 +542,84 @@ def test_run_loop_clamps_non_positive_poll_interval():
     assert all(t >= _MIN_POLL_SECONDS for t in wait_calls), (
         f"Non-positive poll interval was not clamped: got {wait_calls}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-org sweep seam — register_per_org_sweep / clear_per_org_sweeps
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_runs_registered_per_org_sweep_gated_live():
+    """Per-org sweeps registered via register_per_org_sweep are invoked once per
+    org per tick, unconditionally (no expiry_reclamation or lineage_gc gate).
+    Each sweep receives (org_id: str, now: int) exactly once per org.
+    """
+    calls: list[tuple[str, int]] = []
+
+    def fake_sweep(org_id: str, now: int) -> int:
+        calls.append((org_id, now))
+        return 0
+
+    register_per_org_sweep(fake_sweep)
+    try:
+        # Disable both Class-A and Class-B to confirm the per-org sweep runs
+        # unconditionally regardless of those gates.
+        cfg = LineageGCConfig(enabled=False)
+        sched = _scheduler(
+            factory=lambda org_id: _make_ctx(
+                org_id, lineage_gc=cfg, storage=_make_storage()
+            )
+        )
+
+        before = int(time.time())
+        sched._gc_tick(["orgA", "orgB"])
+        after = int(time.time())
+    finally:
+        clear_per_org_sweeps()
+
+    org_ids_called = [c[0] for c in calls]
+    assert org_ids_called == ["orgA", "orgB"], (
+        f"Expected exactly one call per org in order; got {org_ids_called}"
+    )
+    for _, now_val in calls:
+        assert isinstance(now_val, int)
+        assert before <= now_val <= after, (
+            f"now_val={now_val} not in [{before}, {after}]"
+        )
+
+
+def test_gc_tick_isolates_per_org_sweep_failure():
+    """A raising per-org sweep emits capture_anomaly and does NOT skip sibling
+    sweeps registered after it (per-sweep failure isolation).
+    """
+    sibling_calls: list[tuple[str, int]] = []
+
+    def raising_sweep(org_id: str, now: int) -> int:
+        raise RuntimeError("boom")
+
+    def sibling_sweep(org_id: str, now: int) -> int:
+        sibling_calls.append((org_id, now))
+        return 0
+
+    register_per_org_sweep(raising_sweep)
+    register_per_org_sweep(sibling_sweep)
+    try:
+        cfg = LineageGCConfig(enabled=False)
+        sched = _scheduler(
+            factory=lambda org_id: _make_ctx(
+                org_id, lineage_gc=cfg, storage=_make_storage()
+            )
+        )
+
+        with patch.object(gc_scheduler, "capture_anomaly") as mock_anomaly:
+            sched._gc_tick(["orgA"])
+    finally:
+        clear_per_org_sweeps()
+
+    mock_anomaly.assert_called_once_with(
+        "lineage.per_org_sweep.failed",
+        org_id="orgA",
+        sweep=raising_sweep.__qualname__,
+    )
+    assert len(sibling_calls) == 1
+    assert sibling_calls[0][0] == "orgA"

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -16,6 +16,7 @@ from reflexio.server.services.lineage.gc_scheduler import (
     _HIGH_VOLUME_THRESHOLD,
     _MIN_POLL_SECONDS,
     LineageGCScheduler,
+    clear_global_sweeps,
     clear_per_org_sweeps,
     maybe_start_lineage_gc,
     register_per_org_sweep,
@@ -623,3 +624,46 @@ def test_gc_tick_isolates_per_org_sweep_failure():
     )
     assert len(sibling_calls) == 1
     assert sibling_calls[0][0] == "orgA"
+
+
+# ---------------------------------------------------------------------------
+# maybe_start_lineage_gc — registered hooks widen the start gate
+# ---------------------------------------------------------------------------
+
+
+def test_maybe_start_starts_when_a_per_org_sweep_is_registered_even_with_flags_off():
+    """Scheduler must start when any per-org sweep is registered, even if all
+    config flags (lineage_gc.enabled, expiry_reclamation.enabled,
+    governance_retention.audit_events_retention_enabled) are False.
+
+    This preserves the invariant of the deleted GovernanceRetentionScheduler,
+    which started unconditionally so that a non-bootstrap tenant with governance
+    retention ON would still be swept.
+    """
+
+    def fake_sweep(org_id: str, now: int) -> int:
+        return 0
+
+    register_per_org_sweep(fake_sweep)
+    sched = None
+    try:
+        cfg = SimpleNamespace(
+            lineage_gc=SimpleNamespace(enabled=False, poll_interval_seconds=86400),
+            expiry_reclamation=SimpleNamespace(enabled=False),
+            governance_retention=SimpleNamespace(audit_events_retention_enabled=False),
+        )
+        ctx = SimpleNamespace(
+            org_id="org_bootstrap",
+            storage=_make_storage(),
+            configurator=SimpleNamespace(get_config=MagicMock(return_value=cfg)),
+        )
+        sched = maybe_start_lineage_gc(lambda _: ctx, bootstrap_org_id="org_bootstrap")  # type: ignore[arg-type]
+        assert sched is not None, (
+            "Expected scheduler to start when a per-org sweep is registered, "
+            "regardless of config flags"
+        )
+    finally:
+        clear_per_org_sweeps()
+        clear_global_sweeps()
+        if sched is not None:
+            sched.stop(timeout_seconds=1.0)


### PR DESCRIPTION
## Summary

Adds a **per-org** reclamation sweep seam to the lineage GC scheduler — the per-org counterpart to the merged `register_global_sweep` (global) seam (#283). A deployment can register a `Callable[[str, int], int]` that the scheduler invokes **once per org** inside its existing per-org tick loop, keeping the OSS scheduler config-agnostic (no enterprise imports).

The enterprise side uses this to fold its per-org `GovernanceRetentionScheduler` (audit-event retention) into the shared scheduler and delete a standalone daemon (see the enterprise PR).

## Changes

- `gc_scheduler.py`:
  - `_per_org_sweep_hooks` list + `register_per_org_sweep(fn: Callable[[str, int], int])` + `clear_per_org_sweeps()` (test hook), mirroring `register_global_sweep`.
  - `LineageGCScheduler._gc_tick`: after the Class-B block, inside the per-org loop, invokes each registered per-org sweep **unconditionally** with `(org_id, now)` and per-sweep failure isolation (`capture_anomaly("lineage.per_org_sweep.failed", org_id=, sweep=)`). The gate is the enterprise closure's own per-org config — not `lineage_gc`/`expiry_reclamation`.
  - `maybe_start_lineage_gc`: start-gate widened to also start when **any** reclamation sweep is registered (`_per_org_sweep_hooks`/`_global_sweep_hooks` non-empty), so a per-org reclaimer whose real gate lives in a non-bootstrap tenant's config is never silently skipped (preserving the folded daemon's unconditional-start invariant).
  - Docstring: per-org sweeps documented; stale `GovernanceRetentionCapability` references replaced with the generic per-org-sweep description.

## Tests

`test_gc_scheduler.py`: per-org sweep runs once per org; failure-isolation (anomaly + siblings continue); `maybe_start` starts when a per-org sweep is registered even with all config flags off; existing `test_gc_tick_never_runs_governance_retention` stays green (empty hooks → OSS never runs governance). 46 lineage tests pass.

With no registered sweeps (OSS default), behavior is byte-for-byte identical to before.

## Related PRs
- open_source/reflexio: #283 (the global-sweep seam this parallels)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-organization retention sweeps, allowing scheduled maintenance to run for each org.
  * The scheduler now starts when retention-related sweeps are registered, even if other GC settings are off.

* **Bug Fixes**
  * Improved sweep reliability so one failing org-level sweep does not stop other sweeps from running.
  * Updated retention-related warnings and behavior to better reflect enterprise sweep handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->