### PR TITLE
feat(learning): durable learning pipeline infrastructure (flag-OFF)

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -445,12 +445,17 @@ class ReflexioClient:
                 explicit retry after reauth or limit reset.
 
         Returns:
-            PublishUserInteractionResponse: Server response. In
-                ``wait_for_response=False`` mode this is a bare
-                acknowledgement ("Interaction queued for processing")
-                without extraction counts; in ``wait_for_response=True``
-                mode it includes request_id, storage routing, and
-                deltas.
+            PublishUserInteractionResponse: Server response.
+
+                In deferred mode (``wait_for_response=False``) the
+                response carries ``learning_status="deferred"`` and a
+                ``request_id``; ``profiles_added``/``playbooks_added`` are
+                0 because extraction has not run yet. Poll
+                ``get_learning_status(request_id)`` for completion.
+
+                In ``wait_for_response=True`` mode the server waits for
+                extraction and the response includes ``request_id``,
+                storage routing, and real profile/playbook deltas.
         """
         if session_id is None or not session_id.strip():
             raise ValueError("session_id is required and cannot be empty")

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -498,8 +498,8 @@ class ReflexioClient:
         Args:
             request_id: The ``request_id`` of the published interaction, as
                 returned in ``PublishUserInteractionResponse.request_id``
-                (populated on the ``wait_for_response=True`` path) or known
-                by the caller.
+                (populated on both the deferred and ``wait_for_response=True``
+                paths) or known by the caller.
 
         Returns:
             One of: ``"pending"`` | ``"processing"`` | ``"done"`` | ``"failed"``.

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -481,6 +481,35 @@ class ReflexioClient:
         self._cache.invalidate("get_agent_playbooks")
         return result
 
+    def get_learning_status(self, request_id: str) -> str:
+        """Poll the learning status for a previously published request.
+
+        Call this after a deferred ``publish_interaction`` (where
+        ``wait_for_response=False``).  The response carries
+        ``learning_status="deferred"`` to signal that extraction has been
+        queued; use this method to track progress once the durable queue
+        is active.
+
+        Args:
+            request_id: The ``request_id`` of the published interaction, as
+                returned in ``PublishUserInteractionResponse.request_id``
+                (populated on the ``wait_for_response=True`` path) or known
+                by the caller.
+
+        Returns:
+            One of: ``"pending"`` | ``"processing"`` | ``"done"`` | ``"failed"``.
+
+        Raises:
+            requests.HTTPError: 404 when the request_id is not known to the
+                server for this org.
+        """
+        response = self._make_request(
+            "GET",
+            "/api/learning_status",
+            params={"request_id": request_id},
+        )
+        return str(response["status"])
+
     def search_interactions(
         self,
         request: SearchInteractionRequest | dict | None = None,

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -123,6 +123,7 @@ __all__ = [
     "LineageEvent",
     "LineageContext",
     "RecordRef",
+    "LearningStatusResponse",
 ]
 
 # ===============================
@@ -689,6 +690,23 @@ class PublishUserInteractionResponse(BaseModel):
     profiles_updated: int | None = None
     playbooks_added: int | None = None
     playbooks_updated: int | None = None
+    # Set to "deferred" when the server queued extraction asynchronously.
+    # None on the sync (wait_for_response=True) path. Poll GET
+    # /api/learning_status?request_id=... to track progress once the
+    # durable queue is active.
+    learning_status: str | None = None
+
+
+class LearningStatusResponse(BaseModel):
+    """Response for GET /api/learning_status.
+
+    Attributes:
+        status: One of ``pending | processing | done | failed``.
+            Coverage-based: reflects whether a durable learning job has
+            processed through the request's creation timestamp.
+    """
+
+    status: str
 
 
 # whoami response — caller identity + resolved storage routing (masked)

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -706,7 +706,7 @@ class LearningStatusResponse(BaseModel):
             processed through the request's creation timestamp.
     """
 
-    status: str
+    status: Literal["pending", "processing", "done", "failed"]
 
 
 # whoami response — caller identity + resolved storage routing (masked)

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -345,6 +345,9 @@ def create_app(
     )
     from reflexio.server.extensions import AppContext
     from reflexio.server.llm.model_defaults import validate_llm_availability
+    from reflexio.server.services.durable_learning import (
+        maybe_start_durable_learning,
+    )
     from reflexio.server.services.extraction.resume_scheduler import (
         maybe_start_resume_scheduler,
     )
@@ -356,6 +359,7 @@ def create_app(
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
         scheduler = None
         gc_scheduler = None
+        durable_learning_scheduler = None
         started_caps: list = []
         if mounts_data_plane:
             log_publish_hardware_capacity()
@@ -373,6 +377,14 @@ def create_app(
                 bootstrap_org_id=bootstrap_org_id,
             )
             gc_scheduler = maybe_start_lineage_gc(
+                lambda org_id: RequestContext(org_id=org_id),
+                bootstrap_org_id=bootstrap_org_id,
+            )
+            # Durable learning drains the learning_jobs queue per org. Gated on
+            # REFLEXIO_DURABLE_LEARNING_QUEUE; the default provider discovers
+            # orgs-with-work via the bootstrap storage (single-ref). Enterprise
+            # cross-ref fan-out is a deferred follow-up.
+            durable_learning_scheduler = maybe_start_durable_learning(
                 lambda org_id: RequestContext(org_id=org_id),
                 bootstrap_org_id=bootstrap_org_id,
             )
@@ -397,10 +409,9 @@ def create_app(
                         cap,
                         exc_info=True,
                     )
-            if scheduler is not None:
-                scheduler.stop()
-            if gc_scheduler is not None:
-                gc_scheduler.stop()
+            for sched in (scheduler, gc_scheduler, durable_learning_scheduler):
+                if sched is not None:
+                    sched.stop()
             from reflexio.server.services.publish_learning_worker import (
                 stop_publish_learning_worker,
             )

--- a/reflexio/server/routes/interactions.py
+++ b/reflexio/server/routes/interactions.py
@@ -1,6 +1,7 @@
 """Interaction route handlers (extracted from api.py, Tier3 A2)."""
 
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -81,6 +82,14 @@ def publish_user_interaction(
             ),
         )
 
+    # Resolve the request_id BEFORE backgrounding so we can return it to the
+    # caller for polling. GenerationService uses a caller-supplied request_id
+    # verbatim (and generates one only when absent), so pinning it on the
+    # payload guarantees the background task stores its status under the same
+    # id we hand back here.
+    request_id = payload.request_id or str(uuid.uuid4())
+    payload.request_id = request_id
+
     def _publish_task() -> None:
         try:
             publisher_api.add_user_interaction(
@@ -93,11 +102,13 @@ def publish_user_interaction(
 
     # Run in background — caller gets immediate acknowledgement.
     # learning_status="deferred" tells the caller that extraction has not yet
-    # run; they can poll GET /api/learning_status?request_id=... to track it.
+    # run; they can poll GET /api/learning_status?request_id=... (using the
+    # request_id returned here) to track it.
     background_tasks.add_task(_publish_task)
     return PublishUserInteractionResponse(
         success=True,
         message="Interaction queued for processing",
+        request_id=request_id,
         learning_status="deferred",
     )
 
@@ -268,6 +279,7 @@ def get_requests_endpoint(
 @router.get(
     "/api/learning_status",
     response_model=LearningStatusResponse,
+    response_model_exclude_none=True,
 )
 @limiter.limit("120/minute")
 def get_learning_status(

--- a/reflexio/server/routes/interactions.py
+++ b/reflexio/server/routes/interactions.py
@@ -10,6 +10,7 @@ from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    HTTPException,
     Request,
 )
 
@@ -30,6 +31,7 @@ from reflexio.models.api_schema.service_schemas import (
     DeleteSessionResponse,
     DeleteUserInteractionRequest,
     DeleteUserInteractionResponse,
+    LearningStatusResponse,
     PublishUserInteractionRequest,
     PublishUserInteractionResponse,
 )
@@ -89,10 +91,14 @@ def publish_user_interaction(
         except Exception:
             logger.exception("Background publish failed for org %s", org_id)
 
-    # Run in background — caller gets immediate acknowledgement
+    # Run in background — caller gets immediate acknowledgement.
+    # learning_status="deferred" tells the caller that extraction has not yet
+    # run; they can poll GET /api/learning_status?request_id=... to track it.
     background_tasks.add_task(_publish_task)
     return PublishUserInteractionResponse(
-        success=True, message="Interaction queued for processing"
+        success=True,
+        message="Interaction queued for processing",
+        learning_status="deferred",
     )
 
 
@@ -257,3 +263,46 @@ def get_requests_endpoint(
         has_more=internal_response.has_more,
         msg=internal_response.msg,
     )
+
+
+@router.get(
+    "/api/learning_status",
+    response_model=LearningStatusResponse,
+)
+@limiter.limit("120/minute")
+def get_learning_status(
+    request: Request,
+    request_id: str,
+    org_id: str = Depends(default_get_org_id),
+) -> LearningStatusResponse:
+    """Return the coverage-based learning status for a published request.
+
+    The status reflects whether a durable learning job has processed through
+    the request's creation timestamp:
+
+    - ``pending``: not yet picked up.
+    - ``processing``: a worker currently holds the job.
+    - ``done``: at least one completed job covers this request.
+    - ``failed``: a dead job covers this request and no done job does.
+
+    Note: this endpoint reads ``learning_jobs`` rows written by the durable
+    queue. When the durable queue is OFF (in-memory deferred path) it returns
+    absence-based status (``pending`` for recent requests, ``done`` for old
+    ones) — acceptable for v1; the poll contract is tied to the durable queue.
+
+    Raises:
+        HTTPException: 404 when ``request_id`` is not found for this org.
+            Never reports ``done`` for a request that never existed.
+    """
+    reflexio = reflexio_cache.get_reflexio(org_id=org_id)
+    storage = reflexio.request_context.storage
+    if storage is None:
+        raise HTTPException(status_code=503, detail="Storage not configured")
+    req = storage.get_request(request_id)
+    if req is None:
+        raise HTTPException(status_code=404, detail="request not found")
+    status = storage.get_learning_status_for_request(
+        user_id=req.user_id,
+        request_created_at=float(req.created_at),
+    )
+    return LearningStatusResponse(status=status)

--- a/reflexio/server/services/durable_learning/__init__.py
+++ b/reflexio/server/services/durable_learning/__init__.py
@@ -1,5 +1,13 @@
 """Durable learning worker: claim → process in commit_scope → fenced completion."""
 
+from reflexio.server.services.durable_learning.scheduler import (
+    DurableLearningScheduler,
+    maybe_start_durable_learning,
+)
 from reflexio.server.services.durable_learning.worker import DurableLearningWorker
 
-__all__ = ["DurableLearningWorker"]
+__all__ = [
+    "DurableLearningScheduler",
+    "DurableLearningWorker",
+    "maybe_start_durable_learning",
+]

--- a/reflexio/server/services/durable_learning/__init__.py
+++ b/reflexio/server/services/durable_learning/__init__.py
@@ -1,0 +1,5 @@
+"""Durable learning worker: claim → process in commit_scope → fenced completion."""
+
+from reflexio.server.services.durable_learning.worker import DurableLearningWorker
+
+__all__ = ["DurableLearningWorker"]

--- a/reflexio/server/services/durable_learning/scheduler.py
+++ b/reflexio/server/services/durable_learning/scheduler.py
@@ -1,0 +1,142 @@
+"""Process-local scheduler for the durable learning-job queue (Task 6).
+
+Each tick discovers the orgs with actionable learning jobs (via an injected
+``org_ids_provider``) and drains each through a :class:`DurableLearningWorker`.
+The worker's claims are org-scoped and the fenced complete/fail transitions make
+the drain exactly-once, so racing scheduler instances across processes are safe.
+
+Gating: startup is gated on ``REFLEXIO_DURABLE_LEARNING_QUEUE`` (a rollout flag,
+scalability design 2026-07-04 §8 stage 2). When off, :meth:`start` is a no-op.
+
+Multi-ref capability (design §3.1, per-ref polling): the mechanism supports
+per-data-ref fan-out — inject an ``org_ids_provider`` that yields orgs across
+refs plus a ``request_context_factory`` that routes each org to its ref's
+storage. The default provider (single-ref: bootstrap-storage discovery) is wired
+in :func:`maybe_start_durable_learning`; the enterprise cross-ref enumerator is a
+deferred follow-up (tracked with the pre-Task-8 gates).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.env_utils import env_str, env_truthy
+from reflexio.server.scheduling import ThreadedScheduler
+from reflexio.server.services.durable_learning.worker import DurableLearningWorker
+
+logger = logging.getLogger(__name__)
+
+
+class DurableLearningScheduler(ThreadedScheduler):
+    """Polling daemon that drains the durable learning queue per org.
+
+    Args:
+        request_context_factory: Builds an org-scoped :class:`RequestContext`.
+            Passed straight to the worker; a multi-ref deployment routes each org
+            to its data ref's storage here.
+        org_ids_provider: Called once per tick; yields the org_ids to drain. The
+            single-ref default (see :func:`maybe_start_durable_learning`) reads
+            them from the bootstrap storage's cross-org discovery query.
+        instance_id: Stable label written to ``claimed_by`` on each claim.
+    """
+
+    def __init__(
+        self,
+        *,
+        request_context_factory: Callable[[str], RequestContext],
+        org_ids_provider: Callable[[], Iterable[str]],
+        instance_id: str | None = None,
+    ) -> None:
+        super().__init__(thread_name="reflexio-durable-learning-scheduler")
+        self._worker = DurableLearningWorker(
+            request_context_factory, instance_id=instance_id
+        )
+        self._org_ids_provider = org_ids_provider
+        # Read env INSIDE __init__ so tests can set the values before construction.
+        self._poll = float(env_str("REFLEXIO_DURABLE_LEARNING_POLL_SECONDS", "2.0"))
+        self._batch = int(env_str("REFLEXIO_DURABLE_LEARNING_BATCH", "16"))
+        self._lease = int(env_str("REFLEXIO_DURABLE_LEARNING_LEASE_SECONDS", "300"))
+
+    def _should_start(self) -> bool:
+        if env_truthy(env_str("REFLEXIO_DURABLE_LEARNING_QUEUE", "false")):
+            return True
+        logger.info(
+            "event=durable_learning_scheduler_disabled "
+            "REFLEXIO_DURABLE_LEARNING_QUEUE not set — not starting"
+        )
+        return False
+
+    def _on_started(self) -> None:
+        logger.info("event=durable_learning_scheduler_started")
+
+    def _on_stopped(self) -> None:
+        logger.info("event=durable_learning_scheduler_stopped")
+
+    def _run_once(self) -> float:
+        """Drain every discovered org once; per-org error isolation.
+
+        A single org raising never aborts the tick, and a failure to enumerate
+        orgs never kills the daemon thread. Returns the poll interval.
+        """
+        try:
+            for org_id in self._org_ids_provider():
+                if self._stop_event.is_set():
+                    break
+                try:
+                    self._worker.drain_org(org_id, self._batch, self._lease)
+                except Exception:
+                    logger.exception(
+                        "event=durable_learning_drain_failed org_id=%s", org_id
+                    )
+        except Exception:
+            logger.exception("event=durable_learning_tick_failed")
+        return self._poll
+
+
+def maybe_start_durable_learning(
+    request_context_factory: Callable[[str], RequestContext],
+    *,
+    bootstrap_org_id: str,
+    org_ids_provider: Callable[[], Iterable[str]] | None = None,
+) -> DurableLearningScheduler | None:
+    """Start the durable-learning scheduler when the rollout flag is on.
+
+    Returns ``None`` when ``REFLEXIO_DURABLE_LEARNING_QUEUE`` is off (mirrors
+    ``maybe_start_resume_scheduler``). The default ``org_ids_provider`` performs
+    single-ref discovery: it queries the bootstrap org's storage for every org
+    with actionable work (covers OSS/local and the shared managed DATA ref). The
+    enterprise cross-ref enumerator is a deferred follow-up.
+
+    Args:
+        request_context_factory: Builds an org-scoped :class:`RequestContext`.
+        bootstrap_org_id: Org used to reach a storage for cross-org discovery.
+        org_ids_provider: Optional explicit provider (e.g. a future enterprise
+            cross-ref enumerator); when ``None`` the single-ref default is used.
+    """
+    if not env_truthy(env_str("REFLEXIO_DURABLE_LEARNING_QUEUE", "false")):
+        return None
+
+    def _default_provider() -> list[str]:
+        try:
+            ctx = request_context_factory(bootstrap_org_id)
+            storage = getattr(ctx, "storage", None)
+            if storage is None:
+                return []
+            return list(storage.list_org_ids_with_pending_learning_jobs())
+        except NotImplementedError:
+            return []
+        except Exception:
+            logger.exception(
+                "event=durable_learning_discovery_failed bootstrap_org_id=%s",
+                bootstrap_org_id,
+            )
+            return []
+
+    scheduler = DurableLearningScheduler(
+        request_context_factory=request_context_factory,
+        org_ids_provider=org_ids_provider or _default_provider,
+    )
+    scheduler.start()
+    return scheduler

--- a/reflexio/server/services/durable_learning/worker.py
+++ b/reflexio/server/services/durable_learning/worker.py
@@ -142,12 +142,12 @@ class DurableLearningWorker:
             )
             return False
 
-        reflexio = get_reflexio(
-            org_id=ctx.org_id, storage_base_dir=ctx.storage_base_dir
-        )
-        gen = GenerationService(llm_client=reflexio.llm_client, request_context=ctx)
-
         try:
+            reflexio = get_reflexio(
+                org_id=ctx.org_id, storage_base_dir=ctx.storage_base_dir
+            )
+            gen = GenerationService(llm_client=reflexio.llm_client, request_context=ctx)
+
             with storage.commit_scope():
                 gen.run_deferred_learning(
                     user_id=job.user_id,

--- a/reflexio/server/services/durable_learning/worker.py
+++ b/reflexio/server/services/durable_learning/worker.py
@@ -1,0 +1,193 @@
+"""DurableLearningWorker: claim jobs from the durable queue, process in a fenced
+commit_scope so exactly one of N racing workers commits its outputs.
+
+Design constraints (v1 — do not remove):
+- LLM calls are inside the commit_scope (compute/persist separation is deferred).
+- No heartbeat thread (deferred; would deadlock a SQLite scope anyway).
+- Exactly-once is guaranteed by the fenced complete_learning_job:
+    rowcount == 0  -> lease was stolen -> _SupersededError -> rollback.
+    rowcount == 1  -> we own the lease -> commit succeeds.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Callable
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.cache.reflexio_cache import get_reflexio
+from reflexio.server.services.generation_service import GenerationService
+from reflexio.server.services.storage.storage_base._learning_jobs import LearningJob
+
+logger = logging.getLogger(__name__)
+
+
+class _SupersededError(Exception):
+    """Raised inside commit_scope when complete_learning_job returns 0.
+
+    Propagating this exception causes commit_scope to roll back all writes
+    (profiles, playbooks) made by run_deferred_learning for the superseded
+    worker — guaranteeing exactly-once side effects.
+    """
+
+    def __init__(self, job_id: str) -> None:
+        super().__init__(f"learning job {job_id} superseded (lease stolen)")
+
+
+class DurableLearningWorker:
+    """Claim durable learning jobs and process each in a fenced commit_scope.
+
+    Two instances racing the same job produce profile/playbook side effects
+    identical to a single run: the loser's complete_learning_job returns 0,
+    which raises _SupersededError inside the scope, rolling back its writes.
+
+    Args:
+        request_context_factory: Callable that returns a RequestContext for a
+            given org_id.  Called once per drain_org invocation.
+        instance_id: Stable label written to claimed_by on each claim.
+            Defaults to a random short UUID suffix.
+    """
+
+    def __init__(
+        self,
+        request_context_factory: Callable[[str], RequestContext],
+        *,
+        instance_id: str | None = None,
+    ) -> None:
+        self._factory = request_context_factory
+        self._instance_id = instance_id or str(uuid.uuid4())[:8]
+
+    def drain_org(self, org_id: str, batch_size: int, lease_seconds: int) -> int:
+        """Claim up to batch_size of this org's jobs and process each.
+
+        Args:
+            org_id: Organisation to drain.
+            batch_size: Maximum number of jobs to claim in one call.
+            lease_seconds: Lease duration passed to claim_learning_jobs.
+
+        Returns:
+            Number of jobs successfully completed (not counting superseded or failed).
+        """
+        ctx = self._factory(org_id)
+        storage = ctx.storage
+        if storage is None:
+            logger.error("event=learning_worker_no_storage org_id=%s", org_id)
+            return 0
+        jobs = storage.claim_learning_jobs(
+            claimed_by=self._instance_id,
+            limit=batch_size,
+            lease_seconds=lease_seconds,
+        )
+        processed = 0
+        for job in jobs:
+            if self._process_job(ctx, job):
+                processed += 1
+        return processed
+
+    def _process_job(self, ctx: RequestContext, job: LearningJob) -> bool:
+        """Process a single claimed job.
+
+        Args:
+            ctx: RequestContext for the job's org.
+            job: The claimed LearningJob (claim_token set).
+
+        Returns:
+            True if the job was successfully completed; False if superseded or failed.
+        """
+        storage = ctx.storage
+        if storage is None:
+            logger.error(
+                "event=learning_job_no_storage job_id=%s org_id=%s",
+                job.job_id,
+                job.org_id,
+            )
+            return False
+
+        # claim_learning_jobs always sets claim_token on a returned job.
+        claim_token = job.claim_token
+        if claim_token is None:
+            logger.error(
+                "event=learning_job_no_claim_token job_id=%s org_id=%s",
+                job.job_id,
+                job.org_id,
+            )
+            return False
+
+        dead = job.attempts >= job.max_attempts
+
+        # The job does not carry agent_version / session_id / source.
+        # These must be read from the durably-persisted Request.
+        if job.latest_request_id is None:
+            logger.error(
+                "event=learning_job_no_request_id job_id=%s org_id=%s user_id=%s",
+                job.job_id,
+                job.org_id,
+                job.user_id,
+            )
+            storage.fail_learning_job(
+                job_id=job.job_id, claim_token=claim_token, dead=dead
+            )
+            return False
+
+        request = storage.get_request(job.latest_request_id)
+        if request is None:
+            logger.error(
+                "event=learning_job_missing_request job_id=%s request_id=%s",
+                job.job_id,
+                job.latest_request_id,
+            )
+            storage.fail_learning_job(
+                job_id=job.job_id, claim_token=claim_token, dead=dead
+            )
+            return False
+
+        reflexio = get_reflexio(
+            org_id=ctx.org_id, storage_base_dir=ctx.storage_base_dir
+        )
+        gen = GenerationService(llm_client=reflexio.llm_client, request_context=ctx)
+
+        try:
+            with storage.commit_scope():
+                gen.run_deferred_learning(
+                    user_id=job.user_id,
+                    request_id=job.latest_request_id,
+                    session_id=request.session_id,
+                    source=request.source,
+                    agent_version=request.agent_version,
+                    force_extraction=job.force_extraction,
+                    skip_aggregation=job.skip_aggregation,
+                    sequential=True,  # prevent ThreadPoolExecutor deadlock on commit_scope RLock
+                )
+                rows = storage.complete_learning_job(
+                    job_id=job.job_id, claim_token=claim_token
+                )
+                if rows == 0:
+                    raise _SupersededError(job.job_id)
+            logger.info(
+                "event=learning_job_done job_id=%s org_id=%s user_id=%s",
+                job.job_id,
+                job.org_id,
+                job.user_id,
+            )
+            return True
+        except _SupersededError:
+            logger.info(
+                "event=learning_job_superseded job_id=%s org_id=%s",
+                job.job_id,
+                job.org_id,
+            )
+            return False
+        except Exception:
+            logger.exception(
+                "event=learning_job_failed job_id=%s org_id=%s user_id=%s",
+                job.job_id,
+                job.org_id,
+                job.user_id,
+            )
+            # attempts was incremented by claim_learning_jobs; go dead when we've
+            # exhausted max_attempts total claim attempts.
+            storage.fail_learning_job(
+                job_id=job.job_id, claim_token=claim_token, dead=dead
+            )
+            return False

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -514,7 +514,16 @@ class GenerationService:
         agent_version: str,
         force_extraction: bool,
         skip_aggregation: bool,
+        sequential: bool = False,
     ) -> GenerationServiceResult:
+        """Run the learning steps for a deferred job.
+
+        Args:
+            sequential: When True, run profile and playbook generation on the
+                calling thread (no ThreadPoolExecutor).  Required when the
+                caller already holds the storage commit_scope lock — spawning
+                worker threads inside that scope would deadlock on the RLock.
+        """
         result = GenerationServiceResult(request_id=request_id)
         self._run_learning_steps(
             user_id=user_id,
@@ -524,6 +533,7 @@ class GenerationService:
             skip_aggregation=skip_aggregation,
             source=source,
             result=result,
+            parallel=not sequential,
         )
         return result
 
@@ -541,6 +551,7 @@ class GenerationService:
         skip_aggregation: bool,
         source: str | None,
         result: GenerationServiceResult,
+        parallel: bool = True,
     ) -> None:
         # Reflection runs as its own sliding-window step BEFORE the extractor
         # pool spins up, so replacements are visible to extractors.
@@ -573,6 +584,39 @@ class GenerationService:
             source=source,
             force_extraction=force_extraction,
         )
+
+        if not parallel:
+            # Sequential mode: run both services on the calling thread.
+            # Required when the caller holds a commit_scope lock — spawning
+            # child threads inside that scope would deadlock the SQLite RLock.
+            for svc_name, _run in (
+                (
+                    "profile_generation",
+                    lambda: profile_generation_service.run(profile_generation_request),
+                ),
+                (
+                    "playbook_generation",
+                    lambda: playbook_generation_service.run(
+                        playbook_generation_request
+                    ),
+                ),
+            ):
+                try:
+                    _run()
+                except Exception as e:
+                    msg = f"{svc_name} failed: {e}"
+                    with sentry_tags(
+                        subsystem="generation",
+                        service=svc_name,
+                        request_id=request_id,
+                        error_type=type(e).__name__,
+                    ):
+                        logger.exception(
+                            "Generation service failed for request %s",
+                            request_id,
+                        )
+                    result.warnings.append(msg)
+            return
 
         executor = ThreadPoolExecutor(max_workers=2)
         try:

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -616,55 +616,54 @@ class GenerationService:
                             request_id,
                         )
                     result.warnings.append(msg)
