### PR TITLE
security: add input-size bounds to request models (SEC-007)

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -599,19 +599,19 @@ class BulkDeleteResponse(BaseModel):
 
 
 class DeleteRequestsByIdsRequest(BaseModel):
-    request_ids: list[str] = Field(min_length=1)
+    request_ids: list[str] = Field(min_length=1, max_length=10_000)
 
 
 class DeleteProfilesByIdsRequest(BaseModel):
-    profile_ids: list[str] = Field(min_length=1)
+    profile_ids: list[str] = Field(min_length=1, max_length=10_000)
 
 
 class DeleteAgentPlaybooksByIdsRequest(BaseModel):
-    agent_playbook_ids: list[int] = Field(min_length=1)
+    agent_playbook_ids: list[int] = Field(min_length=1, max_length=10_000)
 
 
 class DeleteUserPlaybooksByIdsRequest(BaseModel):
-    user_playbook_ids: list[int] = Field(min_length=1)
+    user_playbook_ids: list[int] = Field(min_length=1, max_length=10_000)
 
 
 # Clear all data scoped to a single user_id (interactions, requests, user
@@ -632,16 +632,18 @@ class ClearUserDataResponse(BaseModel):
 # user provided interaction data from the request
 class InteractionData(BaseModel):
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
-    role: str = "User"
-    content: str = ""
-    shadow_content: str = ""
-    expert_content: str = ""
+    role: str = Field(default="User", max_length=1_000)
+    content: str = Field(default="", max_length=1_000_000)
+    shadow_content: str = Field(default="", max_length=1_000_000)
+    expert_content: str = Field(default="", max_length=1_000_000)
     user_action: UserActionType = UserActionType.NONE
-    user_action_description: str = ""
-    interacted_image_url: str = ""
-    image_encoding: str = ""  # base64 encoded image
-    tools_used: list[ToolUsed] = Field(default_factory=list)
-    citations: list[Citation] = Field(default_factory=list)
+    user_action_description: str = Field(default="", max_length=10_000)
+    interacted_image_url: str = Field(default="", max_length=2_048)
+    image_encoding: str = Field(
+        default="", max_length=15_000_000
+    )  # base64 encoded image
+    tools_used: list[ToolUsed] = Field(default_factory=list, max_length=1_000)
+    citations: list[Citation] = Field(default_factory=list, max_length=1_000)
 
     @field_validator("interacted_image_url", mode="after")
     @classmethod
@@ -653,11 +655,10 @@ class InteractionData(BaseModel):
 class PublishUserInteractionRequest(BaseModel):
     request_id: NonEmptyStr | None = None
     user_id: NonEmptyStr
