### PR TITLE
fix: count manual profiles for all users

### DIFF
--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -498,14 +498,12 @@ class ProfileGenerationService(
             )
 
         user_ids = self._count_user_ids(request.user_id, processed_user_ids)
-        total = 0
-        for user_id in user_ids:
-            profiles = self.storage.get_user_profile(  # type: ignore[reportOptionalMemberAccess]
-                user_id=user_id,
-                status_filter=[Status.PENDING],
-            )
-            total += len(profiles)
-        return total
+        if not user_ids:
+            return 0
+        return self.storage.count_user_profiles_by_status(  # type: ignore[reportOptionalMemberAccess]
+            user_ids=user_ids,
+            status=Status.PENDING,
+        )
 
     @staticmethod
     def _count_user_ids(
@@ -692,6 +690,8 @@ class ProfileGenerationService(
                 "source": request.source,
                 "mode": "manual_regular",
             }
+            # total_profiles is computed inside the batch runner via
+            # _get_generated_count(processed_user_ids=...).
             users_processed, total_profiles = self._run_batch_with_progress(
                 user_ids=user_ids,
                 request=request,  # type: ignore[reportArgumentType]
@@ -733,11 +733,9 @@ class ProfileGenerationService(
             Number of profiles with CURRENT status
         """
         user_ids = self._count_user_ids(request.user_id, processed_user_ids)
-        total = 0
-        for user_id in user_ids:
-            profiles = self.storage.get_user_profile(  # type: ignore[reportOptionalMemberAccess]
-                user_id=user_id,
-                status_filter=[None],  # CURRENT profiles
-            )
-            total += len(profiles)
-        return total
+        if not user_ids:
+            return 0
+        return self.storage.count_user_profiles_by_status(  # type: ignore[reportOptionalMemberAccess]
+            user_ids=user_ids,
+            status=None,
+        )

--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -477,21 +477,27 @@ class ProfileGenerationService(
 
     def _get_generated_count(
         self,
-        request: RerunProfileGenerationRequest,
+        request: RerunProfileGenerationRequest | ManualProfileGenerationRequest,
         processed_user_ids: list[str] | None = None,
     ) -> int:
-        """Get the count of profiles generated during rerun.
+        """Get the count of profiles generated during batch generation.
 
-        Counts profiles with PENDING status for each processed user.
+        Counts PENDING profiles for rerun requests and CURRENT profiles for manual
+        regular requests, scoped to users the batch runner actually processed.
 
         Args:
-            request: The rerun request object
+            request: The rerun or manual generation request object
             processed_user_ids: List of user IDs processed in the batch
 
         Returns:
             Number of profiles generated
         """
-        user_ids = processed_user_ids or ([request.user_id] if request.user_id else [])
+        if isinstance(request, ManualProfileGenerationRequest):
+            return self._count_manual_generated(
+                request, processed_user_ids=processed_user_ids
+            )
+
+        user_ids = self._count_user_ids(request.user_id, processed_user_ids)
         total = 0
         for user_id in user_ids:
             profiles = self.storage.get_user_profile(  # type: ignore[reportOptionalMemberAccess]
@@ -500,6 +506,16 @@ class ProfileGenerationService(
             )
             total += len(profiles)
         return total
+
+    @staticmethod
+    def _count_user_ids(
+        request_user_id: str | None, processed_user_ids: list[str] | None
+    ) -> list[str]:
+        """Resolve users to count without treating an empty processed batch as missing."""
+
+        if processed_user_ids is not None:
+            return processed_user_ids
+        return [request_user_id] if request_user_id else []
 
     # ===============================
     # Upgrade/Downgrade hook implementations (override base class methods)
@@ -676,15 +692,12 @@ class ProfileGenerationService(
                 "source": request.source,
                 "mode": "manual_regular",
             }
-            users_processed, _ = self._run_batch_with_progress(
+            users_processed, total_profiles = self._run_batch_with_progress(
                 user_ids=user_ids,
                 request=request,  # type: ignore[reportArgumentType]
                 request_params=request_params,
                 state_manager=state_manager,
             )
-
-            # 3. Count generated profiles (CURRENT status = None)
-            total_profiles = self._count_manual_generated(request)
 
             return ManualProfileGenerationResponse(
                 success=True,
@@ -700,20 +713,31 @@ class ProfileGenerationService(
                 profiles_generated=0,
             )
 
-    def _count_manual_generated(self, request: ManualProfileGenerationRequest) -> int:
+    def _count_manual_generated(
+        self,
+        request: ManualProfileGenerationRequest,
+        processed_user_ids: list[str] | None = None,
+    ) -> int:
         """
         Count profiles generated during manual regular generation.
 
-        Counts profiles with CURRENT status (None), optionally filtered by user_id.
+        Counts profiles with CURRENT status (None) for each processed user.
 
         Args:
             request: The manual generation request object
+            processed_user_ids: User IDs processed by the manual batch. When
+                the request omitted user_id, this prevents passing None through
+                to storage methods that require a concrete user.
 
         Returns:
             Number of profiles with CURRENT status
         """
-        profiles = self.storage.get_user_profile(  # type: ignore[reportOptionalMemberAccess]
-            user_id=request.user_id,  # type: ignore[reportArgumentType]
-            status_filter=[None],  # CURRENT profiles
-        )
-        return len(profiles)
+        user_ids = self._count_user_ids(request.user_id, processed_user_ids)
+        total = 0
+        for user_id in user_ids:
+            profiles = self.storage.get_user_profile(  # type: ignore[reportOptionalMemberAccess]
+                user_id=user_id,
+                status_filter=[None],  # CURRENT profiles
+            )
+            total += len(profiles)
+        return total

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
@@ -474,6 +474,24 @@ class ProfileStoreMixin:
         return row["cnt"] if row else 0
 
     @SQLiteStorageBase.handle_exceptions
+    def count_user_profiles_by_status(
+        self, user_ids: list[str], status: Status | None
+    ) -> int:
+        if not user_ids:
+            return 0
+
+        current_ts = _epoch_now()
+        status_frag, status_params = _build_status_sql([status])
+        ph = ",".join("?" for _ in user_ids)
+        sql = (
+            f"SELECT COUNT(*) as cnt FROM profiles "
+            f"WHERE user_id IN ({ph}) "
+            f"AND expiration_timestamp >= ? AND {status_frag}"
+        )
+        row = self._fetchone(sql, [*user_ids, current_ts, *status_params])
+        return row["cnt"] if row else 0
+
+    @SQLiteStorageBase.handle_exceptions
     def update_all_profiles_status(
         self,
         old_status: Status | None,

--- a/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
@@ -110,6 +110,28 @@ class ProfileStoreMixin:
         """
         raise NotImplementedError
 
+    def count_user_profiles_by_status(
+        self, user_ids: list[str], status: Status | None
+    ) -> int:
+        """Count non-expired profiles for concrete users with the given status.
+
+        Storage backends may override this with a single query. The default keeps
+        the storage contract backward-compatible for out-of-tree backends.
+
+        Args:
+            user_ids: Concrete user IDs to include. Empty list returns 0.
+            status: Profile status to match; None means CURRENT.
+
+        Returns:
+            int: Number of matching profiles
+        """
+        if not user_ids:
+            return 0
+        return sum(
+            len(self.get_user_profile(user_id=user_id, status_filter=[status]))
+            for user_id in user_ids
+        )
+
     @abstractmethod
     def update_all_profiles_status(
         self,

--- a/tests/server/services/profile/test_profile_generation_service.py
+++ b/tests/server/services/profile/test_profile_generation_service.py
@@ -8,7 +8,7 @@ _count_manual_generated(), error/exception handling paths, and status change hel
 
 import tempfile
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -402,10 +402,6 @@ class TestRunManualRegular:
         mock_state_mgr = MagicMock()
         mock_state_mgr.check_in_progress.return_value = None
 
-        request_context.storage.get_user_profile.return_value = [
-            MagicMock()
-        ]  # 1 profile
-
         with (
             patch.object(service, "_create_state_manager", return_value=mock_state_mgr),
             patch.object(service, "_run_batch_with_progress", return_value=(1, 1)),
@@ -464,39 +460,31 @@ class TestRunManualRegular:
 class TestCountManualGenerated:
     """Tests for _count_manual_generated."""
 
-    def test_counts_current_profiles(self, service, request_context, sample_profile):
+    def test_counts_current_profiles(self, service, request_context):
         """Counts profiles with CURRENT status (None filter)."""
-        request_context.storage.get_user_profile.return_value = [
-            sample_profile,
-            sample_profile,
-        ]
+        request_context.storage.count_user_profiles_by_status.return_value = 2
 
         request = ManualProfileGenerationRequest(user_id="user_1")
         count = service._count_manual_generated(request)
 
         assert count == 2
-        request_context.storage.get_user_profile.assert_called_once_with(
-            user_id="user_1",
-            status_filter=[None],
+        request_context.storage.count_user_profiles_by_status.assert_called_once_with(
+            user_ids=["user_1"],
+            status=None,
         )
 
     def test_returns_zero_when_no_profiles(self, service, request_context):
         """Returns 0 when no profiles exist."""
-        request_context.storage.get_user_profile.return_value = []
+        request_context.storage.count_user_profiles_by_status.return_value = 0
 
         request = ManualProfileGenerationRequest(user_id="user_1")
         count = service._count_manual_generated(request)
 
         assert count == 0
 
-    def test_counts_processed_users_without_user_id(
-        self, service, request_context, sample_profile
-    ):
+    def test_counts_processed_users_without_user_id(self, service, request_context):
         """When user_id is None, counts concrete processed users."""
-        request_context.storage.get_user_profile.side_effect = [
-            [sample_profile],
-            [sample_profile, sample_profile],
-        ]
+        request_context.storage.count_user_profiles_by_status.return_value = 3
 
         request = ManualProfileGenerationRequest()
         count = service._count_manual_generated(
@@ -504,10 +492,10 @@ class TestCountManualGenerated:
         )
 
         assert count == 3
-        assert request_context.storage.get_user_profile.call_args_list == [
-            call(user_id="u1", status_filter=[None]),
-            call(user_id="u2", status_filter=[None]),
-        ]
+        request_context.storage.count_user_profiles_by_status.assert_called_once_with(
+            user_ids=["u1", "u2"],
+            status=None,
+        )
 
     def test_empty_processed_users_does_not_fallback_to_request_user(
         self, service, request_context
@@ -518,7 +506,7 @@ class TestCountManualGenerated:
         count = service._count_manual_generated(request, processed_user_ids=[])
 
         assert count == 0
-        request_context.storage.get_user_profile.assert_not_called()
+        request_context.storage.count_user_profiles_by_status.assert_not_called()
 
 
 # ===============================
@@ -762,19 +750,15 @@ class TestRerunHooks:
             RerunProfileGenerationRequest,
         )
 
-        request_context.storage.get_user_profile.return_value = [
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-        ]
+        request_context.storage.count_user_profiles_by_status.return_value = 3
 
         request = RerunProfileGenerationRequest(user_id="user_1")
         count = service._get_generated_count(request)
 
         assert count == 3
-        request_context.storage.get_user_profile.assert_called_once_with(
-            user_id="user_1",
-            status_filter=[Status.PENDING],
+        request_context.storage.count_user_profiles_by_status.assert_called_once_with(
+            user_ids=["user_1"],
+            status=Status.PENDING,
         )
 
     def test_get_generated_count_empty_processed_users_does_not_fallback(
@@ -789,25 +773,22 @@ class TestRerunHooks:
         count = service._get_generated_count(request, processed_user_ids=[])
 
         assert count == 0
-        request_context.storage.get_user_profile.assert_not_called()
+        request_context.storage.count_user_profiles_by_status.assert_not_called()
 
     def test_get_generated_count_manual_uses_processed_users(
-        self, service, request_context, sample_profile
+        self, service, request_context
     ):
         """Manual batch counts CURRENT profiles only for successful users."""
-        request_context.storage.get_user_profile.side_effect = [
-            [sample_profile],
-            [sample_profile, sample_profile],
-        ]
+        request_context.storage.count_user_profiles_by_status.return_value = 3
 
         request = ManualProfileGenerationRequest()
         count = service._get_generated_count(request, processed_user_ids=["u1", "u3"])
 
         assert count == 3
-        assert request_context.storage.get_user_profile.call_args_list == [
-            call(user_id="u1", status_filter=[None]),
-            call(user_id="u3", status_filter=[None]),
-        ]
+        request_context.storage.count_user_profiles_by_status.assert_called_once_with(
+            user_ids=["u1", "u3"],
+            status=None,
+        )
 
     def test_create_rerun_response(self, service):
         """_create_rerun_response creates RerunProfileGenerationResponse."""

--- a/tests/server/services/profile/test_profile_generation_service.py
+++ b/tests/server/services/profile/test_profile_generation_service.py
@@ -8,7 +8,7 @@ _count_manual_generated(), error/exception handling paths, and status change hel
 
 import tempfile
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -441,17 +441,18 @@ class TestRunManualRegular:
         mock_state_mgr = MagicMock()
         mock_state_mgr.check_in_progress.return_value = None
 
-        request_context.storage.get_all_user_ids.return_value = ["u1", "u2", "u3"]
-        request_context.storage.get_user_profile.return_value = []
+        request_context.storage.get_all_user_ids.return_value = ["u1", "u2"]
 
         with (
             patch.object(service, "_create_state_manager", return_value=mock_state_mgr),
-            patch.object(service, "_run_batch_with_progress", return_value=(3, 0)),
+            patch.object(service, "_run_batch_with_progress", return_value=(2, 3)),
         ):
             request = ManualProfileGenerationRequest()
             response = service.run_manual_regular(request)
 
         assert response.success is True
+        assert response.profiles_generated == 3
+        assert response.msg == "Generated 3 profiles for 2 user(s)"
         request_context.storage.get_all_user_ids.assert_called_once()
 
 
@@ -488,17 +489,36 @@ class TestCountManualGenerated:
 
         assert count == 0
 
-    def test_no_user_id_filter(self, service, request_context):
-        """When user_id is None, passes None to storage."""
-        request_context.storage.get_user_profile.return_value = []
+    def test_counts_processed_users_without_user_id(
+        self, service, request_context, sample_profile
+    ):
+        """When user_id is None, counts concrete processed users."""
+        request_context.storage.get_user_profile.side_effect = [
+            [sample_profile],
+            [sample_profile, sample_profile],
+        ]
 
         request = ManualProfileGenerationRequest()
-        service._count_manual_generated(request)
-
-        request_context.storage.get_user_profile.assert_called_once_with(
-            user_id=None,
-            status_filter=[None],
+        count = service._count_manual_generated(
+            request, processed_user_ids=["u1", "u2"]
         )
+
+        assert count == 3
+        assert request_context.storage.get_user_profile.call_args_list == [
+            call(user_id="u1", status_filter=[None]),
+            call(user_id="u2", status_filter=[None]),
+        ]
+
+    def test_empty_processed_users_does_not_fallback_to_request_user(
+        self, service, request_context
+    ):
+        """When all processing fails, no stale CURRENT profiles are counted."""
+        request = ManualProfileGenerationRequest(user_id="user_1")
+
+        count = service._count_manual_generated(request, processed_user_ids=[])
+
+        assert count == 0
+        request_context.storage.get_user_profile.assert_not_called()
 
 
 # ===============================
@@ -756,6 +776,38 @@ class TestRerunHooks:
             user_id="user_1",
             status_filter=[Status.PENDING],
         )
+
+    def test_get_generated_count_empty_processed_users_does_not_fallback(
+        self, service, request_context
+    ):
+        """Rerun counts keep an empty successful-user batch empty."""
+        from reflexio.models.api_schema.service_schemas import (
+            RerunProfileGenerationRequest,
+        )
+
+        request = RerunProfileGenerationRequest(user_id="user_1")
+        count = service._get_generated_count(request, processed_user_ids=[])
+
+        assert count == 0
+        request_context.storage.get_user_profile.assert_not_called()
+
+    def test_get_generated_count_manual_uses_processed_users(
+        self, service, request_context, sample_profile
+    ):
+        """Manual batch counts CURRENT profiles only for successful users."""
+        request_context.storage.get_user_profile.side_effect = [
+            [sample_profile],
+            [sample_profile, sample_profile],
+        ]
+
+        request = ManualProfileGenerationRequest()
+        count = service._get_generated_count(request, processed_user_ids=["u1", "u3"])
+
+        assert count == 3
+        assert request_context.storage.get_user_profile.call_args_list == [
+            call(user_id="u1", status_filter=[None]),
+            call(user_id="u3", status_filter=[None]),
+        ]
 
     def test_create_rerun_response(self, service):
         """_create_rerun_response creates RerunProfileGenerationResponse."""

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -220,6 +220,25 @@ class TestProfileCRUD:
         )
         assert storage.count_all_profiles() == 2
 
+    def test_count_user_profiles_by_status_filters_users_and_status(
+        self, storage: BaseStorage
+    ) -> None:
+        current_1 = _make_profile("u1", "p-current-1", "likes sushi")
+        current_2 = _make_profile("u2", "p-current-2", "likes ramen")
+        pending = _make_profile("u2", "p-pending", "likes pizza")
+        pending.status = Status.PENDING
+        outside_user = _make_profile("u3", "p-current-3", "likes tacos")
+        expired = _make_profile("u1", "p-expired", "old preference")
+        expired.expiration_timestamp = 1
+
+        storage.add_user_profile("u1", [current_1, expired])
+        storage.add_user_profile("u2", [current_2, pending])
+        storage.add_user_profile("u3", [outside_user])
+
+        assert storage.count_user_profiles_by_status(["u1", "u2"], None) == 2
+        assert storage.count_user_profiles_by_status(["u1", "u2"], Status.PENDING) == 1
+        assert storage.count_user_profiles_by_status([], None) == 0
+
 
 class TestGetProfilesByIds:
     """Contract tests for get_profiles_by_ids (used by ReflectionService)."""


### PR DESCRIPTION
## Summary
- Fix manual profile generation counts when the request omits `user_id` and processes all interaction users.
- Preserve `processed_user_ids=[]` as an empty successful-user batch so failed or cancelled users do not recount stale profiles.
- Count generated profiles through a storage-layer batch count instead of hydrating profiles once per processed user.

## Broken Before
- All-user manual generation (`user_id=None`) could report generated-profile totals from the wrong scope because counting fell back to request-level user context instead of the concrete users processed by the batch.
- A zero-success batch for a specific `user_id` could still count stale pre-existing CURRENT profiles for that user, producing self-contradictory results like generated profiles for `0` processed users.
- The first fix iteration avoided the all-user overcount but introduced per-user profile hydration during counting, increasing query count and transient DB failure surface with batch size.

## Fixed Now
- Batch counting is scoped to `processed_user_ids`, with `[]` treated as an intentional empty result rather than a missing value.
- Manual generation counts CURRENT profiles and rerun generation counts PENDING profiles through the same generated-count hook used by `_run_batch_with_progress()`.
- SQLite now has a single-query `count_user_profiles_by_status(user_ids, status)` override; storage backends without an override use the backward-compatible BaseStorage fallback.

## Expected Behavior
- Manual generation for all users reports profiles generated only for users that successfully processed in that run.
- If every user fails or the operation is cancelled before any user succeeds, the generated-profile count is `0` and no stale profiles are reported as new output.
- Rerun counts continue to count PENDING profiles, but empty processed-user batches stay empty.
- Counting does not require one `get_user_profile()` call per processed user on SQLite.

## Changes
- `ProfileGenerationService._get_generated_count()` dispatches manual runs to CURRENT-profile counting and reruns to PENDING-profile counting.
- `run_manual_regular()` uses the count returned by `_run_batch_with_progress()`; the count now flows through `_get_generated_count(processed_user_ids=...)`.
- Added backward-compatible `count_user_profiles_by_status(user_ids, status)` storage support; SQLite overrides it with a single-query implementation so profile generation can count concrete users/statuses without per-user hydration.
- Empty user lists return `0` before hitting storage, preserving the no-stale-count behavior for zero-success batches.
- Removed dead test setup that implied `run_manual_regular()` exercised profile hydration directly.

## Test Plan
- `uv run pytest tests/server/services/profile/test_profile_generation_service.py tests/server/services/storage/test_storage_contract_profiles.py -q --no-cov`
- `uv run pytest tests/server/services/test_profile_generation_service.py tests/server/services/profile/test_profile_generation_service.py tests/server/services/storage/test_storage_contract_profiles.py -q --no-cov`
- `uv run ruff check reflexio/server/services/profile/service.py reflexio/server/services/storage/storage_base/profiles/_profile_store.py reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py tests/server/services/profile/test_profile_generation_service.py tests/server/services/storage/test_storage_contract_profiles.py`
- `uv run ruff format --check reflexio/server/services/profile/service.py reflexio/server/services/storage/storage_base/profiles/_profile_store.py reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py tests/server/services/profile/test_profile_generation_service.py tests/server/services/storage/test_storage_contract_profiles.py`
- `uv run pyright reflexio/server/services/profile/service.py reflexio/server/services/storage/storage_base/profiles/_profile_store.py reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py tests/server/services/profile/test_profile_generation_service.py tests/server/services/storage/test_storage_contract_profiles.py`

