### PR TITLE
governance: retain lineage_event skeleton on SQLite erase (SEC-016 parity)

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/governance/_erase_execution.py
+++ b/reflexio/server/services/storage/sqlite_storage/governance/_erase_execution.py
@@ -30,7 +30,6 @@ resolve through the composed MRO.
 
 from __future__ import annotations
 
-import json
 import sqlite3
 import threading
 from collections.abc import Callable
@@ -157,13 +156,6 @@ class GovernanceEraseExecutionMixin:
             raise ValueError(
                 "Current user playbooks no longer match prepared purge snapshot"
             )
-        request_ids = [
-            str(row["request_id"])
-            for row in self.conn.execute(
-                "SELECT request_id FROM requests WHERE user_id = ?",
-                (user_id,),
-            ).fetchall()
-        ]
         profile_rows = self.conn.execute(
             "SELECT rowid, profile_id FROM profiles WHERE user_id = ?",
             (user_id,),
@@ -183,40 +175,12 @@ class GovernanceEraseExecutionMixin:
         )
         purge_upb_ids = [int(entity_id) for entity_id in purge_upb_str_ids]
         delete_upb_ids = [int(entity_id) for entity_id in delete_upb_str_ids]
-        erased_entity_ids = [
-            *request_ids,
-            *[str(interaction_id) for interaction_id in interaction_ids],
-            *all_profile_ids,
-            *[str(user_playbook_id) for user_playbook_id in raw_upb_ids],
-        ]
-        if erased_entity_ids:
-            erased_entity_id_set = set(erased_entity_ids)
-            lineage_source_event_ids: list[int] = []
-            for row in self.conn.execute(
-                "SELECT event_id, source_ids FROM lineage_event WHERE org_id = ?",
-                (self.org_id,),
-            ).fetchall():
-                try:
-                    source_ids = json.loads(str(row["source_ids"] or "[]"))
-                except json.JSONDecodeError:
-                    source_ids = []
-                if any(
-                    str(source_id) in erased_entity_id_set for source_id in source_ids
-                ):
-                    lineage_source_event_ids.append(int(row["event_id"]))
-            deps._delete_in_chunks(
-                "lineage_event", "event_id", lineage_source_event_ids
-            )
-            placeholders = ",".join("?" for _ in erased_entity_ids)
-            self.conn.execute(
-                f"""DELETE FROM lineage_event
-                    WHERE org_id = ?
-                      AND (
-                        request_id IN ({placeholders})
-                        OR entity_id IN ({placeholders})
-                      )""",  # noqa: S608
-                [self.org_id, *erased_entity_ids, *erased_entity_ids],
-            )
+        # SEC-016: retain the content-free lineage_event skeleton on erase to
+        # match Supabase (which never enumerates lineage_event for erasure).
+        # lineage_event has no PII/content column, no foreign keys, and no
+        # FTS/vec shadow tables, so leaving these rows in place is safe and
+        # preserves the audit/lineage skeleton. Content-bearing entities are
+        # still deleted/purged below.
         delete_profile_rowids = [
             profile_rowid_by_id[profile_id]
             for profile_id in delete_profile_ids

--- a/tests/server/services/storage/sqlite_storage/test_governance_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_governance_storage.py
@@ -3212,9 +3212,17 @@ def test_apply_governance_user_data_delete_preserves_org_agent_playbooks_without
     }
 
 
-def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
+def test_apply_governance_user_data_delete_retains_lineage_skeleton(
     storage,
 ):
+    """SEC-016: erase retains the content-free lineage_event skeleton.
+
+    The SQLite erase path must converge with Supabase, which never enumerates
+    ``lineage_event`` for deletion. A pre-existing lineage_event referencing an
+    erased entity (here via ``source_ids``) must STILL EXIST after
+    ``apply_governance_user_data_delete`` — only content-bearing entity rows are
+    deleted or purged.
+    """
     purge_id = "purge_delete_after_hide"
     user_id = "user-delete-hide-complete"
     storage.begin_purge_operation(
@@ -3299,27 +3307,23 @@ def test_apply_governance_user_data_delete_succeeds_after_hide_targets_complete(
         ).fetchone()[0]
         == 1
     )
+    # SEC-016: the pre-existing lineage_event referencing the erased
+    # user_playbook (via source_ids) is the content-free skeleton and must be
+    # RETAINED after erase — matching Supabase, which never deletes it.
     assert (
         storage.conn.execute(
             """SELECT COUNT(*)
                FROM lineage_event
                WHERE org_id = ?
-                 AND (
-                    request_id = ?
-                    OR entity_id IN (?, ?, ?, ?)
-                    OR source_ids = ?
-                 )""",
+                 AND entity_id = 'agent_survivor'
+                 AND request_id = 'req-unrelated'
+                 AND source_ids = ?""",
             (
                 storage.org_id,
-                "req-delete-hide-complete",
-                "req-delete-hide-complete",
-                "101",
-                "profile_seed",
-                str(affected_user_playbook_id),
                 json.dumps([str(affected_user_playbook_id)]),
             ),
         ).fetchone()[0]
-        == 0
+        == 1
     )
     delete_targets = storage.list_purge_targets(purge_id, phase="delete")
     assert {target.target_name: target.deleted_count for target in delete_targets} == {


### PR DESCRIPTION
## Summary

**SEC-016** — cross-backend GDPR-erase parity on `lineage_event`. On user-data erase, **SQLite hard-DELETEd** `lineage_event` rows referencing erased entities, while **Supabase retains** the content-free lineage skeleton (its erase path never enumerates `lineage_event` — it's in neither the purge nor the delete set; the #219/#383 content-purge design keeps a content-free skeleton and purges PII on the entity tables). This converges SQLite onto the intended model.

## Change
- **Stop deleting `lineage_event` on erase** (`sqlite_storage/governance/_erase_execution.py`). Safe because `lineage_event` has **no PII/content column, no foreign keys, no FTS/vec shadow tables** — retaining the row is exactly the content-free skeleton the design intends, and lineage reconstruction is *helped* (the retained `status_change` signal survives). Removed the delete block + now-dead `erased_entity_ids`/`request_ids`/`import json`. Entity-table deletes + `purge_content` calls are untouched.
- **Inverted the test** that codified the old behavior (`test_governance_storage.py`): `test_apply_governance_user_data_delete_retains_lineage_skeleton` now asserts the pre-seeded skeleton row **still exists** (`== 1`) after erase, instead of `== 0`.

## Note on scope
The retained values are opaque surrogate IDs (`profile_id`/`request_id`/`entity_id`) in a content-free table — this matches the **already-shipped Supabase behavior**, so this is a convergence, not a new retention decision. (If those internal IDs should ever be treated as PII, that's a separate cross-backend change requiring Supabase to scrub too.)

## Verification
`governance/erase/lineage/purge` tests: **473 passed**; full sqlite storage suite: **390 passed**; ruff + pyright clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated data-deletion behavior so non-sensitive lineage “skeleton” records are preserved after governance erasure, while content-bearing user data is still removed.
  * Aligned deletion handling with expected behavior to avoid removing valid lineage context tied to unrelated records.

* **Tests**
  * Revised coverage to verify that retained lineage records remain after user data deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->