-    interaction_data_list: list[InteractionData] = Field(min_length=1)
-    source: str = ""
-    agent_version: str = (
-        ""  # this is used for aggregating interactions for generating agent playbooks
-    )
+    interaction_data_list: list[InteractionData] = Field(min_length=1, max_length=1_000)
+    source: str = Field(default="", max_length=1_000)
+    # this is used for aggregating interactions for generating agent playbooks
+    agent_version: str = Field(default="", max_length=1_000)
     session_id: NonEmptyStr  # used for grouping requests together
     skip_aggregation: bool = (
         False  # when True, extract profiles/playbooks but skip aggregation
@@ -730,7 +731,7 @@ class MyConfigResponse(BaseModel):
 
 # add user playbook request/response
 class AddUserPlaybookRequest(BaseModel):
-    user_playbooks: list[UserPlaybook] = Field(min_length=1)
+    user_playbooks: list[UserPlaybook] = Field(min_length=1, max_length=1_000)
 
     @model_validator(mode="after")
     def check_content_fields(self) -> Self:

--- a/tests/models/api_schema/test_input_size_bounds.py
+++ b/tests/models/api_schema/test_input_size_bounds.py
@@ -1,0 +1,147 @@
+"""SEC-007: input-size bounds on user-input request models.
+
+Guards against a single request amplifying into memory exhaustion via an
+unbounded batch (list cardinality) or an unbounded free-text/base64 field.
+Each capped field must:
+  - reject ``N+1`` items / over-length strings with ``ValidationError``;
+  - accept an at-cap payload;
+  - keep existing ``min_length=1`` behavior (empty list still rejected).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from reflexio.models.api_schema.common import ToolUsed
+from reflexio.models.api_schema.domain.entities import (
+    AddUserPlaybookRequest,
+    Citation,
+    DeleteAgentPlaybooksByIdsRequest,
+    DeleteProfilesByIdsRequest,
+    DeleteRequestsByIdsRequest,
+    DeleteUserPlaybooksByIdsRequest,
+    InteractionData,
+    PublishUserInteractionRequest,
+    UserPlaybook,
+)
+
+
+def _playbook() -> UserPlaybook:
+    return UserPlaybook(
+        agent_version="v1",
+        request_id="r1",
+        trigger="t",
+        content="c",
+        rationale="r",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Part 1: list cardinality caps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("model", "field", "item", "cap"),
+    [
+        (DeleteRequestsByIdsRequest, "request_ids", "x", 10_000),
+        (DeleteProfilesByIdsRequest, "profile_ids", "x", 10_000),
+        (DeleteAgentPlaybooksByIdsRequest, "agent_playbook_ids", 1, 10_000),
+        (DeleteUserPlaybooksByIdsRequest, "user_playbook_ids", 1, 10_000),
+    ],
+)
+def test_delete_by_ids_list_cardinality(
+    model: type, field: str, item: object, cap: int
+) -> None:
+    # at cap: accepted
+    model(**{field: [item] * cap})
+    # N+1: rejected
+    with pytest.raises(ValidationError):
+        model(**{field: [item] * (cap + 1)})
+    # empty: still rejected (min_length=1 preserved)
+    with pytest.raises(ValidationError):
+        model(**{field: []})
+
+
+def test_add_user_playbook_request_cardinality() -> None:
+    cap = 1_000
+    AddUserPlaybookRequest(user_playbooks=[_playbook()] * cap)
+    with pytest.raises(ValidationError):
+        AddUserPlaybookRequest(user_playbooks=[_playbook()] * (cap + 1))
+    with pytest.raises(ValidationError):
+        AddUserPlaybookRequest(user_playbooks=[])
+
+
+def _publish(**overrides: object) -> PublishUserInteractionRequest:
+    kwargs: dict[str, object] = {
+        "user_id": "u1",
+        "session_id": "s1",
+        "interaction_data_list": [InteractionData(content="hi")],
+    }
+    kwargs.update(overrides)
+    return PublishUserInteractionRequest(**kwargs)  # type: ignore[arg-type]
+
+
+def test_interaction_data_list_cardinality() -> None:
+    cap = 1_000
+    _publish(interaction_data_list=[InteractionData(content="hi")] * cap)
+    with pytest.raises(ValidationError):
+        _publish(interaction_data_list=[InteractionData(content="hi")] * (cap + 1))
+    with pytest.raises(ValidationError):
+        _publish(interaction_data_list=[])
+
+
+# ---------------------------------------------------------------------------
+# Part 2: InteractionData string + nested-list bounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "cap"),
+    [
+        ("content", 1_000_000),
+        ("shadow_content", 1_000_000),
+        ("expert_content", 1_000_000),
+        ("image_encoding", 15_000_000),
+        ("user_action_description", 10_000),
+        ("role", 1_000),
+    ],
+)
+def test_interaction_data_string_bounds(field: str, cap: int) -> None:
+    # at limit: accepted
+    InteractionData(**{field: "a" * cap})  # type: ignore[arg-type]
+    # over limit: rejected
+    with pytest.raises(ValidationError):
+        InteractionData(**{field: "a" * (cap + 1)})  # type: ignore[arg-type]
+
+
+def test_interaction_data_interacted_image_url_bound() -> None:
+    cap = 2_048
+    # must be a valid image URL (SSRF validator); a data: URI passes without
+    # host checks, so pad one to exactly the cap.
+    prefix = "data:image/png;base64,"
+    base = prefix + "A" * (cap - len(prefix))
+    assert len(base) == cap
+    InteractionData(interacted_image_url=base)
+    with pytest.raises(ValidationError):
+        InteractionData(interacted_image_url=base + "A")
+
+
+def test_interaction_data_nested_list_bounds() -> None:
+    cap = 1_000
+    tool = ToolUsed(tool_name="t")
+    citation = Citation(kind="playbook", real_id="x")
+    InteractionData(tools_used=[tool] * cap, citations=[citation] * cap)
+    with pytest.raises(ValidationError):
+        InteractionData(tools_used=[tool] * (cap + 1))
+    with pytest.raises(ValidationError):
+        InteractionData(citations=[citation] * (cap + 1))
+
+
+def test_publish_request_string_bounds() -> None:
+    cap = 1_000
+    _publish(source="s" * cap)
+    _publish(agent_version="v" * cap)
+    with pytest.raises(ValidationError):
+        _publish(source="s" * (cap + 1))
+    with pytest.raises(ValidationError):
+        _publish(agent_version="v" * (cap + 1))


### PR DESCRIPTION
## Summary

**SEC-007** (security readiness): the hot request models declared `min_length=1` but **no `max_length`**, so a single request could carry an unbounded batch, free-text, or base64 payload — per-request memory amplification (a cheap DoS vector across managed/self-host/local).

## Bounds added (`models/api_schema/domain/entities.py`)

- **List cardinality caps:** `DeleteRequestsByIdsRequest.request_ids`, `DeleteProfilesByIdsRequest.profile_ids`, `DeleteAgentPlaybooksByIdsRequest.agent_playbook_ids`, `DeleteUserPlaybooksByIdsRequest.user_playbook_ids` → **10_000**; `PublishUserInteractionRequest.interaction_data_list`, `AddUserPlaybookRequest.user_playbooks` → **1_000**.
- **`InteractionData` free-text / base64:** `content`/`shadow_content`/`expert_content` → **1_000_000** each; `image_encoding` (base64) → **15_000_000**; `interacted_image_url` → **2_048**; `user_action_description` → **10_000**; `role` (+ request `source`/`agent_version`) → **1_000**; nested `tools_used`/`citations` → **1_000**.

Caps are generous (won't truncate legitimate long LLM content) but finite. `min_length=1` is preserved (empty batches still rejected).

## Safety

`InteractionData` is a **request-input-only** DTO — grep confirms it's constructed only at request boundaries (CLI parser, client publish builder); the internal/persisted representation is a separate `RequestInteractionDataModel`. So bounding the shared model rejects no valid internal construction.

## Tests
New `tests/models/api_schema/test_input_size_bounds.py` (15 cases: at-cap accepted / N+1 rejected / empty-still-rejected per list; over-length & at-limit for bounded strings). Broader schema sweep: **695 passed, 3 skipped, 8 snapshots** — no existing test broke.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter size limits to several API request fields to help prevent oversized submissions and improve validation feedback.
  * Tightened text and list limits for interaction details, including content, media URLs, tools, and citations.
  * Limited batch request sizes for delete, publish, and add-playbook operations.
* **Tests**
  * Added coverage for boundary cases to confirm valid maximum-size payloads are accepted and larger or empty payloads are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->