-            return
+        else:
+            executor = ThreadPoolExecutor(max_workers=2)
+            try:
+                futures = [
+                    executor.submit(
+                        contextvars.copy_context().run,
+                        profile_generation_service.run,
+                        profile_generation_request,
+                    ),
+                    executor.submit(
+                        contextvars.copy_context().run,
+                        playbook_generation_service.run,
+                        playbook_generation_request,
+                    ),
+                ]
 
-        executor = ThreadPoolExecutor(max_workers=2)
-        try:
-            futures = [
-                executor.submit(
-                    contextvars.copy_context().run,
-                    profile_generation_service.run,
-                    profile_generation_request,
-                ),
-                executor.submit(
-                    contextvars.copy_context().run,
-                    playbook_generation_service.run,
-                    playbook_generation_request,
-                ),
-            ]
-
-            service_names = ["profile_generation", "playbook_generation"]
-            for future, service_name in zip(futures, service_names, strict=True):
-                try:
-                    future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
-                except FuturesTimeoutError:  # noqa: PERF203
-                    msg = (
-                        f"{service_name} timed out after "
-                        f"{GENERATION_SERVICE_TIMEOUT_SECONDS}s"
-                    )
-                    with sentry_tags(
-                        subsystem="generation",
-                        service=service_name,
-                        request_id=request_id,
-                        error_type="timeout",
-                    ):
-                        logger.error("%s for request %s", msg, request_id)
-                    result.warnings.append(msg)
-                except Exception as e:
-                    msg = f"{service_name} failed: {e}"
-                    with sentry_tags(
-                        subsystem="generation",
-                        service=service_name,
-                        request_id=request_id,
-                        error_type=type(e).__name__,
-                    ):
-                        logger.exception(
-                            "Generation service failed for request %s",
-                            request_id,
+                service_names = ["profile_generation", "playbook_generation"]
+                for future, service_name in zip(futures, service_names, strict=True):
+                    try:
+                        future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
+                    except FuturesTimeoutError:  # noqa: PERF203
+                        msg = (
+                            f"{service_name} timed out after "
+                            f"{GENERATION_SERVICE_TIMEOUT_SECONDS}s"
                         )
-                    result.warnings.append(msg)
-        finally:
-            executor.shutdown(wait=False, cancel_futures=True)
+                        with sentry_tags(
+                            subsystem="generation",
+                            service=service_name,
+                            request_id=request_id,
+                            error_type="timeout",
+                        ):
+                            logger.error("%s for request %s", msg, request_id)
+                        result.warnings.append(msg)
+                    except Exception as e:
+                        msg = f"{service_name} failed: {e}"
+                        with sentry_tags(
+                            subsystem="generation",
+                            service=service_name,
+                            request_id=request_id,
+                            error_type=type(e).__name__,
+                        ):
+                            logger.exception(
+                                "Generation service failed for request %s",
+                                request_id,
+                            )
+                        result.warnings.append(msg)
+            finally:
+                executor.shutdown(wait=False, cancel_futures=True)
 
         try:
             schedule_tagging(

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -340,13 +340,17 @@ class GenerationService:
                     with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
                         self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
                         self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
-                            user_id=user_id, interactions=new_interactions
+                            user_id=user_id,
+                            interactions=new_interactions,
+                            embeddings_prepared=True,
                         )
                         self.storage.enqueue_learning_job(  # type: ignore[reportOptionalMemberAccess]
                             org_id=self.org_id,
                             user_id=user_id,
                             request_id=request_id,
                             covers_through=covers_through,
+                            force_extraction=publish_user_interaction_request.force_extraction,
+                            skip_aggregation=publish_user_interaction_request.skip_aggregation,
                         )
                     self._schedule_group_evaluation_if_needed(
                         new_request=new_request,

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -22,6 +22,7 @@ from reflexio.models.api_schema.service_schemas import (
 )
 from reflexio.models.config_schema import Config
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.env_utils import env_str, env_truthy
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.operation_limiter import operation_limit
 from reflexio.server.services.agent_success_evaluation.runner import (
@@ -249,17 +250,32 @@ class GenerationService:
                 session_id=publish_user_interaction_request.session_id,
                 evaluation_only=publish_user_interaction_request.evaluation_only,
             )
-            self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
 
-            # Add interactions to storage (bulk insert with batched embedding generation)
-            self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
-                user_id=user_id, interactions=new_interactions
+            # When the durable queue is enabled and this is a deferred publish, the
+            # request + interactions + job row are written together inside a single
+            # commit_scope (below).  Every other path persists here unconditionally.
+            use_durable_queue = env_truthy(
+                env_str("REFLEXIO_DURABLE_LEARNING_QUEUE", "false")
             )
+            _durable_defer = defer_learning and use_durable_queue
+
+            if not _durable_defer:
+                self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
+                # Add interactions to storage (bulk insert with batched embedding generation)
+                self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
+                    user_id=user_id, interactions=new_interactions
+                )
 
             # Extract source (empty string treated as None)
             source = publish_user_interaction_request.source or None
 
             if publish_user_interaction_request.evaluation_only:
+                if _durable_defer:
+                    # evaluation_only returns early; ensure data lands even on durable path.
+                    self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
+                    self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
+                        user_id=user_id, interactions=new_interactions
+                    )
                 self._schedule_group_evaluation_if_needed(
                     new_request=new_request,
                     user_id=user_id,
@@ -290,6 +306,12 @@ class GenerationService:
                 not publish_user_interaction_request.override_learning_stall
                 and (stall_warning := self._active_learning_stall_warning()) is not None
             ):
+                if _durable_defer:
+                    # Stall skips learning but data must still land.
+                    self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
+                    self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
+                        user_id=user_id, interactions=new_interactions
+                    )
                 result.warnings.append(stall_warning)
                 logger.warning("%s; skipping automatic extraction", stall_warning)
                 record_usage_event(
@@ -309,6 +331,50 @@ class GenerationService:
                 return result
 
             if defer_learning:
+                if _durable_defer:
+                    # Durable atomic path: pre-generate embeddings OUTSIDE the
+                    # transaction (network call), then persist request + interactions
+                    # + job in one commit_scope.
+                    self.storage.prepare_interaction_embeddings(new_interactions)  # type: ignore[reportOptionalMemberAccess]
+                    covers_through = max(i.created_at for i in new_interactions)
+                    with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
+                        self.storage.add_request(new_request)  # type: ignore[reportOptionalMemberAccess]
+                        self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
+                            user_id=user_id, interactions=new_interactions
+                        )
+                        self.storage.enqueue_learning_job(  # type: ignore[reportOptionalMemberAccess]
+                            org_id=self.org_id,
+                            user_id=user_id,
+                            request_id=request_id,
+                            covers_through=covers_through,
+                        )
+                    self._schedule_group_evaluation_if_needed(
+                        new_request=new_request,
+                        user_id=user_id,
+                        agent_version=agent_version,
+                        source=source,
+                    )
+                    record_usage_event(
+                        org_id=self.org_id,
+                        user_id=user_id,
+                        request_id=request_id,
+                        session_id=new_request.session_id,
+                        source=source,
+                        agent_version=agent_version,
+                        backend="durable",
+                        event_name="publish_request_succeeded",
+                        event_category="publish",
+                        outcome="success",
+                        count_value=len(new_interactions),
+                        duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                        metadata={
+                            "defer_learning": True,
+                            "durable_queue": True,
+                            "warning_count": len(result.warnings),
+                        },
+                    )
+                    return result
+
                 from reflexio.server.services.publish_learning_worker import (
                     PublishLearningJob,
                     enqueue_publish_learning,

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -1,3 +1,4 @@
+from ._learning_jobs import SQLiteLearningJobStoreMixin
 from ._base import (
     SQLiteStorageBase,
     _cosine_similarity,
@@ -48,6 +49,7 @@ from .profiles import InteractionStoreMixin, ProfileSearchMixin, ProfileStoreMix
 
 
 class SQLiteStorage(
+    SQLiteLearningJobStoreMixin,
     SQLiteAgentRunStoreMixin,
     SQLitePendingToolCallStoreMixin,
     SQLiteRunToolDependencyStoreMixin,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -759,6 +759,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         self._migrate_retire_profile_change_logs()
         self._migrate_retire_playbook_aggregation_change_logs()
         init_stall_state_table(self.conn)
+        self._migrate_learning_jobs()
         return True
 
     def _try_load_sqlite_vec(self) -> bool:
@@ -1305,6 +1306,43 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 "(Track B Task 4 retirement)"
             )
             self.conn.commit()
+
+    def _migrate_learning_jobs(self) -> None:
+        """Create the learning_jobs table + partial indexes if missing (idempotent).
+
+        New columns are backfilled via PRAGMA table_info inspection (additive only).
+        Called at the end of migrate() so the table is always present on startup.
+        """
+        with self._lock:
+            self.conn.executescript("""
+                CREATE TABLE IF NOT EXISTS learning_jobs (
+                    job_id TEXT PRIMARY KEY,
+                    org_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    job_type TEXT NOT NULL DEFAULT 'learning',
+                    latest_request_id TEXT,
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    max_attempts INTEGER NOT NULL DEFAULT 3,
+                    claimed_by TEXT,
+                    claim_token TEXT,
+                    claim_expires_at TEXT,
+                    covers_through TEXT,
+                    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                );
+                CREATE UNIQUE INDEX IF NOT EXISTS learning_jobs_coalesce
+                    ON learning_jobs (org_id, user_id, job_type) WHERE status = 'pending';
+                CREATE INDEX IF NOT EXISTS learning_jobs_poll
+                    ON learning_jobs (created_at) WHERE status IN ('pending','claimed');
+            """)
+            self.conn.commit()
+
+    def learning_jobs_columns(self) -> list[str]:
+        """Return the column names of the learning_jobs table."""
+        with self._lock:
+            rows = self.conn.execute("PRAGMA table_info(learning_jobs)").fetchall()
+        return [row["name"] for row in rows]
 
     def _migrate_agent_playbook_source_windows(self) -> None:
         """Add source window snapshots to existing agent source mappings."""
@@ -2138,5 +2176,30 @@ CREATE TABLE IF NOT EXISTS lineage_event (
     UNIQUE (org_id, entity_type, entity_id, op, request_id)
 );
 CREATE INDEX IF NOT EXISTS idx_lineage_entity ON lineage_event (entity_type, entity_id);
+
+-- ============================================================================
+-- Durable learning pipeline — cross-org job queue
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS learning_jobs (
+    job_id TEXT PRIMARY KEY,
+    org_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    job_type TEXT NOT NULL DEFAULT 'learning',
+    latest_request_id TEXT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    claimed_by TEXT,
+    claim_token TEXT,
+    claim_expires_at TEXT,
+    covers_through TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS learning_jobs_coalesce
+    ON learning_jobs (org_id, user_id, job_type) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS learning_jobs_poll
+    ON learning_jobs (created_at) WHERE status IN ('pending','claimed');
 
 """

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -700,8 +700,8 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 finally:
                     self._scope_depth -= 1
                 return
-            self._scope_depth = 1
             self.conn.execute("BEGIN IMMEDIATE")
+            self._scope_depth = 1
             try:
                 yield
                 self.conn.commit()

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -15,7 +15,7 @@ import math
 import re
 import sqlite3
 import threading
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Generator, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar, Literal
@@ -685,7 +685,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         return self._scope_depth == 0
 
     @contextlib.contextmanager
-    def commit_scope(self) -> Iterator[None]:  # type: ignore[override]
+    def commit_scope(self) -> Generator[None, None, None]:
         """Group writes into one atomic commit; defer FTS/vec index ops.
 
         Nested scopes join the outermost: only the outer scope commits. On

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -7,6 +7,7 @@ are available.
 
 """
 
+import contextlib
 import functools
 import json
 import logging
@@ -14,7 +15,7 @@ import math
 import re
 import sqlite3
 import threading
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, ClassVar, Literal
@@ -590,6 +591,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     # FTS/vec index helpers provided by SQLiteFtsVecMixin via the composed
     # SQLiteStorage MRO; declared here for _migrate_vec_tables's benefit.
     _vec_upsert: Any
+    _flush_index_op: Any
 
     @staticmethod
     def handle_exceptions(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -633,6 +635,10 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
 
         self.db_path = db_path
         self._lock = threading.RLock()
+        self._scope_depth = 0
+        self._deferred_index_ops: list[
+            tuple[str, Any]
+        ] = []  # (kind, args) flushed post-commit
 
         logger.info("SQLite Storage for org %s using db_path: %s", org_id, db_path)
 
@@ -669,6 +675,45 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
 
         # Create tables
         self.migrate()
+
+    # ------------------------------------------------------------------
+    # Transaction scope
+    # ------------------------------------------------------------------
+
+    def _own_transaction(self) -> bool:
+        """True when the caller is NOT inside a commit_scope (owns its BEGIN/commit)."""
+        return self._scope_depth == 0
+
+    @contextlib.contextmanager
+    def commit_scope(self) -> Iterator[None]:  # type: ignore[override]
+        """Group writes into one atomic commit; defer FTS/vec index ops.
+
+        Nested scopes join the outermost: only the outer scope commits. On
+        exception the whole transaction rolls back and deferred index ops
+        are discarded.
+        """
+        with self._lock:
+            if self._scope_depth > 0:
+                self._scope_depth += 1
+                try:
+                    yield
+                finally:
+                    self._scope_depth -= 1
+                return
+            self._scope_depth = 1
+            self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                yield
+                self.conn.commit()
+                ops, self._deferred_index_ops = self._deferred_index_ops, []
+                for kind, args in ops:
+                    self._flush_index_op(kind, args)  # self-commits — fine post-commit
+            except Exception:
+                self.conn.rollback()
+                self._deferred_index_ops = []
+                raise
+            finally:
+                self._scope_depth = 0
 
     # ------------------------------------------------------------------
     # DDL / migration

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1311,10 +1311,9 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         """Create the learning_jobs table + partial indexes if missing (idempotent).
 
         Runs ``CREATE TABLE IF NOT EXISTS`` and ``CREATE INDEX IF NOT EXISTS`` only —
-        both are no-ops when the table / indexes already exist.  No column backfill is
-        performed here.  If a new column is added to learning_jobs in a later task,
-        a separate ``PRAGMA table_info`` + ``ALTER TABLE … ADD COLUMN`` step must be
-        added (mirroring ``_migrate_lineage_event_table``), because
+        both are no-ops when the table / indexes already exist.  New columns added in
+        subsequent tasks are backfilled via ``PRAGMA table_info`` + ``ALTER TABLE … ADD
+        COLUMN`` (mirroring ``_migrate_lineage_event_table``), because
         ``CREATE TABLE IF NOT EXISTS`` silently skips the DDL on existing databases.
 
         Called at the end of migrate() so the table is always present on startup.
@@ -1334,6 +1333,8 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     claim_token TEXT,
                     claim_expires_at TEXT,
                     covers_through TEXT,
+                    force_extraction INTEGER NOT NULL DEFAULT 0,
+                    skip_aggregation INTEGER NOT NULL DEFAULT 0,
                     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
                 );
@@ -1342,6 +1343,22 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 CREATE INDEX IF NOT EXISTS learning_jobs_poll
                     ON learning_jobs (created_at) WHERE status IN ('pending','claimed');
             """)
+            # Backfill columns added after the initial release (existing DBs skip
+            # CREATE TABLE IF NOT EXISTS so these must be applied separately).
+            existing_cols = {
+                row["name"]
+                for row in self.conn.execute(
+                    "PRAGMA table_info(learning_jobs)"
+                ).fetchall()
+            }
+            if "force_extraction" not in existing_cols:
+                self.conn.execute(
+                    "ALTER TABLE learning_jobs ADD COLUMN force_extraction INTEGER NOT NULL DEFAULT 0"
+                )
+            if "skip_aggregation" not in existing_cols:
+                self.conn.execute(
+                    "ALTER TABLE learning_jobs ADD COLUMN skip_aggregation INTEGER NOT NULL DEFAULT 0"
+                )
             self.conn.commit()
 
     def learning_jobs_columns(self) -> list[str]:
@@ -2200,6 +2217,8 @@ CREATE TABLE IF NOT EXISTS learning_jobs (
     claim_token TEXT,
     claim_expires_at TEXT,
     covers_through TEXT,
+    force_extraction INTEGER NOT NULL DEFAULT 0,
+    skip_aggregation INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
 );

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1557,7 +1557,8 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     ) -> sqlite3.Cursor:
         with self._lock:
             cur = self.conn.execute(sql, params)
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
             return cur
 
     def _fetchone(

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1310,7 +1310,13 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     def _migrate_learning_jobs(self) -> None:
         """Create the learning_jobs table + partial indexes if missing (idempotent).
 
-        New columns are backfilled via PRAGMA table_info inspection (additive only).
+        Runs ``CREATE TABLE IF NOT EXISTS`` and ``CREATE INDEX IF NOT EXISTS`` only —
+        both are no-ops when the table / indexes already exist.  No column backfill is
+        performed here.  If a new column is added to learning_jobs in a later task,
+        a separate ``PRAGMA table_info`` + ``ALTER TABLE … ADD COLUMN`` step must be
+        added (mirroring ``_migrate_lineage_event_table``), because
+        ``CREATE TABLE IF NOT EXISTS`` silently skips the DDL on existing databases.
+
         Called at the end of migrate() so the table is always present on startup.
         """
         with self._lock:

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -1340,8 +1340,12 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 );
                 CREATE UNIQUE INDEX IF NOT EXISTS learning_jobs_coalesce
                     ON learning_jobs (org_id, user_id, job_type) WHERE status = 'pending';
+                -- Recreate the poll index with 'failed' in the predicate. CREATE
+                -- INDEX IF NOT EXISTS is a no-op on an existing index with the old
+                -- ('pending','claimed') predicate, so DROP first to migrate it.
+                DROP INDEX IF EXISTS learning_jobs_poll;
                 CREATE INDEX IF NOT EXISTS learning_jobs_poll
-                    ON learning_jobs (created_at) WHERE status IN ('pending','claimed');
+                    ON learning_jobs (created_at) WHERE status IN ('pending','failed','claimed');
             """)
             # Backfill columns added after the initial release (existing DBs skip
             # CREATE TABLE IF NOT EXISTS so these must be applied separately).
@@ -2226,6 +2230,6 @@ CREATE TABLE IF NOT EXISTS learning_jobs (
 CREATE UNIQUE INDEX IF NOT EXISTS learning_jobs_coalesce
     ON learning_jobs (org_id, user_id, job_type) WHERE status = 'pending';
 CREATE INDEX IF NOT EXISTS learning_jobs_poll
-    ON learning_jobs (created_at) WHERE status IN ('pending','claimed');
+    ON learning_jobs (created_at) WHERE status IN ('pending','failed','claimed');
 
 """

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -371,7 +371,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
             return "pending"
         if has_dead_covering:
             return "failed"
-        # Absence semantics: terminal rows (done/dead) are GC'd after 24–72 h.
+        # Absence semantics: terminal rows (done/dead) are GC'd after 24-72 h.
         # Only treat absence as "done" once the request is old enough that a done
         # row would have been reaped; a recent request with no rows is still pending.
         if time.time() - request_created_at >= _ABSENCE_DONE_AFTER_SECONDS:

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -1,8 +1,13 @@
 """SQLite implementation of the durable learning-job queue (Task 3)."""
 
 import sqlite3
+import time
 import uuid
 from typing import Any
+
+# Matches the upper bound of the done-row retention window (24–72 h).
+# Err toward "not done" until we are sure a done row would have been GC'd.
+_ABSENCE_DONE_AFTER_SECONDS = 72 * 3600
 
 from reflexio.server.services.storage.storage_base._learning_jobs import (
     LearningJob,
@@ -55,6 +60,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
     ) -> str:
         """Coalescing upsert — safe to call inside a commit_scope."""
         job_id = str(uuid.uuid4())
+        # int() truncates sub-second precision — intentional (second-precision epochs).
         iso_covers = _epoch_to_iso(int(covers_through))
         with self._lock:
             own_txn = self._own_transaction()
@@ -255,7 +261,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                         claim_token = CASE WHEN ? THEN claim_token ELSE NULL END,
                         claim_expires_at = CASE WHEN ? THEN claim_expires_at ELSE NULL END,
                         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-                    WHERE job_id = ? AND claim_token = ?
+                    WHERE job_id = ? AND claim_token = ? AND status = 'claimed'
                     """,
                     (new_status, dead, dead, job_id, claim_token),
                 )
@@ -266,6 +272,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                     self.conn.rollback()
                 raise
 
+    @SQLiteStorageBase.handle_exceptions
     def get_learning_status_for_request(
         self,
         *,
@@ -299,10 +306,14 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                 has_claimed_covering = True
             if covers and status == "dead":
                 has_dead_covering = True
+            if status == "failed":
+                # 'failed' is reclaimable (attempts < max_attempts); treat as pending.
+                return "pending"
             if status == "pending":
                 has_pending = True
             if status == "claimed":
-                # A claimed job in progress will eventually cover this request.
+                # Deliberately treats any claimed job as covering, regardless of its
+                # covers_through value — it will extend the window once it completes.
                 has_claimed_covering = True
 
         if has_claimed_covering:
@@ -311,7 +322,9 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
             return "pending"
         if has_dead_covering:
             return "failed"
-        # Absence semantics: terminal rows (done/failed/dead) are GC'd after
-        # 24–72 h; polling is minutes-scale so no rows long after the fact means
-        # the job completed and was already reaped.
-        return "done"
+        # Absence semantics: terminal rows (done/dead) are GC'd after 24–72 h.
+        # Only treat absence as "done" once the request is old enough that a done
+        # row would have been reaped; a recent request with no rows is still pending.
+        if time.time() - request_created_at >= _ABSENCE_DONE_AFTER_SECONDS:
+            return "done"
+        return "pending"

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -30,6 +30,7 @@ def _row_to_learning_job(row: sqlite3.Row) -> LearningJob:
         covers_through=float(_iso_to_epoch(ct)) if ct else None,
         force_extraction=bool(d.get("force_extraction", 0)),
         skip_aggregation=bool(d.get("skip_aggregation", 0)),
+        max_attempts=int(d.get("max_attempts", 3)),
     )
 
 

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -294,6 +294,27 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                 raise
 
     @SQLiteStorageBase.handle_exceptions
+    def list_org_ids_with_pending_learning_jobs(self) -> list[str]:
+        """Distinct org_ids with actionable jobs (cross-org, not org-scoped).
+
+        Uses the DB's now() for the expired-lease comparison to avoid clock skew,
+        mirroring ``claim_learning_jobs``. Index-covered by ``learning_jobs_poll``
+        (predicate now includes 'failed').
+        """
+        rows = self._fetchall(
+            """
+            SELECT DISTINCT org_id FROM learning_jobs
+            WHERE status = 'pending'
+               OR status = 'failed'
+               OR (status = 'claimed'
+                   AND claim_expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+            ORDER BY org_id ASC
+            """,
+            (),
+        )
+        return [str(row["org_id"]) for row in rows]
+
+    @SQLiteStorageBase.handle_exceptions
     def get_learning_status_for_request(
         self,
         *,

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -9,6 +9,7 @@ from reflexio.server.services.storage.storage_base._learning_jobs import (
     _ABSENCE_DONE_AFTER_SECONDS,
     LearningJob,
     LearningJobStoreABC,
+    LearningStatus,
 )
 
 from ._base import SQLiteStorageBase, _epoch_to_iso, _iso_to_epoch
@@ -321,7 +322,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         *,
         user_id: str,
         request_created_at: float,
-    ) -> str:
+    ) -> LearningStatus:
         """Coverage-based status lookup (§3.6 rule).
 
         Converts request_created_at epoch to ISO for lexicographic comparison

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -298,8 +298,9 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         """Distinct org_ids with actionable jobs (cross-org, not org-scoped).
 
         Uses the DB's now() for the expired-lease comparison to avoid clock skew,
