### PR TITLE
test/fix: update fixtures for NEW-N/governance validators + storage decomposition (audit findings)

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -523,7 +523,7 @@ class TextGenerationMixin:
 
             # The loop only exits with a drained result (every no-result path
             # above raises); the assert makes that invariant explicit for pyright.
-            assert result is not None
+            assert result is not None  # noqa: S101
             status, payload = result
             # The payload is drained, so the feeder is unblocked and the child can
             # exit. Reap it (terminating if it lingers) to avoid a zombie.

--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -110,6 +110,7 @@ __all__ = [
     "create_litellm_client",
 ]
 
+
 class LiteLLMClient(TextGenerationMixin, EmbeddingMixin, StructuredOutputMixin):
     """
     Unified LLM client using LiteLLM for multi-provider support.

--- a/reflexio/server/services/extraction/resume_scheduler.py
+++ b/reflexio/server/services/extraction/resume_scheduler.py
@@ -107,9 +107,7 @@ class ExtractionResumeScheduler(ThreadedScheduler):
         try:
             bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
             config = bootstrap_ctx.configurator.get_config()
-            poll_interval = (
-                config.pending_tool_call_config.resume_poll_interval_seconds
-            )
+            poll_interval = config.pending_tool_call_config.resume_poll_interval_seconds
             self._expire_pending_tool_calls(bootstrap_ctx)
             for org_id in self._discover_org_ids(bootstrap_ctx):
                 if self._stop_event.is_set():

--- a/tests/benchmarks/test_retrieval_latency_smoke.py
+++ b/tests/benchmarks/test_retrieval_latency_smoke.py
@@ -26,7 +26,7 @@ from reflexio.benchmarks.retrieval_latency.report import (
     cell_key_str,
     load_baseline,
 )
-from tests.server.test_utils import skip_in_precommit
+from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
 _SMOKE_SIZES = "50"
 _SMOKE_TRIALS = 10
@@ -36,6 +36,7 @@ _REGRESSION_TOLERANCE = 3.0  # Allow up to 3× slowdown before failing.
 _BASELINE_PATH = Path(__file__).resolve().parent / "baseline.json"
 
 
+@skip_low_priority
 @skip_in_precommit
 @pytest.mark.integration
 def test_retrieval_latency_smoke(tmp_path: Path) -> None:

--- a/tests/cli/test_env_loader_user_env_file.py
+++ b/tests/cli/test_env_loader_user_env_file.py
@@ -29,7 +29,9 @@ def test_user_env_file_honors_override(monkeypatch, tmp_path):
 
 def test_user_env_file_expands_user(monkeypatch):
     monkeypatch.setenv(_ENV, "~/.claude-smart/.env")
-    assert env_loader.user_env_file() == (env_loader.Path.home() / ".claude-smart" / ".env")
+    assert env_loader.user_env_file() == (
+        env_loader.Path.home() / ".claude-smart" / ".env"
+    )
 
 
 def test_blank_override_falls_back_to_default(monkeypatch):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+
 from reflexio.server.extensions import reset_services
 
 _THIS_DIR = Path(__file__).resolve().parent  # tests/

--- a/tests/e2e_tests/test_complete_workflows.py
+++ b/tests/e2e_tests/test_complete_workflows.py
@@ -835,12 +835,8 @@ def test_rerun_operations_consistency(
 
     # Record initial state
     initial_interactions = storage.get_all_interactions()
-    initial_current_profiles = storage.get_user_profile(
-        user_id, status_filter=[None]
-    )
-    initial_playbooks = storage.get_user_playbooks(
-        playbook_name="test_playbook"
-    )
+    initial_current_profiles = storage.get_user_profile(user_id, status_filter=[None])
+    initial_playbooks = storage.get_user_playbooks(playbook_name="test_playbook")
     initial_agent_success = storage.get_agent_success_evaluation_results(
         agent_version=agent_version
     )
@@ -874,9 +870,7 @@ def test_rerun_operations_consistency(
         assert profile.content == initial_current_profiles[i].content
 
     # Step 4: Verify PENDING profiles were created
-    pending_profiles = storage.get_user_profile(
-        user_id, status_filter=[Status.PENDING]
-    )
+    pending_profiles = storage.get_user_profile(user_id, status_filter=[Status.PENDING])
     assert len(pending_profiles) > 0, "PENDING profiles should be created"
 
     # Step 5: Verify interactions unchanged
@@ -886,9 +880,7 @@ def test_rerun_operations_consistency(
     )
 
     # Step 6: Verify playbooks unchanged
-    playbooks_after_rerun = storage.get_user_playbooks(
-        playbook_name="test_playbook"
-    )
+    playbooks_after_rerun = storage.get_user_playbooks(playbook_name="test_playbook")
     assert len(playbooks_after_rerun) == initial_playbook_count, (
         "User playbooks should remain unchanged"
     )
@@ -919,9 +911,7 @@ def test_rerun_operations_consistency(
     assert len(pending_profiles_after_second) >= pending_count_before_second_rerun
 
     # Step 9: Verify CURRENT profiles still unchanged after second rerun
-    current_profiles_final = storage.get_user_profile(
-        user_id, status_filter=[None]
-    )
+    current_profiles_final = storage.get_user_profile(user_id, status_filter=[None])
     assert len(current_profiles_final) == initial_profile_count, (
         "CURRENT profiles should still be unchanged after second rerun"
     )

--- a/tests/e2e_tests/test_failure_path_polarity_e2e.py
+++ b/tests/e2e_tests/test_failure_path_polarity_e2e.py
@@ -47,12 +47,12 @@ from reflexio.models.api_schema.domain.entities import (
 from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.config_schema import Config, ReflectionConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.services.reflection.service import ReflectionService
 from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionDecision,
     ReflectionOutput,
     ReflectionServiceRequest,
 )
+from reflexio.server.services.reflection.service import ReflectionService
 
 pytestmark = pytest.mark.e2e
 

--- a/tests/eval/consolidation/fixtures/illustrative_cases.json
+++ b/tests/eval/consolidation/fixtures/illustrative_cases.json
@@ -11,7 +11,7 @@
       }
     ],
     "candidate": {
-      "new_id": "cand-1",
+      "new_id": "NEW-1",
       "content": "Always add a brief summary at the start of any report you produce.",
       "trigger": "generating a report for the user",
       "rationale": "A leading summary helps the reader orient quickly."
@@ -31,7 +31,7 @@
       }
     ],
     "candidate": {
-      "new_id": "cand-2",
+      "new_id": "NEW-2",
       "content": "Do not attach internal-only files to a customer email.",
       "trigger": "drafting a customer email",
       "rationale": "Internal files can leak confidential data to the customer."
@@ -51,7 +51,7 @@
       }
     ],
     "candidate": {
-      "new_id": "cand-3",
+      "new_id": "NEW-3",
       "content": "Do not answer immediately; ask a clarifying question first.",
       "trigger": "the user asks a factual question",
       "rationale": "Some questions are ambiguous and answering blindly misleads the user."
@@ -71,7 +71,7 @@
       }
     ],
     "candidate": {
-      "new_id": "cand-4",
+      "new_id": "NEW-4",
       "content": "Always run the tests before approving a change.",
       "trigger": "reviewing a proposed code change",
       "rationale": "Tests catch regressions."
@@ -91,7 +91,7 @@
       }
     ],
     "candidate": {
-      "new_id": "cand-5",
+      "new_id": "NEW-5",
       "content": "Use metric units when reporting measurements.",
       "trigger": "reporting a physical measurement to the user",
       "rationale": "The user's region uses the metric system."

--- a/tests/eval/consolidation/test_consolidation_eval.py
+++ b/tests/eval/consolidation/test_consolidation_eval.py
@@ -38,7 +38,7 @@ from tests.eval.consolidation.runner import EvalResults, run_eval, score_case
 # ---------------------------------------------------------------------------
 
 
-def _unify(new_id: str = "n1", **kw: object) -> UnifyDecision:
+def _unify(new_id: str = "NEW-1", **kw: object) -> UnifyDecision:
     base: dict[str, object] = {
         "new_id": new_id,
         "content": "Always summarize the report.",
@@ -50,14 +50,16 @@ def _unify(new_id: str = "n1", **kw: object) -> UnifyDecision:
 
 
 def _reject(
-    new_id: str = "n1", superseded_by_existing_id: int = 1
+    new_id: str = "NEW-1", superseded_by_existing_id: int = 1
 ) -> RejectNewDecision:
     return RejectNewDecision(
         new_id=new_id, superseded_by_existing_id=superseded_by_existing_id
     )
 
 
-def _differentiate(new_id: str = "n1", existing_id: int = 1) -> DifferentiateDecision:
+def _differentiate(
+    new_id: str = "NEW-1", existing_id: int = 1
+) -> DifferentiateDecision:
     return DifferentiateDecision(
         new_id=new_id,
         existing_id=existing_id,
@@ -66,7 +68,7 @@ def _differentiate(new_id: str = "n1", existing_id: int = 1) -> DifferentiateDec
     )
 
 
-def _independent(new_id: str = "n1") -> IndependentDecision:
+def _independent(new_id: str = "NEW-1") -> IndependentDecision:
     return IndependentDecision(new_id=new_id)
 
 
@@ -79,7 +81,7 @@ def _case(case_id: str = "c1", gold_kind: str = "unify") -> ConsolidationEvalCas
                 {"id": 1, "content": "existing rule", "trigger": "t", "rationale": ""}
             ],
             "candidate": {
-                "new_id": "n1",
+                "new_id": "NEW-1",
                 "content": "candidate rule",
                 "trigger": "t",
                 "rationale": "",
@@ -556,7 +558,7 @@ def test_real_judge_smoke():  # pragma: no cover - manual, costs money
                 }
             ],
             "candidate": {
-                "new_id": "n1",
+                "new_id": "NEW-1",
                 "content": "Do not attach internal-only files to a customer email.",
                 "trigger": "drafting a customer email",
                 "rationale": "Internal files can leak confidential data.",
@@ -567,7 +569,7 @@ def test_real_judge_smoke():  # pragma: no cover - manual, costs money
         }
     )
     decision = UnifyDecision(
-        new_id="n1",
+        new_id="NEW-1",
         archive_existing_ids=[1],
         content=(
             "Always greet the recipient by name; do not attach internal-only "

--- a/tests/lib/test_config_unit.py
+++ b/tests/lib/test_config_unit.py
@@ -142,7 +142,9 @@ class TestSetConfig:
         response = mixin.set_config(config)
 
         assert response.success is True
-        _get_configurator(mixin).is_storage_config_ready_to_test.assert_called_once_with(
+        _get_configurator(
+            mixin
+        ).is_storage_config_ready_to_test.assert_called_once_with(
             storage_config=new_storage_config
         )
         _get_configurator(mixin).test_and_init_storage_config.assert_called_once_with(

--- a/tests/lib/test_generation_unit.py
+++ b/tests/lib/test_generation_unit.py
@@ -55,9 +55,7 @@ def _make_mixin(*, storage_configured: bool = True) -> GenerationMixin:
 
 class TestRunPlaybookAggregation:
     @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
-    def test_calls_aggregator_run_with_correct_args(
-        self, mock_agg_cls
-    ):
+    def test_calls_aggregator_run_with_correct_args(self, mock_agg_cls):
         """Constructs PlaybookAggregator and calls run() with correct request."""
         mixin = _make_mixin()
         mock_agg_instance = MagicMock()

--- a/tests/lib/test_search_unit.py
+++ b/tests/lib/test_search_unit.py
@@ -219,9 +219,9 @@ class TestUnifiedSearch:
         mixin.llm_client = MagicMock()
         mock_config = MagicMock()
         mock_config.llm_config = None
-        cast(Any, mixin.request_context.configurator.get_config).return_value = (
-            mock_config
-        )
+        cast(
+            Any, mixin.request_context.configurator.get_config
+        ).return_value = mock_config
 
         expected_response = UnifiedSearchResponse(success=True)
 
@@ -245,9 +245,9 @@ class TestUnifiedSearch:
         mixin.llm_client = MagicMock()
         mock_config = MagicMock()
         mock_config.llm_config = None
-        cast(Any, mixin.request_context.configurator.get_config).return_value = (
-            mock_config
-        )
+        cast(
+            Any, mixin.request_context.configurator.get_config
+        ).return_value = mock_config
 
         events: list[tuple[str, str, dict[str, object] | None]] = []
 
@@ -313,9 +313,9 @@ class TestUnifiedSearch:
         mixin.llm_client = MagicMock()
         mock_config = MagicMock()
         mock_config.llm_config = None
-        cast(Any, mixin.request_context.configurator.get_config).return_value = (
-            mock_config
-        )
+        cast(
+            Any, mixin.request_context.configurator.get_config
+        ).return_value = mock_config
 
         expected_response = UnifiedSearchResponse(success=True)
 

--- a/tests/models/test_lineage_models.py
+++ b/tests/models/test_lineage_models.py
@@ -1,7 +1,11 @@
-from reflexio.models.api_schema.domain.enums import Status
 from reflexio.models.api_schema.domain.entities import (
-    UserPlaybook, AgentPlaybook, UserProfile, LineageEvent, LineageContext, RecordRef,
+    LineageContext,
+    LineageEvent,
+    RecordRef,
+    UserPlaybook,
+    UserProfile,
 )
+from reflexio.models.api_schema.domain.enums import Status
 
 
 def test_status_has_tombstone_values():
@@ -17,23 +21,38 @@ def test_playbook_pointers_default_none_and_are_int():
 
 
 def test_profile_pointers_are_str():
-    p = UserProfile(profile_id="p1", user_id="u1", content="c",
-                    last_modified_timestamp=0, generated_from_request_id="r1")
+    p = UserProfile(
+        profile_id="p1",
+        user_id="u1",
+        content="c",
+        last_modified_timestamp=0,
+        generated_from_request_id="r1",
+    )
     assert p.merged_into is None
     p.merged_into = "p2"
     assert UserProfile.model_validate(p.model_dump()).merged_into == "p2"
 
 
 def test_lineage_event_is_content_free_and_idempotency_keyed():
-    e = LineageEvent(org_id="org-42", entity_type="user_playbook", entity_id="UP-1",
-                     op="merge", prov_relation="wasDerivedFrom", source_ids=["UP-1"],
-                     actor="consolidator", request_id="req-7", reason="dup")
+    e = LineageEvent(
+        org_id="org-42",
+        entity_type="user_playbook",
+        entity_id="UP-1",
+        op="merge",
+        prov_relation="wasDerivedFrom",
+        source_ids=["UP-1"],
+        actor="consolidator",
+        request_id="req-7",
+        reason="dup",
+    )
     assert e.event_id == 0  # storage assigns
     assert not hasattr(e, "content")
 
 
 def test_lineage_context_and_record_ref():
-    ctx = LineageContext(op_kind="merge", actor="consolidator", source_ids=["UP-1"], reason="dup")
+    ctx = LineageContext(
+        op_kind="merge", actor="consolidator", source_ids=["UP-1"], reason="dup"
+    )
     assert ctx.request_id is None or isinstance(ctx.request_id, str)
     ref = RecordRef(id="UP-2", is_purged=False)
     assert ref.id == "UP-2" and ref.is_purged is False

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -78,7 +78,9 @@ def _patch_unified_search(
     # Prevent platform_llm_from_config from iterating MagicMock.values()
     mock_reflexio.request_context.configurator.get_config.return_value = None
 
-    with patch("reflexio.server.cache.reflexio_cache.get_reflexio", return_value=mock_reflexio):
+    with patch(
+        "reflexio.server.cache.reflexio_cache.get_reflexio", return_value=mock_reflexio
+    ):
         yield
 
 
@@ -263,7 +265,8 @@ def test_metering_failure_does_not_break_search_response() -> None:
         )
 
         with patch(
-            "reflexio.server.cache.reflexio_cache.get_reflexio", return_value=mock_reflexio_search
+            "reflexio.server.cache.reflexio_cache.get_reflexio",
+            return_value=mock_reflexio_search,
         ):
             resp = _client("production_agent").post(
                 "/api/search", json={"query": "x", "user_id": "u1"}
@@ -301,7 +304,9 @@ def _patch_service_method(method_name: str, response_attr: str, items: list):
     getattr(mock_reflexio, method_name).return_value = mock_response
     mock_reflexio.request_context.configurator.get_config.return_value = None
 
-    with patch("reflexio.server.cache.reflexio_cache.get_reflexio", return_value=mock_reflexio):
+    with patch(
+        "reflexio.server.cache.reflexio_cache.get_reflexio", return_value=mock_reflexio
+    ):
         yield
 
 

--- a/tests/server/api_endpoints/test_evaluations_regenerate_api.py
+++ b/tests/server/api_endpoints/test_evaluations_regenerate_api.py
@@ -51,7 +51,9 @@ def test_post_409_when_job_already_running(client_with_org_and_evaluator):
     # Patch the regen ThreadPoolExecutor's submit so the worker never starts
     # and the first job stays "running" — otherwise the empty-storage worker
     # would finish immediately and the second POST would succeed.
-    with patch("reflexio.server.routes.evaluation._regen_executor.submit", return_value=None):
+    with patch(
+        "reflexio.server.routes.evaluation._regen_executor.submit", return_value=None
+    ):
         first = client.post("/api/evaluations/regenerate", json=body)
         assert first.status_code == 200, first.text
         second = client.post("/api/evaluations/regenerate", json=body)
@@ -91,7 +93,9 @@ def test_delete_cancels_running_job(client_with_org_and_evaluator):
         "from_ts": 0,
         "to_ts": 9_999_999_999,
     }
-    with patch("reflexio.server.routes.evaluation._regen_executor.submit", return_value=None):
+    with patch(
+        "reflexio.server.routes.evaluation._regen_executor.submit", return_value=None
+    ):
         resp = client.post("/api/evaluations/regenerate", json=body)
         assert resp.status_code == 200, resp.text
         job_id = resp.json()["job_id"]

--- a/tests/server/api_endpoints/test_grade_on_demand_integration.py
+++ b/tests/server/api_endpoints/test_grade_on_demand_integration.py
@@ -180,7 +180,9 @@ def test_grade_on_demand_second_call_returns_cached(client_with_org):
     fake = _fake_runner_factory(
         storage, agent_version="v1", evaluation_name="overall_success"
     )
-    with patch("reflexio.server.routes.evaluation.run_group_evaluation", side_effect=fake) as runner:
+    with patch(
+        "reflexio.server.routes.evaluation.run_group_evaluation", side_effect=fake
+    ) as runner:
         first = client.post(
             "/api/evaluations/grade_on_demand",
             json={

--- a/tests/server/cache/test_reflexio_cache.py
+++ b/tests/server/cache/test_reflexio_cache.py
@@ -201,9 +201,7 @@ class TestGetReflexio:
             assert first.result(timeout=2) is constructed
             assert second.result(timeout=2) is constructed
 
-        mock_reflexio_cls.assert_called_once_with(
-            org_id="org-1", storage_base_dir=None
-        )
+        mock_reflexio_cls.assert_called_once_with(org_id="org-1", storage_base_dir=None)
 
 
 # =============================================================================

--- a/tests/server/llm/test_openclaw_provider.py
+++ b/tests/server/llm/test_openclaw_provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -147,15 +147,19 @@ class TestCallCli:
         monkeypatch.setenv(ocp.ENV_CLI_PATH, str(fake))
 
         proc = _fake_completed_process("", stderr="bad model", returncode=2)
-        with patch("subprocess.run", return_value=proc):
-            with pytest.raises(ocp.OpenClawCLIError, match="bad model"):
-                ocp._call_cli(prompt="p", model=None, timeout_s=10)
+        with (
+            patch("subprocess.run", return_value=proc),
+            pytest.raises(ocp.OpenClawCLIError, match="bad model"),
+        ):
+            ocp._call_cli(prompt="p", model=None, timeout_s=10)
 
     def test_raises_on_missing_cli(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv(ocp.ENV_CLI_PATH, raising=False)
-        with patch("shutil.which", return_value=None):
-            with pytest.raises(ocp.OpenClawCLIError, match="not found"):
-                ocp._call_cli(prompt="p", model=None, timeout_s=10)
+        with (
+            patch("shutil.which", return_value=None),
+            pytest.raises(ocp.OpenClawCLIError, match="not found"),
+        ):
+            ocp._call_cli(prompt="p", model=None, timeout_s=10)
 
     def test_raises_on_invalid_json(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path
@@ -166,9 +170,11 @@ class TestCallCli:
         monkeypatch.setenv(ocp.ENV_CLI_PATH, str(fake))
 
         proc = _fake_completed_process("not json")
-        with patch("subprocess.run", return_value=proc):
-            with pytest.raises(ocp.OpenClawCLIError, match="non-JSON"):
-                ocp._call_cli(prompt="p", model=None, timeout_s=10)
+        with (
+            patch("subprocess.run", return_value=proc),
+            pytest.raises(ocp.OpenClawCLIError, match="non-JSON"),
+        ):
+            ocp._call_cli(prompt="p", model=None, timeout_s=10)
 
     def test_raises_on_empty_completion(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path
@@ -179,9 +185,11 @@ class TestCallCli:
         monkeypatch.setenv(ocp.ENV_CLI_PATH, str(fake))
 
         proc = _fake_completed_process(json.dumps({"unrelated": "x"}))
-        with patch("subprocess.run", return_value=proc):
-            with pytest.raises(ocp.OpenClawCLIError, match="no completion text"):
-                ocp._call_cli(prompt="p", model=None, timeout_s=10)
+        with (
+            patch("subprocess.run", return_value=proc),
+            pytest.raises(ocp.OpenClawCLIError, match="no completion text"),
+        ):
+            ocp._call_cli(prompt="p", model=None, timeout_s=10)
 
 
 class TestRegisterIfEnabled:
@@ -189,9 +197,7 @@ class TestRegisterIfEnabled:
         monkeypatch.delenv(ocp.ENV_ENABLE, raising=False)
         assert ocp.register_if_enabled() is False
 
-    def test_skips_when_cli_missing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_skips_when_cli_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv(ocp.ENV_ENABLE, "1")
         monkeypatch.delenv(ocp.ENV_CLI_PATH, raising=False)
         with patch("shutil.which", return_value=None):
@@ -208,9 +214,7 @@ class TestRegisterIfEnabled:
         assert ocp.register_if_enabled() is True
         assert ocp._REGISTERED is True
 
-    def test_idempotent(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path
-    ) -> None:
+    def test_idempotent(self, monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
         fake = tmp_path / "openclaw"
         fake.write_text("#!/bin/sh")
         fake.chmod(0o755)

--- a/tests/server/llm/test_openclaw_provider_integration.py
+++ b/tests/server/llm/test_openclaw_provider_integration.py
@@ -25,7 +25,9 @@ def _fake_completed_process(stdout: str, *, stderr: str = "", returncode: int = 
     """Build a CompletedProcess look-alike for ``patch('subprocess.run')``."""
     from subprocess import CompletedProcess
 
-    return CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+    return CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -33,9 +35,7 @@ def _reset_provider_state(monkeypatch: pytest.MonkeyPatch):
     """Each test starts with the provider unregistered + a clean LiteLLM map."""
     monkeypatch.setattr(ocp, "_REGISTERED", False, raising=False)
     monkeypatch.setattr(ocp, "_HANDLER", None, raising=False)
-    monkeypatch.setattr(
-        litellm, "custom_provider_map", [], raising=False
-    )
+    monkeypatch.setattr(litellm, "custom_provider_map", [], raising=False)
     yield
 
 

--- a/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py
@@ -46,7 +46,9 @@ def _wait_until(assertion: Callable[[], None], timeout_s: float = 5.0) -> None:
 def _interaction_pair(label: str) -> list[InteractionData]:
     return [
         InteractionData(content=f"Please help with {label}", role="User"),
-        InteractionData(content=f"Resolved {label} with steps A and B.", role="Assistant"),
+        InteractionData(
+            content=f"Resolved {label} with steps A and B.", role="Assistant"
+        ),
     ]
 
 
@@ -91,7 +93,9 @@ def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
         self: AgentSuccessEvaluationService,
         request: AgentSuccessEvaluationRequest,
     ) -> None:
-        observed_request_model_counts.append(len(request.request_interaction_data_models))
+        observed_request_model_counts.append(
+            len(request.request_interaction_data_models)
+        )
         return original_run(self, request)
 
     monkeypatch.setattr(AgentSuccessEvaluationService, "run", recording_run)

--- a/tests/server/services/lineage/test_gc_scheduler_multitenant_integration.py
+++ b/tests/server/services/lineage/test_gc_scheduler_multitenant_integration.py
@@ -172,7 +172,9 @@ def test_provider_short_circuits_storage_list_org_ids(multitenant):
     # Make list_org_ids explode so any accidental use is caught.
     for storage in storages.values():
         storage.list_org_ids = MagicMock(  # type: ignore[method-assign]
-            side_effect=AssertionError("list_org_ids must not be called with a provider")
+            side_effect=AssertionError(
+                "list_org_ids must not be called with a provider"
+            )
         )
 
     sched = LineageGCScheduler(

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -110,7 +110,7 @@ def _publish_and_get_profile(reflexio: Reflexio) -> object:
     profiles = storage.get_user_profile(user_id)
     assert len(profiles) == 1, (
         "publish_interaction must produce exactly one profile via the real "
-        "calculate_expiration_timestamp path; got %d" % len(profiles)
+        f"calculate_expiration_timestamp path; got {len(profiles)}"
     )
     return profiles[0]
 

--- a/tests/server/services/lineage/test_reclamation_class_b_integration.py
+++ b/tests/server/services/lineage/test_reclamation_class_b_integration.py
@@ -50,7 +50,9 @@ def _make_ctx_factory(
     """Build (storage, factory) pair for the given flag combination."""
     storage = SQLiteStorage(org_id=_ORG_ID, db_path=str(tmp_path / "gc_b_test.db"))
     cfg = SimpleNamespace(
-        lineage_gc=LineageGCConfig(enabled=lineage_gc_enabled, tombstone_grace_window_days=1),
+        lineage_gc=LineageGCConfig(
+            enabled=lineage_gc_enabled, tombstone_grace_window_days=1
+        ),
         expiry_reclamation=ExpiryReclamationConfig(enabled=expiry_reclamation_enabled),
     )
 

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -1018,8 +1018,12 @@ def test_optimizer_passes_distinct_train_and_validation_sets_to_gepa(tmp_path):
 
 def test_sqlite_persists_source_mapping_and_winner_candidate(tmp_path):
     storage = _sqlite_storage(tmp_path)
-    storage.set_source_user_playbook_ids_for_agent_playbook(10, [2, 3, 2])
-    assert storage.get_source_user_playbook_ids_for_agent_playbook(10) == [2, 3]
+    up1 = UserPlaybook(user_id="u1", agent_version="v1", request_id="r-src-1")
+    up2 = UserPlaybook(user_id="u1", agent_version="v1", request_id="r-src-2")
+    storage.save_user_playbooks([up1, up2])
+    id1, id2 = up1.user_playbook_id, up2.user_playbook_id
+    storage.set_source_user_playbook_ids_for_agent_playbook(10, [id1, id2, id1])
+    assert storage.get_source_user_playbook_ids_for_agent_playbook(10) == [id1, id2]
 
     job = storage.create_playbook_optimization_job(
         PlaybookOptimizationJob(target_kind="agent_playbook", target_id=10)
@@ -1085,29 +1089,30 @@ def test_scenario_resolver_uses_snapshotted_source_windows_after_user_delete(tmp
     _seed_request_and_user_interaction(
         storage, interaction_id=101, request_id="r101", content="original ask"
     )
-    storage.save_user_playbooks(
-        [
-            UserPlaybook(
-                user_playbook_id=7,
-                user_id="u1",
-                agent_version="v1",
-                request_id="r101",
-                playbook_name="support",
-                content="source",
-                source_interaction_ids=[101],
-            )
-        ]
+    up = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="r101",
+        playbook_name="support",
+        content="source",
+        source_interaction_ids=[101],
     )
+    storage.save_user_playbooks([up])
+    actual_id = up.user_playbook_id
     storage.set_source_windows_for_agent_playbook(
         10,
-        [AgentPlaybookSourceWindow(user_playbook_id=7, source_interaction_ids=[101])],
+        [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=actual_id, source_interaction_ids=[101]
+            )
+        ],
     )
-    storage.delete_user_playbooks_by_ids([7])
+    storage.delete_user_playbooks_by_ids([actual_id])
 
     windows = ScenarioResolver(storage).for_agent_playbook(10)
 
     assert len(windows) == 1
-    assert windows[0].user_playbook_id == 7
+    assert windows[0].user_playbook_id == actual_id
     assert windows[0].source_interaction_ids == [101]
     assert [turn.content for turn in windows[0].user_turns] == ["original ask"]
 
@@ -1143,6 +1148,9 @@ def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
     _seed_request_and_user_interaction(
         storage, interaction_id=201, request_id="r201", content="validate"
     )
+    seed_up = UserPlaybook(user_id="u1", agent_version="v1", request_id="r-seed")
+    storage.save_user_playbooks([seed_up])
+    seed_up_id = seed_up.user_playbook_id
     [agent_playbook] = storage.save_agent_playbooks(
         [
             AgentPlaybook(
@@ -1155,7 +1163,11 @@ def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
     )
     storage.set_source_windows_for_agent_playbook(
         agent_playbook.agent_playbook_id,
-        [AgentPlaybookSourceWindow(user_playbook_id=12, source_interaction_ids=[201])],
+        [
+            AgentPlaybookSourceWindow(
+                user_playbook_id=seed_up_id, source_interaction_ids=[201]
+            )
+        ],
     )
     config = Config(
         storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
@@ -1170,7 +1182,7 @@ def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
     )
     optimizer = _optimizer_for_test(storage, config)
     optimizer._resolve_windows = Mock(  # type: ignore[method-assign]
-        return_value=[_scenario_window(12)]
+        return_value=[_scenario_window(seed_up_id)]
     )
 
     def fake_run_gepa(config, seed_content, train_windows, validation_windows, adapter):  # noqa: ARG001
@@ -1181,8 +1193,8 @@ def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
                 candidate_id=candidate.candidate_id,
                 target_kind="agent_playbook",
                 target_id=agent_playbook.agent_playbook_id,
-                scenario_user_playbook_id=12,
-                source_interaction_ids=[120],
+                scenario_user_playbook_id=seed_up_id,
+                source_interaction_ids=[seed_up_id * 10],
                 score=0.9,
                 verdict="candidate",
                 likert=5,
@@ -1211,7 +1223,11 @@ def test_optimizer_successor_preserves_source_window_snapshots(tmp_path):
     assert len(successors) == 1
     assert storage.get_source_windows_for_agent_playbook(
         successors[0].agent_playbook_id
-    ) == [AgentPlaybookSourceWindow(user_playbook_id=12, source_interaction_ids=[201])]
+    ) == [
+        AgentPlaybookSourceWindow(
+            user_playbook_id=seed_up_id, source_interaction_ids=[201]
+        )
+    ]
 
 
 def test_commit_thresholds_only_count_winner_candidate(tmp_path):

--- a/tests/server/services/profile/test_dedup_always_soft_integration.py
+++ b/tests/server/services/profile/test_dedup_always_soft_integration.py
@@ -47,9 +47,7 @@ _DEDUP_FLAG = "reflexio.server.site_var.feature_flags.is_deduplicator_enabled"
 _DEDUP_CLS = (
     "reflexio.server.services.profile.components.consolidator.ProfileConsolidator"
 )
-_CAPTURE_ANOMALY = (
-    "reflexio.server.services.profile.service.capture_anomaly"
-)
+_CAPTURE_ANOMALY = "reflexio.server.services.profile.service.capture_anomaly"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/profile/test_profile_module_contract.py
+++ b/tests/server/services/profile/test_profile_module_contract.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 _PROFILE_DIR = (
-    Path(__file__).resolve().parents[4]
-    / "reflexio"
-    / "server"
-    / "services"
-    / "profile"
+    Path(__file__).resolve().parents[4] / "reflexio" / "server" / "services" / "profile"
 )
 _REMOVED_FILES = {"profile_generation_service.py", "profile_extractor.py"}
 

--- a/tests/server/services/storage/sqlite_storage/test_agent_run_characterization.py
+++ b/tests/server/services/storage/sqlite_storage/test_agent_run_characterization.py
@@ -124,7 +124,9 @@ def test_create_or_attach_creates_when_no_active_call(storage):
 
     result = storage.create_or_attach_pending_tool_call(
         record=_pending("ptc_1", now=now),
-        dependency=RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1"),
+        dependency=RunToolDependencyRecord(
+            run_id="run_1", pending_tool_call_id="ptc_1"
+        ),
         now=now,
     )
 
@@ -147,12 +149,16 @@ def test_create_or_attach_attaches_to_existing_active_call(storage):
 
     first = storage.create_or_attach_pending_tool_call(
         record=_pending("ptc_1", now=now),
-        dependency=RunToolDependencyRecord(run_id="run_1", pending_tool_call_id="ptc_1"),
+        dependency=RunToolDependencyRecord(
+            run_id="run_1", pending_tool_call_id="ptc_1"
+        ),
         now=now,
     )
     second = storage.create_or_attach_pending_tool_call(
         record=_pending("ptc_2", now=now),
-        dependency=RunToolDependencyRecord(run_id="run_2", pending_tool_call_id="ptc_2"),
+        dependency=RunToolDependencyRecord(
+            run_id="run_2", pending_tool_call_id="ptc_2"
+        ),
         now=now,
     )
 
@@ -162,9 +168,9 @@ def test_create_or_attach_attaches_to_existing_active_call(storage):
     assert second.pending_tool_call.id == "ptc_1"
     assert storage.get_pending_tool_call("ptc_2") is None
     # run_2's dependency points at the existing call (ptc_1), not ptc_2.
-    assert [d.pending_tool_call_id for d in storage.list_run_tool_dependencies("run_2")] == [
-        "ptc_1"
-    ]
+    assert [
+        d.pending_tool_call_id for d in storage.list_run_tool_dependencies("run_2")
+    ] == ["ptc_1"]
 
 
 def test_create_or_attach_is_idempotent_on_repeat(storage):
@@ -334,7 +340,9 @@ def test_consume_run_tool_dependencies_guards_and_double_consume(storage):
 
     assert first == 1
     assert second == 0
-    deps = {d.pending_tool_call_id: d for d in storage.list_run_tool_dependencies("run_1")}
+    deps = {
+        d.pending_tool_call_id: d for d in storage.list_run_tool_dependencies("run_1")
+    }
     assert deps["ptc_resolved"].consumed_at is not None
     assert deps["ptc_unresolved"].consumed_at is None
 
@@ -396,7 +404,9 @@ def test_delete_expired_pending_tool_calls_only_deletes_expired_past_grace(stora
         )
     )
 
-    deleted = storage.delete_expired_pending_tool_calls(now=now_epoch, grace_seconds=grace)
+    deleted = storage.delete_expired_pending_tool_calls(
+        now=now_epoch, grace_seconds=grace
+    )
 
     assert deleted == 1
     assert storage.get_pending_tool_call("expired_old") is None
@@ -489,7 +499,9 @@ def test_count_unresolved_followup_dependencies_joins_three_tables(storage):
     )
 
     # Excluded: dependency already resolved.
-    storage.create_pending_tool_call(_pending("ptc_resolved_dep", now=now, question="q3"))
+    storage.create_pending_tool_call(
+        _pending("ptc_resolved_dep", now=now, question="q3")
+    )
     storage.attach_run_tool_dependency(
         RunToolDependencyRecord(
             run_id="run_1", pending_tool_call_id="ptc_resolved_dep", resolved_at=now
@@ -509,7 +521,9 @@ def test_count_unresolved_followup_dependencies_joins_three_tables(storage):
         )
     )
     storage.attach_run_tool_dependency(
-        RunToolDependencyRecord(run_id="run_2", pending_tool_call_id="ptc_call_resolved")
+        RunToolDependencyRecord(
+            run_id="run_2", pending_tool_call_id="ptc_call_resolved"
+        )
     )
 
     # Excluded: run of a different extractor_kind.
@@ -560,7 +574,9 @@ def test_list_pending_tool_calls_filters_clamps_and_orders(storage):
 
     all_calls = storage.list_pending_tool_calls()
     pending_only = storage.list_pending_tool_calls(status=PendingToolCallStatus.PENDING)
-    resolved_only = storage.list_pending_tool_calls(status=PendingToolCallStatus.RESOLVED)
+    resolved_only = storage.list_pending_tool_calls(
+        status=PendingToolCallStatus.RESOLVED
+    )
     clamped_low = storage.list_pending_tool_calls(limit=0)
     clamped_high = storage.list_pending_tool_calls(limit=100_000)
 
@@ -608,7 +624,9 @@ def test_claim_ready_agent_run_resuming_status_guard_is_compare_and_set(storage)
 
     first = storage.claim_ready_agent_run(org_id="org_1", worker_id="worker_1", now=now)
     # Second claim WITHOUT consuming: the only thing blocking it is the status.
-    second = storage.claim_ready_agent_run(org_id="org_1", worker_id="worker_2", now=now)
+    second = storage.claim_ready_agent_run(
+        org_id="org_1", worker_id="worker_2", now=now
+    )
     # Once the RESUMING claim is stale (past the TTL) it is re-claimable.
     stale_now = now + timedelta(seconds=700)
     third = storage.claim_ready_agent_run(

--- a/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_pending_tool_call_expiry_integration.py
@@ -75,7 +75,9 @@ def test_delete_expired_pending_tool_calls_spares_resolved(tmp_path):
         call_id="b",
         status="resolved",
         valid_until=(now + timedelta(days=5)).isoformat(),
-        expires_at=(now - timedelta(days=2)).isoformat(),  # past expires_at but RESOLVED
+        expires_at=(
+            now - timedelta(days=2)
+        ).isoformat(),  # past expires_at but RESOLVED
     )
     deleted = s.delete_expired_pending_tool_calls(
         now=int(now.timestamp()), grace_seconds=86400

--- a/tests/server/services/storage/sqlite_storage/test_playbook_optimization_candidate_metadata_migration.py
+++ b/tests/server/services/storage/sqlite_storage/test_playbook_optimization_candidate_metadata_migration.py
@@ -40,7 +40,9 @@ def _candidate_columns(db_path: str) -> set[str]:
         conn.close()
 
 
-def test_migration_adds_candidate_metadata_column_and_persists_metadata(tmp_path) -> None:
+def test_migration_adds_candidate_metadata_column_and_persists_metadata(
+    tmp_path,
+) -> None:
     db_path = str(tmp_path / "legacy.db")
     conn = sqlite3.connect(db_path)
     conn.executescript(_LEGACY_CANDIDATE_DDL)

--- a/tests/server/services/storage/sqlite_storage/test_share_link_expiry_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_share_link_expiry_integration.py
@@ -21,17 +21,21 @@ def _link(n: int, expires_at: int | None) -> dict:
 
 def test_delete_expired_share_links(tmp_path):
     s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
-    s.create_share_link(**_link(1, expires_at=1))        # long expired
-    s.create_share_link(**_link(2, expires_at=10_000))   # fresh
-    s.create_share_link(**_link(3, expires_at=None))     # never expires
+    s.create_share_link(**_link(1, expires_at=1))  # long expired
+    s.create_share_link(**_link(2, expires_at=10_000))  # fresh
+    s.create_share_link(**_link(3, expires_at=None))  # never expires
     assert s.delete_expired_share_links(now=1000, grace_seconds=0) == 1
     assert {lnk.id for lnk in s.get_share_links()} == {2, 3}
 
 
 def test_delete_expired_share_links_respects_grace(tmp_path):
     s = SQLiteStorage(db_path=str(tmp_path / "t.db"), org_id="org_test")
-    s.create_share_link(**_link(1, expires_at=900))   # expired_at=900, now=1000, grace=200 → cutoff=800 → not past grace
-    s.create_share_link(**_link(2, expires_at=700))   # expired_at=700, cutoff=800 → past grace, deleted
+    s.create_share_link(
+        **_link(1, expires_at=900)
+    )  # expired_at=900, now=1000, grace=200 → cutoff=800 → not past grace
+    s.create_share_link(
+        **_link(2, expires_at=700)
+    )  # expired_at=700, cutoff=800 → past grace, deleted
     assert s.delete_expired_share_links(now=1000, grace_seconds=200) == 1
     remaining = {lnk.id for lnk in s.get_share_links()}
     assert len(remaining) == 1  # only expires_at=900 row survives

--- a/tests/server/services/storage/test_hard_delete_events_integration.py
+++ b/tests/server/services/storage/test_hard_delete_events_integration.py
@@ -1,6 +1,7 @@
 import pytest
-from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
 from reflexio.models.api_schema.domain.entities import UserPlaybook
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
 
@@ -11,6 +12,8 @@ def test_hard_delete_emits_event_then_removes_row(tmp_path):
     pb = UserPlaybook(user_id="u", agent_version="v", request_id="r", content="c")
     s.save_user_playbooks([pb])
     s.delete_user_playbooks_by_ids([pb.user_playbook_id])
-    assert s.get_user_playbook_by_id(pb.user_playbook_id, include_tombstones=True) is None
+    assert (
+        s.get_user_playbook_by_id(pb.user_playbook_id, include_tombstones=True) is None
+    )
     events = s.get_lineage_events(entity_id=str(pb.user_playbook_id))
     assert any(e.op == "hard_delete" for e in events)

--- a/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
+++ b/tests/server/services/storage/test_lineage_b1_statuschange_integration.py
@@ -555,7 +555,9 @@ def test_update_all_profiles_status_structured_fields(tmp_path):
     s.add_user_profile("u1", [profile])
     s.update_all_profiles_status(old_status=None, new_status=Status.ARCHIVED)
     evts = [
-        e for e in s.get_lineage_events(entity_id="struct_p1") if e.op == "status_change"
+        e
+        for e in s.get_lineage_events(entity_id="struct_p1")
+        if e.op == "status_change"
     ]
     assert len(evts) == 1
     assert evts[0].from_status is None
@@ -570,7 +572,9 @@ def test_archive_profile_by_id_structured_fields(tmp_path):
     s.add_user_profile("u1", [profile])
     s.archive_profile_by_id("u1", "struct_p2")
     evts = [
-        e for e in s.get_lineage_events(entity_id="struct_p2") if e.op == "status_change"
+        e
+        for e in s.get_lineage_events(entity_id="struct_p2")
+        if e.op == "status_change"
     ]
     assert len(evts) == 1
     assert evts[0].from_status is None

--- a/tests/server/services/storage/test_lineage_b3b_reconstruct_playbook_changelog_integration.py
+++ b/tests/server/services/storage/test_lineage_b3b_reconstruct_playbook_changelog_integration.py
@@ -335,7 +335,9 @@ def test_added_then_superseded_still_in_added(tmp_path):
     s = _store(tmp_path)
 
     # Run 1 adds playbook X.
-    pb_x = _make_playbook(playbook_name="pb", agent_version="v1", content="X added in run1")
+    pb_x = _make_playbook(
+        playbook_name="pb", agent_version="v1", content="X added in run1"
+    )
     x_id = _add_playbook(s, pb_x)
     _emit_aggregate_event(s, entity_id=str(x_id), request_id="run-1")
 
@@ -453,9 +455,7 @@ def test_limit_applies_to_post_filter_set(tmp_path):
     )
     # Most-recent-first: the two newest fb_A runs, oldest dropped, fb_B excluded.
     contents = [
-        snap.content
-        for log in result.change_logs
-        for snap in log.added_agent_playbooks
+        snap.content for log in result.change_logs for snap in log.added_agent_playbooks
     ]
     assert contents == ["A newest", "A middle"], contents
     assert all(log.playbook_name == "fb_A" for log in result.change_logs)

--- a/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
+++ b/tests/server/services/storage/test_shadow_verdicts_contract_integration.py
@@ -194,18 +194,24 @@ def test_base_recent_verdicts_nonpositive_limit_skips_window_read() -> None:
 
     storage = GuardedShadowStorage()
 
-    assert storage.get_recent_shadow_comparison_verdicts(
-        from_ts=0,
-        to_ts=1,
-        judge_prompt_version="v1.0.0",
-        limit=0,
-    ) == []
-    assert storage.get_recent_shadow_comparison_verdicts(
-        from_ts=0,
-        to_ts=1,
-        judge_prompt_version="v1.0.0",
-        limit=-1,
-    ) == []
+    assert (
+        storage.get_recent_shadow_comparison_verdicts(
+            from_ts=0,
+            to_ts=1,
+            judge_prompt_version="v1.0.0",
+            limit=0,
+        )
+        == []
+    )
+    assert (
+        storage.get_recent_shadow_comparison_verdicts(
+            from_ts=0,
+            to_ts=1,
+            judge_prompt_version="v1.0.0",
+            limit=-1,
+        )
+        == []
+    )
 
 
 def test_delete_by_session_returns_count(storage: BaseStorage) -> None:

--- a/tests/server/services/storage/test_sqlite_lineage_columns_integration.py
+++ b/tests/server/services/storage/test_sqlite_lineage_columns_integration.py
@@ -17,8 +17,14 @@ pytestmark = pytest.mark.integration
 def test_user_playbook_pointers_roundtrip(tmp_path):
     s = SQLiteStorage(org_id="test-org", db_path=str(tmp_path / "t.db"))
     s.migrate()
-    pb = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1",
-                      content="c", merged_into=42, superseded_by=None)
+    pb = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="r1",
+        content="c",
+        merged_into=42,
+        superseded_by=None,
+    )
     s.save_user_playbooks([pb])
     got = s.get_user_playbook_by_id(pb.user_playbook_id)
     assert got is not None and got.merged_into == 42 and got.superseded_by is None

--- a/tests/server/services/storage/test_sqlite_merge_records_integration.py
+++ b/tests/server/services/storage/test_sqlite_merge_records_integration.py
@@ -10,15 +10,28 @@ pytestmark = pytest.mark.integration
 def test_merge_records_tombstones_sources_sets_pointer_and_logs(tmp_path):
     s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
     s.migrate()
-    survivor = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="merged")
+    survivor = UserPlaybook(
+        user_id="u1", agent_version="v1", request_id="r1", content="merged"
+    )
     src = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="old")
     s.save_user_playbooks([survivor, src])
-    ctx = LineageContext(op_kind="merge", actor="consolidator", source_ids=[str(src.user_playbook_id)],
-                         reason="dup", request_id="r1")
-    s.merge_records(entity_type="user_playbook", survivor_id=str(survivor.user_playbook_id),
-                    source_ids=[str(src.user_playbook_id)], context=ctx)
+    ctx = LineageContext(
+        op_kind="merge",
+        actor="consolidator",
+        source_ids=[str(src.user_playbook_id)],
+        reason="dup",
+        request_id="r1",
+    )
+    s.merge_records(
+        entity_type="user_playbook",
+        survivor_id=str(survivor.user_playbook_id),
+        source_ids=[str(src.user_playbook_id)],
+        context=ctx,
+    )
     tomb = s.get_user_playbook_by_id(src.user_playbook_id, include_tombstones=True)
-    assert tomb.status is Status.MERGED and tomb.merged_into == survivor.user_playbook_id
+    assert (
+        tomb.status is Status.MERGED and tomb.merged_into == survivor.user_playbook_id
+    )
     events = s.get_lineage_events(entity_id=str(survivor.user_playbook_id))
     assert any(e.op == "merge" for e in events)
     # survivor still current
@@ -28,11 +41,20 @@ def test_merge_records_tombstones_sources_sets_pointer_and_logs(tmp_path):
 def test_supersede_returns_false_when_incumbent_not_current(tmp_path):
     s = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "t.db"))
     s.migrate()
-    inc = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="v1",
-                       status=Status.ARCHIVED)
+    inc = UserPlaybook(
+        user_id="u1",
+        agent_version="v1",
+        request_id="r1",
+        content="v1",
+        status=Status.ARCHIVED,
+    )
     succ = UserPlaybook(user_id="u1", agent_version="v1", request_id="r1", content="v2")
     s.save_user_playbooks([inc, succ])
     ctx = LineageContext(op_kind="revise", actor="optimizer", request_id="r1")
-    ok = s.supersede_record(entity_type="user_playbook", incumbent_id=str(inc.user_playbook_id),
-                            successor_id=str(succ.user_playbook_id), context=ctx)
+    ok = s.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(inc.user_playbook_id),
+        successor_id=str(succ.user_playbook_id),
+        context=ctx,
+    )
     assert ok is False  # incumbent wasn't CURRENT — atomic guard rejects

--- a/tests/server/services/storage/test_sqlite_share_links.py
+++ b/tests/server/services/storage/test_sqlite_share_links.py
@@ -141,8 +141,11 @@ class TestDeleteExpiredShareLinks:
         grace = 7 * 86400
         # Expired beyond grace
         storage.create_share_link(
-            token="shr_old", resource_type="profile", resource_id="p1",
-            expires_at=1, created_by_email=None,
+            token="shr_old",
+            resource_type="profile",
+            resource_id="p1",
+            expires_at=1,
+            created_by_email=None,
         )
         count = storage.delete_expired_share_links(now=now, grace_seconds=grace)
         assert count == 1
@@ -154,8 +157,11 @@ class TestDeleteExpiredShareLinks:
         grace = 7 * 86400
         # Expired just 1 second ago (within 7-day grace)
         storage.create_share_link(
-            token="shr_recent", resource_type="profile", resource_id="p2",
-            expires_at=now - 1, created_by_email=None,
+            token="shr_recent",
+            resource_type="profile",
+            resource_id="p2",
+            expires_at=now - 1,
+            created_by_email=None,
         )
         count = storage.delete_expired_share_links(now=now, grace_seconds=grace)
         assert count == 0
@@ -164,8 +170,11 @@ class TestDeleteExpiredShareLinks:
     def test_preserves_link_without_expires_at(self, storage):
         """Links with expires_at=None (never-expire) must never be deleted."""
         storage.create_share_link(
-            token="shr_noexp", resource_type="profile", resource_id="p3",
-            expires_at=None, created_by_email=None,
+            token="shr_noexp",
+            resource_type="profile",
+            resource_id="p3",
+            expires_at=None,
+            created_by_email=None,
         )
         count = storage.delete_expired_share_links(now=2_000_000_000, grace_seconds=0)
         assert count == 0
@@ -176,8 +185,11 @@ class TestDeleteExpiredShareLinks:
         now = 2_000_000_000
         for i in range(5):
             storage.create_share_link(
-                token=f"shr_exp_{i}", resource_type="profile", resource_id=f"p{i}",
-                expires_at=1, created_by_email=None,
+                token=f"shr_exp_{i}",
+                resource_type="profile",
+                resource_id=f"p{i}",
+                expires_at=1,
+                created_by_email=None,
             )
         count = storage.delete_expired_share_links(now=now, grace_seconds=0, limit=3)
         assert count == 3

--- a/tests/server/services/tagging/test_module_contract.py
+++ b/tests/server/services/tagging/test_module_contract.py
@@ -20,4 +20,4 @@ def test_legacy_tagging_module_file_removed() -> None:
     repo_root = Path(__file__).resolve().parents[4]
     tagging_dir = repo_root / "reflexio/server/services/tagging"
 
-    assert not (tagging_dir / ("tagging_" "service.py")).exists()
+    assert not (tagging_dir / ("tagging_service.py")).exists()

--- a/tests/server/services/test_profile_source_filtering.py
+++ b/tests/server/services/test_profile_source_filtering.py
@@ -108,7 +108,9 @@ def test_profile_extractor_filters_by_source_api(mock_chat_completion):
         )
         _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
+            _storage(profile_generation_service).add_user_interaction(
+                user_id, interaction_obj
+            )
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -174,7 +176,9 @@ def test_profile_extractor_filters_by_source_webhook(mock_chat_completion):
         )
         _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
+            _storage(profile_generation_service).add_user_interaction(
+                user_id, interaction_obj
+            )
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -240,7 +244,9 @@ def test_profile_extractor_none_enables_all_sources(mock_chat_completion):
         )
         _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
+            _storage(profile_generation_service).add_user_interaction(
+                user_id, interaction_obj
+            )
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,
@@ -306,7 +312,9 @@ def test_profile_extractor_empty_list_enables_all_sources(mock_chat_completion):
         )
         _storage(profile_generation_service).add_request(request_obj)
         for interaction_obj in interactions:
-            _storage(profile_generation_service).add_user_interaction(user_id, interaction_obj)
+            _storage(profile_generation_service).add_user_interaction(
+                user_id, interaction_obj
+            )
 
         profile_generation_request = ProfileGenerationRequest(
             user_id=user_id,

--- a/tests/server/test_billing_meter.py
+++ b/tests/server/test_billing_meter.py
@@ -12,14 +12,19 @@ HOOK = "reflexio.server.billing_meter.record_usage_event"
 def test_record_extraction_tokens_emits_event_when_platform_llm():
     with patch(HOOK) as hook:
         record_extraction_tokens(
-            org_id="org1", billing_input_tokens=1100, prompt_tokens=1200,
-            completion_tokens=300, platform_llm=True, platform_storage=None, pipeline="profile",
+            org_id="org1",
+            billing_input_tokens=1100,
+            prompt_tokens=1200,
+            completion_tokens=300,
+            platform_llm=True,
+            platform_storage=None,
+            pipeline="profile",
         )
     hook.assert_called_once()
     kwargs = hook.call_args.kwargs
     assert kwargs["event_name"] == "extraction_tokens"
     assert kwargs["event_category"] == "learning"
-    assert kwargs["count_value"] == 1100   # billing_input_tokens is the metered count
+    assert kwargs["count_value"] == 1100  # billing_input_tokens is the metered count
     assert kwargs["prompt_tokens"] == 1200
     assert kwargs["platform_llm"] is True
     assert kwargs["caller_type"] == "internal"
@@ -29,8 +34,12 @@ def test_record_extraction_tokens_still_captures_on_byo_llm():
     # Even on BYO-LLM we capture (platform_llm=False); the rating layer drops the charge.
     with patch(HOOK) as hook:
         record_extraction_tokens(
-            org_id="org1", billing_input_tokens=850, prompt_tokens=900,
-            completion_tokens=100, platform_llm=False, platform_storage=None,
+            org_id="org1",
+            billing_input_tokens=850,
+            prompt_tokens=900,
+            completion_tokens=100,
+            platform_llm=False,
+            platform_storage=None,
         )
     hook.assert_called_once()
     assert hook.call_args.kwargs["platform_llm"] is False
@@ -40,23 +49,38 @@ def test_record_extraction_tokens_noop_on_negative():
     # Negative billing_input_tokens (e.g. from a corrupt trace) must not emit an event.
     with patch(HOOK) as hook:
         record_extraction_tokens(
-            org_id="org1", billing_input_tokens=-1, prompt_tokens=0,
-            completion_tokens=0, platform_llm=True, platform_storage=None,
+            org_id="org1",
+            billing_input_tokens=-1,
+            prompt_tokens=0,
+            completion_tokens=0,
+            platform_llm=True,
+            platform_storage=None,
         )
     hook.assert_not_called()
 
 
 def test_record_extraction_tokens_noop_when_zero_input():
     with patch(HOOK) as hook:
-        record_extraction_tokens(org_id="org1", billing_input_tokens=0, prompt_tokens=0,
-                                 completion_tokens=0, platform_llm=True, platform_storage=None)
+        record_extraction_tokens(
+            org_id="org1",
+            billing_input_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
+            platform_llm=True,
+            platform_storage=None,
+        )
     hook.assert_not_called()
 
 
 def test_record_learnings_generated_uses_count_value():
     with patch(HOOK) as hook:
-        record_learnings_generated(org_id="org1", count=3, platform_llm=True,
-                                   platform_storage=None, pipeline="playbook")
+        record_learnings_generated(
+            org_id="org1",
+            count=3,
+            platform_llm=True,
+            platform_storage=None,
+            pipeline="playbook",
+        )
     kwargs = hook.call_args.kwargs
     assert kwargs["event_name"] == "learnings_generated"
     assert kwargs["event_category"] == "learning"
@@ -65,14 +89,21 @@ def test_record_learnings_generated_uses_count_value():
 
 def test_record_learnings_generated_noop_for_zero():
     with patch(HOOK) as hook:
-        record_learnings_generated(org_id="org1", count=0, platform_llm=True, platform_storage=None)
+        record_learnings_generated(
+            org_id="org1", count=0, platform_llm=True, platform_storage=None
+        )
     hook.assert_not_called()
 
 
 def test_record_applied_learnings_billable_only_for_production_agent():
     with patch(HOOK) as hook:
-        record_applied_learnings(org_id="org1", surfaced_count=4,
-                                 caller_type="production_agent", platform_llm=True, platform_storage=None)
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=4,
+            caller_type="production_agent",
+            platform_llm=True,
+            platform_storage=None,
+        )
     assert hook.call_count == 1
     assert hook.call_args.kwargs["count_value"] == 4
     assert hook.call_args.kwargs["caller_type"] == "production_agent"
@@ -80,13 +111,23 @@ def test_record_applied_learnings_billable_only_for_production_agent():
 
 def test_record_applied_learnings_noop_for_dashboard():
     with patch(HOOK) as hook:
-        record_applied_learnings(org_id="org1", surfaced_count=4,
-                                 caller_type="dashboard", platform_llm=True, platform_storage=None)
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=4,
+            caller_type="dashboard",
+            platform_llm=True,
+            platform_storage=None,
+        )
     hook.assert_not_called()
 
 
 def test_record_applied_learnings_noop_for_empty_result():
     with patch(HOOK) as hook:
-        record_applied_learnings(org_id="org1", surfaced_count=0,
-                                 caller_type="production_agent", platform_llm=True, platform_storage=None)
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=0,
+            caller_type="production_agent",
+            platform_llm=True,
+            platform_storage=None,
+        )
     hook.assert_not_called()

--- a/tests/server/test_logging_timezone.py
+++ b/tests/server/test_logging_timezone.py
@@ -91,9 +91,7 @@ class TestConsoleDebugPolicy:
 
         assert _debug_log_to_console_enabled() is False
 
-    def test_sentry_environment_does_not_define_production(
-        self, monkeypatch
-    ) -> None:
+    def test_sentry_environment_does_not_define_production(self, monkeypatch) -> None:
         monkeypatch.delenv("ENVIRONMENT", raising=False)
         monkeypatch.setenv("SENTRY_ENVIRONMENT", "production")
         monkeypatch.setenv("DEBUG_LOG_TO_CONSOLE", "true")


### PR DESCRIPTION
## Update test fixtures for hardened validators + storage decomposition (found by the test-skill audit)

A live audit run surfaced test-vs-code drift where fixtures weren't updated after model/validation refactors. All are test/fixture fixes (+ lint/format); no product-logic change.

- **Consolidation eval (21 failing tests)** — builder helpers + fixtures defaulted `new_id='n1'`, which the `_coerce_new_id` `NEW-N` validator now rejects. Updated to `NEW-1`/`NEW-N` (helpers, `_case()`, `illustrative_cases.json`, `test_real_judge_smoke`).
- **Playbook optimizer (3 failing tests)** — `set_source_windows_for_agent_playbook` gained a governance existence-check; tests now create the `UserPlaybook` rows first.
- **Benchmark** — `test_retrieval_latency_smoke` needs real embeddings; added `@skip_low_priority` so it isn't run in the standard tier.
- **Lint** — `# noqa: S101` on a pyright-invariant assert; SIM117/UP031 cleanups; `ruff format` normalization.

### Test plan
- `uv run pytest tests/eval/consolidation/test_consolidation_eval.py tests/server/services/playbook_optimizer/test_playbook_optimizer.py -o 'addopts='` → 57 passed, 2 skipped.
- `ruff check` + `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing event coverage by adding a negative check to ensure no event is recorded when nothing is surfaced.
  * Adjusted one benchmark smoke test to skip in more low-priority scenarios.

* **Tests**
  * Updated several test cases and fixtures to use new identifier values and dynamic IDs.
  * Refined multiple assertions and mock setups for clearer, more consistent test behavior.

* **Style**
  * Cleaned up formatting across code and tests for readability, with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->