### PR TITLE
feat(billing): meter learnings_generated on non-extraction learning paths

### DIFF
--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -8,7 +8,13 @@ wrapper over the ``record_usage_event`` hook (which only enqueues). No DB I/O.
 
 from __future__ import annotations
 
+import logging
+from collections.abc import Mapping
+from typing import Any
+
 from reflexio.server.usage_metrics import record_usage_event
+
+logger = logging.getLogger(__name__)
 
 _INTERNAL = (
     "internal"  # == BillingCallerType.INTERNAL.value (kept literal; OSS stays clean)
@@ -68,8 +74,14 @@ def record_learnings_generated(
     platform_llm: bool | None,
     platform_storage: bool | None,
     pipeline: str | None = None,
+    user_id: str | None = None,
     request_id: str | None = None,
     session_id: str | None = None,
+    source: str | None = None,
+    agent_version: str | None = None,
+    playbook_name: str | None = None,
+    entity_type: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
 ) -> None:
     """Emit the Learning value facet — number of profiles/playbooks generated.
 
@@ -81,8 +93,14 @@ def record_learnings_generated(
         platform_llm: True iff the platform supplies the LLM for this org.
         platform_storage: True iff the platform supplies storage; None defers to rollup.
         pipeline: Optional pipeline tag (e.g. ``"playbook"``).
+        user_id: Optional user ID tied to the generated learning.
         request_id: Optional request correlation ID.
         session_id: Optional session ID.
+        source: Optional metering source/path label.
+        agent_version: Optional agent version tied to the generated learning.
+        playbook_name: Optional playbook name for playbook learnings.
+        entity_type: Optional entity type (e.g. ``"profile"``).
+        metadata: Optional path-specific usage metadata.
     """
     if count <= 0:
         return
@@ -91,13 +109,87 @@ def record_learnings_generated(
         event_name="learnings_generated",
         event_category="learning",
         pipeline=pipeline,
+        user_id=user_id,
         request_id=request_id,
         session_id=session_id,
+        source=source,
+        agent_version=agent_version,
+        playbook_name=playbook_name,
+        entity_type=entity_type,
         count_value=count,
         platform_llm=platform_llm,
         platform_storage=platform_storage,
         caller_type=_INTERNAL,
+        metadata=metadata,
     )
+
+
+def emit_learnings_generated(
+    *,
+    org_id: str,
+    configurator: Any,
+    count: int,
+    source: str,
+    pipeline: str | None = None,
+    user_id: str | None = None,
+    request_id: str | None = None,
+    agent_version: str | None = None,
+    playbook_name: str | None = None,
+    entity_type: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    """Resolve ``platform_llm`` from config and emit the Learning value facet.
+
+    Convenience wrapper for the non-extraction learning-mutation paths (reflection,
+    resumable-extraction finalization, aggregation, offline-tuner auto-apply). It
+    owns the ``configurator.get_config()`` + ``platform_llm_from_config`` lookup so
+    each call site stays a thin one-liner, and — critically — is **guarded**: the
+    product path must never fail because metering failed, so config resolution and
+    emission are wrapped and any exception is logged and swallowed (mirroring the
+    extraction path's ``_record_billing_learning_events``). No-op when
+    ``count <= 0``.
+
+    Args:
+        org_id: Organisation identifier.
+        configurator: Object exposing ``get_config()`` for platform-LLM resolution.
+        count: Number of learnings durably produced by this path.
+        source: Metering source/path label (e.g. ``"reflection"``).
+        pipeline: Optional pipeline tag (e.g. ``"playbook"``).
+        user_id: Optional user ID tied to the generated learning.
+        request_id: Optional request correlation ID.
+        agent_version: Optional agent version tied to the generated learning.
+        playbook_name: Optional playbook name for playbook learnings.
+        entity_type: Optional entity type (e.g. ``"profile"``).
+        metadata: Optional path-specific usage metadata.
+    """
+    if count <= 0:
+        return
+    try:
+        from reflexio.server.billing_signals import platform_llm_from_config
+
+        config = configurator.get_config()
+        record_learnings_generated(
+            org_id=org_id,
+            count=count,
+            platform_llm=platform_llm_from_config(config),
+            platform_storage=None,
+            pipeline=pipeline,
+            user_id=user_id,
+            request_id=request_id,
+            source=source,
+            agent_version=agent_version,
+            playbook_name=playbook_name,
+            entity_type=entity_type,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.warning(
+            "emit_learnings_generated failed for source=%s org=%s; "
+            "learnings_generated event not emitted",
+            source,
+            org_id,
+            exc_info=True,
+        )
 
 
 def record_applied_learnings(

--- a/reflexio/server/services/base_generation/_usage_billing.py
+++ b/reflexio/server/services/base_generation/_usage_billing.py
@@ -189,8 +189,9 @@ class UsageBillingMixin(Generic[TExtractorConfig, TGenerationServiceConfig]):  #
         ``None`` here and resolved enterprise-side at rollup (Phase 1).
 
         Gated by ``EMITS_LEARNING_BILLING`` — only profile/playbook generation
-        services opt in. Evaluation, reflection, consolidation and aggregation
-        are bundled and must NOT separately meter the ② Learning line.
+        services opt in here. Non-extraction learning mutation paths emit their
+        own ``learnings_generated`` value-facet events when they durably apply
+        revisions/successors.
 
         Args:
             prepared: The prepared generation run (used for input-text computation).
@@ -227,7 +228,10 @@ class UsageBillingMixin(Generic[TExtractorConfig, TGenerationServiceConfig]):  #
                 platform_llm=platform_llm,
                 platform_storage=None,
                 pipeline=ctx.get("pipeline"),
+                user_id=ctx.get("user_id"),
                 request_id=ctx.get("request_id"),
+                source=ctx.get("source"),
+                agent_version=ctx.get("agent_version"),
             )
 
             # ② Learning — cost: input-anchored extraction tokens + real provider tokens.

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -159,8 +159,9 @@ class BaseGenerationService(
     ABC,
     Generic[TExtractorConfig, TExtractor, TGenerationServiceConfig, TRequest],  # noqa: UP046
 ):
-    # Only profile/playbook GENERATION services bill the ② Learning line;
-    # reflection/consolidation/aggregation/evaluation are bundled, not metered.
+    # Only profile/playbook GENERATION services emit extraction-run billing here.
+    # Non-extraction learning mutation paths emit their value facet at their own
+    # durable-success point.
     # Default is False so any future subclass is safe by default (opt-IN).
     EMITS_LEARNING_BILLING: bool = False
     """

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -764,6 +764,7 @@ class ExtractionResumeWorker:
                 force_extraction=True,
             )
             service._finalize_extracted_items(items)
+            self._record_finalized_learnings(run, items, entity_type="profile")
             return
         if run.binding.extractor_kind == "playbook":
             service = PlaybookGenerationService(
@@ -779,9 +780,31 @@ class ExtractionResumeWorker:
                 force_extraction=True,
             )
             service._finalize_extracted_items(items)
+            self._record_finalized_learnings(run, items, entity_type="user_playbook")
             return
         raise ResumeWorkerError(
             f"Unsupported extractor kind {run.binding.extractor_kind!r}"
+        )
+
+    def _record_finalized_learnings(
+        self, run: AgentRunRecord, items: list[Any], *, entity_type: str
+    ) -> None:
+        from reflexio.server.billing_meter import emit_learnings_generated
+
+        emit_learnings_generated(
+            org_id=self.request_context.org_id,
+            configurator=self.request_context.configurator,
+            count=len(items),
+            source="resumable_extraction",
+            pipeline=run.binding.extractor_kind,
+            user_id=run.binding.user_id,
+            request_id=run.binding.request_id,
+            agent_version=run.binding.agent_version,
+            entity_type=entity_type,
+            metadata={
+                "run_id": run.id,
+                "extractor_kind": run.binding.extractor_kind,
+            },
         )
 
     def _schedule_finalized_tagging(self, run: AgentRunRecord) -> None:

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -4,8 +4,8 @@ import logging
 import os
 import time
 import uuid
-from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import numpy as np
@@ -728,6 +728,12 @@ class PlaybookAggregator:
                 duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
                 metadata=stats,
             )
+            self._record_learnings_generated(
+                count=len(saved_playbook_list),
+                playbook_name=playbook_name,
+                request_id=_run_id,
+                metadata=stats,
+            )
             return stats
 
         except Exception as e:
@@ -759,6 +765,29 @@ class PlaybookAggregator:
                 )
             # Re-raise the exception after restoring
             raise
+
+    def _record_learnings_generated(
+        self,
+        *,
+        count: int,
+        playbook_name: str,
+        request_id: str,
+        metadata: Mapping[str, Any],
+    ) -> None:
+        from reflexio.server.billing_meter import emit_learnings_generated
+
+        emit_learnings_generated(
+            org_id=self.request_context.org_id,
+            configurator=self.configurator,
+            count=count,
+            source="aggregation",
+            pipeline="playbook",
+            request_id=request_id,
+            agent_version=self.agent_version,
+            playbook_name=playbook_name,
+            entity_type="agent_playbook",
+            metadata=metadata,
+        )
 
     def get_clusters(
         self,

--- a/reflexio/server/services/reflection/service.py
+++ b/reflexio/server/services/reflection/service.py
@@ -277,6 +277,8 @@ class ReflectionService:
             user_id=request.user_id,
         )
 
+        self._record_learnings_generated(request, result)
+
         logger.info(
             "event=reflection_done user_id=%s gate_open=%s ran=%s "
             "cited=%d considered=%d no_change=%d revised=%d "
@@ -301,6 +303,31 @@ class ReflectionService:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _record_learnings_generated(
+        self, request: ReflectionServiceRequest, result: ReflectionResult
+    ) -> None:
+        from reflexio.server.billing_meter import emit_learnings_generated
+
+        emit_learnings_generated(
+            org_id=self.request_context.org_id,
+            configurator=self.request_context.configurator,
+            count=result.revised_count,
+            source="reflection",
+            pipeline="reflection",
+            user_id=request.user_id,
+            request_id=request.request_id,
+            metadata={
+                "cited_count": result.cited_count,
+                "considered_count": result.considered_count,
+                "trigger_revised_count": result.trigger_revised_count,
+                "content_revised_count": result.content_revised_count,
+                "ttl_changed_count": result.ttl_changed_count,
+                "capped_count": result.capped_count,
+                "skipped_count": result.skipped_count,
+                "failed_count": result.failed_count,
+            },
+        )
 
     def _resolve_cited_rows(
         self,

--- a/reflexio/server/services/reflection/service.py
+++ b/reflexio/server/services/reflection/service.py
@@ -317,6 +317,7 @@ class ReflectionService:
             pipeline="reflection",
             user_id=request.user_id,
             request_id=request.request_id,
+            agent_version=request.agent_version,
             metadata={
                 "cited_count": result.cited_count,
                 "considered_count": result.considered_count,

--- a/tests/server/services/test_non_extraction_learning_metering.py
+++ b/tests/server/services/test_non_extraction_learning_metering.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.extraction.resume_worker import ExtractionResumeWorker
+from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
+from reflexio.server.services.reflection.reflection_service_utils import (
+    ReflectionResult,
+    ReflectionServiceRequest,
+)
+from reflexio.server.services.reflection.service import ReflectionService
+from reflexio.server.services.storage.storage_base import (
+    AgentBinding,
+    AgentRunRecord,
+    AgentRunStatus,
+)
+from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
+
+
+@pytest.fixture(autouse=True)
+def _reset_usage_recorder():
+    configure_usage_event_recorder(None)
+    yield
+    configure_usage_event_recorder(None)
+
+
+def _request_context() -> RequestContext:
+    ctx = RequestContext.__new__(RequestContext)
+    ctx.org_id = "org-1"
+    ctx.storage = MagicMock()
+    ctx.configurator = MagicMock()
+    ctx.configurator.get_config.return_value = None
+    return ctx
+
+
+def test_reflection_revision_records_learnings_generated() -> None:
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    service = ReflectionService(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+    result = ReflectionResult(
+        revised_count=2,
+        cited_count=3,
+        considered_count=2,
+        trigger_revised_count=1,
+        content_revised_count=2,
+        ttl_changed_count=1,
+    )
+
+    service._record_learnings_generated(
+        ReflectionServiceRequest(user_id="user-1", request_id="req-1"),
+        result,
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_name == "learnings_generated"
+    assert event.event_category == "learning"
+    assert event.count_value == 2
+    assert event.pipeline == "reflection"
+    assert event.source == "reflection"
+    assert event.user_id == "user-1"
+    assert event.request_id == "req-1"
+    assert event.metadata["content_revised_count"] == 2
+
+
+def test_reflection_zero_revisions_records_nothing() -> None:
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    service = ReflectionService(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+
+    service._record_learnings_generated(
+        ReflectionServiceRequest(user_id="user-1", request_id="req-1"),
+        ReflectionResult(revised_count=0),
+    )
+
+    assert events == []
+
+
+def test_resumable_finalization_records_learnings_generated() -> None:
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = ExtractionResumeWorker(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+    run = AgentRunRecord(
+        id="run-1",
+        binding=AgentBinding(
+            org_id="org-1",
+            extractor_kind="profile",
+            user_id="user-1",
+            request_id="req-1",
+            agent_version="v1",
+            source="api",
+        ),
+        status=AgentRunStatus.FINALIZING,
+        generation_request_snapshot={},
+    )
+
+    worker._record_finalized_learnings(
+        run,
+        [object(), object()],
+        entity_type="profile",
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_name == "learnings_generated"
+    assert event.count_value == 2
+    assert event.pipeline == "profile"
+    assert event.source == "resumable_extraction"
+    assert event.entity_type == "profile"
+    assert event.metadata == {"run_id": "run-1", "extractor_kind": "profile"}
+
+
+def test_aggregation_records_attributed_learnings_generated() -> None:
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=_request_context(),
+        agent_version="v1",
+    )
+
+    aggregator._record_learnings_generated(
+        count=3,
+        playbook_name="agent_rules",
+        request_id="agg-run-1",
+        metadata={"playbooks_generated": 3},
+    )
+
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_name == "learnings_generated"
+    assert event.count_value == 3
+    assert event.pipeline == "playbook"
+    assert event.source == "aggregation"
+    assert event.entity_type == "agent_playbook"
+    assert event.agent_version == "v1"
+    assert event.playbook_name == "agent_rules"
+
+
+def test_metering_failure_is_isolated_from_the_product_path() -> None:
+    """A metering-side exception must never propagate into the caller.
+
+    All four non-extraction paths route through the shared, guarded
+    ``emit_learnings_generated`` helper. Simulate config resolution blowing up
+    (the one bit of pre-emit work that can raise) and assert the caller neither
+    raises nor emits a phantom event.
+    """
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    ctx = _request_context()
+    configurator = MagicMock()
+    configurator.get_config.side_effect = RuntimeError("config boom")
+    ctx.configurator = configurator
+    service = ReflectionService(request_context=ctx, llm_client=MagicMock())
+
+    # Must not raise despite get_config() blowing up mid-emit.
+    service._record_learnings_generated(
+        ReflectionServiceRequest(user_id="user-1", request_id="req-1"),
+        ReflectionResult(revised_count=2),
+    )
+
+    assert events == []

--- a/tests/server/services/test_non_extraction_learning_metering.py
+++ b/tests/server/services/test_non_extraction_learning_metering.py
@@ -53,7 +53,9 @@ def test_reflection_revision_records_learnings_generated() -> None:
     )
 
     service._record_learnings_generated(
-        ReflectionServiceRequest(user_id="user-1", request_id="req-1"),
+        ReflectionServiceRequest(
+            user_id="user-1", request_id="req-1", agent_version="agent-v9"
+        ),
         result,
     )
 
@@ -66,6 +68,7 @@ def test_reflection_revision_records_learnings_generated() -> None:
     assert event.source == "reflection"
     assert event.user_id == "user-1"
     assert event.request_id == "req-1"
+    assert event.agent_version == "agent-v9"
     assert event.metadata["content_revised_count"] == 2
 
 


### PR DESCRIPTION
## Summary

Emit the canonical `learnings_generated` value event from the **non-extraction learning-mutation paths** — reflection revisions, resumable-extraction finalization, and playbook aggregation — which were previously bundled and never metered on the ② Learning line. This closes the gap so the value facet reflects learnings produced across all paths, not just the synchronous extraction run.

## Changes

- **New guarded helper `emit_learnings_generated()` in `billing_meter.py`.** It owns the `configurator.get_config()` + `platform_llm_from_config()` resolution and wraps everything in a `try/except: logger.warning(...)`, mirroring the extraction path's `_record_billing_learning_events`. Metering can never break the product path — notably it removes a hazard where a metrics-side exception in aggregation (inside the archive-restore `try`) would have rolled back a successful aggregation and re-raised.
- **Route reflection, resumable finalization, and aggregation** through the shared helper (four near-identical inline copies collapsed to one; the offline-tuner path in the enterprise repo uses the same helper).
- **Extend `record_learnings_generated`** with optional `source` / `user_id` / `agent_version` / `playbook_name` / `entity_type` / `metadata` attribution fields, plumbed through to `record_usage_event`.
- **Tests**: per-path attribution assertions, zero-count no-ops, and a metering-failure-isolation regression test proving a raising `get_config()` neither propagates nor emits a phantom event.

## Test Plan

- `pytest tests/server/services/test_non_extraction_learning_metering.py` — 5 passed
- `ruff check` + `pyright` clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded “learnings generated” metering/telemetry across reflection, resumable extraction finalization, and playbook aggregation.
  * Enriched learning events with additional attribution/context (user, source, agent version, playbook name) and detailed metadata.
* **Bug Fixes**
  * Prevented metering emission/config resolution failures from impacting the main workflow.
  * Avoided emitting learning events when the generated count is zero.
* **Tests**
  * Added automated coverage for correct event emission, metadata accuracy, and non-blocking behavior on metering-side failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-ups

- **Reflection `agent_version` attribution** (23db4015, addresses CodeRabbit): `_record_learnings_generated` now forwards `agent_version=request.agent_version`, matching the resumable-extraction and aggregation call sites; test extended to assert it.
