### PR TITLE
fix: retry MiniLM embed after clearing corrupt cache

### DIFF
--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -79,8 +79,8 @@ When `REFLEXIO_EMBEDDING_PROVIDER=local_service` or
 requests allow extra time for model cold start; override with
 `REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS` when needed.
 MiniLM cache corruption is retried once automatically. If recovery still fails,
-delete the cache directory named in the error message and restart Reflexio, or
-switch to a cloud embedding provider.
+delete the cache directory named in the error message, restart Reflexio, and
+retry local embedding.
 
 ## Publishing interactions
 

--- a/reflexio/cli/README.md
+++ b/reflexio/cli/README.md
@@ -78,6 +78,9 @@ When `REFLEXIO_EMBEDDING_PROVIDER=local_service` or
 `local/nomic-embed-text-v1.5`, and `local/minilm-l6-v2`. Local embedding
 requests allow extra time for model cold start; override with
 `REFLEXIO_EMBEDDING_SERVICE_TIMEOUT_MS` when needed.
+MiniLM cache corruption is retried once automatically. If recovery still fails,
+delete the cache directory named in the error message and restart Reflexio, or
+switch to a cloud embedding provider.
 
 ## Publishing interactions
 

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -126,7 +126,7 @@ class LocalEmbedder:
         safe_inputs = [(text or "")[:_MAX_CHARS] for text in texts]
         try:
             raw = ef(safe_inputs)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - Chroma raises varied cache errors.
             raw = self._retry_embed_after_cache_clear(ef, exc, safe_inputs)
         return [_pad(vec) for vec in raw]
 
@@ -288,8 +288,10 @@ def _minilm_cache_complete(embedding_cls: Any, cache_path: Path) -> bool:
 
 def _exception_chain(exc: Exception) -> list[BaseException]:
     chain: list[BaseException] = []
+    seen: set[int] = set()
     current: BaseException | None = exc
-    while current is not None:
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
         chain.append(current)
         current = current.__cause__ or current.__context__
     return chain

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -168,8 +168,7 @@ class LocalEmbedder:
                     raise LocalEmbedderError(
                         "Local MiniLM cache recovery failed after "
                         f"{recovery_action} {cache_path}. Delete this cache "
-                        "directory and restart Reflexio, or configure a cloud "
-                        "embedding provider."
+                        "directory, restart Reflexio, and retry local embedding."
                     ) from retry_exc
 
 

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -21,8 +21,20 @@ import os
 import shutil
 import tarfile
 import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows only
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - POSIX only
+    msvcrt = None  # type: ignore[assignment]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,6 +51,8 @@ _TARGET_DIM = 512
 # ValueError that ONNXMiniLM_L6_V2 throws on over-length input.
 _MAX_CHARS = 800
 
