### PR TITLE
Add --skip-if-running for idempotent service starts

### DIFF
--- a/reflexio/cli/commands/services.py
+++ b/reflexio/cli/commands/services.py
@@ -20,6 +20,26 @@ _logger = logging.getLogger(__name__)
 app = typer.Typer(help="Start and stop Reflexio services.")
 
 
+def _backend_already_healthy_for_skip(
+    *,
+    backend_port: int | None,
+    docs_port: int | None,
+    embedding_port: int | None,
+) -> bool:
+    """Return True when ``--skip-if-running`` can bypass backend setup prompts."""
+    from reflexio.cli.utils import service_port_healthy
+
+    ports = run_mod.resolve_ports(
+        argparse.Namespace(
+            backend_port=backend_port,
+            docs_port=docs_port,
+            embedding_port=embedding_port,
+        ),
+        defaults=run_mod.DEFAULT_OSS_PORTS,
+    )
+    return service_port_healthy("backend", ports["backend"])
+
+
 def _ensure_llm_configured(env_path: Path) -> None:
     """Run the first-run LLM + embedding wizard when no key is configured.
 
@@ -218,6 +238,16 @@ def start(
             help="Seconds to drain in-flight requests on shutdown.",
         ),
     ] = 30,
+    skip_if_running: Annotated[
+        bool,
+        typer.Option(
+            "--skip-if-running",
+            help=(
+                "Skip selected services whose health endpoint is already responding. "
+                "Does not detect code changes; stop then start to reload."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Start Reflexio services (backend, docs)."""
     from reflexio.cli.bootstrap_config import resolve_storage, save_storage_to_config
@@ -238,7 +268,18 @@ def start(
     # First-run guard: if the backend's lifespan validator would reject the
     # current env (no LLM key, or no embedding-capable provider), prompt now
     # so users see a friendly wizard instead of a lifespan traceback.
-    if "backend" in selected_services:
+    skip_backend_guard = (
+        skip_if_running
+        and "backend" in selected_services
+        and _backend_already_healthy_for_skip(
+            backend_port=backend_port,
+            docs_port=docs_port,
+            embedding_port=embedding_port,
+        )
+    )
+    # Only the first-run guard uses this early backend precheck; the launcher
+    # still re-probes every selected service before deciding to skip startup.
+    if "backend" in selected_services and not skip_backend_guard:
         _ensure_llm_configured(get_env_path())
 
     resolved = resolve_storage(storage)
@@ -264,6 +305,7 @@ def start(
         max_requests=max_requests,
         max_requests_jitter=max_requests_jitter,
         graceful_shutdown_sec=graceful_shutdown_sec,
+        skip_if_running=skip_if_running,
     )
     run_mod.execute(args)
 

--- a/reflexio/cli/run_services.py
+++ b/reflexio/cli/run_services.py
@@ -99,6 +99,14 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
         default=30,
         help="Drain window on shutdown. Default 30.",
     )
+    parser.add_argument(
+        "--skip-if-running",
+        action="store_true",
+        help=(
+            "Skip selected services whose health endpoint is already responding. "
+            "Does not detect code changes; stop then start to reload."
+        ),
+    )
 
 
 def _build_run_services_parser() -> argparse.ArgumentParser:
@@ -396,5 +404,12 @@ def execute(args: argparse.Namespace) -> None:
         return
 
     started_ports = {s.name: ports[s.name] for s in services}
-    print(f"Starting services: {', '.join(s.name for s in services)}")
-    run_services(services, started_ports)
+    if getattr(args, "skip_if_running", False):
+        print(f"Starting services if needed: {', '.join(s.name for s in services)}")
+    else:
+        print(f"Starting services: {', '.join(s.name for s in services)}")
+    run_services(
+        services,
+        started_ports,
+        skip_if_running=getattr(args, "skip_if_running", False),
+    )

