### PR TITLE
fix: include claude cli stdout diagnostics

### DIFF
--- a/reflexio/server/llm/providers/claude_code_provider.py
+++ b/reflexio/server/llm/providers/claude_code_provider.py
@@ -89,6 +89,12 @@ class ClaudeCodeCLIError(RuntimeError):
     """Raised when the claude CLI subprocess fails in a way we cannot recover from."""
 
 
+def _diagnostic_excerpt(text: str, limit: int = 500) -> str:
+    """Return a bounded single-line excerpt for local CLI diagnostics."""
+    compact = " ".join((text or "").split())
+    return compact[:limit]
+
+
 def _env_enabled() -> bool:
     """Return True when ``CLAUDE_SMART_USE_LOCAL_CLI`` is set to a truthy value.
 
@@ -1037,7 +1043,9 @@ class ClaudeCodeLLM(CustomLLM):
         self._record_stall_safely(result)
         raise ClaudeCodeCLIError(
             f"claude -p stream failed; retry_errors={result.retry_errors}; "
-            f"stderr={result.stderr_text[:200]!r}"
+            f"stderr={_diagnostic_excerpt(result.stderr_text)!r}; "
+            f"stdout={_diagnostic_excerpt(result.terminal_text)!r}; "
+            f"parsed={result.raw_lines_parsed}; failed={result.raw_lines_failed}"
         )
 
     def _record_stall_safely(self, result: ParseResult) -> None:

--- a/tests/server/llm/test_claude_code_provider.py
+++ b/tests/server/llm/test_claude_code_provider.py
@@ -441,6 +441,33 @@ class TestClaudeCodeLLMCompletion:
                 messages=[{"role": "user", "content": "hi"}],
             )
 
+    def test_non_zero_exit_includes_stdout_diagnostic(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            ccp.subprocess,
+            "run",
+            MagicMock(
+                return_value=_fake_completed_process(
+                    stdout=_stream_json("oauth token has expired"),
+                    stderr="",
+                    returncode=1,
+                )
+            ),
+        )
+        monkeypatch.setattr(ccp, "_resolve_cli_path", lambda: "/usr/local/bin/claude")
+        llm = ClaudeCodeLLM()
+
+        with pytest.raises(ClaudeCodeCLIError) as exc:
+            llm.completion(
+                model="claude-code/default",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        message = str(exc.value)
+        assert "stdout='oauth token has expired'" in message
+        assert "stderr=''" in message
+
     def test_timeout_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(
             ccp.subprocess,


### PR DESCRIPTION
## Summary
- Preserve Reflexio's separation from claude-smart while improving local Claude CLI failure diagnostics.
- Include bounded stdout excerpts and stream parse counts when `claude -p` exits nonzero, so extraction failures surface actionable provider output.

## Changes
- Add a compact diagnostic excerpt helper for Claude CLI stdout/stderr.
- Include stdout, stderr, parsed count, and failed count in `ClaudeCodeCLIError`.
- Add regression coverage for nonzero exits where the useful error text appears on stdout.

## Test Plan
- `uv run pytest tests/server/api_endpoints/test_api_routes.py::TestHealthEndpoints tests/server/llm/test_claude_code_provider.py::TestClaudeCodeLLMCompletion::test_non_zero_exit_includes_stdout_diagnostic -q --no-cov`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error messages to include clearer, bounded diagnostics from both standard output and error output.
  * Added extra parse details to make failed responses easier to understand when a completion request fails.

* **Tests**
  * Added coverage to verify failed CLI runs surface both output streams in the reported error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-ups
- Merge before the enterprise submodule pointer PR that consumes this diagnostic change.