-        mirroring ``claim_learning_jobs``. Index-covered by ``learning_jobs_poll``
-        (predicate now includes 'failed').
+        mirroring ``claim_learning_jobs``. Index-aided by ``learning_jobs_poll``
+        (partial index narrows the scan to non-terminal rows; org_id still requires
+        a heap fetch).
         """
         rows = self._fetchall(
             """

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -5,11 +5,8 @@ import time
 import uuid
 from typing import Any
 
-# Matches the upper bound of the done-row retention window (24–72 h).
-# Err toward "not done" until we are sure a done row would have been GC'd.
-_ABSENCE_DONE_AFTER_SECONDS = 72 * 3600
-
 from reflexio.server.services.storage.storage_base._learning_jobs import (
+    _ABSENCE_DONE_AFTER_SECONDS,
     LearningJob,
     LearningJobStoreABC,
 )
@@ -294,6 +291,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         has_pending = False
         has_claimed_covering = False
         has_dead_covering = False
+        has_failed = False
 
         for row in rows:
             status = row["status"]
@@ -308,7 +306,9 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                 has_dead_covering = True
             if status == "failed":
                 # 'failed' is reclaimable (attempts < max_attempts); treat as pending.
-                return "pending"
+                # Accumulate as a flag so a covering done row (encountered later in the
+                # iteration) is not shadowed by a failed row yielded earlier.
+                has_failed = True
             if status == "pending":
                 has_pending = True
             if status == "claimed":
@@ -319,6 +319,8 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         if has_claimed_covering:
             return "processing"
         if has_pending:
+            return "pending"
+        if has_failed:
             return "pending"
         if has_dead_covering:
             return "failed"

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -28,6 +28,8 @@ def _row_to_learning_job(row: sqlite3.Row) -> LearningJob:
         attempts=d["attempts"],
         claim_token=d.get("claim_token"),
         covers_through=float(_iso_to_epoch(ct)) if ct else None,
+        force_extraction=bool(d.get("force_extraction", 0)),
+        skip_aggregation=bool(d.get("skip_aggregation", 0)),
     )
 
 
@@ -54,11 +56,15 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         request_id: str,
         covers_through: float,
         job_type: str = "learning",
+        force_extraction: bool = False,
+        skip_aggregation: bool = False,
     ) -> str:
         """Coalescing upsert — safe to call inside a commit_scope."""
         job_id = str(uuid.uuid4())
         # int() truncates sub-second precision — intentional (second-precision epochs).
         iso_covers = _epoch_to_iso(int(covers_through))
+        fe_int = int(force_extraction)
+        sa_int = int(skip_aggregation)
         with self._lock:
             own_txn = self._own_transaction()
             try:
@@ -68,11 +74,11 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                     """
                     INSERT INTO learning_jobs
                         (job_id, org_id, user_id, job_type, latest_request_id,
-                         covers_through, status,
+                         covers_through, status, force_extraction, skip_aggregation,
                          created_at, updated_at)
                     VALUES
                         (?, ?, ?, ?, ?,
-                         ?, 'pending',
+                         ?, 'pending', ?, ?,
                          strftime('%Y-%m-%dT%H:%M:%fZ','now'),
                          strftime('%Y-%m-%dT%H:%M:%fZ','now'))
                     ON CONFLICT (org_id, user_id, job_type) WHERE status = 'pending'
@@ -83,10 +89,21 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                             THEN learning_jobs.covers_through
                             ELSE excluded.covers_through
                         END,
+                        force_extraction = excluded.force_extraction,
+                        skip_aggregation = excluded.skip_aggregation,
                         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
                     RETURNING job_id
                     """,
-                    (job_id, org_id, user_id, job_type, request_id, iso_covers),
+                    (
+                        job_id,
+                        org_id,
+                        user_id,
+                        job_type,
+                        request_id,
+                        iso_covers,
+                        fe_int,
+                        sa_int,
+                    ),
                 ).fetchone()
                 if own_txn:
                     self.conn.commit()

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -1,0 +1,317 @@
+"""SQLite implementation of the durable learning-job queue (Task 3)."""
+
+import sqlite3
+import uuid
+from typing import Any
+
+from reflexio.server.services.storage.storage_base._learning_jobs import (
+    LearningJob,
+    LearningJobStoreABC,
+)
+
+from ._base import SQLiteStorageBase, _epoch_to_iso, _iso_to_epoch
+
+
+def _row_to_learning_job(row: sqlite3.Row) -> LearningJob:
+    """Convert a sqlite3.Row from learning_jobs to a LearningJob dataclass."""
+    d = dict(row)
+    ct = d.get("covers_through")
+    return LearningJob(
+        job_id=d["job_id"],
+        org_id=d["org_id"],
+        user_id=d["user_id"],
+        job_type=d["job_type"],
+        latest_request_id=d.get("latest_request_id"),
+        status=d["status"],
+        attempts=d["attempts"],
+        claim_token=d.get("claim_token"),
+        covers_through=float(_iso_to_epoch(ct)) if ct else None,
+    )
+
+
+class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
+    """SQLite implementation of the learning-job queue.
+
+    Relies on instance attributes provided by SQLiteStorageBase via MRO:
+    ``conn``, ``_lock``, ``_own_transaction``, ``org_id``.
+    """
+
+    # Type annotations for attributes/methods supplied by SQLiteStorageBase via MRO
+    _lock: Any
+    conn: sqlite3.Connection
+    org_id: str
+    _own_transaction: Any
+    _fetchall: Any
+
+    @SQLiteStorageBase.handle_exceptions
+    def enqueue_learning_job(
+        self,
+        *,
+        org_id: str,
+        user_id: str,
+        request_id: str,
+        covers_through: float,
+        job_type: str = "learning",
+    ) -> str:
+        """Coalescing upsert — safe to call inside a commit_scope."""
+        job_id = str(uuid.uuid4())
+        iso_covers = _epoch_to_iso(int(covers_through))
+        with self._lock:
+            own_txn = self._own_transaction()
+            try:
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                row = self.conn.execute(
+                    """
+                    INSERT INTO learning_jobs
+                        (job_id, org_id, user_id, job_type, latest_request_id,
+                         covers_through, status,
+                         created_at, updated_at)
+                    VALUES
+                        (?, ?, ?, ?, ?,
+                         ?, 'pending',
+                         strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+                         strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                    ON CONFLICT (org_id, user_id, job_type) WHERE status = 'pending'
+                    DO UPDATE SET
+                        latest_request_id = excluded.latest_request_id,
+                        covers_through = CASE
+                            WHEN learning_jobs.covers_through > excluded.covers_through
+                            THEN learning_jobs.covers_through
+                            ELSE excluded.covers_through
+                        END,
+                        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                    RETURNING job_id
+                    """,
+                    (job_id, org_id, user_id, job_type, request_id, iso_covers),
+                ).fetchone()
+                if own_txn:
+                    self.conn.commit()
+            except Exception:
+                if own_txn:
+                    self.conn.rollback()
+                raise
+        if row is None:
+            raise RuntimeError("enqueue_learning_job RETURNING job_id returned no row")
+        return str(row["job_id"])
+
+    @SQLiteStorageBase.handle_exceptions
+    def claim_learning_jobs(
+        self,
+        *,
+        claimed_by: str,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[LearningJob]:
+        """BEGIN IMMEDIATE + SELECT + UPDATE to atomically claim jobs."""
+        with self._lock:
+            own_txn = self._own_transaction()
+            try:
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
+
+                # Find candidate job_ids using DB's now() to avoid clock skew
+                candidate_rows = self.conn.execute(
+                    """
+                    SELECT job_id FROM learning_jobs
+                    WHERE org_id = ?
+                      AND (
+                            status = 'pending'
+                            OR (status = 'claimed'
+                                AND claim_expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                          )
+                    ORDER BY created_at
+                    LIMIT ?
+                    """,
+                    (self.org_id, limit),
+                ).fetchall()
+
+                claimed: list[LearningJob] = []
+                for cand in candidate_rows:
+                    job_id = cand["job_id"]
+                    claim_token = str(uuid.uuid4())
+                    updated = self.conn.execute(
+                        """
+                        UPDATE learning_jobs SET
+                            status = 'claimed',
+                            claimed_by = ?,
+                            claim_token = ?,
+                            claim_expires_at = strftime(
+                                '%Y-%m-%dT%H:%M:%fZ', 'now',
+                                ? || ' seconds'
+                            ),
+                            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+                            attempts = attempts + 1
+                        WHERE job_id = ?
+                        RETURNING *
+                        """,
+                        (claimed_by, claim_token, str(lease_seconds), job_id),
+                    ).fetchone()
+                    if updated is not None:
+                        claimed.append(_row_to_learning_job(updated))
+
+                if own_txn:
+                    self.conn.commit()
+            except Exception:
+                if own_txn:
+                    self.conn.rollback()
+                raise
+
+        return claimed
+
+    @SQLiteStorageBase.handle_exceptions
+    def heartbeat_learning_job(
+        self,
+        *,
+        job_id: str,
+        claim_token: str,
+        lease_seconds: int,
+    ) -> bool:
+        """Extend the lease; return True if the token is still live."""
+        with self._lock:
+            own_txn = self._own_transaction()
+            try:
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                cur = self.conn.execute(
+                    """
+                    UPDATE learning_jobs SET
+                        claim_expires_at = strftime(
+                            '%Y-%m-%dT%H:%M:%fZ', 'now',
+                            ? || ' seconds'
+                        ),
+                        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                    WHERE job_id = ? AND claim_token = ? AND status = 'claimed'
+                    """,
+                    (str(lease_seconds), job_id, claim_token),
+                )
+                updated = cur.rowcount == 1
+                if own_txn:
+                    self.conn.commit()
+            except Exception:
+                if own_txn:
+                    self.conn.rollback()
+                raise
+
+        return updated
+
+    @SQLiteStorageBase.handle_exceptions
+    def complete_learning_job(
+        self,
+        *,
+        job_id: str,
+        claim_token: str,
+    ) -> int:
+        """Fenced completion — returns rowcount (0=superseded, 1=success).
+
+        Safe to call inside a commit_scope — no own BEGIN/COMMIT issued.
+        """
+        with self._lock:
+            own_txn = self._own_transaction()
+            try:
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                cur = self.conn.execute(
+                    """
+                    UPDATE learning_jobs SET
+                        status = 'done',
+                        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                    WHERE job_id = ? AND claim_token = ? AND status = 'claimed'
+                    """,
+                    (job_id, claim_token),
+                )
+                rowcount = cur.rowcount
+                if own_txn:
+                    self.conn.commit()
+            except Exception:
+                if own_txn:
+                    self.conn.rollback()
+                raise
+
+        return rowcount
+
+    @SQLiteStorageBase.handle_exceptions
+    def fail_learning_job(
+        self,
+        *,
+        job_id: str,
+        claim_token: str,
+        dead: bool,
+    ) -> None:
+        """Fenced fail/dead transition — increments attempts, clears token for retry."""
+        new_status = "dead" if dead else "failed"
+        # Clear claim_token and claim_expires_at only for 'failed' so it's reclaimable.
+        # For 'dead', we keep claim_token set for auditability (won't be reclaimed anyway).
+        with self._lock:
+            own_txn = self._own_transaction()
+            try:
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
+                self.conn.execute(
+                    """
+                    UPDATE learning_jobs SET
+                        status = ?,
+                        attempts = attempts + 1,
+                        claim_token = CASE WHEN ? THEN claim_token ELSE NULL END,
+                        claim_expires_at = CASE WHEN ? THEN claim_expires_at ELSE NULL END,
+                        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                    WHERE job_id = ? AND claim_token = ?
+                    """,
+                    (new_status, dead, dead, job_id, claim_token),
+                )
+                if own_txn:
+                    self.conn.commit()
+            except Exception:
+                if own_txn:
+                    self.conn.rollback()
+                raise
+
+    def get_learning_status_for_request(
+        self,
+        *,
+        user_id: str,
+        request_created_at: float,
+    ) -> str:
+        """Coverage-based status lookup (§3.6 rule).
+
+        Converts request_created_at epoch to ISO for lexicographic comparison
+        with stored covers_through ISO strings (same format, both UTC).
+        """
+        req_iso = _epoch_to_iso(int(request_created_at))
+        rows = self._fetchall(
+            "SELECT status, covers_through FROM learning_jobs "
+            "WHERE org_id = ? AND user_id = ?",
+            (self.org_id, user_id),
+        )
+
+        has_pending = False
+        has_claimed_covering = False
+        has_dead_covering = False
+
+        for row in rows:
+            status = row["status"]
+            ct: str | None = row["covers_through"]
+            covers = ct is not None and ct >= req_iso
+
+            if covers and status == "done":
+                return "done"
+            if covers and status == "claimed":
+                has_claimed_covering = True
+            if covers and status == "dead":
+                has_dead_covering = True
+            if status == "pending":
+                has_pending = True
+            if status == "claimed":
+                # A claimed job in progress will eventually cover this request.
+                has_claimed_covering = True
+
+        if has_claimed_covering:
+            return "processing"
+        if has_pending:
+            return "pending"
+        if has_dead_covering:
+            return "failed"
+        # Absence semantics: terminal rows (done/failed/dead) are GC'd after
+        # 24–72 h; polling is minutes-scale so no rows long after the fact means
+        # the job completed and was already reaped.
+        return "done"

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -131,13 +131,16 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                 if own_txn:
                     self.conn.execute("BEGIN IMMEDIATE")
 
-                # Find candidate job_ids using DB's now() to avoid clock skew
+                # Find candidate job_ids using DB's now() to avoid clock skew.
+                # Include 'failed' so a failed-but-not-dead job is naturally
+                # reclaimable without a manual status reset.
                 candidate_rows = self.conn.execute(
                     """
                     SELECT job_id FROM learning_jobs
                     WHERE org_id = ?
                       AND (
                             status = 'pending'
+                            OR status = 'failed'
                             OR (status = 'claimed'
                                 AND claim_expires_at < strftime('%Y-%m-%dT%H:%M:%fZ','now'))
                           )
@@ -259,7 +262,11 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         claim_token: str,
         dead: bool,
     ) -> None:
-        """Fenced fail/dead transition — increments attempts, clears token for retry."""
+        """Fenced fail/dead transition — sets status, clears token for retry.
+
+        Does NOT increment attempts: claim_learning_jobs already incremented on
+        delivery.  attempts tracks delivery count; fail only transitions status.
+        """
         new_status = "dead" if dead else "failed"
         # Clear claim_token and claim_expires_at only for 'failed' so it's reclaimable.
         # For 'dead', we keep claim_token set for auditability (won't be reclaimed anyway).
@@ -272,7 +279,6 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
                     """
                     UPDATE learning_jobs SET
                         status = ?,
-                        attempts = attempts + 1,
                         claim_token = CASE WHEN ? THEN claim_token ELSE NULL END,
                         claim_expires_at = CASE WHEN ? THEN claim_expires_at ELSE NULL END,
                         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -127,6 +127,7 @@ class SQLiteLineageMixin:
     conn: sqlite3.Connection
     _lock: threading.RLock
     org_id: str
+    _own_transaction: Any
 
     def append_lineage_event(self, event: LineageEvent) -> int:
         """Append an event; idempotent on (org_id, entity_type, entity_id, op, request_id).
@@ -173,10 +174,12 @@ class SQLiteLineageMixin:
                     ),
                 ).fetchone()
                 eid = row[0] if row else None
-                self.conn.commit()
+                if self._own_transaction():
+                    self.conn.commit()
                 return int(eid) if eid is not None else 0
             last = cur.lastrowid
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
             return int(last) if last is not None else 0
 
     def get_lineage_events(
@@ -301,7 +304,8 @@ class SQLiteLineageMixin:
                 request_id=context.request_id,
                 reason=context.reason,
             )
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
 
     def supersede_record(
         self,
@@ -343,7 +347,8 @@ class SQLiteLineageMixin:
                 (Status.SUPERSEDED.value, successor_id, _epoch_now(), incumbent_id),
             )
             if cur.rowcount == 0:
-                self.conn.commit()
+                if self._own_transaction():
+                    self.conn.commit()
                 return False
             _append_event_stmt(
                 self.conn,
@@ -357,7 +362,8 @@ class SQLiteLineageMixin:
                 request_id=context.request_id,
                 reason=context.reason,
             )
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
             return True
 
     def purge_content(self, *, entity_type: EntityType, entity_id: str) -> bool:

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -42,8 +42,8 @@ class RequestMixin:
     def add_request(self, request: Request) -> None:
         created_at_iso = _epoch_to_iso(request.created_at)
         subject_ref = self._subject_ref_for_user_id(request.user_id)
-        own_txn = self._own_transaction()
         with self._lock:
+            own_txn = self._own_transaction()
             try:
                 if own_txn:
                     self.conn.execute("BEGIN IMMEDIATE")

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -32,6 +32,7 @@ class RequestMixin:
     _fetchall: Any
     _subject_ref_for_user_id: Any
     _assert_subject_writable_locked: Any
+    _own_transaction: Any
 
     # ------------------------------------------------------------------
     # Request methods
@@ -41,9 +42,11 @@ class RequestMixin:
     def add_request(self, request: Request) -> None:
         created_at_iso = _epoch_to_iso(request.created_at)
         subject_ref = self._subject_ref_for_user_id(request.user_id)
+        own_txn = self._own_transaction()
         with self._lock:
             try:
-                self.conn.execute("BEGIN IMMEDIATE")
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
                 self._assert_subject_writable_locked(subject_ref)
                 self.conn.execute(
                     """INSERT OR REPLACE INTO requests
@@ -61,9 +64,11 @@ class RequestMixin:
                         subject_ref,
                     ),
                 )
-                self.conn.commit()
+                if own_txn:
+                    self.conn.commit()
             except Exception:
-                self.conn.rollback()
+                if own_txn:
+                    self.conn.rollback()
                 raise
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
@@ -55,6 +55,8 @@ class SQLiteFtsVecMixin:
         elif kind == "vec_delete":
             table, rowid = args
             self._vec_delete_now(table, rowid)
+        else:
+            raise ValueError(f"unknown index op kind: {kind!r}")
 
     # ------------------------------------------------------------------
     # FTS helpers — public (defer when in scope) + _now (immediate)

--- a/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_fts_vec.py
@@ -6,6 +6,11 @@ index sidecar update is durable. They are sqlite-only — there is no
 supabase/postgres counterpart. Composed into ``SQLiteStorage`` ahead of
 ``SQLiteStorageBase``; the boot-time ``_migrate_vec_tables`` (residual in
 ``_base.py``) resolves ``self._vec_upsert`` through the composed MRO.