--- a/reflexio/cli/utils.py
+++ b/reflexio/cli/utils.py
@@ -361,9 +361,7 @@ def run_services(
         ensure_requested_service_ports_unique(ports)
         services, ports, skipped = skip_healthy_services(services, ports)
         if skipped:
-            sys.stdout.write(
-                "Services already running: " + ", ".join(sorted(skipped)) + "\n"
-            )
+            sys.stdout.write(f"Services already running: {', '.join(sorted(skipped))}\n")
             sys.stdout.flush()
         if not services:
             return

--- a/reflexio/cli/utils.py
+++ b/reflexio/cli/utils.py
@@ -13,6 +13,8 @@ import sys
 import tempfile
 import threading
 import time
+import urllib.error
+import urllib.request
 from collections.abc import Callable
 from pathlib import Path
 
@@ -79,15 +81,7 @@ def find_pids_by_pattern(pattern: str) -> list[int]:
 def get_requested_port_conflicts(ports: dict[str, int]) -> list[str]:
     """Return startup-blocking conflicts for requested service ports."""
     conflicts: list[str] = []
-    services_by_port: dict[int, list[str]] = {}
-    for name, port in ports.items():
-        services_by_port.setdefault(port, []).append(name)
-
-    for port, names in sorted(services_by_port.items()):
-        if len(names) > 1:
-            conflicts.append(
-                f"port {port} is assigned to multiple services: {', '.join(sorted(names))}"
-            )
+    conflicts.extend(get_duplicate_port_conflicts(ports))
 
     for name, port in sorted(ports.items()):
         pids = find_pids_on_port(port)
@@ -100,9 +94,22 @@ def get_requested_port_conflicts(ports: dict[str, int]) -> list[str]:
     return conflicts
 
 
-def ensure_requested_ports_available(ports: dict[str, int]) -> None:
-    """Exit with a clear message when requested service ports are unavailable."""
-    conflicts = get_requested_port_conflicts(ports)
+def get_duplicate_port_conflicts(ports: dict[str, int]) -> list[str]:
+    """Return conflicts caused by assigning one port to multiple services."""
+    conflicts: list[str] = []
+    services_by_port: dict[int, list[str]] = {}
+    for name, port in ports.items():
+        services_by_port.setdefault(port, []).append(name)
+
+    for port, names in sorted(services_by_port.items()):
+        if len(names) > 1:
+            conflicts.append(
+                f"port {port} is assigned to multiple services: {', '.join(sorted(names))}"
+            )
+    return conflicts
+
+
+def _exit_for_port_conflicts(conflicts: list[str]) -> None:
     if not conflicts:
         return
 
@@ -115,6 +122,16 @@ def ensure_requested_ports_available(ports: dict[str, int]) -> None:
     )
     sys.stdout.flush()
     sys.exit(1)
