### PR TITLE
fix(logging): emit INFO app logs to stdout in production

### DIFF
--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -230,5 +230,24 @@ if DEBUG_LOG_TO_CONSOLE:
         logging.ERROR
     )
 else:
-    # Default to WARNING level when DEBUG_LOG_TO_CONSOLE is not set or is false
-    root_logger.setLevel(logging.WARNING)
+    # Production (DEBUG_LOG_TO_CONSOLE off): emit INFO+ app logs to stdout so the
+    # container log driver (e.g. CloudWatch awslogs) captures business-logic audit
+    # lines — billing/webhook/enforcement, etc. Without an explicit handler the
+    # stdlib "handler of last resort" emits only WARNING+ to stderr, so INFO logs
+    # were silently dropped in production. Plain formatter (no colors/files/dedup)
+    # keeps this lean and log-driver friendly — none of the DEBUG-branch overhead.
+    root_logger.setLevel(logging.INFO)
+    if not any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers):
+        prod_console_handler = logging.StreamHandler(sys.stdout)
+        prod_console_handler.setLevel(logging.INFO)
+        prod_console_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s")
+        )
+        root_logger.addHandler(prod_console_handler)
+
+    # Keep noisy loggers quiet even at INFO (mirror the debug branch's suppression).
+    for _noisy in ("litellm", "LiteLLM", "httpx", "httpcore", "openai", "urllib3"):
+        logging.getLogger(_noisy).setLevel(logging.WARNING)
+    logging.getLogger("reflexio.server.site_var.site_var_manager").setLevel(
+        logging.ERROR
+    )


### PR DESCRIPTION
In production (`DEBUG_LOG_TO_CONSOLE` off), the root logger was pinned at `WARNING` with no explicit stdout handler, so `INFO` business-logic logs — billing/webhook/enforcement audit lines — were silently dropped; only `WARNING+` reached the container log driver (CloudWatch) via the stdlib handler-of-last-resort. This left the prod money path unobservable in logs (discovered during the Stripe test-in-prod rehearsal: a webhook round-trip had to be proven via a DB state transition because no handler log line existed).

**Fix:** in the production branch, add a plain `INFO` `StreamHandler(sys.stdout)` (no file handlers, no ANSI colors, no dedup filter — none of the heavy `DEBUG_LOG_TO_CONSOLE` overhead) and set the root logger to `INFO`, keeping noisy third-party loggers (`litellm`/`httpx`/`openai`/…) at `WARNING`. Result: app `INFO` audit lines reach stdout → CloudWatch.

Existing logging tests pass (13). Paired with reflexio-enterprise PR (billing C2 log-level split).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production logging so informational messages are no longer dropped.
  * Console output now appears consistently in non-debug mode with a simpler log format.
  * Reduced noisy log output from several background services, making important messages easier to spot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->