+
+When a ``commit_scope`` is active (``_scope_depth > 0``), the public helpers
+buffer the operation into ``_deferred_index_ops`` for post-commit flushing;
+the ``_..._now`` variants always execute immediately and are called by
+``_flush_index_op`` after the outer commit.
 """
 
 from __future__ import annotations
@@ -23,10 +28,48 @@ class SQLiteFtsVecMixin:
     conn: sqlite3.Connection
     _fetchall: Any
     _has_sqlite_vec: bool
+    _scope_depth: int
+    _deferred_index_ops: list[tuple[str, Any]]
 
-    # FTS helpers
+    # ------------------------------------------------------------------
+    # Dispatcher — called by commit_scope after the outer commit
+    # ------------------------------------------------------------------
+
+    def _flush_index_op(self, kind: str, args: Any) -> None:
+        """Dispatch a buffered index op after the outer commit."""
+        if kind == "fts_upsert":
+            table, rowid, text_fields = args
+            self._fts_upsert_now(table, rowid, **text_fields)
+        elif kind == "fts_delete":
+            table, rowid = args
+            self._fts_delete_now(table, rowid)
+        elif kind == "fts_upsert_profile":
+            profile_id, content = args
+            self._fts_upsert_profile_now(profile_id, content)
+        elif kind == "fts_delete_profile":
+            (profile_id,) = args
+            self._fts_delete_profile_now(profile_id)
+        elif kind == "vec_upsert":
+            table, rowid, embedding = args
+            self._vec_upsert_now(table, rowid, embedding)
+        elif kind == "vec_delete":
+            table, rowid = args
+            self._vec_delete_now(table, rowid)
+
+    # ------------------------------------------------------------------
+    # FTS helpers — public (defer when in scope) + _now (immediate)
+    # ------------------------------------------------------------------
+
     def _fts_upsert(self, table: str, rowid: int, **text_fields: str | None) -> None:
         """Insert or update an FTS row.  Deletes old entry first to avoid duplicates."""
+        if self._scope_depth > 0:
+            self._deferred_index_ops.append(("fts_upsert", (table, rowid, text_fields)))
+            return
+        self._fts_upsert_now(table, rowid, **text_fields)
+
+    def _fts_upsert_now(
+        self, table: str, rowid: int, **text_fields: str | None
+    ) -> None:
         with self._lock:
             self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))  # noqa: S608
             cols = list(text_fields.keys())
@@ -40,12 +83,26 @@ class SQLiteFtsVecMixin:
             self.conn.commit()
 
     def _fts_delete(self, table: str, rowid: int) -> None:
+        if self._scope_depth > 0:
+            self._deferred_index_ops.append(("fts_delete", (table, rowid)))
+            return
+        self._fts_delete_now(table, rowid)
+
+    def _fts_delete_now(self, table: str, rowid: int) -> None:
         with self._lock:
             self.conn.execute(f"DELETE FROM {table} WHERE rowid = ?", (rowid,))  # noqa: S608
             self.conn.commit()
 
     def _fts_upsert_profile(self, profile_id: str, content: str) -> None:
         """FTS for profiles uses profile_id TEXT as key column."""
+        if self._scope_depth > 0:
+            self._deferred_index_ops.append(
+                ("fts_upsert_profile", (profile_id, content))
+            )
+            return
+        self._fts_upsert_profile_now(profile_id, content)
+
+    def _fts_upsert_profile_now(self, profile_id: str, content: str) -> None:
         with self._lock:
             self.conn.execute(
                 "DELETE FROM profiles_fts WHERE profile_id = ?", (profile_id,)
@@ -57,15 +114,32 @@ class SQLiteFtsVecMixin:
             self.conn.commit()
 
     def _fts_delete_profile(self, profile_id: str) -> None:
+        if self._scope_depth > 0:
+            self._deferred_index_ops.append(("fts_delete_profile", (profile_id,)))
+            return
+        self._fts_delete_profile_now(profile_id)
+
+    def _fts_delete_profile_now(self, profile_id: str) -> None:
         with self._lock:
             self.conn.execute(
                 "DELETE FROM profiles_fts WHERE profile_id = ?", (profile_id,)
             )
             self.conn.commit()
 
-    # Vec helpers (sqlite-vec)
+    # ------------------------------------------------------------------
+    # Vec helpers (sqlite-vec) — public (defer when in scope) + _now (immediate)
+    # ------------------------------------------------------------------
+
     def _vec_upsert(self, table: str, rowid: int, embedding: list[float]) -> None:
         """Insert or update a vec table row. No-op when sqlite-vec is unavailable."""
+        if not self._has_sqlite_vec:
+            return
+        if self._scope_depth > 0:
+            self._deferred_index_ops.append(("vec_upsert", (table, rowid, embedding)))
+            return
+        self._vec_upsert_now(table, rowid, embedding)
+
+    def _vec_upsert_now(self, table: str, rowid: int, embedding: list[float]) -> None:
         if not self._has_sqlite_vec:
             return
         with self._lock:
@@ -78,6 +152,14 @@ class SQLiteFtsVecMixin:
 
     def _vec_delete(self, table: str, rowid: int) -> None:
         """Delete a vec table row. No-op when sqlite-vec is unavailable."""
+        if not self._has_sqlite_vec:
+            return
+        if self._scope_depth > 0:
+            self._deferred_index_ops.append(("vec_delete", (table, rowid)))
+            return
+        self._vec_delete_now(table, rowid)
+
+    def _vec_delete_now(self, table: str, rowid: int) -> None:
         if not self._has_sqlite_vec:
             return
         with self._lock:

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -87,6 +87,7 @@ class AgentPlaybookStoreMixin:
     _fts_upsert: Any
     _vec_upsert: Any
     _delete_playbook_search_rows: Any
+    _own_transaction: Any
 
     def _index_agent_playbook_fts_vec(self, ap: AgentPlaybook) -> None:
         """Update the FTS and vector indexes for a single agent playbook row.
@@ -178,7 +179,8 @@ class AgentPlaybookStoreMixin:
             created_at_iso = _epoch_to_iso(ap.created_at)
             with self._lock:
                 self._insert_agent_playbook_row(self.conn, ap, created_at_iso)
-                self.conn.commit()
+                if self._own_transaction():
+                    self.conn.commit()
 
             self._index_agent_playbook_fts_vec(ap)
             saved.append(ap)
@@ -228,6 +230,7 @@ class AgentPlaybookStoreMixin:
 
         created_at_iso = _epoch_to_iso(ap.created_at)
         with self._lock:
+            own_txn = self._own_transaction()
             try:
                 self._insert_agent_playbook_row(self.conn, ap, created_at_iso)
                 _append_event_stmt(
@@ -242,9 +245,11 @@ class AgentPlaybookStoreMixin:
                     request_id=request_id,
                     reason=f"{AGGREGATE_REASON_PREFIX}{run_mode}",
                 )
-                self.conn.commit()
+                if own_txn:
+                    self.conn.commit()
             except Exception:
-                self.conn.rollback()
+                if own_txn:
+                    self.conn.rollback()
                 raise
 
         # FTS/vec indexing AFTER commit — these helpers self-commit and must
@@ -609,7 +614,8 @@ class AgentPlaybookStoreMixin:
                     to_status="archived",
                     status_namespace="lifecycle_status",
                 )
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def archive_agent_playbooks_by_ids(self, agent_playbook_ids: list[int]) -> None:
@@ -648,7 +654,8 @@ class AgentPlaybookStoreMixin:
                     to_status="archived",
                     status_namespace="lifecycle_status",
                 )
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def supersede_agent_playbooks_by_ids(
@@ -712,7 +719,8 @@ class AgentPlaybookStoreMixin:
                         request_id=request_id,
                     )
                     updated += 1
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
         return updated
 
     @SQLiteStorageBase.handle_exceptions
@@ -773,7 +781,8 @@ class AgentPlaybookStoreMixin:
                         request_id=request_id,
                     )
                     updated += 1
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
         return updated
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_source_linkage.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_source_linkage.py
@@ -22,6 +22,7 @@ class PlaybookSourceLinkageMixin:
     _fetchall: Any
     _subject_ref_for_user_id: Any
     _assert_subject_writable_locked: Any
+    _own_transaction: Any
 
     @SQLiteStorageBase.handle_exceptions
     def set_source_user_playbook_ids_for_agent_playbook(
@@ -87,8 +88,10 @@ class PlaybookSourceLinkageMixin:
                     ids.append(source_id)
                     seen.add(source_id)
         with self._lock:
+            own_txn = self._own_transaction()
             try:
-                self.conn.execute("BEGIN IMMEDIATE")
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
                 for user_playbook_id in by_id:
                     row = self.conn.execute(
                         """SELECT user_id, governance_subject_ref FROM user_playbooks
@@ -120,9 +123,11 @@ class PlaybookSourceLinkageMixin:
                         for upid, source_interaction_ids in by_id.items()
                     ],
                 )
-                self.conn.commit()
+                if own_txn:
+                    self.conn.commit()
             except Exception:
-                self.conn.rollback()
+                if own_txn:
+                    self.conn.rollback()
                 raise
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -71,6 +71,7 @@ class UserPlaybookStoreMixin:
     _delete_playbook_search_rows: Any
     _subject_ref_for_user_id: Any
     _assert_subject_writable_locked: Any
+    _own_transaction: Any
 
     def _subject_ref_from_user_playbook_row(self, row: sqlite3.Row) -> str:
         subject_ref = row["governance_subject_ref"]
@@ -119,8 +120,10 @@ class UserPlaybookStoreMixin:
 
             created_at_iso = _epoch_to_iso(up.created_at)
             with self._lock:
+                own_txn = self._own_transaction()
                 try:
-                    self.conn.execute("BEGIN IMMEDIATE")
+                    if own_txn:
+                        self.conn.execute("BEGIN IMMEDIATE")
                     self._assert_subject_writable_locked(subject_ref)
                     cur = self.conn.execute(
                         """INSERT INTO user_playbooks
@@ -159,9 +162,11 @@ class UserPlaybookStoreMixin:
                     )
                     upid = cur.lastrowid or 0
                     up.user_playbook_id = upid
-                    self.conn.commit()
+                    if own_txn:
+                        self.conn.commit()
                 except Exception:
-                    self.conn.rollback()
+                    if own_txn:
+                        self.conn.rollback()
                     raise
 
             fts_parts = [up.trigger or "", up.content or ""]
@@ -789,7 +794,8 @@ class UserPlaybookStoreMixin:
                         to_status=None,
                         status_namespace=None,
                     )
-                self.conn.commit()
+                if self._own_transaction():
+                    self.conn.commit()
 
     @SQLiteStorageBase.handle_exceptions
     def supersede_user_playbooks_by_ids(
@@ -840,5 +846,6 @@ class UserPlaybookStoreMixin:
                         request_id=request_id,
                     )
                     updated += 1
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
         return updated

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -45,6 +45,7 @@ class InteractionStoreMixin:
     embedding_dimensions: int
     _subject_ref_for_user_id: Any
     _assert_subject_writable_locked: Any
+    _own_transaction: Any
 
     # ------------------------------------------------------------------
     # CRUD — Interactions
@@ -80,9 +81,11 @@ class InteractionStoreMixin:
     def _insert_interaction(self, interaction: Interaction) -> int:
         created_at_iso = _epoch_to_iso(interaction.created_at)
         subject_ref = self._subject_ref_for_user_id(interaction.user_id)
+        own_txn = self._own_transaction()
         with self._lock:
             try:
-                self.conn.execute("BEGIN IMMEDIATE")
+                if own_txn:
+                    self.conn.execute("BEGIN IMMEDIATE")
                 self._assert_subject_writable_locked(subject_ref)
                 if interaction.interaction_id:
                     self.conn.execute(
@@ -148,9 +151,11 @@ class InteractionStoreMixin:
                     )
                     iid = cur.lastrowid or 0
                     interaction.interaction_id = iid
-                self.conn.commit()
+                if own_txn:
+                    self.conn.commit()
             except Exception:
-                self.conn.rollback()
+                if own_txn:
+                    self.conn.rollback()
                 raise
         # Update FTS and vec
         self._fts_upsert(

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -176,9 +176,47 @@ class InteractionStoreMixin:
     ) -> None:
         if not interactions:
             return
+        # Only generate embeddings for interactions that do not already have them.
+        # This allows callers to pre-populate embeddings (e.g. via
+        # prepare_interaction_embeddings) before opening a commit_scope so that no
+        # network I/O occurs inside the transaction.
+        to_embed = [i for i in interactions if not i.embedding]
+        if to_embed:
+            texts = [
+                "\n".join([i.content or "", i.user_action_description or ""])
+                for i in to_embed
+            ]
+            try:
+                embeddings = self.llm_client.get_embeddings(
+                    texts, self.embedding_model_name, self.embedding_dimensions
+                )
+            except EmbeddingUnavailableError as exc:
+                logger.warning(
+                    "Embedding unavailable for interaction bulk insert; "
+                    "continuing without vectors: %s",
+                    exc,
+                )
+                embeddings = [[] for _ in texts]
+            for interaction, embedding in zip(to_embed, embeddings, strict=False):
+                interaction.embedding = embedding
+        for interaction in interactions:
+            self._insert_interaction(interaction)
+
+    @SQLiteStorageBase.handle_exceptions
+    def prepare_interaction_embeddings(self, interactions: list[Interaction]) -> None:
+        """Pre-populate interaction.embedding for each interaction (no DB write).
+
+        Generates embeddings in one batch call so the write path inside a
+        commit_scope can skip the network round-trip.
+        """
+        if not interactions:
+            return
+        to_embed = [i for i in interactions if not i.embedding]
+        if not to_embed:
+            return
         texts = [
             "\n".join([i.content or "", i.user_action_description or ""])
-            for i in interactions
+            for i in to_embed
         ]
         try:
             embeddings = self.llm_client.get_embeddings(
@@ -186,14 +224,13 @@ class InteractionStoreMixin:
             )
         except EmbeddingUnavailableError as exc:
             logger.warning(
-                "Embedding unavailable for interaction bulk insert; "
+                "Embedding unavailable during prepare_interaction_embeddings; "
                 "continuing without vectors: %s",
                 exc,
             )
             embeddings = [[] for _ in texts]
-        for interaction, embedding in zip(interactions, embeddings, strict=False):
+        for interaction, embedding in zip(to_embed, embeddings, strict=False):
             interaction.embedding = embedding
-            self._insert_interaction(interaction)
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -173,32 +173,35 @@ class InteractionStoreMixin:
         self,
         user_id: str,  # noqa: ARG002
         interactions: list[Interaction],
+        *,
+        embeddings_prepared: bool = False,
     ) -> None:
         if not interactions:
             return
-        # Only generate embeddings for interactions that do not already have them.
-        # This allows callers to pre-populate embeddings (e.g. via
-        # prepare_interaction_embeddings) before opening a commit_scope so that no
-        # network I/O occurs inside the transaction.
-        to_embed = [i for i in interactions if not i.embedding]
-        if to_embed:
-            texts = [
-                "\n".join([i.content or "", i.user_action_description or ""])
-                for i in to_embed
-            ]
-            try:
-                embeddings = self.llm_client.get_embeddings(
-                    texts, self.embedding_model_name, self.embedding_dimensions
-                )
-            except EmbeddingUnavailableError as exc:
-                logger.warning(
-                    "Embedding unavailable for interaction bulk insert; "
-                    "continuing without vectors: %s",
-                    exc,
-                )
-                embeddings = [[] for _ in texts]
-            for interaction, embedding in zip(to_embed, embeddings, strict=False):
-                interaction.embedding = embedding
+        if not embeddings_prepared:
+            # Only generate embeddings for interactions that do not already have them.
+            # This allows callers to pre-populate embeddings (e.g. via
+            # prepare_interaction_embeddings) before opening a commit_scope so that no
+            # network I/O occurs inside the transaction.
+            to_embed = [i for i in interactions if not i.embedding]
+            if to_embed:
+                texts = [
+                    "\n".join([i.content or "", i.user_action_description or ""])
+                    for i in to_embed
+                ]
+                try:
+                    embeddings = self.llm_client.get_embeddings(
+                        texts, self.embedding_model_name, self.embedding_dimensions
+                    )
+                except EmbeddingUnavailableError as exc:
+                    logger.warning(
+                        "Embedding unavailable for interaction bulk insert; "
+                        "continuing without vectors: %s",
+                        exc,
+                    )
+                    embeddings = [[] for _ in texts]
+                for interaction, embedding in zip(to_embed, embeddings, strict=False):
+                    interaction.embedding = embedding
         for interaction in interactions:
             self._insert_interaction(interaction)
 

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -81,8 +81,8 @@ class InteractionStoreMixin:
     def _insert_interaction(self, interaction: Interaction) -> int:
         created_at_iso = _epoch_to_iso(interaction.created_at)
         subject_ref = self._subject_ref_for_user_id(interaction.user_id)
-        own_txn = self._own_transaction()
         with self._lock:
+            own_txn = self._own_transaction()
             try:
                 if own_txn:
                     self.conn.execute("BEGIN IMMEDIATE")

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
@@ -77,6 +77,7 @@ class ProfileStoreMixin:
     _has_sqlite_vec: bool
     _subject_ref_for_user_id: Any
     _assert_subject_writable_locked: Any
+    _own_transaction: Any
 
     def _subject_ref_from_profile_row(self, row: sqlite3.Row) -> str:
         subject_ref = row["governance_subject_ref"]
@@ -224,8 +225,10 @@ class ProfileStoreMixin:
                 profile.embedding = self._get_embedding(embedding_text)
             embedding = profile.embedding
             with self._lock:
+                own_txn = self._own_transaction()
                 try:
