### PR TITLE
fix(logging): make production INFO opt-in per subsystem (prod OOM fix)

### DIFF
--- a/reflexio/server/__init__.py
+++ b/reflexio/server/__init__.py
@@ -230,13 +230,16 @@ if DEBUG_LOG_TO_CONSOLE:
         logging.ERROR
     )
 else:
-    # Production (DEBUG_LOG_TO_CONSOLE off): emit INFO+ app logs to stdout so the
-    # container log driver (e.g. CloudWatch awslogs) captures business-logic audit
-    # lines — billing/webhook/enforcement, etc. Without an explicit handler the
-    # stdlib "handler of last resort" emits only WARNING+ to stderr, so INFO logs
-    # were silently dropped in production. Plain formatter (no colors/files/dedup)
-    # keeps this lean and log-driver friendly — none of the DEBUG-branch overhead.
-    root_logger.setLevel(logging.INFO)
+    # Production (DEBUG_LOG_TO_CONSOLE off): default the root logger to WARNING.
+    # App-wide INFO on a busy server drove ~3x log volume and grew memory to the
+    # container ceiling over a few hours (prod incident 2026-07-04) — so INFO is
+    # OPT-IN per subsystem, not global. A stdout StreamHandler is still attached at
+    # INFO so that any logger explicitly raised to INFO reaches the container log
+    # driver (e.g. CloudWatch awslogs); everything else stays WARNING+ and cheap.
+    #
+    # REFLEXIO_INFO_LOGGERS: comma-separated logger-name prefixes to surface at INFO
+    # (e.g. the billing money-path). Empty/unset => WARNING-only (the safe default).
+    root_logger.setLevel(logging.WARNING)
     if not any(isinstance(h, logging.StreamHandler) for h in root_logger.handlers):
         prod_console_handler = logging.StreamHandler(sys.stdout)
         prod_console_handler.setLevel(logging.INFO)
@@ -245,7 +248,14 @@ else:
         )
         root_logger.addHandler(prod_console_handler)
 
-    # Keep noisy loggers quiet even at INFO (mirror the debug branch's suppression).
+    for _info_logger in (
+        name.strip()
+        for name in os.getenv("REFLEXIO_INFO_LOGGERS", "").split(",")
+        if name.strip()
+    ):
+        logging.getLogger(_info_logger).setLevel(logging.INFO)
+
+    # Keep noisy loggers quiet regardless of the above (mirror the debug branch).
     for _noisy in ("litellm", "LiteLLM", "httpx", "httpcore", "openai", "urllib3"):
         logging.getLogger(_noisy).setLevel(logging.WARNING)
     logging.getLogger("reflexio.server.site_var.site_var_manager").setLevel(


### PR DESCRIPTION
**Incident fix.** The prior change set the production root logger to `INFO` app-wide. On a busy prod server that ~3x'd log volume and grew container memory to the 4GB ceiling over a few hours, ending in a task-kill + brief outage (2026-07-04; `:37` was memory-stable ~60%, `:38` climbed to 93% pinned).

**Fix:** default the root logger back to `WARNING`; keep the INFO stdout handler; add **`REFLEXIO_INFO_LOGGERS`** (comma-separated logger prefixes) to opt SPECIFIC subsystems into INFO. Prod sets it to the billing money-path only — targeted observability at a fraction of the volume. Empty/unset ⇒ WARNING-only (safe default). Verified: listed logger emits INFO, unlisted suppressed, WARNING preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Production logging is now quieter by default, reducing unnecessary `INFO` output.
  * You can now selectively re-enable `INFO` logs for chosen logger prefixes using a comma-separated setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->