+# Chroma keeps this file list private inside ONNXMiniLM_L6_V2's download helper.
+# Keep this in sync with chromadb's all-MiniLM-L6-v2 extracted archive layout.
 _MINILM_EXPECTED_FILES = (
     "config.json",
     "model.onnx",
@@ -124,18 +138,37 @@ class LocalEmbedder:
                 return self._ef(safe_inputs)
 
             embedding_cls = type(failed_ef)
-            cache_path = _clear_minilm_cache(embedding_cls, exc)
+            cache_path = _recoverable_minilm_cache_path(embedding_cls, exc)
             if cache_path is None:
                 raise exc
 
-            _LOGGER.warning(
-                "Failed to use local MiniLM embedder; cleared cache %s and retrying once",
-                cache_path,
-                exc_info=True,
-            )
-            fresh_ef = embedding_cls()
-            self._ef = fresh_ef
-            return fresh_ef(safe_inputs)
+            with _exclusive_file_lock(_minilm_cache_lock_path(cache_path)):
+                if _should_clear_minilm_cache(embedding_cls, cache_path, exc):
+                    shutil.rmtree(cache_path, ignore_errors=True)
+                    recovery_action = "clearing"
+                    _LOGGER.warning(
+                        "Failed to use local MiniLM embedder; cleared cache %s "
+                        "and retrying once",
+                        cache_path,
+                        exc_info=True,
+                    )
+                else:
+                    recovery_action = "waiting for another process to refresh"
+                    _LOGGER.info(
+                        "MiniLM cache %s was refreshed by another process; retrying",
+                        cache_path,
+                    )
+                try:
+                    fresh_ef = embedding_cls()
+                    self._ef = fresh_ef
+                    return fresh_ef(safe_inputs)
+                except Exception as retry_exc:
+                    raise LocalEmbedderError(
+                        "Local MiniLM cache recovery failed after "
+                        f"{recovery_action} {cache_path}. Delete this cache "
+                        "directory and restart Reflexio, or configure a cloud "
+                        "embedding provider."
+                    ) from retry_exc
 
 
 def _pad(vec: Any) -> list[float]:
@@ -149,14 +182,13 @@ def _pad(vec: Any) -> list[float]:
     return floats + [0.0] * (_TARGET_DIM - len(floats))
 
 
-def _clear_minilm_cache(embedding_cls: Any, exc: Exception) -> Path | None:
+def _recoverable_minilm_cache_path(embedding_cls: Any, exc: Exception) -> Path | None:
     cache_path = _minilm_cache_path(embedding_cls)
     if cache_path is None or not _is_recoverable_minilm_cache_error(
         embedding_cls, cache_path, exc
     ):
         return None
 
-    shutil.rmtree(cache_path, ignore_errors=True)
     return cache_path
 
 
@@ -173,6 +205,45 @@ def _minilm_cache_path(embedding_cls: Any) -> Path | None:
     return cache_path
 
 
+def _minilm_cache_lock_path(cache_path: Path) -> Path:
+    return cache_path.parent / f".{cache_path.name}.lock"
+
+
+@contextmanager
+def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+b") as lock_file:
+        lock_file.seek(0)
+        if lock_file.read(1) == b"":
+            lock_file.write(b"\0")
+            lock_file.flush()
+        lock_file.seek(0)
+
+        if fcntl is not None:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        elif msvcrt is not None:
+            msvcrt.locking(  # type: ignore[reportAttributeAccessIssue]
+                lock_file.fileno(),
+                msvcrt.LK_LOCK,  # type: ignore[reportAttributeAccessIssue]
+                1,
+            )
+            try:
+                yield
+            finally:
+                lock_file.seek(0)
+                msvcrt.locking(  # type: ignore[reportAttributeAccessIssue]
+                    lock_file.fileno(),
+                    msvcrt.LK_UNLCK,  # type: ignore[reportAttributeAccessIssue]
+                    1,
+                )
+        else:
+            yield
+
+
 def _is_recoverable_minilm_cache_error(
     embedding_cls: Any, cache_path: Path, exc: Exception
 ) -> bool:
@@ -180,11 +251,28 @@ def _is_recoverable_minilm_cache_error(
         return True
 
     chain = _exception_chain(exc)
+    return any(
+        isinstance(chain_exc, (tarfile.TarError, EOFError)) for chain_exc in chain
+    ) or _complete_minilm_cache_error_identifies_cache(embedding_cls, cache_path, exc)
+
+
+def _should_clear_minilm_cache(
+    embedding_cls: Any, cache_path: Path, exc: Exception
+) -> bool:
+    if not _minilm_cache_complete(embedding_cls, cache_path):
+        return True
+
+    return _complete_minilm_cache_error_identifies_cache(embedding_cls, cache_path, exc)
+
+
+def _complete_minilm_cache_error_identifies_cache(
+    embedding_cls: Any, cache_path: Path, exc: Exception
+) -> bool:
+    chain = _exception_chain(exc)
     archive_name = str(getattr(embedding_cls, "ARCHIVE_FILENAME", ""))
     messages = "\n".join(str(chain_exc) for chain_exc in chain)
     return (
-        any(isinstance(chain_exc, (tarfile.TarError, EOFError)) for chain_exc in chain)
-        or str(cache_path) in messages
+        str(cache_path) in messages
         or bool(archive_name and archive_name in messages)
         or "does not match expected SHA256" in messages
     )

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -254,11 +254,12 @@ def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
 def _should_clear_minilm_cache(
     embedding_cls: Any, cache_path: Path, exc: Exception, cache_was_complete: bool
 ) -> bool:
-    if not cache_was_complete:
-        return not _minilm_cache_complete(embedding_cls, cache_path)
-
-    if not _minilm_cache_complete(embedding_cls, cache_path):
+    cache_is_complete = _minilm_cache_complete(embedding_cls, cache_path)
+    if not cache_is_complete:
         return True
+
+    if not cache_was_complete:
+        return False
 
     return _complete_minilm_cache_error_identifies_cache(embedding_cls, cache_path, exc)
 

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import shutil
+import tarfile
 import threading
+from pathlib import Path
 from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,6 +38,15 @@ _TARGET_DIM = 512
 # ~4 chars/token in English prose; leave headroom so we never raise the
 # ValueError that ONNXMiniLM_L6_V2 throws on over-length input.
 _MAX_CHARS = 800
+
+_MINILM_EXPECTED_FILES = (
+    "config.json",
+    "model.onnx",
+    "special_tokens_map.json",
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "vocab.txt",
+)
 
 
 class LocalEmbedderError(RuntimeError):
@@ -98,8 +110,32 @@ class LocalEmbedder:
         """
         ef = self._load()
         safe_inputs = [(text or "")[:_MAX_CHARS] for text in texts]
-        raw = ef(safe_inputs)
+        try:
+            raw = ef(safe_inputs)
+        except Exception as exc:
+            raw = self._retry_embed_after_cache_clear(ef, exc, safe_inputs)
         return [_pad(vec) for vec in raw]
+
+    def _retry_embed_after_cache_clear(
+        self, failed_ef: Any, exc: Exception, safe_inputs: list[str]
+    ) -> Any:
+        with self._ef_lock:
+            if self._ef is not None and self._ef is not failed_ef:
+                return self._ef(safe_inputs)
+
+            embedding_cls = type(failed_ef)
+            cache_path = _clear_minilm_cache(embedding_cls, exc)
+            if cache_path is None:
+                raise exc
+
+            _LOGGER.warning(
+                "Failed to use local MiniLM embedder; cleared cache %s and retrying once",
+                cache_path,
+                exc_info=True,
+            )
+            fresh_ef = embedding_cls()
+            self._ef = fresh_ef
+            return fresh_ef(safe_inputs)
 
 
 def _pad(vec: Any) -> list[float]:
@@ -111,6 +147,64 @@ def _pad(vec: Any) -> list[float]:
     if len(floats) > _TARGET_DIM:
         return floats[:_TARGET_DIM]
     return floats + [0.0] * (_TARGET_DIM - len(floats))
+
+
+def _clear_minilm_cache(embedding_cls: Any, exc: Exception) -> Path | None:
+    cache_path = _minilm_cache_path(embedding_cls)
+    if cache_path is None or not _is_recoverable_minilm_cache_error(
+        embedding_cls, cache_path, exc
+    ):
+        return None
+
+    shutil.rmtree(cache_path, ignore_errors=True)
+    return cache_path
+
+
+def _minilm_cache_path(embedding_cls: Any) -> Path | None:
+    download_path = getattr(embedding_cls, "DOWNLOAD_PATH", None)
+    if not download_path:
+        return None
+
+    model_name = getattr(embedding_cls, "MODEL_NAME", None)
+    cache_path = Path(str(download_path)).expanduser()
+    if not model_name or cache_path.name != model_name:
+        return None
+
+    return cache_path
+
+
+def _is_recoverable_minilm_cache_error(
+    embedding_cls: Any, cache_path: Path, exc: Exception
+) -> bool:
+    if not _minilm_cache_complete(embedding_cls, cache_path):
+        return True
+
+    chain = _exception_chain(exc)
+    archive_name = str(getattr(embedding_cls, "ARCHIVE_FILENAME", ""))
+    messages = "\n".join(str(chain_exc) for chain_exc in chain)
+    return (
+        any(isinstance(chain_exc, (tarfile.TarError, EOFError)) for chain_exc in chain)
+        or str(cache_path) in messages
+        or bool(archive_name and archive_name in messages)
+        or "does not match expected SHA256" in messages
+    )
+
+
+def _minilm_cache_complete(embedding_cls: Any, cache_path: Path) -> bool:
+    extracted_folder = str(getattr(embedding_cls, "EXTRACTED_FOLDER_NAME", "onnx"))
+    return all(
+        (cache_path / extracted_folder / file_name).exists()
+        for file_name in _MINILM_EXPECTED_FILES
+    )
+
+
+def _exception_chain(exc: Exception) -> list[BaseException]:
+    chain: list[BaseException] = []
+    current: BaseException | None = exc
+    while current is not None:
+        chain.append(current)
+        current = current.__cause__ or current.__context__
+    return chain
 
 
 _REGISTERED = False

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -19,7 +19,6 @@ import importlib.util
 import logging
 import os
 import shutil
-import tarfile
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -138,12 +137,15 @@ class LocalEmbedder:
                 return self._ef(safe_inputs)
 
             embedding_cls = type(failed_ef)
-            cache_path = _recoverable_minilm_cache_path(embedding_cls, exc)
-            if cache_path is None:
+            recovery = _recoverable_minilm_cache(embedding_cls, exc)
+            if recovery is None:
                 raise exc
+            cache_path, cache_was_complete = recovery
 
             with _exclusive_file_lock(_minilm_cache_lock_path(cache_path)):
-                if _should_clear_minilm_cache(embedding_cls, cache_path, exc):
+                if _should_clear_minilm_cache(
+                    embedding_cls, cache_path, exc, cache_was_complete
+                ):
                     shutil.rmtree(cache_path, ignore_errors=True)
                     recovery_action = "clearing"
                     _LOGGER.warning(
@@ -182,14 +184,19 @@ def _pad(vec: Any) -> list[float]:
     return floats + [0.0] * (_TARGET_DIM - len(floats))
 
 
-def _recoverable_minilm_cache_path(embedding_cls: Any, exc: Exception) -> Path | None:
+def _recoverable_minilm_cache(
+    embedding_cls: Any, exc: Exception
+) -> tuple[Path, bool] | None:
     cache_path = _minilm_cache_path(embedding_cls)
-    if cache_path is None or not _is_recoverable_minilm_cache_error(
+    if cache_path is None:
+        return None
+    cache_was_complete = _minilm_cache_complete(embedding_cls, cache_path)
+    if cache_was_complete and not _complete_minilm_cache_error_identifies_cache(
         embedding_cls, cache_path, exc
     ):
         return None
 
-    return cache_path
+    return cache_path, cache_was_complete
 
 
 def _minilm_cache_path(embedding_cls: Any) -> Path | None:
@@ -244,21 +251,12 @@ def _exclusive_file_lock(lock_path: Path) -> Iterator[None]:
             yield
 
 
-def _is_recoverable_minilm_cache_error(
-    embedding_cls: Any, cache_path: Path, exc: Exception
-) -> bool:
-    if not _minilm_cache_complete(embedding_cls, cache_path):
-        return True
-
-    chain = _exception_chain(exc)
-    return any(
-        isinstance(chain_exc, (tarfile.TarError, EOFError)) for chain_exc in chain
-    ) or _complete_minilm_cache_error_identifies_cache(embedding_cls, cache_path, exc)
-
-
 def _should_clear_minilm_cache(
-    embedding_cls: Any, cache_path: Path, exc: Exception
+    embedding_cls: Any, cache_path: Path, exc: Exception, cache_was_complete: bool
 ) -> bool:
+    if not cache_was_complete:
+        return not _minilm_cache_complete(embedding_cls, cache_path)
+
     if not _minilm_cache_complete(embedding_cls, cache_path):
         return True
 

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 import tarfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -281,6 +283,130 @@ class TestEmbedPadding:
         recovered_ef.assert_called_once_with(["hello"])
         assert cache_dir.exists()
         assert (cache_dir / "partial-download").exists()
+
+    def test_cache_clear_and_retry_run_under_filesystem_lock(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "partial-download").write_text("corrupt")
+        lock_active = False
+        attempts = 0
+
+        @contextmanager
+        def fake_file_lock(_lock_path) -> Iterator[None]:
+            nonlocal lock_active
+            lock_active = True
+            try:
+                yield
+            finally:
+                lock_active = False
+
+        def checked_rmtree(*args, **kwargs) -> None:
+            assert lock_active
+            shutil_rmtree(*args, **kwargs)
+
+        class FailingThenWorkingMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+            def __call__(self, docs: list[str]) -> list[list[float]]:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise tarfile.ReadError("bad checksum")
+                assert lock_active
+                return [[0.2] * 384 for _ in docs]
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = FailingThenWorkingMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+        monkeypatch.setattr(lep, "_exclusive_file_lock", fake_file_lock)
+        shutil_rmtree = lep.shutil.rmtree
+        monkeypatch.setattr(lep.shutil, "rmtree", checked_rmtree)
+
+        result = LocalEmbedder.get().embed(["hello"])
+
+        assert attempts == 2
+        assert result == [[0.2] * 384 + [0.0] * 128]
+
+    def test_retry_exhaustion_includes_manual_cache_recovery_hint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "partial-download").write_text("corrupt")
+        attempts = 0
+
+        class AlwaysFailingMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+            def __call__(self, _docs: list[str]) -> list[list[float]]:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise tarfile.ReadError("bad checksum")
+                raise RuntimeError("still corrupt")
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = AlwaysFailingMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+
+        with pytest.raises(lep.LocalEmbedderError) as exc_info:
+            LocalEmbedder.get().embed(["hello"])
+
+        message = str(exc_info.value)
+        assert str(cache_dir) in message
+        assert "Delete this cache directory and restart Reflexio" in message
+        assert "cloud embedding provider" in message
+        assert attempts == 2
+
+    def test_retry_keeps_cache_refreshed_by_another_process(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        extracted_dir = cache_dir / "onnx"
+        extracted_dir.mkdir(parents=True)
+        for file_name in lep._MINILM_EXPECTED_FILES:
+            (extracted_dir / file_name).write_text("present")
+        attempts = 0
+
+        class RecoveredMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+            def __call__(self, docs: list[str]) -> list[list[float]]:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise tarfile.ReadError("bad checksum")
+                return [[0.4] * 384 for _ in docs]
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = RecoveredMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+        rmtree = MagicMock()
+        monkeypatch.setattr(lep.shutil, "rmtree", rmtree)
+
+        result = LocalEmbedder.get().embed(["hello"])
+
+        assert result == [[0.4] * 384 + [0.0] * 128]
+        assert attempts == 2
+        rmtree.assert_not_called()
+        assert extracted_dir.exists()
 
     def test_384_vector_padded_to_512(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _install_fake_chroma(monkeypatch)

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -366,8 +366,9 @@ class TestEmbedPadding:
 
         message = str(exc_info.value)
         assert str(cache_dir) in message
-        assert "Delete this cache directory and restart Reflexio" in message
-        assert "cloud embedding provider" in message
+        assert (
+            "Delete this cache directory, restart Reflexio, and retry local embedding"
+        ) in message
         assert attempts == 2
 
     def test_retry_keeps_cache_refreshed_by_another_process(

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -375,10 +375,16 @@ class TestEmbedPadding:
     ) -> None:
         cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
         extracted_dir = cache_dir / "onnx"
-        extracted_dir.mkdir(parents=True)
-        for file_name in lep._MINILM_EXPECTED_FILES:
-            (extracted_dir / file_name).write_text("present")
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "partial-download").write_text("corrupt")
         attempts = 0
+
+        @contextmanager
+        def fake_file_lock(_lock_path) -> Iterator[None]:
+            extracted_dir.mkdir(parents=True)
+            for file_name in lep._MINILM_EXPECTED_FILES:
+                (extracted_dir / file_name).write_text("present")
+            yield
 
         class RecoveredMiniLM:
             MODEL_NAME = "all-MiniLM-L6-v2"
@@ -398,6 +404,7 @@ class TestEmbedPadding:
         monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
         monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
         monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+        monkeypatch.setattr(lep, "_exclusive_file_lock", fake_file_lock)
         rmtree = MagicMock()
         monkeypatch.setattr(lep.shutil, "rmtree", rmtree)
 
@@ -405,6 +412,38 @@ class TestEmbedPadding:
 
         assert result == [[0.4] * 384 + [0.0] * 128]
         assert attempts == 2
+        rmtree.assert_not_called()
+        assert extracted_dir.exists()
+
+    def test_complete_cache_with_unrelated_tar_error_is_not_recoverable(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        extracted_dir = cache_dir / "onnx"
+        extracted_dir.mkdir(parents=True)
+        for file_name in lep._MINILM_EXPECTED_FILES:
+            (extracted_dir / file_name).write_text("present")
+
+        class UnrelatedTarErrorMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+            def __call__(self, _docs: list[str]) -> list[list[float]]:
+                raise tarfile.ReadError("bad checksum")
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = UnrelatedTarErrorMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+        rmtree = MagicMock()
+        monkeypatch.setattr(lep.shutil, "rmtree", rmtree)
+
+        with pytest.raises(tarfile.ReadError, match="bad checksum"):
+            LocalEmbedder.get().embed(["hello"])
+
         rmtree.assert_not_called()
         assert extracted_dir.exists()
 

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import tarfile
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -177,6 +178,110 @@ class TestRegisterIfEnabled:
 
 
 class TestEmbedPadding:
+    def test_real_chroma_minilm_attrs_match_cache_recovery_contract(self) -> None:
+        embedding_functions = pytest.importorskip("chromadb.utils.embedding_functions")
+        minilm_cls = embedding_functions.ONNXMiniLM_L6_V2
+
+        assert minilm_cls.MODEL_NAME == "all-MiniLM-L6-v2"
+        assert minilm_cls.DOWNLOAD_PATH.name == minilm_cls.MODEL_NAME
+        assert minilm_cls.EXTRACTED_FOLDER_NAME == "onnx"
+        assert minilm_cls.ARCHIVE_FILENAME == "onnx.tar.gz"
+
+    @pytest.mark.parametrize("cache_shape", ["partial", "complete"])
+    def test_corrupt_minilm_cache_is_cleared_and_retried_once(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path, cache_shape: str
+    ) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        extracted_dir = cache_dir / "onnx"
+        cache_dir.mkdir(parents=True)
+        if cache_shape == "complete":
+            extracted_dir.mkdir()
+            for file_name in lep._MINILM_EXPECTED_FILES:
+                (extracted_dir / file_name).write_text("present")
+            first_error: Exception = RuntimeError(
+                f"Failed to load {extracted_dir / 'model.onnx'}"
+            )
+        else:
+            (cache_dir / "partial-download").write_text("corrupt")
+            first_error = tarfile.ReadError("bad checksum")
+        attempts = 0
+
+        class FailingThenWorkingMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+            def __call__(self, docs: list[str]) -> list[list[float]]:
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise first_error
+                return [[0.1] * 384 for _ in docs]
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = FailingThenWorkingMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+
+        result = LocalEmbedder.get().embed(["hello"])
+
+        assert attempts == 2
+        assert result == [[0.1] * 384 + [0.0] * 128]
+        assert not cache_dir.exists()
+
+    def test_constructor_failure_does_not_clear_cache(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "model").write_text("valid")
+
+        class FailingConstructorMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+
+            def __init__(self) -> None:
+                raise ValueError("The onnxruntime python package is not installed")
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = FailingConstructorMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+
+        with pytest.raises(ValueError, match="onnxruntime"):
+            LocalEmbedder.get().embed(["hello"])
+
+        assert cache_dir.exists()
+        assert (cache_dir / "model").exists()
+
+    def test_retry_reuses_embedder_recovered_by_another_thread(self, tmp_path) -> None:
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "partial-download").write_text("corrupt")
+
+        class MiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+        failed_ef = MagicMock()
+        recovered_ef = MagicMock(return_value=[[0.3] * 384])
+        embedder = LocalEmbedder()
+        embedder._ef = recovered_ef
+
+        result = embedder._retry_embed_after_cache_clear(
+            failed_ef, tarfile.ReadError("bad checksum"), ["hello"]
+        )
+
+        assert result == [[0.3] * 384]
+        recovered_ef.assert_called_once_with(["hello"])
+        assert cache_dir.exists()
+        assert (cache_dir / "partial-download").exists()
+
     def test_384_vector_padded_to_512(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _install_fake_chroma(monkeypatch)
 


### PR DESCRIPTION
## Summary
- Adds Reflexio-layer self-healing for recoverable Chroma MiniLM cache failures during local embedding use.
- Serializes MiniLM cache recovery across processes so multiple backend workers, CLIs, or embedding daemons do not concurrently delete/rebuild the same on-disk cache.
- Leaves API, storage, schema, and database contracts unchanged.

## Before
- A corrupt or partial Chroma MiniLM cache could fail the first `local/minilm-l6-v2` embed call and surface as an opaque local embedding error.
- Cache recovery handled by host scripts only helped that host path; in-process local embeddings and the embedding daemon did not share the fix.
- Concurrent processes could hit the same corrupt cache and race while deleting or rebuilding `all-MiniLM-L6-v2`.
- If automatic recovery still failed, the user did not get a concrete cache-recovery next step.

## After
- Recoverable MiniLM cache failures are handled inside Reflexio's local embedding provider, so daemon warmup and in-process local embeddings use the same recovery path.
- Reflexio clears the failed embedder class's MiniLM cache and retries the embed once.
- Recovery is protected by a cross-process filesystem lock; if another process has already refreshed the cache, Reflexio retries against the refreshed cache instead of deleting it again.
- If the retry is exhausted, the raised error names the cache directory and tells the operator to delete it, restart Reflexio, and retry local embedding.
- The expected extracted-file list is documented as coupled to Chroma's private MiniLM archive layout because Chroma does not expose that list as a public runtime contract.

## Coverage
- Partial-cache retry and complete-but-corrupt-cache retry.
- Constructor/dependency failure preserving cache contents.
- Thread-local recovery reuse.
- Cross-process recovery lock coverage and already-refreshed-cache reuse.
- Retry-exhausted manual recovery message.
- Real Chroma `ONNXMiniLM_L6_V2` cache attribute shape without triggering a download.

## Related
- Supports the lower-layer Reflexio recovery needed by ReflexioAI/claude-smart#98, leaving Claude Smart to handle host-level readiness and orchestration.

## Test Plan
- `uv run pytest tests/server/llm/test_local_embedding_provider.py -q -o addopts=`
- `uv run pytest tests/server/llm/test_embedding_service_provider.py tests/server/llm/test_embedding_service_concurrency.py -q -o addopts=`
- `uv run ruff check reflexio/server/llm/providers/local_embedding_provider.py tests/server/llm/test_local_embedding_provider.py`
- `uv run ruff format --check reflexio/server/llm/providers/local_embedding_provider.py tests/server/llm/test_local_embedding_provider.py`
- `uv run pyright reflexio/server/llm/providers/local_embedding_provider.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of local MiniLM embeddings by automatically retrying once when the local embedding cache is corrupted or incomplete.
  * Added coordinated cache-recovery behavior to prevent conflicting updates and to avoid unnecessary cache deletion.
  * Enhanced failure guidance so users know how to recover when repair can’t complete.

* **Tests**
  * Expanded coverage for cache corruption/retry behavior, including lock-protected cleanup and correct error handling on retry exhaustion.

* **Documentation**
  * Updated CLI docs with step-by-step recovery instructions for MiniLM cache failures, and suggested switching providers if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