-                    self.conn.execute("BEGIN IMMEDIATE")
+                    if own_txn:
+                        self.conn.execute("BEGIN IMMEDIATE")
                     self._assert_subject_writable_locked(subject_ref)
                     self.conn.execute(
                         """INSERT OR REPLACE INTO profiles
@@ -261,9 +264,11 @@ class ProfileStoreMixin:
                             subject_ref,
                         ),
                     )
-                    self.conn.commit()
+                    if own_txn:
+                        self.conn.commit()
                 except Exception:
-                    self.conn.rollback()
+                    if own_txn:
+                        self.conn.rollback()
                     raise
             fts_parts = [profile.content or ""]
             if profile.custom_features:
@@ -809,7 +814,8 @@ class ProfileStoreMixin:
                         status_namespace="lifecycle_status",
                     )
                     committed_ids.append(pid)
-            self.conn.commit()
+            if self._own_transaction():
+                self.conn.commit()
         return committed_ids
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -262,6 +262,15 @@ class BaseStorage(
             "purged_user_playbooks": len(purge_upb_ids),
         }
 
+    def learning_jobs_columns(self) -> list[str]:
+        """Return the column names of the learning_jobs table.
+
+        Each backend overrides this to query its own schema introspection
+        mechanism (SQLite: PRAGMA table_info; Postgres/Supabase:
+        information_schema.columns).
+        """
+        raise NotImplementedError
+
 
 __all__ = [
     "CommitScopeMixin",

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -22,6 +22,7 @@ from ._agent_run import (
     not_applicable_tool_result,
 )
 from ._base import BaseStorageCore, matches_status_filter
+from ._commit_scope import CommitScopeMixin
 from ._extras import ExtrasMixin
 from ._lineage import EntityType, LineageEventMixin
 from ._operations import OperationMixin
@@ -48,6 +49,7 @@ from .profiles import InteractionStoreMixin, ProfileSearchMixin, ProfileStoreMix
 
 
 class BaseStorage(
+    CommitScopeMixin,
     AgentRunMixin,
     ProfileStoreMixin,
     InteractionStoreMixin,
@@ -262,6 +264,7 @@ class BaseStorage(
 
 
 __all__ = [
+    "CommitScopeMixin",
     "AgentBinding",
     "AgentRunMixin",
     "EntityType",

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -1,5 +1,6 @@
 from reflexio.models.api_schema.domain.enums import Status
 
+from ._learning_jobs import LearningJob, LearningJobStatus, LearningJobStoreABC
 from ._agent_run import (
     NOT_APPLICABLE_ANSWER,
     AgentBinding,
@@ -49,6 +50,7 @@ from .profiles import InteractionStoreMixin, ProfileSearchMixin, ProfileStoreMix
 
 
 class BaseStorage(
+    LearningJobStoreABC,
     CommitScopeMixin,
     AgentRunMixin,
     ProfileStoreMixin,
@@ -273,6 +275,9 @@ class BaseStorage(
 
 
 __all__ = [
+    "LearningJob",
+    "LearningJobStatus",
+    "LearningJobStoreABC",
     "CommitScopeMixin",
     "AgentBinding",
     "AgentRunMixin",

--- a/reflexio/server/services/storage/storage_base/_commit_scope.py
+++ b/reflexio/server/services/storage/storage_base/_commit_scope.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+from contextlib import AbstractContextManager
+
+
+class CommitScopeMixin(ABC):
+    @abstractmethod
+    def commit_scope(self) -> AbstractContextManager[None]:
+        """Atomic multi-write transaction; see Workstream A plan Task 1."""
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -145,11 +145,17 @@ class LearningJobStoreABC(ABC):
         claim_token: str,
         dead: bool,
     ) -> None:
-        """Fenced fail/dead transition.
+        """Fenced fail/dead transition — sets status, does NOT increment attempts.
 
-        Fenced on ``claim_token``.  Increments ``attempts``.  Sets
+        Fenced on ``claim_token`` and ``status='claimed'``.  Sets
         ``status='dead'`` when ``dead=True``, else ``status='failed'`` (and
         clears ``claim_token``/``claim_expires_at`` so the job is reclaimable).
+
+        ``attempts`` is intentionally NOT incremented here.  It is incremented
+        once per delivery attempt exclusively by ``claim_learning_jobs``; the
+        worker's dead-gate (``job.attempts >= max_attempts``) depends on that
+        single-increment-per-claim invariant.  Incrementing here would
+        double-count and misfire the dead transition.
         """
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -148,6 +148,25 @@ class LearningJobStoreABC(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def list_org_ids_with_pending_learning_jobs(self) -> list[str]:
+        """Return distinct org_ids that have actionable learning jobs.
+
+        Cross-org discovery query for the :class:`DurableLearningScheduler`:
+        surfaces every org with at least one job that is ``pending``, ``failed``
+        (reclaimable), or ``claimed`` with an expired lease (a stolen/abandoned
+        claim). Terminal ``done``/``dead`` rows and live claims are excluded.
+
+        Mirrors ``list_resumable_work_org_ids``: NOT scoped to ``self.org_id`` —
+        on the shared global table (Postgres ``public.learning_jobs``, or a
+        SQLite DB shared across orgs) it returns every org with work in one
+        query so the scheduler need not enumerate all orgs.
+
+        Returns:
+            list[str]: Distinct org_ids with actionable work, ordered ascending.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def get_learning_status_for_request(
         self,
         *,

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -33,6 +33,7 @@ class LearningJob:
     )  # epoch seconds (converted from stored ISO/timestamptz)
     force_extraction: bool = False
     skip_aggregation: bool = False
+    max_attempts: int = 3
 
 
 class LearningJobStoreABC(ABC):

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -4,6 +4,11 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
 
+# Upper bound of the done-row retention window.
+# Shared by all backends so the value cannot drift between implementations.
+# Err toward "not done" until we are sure a done row would have been GC'd.
+_ABSENCE_DONE_AFTER_SECONDS = 72 * 3600
+
 
 class LearningJobStatus(StrEnum):
     PENDING = "pending"
@@ -169,6 +174,7 @@ class LearningJobStoreABC(ABC):
 
 
 __all__ = [
+    "_ABSENCE_DONE_AFTER_SECONDS",
     "LearningJob",
     "LearningJobStatus",
     "LearningJobStoreABC",

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -1,0 +1,172 @@
+"""ABC, dataclass, and enum for the durable learning-job queue (Task 3)."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class LearningJobStatus(StrEnum):
+    PENDING = "pending"
+    CLAIMED = "claimed"
+    DONE = "done"
+    FAILED = "failed"
+    DEAD = "dead"
+
+
+@dataclass(frozen=True)
+class LearningJob:
+    job_id: str
+    org_id: str
+    user_id: str
+    job_type: str
+    latest_request_id: str | None
+    status: str
+    attempts: int
+    claim_token: str | None
+    covers_through: (
+        float | None
+    )  # epoch seconds (converted from stored ISO/timestamptz)
+
+
+class LearningJobStoreABC(ABC):
+    """Abstract interface for durable learning-job queue operations.
+
+    All methods are scoped to the storage instance's own org (``self.org_id``).
+    ``enqueue_learning_job`` and ``complete_learning_job`` are safe to call
+    inside a ``commit_scope`` — they issue plain SQL on the scope's connection
+    without owning a separate BEGIN/COMMIT.
+    """
+
+    @abstractmethod
+    def enqueue_learning_job(
+        self,
+        *,
+        org_id: str,
+        user_id: str,
+        request_id: str,
+        covers_through: float,
+        job_type: str = "learning",
+    ) -> str:
+        """Coalescing upsert into the learning_jobs queue.
+
+        If a pending job for ``(org_id, user_id, job_type)`` already exists,
+        update its ``latest_request_id`` and keep the max ``covers_through``;
+        otherwise insert a new ``pending`` row.  Returns the ``job_id`` of the
+        pending row (existing or newly inserted).
+
+        Safe to call inside a ``commit_scope`` — no own BEGIN/COMMIT issued.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def claim_learning_jobs(
+        self,
+        *,
+        claimed_by: str,
+        limit: int,
+        lease_seconds: int,
+    ) -> list[LearningJob]:
+        """Atomically claim up to ``limit`` of this org's claimable jobs.
+
+        A job is claimable when it is ``pending`` OR (``claimed`` AND
+        ``claim_expires_at < now``).  Each claimed job receives a fresh
+        ``claim_token``, ``claimed_by``, and ``claim_expires_at``.
+
+        Postgres/Supabase: uses ``FOR UPDATE SKIP LOCKED`` via the
+        ``claim_learning_jobs`` SQL function.  SQLite: ``BEGIN IMMEDIATE``.
+        The claim predicate uses the DB's ``now()`` to avoid app/DB clock skew.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def heartbeat_learning_job(
+        self,
+        *,
+        job_id: str,
+        claim_token: str,
+        lease_seconds: int,
+    ) -> bool:
+        """Extend the lease on a claimed job.
+
+        Updates ``claim_expires_at = now + lease_seconds`` only when
+        ``claim_token`` matches and status is still ``claimed``.
+
+        Returns:
+            True if the lease was extended (rowcount == 1), False if the token
+            was superseded or the job is no longer claimed.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def complete_learning_job(
+        self,
+        *,
+        job_id: str,
+        claim_token: str,
+    ) -> int:
+        """Fenced transition to ``done``.
+
+        Executes::
+
+            UPDATE learning_jobs
+               SET status='done', updated_at=now()
+             WHERE job_id=:job_id AND claim_token=:claim_token AND status='claimed'
+
+        Returns:
+            rowcount — 0 if the token was superseded or the job is already
+            done/dead/failed; 1 on success.  Callers MUST raise on 0 to roll
+            back the enclosing ``commit_scope``.
+
+        Safe to call inside a ``commit_scope`` — no own BEGIN/COMMIT issued.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def fail_learning_job(
+        self,
+        *,
+        job_id: str,
+        claim_token: str,
+        dead: bool,
+    ) -> None:
+        """Fenced fail/dead transition.
+
+        Fenced on ``claim_token``.  Increments ``attempts``.  Sets
+        ``status='dead'`` when ``dead=True``, else ``status='failed'`` (and
+        clears ``claim_token``/``claim_expires_at`` so the job is reclaimable).
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_learning_status_for_request(
+        self,
+        *,
+        user_id: str,
+        request_created_at: float,
+    ) -> str:
+        """Coverage-based status for a single request (§3.6 rule).
+
+        Returns one of ``"done" | "processing" | "pending" | "failed"``.
+
+        Coverage rule (evaluated in priority order):
+
+        1. Any ``done`` job with ``covers_through >= request_created_at``
+           → ``"done"`` (correct even for zero-yield windows).
+        2. Any ``claimed`` job with ``covers_through >= request_created_at``
+           → ``"processing"``.
+        3. Any ``pending`` job for this user
+           → ``"pending"``.
+        4. Any ``dead`` job with ``covers_through >= request_created_at``
+           → ``"failed"``.
+        5. No rows (terminal rows are GC'd after 24–72 h; polling is
+           minutes-scale so absence long after the fact means completion)
+           → ``"done"``.
+        """
+        raise NotImplementedError
+
+
+__all__ = [
+    "LearningJob",
+    "LearningJobStatus",
+    "LearningJobStoreABC",
+]

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -84,7 +84,8 @@ class LearningJobStoreABC(ABC):
     ) -> list[LearningJob]:
         """Atomically claim up to ``limit`` of this org's claimable jobs.
 
-        A job is claimable when it is ``pending`` OR (``claimed`` AND
+        A job is claimable when it is ``pending``, ``failed`` (reclaimable —
+        attempts < max_attempts), OR (``claimed`` AND
         ``claim_expires_at < now``).  Each claimed job receives a fresh
         ``claim_token``, ``claimed_by``, and ``claim_expires_at``.
 

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -31,6 +31,8 @@ class LearningJob:
     covers_through: (
         float | None
     )  # epoch seconds (converted from stored ISO/timestamptz)
+    force_extraction: bool = False
+    skip_aggregation: bool = False
 
 
 class LearningJobStoreABC(ABC):
@@ -51,6 +53,8 @@ class LearningJobStoreABC(ABC):
         request_id: str,
         covers_through: float,
         job_type: str = "learning",
+        force_extraction: bool = False,
+        skip_aggregation: bool = False,
     ) -> str:
         """Coalescing upsert into the learning_jobs queue.
 

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -152,15 +152,18 @@ class LearningJobStoreABC(ABC):
 
         1. Any ``done`` job with ``covers_through >= request_created_at``
            → ``"done"`` (correct even for zero-yield windows).
-        2. Any ``claimed`` job with ``covers_through >= request_created_at``
+        2. Any ``claimed`` job (any ``covers_through``)
            → ``"processing"``.
         3. Any ``pending`` job for this user
            → ``"pending"``.
-        4. Any ``dead`` job with ``covers_through >= request_created_at``
+        4. Any ``failed`` (reclaimable) job
+           → ``"pending"``.
+        5. Any ``dead`` job with ``covers_through >= request_created_at``
            → ``"failed"``.
-        5. No rows (terminal rows are GC'd after 24–72 h; polling is
-           minutes-scale so absence long after the fact means completion)
-           → ``"done"``.
+        6. No rows AND ``now - request_created_at >= 72 h`` (retention window)
+           → ``"done"`` (done row would have been GC'd by now).
+        7. No rows AND request is recent
+           → ``"pending"`` (err toward not-done until retention window passes).
         """
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -3,11 +3,17 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Literal
 
 # Upper bound of the done-row retention window.
 # Shared by all backends so the value cannot drift between implementations.
 # Err toward "not done" until we are sure a done row would have been GC'd.
 _ABSENCE_DONE_AFTER_SECONDS = 72 * 3600
+
+# Coverage-based status reported for a single request (§3.6). This is a
+# collapsed view of the raw job statuses (e.g. claimed -> processing,
+# reclaimable failed -> pending) and matches LearningStatusResponse.status.
+LearningStatus = Literal["pending", "processing", "done", "failed"]
 
 
 class LearningJobStatus(StrEnum):
@@ -172,7 +178,7 @@ class LearningJobStoreABC(ABC):
         *,
         user_id: str,
         request_created_at: float,
-    ) -> str:
+    ) -> LearningStatus:
         """Coverage-based status for a single request (§3.6 rule).
 
         Returns one of ``"done" | "processing" | "pending" | "failed"``.
@@ -201,5 +207,6 @@ __all__ = [
     "_ABSENCE_DONE_AFTER_SECONDS",
     "LearningJob",
     "LearningJobStatus",
+    "LearningStatus",
     "LearningJobStoreABC",
 ]

--- a/reflexio/server/services/storage/storage_base/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_interaction_store.py
@@ -38,6 +38,19 @@ class InteractionStoreMixin:
         """
         raise NotImplementedError
 
+    def prepare_interaction_embeddings(self, interactions: list[Interaction]) -> None:
+        """Pre-populate interaction.embedding for each interaction without writing to storage.
+
+        Call this before opening a commit_scope to avoid a network round-trip inside
+        the transaction.  Subclasses that generate embeddings client-side MUST override
+        this to call get_embeddings and populate interaction.embedding before the scope
+        is opened; backends where the embedding is generated server-side can leave this
+        as a no-op.
+
+        Args:
+            interactions: Interactions whose embedding fields will be populated in-place.
+        """
+
     @abstractmethod
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:
         raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_interaction_store.py
@@ -28,17 +28,25 @@ class InteractionStoreMixin:
 
     @abstractmethod
     def add_user_interactions_bulk(
-        self, user_id: str, interactions: list[Interaction]
+        self,
+        user_id: str,
+        interactions: list[Interaction],
+        *,
+        embeddings_prepared: bool = False,
     ) -> None:
         """Add multiple user interactions with batched embedding generation.
 
         Args:
             user_id: The user ID
             interactions: List of interactions to add
+            embeddings_prepared: When True, skip all embedding generation and write
+                whatever embedding is already on each interaction (real or ``[]``).
+                Use on the durable path after ``prepare_interaction_embeddings`` to
+                ensure no network I/O occurs inside an open ``commit_scope``.
         """
         raise NotImplementedError
 
-    def prepare_interaction_embeddings(self, interactions: list[Interaction]) -> None:
+    def prepare_interaction_embeddings(self, interactions: list[Interaction]) -> None:  # noqa: ARG002
         """Pre-populate interaction.embedding for each interaction without writing to storage.
 
         Call this before opening a commit_scope to avoid a network round-trip inside
@@ -50,6 +58,7 @@ class InteractionStoreMixin:
         Args:
             interactions: Interactions whose embedding fields will be populated in-place.
         """
+        return
 
     @abstractmethod
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:

--- a/tests/server/api_endpoints/test_learning_status.py
+++ b/tests/server/api_endpoints/test_learning_status.py
@@ -1,0 +1,205 @@
+"""Tests for the learning_status API surface (Task 7).
+
+Covers:
+- Deferred publish response carries learning_status="deferred".
+- Sync publish (wait_for_response=True) leaves learning_status absent.
+- GET /api/learning_status returns a valid status for a known request.
+- GET /api/learning_status returns 404 for an unknown request (never
+  reports "done" for a request that never existed).
+- ReflexioClient.get_learning_status deserialises the status string.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.client import ReflexioClient
+from reflexio.models.api_schema.domain.entities import Request
+from reflexio.models.api_schema.service_schemas import PublishUserInteractionResponse
+from reflexio.server.api import create_app
+from reflexio.server.cache.reflexio_cache import get_reflexio, invalidate_reflexio_cache
+
+_VALID_STATUS_VALUES = {"pending", "processing", "done", "failed"}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _publish_payload():
+    return {
+        "user_id": "user-test",
+        "session_id": "sess-test",
+        "interaction_data_list": [
+            {
+                "role": "User",
+                "content": "Hello",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def test_app():
+    """FastAPI test app with a fixed org_id (no auth)."""
+    return create_app(get_org_id=lambda: "test-org")
+
+
+@pytest.fixture
+def client(test_app):
+    """TestClient wrapping test_app."""
+    from fastapi.testclient import TestClient
+
+    return TestClient(test_app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def patched_reflexio():
+    """Patch reflexio_cache.get_reflexio with a MagicMock instance."""
+    mock = MagicMock()
+    with patch(
+        "reflexio.server.cache.reflexio_cache.get_reflexio",
+        return_value=mock,
+    ):
+        yield mock
+
+
+@pytest.fixture
+def client_with_storage():
+    """TestClient + real (cache-warmed) storage for endpoint integration tests.
+
+    Uses the same reflexio_cache warming pattern as ``client_with_org`` in
+    conftest.py: warm the cache first so every ``reflexio_cache.get_reflexio``
+    call inside the endpoint returns the same instance the test can seed data
+    into.
+    """
+    from fastapi.testclient import TestClient
+
+    org_id = f"test-ls-{uuid.uuid4().hex[:10]}"
+    app = create_app(get_org_id=lambda: org_id)
+    http_client = TestClient(app, raise_server_exceptions=False)
+    # Warm the per-org cache entry.
+    reflexio = get_reflexio(org_id=org_id)
+    storage = reflexio.request_context.storage
+    try:
+        yield http_client, storage
+    finally:
+        invalidate_reflexio_cache(org_id=org_id)
+
+
+# ---------------------------------------------------------------------------
+# Deferred publish sets learning_status="deferred"
+# ---------------------------------------------------------------------------
+
+
+class TestDeferredPublishField:
+    def test_deferred_publish_returns_learning_status_deferred(
+        self, client, patched_reflexio
+    ):
+        response = client.post("/api/publish_interaction", json=_publish_payload())
+        assert response.status_code == 200
+        data = response.json()
+        assert data["learning_status"] == "deferred"
+
+    def test_sync_publish_leaves_learning_status_none(self, client, patched_reflexio):
+        """Sync path returns real extraction counts — learning_status excluded."""
+        mock_response = PublishUserInteractionResponse(
+            success=True,
+            message="Interaction processed",
+            profiles_added=0,
+            playbooks_added=0,
+        )
+
+        def run_immediately(**kwargs):
+            return kwargs["fn"]()
+
+        with (
+            patch(
+                "reflexio.server.routes._common.run_with_operation_limit",
+                side_effect=run_immediately,
+            ),
+            patch(
+                "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
+                return_value=mock_response,
+            ),
+        ):
+            response = client.post(
+                "/api/publish_interaction",
+                params={"wait_for_response": "true"},
+                json=_publish_payload(),
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        # response_model_exclude_none=True — field must be absent, not null
+        assert "learning_status" not in data
+
+
+# ---------------------------------------------------------------------------
+# GET /api/learning_status
+# ---------------------------------------------------------------------------
+
+
+class TestLearningStatusEndpoint:
+    def test_unknown_request_returns_404(self, client_with_storage):
+        http_client, _ = client_with_storage
+        response = http_client.get(
+            "/api/learning_status", params={"request_id": "no-such-request"}
+        )
+        assert response.status_code == 404
+        # Must NOT silently claim "done" for a request that never existed.
+        body = response.json()
+        assert "done" not in str(body).lower() or body.get("status") != "done"
+
+    def test_known_request_returns_valid_status(self, client_with_storage):
+        http_client, storage = client_with_storage
+        req = Request(
+            request_id="req-ls-test-001",
+            user_id="user-ls",
+            session_id="sess-ls",
+        )
+        storage.add_request(req)
+
+        response = http_client.get(
+            "/api/learning_status", params={"request_id": req.request_id}
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "status" in data
+        assert data["status"] in _VALID_STATUS_VALUES
+
+    def test_missing_request_id_param_returns_422(self, client_with_storage):
+        http_client, _ = client_with_storage
+        response = http_client.get("/api/learning_status")
+        assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# ReflexioClient.get_learning_status
+# ---------------------------------------------------------------------------
+
+
+class TestClientGetLearningStatus:
+    def test_returns_status_string(self):
+        """Client deserialises {"status": "pending"} and returns the string."""
+        c = ReflexioClient.__new__(ReflexioClient)
+        with patch.object(c, "_make_request", return_value={"status": "pending"}):
+            result = c.get_learning_status("req-abc")
+        assert result == "pending"
+
+    def test_calls_correct_endpoint(self):
+        """Client calls GET /api/learning_status with request_id param."""
+        c = ReflexioClient.__new__(ReflexioClient)
+        with patch.object(c, "_make_request", return_value={"status": "done"}) as m:
+            c.get_learning_status("req-xyz")
+        m.assert_called_once_with(
+            "GET",
+            "/api/learning_status",
+            params={"request_id": "req-xyz"},
+        )

--- a/tests/server/api_endpoints/test_learning_status.py
+++ b/tests/server/api_endpoints/test_learning_status.py
@@ -228,6 +228,24 @@ class TestLearningStatusEndpoint:
         response = http_client.get("/api/learning_status")
         assert response.status_code == 422
 
+    def test_deferred_publish_request_id_is_pollable(self, client_with_storage):
+        """request_id from a deferred publish can round-trip to GET /api/learning_status.
+
+        TestClient runs background tasks synchronously, so after the deferred
+        publish completes the request is stored and the poll must succeed.
+        """
+        http_client, _ = client_with_storage
+        response = http_client.post("/api/publish_interaction", json=_publish_payload())
+        assert response.status_code == 200
+        request_id = response.json().get("request_id")
+        assert request_id  # deferred response must carry a pollable id
+
+        status_response = http_client.get(
+            "/api/learning_status", params={"request_id": request_id}
+        )
+        assert status_response.status_code == 200
+        assert status_response.json()["status"] in _VALID_STATUS_VALUES
+
     def test_cross_org_request_id_returns_404(self, two_org_clients):
         """Org A must NOT see Org B's request status by request_id.
 

--- a/tests/server/api_endpoints/test_learning_status.py
+++ b/tests/server/api_endpoints/test_learning_status.py
@@ -93,6 +93,51 @@ def client_with_storage():
         invalidate_reflexio_cache(org_id=org_id)
 
 
+@pytest.fixture
+def two_org_clients():
+    """Two orgs, each routed to its own org-scoped storage.
+
+    Yields ``(client_a, client_b, storage_b)``. Each client authenticates as
+    a distinct org, and ``reflexio_cache.get_reflexio`` is patched to return a
+    per-org mock so Org A resolves ONLY Org A's storage and Org B resolves
+    ONLY Org B's storage. This mirrors the production isolation seam
+    (schema-per-org): the endpoint reads whichever storage
+    ``get_reflexio(org_id)`` returns, so a request that lives under Org B is
+    invisible to Org A.
+
+    The OSS SQLite backend shares one db file across orgs (isolation is by
+    separate files / enterprise schemas, not an org column), so a real-storage
+    fixture cannot express cross-org isolation here — the per-org mock does.
+    """
+    from fastapi.testclient import TestClient
+
+    org_a = f"test-ls-a-{uuid.uuid4().hex[:10]}"
+    org_b = f"test-ls-b-{uuid.uuid4().hex[:10]}"
+
+    # Org A's storage knows about no requests; Org B's storage owns the seeded
+    # request. Tests seed Org B via ``storage_b.get_request``.
+    storage_a = MagicMock()
+    storage_a.get_request.return_value = None
+    storage_b = MagicMock()
+
+    def _reflexio_for(org_id: str, storage_base_dir=None):
+        mock = MagicMock()
+        mock.request_context.storage = storage_a if org_id == org_a else storage_b
+        return mock
+
+    with patch(
+        "reflexio.server.cache.reflexio_cache.get_reflexio",
+        side_effect=_reflexio_for,
+    ):
+        client_a = TestClient(
+            create_app(get_org_id=lambda: org_a), raise_server_exceptions=False
+        )
+        client_b = TestClient(
+            create_app(get_org_id=lambda: org_b), raise_server_exceptions=False
+        )
+        yield client_a, client_b, storage_b
+
+
 # ---------------------------------------------------------------------------
 # Deferred publish sets learning_status="deferred"
 # ---------------------------------------------------------------------------
@@ -106,6 +151,9 @@ class TestDeferredPublishField:
         assert response.status_code == 200
         data = response.json()
         assert data["learning_status"] == "deferred"
+        # Deferred response must carry a request_id so the caller can poll
+        # GET /api/learning_status — otherwise the poll contract is broken.
+        assert data.get("request_id")
 
     def test_sync_publish_leaves_learning_status_none(self, client, patched_reflexio):
         """Sync path returns real extraction counts — learning_status excluded."""
@@ -153,9 +201,10 @@ class TestLearningStatusEndpoint:
             "/api/learning_status", params={"request_id": "no-such-request"}
         )
         assert response.status_code == 404
-        # Must NOT silently claim "done" for a request that never existed.
+        # Must NOT silently claim "done" for a request that never existed —
+        # a 404 body carries an error detail, never a status field.
         body = response.json()
-        assert "done" not in str(body).lower() or body.get("status") != "done"
+        assert "status" not in body
 
     def test_known_request_returns_valid_status(self, client_with_storage):
         http_client, storage = client_with_storage
@@ -178,6 +227,36 @@ class TestLearningStatusEndpoint:
         http_client, _ = client_with_storage
         response = http_client.get("/api/learning_status")
         assert response.status_code == 422