+
+
+def ensure_requested_service_ports_unique(ports: dict[str, int]) -> None:
+    """Exit when one start request assigns the same port to multiple services."""
+    _exit_for_port_conflicts(get_duplicate_port_conflicts(ports))
+
+
+def ensure_requested_ports_available(ports: dict[str, int]) -> None:
+    """Exit with a clear message when requested service ports are unavailable."""
+    _exit_for_port_conflicts(get_requested_port_conflicts(ports))
 
 
 def kill_processes(
@@ -198,6 +215,70 @@ _NOISE_SUPPRESSION_ENV: dict[str, dict[str, str]] = {
     "docs": {"NODE_NO_WARNINGS": "1"},
 }
 
+# Only list services with dedicated health endpoints. Root HTML pages such as
+# docs/frontend can return 200 for unrelated servers, so they are not safe
+# skip-if-running signals.
+_HEALTH_PATHS: dict[str, str] = {
+    "backend": "/health",
+    "embedding": "/health",
+}
+
+
+def service_port_healthy(service_name: str, port: int, *, timeout: float = 1.0) -> bool:
+    """Return whether the selected service answers on its health endpoint.
+
+    Args:
+        service_name: Name of the service to probe. Only services with a
+            marker health path in ``_HEALTH_PATHS`` are probed.
+        port: Loopback TCP port for the selected service.
+        timeout: Maximum seconds to wait for the health response.
+
+    Returns:
+        ``True`` when the service has a known health endpoint and returns a
+        2xx or 3xx HTTP status; otherwise ``False``.
+    """
+    path = _HEALTH_PATHS.get(service_name)
+    if path is None:
+        return False
+
+    request = urllib.request.Request(f"http://127.0.0.1:{port}{path}", method="GET")
+    try:
+        # Fixed loopback URL assembled from a known service path and integer port.
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+            return 200 <= response.status < 400
+    except (OSError, urllib.error.URLError, TimeoutError):
+        return False
+
+
+def skip_healthy_services(
+    services: list[ServiceConfig],
+    ports: dict[str, int],
+) -> tuple[list[ServiceConfig], dict[str, int], list[str]]:
+    """Filter already-healthy services from a requested start set.
+
+    Args:
+        services: Requested service configurations in start order.
+        ports: Resolved port map keyed by service name.
+    Returns:
+        A tuple of ``(remaining_services, remaining_ports, skipped_names)``.
+        ``remaining_services`` contains services that still need to start;
+        ``remaining_ports`` contains known ports for those services;
+        ``skipped_names`` lists services that were already healthy.
+    """
+    remaining_services: list[ServiceConfig] = []
+    skipped: list[str] = []
+    for svc in services:
+        port = ports.get(svc.name)
+        if port is not None and service_port_healthy(svc.name, port):
+            skipped.append(svc.name)
+            continue
+        remaining_services.append(svc)
+
+    remaining_ports = {
+        svc.name: ports[svc.name] for svc in remaining_services if svc.name in ports
+    }
+    return remaining_services, remaining_ports, skipped
+
 
 def _stream_output(
     proc: subprocess.Popen[bytes],
@@ -233,6 +314,7 @@ def run_services(
     ports: dict[str, int],
     *,
     on_all_ready: Callable[[dict[str, int]], None] | None = None,
+    skip_if_running: bool = False,
 ) -> None:
     """Launch services, pipe output with prefixes, and manage lifecycle.
 
@@ -244,6 +326,7 @@ def run_services(
         services: List of service configurations to launch.
         ports: Port mapping for pidfile identification.
         on_all_ready: Optional callback invoked with ports when all services are ready.
+        skip_if_running: If True, do not launch services that already answer health.
     """
     processes: dict[str, subprocess.Popen[bytes]] = {}
     threads: list[threading.Thread] = []
@@ -273,6 +356,17 @@ def run_services(
 
     signal.signal(signal.SIGINT, shutdown)
     signal.signal(signal.SIGTERM, shutdown)
+
+    if skip_if_running:
+        ensure_requested_service_ports_unique(ports)
+        services, ports, skipped = skip_healthy_services(services, ports)
+        if skipped:
+            sys.stdout.write(
+                "Services already running: " + ", ".join(sorted(skipped)) + "\n"
+            )
+            sys.stdout.flush()
+        if not services:
+            return
 
     ensure_requested_ports_available(ports)
 

--- a/tests/cli/test_run_services_workers.py
+++ b/tests/cli/test_run_services_workers.py
@@ -80,6 +80,7 @@ def test_run_services_parser_accepts_new_flags() -> None:
             "500",
             "--graceful-shutdown-sec",
             "20",
+            "--skip-if-running",
         ]
     )
     assert args.no_reload is True
@@ -87,6 +88,7 @@ def test_run_services_parser_accepts_new_flags() -> None:
     assert args.max_requests == 5000
     assert args.max_requests_jitter == 500
     assert args.graceful_shutdown_sec == 20
+    assert args.skip_if_running is True
 
 
 def test_sqlite_plus_multi_worker_logs_warning(

--- a/tests/cli/test_services_first_run.py
+++ b/tests/cli/test_services_first_run.py
@@ -308,3 +308,62 @@ def test_embedding_only_start_skips_first_run_llm_guard(monkeypatch) -> None:
 
     assert called_args is not None
     assert called_args.only == "embedding"
+
+
+def test_backend_skip_if_running_bypasses_first_run_guard_when_healthy(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from reflexio.cli.commands import services
+
+    called_args = None
+
+    def _capture_execute(args) -> None:
+        nonlocal called_args
+        called_args = args
+
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.setattr("reflexio.cli.env_loader.load_reflexio_env", lambda: None)
+    monkeypatch.setattr("reflexio.cli.env_loader.get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(
+        "reflexio.cli.bootstrap_config.resolve_storage", lambda _: "sqlite"
+    )
+    monkeypatch.setattr(
+        services, "_backend_already_healthy_for_skip", lambda **_kwargs: True
+    )
+    monkeypatch.setattr(services, "_ensure_llm_configured", lambda _: pytest.fail())
+    monkeypatch.setattr(services.run_mod, "execute", _capture_execute)
+
+    services.start(only="backend", skip_if_running=True)
+
+    assert called_args is not None
+    assert called_args.only == "backend"
+    assert called_args.skip_if_running is True
+
+
+def test_backend_skip_if_running_keeps_first_run_guard_when_unhealthy(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from reflexio.cli.commands import services
+
+    guard_paths: list[Path] = []
+
+    def _capture_guard(path: Path) -> None:
+        guard_paths.append(path)
+
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.setattr("reflexio.cli.env_loader.load_reflexio_env", lambda: None)
+    monkeypatch.setattr("reflexio.cli.env_loader.get_env_path", lambda: tmp_path / ".env")
+    monkeypatch.setattr(
+        "reflexio.cli.bootstrap_config.resolve_storage", lambda _: "sqlite"
+    )
+    monkeypatch.setattr(
+        services, "_backend_already_healthy_for_skip", lambda **_kwargs: False
+    )
+    monkeypatch.setattr(services, "_ensure_llm_configured", _capture_guard)
+    monkeypatch.setattr(services.run_mod, "execute", lambda _args: None)
+
+    services.start(only="backend", skip_if_running=True)
+
+    assert guard_paths == [tmp_path / ".env"]

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -200,6 +200,7 @@ def test_run_services_skip_if_running_returns_without_conflict_or_spawn(
     capsys,
 ) -> None:
     monkeypatch.setattr(utils, "service_port_healthy", lambda _name, _port: True)
+    monkeypatch.setattr(utils.signal, "signal", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         utils,
         "ensure_requested_ports_available",
@@ -282,6 +283,7 @@ def test_run_services_skip_if_running_rejects_duplicate_ports_before_health(
     capsys,
 ) -> None:
     monkeypatch.setattr(utils, "service_port_healthy", lambda _name, _port: True)
+    monkeypatch.setattr(utils.signal, "signal", lambda *_args, **_kwargs: None)
     monkeypatch.setattr(
         utils.subprocess,
         "Popen",

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import tempfile
+from email.message import Message
 from pathlib import Path
 from subprocess import CompletedProcess
+from urllib.error import HTTPError
+
+import pytest
 
 from reflexio.cli import utils
 
@@ -61,3 +65,242 @@ def test_requested_port_conflicts_detect_occupied_ports(monkeypatch) -> None:
     conflicts = utils.get_requested_port_conflicts({"frontend": 8090, "docs": 8092})
 
     assert conflicts == ["frontend port 8090 is already in use by PID(s): 123, 456"]
+
+
+class _FakeResponse:
+    def __init__(self, status: int) -> None:
+        self.status = status
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+def test_service_port_healthy_uses_service_health_path(monkeypatch) -> None:
+    calls: list[tuple[str, float]] = []
+
+    def fake_urlopen(request: object, *, timeout: float) -> _FakeResponse:
+        calls.append((request.full_url, timeout))  # type: ignore[attr-defined]
+        return _FakeResponse(200)
+
+    monkeypatch.setattr(utils.urllib.request, "urlopen", fake_urlopen)
+
+    assert utils.service_port_healthy("backend", 8061, timeout=0.25)
+    assert calls == [("http://127.0.0.1:8061/health", 0.25)]
+
+
+def test_service_port_healthy_rejects_unhealthy_status(monkeypatch) -> None:
+    def fake_urlopen(request: object, *, timeout: float) -> _FakeResponse:
+        raise HTTPError(
+            request.full_url,  # type: ignore[attr-defined]
+            503,
+            "Service unavailable",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    monkeypatch.setattr(utils.urllib.request, "urlopen", fake_urlopen)
+
+    assert not utils.service_port_healthy("backend", 8061)
+
+
+def test_service_port_healthy_does_not_guess_without_health_path(monkeypatch) -> None:
+    monkeypatch.setattr(
+        utils.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("should not probe unknown health path")
+        ),
+    )
+
+    assert not utils.service_port_healthy("docs", 8062)
+    assert not utils.service_port_healthy("frontend", 8063)
+
+
+def test_service_port_healthy_handles_connection_refused(monkeypatch) -> None:
+    def fake_urlopen(request: object, *, timeout: float) -> _FakeResponse:
+        raise ConnectionRefusedError("refused")
+
+    monkeypatch.setattr(utils.urllib.request, "urlopen", fake_urlopen)
+
+    assert not utils.service_port_healthy("backend", 8061)
+
+
+def test_skip_healthy_services_filters_only_healthy_requested_services(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        utils,
+        "service_port_healthy",
+        lambda name, _port: name == "backend",
+    )
+    backend = utils.ServiceConfig("backend", ["backend"])
+    docs = utils.ServiceConfig("docs", ["docs"])
+
+    services, ports, skipped = utils.skip_healthy_services(
+        [backend, docs],
+        {"backend": 8061, "docs": 8062},
+    )
+
+    assert services == [docs]
+    assert ports == {"docs": 8062}
+    assert skipped == ["backend"]
+
+
+def test_skip_healthy_services_probes_health_at_filter_time(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, int]] = []
+
+    def fake_service_port_healthy(name: str, port: int) -> bool:
+        calls.append((name, port))
+        return False
+
+    monkeypatch.setattr(
+        utils,
+        "service_port_healthy",
+        fake_service_port_healthy,
+    )
+    backend = utils.ServiceConfig("backend", ["backend"])
+
+    services, ports, skipped = utils.skip_healthy_services(
+        [backend],
+        {"backend": 8061},
+    )
+
+    assert services == [backend]
+    assert ports == {"backend": 8061}
+    assert skipped == []
+    assert calls == [("backend", 8061)]
+
+
+def test_skip_healthy_services_handles_service_without_port_entry(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        utils,
+        "service_port_healthy",
+        lambda _name, _port: (_ for _ in ()).throw(
+            AssertionError("should not probe missing port")
+        ),
+    )
+    orphan = utils.ServiceConfig("orphan", ["orphan"])
+
+    services, ports, skipped = utils.skip_healthy_services([orphan], {})
+
+    assert services == [orphan]
+    assert ports == {}
+    assert skipped == []
+
+
+def test_run_services_skip_if_running_returns_without_conflict_or_spawn(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(utils, "service_port_healthy", lambda _name, _port: True)
+    monkeypatch.setattr(
+        utils,
+        "ensure_requested_ports_available",
+        lambda _ports: (_ for _ in ()).throw(AssertionError("should not check ports")),
+    )
+    monkeypatch.setattr(
+        utils.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("should not spawn")
+        ),
+    )
+
+    utils.run_services(
+        [utils.ServiceConfig("backend", ["backend"])],
+        {"backend": 8061},
+        skip_if_running=True,
+    )
+
+    assert capsys.readouterr().out == "Services already running: backend\n"
+
+
+def test_run_services_skip_if_running_spawns_only_unhealthy_service(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(
+        utils,
+        "service_port_healthy",
+        lambda name, _port: name == "backend",
+    )
+    monkeypatch.setattr(utils, "ensure_requested_ports_available", lambda _ports: None)
+    monkeypatch.setattr(utils, "write_pidfile", lambda _pidfile, _data: None)
+    monkeypatch.setattr(utils, "remove_pidfile", lambda _pidfile: None)
+    monkeypatch.setattr(utils.signal, "signal", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(utils.time, "sleep", lambda _seconds: None)
+    spawned: list[str] = []
+
+    class _FakeStdout:
+        def __iter__(self):
+            return iter(())
+
+    class _FakeProc:
+        pid = 1234
+        stdout = _FakeStdout()
+
+        def poll(self) -> int:
+            return 0
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def terminate(self) -> None:
+            return None
+
+        def kill(self) -> None:
+            return None
+
+    def fake_popen(cmd: list[str], **_kwargs: object) -> _FakeProc:
+        spawned.append(cmd[0])
+        return _FakeProc()
+
+    monkeypatch.setattr(utils.subprocess, "Popen", fake_popen)
+
+    utils.run_services(
+        [
+            utils.ServiceConfig("backend", ["backend"]),
+            utils.ServiceConfig("docs", ["docs"]),
+        ],
+        {"backend": 8061, "docs": 8062},
+        skip_if_running=True,
+    )
+
+    assert spawned == ["docs"]
+    assert "Services already running: backend" in capsys.readouterr().out
+
+
+def test_run_services_skip_if_running_rejects_duplicate_ports_before_health(
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr(utils, "service_port_healthy", lambda _name, _port: True)
+    monkeypatch.setattr(
+        utils.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("should not spawn")
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        utils.run_services(
+            [
+                utils.ServiceConfig("backend", ["backend"]),
+                utils.ServiceConfig("docs", ["docs"]),
+            ],
+            {"backend": 8061, "docs": 8061},
+            skip_if_running=True,
+        )
+
+    assert (
+        "port 8061 is assigned to multiple services: backend, docs"
+        in capsys.readouterr().out
+    )


### PR DESCRIPTION
## What Was Annoying

Callers that legitimately want an idempotent ensure-running command had to duplicate Reflexio health checks before calling `reflexio services start`, or call it anyway and tolerate port conflicts when the selected backend or embedding service was already healthy.

## What Changed

- Add `--skip-if-running` to `reflexio services start` and the lower-level service runner.
- When the flag is used, Reflexio performs a final in-process health reprobe before deciding to skip startup.
- Limit health-based skipping to backend and embedding because they have dedicated health endpoints.
- Leave docs/frontend on normal startup and port-conflict behavior until they have reliable service health endpoints.
- Keep the flag as ensure-running behavior only; it does not reload, restart, or detect changed service code.

## Behavior After Fix

Healthy selected backend/embedding services are treated as already satisfied and are not relaunched. Unhealthy, missing, or no-longer-healthy selected services continue through the normal startup path.

If service code changes and a fresh process is required, the caller must make that restart decision explicitly, such as with `reflexio services stop` followed by `reflexio services start`, or with caller-owned upgrade/restart logic before invoking this ensure-running path.

## Positioning

This is a good-to-have generic CLI idempotency improvement for Reflexio. It is not a required dependency for claude-smart update/reload behavior, and it does not move host-specific identity, version, or compatibility decisions into Reflexio.

## Validation

- `uv run pytest --no-cov tests/cli/test_utils.py tests/cli/test_run_services_workers.py tests/cli/test_services_first_run.py -q` -> 36 passed
- `uv run ruff check reflexio/cli/commands/services.py reflexio/cli/run_services.py reflexio/cli/utils.py tests/cli/test_utils.py tests/cli/test_run_services_workers.py tests/cli/test_services_first_run.py` -> passed
- `uv run pyright reflexio/cli/commands/services.py reflexio/cli/run_services.py reflexio/cli/utils.py tests/cli/test_utils.py tests/cli/test_run_services_workers.py tests/cli/test_services_first_run.py` -> 0 errors
- `git diff --check` -> passed