+
+    def test_cross_org_request_id_returns_404(self, two_org_clients):
+        """Org A must NOT see Org B's request status by request_id.
+
+        Org B owns a request; querying that request_id from Org A returns 404
+        (the request is invisible cross-tenant), never Org B's real status.
+        """
+        client_a, client_b, storage_b = two_org_clients
+        req = Request(
+            request_id="req-cross-org-001",
+            user_id="user-b",
+            session_id="sess-b",
+        )
+        # Seed the request into Org B's storage only.
+        storage_b.get_request.return_value = req
+        storage_b.get_learning_status_for_request.return_value = "pending"
+
+        # Sanity: Org B (the owner) can read its own status.
+        owner_response = client_b.get(
+            "/api/learning_status", params={"request_id": req.request_id}
+        )
+        assert owner_response.status_code == 200
+        assert owner_response.json()["status"] in _VALID_STATUS_VALUES
+
+        # Org A must get a 404 for Org B's request_id — no cross-tenant leak.
+        cross_response = client_a.get(
+            "/api/learning_status", params={"request_id": req.request_id}
+        )
+        assert cross_response.status_code == 404
+        assert "status" not in cross_response.json()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/durable_learning/test_scheduler.py
+++ b/tests/server/services/durable_learning/test_scheduler.py
@@ -128,7 +128,7 @@ def test_scheduler_gated_off_by_default(monkeypatch):
 
 def test_run_once_drains_discovered_orgs():
     """_run_once drives the worker over each org the provider yields; a seeded
-    pending job is drained (no longer claimable) and the poll interval returned."""
+    pending job is drained to status='done' and the poll interval returned."""
     with tempfile.TemporaryDirectory() as tmp_dir:
         factory = _factory(tmp_dir)
         ctx = factory("org_a")
@@ -136,9 +136,6 @@ def test_run_once_drains_discovered_orgs():
         _seed_pending_job(
             ctx.storage, org_id="org_a", user_id="u_a", request_id="req_a"
         )
-        assert _still_pending(ctx.storage, "u_a"), "precondition: job is pending"
-        # Undo the probe claim so the scheduler tick sees a claimable job.
-        ctx2 = factory("org_a")
 
         scheduler = DurableLearningScheduler(
             request_context_factory=factory,
@@ -147,9 +144,12 @@ def test_run_once_drains_discovered_orgs():
         interval = scheduler._run_once()
 
         assert interval == 2.0, "default poll interval is 2.0s"
-        assert not _still_pending(ctx2.storage, "u_a"), (
-            "the discovered org's pending job must be drained by the tick"
-        )
+        assert (
+            ctx.storage.get_learning_status_for_request(
+                user_id="u_a", request_created_at=1.0
+            )
+            == "done"
+        ), "the discovered org's pending job must reach status='done' after the tick"
 
 
 # ---------------------------------------------------------------------------
@@ -186,12 +186,18 @@ def test_scheduler_drains_multiple_sources_in_one_tick():
         )
         scheduler._run_once()
 
-        assert not _still_pending(factory("org_a").storage, "u_a"), (
-            "org_a's job must be drained"
-        )
-        assert not _still_pending(factory("org_b").storage, "u_b"), (
-            "org_b's job (a second ref) must also be drained in the same tick"
-        )
+        assert (
+            ctx_a.storage.get_learning_status_for_request(
+                user_id="u_a", request_created_at=1.0
+            )
+            == "done"
+        ), "org_a's job must reach status='done'"
+        assert (
+            ctx_b.storage.get_learning_status_for_request(
+                user_id="u_b", request_created_at=1.0
+            )
+            == "done"
+        ), "org_b's job (a second ref) must also reach status='done' in the same tick"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/durable_learning/test_scheduler.py
+++ b/tests/server/services/durable_learning/test_scheduler.py
@@ -1,0 +1,233 @@
+"""Tests for DurableLearningScheduler — Task 6.
+
+Headline: one tick discovers orgs-with-work and drains each via the worker,
+proving multi-ref capability (two org_ids backed by two storages, both drained
+in a single _run_once).
+
+SQLite storage; LLM mocked globally by conftest; embeddings disabled
+(REFLEXIO_EMBEDDING_PROVIDER=off) so extraction writes land with empty vectors
+without loading the local ONNX model.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import time
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import Interaction, Request
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.durable_learning.scheduler import (
+    DurableLearningScheduler,
+)
+
+
+@pytest.fixture(autouse=True)
+def _disable_embeddings(monkeypatch):
+    """Disable the local ONNX embedder so extraction runs without model load."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "off")
+
+
+def _factory(base_dir: str):
+    """Return a request-context factory pointing every org at ``base_dir``."""
+
+    def _make(org_id: str) -> RequestContext:
+        return RequestContext(org_id=org_id, storage_base_dir=base_dir)
+
+    return _make
+
+
+def _routing_factory(dir_by_org: dict[str, str]):
+    """Return a factory that routes each org to its own storage base dir.
+
+    Models the enterprise cross-ref case in miniature: each org resolves to a
+    distinct storage (a distinct SQLite DB file == a distinct data ref).
+    """
+
+    def _make(org_id: str) -> RequestContext:
+        return RequestContext(org_id=org_id, storage_base_dir=dir_by_org[org_id])
+
+    return _make
+
+
+def _seed_pending_job(
+    storage,
+    *,
+    org_id: str,
+    user_id: str,
+    request_id: str,
+) -> None:
+    """Persist a request + interaction + a pending learning job (no embeddings)."""
+    assert storage is not None
+    req = Request(
+        request_id=request_id,
+        user_id=user_id,
+        session_id="sess1",
+        agent_version="v1",
+        source="test_src",
+    )
+    interaction = Interaction(
+        user_id=user_id,
+        request_id=request_id,
+        content="test interaction content",
+        embedding=[],
+    )
+    with storage.commit_scope():
+        storage.add_request(req)
+        storage.add_user_interactions_bulk(
+            user_id, [interaction], embeddings_prepared=True
+        )
+        storage.enqueue_learning_job(
+            org_id=org_id,
+            user_id=user_id,
+            request_id=request_id,
+            covers_through=float(int(time.time())),
+        )
+
+
+def _still_pending(storage, user_id: str) -> bool:
+    """Whether ``user_id`` still has a claimable (pending/failed) job."""
+    claimed = [
+        j
+        for j in storage.claim_learning_jobs(
+            claimed_by="probe", limit=10, lease_seconds=300
+        )
+        if j.user_id == user_id
+    ]
+    return bool(claimed)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: gated off by default (flag unset → start() spawns no thread)
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_gated_off_by_default(monkeypatch):
+    """With REFLEXIO_DURABLE_LEARNING_QUEUE unset/false, start() must not spawn
+    the daemon thread (``_should_start`` vetoes)."""
+    monkeypatch.delenv("REFLEXIO_DURABLE_LEARNING_QUEUE", raising=False)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        scheduler = DurableLearningScheduler(
+            request_context_factory=_factory(tmp_dir),
+            org_ids_provider=lambda: [],
+        )
+        scheduler.start()
+        try:
+            assert not scheduler.is_running(), (
+                "scheduler must not start when the queue flag is off"
+            )
+        finally:
+            scheduler.stop()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: one tick drains the discovered orgs
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_drains_discovered_orgs():
+    """_run_once drives the worker over each org the provider yields; a seeded
+    pending job is drained (no longer claimable) and the poll interval returned."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_a")
+        assert ctx.storage is not None
+        _seed_pending_job(
+            ctx.storage, org_id="org_a", user_id="u_a", request_id="req_a"
+        )
+        assert _still_pending(ctx.storage, "u_a"), "precondition: job is pending"
+        # Undo the probe claim so the scheduler tick sees a claimable job.
+        ctx2 = factory("org_a")
+
+        scheduler = DurableLearningScheduler(
+            request_context_factory=factory,
+            org_ids_provider=lambda: ["org_a"],
+        )
+        interval = scheduler._run_once()
+
+        assert interval == 2.0, "default poll interval is 2.0s"
+        assert not _still_pending(ctx2.storage, "u_a"), (
+            "the discovered org's pending job must be drained by the tick"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: one tick drains MULTIPLE sources (multi-ref capability)
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_drains_multiple_sources_in_one_tick():
+    """A provider yielding two org_ids backed by two distinct storages (two DB
+    files == two data refs) must have BOTH drained in a single _run_once.
+
+    Proves the mechanism supports per-ref fan-out without wiring the enterprise
+    cross-ref enumerator (that provider is a deferred follow-up).
+    """
+    with (
+        tempfile.TemporaryDirectory() as dir_a,
+        tempfile.TemporaryDirectory() as dir_b,
+    ):
+        factory = _routing_factory({"org_a": dir_a, "org_b": dir_b})
+
+        ctx_a = factory("org_a")
+        ctx_b = factory("org_b")
+        assert ctx_a.storage is not None and ctx_b.storage is not None
+        _seed_pending_job(
+            ctx_a.storage, org_id="org_a", user_id="u_a", request_id="req_a"
+        )
+        _seed_pending_job(
+            ctx_b.storage, org_id="org_b", user_id="u_b", request_id="req_b"
+        )
+
+        scheduler = DurableLearningScheduler(
+            request_context_factory=factory,
+            org_ids_provider=lambda: ["org_a", "org_b"],
+        )
+        scheduler._run_once()
+
+        assert not _still_pending(factory("org_a").storage, "u_a"), (
+            "org_a's job must be drained"
+        )
+        assert not _still_pending(factory("org_b").storage, "u_b"), (
+            "org_b's job (a second ref) must also be drained in the same tick"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: one org failing does not abort the tick (per-org isolation)
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_isolates_per_org_failures():
+    """A provider whose first org raises inside the worker must not prevent the
+    second, healthy org from being drained."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_ok")
+        assert ctx.storage is not None
+        _seed_pending_job(
+            ctx.storage, org_id="org_ok", user_id="u_ok", request_id="req_ok"
+        )
+
+        def _provider():
+            yield "org_boom"  # no storage seeded for this org, but drain is safe
+            yield "org_ok"
+
+        # Make the boom org explode in the factory to exercise isolation.
+        real_factory = factory
+
+        def _explode_factory(org_id: str):
+            if org_id == "org_boom":
+                raise RuntimeError("simulated per-org failure")
+            return real_factory(org_id)
+
+        scheduler = DurableLearningScheduler(
+            request_context_factory=_explode_factory,
+            org_ids_provider=_provider,
+        )
+        scheduler._run_once()
+
+        assert not _still_pending(factory("org_ok").storage, "u_ok"), (
+            "healthy org must still be drained after a prior org raised"
+        )

--- a/tests/server/services/durable_learning/test_worker.py
+++ b/tests/server/services/durable_learning/test_worker.py
@@ -8,17 +8,19 @@ Test taxonomy:
 3. Missing Request → job failed (not dead), not processed.
 4. Dead transition — job goes dead after max_attempts threshold.
 5. Superseded job — complete_learning_job=0 rolls back profile writes.
+6. Failed job is re-claimable (no manual status reset required).
 
 SQLite storage; LLM mocked globally by conftest; embeddings disabled
 (REFLEXIO_EMBEDDING_PROVIDER=off) so _get_embedding returns [] immediately
 without loading the local ONNX model.
 
 Dead-transition semantics:
-  Both claim_learning_jobs and fail_learning_job increment `attempts`.
+  Only claim_learning_jobs increments `attempts` (fail_learning_job does not).
   With max_attempts=3 (DB default):
-    Claim 1 → attempts=1 (1<3, not dead) → fail → DB=2
-    Claim 2 → attempts=3 (3>=3, dead) → fail(dead=True)
-  So the job goes dead after 2 failure cycles.
+    Claim 1 → attempts=1 (1<3, not dead) → fail(dead=False) → status='failed'
+    Claim 2 → attempts=2 (2<3, not dead) → fail(dead=False) → status='failed'
+    Claim 3 → attempts=3 (3>=3, dead)    → fail(dead=True)  → status='dead'
+  So the job goes dead after 3 delivery attempts.
 """
 
 from __future__ import annotations
@@ -80,6 +82,7 @@ def _setup_job(
     skip_aggregation: bool = False,
 ) -> None:
     """Directly add request + interaction + job to storage without embedding calls."""
+    assert storage is not None, "_setup_job requires non-None storage"
     req = Request(
         request_id=request_id,
         user_id=user_id,
@@ -132,6 +135,7 @@ def test_exactly_once_under_claim_race():
 
         # Baseline: single worker run
         ctx_single = factory("org_single")
+        assert ctx_single.storage is not None
         _setup_job(
             ctx_single.storage,
             org_id="org_single",
@@ -150,6 +154,7 @@ def test_exactly_once_under_claim_race():
 
         # Race: two workers, same job
         ctx_race = factory("org_race")
+        assert ctx_race.storage is not None
         _setup_job(
             ctx_race.storage,
             org_id="org_race",
@@ -224,6 +229,7 @@ def test_per_job_flags_honored():
     with tempfile.TemporaryDirectory() as tmp_dir:
         factory = _factory(tmp_dir)
         ctx = factory("org_flags")
+        assert ctx.storage is not None
 
         _setup_job(
             ctx.storage,
@@ -289,6 +295,7 @@ def test_missing_request_fails_job():
     with tempfile.TemporaryDirectory() as tmp_dir:
         factory = _factory(tmp_dir)
         ctx = factory("org_missing")
+        assert ctx.storage is not None
 
         _setup_job(
             ctx.storage,
@@ -340,16 +347,19 @@ def test_missing_request_fails_job():
 
 
 def test_dead_transition_after_max_attempts():
-    """Job goes dead when claim raises job.attempts to max_attempts.
+    """Job goes dead after exactly max_attempts (3) delivery attempts.
 
-    Both claim_learning_jobs and fail_learning_job increment `attempts`.
+    Only claim_learning_jobs increments attempts; fail_learning_job does not.
     With max_attempts=3 (DB default):
-      Cycle 1: claim -> attempts=1 (1<3, not dead) -> fail(dead=False) -> DB=2
-      Cycle 2: claim -> attempts=3 (3>=3, dead)    -> fail(dead=True)  -> dead
+      Cycle 1: claim -> attempts=1 (1<3, not dead) -> fail(dead=False) -> status='failed'
+      Cycle 2: claim -> attempts=2 (2<3, not dead) -> fail(dead=False) -> status='failed'
+      Cycle 3: claim -> attempts=3 (3>=3, dead)    -> fail(dead=True)  -> status='dead'
+    Failed jobs are re-claimable naturally (no manual status reset needed).
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         factory = _factory(tmp_dir)
         ctx = factory("org_dead")
+        assert ctx.storage is not None
 
         _setup_job(
             ctx.storage,
@@ -374,7 +384,7 @@ def test_dead_transition_after_max_attempts():
         ):
             raise RuntimeError("simulated extraction failure")
 
-        # Cycle 1: claim -> attempts=1 -> not dead -> fail(dead=False) -> DB=2
+        # Cycle 1: claim -> attempts=1 (1<3, not dead) -> fail(dead=False) -> status='failed'
         [job1] = ctx.storage.claim_learning_jobs(
             claimed_by="dead_w", limit=1, lease_seconds=300
         )
@@ -393,25 +403,35 @@ def test_dead_transition_after_max_attempts():
             == "pending"
         ), "cycle 1 fail must leave job as 'pending' (reclaimable)"
 
-        # Reset to 'pending' so cycle 2 can claim it (claim only picks pending/expired)
-        with ctx.storage._lock:
-            ctx.storage.conn.execute(
-                "UPDATE learning_jobs SET status='pending', claim_token=NULL, "
-                "claim_expires_at=NULL WHERE user_id=? AND status='failed'",
-                ("u_dead",),
-            )
-            ctx.storage.conn.commit()
-
-        # Cycle 2: DB attempts=2 -> claim -> attempts=3 (>=3) -> dead=True
+        # Cycle 2: failed job is re-claimable without manual reset
+        # claim -> attempts=2 (2<3, not dead) -> fail(dead=False) -> status='failed'
         [job2] = ctx.storage.claim_learning_jobs(
             claimed_by="dead_w", limit=1, lease_seconds=300
         )
-        assert job2.attempts == 3, f"cycle 2: expected attempts=3, got {job2.attempts}"
+        assert job2.attempts == 2, f"cycle 2: expected attempts=2, got {job2.attempts}"
         with mock.patch.object(
             GenerationService, "run_deferred_learning", _always_raise
         ):
             r2 = worker._process_job(factory("org_dead"), job2)
         assert r2 is False
+
+        assert (
+            ctx.storage.get_learning_status_for_request(
+                user_id="u_dead", request_created_at=0.0
+            )
+            == "pending"
+        ), "cycle 2 fail must leave job as 'pending' (reclaimable)"
+
+        # Cycle 3: claim -> attempts=3 (3>=3, dead=True) -> fail(dead=True) -> status='dead'
+        [job3] = ctx.storage.claim_learning_jobs(
+            claimed_by="dead_w", limit=1, lease_seconds=300
+        )
+        assert job3.attempts == 3, f"cycle 3: expected attempts=3, got {job3.attempts}"
+        with mock.patch.object(
+            GenerationService, "run_deferred_learning", _always_raise
+        ):
+            r3 = worker._process_job(factory("org_dead"), job3)
+        assert r3 is False
 
         # Job must now be dead
         assert (
@@ -419,7 +439,7 @@ def test_dead_transition_after_max_attempts():
                 user_id="u_dead", request_created_at=0.0
             )
             == "failed"
-        ), "cycle 2 dead-fail must surface as 'failed'"
+        ), "cycle 3 dead-fail must surface as 'failed'"
 
         # Dead job must NOT be reclaimable
         still_claimable = ctx.storage.claim_learning_jobs(
@@ -441,6 +461,7 @@ def test_superseded_job_does_not_commit_outputs():
     with tempfile.TemporaryDirectory() as tmp_dir:
         factory = _factory(tmp_dir)
         ctx = factory("org_supersede")
+        assert ctx.storage is not None
 
         _setup_job(
             ctx.storage,
@@ -469,4 +490,109 @@ def test_superseded_job_does_not_commit_outputs():
         assert profiles_after == profiles_before, (
             "superseded worker must NOT commit profile writes: "
             f"before={profiles_before}, after={profiles_after}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Failed job is re-claimable without manual status reset
+# ---------------------------------------------------------------------------
+
+
+def test_failed_job_is_reclaimable():
+    """A failed (not dead) job must be re-claimable directly.
+
+    claim_learning_jobs includes status='failed' in its predicate, so a job
+    that fails once is naturally picked up on the next poll without any manual
+    status reset.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_reclaim")
+        assert ctx.storage is not None
+
+        _setup_job(
+            ctx.storage,
+            org_id="org_reclaim",
+            user_id="u_reclaim",
+            request_id="req_reclaim",
+        )
+
+        # Claim and fail the job (not dead — attempts=1 < max_attempts=3)
+        [job1] = ctx.storage.claim_learning_jobs(
+            claimed_by="w_reclaim", limit=1, lease_seconds=300
+        )
+        assert job1.attempts == 1
+        assert job1.claim_token is not None
+        ctx.storage.fail_learning_job(
+            job_id=job1.job_id, claim_token=job1.claim_token, dead=False
+        )
+
+        # Without any manual reset, the job must be immediately re-claimable
+        reclaimed = [
+            j
+            for j in ctx.storage.claim_learning_jobs(
+                claimed_by="w_reclaim2", limit=5, lease_seconds=300
+            )
+            if j.user_id == "u_reclaim"
+        ]
+        assert len(reclaimed) == 1, "failed job must be re-claimable"
+        assert reclaimed[0].attempts == 2, (
+            f"re-claimed job must have attempts=2, got {reclaimed[0].attempts}"
+        )
+        assert reclaimed[0].status == "claimed"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: schedule_tagging is called on the sequential (durable) path
+# ---------------------------------------------------------------------------
+
+
+def test_run_deferred_learning_schedules_tagging():
+    """schedule_tagging must be called even when sequential=True (durable-worker path).
+
+    Previously the sequential branch in _run_learning_steps returned early before
+    reaching schedule_tagging — this test guards that regression.
+    """
+    from reflexio.server.api_endpoints.request_context import RequestContext
+    from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ctx = RequestContext(org_id="org_tag_seq", storage_base_dir=tmp_dir)
+        gen = GenerationService(
+            llm_client=LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini")),
+            request_context=ctx,
+        )
+
+        tagging_calls: list[dict] = []
+
+        def _mock_tagging(**kwargs):
+            tagging_calls.append(kwargs)
+
+        with (
+            mock.patch(
+                "reflexio.server.services.generation_service.schedule_tagging",
+                side_effect=_mock_tagging,
+            ),
+            mock.patch(
+                "reflexio.server.services.generation_service.ProfileGenerationService"
+            ),
+            mock.patch(
+                "reflexio.server.services.generation_service.PlaybookGenerationService"
+            ),
+            mock.patch.object(gen, "_maybe_run_reflection"),
+        ):
+            gen.run_deferred_learning(
+                user_id="u_tag",
+                request_id="r_tag",
+                session_id="s_tag",
+                source="test",
+                agent_version="v1",
+                force_extraction=False,
+                skip_aggregation=False,
+                sequential=True,
+            )
+
+        assert len(tagging_calls) == 1, (
+            f"schedule_tagging must be called exactly once on the sequential path, "
+            f"got {len(tagging_calls)} calls"
         )

--- a/tests/server/services/durable_learning/test_worker.py
+++ b/tests/server/services/durable_learning/test_worker.py
@@ -1,0 +1,472 @@
+"""Tests for DurableLearningWorker — Task 5b.
+
+Headline: exactly-once proof under a claim race (real threads).
+
+Test taxonomy:
+1. Exactly-once under claim race — profile+playbook counts match a single run.
+2. Per-job flags honored — force_extraction/skip_aggregation round-trip.
+3. Missing Request → job failed (not dead), not processed.
+4. Dead transition — job goes dead after max_attempts threshold.
+5. Superseded job — complete_learning_job=0 rolls back profile writes.
+
+SQLite storage; LLM mocked globally by conftest; embeddings disabled
+(REFLEXIO_EMBEDDING_PROVIDER=off) so _get_embedding returns [] immediately
+without loading the local ONNX model.
+
+Dead-transition semantics:
+  Both claim_learning_jobs and fail_learning_job increment `attempts`.
+  With max_attempts=3 (DB default):
+    Claim 1 → attempts=1 (1<3, not dead) → fail → DB=2
+    Claim 2 → attempts=3 (3>=3, dead) → fail(dead=True)
+  So the job goes dead after 2 failure cycles.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import threading
+import time
+from unittest import mock
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import Interaction, Request
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.durable_learning.worker import DurableLearningWorker
+from reflexio.server.services.generation_service import (
+    GenerationService,
+    GenerationServiceResult,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level fixture: disable the local ONNX embedder for all tests.
+# EmbeddingUnavailableError is caught at every call site so writes still land,
+# just with empty embedding vectors (acceptable for count assertions).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _disable_embeddings(monkeypatch):
+    """Set REFLEXIO_EMBEDDING_PROVIDER=off so get_embedding/get_embeddings raise
+    EmbeddingUnavailableError immediately (caught by callers -> empty vectors).
+    This prevents loading the local ONNXMiniLM model during test runs."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "off")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _factory(tmp_dir: str):
+    """Return a request-context factory pointing at tmp_dir."""
+
+    def _make(org_id: str) -> RequestContext:
+        return RequestContext(org_id=org_id, storage_base_dir=tmp_dir)
+
+    return _make
+
+
+def _setup_job(
+    storage,
+    *,
+    org_id: str,
+    user_id: str,
+    request_id: str,
+    session_id: str = "sess1",
+    agent_version: str = "v1",
+    source: str = "test_src",
+    force_extraction: bool = False,
+    skip_aggregation: bool = False,
+) -> None:
+    """Directly add request + interaction + job to storage without embedding calls."""
+    req = Request(
+        request_id=request_id,
+        user_id=user_id,
+        session_id=session_id,
+        agent_version=agent_version,
+        source=source,
+    )
+    interaction = Interaction(
+        user_id=user_id,
+        request_id=request_id,
+        content="test interaction content",
+        embedding=[],
+    )
+    with storage.commit_scope():
+        storage.add_request(req)
+        storage.add_user_interactions_bulk(
+            user_id, [interaction], embeddings_prepared=True
+        )
+        storage.enqueue_learning_job(
+            org_id=org_id,
+            user_id=user_id,
+            request_id=request_id,
+            covers_through=float(int(time.time())),
+            force_extraction=force_extraction,
+            skip_aggregation=skip_aggregation,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Exactly-once under a claim race (the headline)
+# ---------------------------------------------------------------------------
+
+
+def test_exactly_once_under_claim_race():
+    """Two workers racing the same job must produce profile+playbook counts
+    identical to a single-worker run.
+
+    Strategy:
+    - Run a single worker on org_single to record baseline profile/playbook counts.
+    - Set up an identical job on org_race; pre-claim with stale token, re-claim
+      with live token so both workers hold distinct claim tokens for the same job.
+    - Run both workers' _process_job concurrently in real threads.
+    - Assert org_race counts == org_single counts (exactly one committed).
+
+    The fenced complete_learning_job (raises _Superseded on rowcount=0 -> rollback)
+    guarantees the stale worker's writes do not survive.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+
+        # Baseline: single worker run
+        ctx_single = factory("org_single")
+        _setup_job(
+            ctx_single.storage,
+            org_id="org_single",
+            user_id="u_single",
+            request_id="req_single",
+        )
+
+        worker_single = DurableLearningWorker(factory, instance_id="single")
+        n_processed = worker_single.drain_org(
+            "org_single", batch_size=1, lease_seconds=300
+        )
+        assert n_processed == 1, "single worker must complete the job"
+
+        baseline_profiles = ctx_single.storage.count_all_profiles()
+        baseline_playbooks = ctx_single.storage.count_user_playbooks()
+
+        # Race: two workers, same job
+        ctx_race = factory("org_race")
+        _setup_job(
+            ctx_race.storage,
+            org_id="org_race",
+            user_id="u_race",
+            request_id="req_race",
+        )
+
+        # Claim with an immediately-expired lease so a second claim can supersede it.
+        [stale_job] = ctx_race.storage.claim_learning_jobs(
+            claimed_by="pre_stale", limit=1, lease_seconds=-1
+        )
+        # Re-claim: the stale lease is already expired -> this gets the live token.
+        [live_job] = ctx_race.storage.claim_learning_jobs(
+            claimed_by="pre_live", limit=1, lease_seconds=300
+        )
+
+        assert stale_job.job_id == live_job.job_id, "same job re-claimed"
+        assert stale_job.claim_token != live_job.claim_token, "tokens must differ"
+
+        worker_stale = DurableLearningWorker(factory, instance_id="w_stale")
+        worker_live = DurableLearningWorker(factory, instance_id="w_live")
+
+        errors: list[BaseException] = []
+
+        def run_stale() -> None:
+            try:
+                worker_stale._process_job(factory("org_race"), stale_job)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def run_live() -> None:
+            try:
+                worker_live._process_job(factory("org_race"), live_job)
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        t_stale = threading.Thread(target=run_stale, name="worker-stale")
+        t_live = threading.Thread(target=run_live, name="worker-live")
+        t_stale.start()
+        t_live.start()
+        t_stale.join(timeout=60)
+        t_live.join(timeout=60)
+
+        assert not t_stale.is_alive(), "stale worker thread timed out"
+        assert not t_live.is_alive(), "live worker thread timed out"
+        assert not errors, f"Worker threads raised: {errors}"
+
+        # Assert exactly-once: counts must match baseline
+        race_profiles = ctx_race.storage.count_all_profiles()
+        race_playbooks = ctx_race.storage.count_user_playbooks()
+
+        assert race_profiles == baseline_profiles, (
+            f"Exactly-once violated: race produced {race_profiles} profiles "
+            f"but baseline is {baseline_profiles}. "
+            "The stale worker's writes must have been rolled back."
+        )
+        assert race_playbooks == baseline_playbooks, (
+            f"Exactly-once violated: race produced {race_playbooks} playbooks "
+            f"but baseline is {baseline_playbooks}. "
+            "The stale worker's writes must have been rolled back."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Per-job flags honored (force_extraction, skip_aggregation)
+# ---------------------------------------------------------------------------
+
+
+def test_per_job_flags_honored():
+    """force_extraction and skip_aggregation from the job are passed to
+    run_deferred_learning -- not hardcoded False."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_flags")
+
+        _setup_job(
+            ctx.storage,
+            org_id="org_flags",
+            user_id="u_flags",
+            request_id="req_flags",
+            force_extraction=True,
+            skip_aggregation=True,
+        )
+
+        jobs = ctx.storage.claim_learning_jobs(
+            claimed_by="flag_worker", limit=1, lease_seconds=300
+        )
+        assert jobs, "expected a job"
+        job = jobs[0]
+        assert job.force_extraction is True, "force_extraction must be True in job"
+        assert job.skip_aggregation is True, "skip_aggregation must be True in job"
+
+        call_kwargs: dict = {}
+
+        def spy_run_deferred(
+            _self,
+            *,
+            user_id,
+            request_id,
+            session_id,
+            source,
+            agent_version,
+            force_extraction,
+            skip_aggregation,
+            sequential=False,
+        ):
+            call_kwargs.update(
+                force_extraction=force_extraction,
+                skip_aggregation=skip_aggregation,
+            )
+            return GenerationServiceResult(request_id=request_id)
+
+        worker = DurableLearningWorker(factory, instance_id="flag_w")
+
+        with mock.patch.object(
+            GenerationService, "run_deferred_learning", spy_run_deferred
+        ):
+            worker._process_job(factory("org_flags"), job)
+
+        assert call_kwargs.get("force_extraction") is True, (
+            "force_extraction=True must reach run_deferred_learning"
+        )
+        assert call_kwargs.get("skip_aggregation") is True, (
+            "skip_aggregation=True must reach run_deferred_learning"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Missing Request fails the job (not dead on first attempt)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_request_fails_job():
+    """If the stored Request for latest_request_id is absent, the job is failed
+    without calling run_deferred_learning (prevents a run with wrong agent_version).
+    On the first attempt (attempts=1 < max_attempts=3) it is failed, not dead."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_missing")
+
+        _setup_job(
+            ctx.storage,
+            org_id="org_missing",
+            user_id="u_missing",
+            request_id="req_missing",
+        )
+
+        ctx.storage.delete_request("req_missing")
+        assert ctx.storage.get_request("req_missing") is None
+
+        [job] = ctx.storage.claim_learning_jobs(
+            claimed_by="missing_w", limit=1, lease_seconds=300
+        )
+
+        ran_learning = False
+
+        def _should_not_run(*args, **kwargs):
+            nonlocal ran_learning
+            ran_learning = True
+            return  # type: ignore[return-value]
+
+        worker = DurableLearningWorker(factory, instance_id="missing_w")
+
+        with mock.patch.object(
+            GenerationService, "run_deferred_learning", _should_not_run
+        ):
+            result = worker._process_job(factory("org_missing"), job)
+
+        assert result is False, "missing request must not be counted as processed"
+        assert not ran_learning, (
+            "run_deferred_learning must NOT be called when Request is absent"
+        )
+
+        # First failure: attempts=1 < max_attempts=3 -> status='failed' (not dead).
+        # get_learning_status_for_request returns "pending" for a failed non-dead job.
+        status = ctx.storage.get_learning_status_for_request(
+            user_id="u_missing",
+            request_created_at=0.0,
+        )
+        assert status == "pending", (
+            f"after first failure (not dead): expected 'pending', got {status!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Dead transition after max_attempts threshold
+# ---------------------------------------------------------------------------
+
+
+def test_dead_transition_after_max_attempts():
+    """Job goes dead when claim raises job.attempts to max_attempts.
+
+    Both claim_learning_jobs and fail_learning_job increment `attempts`.
+    With max_attempts=3 (DB default):
+      Cycle 1: claim -> attempts=1 (1<3, not dead) -> fail(dead=False) -> DB=2
+      Cycle 2: claim -> attempts=3 (3>=3, dead)    -> fail(dead=True)  -> dead
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_dead")
+
+        _setup_job(
+            ctx.storage,
+            org_id="org_dead",
+            user_id="u_dead",
+            request_id="req_dead",
+        )
+
+        worker = DurableLearningWorker(factory, instance_id="dead_w")
+
+        def _always_raise(
+            _self,
+            *,
+            user_id,
+            request_id,
+            session_id,
+            source,
+            agent_version,
+            force_extraction,
+            skip_aggregation,
+            sequential=False,
+        ):
+            raise RuntimeError("simulated extraction failure")
+
+        # Cycle 1: claim -> attempts=1 -> not dead -> fail(dead=False) -> DB=2
+        [job1] = ctx.storage.claim_learning_jobs(
+            claimed_by="dead_w", limit=1, lease_seconds=300
+        )
+        assert job1.attempts == 1, f"cycle 1: expected attempts=1, got {job1.attempts}"
+        with mock.patch.object(
+            GenerationService, "run_deferred_learning", _always_raise
+        ):
+            r1 = worker._process_job(factory("org_dead"), job1)
+        assert r1 is False
+
+        # status='failed' (not dead); get_learning_status returns "pending"
+        assert (
+            ctx.storage.get_learning_status_for_request(
+                user_id="u_dead", request_created_at=0.0
+            )
+            == "pending"
+        ), "cycle 1 fail must leave job as 'pending' (reclaimable)"
+
+        # Reset to 'pending' so cycle 2 can claim it (claim only picks pending/expired)
+        with ctx.storage._lock:
+            ctx.storage.conn.execute(
+                "UPDATE learning_jobs SET status='pending', claim_token=NULL, "
+                "claim_expires_at=NULL WHERE user_id=? AND status='failed'",
+                ("u_dead",),
+            )
+            ctx.storage.conn.commit()
+
+        # Cycle 2: DB attempts=2 -> claim -> attempts=3 (>=3) -> dead=True
+        [job2] = ctx.storage.claim_learning_jobs(
+            claimed_by="dead_w", limit=1, lease_seconds=300
+        )
+        assert job2.attempts == 3, f"cycle 2: expected attempts=3, got {job2.attempts}"
+        with mock.patch.object(
+            GenerationService, "run_deferred_learning", _always_raise
+        ):
+            r2 = worker._process_job(factory("org_dead"), job2)
+        assert r2 is False
+
+        # Job must now be dead
+        assert (
+            ctx.storage.get_learning_status_for_request(
+                user_id="u_dead", request_created_at=0.0
+            )
+            == "failed"
+        ), "cycle 2 dead-fail must surface as 'failed'"
+
+        # Dead job must NOT be reclaimable
+        still_claimable = ctx.storage.claim_learning_jobs(
+            claimed_by="post_dead", limit=5, lease_seconds=300
+        )
+        assert not any(j.user_id == "u_dead" for j in still_claimable), (
+            "dead job must not be reclaimable"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Superseded job rolls back profile/playbook writes
+# ---------------------------------------------------------------------------
+
+
+def test_superseded_job_does_not_commit_outputs():
+    """A worker whose complete_learning_job returns 0 (stale token) must NOT
+    commit profile/playbook writes."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        factory = _factory(tmp_dir)
+        ctx = factory("org_supersede")
+
+        _setup_job(
+            ctx.storage,
+            org_id="org_supersede",
+            user_id="u_super",
+            request_id="req_super",
+        )
+
+        # Claim with stale token (lease_seconds=-1 -> already expired).
+        [stale_job] = ctx.storage.claim_learning_jobs(
+            claimed_by="w_stale", limit=1, lease_seconds=-1
+        )
+        # Re-claim to supersede; the stale token is now invalid.
+        [live_job] = ctx.storage.claim_learning_jobs(  # noqa: F841
+            claimed_by="w_live", limit=1, lease_seconds=300
+        )
+        assert stale_job.claim_token != live_job.claim_token
+
+        profiles_before = ctx.storage.count_all_profiles()
+
+        worker = DurableLearningWorker(factory, instance_id="w_super")
+        result = worker._process_job(factory("org_supersede"), stale_job)
+
+        assert result is False, "_process_job must return False when superseded"
+        profiles_after = ctx.storage.count_all_profiles()
+        assert profiles_after == profiles_before, (
+            "superseded worker must NOT commit profile writes: "
+            f"before={profiles_before}, after={profiles_after}"
+        )

--- a/tests/server/services/storage/test_learning_writes_atomicity_integration.py
+++ b/tests/server/services/storage/test_learning_writes_atomicity_integration.py
@@ -1,0 +1,91 @@
+"""Contract test: learning-path writes honor ``commit_scope`` atomicity (Task 5a).
+
+Task 1 introduced ``commit_scope`` — a context manager that groups writes into a
+single atomic transaction (one BEGIN IMMEDIATE / one commit) and defers FTS/vec
+index ops until after commit. Writes issued inside a scope must NOT run their own
+BEGIN or commit; ``_own_transaction()`` returns False while ``_scope_depth > 0``.
+
+Before this task, the learning-path writes (profiles, user playbooks, lineage
+events, operation-state bookmarks) each self-committed. That broke atomicity: a
+write inside a ``commit_scope`` would durably commit even when a later write in
+the same scope raised, leaving the DB in a torn, partially-committed state.
+
+This test is the invariant guard: perform one write of each kind inside a single
+``commit_scope`` that then raises, and assert every write rolled back. It fails
+before the own-txn guards are added (the self-committing writes survive) and
+passes once each method honors ``_own_transaction()``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import LineageEvent
+from reflexio.models.api_schema.service_schemas import (
+    ProfileTimeToLive,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+_ORG_ID = "learning-atomic-org"
+_USER_ID = "u-atomic"
+
+
+def _make_profile() -> UserProfile:
+    return UserProfile(
+        user_id=_USER_ID,
+        profile_id="lv-test-pid",
+        content="atomic profile content",
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id="req-lv-test",
+        profile_time_to_live=ProfileTimeToLive.INFINITY,
+    )
+
+
+def _make_playbook() -> UserPlaybook:
+    return UserPlaybook(
+        agent_version="v1",
+        request_id="req-lv-test",
+        user_id=_USER_ID,
+        content="atomic playbook content",
+    )
+
+
+def _make_lineage_event() -> LineageEvent:
+    return LineageEvent(
+        org_id=_ORG_ID,
+        entity_type="profile",
+        entity_id="lv-test-pid",
+        op="create",
+        request_id="req-lv-test",
+        reason="test",
+        actor="test",
+    )
+
+
+def test_learning_writes_roll_back_together_on_scope_failure(tmp_path) -> None:
+    """All four learning-path writes roll back when the enclosing scope raises."""
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage = SQLiteStorage(
+            org_id=_ORG_ID, db_path=str(tmp_path / "learning_atomic.db")
+        )
+        storage.migrate()
+
+        with pytest.raises(RuntimeError, match="boom"), storage.commit_scope():
+            storage.add_user_profile(_USER_ID, [_make_profile()])
+            storage.save_user_playbooks([_make_playbook()])
+            storage.append_lineage_event(_make_lineage_event())
+            storage.upsert_operation_state("test-svc", {"k": "v"})
+            raise RuntimeError("boom")
+
+        # Every write in the failed scope must have rolled back.
+        assert storage.get_user_profile(_USER_ID) == []
+        assert storage.get_user_playbooks(user_id=_USER_ID) == []
+        assert storage.get_lineage_events(entity_id="lv-test-pid") == []
+        assert storage.get_operation_state("test-svc") is None

--- a/tests/server/services/storage/test_storage_contract_commit_scope.py
+++ b/tests/server/services/storage/test_storage_contract_commit_scope.py
@@ -1,0 +1,38 @@
+"""Contract tests for commit_scope atomicity across all storage backends."""
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import Request
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _seed_request(
+    storage: BaseStorage, request_id: str = "r1", user_id: str = "u1"
+) -> None:
+    storage.add_request(
+        Request(
+            request_id=request_id,
+            user_id=user_id,
+            created_at=1000,
+            source="api",
+            agent_version="v1",
+            session_id=request_id,
+        )
+    )
+
+
+class TestCommitScopeAtomicity:
+    def test_exception_in_scope_rolls_back_all_writes(
+        self, storage: BaseStorage
+    ) -> None:
+        with pytest.raises(RuntimeError, match="boom"), storage.commit_scope():
+            _seed_request(storage, "r-atomic", "u-atomic")
+            raise RuntimeError("boom")
+        assert storage.get_request("r-atomic") is None
+
+    def test_clean_scope_persists_all_writes(self, storage: BaseStorage) -> None:
+        with storage.commit_scope():
+            _seed_request(storage, "r-clean", "u-clean")
+        assert storage.get_request("r-clean") is not None

--- a/tests/server/services/storage/test_storage_contract_commit_scope.py
+++ b/tests/server/services/storage/test_storage_contract_commit_scope.py
@@ -36,3 +36,22 @@ class TestCommitScopeAtomicity:
         with storage.commit_scope():
             _seed_request(storage, "r-clean", "u-clean")
         assert storage.get_request("r-clean") is not None
+
+    def test_standalone_write_succeeds_after_failed_scope(
+        self, storage: BaseStorage
+    ) -> None:
+        """After a rolled-back commit_scope, no implicit txn must remain open.
+
+        Regression guard for the Important-1 TOCTOU fix: if own_txn is read
+        outside the lock, a stale False value skips BEGIN IMMEDIATE on the next
+        standalone call, leaving an implicit transaction open that makes the
+        following BEGIN IMMEDIATE raise OperationalError.
+        """
+        with pytest.raises(RuntimeError), storage.commit_scope():
+            _seed_request(storage, "r-fail", "u-fail")
+            raise RuntimeError("trigger rollback")
+        # The rolled-back request must not be visible.
+        assert storage.get_request("r-fail") is None
+        # A standalone write after the failed scope must succeed without error.
+        _seed_request(storage, "r-after", "u-after")
+        assert storage.get_request("r-after") is not None

--- a/tests/server/services/storage/test_storage_contract_commit_scope.py
+++ b/tests/server/services/storage/test_storage_contract_commit_scope.py
@@ -1,5 +1,7 @@
 """Contract tests for commit_scope atomicity across all storage backends."""
 
+import sqlite3
+
 import pytest
 
 from reflexio.models.api_schema.domain.entities import Request
@@ -55,3 +57,47 @@ class TestCommitScopeAtomicity:
         # A standalone write after the failed scope must succeed without error.
         _seed_request(storage, "r-after", "u-after")
         assert storage.get_request("r-after") is not None
+
+    def test_scope_depth_reset_after_begin_failure(self, storage: BaseStorage) -> None:
+        """If BEGIN IMMEDIATE raises, _scope_depth stays 0 so subsequent scopes work.
+
+        Regression guard: _scope_depth was set to 1 *before* BEGIN IMMEDIATE.
+        If BEGIN raised, _scope_depth stayed 1 forever — every subsequent
+        commit_scope treated itself as nested and never committed (silent data
+        loss).  The fix moves _scope_depth = 1 to *after* a successful BEGIN.
+
+        This invariant is SQLite-specific (_scope_depth lives on SQLiteStorage);
+        other backends are skipped.
+        """
+        if not hasattr(storage, "_scope_depth"):
+            pytest.skip("_scope_depth regression is SQLite-specific")
+
+        real_conn = storage.conn  # type: ignore[attr-defined]
+
+        class _FailBeginConn:
+            """Proxy that raises OperationalError on any BEGIN statement."""
+
+            def execute(self, sql: str, *a: object, **kw: object) -> object:
+                if "BEGIN" in sql.upper():
+                    raise sqlite3.OperationalError("database is locked (forced)")
+                return real_conn.execute(sql, *a, **kw)
+
+            def __getattr__(self, name: str) -> object:
+                return getattr(real_conn, name)
+
+        storage.conn = _FailBeginConn()  # type: ignore[assignment]
+        try:
+            with (
+                pytest.raises(sqlite3.OperationalError, match="database is locked"),
+                storage.commit_scope(),
+            ):
+                pass
+        finally:
+            storage.conn = real_conn  # type: ignore[assignment]  # restore regardless
+
+        # _scope_depth must be back to 0 — not stuck at 1.
+        assert storage._scope_depth == 0  # type: ignore[attr-defined]
+        # The connection must still be usable: next scope commits normally.
+        with storage.commit_scope():
+            _seed_request(storage, "r-after-begin-fail", "u-after-begin-fail")
+        assert storage.get_request("r-after-begin-fail") is not None

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -397,6 +397,64 @@ class TestFlagRoundTrip:
         assert job.skip_aggregation is True, "skip_aggregation must round-trip"
 
 
+class TestOrgDiscovery:
+    def test_pending_job_makes_org_discoverable(self, storage) -> None:
+        """An org with a pending job appears in the cross-org discovery list;
+        after its only job is completed, it drops out."""
+        assert storage.org_id not in storage.list_org_ids_with_pending_learning_jobs()
+        _enqueue(storage, "u-disc", "r-disc", 1000.0)
+        assert storage.org_id in storage.list_org_ids_with_pending_learning_jobs()
+
+        # Claim + complete the job → org has no more actionable work.
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-disc"
+        ]
+        assert (
+            storage.complete_learning_job(
+                job_id=job.job_id, claim_token=job.claim_token
+            )
+            == 1
+        )
+        assert storage.org_id not in storage.list_org_ids_with_pending_learning_jobs()
+
+    def test_failed_job_keeps_org_discoverable(self, storage) -> None:
+        """A failed (reclaimable) job keeps the org discoverable so the scheduler
+        retries it."""
+        _enqueue(storage, "u-df", "r-df", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-df"
+        ]
+        # While claimed with a live lease it must NOT be discoverable (in flight).
+        assert storage.org_id not in storage.list_org_ids_with_pending_learning_jobs()
+        storage.fail_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, dead=False
+        )
+        assert storage.org_id in storage.list_org_ids_with_pending_learning_jobs()
+
+    def test_dead_job_is_not_discoverable(self, storage) -> None:
+        """A dead job is terminal and must not surface as actionable work."""
+        _enqueue(storage, "u-dd", "r-dd", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-dd"
+        ]
+        storage.fail_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, dead=True
+        )
+        assert storage.org_id not in storage.list_org_ids_with_pending_learning_jobs()
+
+
 class TestRetrySemantics:
     def test_failed_job_is_reclaimable(self, storage) -> None:
         """A failed (not dead) job must be re-claimable without manual status reset.

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -299,6 +299,47 @@ class TestStatusCoverage:
             == "failed"
         )
 
+    def test_done_wins_over_failed_regardless_of_row_order(self, storage) -> None:
+        """Covering done row must beat a failed row even if DB yields failed first.
+
+        Regression for the early-return bug: `if status == "failed": return "pending"`
+        shadowed a covering done row if the failed row appeared first in the result set.
+        Priority: done > processing > pending > failed(→pending) > dead(→failed).
+        """
+        # Step 1: enqueue, claim, and complete — leaves a done row covering ts=4000.0.
+        _enqueue(storage, "u-df", "r-df-1", covers_through=5000.0)
+        [job1] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-df"
+        ]
+        storage.complete_learning_job(job_id=job1.job_id, claim_token=job1.claim_token)
+
+        # Step 2: enqueue a second job for the same user (first is done, so a new
+        # pending row is inserted), claim it, and fail it (dead=False → status='failed').
+        _enqueue(storage, "u-df", "r-df-2", covers_through=9000.0)
+        [job2] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-df"
+        ]
+        storage.fail_learning_job(
+            job_id=job2.job_id, claim_token=job2.claim_token, dead=False
+        )
+
+        # The done row covers request_created_at=4000.0; the failed row must not
+        # shadow it regardless of which row the DB yields first.
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-df", request_created_at=4000.0
+            )
+            == "done"
+        )
+
 
 class TestHeartbeat:
     def test_heartbeat_extends_live_claim(self, storage) -> None:

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -1,3 +1,4 @@
+import time
 import uuid
 
 import pytest
@@ -160,6 +161,34 @@ class TestFencedCompletion:
             == 0
         )
 
+    def test_fail_after_complete_is_noop(self, storage) -> None:
+        """fail_learning_job on an already-done job is a no-op (status stays 'done')."""
+        _enqueue(storage, "u-fc", "r-fc", 5000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-fc"
+        ]
+        assert (
+            storage.complete_learning_job(
+                job_id=job.job_id, claim_token=job.claim_token
+            )
+            == 1
+        )
+        # Attempt to fail the already-completed job — must be a no-op.
+        storage.fail_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, dead=False
+        )
+        # Status check: job is done and request is in the past → still "done".
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-fc", request_created_at=4000.0
+            )
+            == "done"
+        )
+
 
 class TestStatusCoverage:
     def test_zero_yield_window_reports_done(self, storage) -> None:
@@ -202,13 +231,53 @@ class TestStatusCoverage:
             == "processing"
         )
 
-    def test_no_rows_returns_done_absence_semantics(self, storage) -> None:
-        # No rows for this user → absence semantics → "done"
+    def test_no_rows_old_request_returns_done_absence_semantics(self, storage) -> None:
+        # No rows, request far in the past (older than 72 h retention window) → "done"
         assert (
             storage.get_learning_status_for_request(
-                user_id="u-absent", request_created_at=1000.0
+                user_id="u-absent-old", request_created_at=1000.0
             )
             == "done"
+        )
+
+    def test_no_rows_recent_request_returns_pending(self, storage) -> None:
+        # No rows, but request is recent → absence-done guard fires → "pending"
+        recent_ts = time.time() - 60  # 60 seconds ago — well within 72 h window
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-absent-recent", request_created_at=recent_ts
+            )
+            == "pending"
+        )
+
+    def test_no_rows_old_enough_request_returns_done(self, storage) -> None:
+        # No rows, request older than the retention window (90 h) → "done"
+        old_ts = time.time() - 90 * 3600
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-absent-old2", request_created_at=old_ts
+            )
+            == "done"
+        )
+
+    def test_failed_reclaimable_job_reports_pending(self, storage) -> None:
+        # A failed (not dead) job is reclaimable — should surface as "pending".
+        _enqueue(storage, "u-rfail", "r-rfail", covers_through=5000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-rfail"
+        ]
+        storage.fail_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, dead=False
+        )
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-rfail", request_created_at=4000.0
+            )
+            == "pending"
         )
 
     def test_failed_job_reports_failed(self, storage) -> None:

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -22,6 +22,8 @@ class TestLearningJobsSchema:
             "claim_token",
             "claim_expires_at",
             "covers_through",
+            "force_extraction",
+            "skip_aggregation",
             "created_at",
             "updated_at",
         }
@@ -367,3 +369,29 @@ class TestHeartbeat:
         assert not storage.heartbeat_learning_job(
             job_id=job.job_id, claim_token=str(uuid.uuid4()), lease_seconds=600
         )
+
+
+class TestFlagRoundTrip:
+    def test_force_extraction_and_skip_aggregation_survive_enqueue_claim(
+        self, storage
+    ) -> None:
+        """force_extraction and skip_aggregation persisted on enqueue must be
+        returned on claim so the Task 5 worker can read them."""
+        with storage.commit_scope():
+            storage.enqueue_learning_job(
+                org_id=storage.org_id,
+                user_id="u-flags",
+                request_id="r-flags",
+                covers_through=1000.0,
+                force_extraction=True,
+                skip_aggregation=True,
+            )
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-flags"
+        ]
+        assert job.force_extraction is True, "force_extraction must round-trip"
+        assert job.skip_aggregation is True, "skip_aggregation must round-trip"

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -458,7 +458,7 @@ class TestOrgDiscovery:
         """A job with a live claim hides the org; once the lease expires the org
         resurfaces so the scheduler can reclaim and retry a stuck worker's job."""
         _enqueue(storage, "u-exp", "r-exp", 1000.0)
-        [job] = [
+        [_job] = [
             j
             for j in storage.claim_learning_jobs(
                 claimed_by="w1", limit=10, lease_seconds=1

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -1,0 +1,25 @@
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+class TestLearningJobsSchema:
+    def test_table_exists_with_expected_columns(self, storage) -> None:
+        cols = set(storage.learning_jobs_columns())
+        expected = {
+            "job_id",
+            "org_id",
+            "user_id",
+            "job_type",
+            "latest_request_id",
+            "status",
+            "attempts",
+            "max_attempts",
+            "claimed_by",
+            "claim_token",
+            "claim_expires_at",
+            "covers_through",
+            "created_at",
+            "updated_at",
+        }
+        assert expected <= cols

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 pytestmark = pytest.mark.integration
@@ -23,3 +25,235 @@ class TestLearningJobsSchema:
             "updated_at",
         }
         assert expected <= cols
+
+
+def _enqueue(
+    storage, user_id: str = "u1", request_id: str = "r1", covers_through: float = 1000.0
+) -> str:
+    with storage.commit_scope():
+        return storage.enqueue_learning_job(
+            org_id=storage.org_id,
+            user_id=user_id,
+            request_id=request_id,
+            covers_through=covers_through,
+        )
+
+
+class TestCoalescing:
+    def test_two_pending_publishes_collapse_to_one_job(self, storage) -> None:
+        j1 = _enqueue(storage, "u-c", "r-1", 1000.0)
+        j2 = _enqueue(storage, "u-c", "r-2", 2000.0)
+        assert j1 == j2
+        claimed = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-c"
+        ]
+        assert len(claimed) == 1
+        assert claimed[0].covers_through == 2000.0  # max kept
+
+    def test_different_users_get_separate_jobs(self, storage) -> None:
+        j1 = _enqueue(storage, "u-x1", "r-a", 1000.0)
+        j2 = _enqueue(storage, "u-x2", "r-b", 1000.0)
+        assert j1 != j2
+
+    def test_enqueue_inside_commit_scope_commits_with_scope(self, storage) -> None:
+        """enqueue inside commit_scope does not issue its own BEGIN/COMMIT."""
+        with storage.commit_scope():
+            storage.enqueue_learning_job(
+                org_id=storage.org_id,
+                user_id="u-scope",
+                request_id="r-scope",
+                covers_through=500.0,
+            )
+        claimed = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-scope"
+        ]
+        assert len(claimed) == 1
+
+
+class TestFencedCompletion:
+    def test_stale_token_completion_is_noop(self, storage) -> None:
+        _enqueue(storage, "u-f", "r-f", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-f"
+        ]
+        # Wrong (random) token → rowcount 0
+        assert (
+            storage.complete_learning_job(
+                job_id=job.job_id, claim_token=str(uuid.uuid4())
+            )
+            == 0
+        )
+        # Correct token → rowcount 1
+        assert (
+            storage.complete_learning_job(
+                job_id=job.job_id, claim_token=job.claim_token
+            )
+            == 1
+        )
+
+    def test_reclaim_after_expiry_supersedes_prior_token(self, storage) -> None:
+        _enqueue(storage, "u-r", "r-r", 1000.0)
+        # lease_seconds=-1 sets claim_expires_at to now-1s, which is
+        # deterministically < now() on the very next claim call.
+        [first] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=-1
+            )
+            if j.user_id == "u-r"
+        ]
+        [second] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w2", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-r"
+        ]
+        assert second.claim_token != first.claim_token
+        # First token is now stale
+        assert (
+            storage.complete_learning_job(
+                job_id=first.job_id, claim_token=first.claim_token
+            )
+            == 0
+        )
+        # Second token succeeds
+        assert (
+            storage.complete_learning_job(
+                job_id=second.job_id, claim_token=second.claim_token
+            )
+            == 1
+        )
+
+    def test_double_complete_second_is_noop(self, storage) -> None:
+        """Second complete on the same job (already done) returns 0."""
+        _enqueue(storage, "u-d", "r-d", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-d"
+        ]
+        assert (
+            storage.complete_learning_job(
+                job_id=job.job_id, claim_token=job.claim_token
+            )
+            == 1
+        )
+        assert (
+            storage.complete_learning_job(
+                job_id=job.job_id, claim_token=job.claim_token
+            )
+            == 0
+        )
+
+
+class TestStatusCoverage:
+    def test_zero_yield_window_reports_done(self, storage) -> None:
+        _enqueue(storage, "u-z", "r-z", covers_through=5000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-z"
+        ]
+        storage.complete_learning_job(job_id=job.job_id, claim_token=job.claim_token)
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-z", request_created_at=4000.0
+            )
+            == "done"
+        )
+
+    def test_pending_job_reports_pending_or_processing(self, storage) -> None:
+        _enqueue(storage, "u-p", "r-p", covers_through=5000.0)
+        assert storage.get_learning_status_for_request(
+            user_id="u-p", request_created_at=4000.0
+        ) in {"pending", "processing"}
+
+    def test_claimed_job_reports_processing(self, storage) -> None:
+        _enqueue(storage, "u-cl", "r-cl", covers_through=5000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-cl"
+        ]
+        assert job.status == "claimed"
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-cl", request_created_at=4000.0
+            )
+            == "processing"
+        )
+
+    def test_no_rows_returns_done_absence_semantics(self, storage) -> None:
+        # No rows for this user → absence semantics → "done"
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-absent", request_created_at=1000.0
+            )
+            == "done"
+        )
+
+    def test_failed_job_reports_failed(self, storage) -> None:
+        _enqueue(storage, "u-fail", "r-fail", covers_through=5000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-fail"
+        ]
+        storage.fail_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, dead=True
+        )
+        assert (
+            storage.get_learning_status_for_request(
+                user_id="u-fail", request_created_at=4000.0
+            )
+            == "failed"
+        )
+
+
+class TestHeartbeat:
+    def test_heartbeat_extends_live_claim(self, storage) -> None:
+        _enqueue(storage, "u-hb", "r-hb", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-hb"
+        ]
+        assert storage.heartbeat_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, lease_seconds=600
+        )
+
+    def test_heartbeat_wrong_token_returns_false(self, storage) -> None:
+        _enqueue(storage, "u-hb2", "r-hb2", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-hb2"
+        ]
+        assert not storage.heartbeat_learning_job(
+            job_id=job.job_id, claim_token=str(uuid.uuid4()), lease_seconds=600
+        )

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -454,6 +454,24 @@ class TestOrgDiscovery:
         )
         assert storage.org_id not in storage.list_org_ids_with_pending_learning_jobs()
 
+    def test_expired_claim_makes_org_discoverable(self, storage) -> None:
+        """A job with a live claim hides the org; once the lease expires the org
+        resurfaces so the scheduler can reclaim and retry a stuck worker's job."""
+        _enqueue(storage, "u-exp", "r-exp", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=1
+            )
+            if j.user_id == "u-exp"
+        ]
+        # Live claim: org must not appear as having actionable work.
+        assert storage.org_id not in storage.list_org_ids_with_pending_learning_jobs()
+        # Wait for the 1-second lease to expire.
+        time.sleep(2)
+        # Expired claim: org must be discoverable again.
+        assert storage.org_id in storage.list_org_ids_with_pending_learning_jobs()
+
 
 class TestRetrySemantics:
     def test_failed_job_is_reclaimable(self, storage) -> None:

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -395,3 +395,76 @@ class TestFlagRoundTrip:
         ]
         assert job.force_extraction is True, "force_extraction must round-trip"
         assert job.skip_aggregation is True, "skip_aggregation must round-trip"
+
+
+class TestRetrySemantics:
+    def test_failed_job_is_reclaimable(self, storage) -> None:
+        """A failed (not dead) job must be re-claimable without manual status reset.
+
+        claim_learning_jobs includes status='failed' in its predicate.
+        fail_learning_job does NOT increment attempts — attempts tracks delivery
+        count (incremented only by claim).
+        """
+        _enqueue(storage, "u-retry", "r-retry", 1000.0)
+        [job1] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-retry"
+        ]
+        assert job1.attempts == 1
+        storage.fail_learning_job(
+            job_id=job1.job_id, claim_token=job1.claim_token, dead=False
+        )
+
+        # Job must be re-claimable directly from 'failed' status
+        reclaimed = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w2", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-retry"
+        ]
+        assert len(reclaimed) == 1, "failed job must be re-claimable"
+        assert reclaimed[0].attempts == 2, (
+            f"re-claimed job must have attempts=2 (only claim increments), "
+            f"got {reclaimed[0].attempts}"
+        )
+
+    def test_dead_after_three_delivery_attempts(self, storage) -> None:
+        """Job goes dead after exactly max_attempts (3) delivery attempts.
+
+        Only claim increments attempts; fail does not.
+        """
+        _enqueue(storage, "u-dead3", "r-dead3", 1000.0)
+
+        # Three claim→fail cycles; dead=False for first two, dead=True on third.
+        for cycle, (expected_attempts, expect_dead) in enumerate(
+            [(1, False), (2, False), (3, True)], start=1
+        ):
+            jobs = [
+                j
+                for j in storage.claim_learning_jobs(
+                    claimed_by="w1", limit=10, lease_seconds=300
+                )
+                if j.user_id == "u-dead3"
+            ]
+            assert len(jobs) == 1, f"cycle {cycle}: expected 1 job, got {len(jobs)}"
+            job = jobs[0]
+            assert job.attempts == expected_attempts, (
+                f"cycle {cycle}: expected attempts={expected_attempts}, got {job.attempts}"
+            )
+            storage.fail_learning_job(
+                job_id=job.job_id, claim_token=job.claim_token, dead=expect_dead
+            )
+
+        # After 3 delivery attempts the job is dead — must not be reclaimable
+        post_dead = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-dead3"
+        ]
+        assert not post_dead, "dead job must not be reclaimable"

--- a/tests/server/services/test_generation_service_durable_enqueue.py
+++ b/tests/server/services/test_generation_service_durable_enqueue.py
@@ -98,3 +98,49 @@ def test_enqueue_failure_rolls_back_interactions(monkeypatch):
         assert svc.storage.get_request("r2") is None, (
             "request must not persist when enqueue_learning_job fails inside commit_scope"
         )
+        assert svc.storage.get_user_interaction("u2") == [], (
+            "interactions must not persist when enqueue_learning_job fails inside commit_scope"
+        )
+
+
+def test_no_get_embeddings_inside_scope_when_prepare_degraded(monkeypatch):
+    """Fix 3: when prepare_interaction_embeddings degrades (EmbeddingUnavailableError
+    sets embedding=[]), add_user_interactions_bulk with embeddings_prepared=True must
+    NOT call get_embeddings inside the commit_scope (which holds the SQLite RLock)."""
+    from reflexio.server.llm.providers.embedding_service_provider import (
+        EmbeddingUnavailableError,
+    )
+
+    monkeypatch.setenv("REFLEXIO_DURABLE_LEARNING_QUEUE", "true")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        svc = _make_svc(tmp_dir)
+        req = _publish_request(user_id="u3", request_id="r3")
+
+        # Simulate embedding service being unavailable during prepare.
+        monkeypatch.setattr(
+            svc.storage.llm_client,
+            "get_embeddings",
+            Mock(side_effect=EmbeddingUnavailableError("unavailable")),
+        )
+
+        # Run the durable path — prepare degrades to [], then embeddings_prepared=True
+        # prevents a second get_embeddings call inside the scope.
+        result = svc.run(req, defer_learning=True)
+
+        assert result.request_id == "r3"
+        # Data landed despite degraded embeddings.
+        assert svc.storage is not None
+        assert svc.storage.get_request("r3") is not None
+        interactions = svc.storage.get_user_interaction("u3")
+        assert len(interactions) == 1
+        assert interactions[0].embedding == [], (
+            "degraded embedding should be empty list"
+        )
+
+        # get_embeddings was called once (prepare step) but not again inside the scope.
+        # After the prepare call raises, the mock records exactly 1 call.
+        assert svc.storage.llm_client.get_embeddings.call_count == 1, (
+            "get_embeddings must be called at most once (prepare phase), "
+            "never inside commit_scope"
+        )

--- a/tests/server/services/test_generation_service_durable_enqueue.py
+++ b/tests/server/services/test_generation_service_durable_enqueue.py
@@ -1,0 +1,100 @@
+"""Tests for the durable atomic enqueue path (REFLEXIO_DURABLE_LEARNING_QUEUE=true).
+
+Uses SQLite-backed GenerationService — no real LLM/embedding calls needed.
+"""
+
+from __future__ import annotations
+
+import datetime
+import tempfile
+from datetime import UTC
+from unittest.mock import Mock, patch
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    InteractionData,
+    PublishUserInteractionRequest,
+)
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.server.services.generation_service import GenerationService
+
+
+def _make_svc(tmp_dir: str) -> GenerationService:
+    return GenerationService(
+        llm_client=LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini")),
+        request_context=RequestContext(org_id="test_org", storage_base_dir=tmp_dir),
+    )
+
+
+def _publish_request(*, user_id: str, request_id: str) -> PublishUserInteractionRequest:
+    return PublishUserInteractionRequest(
+        request_id=request_id,
+        user_id=user_id,
+        interaction_data_list=[
+            InteractionData(
+                content="test interaction",
+                created_at=int(datetime.datetime.now(UTC).timestamp()),
+            )
+        ],
+        session_id="test-session",
+    )
+
+
+def test_durable_enqueue_persists_job_atomically(monkeypatch):
+    """When REFLEXIO_DURABLE_LEARNING_QUEUE=true and defer_learning=True, a
+    pending learning job is persisted in the same atomic scope as the request
+    and its interactions."""
+    monkeypatch.setenv("REFLEXIO_DURABLE_LEARNING_QUEUE", "true")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        svc = _make_svc(tmp_dir)
+        req = _publish_request(user_id="u1", request_id="r1")
+
+        with (
+            patch(
+                "reflexio.server.services.generation_service.ProfileGenerationService",
+                side_effect=AssertionError("profile extraction should be deferred"),
+            ),
+            patch(
+                "reflexio.server.services.generation_service.PlaybookGenerationService",
+                side_effect=AssertionError("playbook extraction should be deferred"),
+            ),
+        ):
+            result = svc.run(req, defer_learning=True)
+
+        assert result.request_id == "r1"
+        assert svc.storage is not None
+        assert svc.storage.get_request("r1") is not None
+
+        jobs = svc.storage.claim_learning_jobs(
+            claimed_by="test-worker", limit=10, lease_seconds=300
+        )
+        assert any(j.user_id == "u1" for j in jobs), "expected one pending job for u1"
+
+
+def test_enqueue_failure_rolls_back_interactions(monkeypatch):
+    """Zero-loss proof: if enqueue_learning_job raises inside commit_scope, the
+    entire transaction rolls back — neither the request nor its interactions
+    persist."""
+    monkeypatch.setenv("REFLEXIO_DURABLE_LEARNING_QUEUE", "true")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        svc = _make_svc(tmp_dir)
+        req = _publish_request(user_id="u2", request_id="r2")
+
+        monkeypatch.setattr(
+            type(svc.storage),
+            "enqueue_learning_job",
+            Mock(side_effect=RuntimeError("boom")),
+        )
+
+        with pytest.raises(RuntimeError):
+            svc.run(req, defer_learning=True)
+
+        # Both the request and its interactions must be absent (rolled back).
+        assert svc.storage is not None
+        assert svc.storage.get_request("r2") is None, (
+            "request must not persist when enqueue_learning_job fails inside commit_scope"
+        )


### PR DESCRIPTION
## Durable learning pipeline — infrastructure (flag-OFF)

Adds the OSS half of the durable-learning-queue infrastructure from the scalability-readiness program (Workstream A). **Everything is behind `REFLEXIO_DURABLE_LEARNING_QUEUE` (default OFF)** — with the flag unset, production behavior is byte-for-byte unchanged (verified by a whole-branch review).

Replaces the in-memory, work-losing `PublishLearningWorker` queue (still the default) with a durable, coalesced, claim-based `learning_jobs` table and an exactly-once worker — activatable later via the flag.

### What's here
- **`commit_scope()` storage seam** — a transaction context that groups multi-write persistence into one atomic commit and defers SQLite FTS/vec index maintenance until after commit. Standalone writes are unchanged (guarded by `_own_transaction()`).
- **`learning_jobs` table + `LearningJobStore`** — coalescing enqueue (≤1 pending job per org+user via a partial unique index), `FOR UPDATE SKIP LOCKED` / `BEGIN IMMEDIATE` claim with lease, **fenced completion** (`UPDATE … WHERE claim_token=? AND status='claimed'`, rowcount 0 ⇒ rollback) — the exactly-once guarantee — plus retry→dead accounting (dead after `max_attempts` deliveries; failed jobs reclaimable) and coverage-based status lookup.
- **Atomic durable enqueue** — request + interactions + job row commit in one `commit_scope`; embeddings generated outside the transaction.
- **Atomic learning-write path** — the deferred-learning writes (profile/playbook/lineage/source-linkage/bookmark) honor `commit_scope`.
- **`DurableLearningWorker`** — claim → run extraction in a `commit_scope` → fenced complete; two-worker races produce identical side-effect counts (exactly-once).
- **`DurableLearningScheduler`** — per-source polling daemon, lifespan-wired, flag-gated.
- **`learning_status` API** — deferred publish returns a pollable `request_id` + `learning_status="deferred"`; `GET /api/learning_status` + `client.get_learning_status()`; unknown request → 404.

### Verification
Built task-by-task with per-task + whole-branch review. OSS suite green (2588 passed); the exactly-once, coalescing, fenced-completion, and retry semantics are also verified on live Supabase + Postgres via the enterprise integration tests (in the paired reflexio-enterprise PR).

### Deferred to a follow-up "activation" phase (NOT in this PR)
The deferred-by-default flip and removal of the in-memory worker are gated on: (1) converting the managed-Supabase PostgREST learning-writes (lineage/bookmark/supersede/aggregation) to direct psycopg2 so exactly-once holds for them too; (2) separating LLM compute from the DB-persist transaction. Both are tracked; neither affects this flag-OFF increment.

> Note: this branch predates recent `main`; rebase before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred interaction publishing now returns a pollable request ID plus `learning_status="deferred"` (synchronous responses remain unchanged).
  * Added `GET /api/learning_status` to check processing progress by request ID.
  * Introduced durable learning background processing for deferred extraction/aggregation when enabled.

* **Bug Fixes**
  * Strengthened atomicity and rollback for learning-related writes.
  * Improved safeguards to prevent stale or duplicate job completion and ensure correct status transitions.

* **Tests**
  * Added integration and unit coverage for the learning status API, durable scheduler/worker behavior, and transaction rollback semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->