### PR TITLE
feat: add explicit playbook provenance contracts

### DIFF
--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/state.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/state.py
@@ -36,7 +36,9 @@ _DEFAULT_STATE_DIR = Path.home() / ".openclaw-smart" / "sessions"
 
 _TOOL_DATA_FIELD_MAX_LEN = 256
 
-_VALID_CITATION_KINDS = frozenset({"playbook", "profile"})
+_VALID_CITATION_KINDS = frozenset(
+    {"playbook", "profile", "user_playbook", "agent_playbook"}
+)
 
 
 def _truncate_tool_data_field(value: Any) -> Any:
@@ -240,13 +242,18 @@ def _to_wire_citations(cited_items: Any) -> list[dict[str, str]]:
         kind = item.get("kind")
         if not isinstance(real_id, str) or not real_id:
             continue
-        if kind not in _VALID_CITATION_KINDS:
+        wire_kind = kind
+        if kind == "playbook":
+            source_kind = item.get("source_kind")
+            if source_kind in {"user_playbook", "agent_playbook"}:
+                wire_kind = source_kind
+        if wire_kind not in _VALID_CITATION_KINDS:
             continue
         tag = item.get("id")
         title = item.get("title")
         out.append(
             {
-                "kind": kind,
+                "kind": wire_kind,
                 "real_id": real_id,
                 "tag": tag if isinstance(tag, str) else "",
                 "title": title if isinstance(title, str) else "",

--- a/reflexio/integrations/openclaw/plugin/tests/test_state.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_state.py
@@ -233,3 +233,31 @@ def test_safe_session_ids_accepted():
         path = state.session_path(sid)
         assert path is not None, f"safe id {sid!r} should have been accepted"
         assert path.name == f"{sid}.jsonl"
+
+
+def test_to_wire_citations_preserves_explicit_playbook_source_kind() -> None:
+    wire = state._to_wire_citations(
+        [
+            {
+                "id": "s1-1",
+                "kind": "playbook",
+                "source_kind": "agent_playbook",
+                "real_id": "20",
+                "title": "Agent",
+            },
+            {
+                "id": "s2-1",
+                "kind": "playbook",
+                "source_kind": "user_playbook",
+                "real_id": "101",
+                "title": "User",
+            },
+            {"id": "p1-1", "kind": "profile", "real_id": "p1", "title": "Profile"},
+        ]
+    )
+
+    assert [item["kind"] for item in wire] == [
+        "agent_playbook",
+        "user_playbook",
+        "profile",
+    ]

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -150,7 +150,8 @@ class Citation(BaseModel):
             ``"agent_playbook"`` references an org-level playbook row.
             ``"profile"`` references a user profile row.
         real_id (str): Stable storage id — ``user_playbook_id`` for
-            playbooks, ``profile_id`` for profiles.
+            user playbooks, ``agent_playbook_id`` for agent playbooks,
+            and ``profile_id`` for profiles.
         tag (str): Injection-time rank tag (e.g. ``"r1-301"``,
             ``"p1-0f37"``). Per-injection, not stable across sessions;
             kept as a debug aid.

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -407,16 +407,64 @@ class AgentSuccessEvaluationResult(BaseModel):
 
 
 class PlaybookRetrievalLogItem(BaseModel):
-    """One retrieved agent playbook plus the serve-time attribution snapshot."""
+    """One retrieved playbook plus the serve-time attribution snapshot.
+
+    ``agent_playbook_id`` remains as a nullable legacy compatibility field for
+    old agent-only rows. New rows should prefer ``target_kind`` + ``target_id``.
+    """
 
     retrieval_log_item_id: int = 0
     retrieval_log_id: int = 0
     ordinal: int
-    agent_playbook_id: int
+    agent_playbook_id: int | None = Field(default=None, gt=0)
+    target_kind: Literal["agent_playbook", "user_playbook"] | None = None
+    target_id: int | None = Field(default=None, gt=0)
+    target_title: str = ""
+    target_content: str = ""
+    target_trigger: str | None = None
     source_user_playbook_ids: list[int] = Field(default_factory=list)
     source_interaction_ids_by_user_playbook_id: dict[str, list[int]] = Field(
         default_factory=dict
     )
+    source_window_snapshot_mode: Literal["final_response", "live_lookup_compat"] = (
+        "live_lookup_compat"
+    )
+
+    @model_validator(mode="after")
+    def backfill_legacy_target_fields(self) -> Self:
+        if self.target_kind is None:
+            if self.agent_playbook_id is None:
+                raise ValueError(
+                    "PlaybookRetrievalLogItem requires target_kind/target_id or"
+                    " legacy agent_playbook_id"
+                )
+            self.target_kind = "agent_playbook"
+            self.target_id = self.agent_playbook_id
+            return self
+
+        if self.target_id is None:
+            if self.target_kind != "agent_playbook" or self.agent_playbook_id is None:
+                raise ValueError(
+                    "PlaybookRetrievalLogItem.target_id is required for explicit"
+                    " targets"
+                )
+            self.target_id = self.agent_playbook_id
+
+        if self.target_kind == "user_playbook":
+            if self.agent_playbook_id is not None:
+                raise ValueError(
+                    "user_playbook retrieval-log items cannot carry agent_playbook_id"
+                )
+            return self
+
+        if self.agent_playbook_id is None:
+            self.agent_playbook_id = self.target_id
+        elif self.agent_playbook_id != self.target_id:
+            raise ValueError(
+                "agent_playbook retrieval-log item agent_playbook_id must match"
+                " target_id"
+            )
+        return self
 
 
 class PlaybookRetrievalLog(BaseModel):

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -33,6 +33,7 @@ __all__ = [
     "BlockingIssue",
     "BlockingIssueKind",
     "ToolUsed",
+    "CitationKind",
     "Citation",
     "Interaction",
     "Request",
@@ -130,6 +131,8 @@ __all__ = [
 # Data Models
 # ===============================
 
+type CitationKind = Literal["playbook", "profile", "user_playbook", "agent_playbook"]
+
 
 class Citation(BaseModel):
     """A playbook or profile item the agent cited as influential.
@@ -141,8 +144,11 @@ class Citation(BaseModel):
     it was applied?).
 
     Attributes:
-        kind (Literal["playbook", "profile"]): Which kind of cited
-            item this references.
+        kind (CitationKind): Which kind of cited item this references.
+            ``"playbook"`` is the legacy compatibility value.
+            ``"user_playbook"`` is the direct tuner target.
+            ``"agent_playbook"`` references an org-level playbook row.
+            ``"profile"`` references a user profile row.
         real_id (str): Stable storage id — ``user_playbook_id`` for
             playbooks, ``profile_id`` for profiles.
         tag (str): Injection-time rank tag (e.g. ``"r1-301"``,
@@ -151,7 +157,7 @@ class Citation(BaseModel):
         title (str): Short human-readable label for logs and UI.
     """
 
-    kind: Literal["playbook", "profile"]
+    kind: CitationKind
     real_id: str
     tag: str = ""
     title: str = ""

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -11,6 +11,7 @@ from typing import Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from reflexio.models.api_schema.domain import CitationKind
 from reflexio.models.api_schema.validators import NonEmptyStr
 from reflexio.models.structured_output import StrictStructuredOutput
 
@@ -79,7 +80,7 @@ class RuleAttributionRow(BaseModel):
     """One row in the "rules that moved the needle" panel."""
 
     rule_id: str
-    kind: Literal["playbook", "profile"]
+    kind: CitationKind
     title: str = ""
     successes_with: int = Field(ge=0)
     failures_with: int = Field(ge=0)

--- a/reflexio/models/api_schema/internal_schema.py
+++ b/reflexio/models/api_schema/internal_schema.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 
 from pydantic import BaseModel
 
+from .domain import CitationKind
 from .service_schemas import Interaction, Request
 
 
@@ -42,6 +43,6 @@ class SessionCitation(NamedTuple):
 
     user_id: str
     session_id: str
-    kind: str
+    kind: CitationKind
     real_id: str
     title: str

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -6,6 +6,7 @@ from typing import Literal, Self
 from pydantic import BaseModel, Field, model_validator
 
 from ..config_schema import SearchMode
+from .domain import CitationKind
 from .service_schemas import (
     AgentPlaybook,
     AgentSuccessEvaluationResult,
@@ -593,8 +594,10 @@ class PlaybookApplicationStat(BaseModel):
         real_id (str): Stable id of the cited item — ``user_playbook_id``,
             ``agent_playbook_id``, or ``profile_id`` (always serialized as a
             string).
-        kind (str): ``"playbook"`` or ``"profile"`` — the citation kind, as
-            recorded on ``Interaction.citations``.
+        kind (CitationKind): Citation kind recorded on
+            ``Interaction.citations``. ``"playbook"`` is the legacy
+            compatibility value; ``"user_playbook"`` is the explicit
+            direct-tuner target.
         title (str): Human-readable label for the rule. Empty string when
             the underlying row has been deleted but old citations remain.
         applied_count (int): Number of interactions in the window whose
@@ -609,7 +612,7 @@ class PlaybookApplicationStat(BaseModel):
     """
 
     real_id: str
-    kind: Literal["playbook", "profile"]
+    kind: CitationKind
     title: str = ""
     applied_count: int = Field(ge=0)
     last_applied_at: int | None = None

--- a/reflexio/server/services/evaluation_overview/components/rule_attribution.py
+++ b/reflexio/server/services/evaluation_overview/components/rule_attribution.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
-CitationKey = tuple[str, str]  # (kind, real_id) — matches PlaybookApplicationStat
+from reflexio.models.api_schema.domain import CitationKind
+
+CitationKey = tuple[CitationKind, str]  # (kind, real_id) — matches PlaybookApplicationStat
 SessionIdentity = tuple[str, str]  # (user_id, session_id)
 
 
@@ -19,7 +21,7 @@ class RuleAttribution:
     """One row of the "rules that moved the needle" panel."""
 
     rule_id: str
-    kind: str
+    kind: CitationKind
     title: str
     successes_with: int
     failures_with: int

--- a/reflexio/server/services/reflection/service.py
+++ b/reflexio/server/services/reflection/service.py
@@ -29,7 +29,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from reflexio.models.api_schema.domain.entities import (
     Citation,
@@ -168,7 +168,9 @@ class ReflectionService:
 
         eligible_citations = [e.citation for e in eligible]
         horizon_by_key = {
-            (e.citation.kind, e.citation.real_id): e.has_full_horizon for e in eligible
+            (target_kind, e.citation.real_id): e.has_full_horizon
+            for e in eligible
+            if (target_kind := _reflection_target_kind(e.citation)) is not None
         }
         cited_profiles, cited_playbooks, missing = self._resolve_cited_rows(
             user_id=request.user_id,
@@ -352,9 +354,10 @@ class ReflectionService:
         wanted_profile_ids: set[str] = set()
         wanted_playbook_ids: set[int] = set()
         for c in citations:
-            if c.kind == "profile":
+            target_kind = _reflection_target_kind(c)
+            if target_kind == "profile":
                 wanted_profile_ids.add(c.real_id)
-            elif c.kind == "playbook":
+            elif target_kind == "playbook":
                 try:
                     wanted_playbook_ids.add(int(c.real_id))
                 except (TypeError, ValueError):
@@ -766,6 +769,16 @@ def _collect_citations(interactions: list[Interaction]) -> list[Citation]:
             seen.add(key)
             out.append(c)
     return out
+
+
+def _reflection_target_kind(citation: Citation) -> Literal["playbook", "profile"] | None:
+    if citation.kind == "user_playbook":
+        return "playbook"
+    if citation.kind == "playbook":
+        return "playbook"
+    if citation.kind == "profile":
+        return "profile"
+    return None
 
 
 @dataclass(frozen=True)

--- a/reflexio/server/services/reflection/service.py
+++ b/reflexio/server/services/reflection/service.py
@@ -167,10 +167,10 @@ class ReflectionService:
             return result
 
         eligible_citations = [e.citation for e in eligible]
-        horizon_by_key = {
-            (target_kind, e.citation.real_id): e.has_full_horizon
+        horizon_by_key: dict[tuple[str, str], bool] = {
+            key: e.has_full_horizon
             for e in eligible
-            if (target_kind := _reflection_target_kind(e.citation)) is not None
+            if (key := _reflection_citation_key(e.citation)) is not None
         }
         cited_profiles, cited_playbooks, missing = self._resolve_cited_rows(
             user_id=request.user_id,
@@ -756,14 +756,16 @@ def _flatten(
 
 
 def _collect_citations(interactions: list[Interaction]) -> list[Citation]:
-    """Pull distinct citations off Assistant interactions."""
-    seen: set[tuple[str, str]] = set()
+    """Pull distinct reflection-eligible citations off Assistant interactions."""
+    seen: set[tuple[Literal["playbook", "profile"], str]] = set()
     out: list[Citation] = []
     for i in interactions:
         if i.role != "Assistant":
             continue
         for c in i.citations:
-            key = (c.kind, c.real_id)
+            key = _reflection_citation_key(c)
+            if key is None:
+                continue
             if key in seen:
                 continue
             seen.add(key)
@@ -779,6 +781,15 @@ def _reflection_target_kind(citation: Citation) -> Literal["playbook", "profile"
     if citation.kind == "profile":
         return "profile"
     return None
+
+
+def _reflection_citation_key(
+    citation: Citation,
+) -> tuple[Literal["playbook", "profile"], str] | None:
+    target_kind = _reflection_target_kind(citation)
+    if target_kind is None:
+        return None
+    return (target_kind, citation.real_id)
 
 
 @dataclass(frozen=True)
@@ -809,8 +820,8 @@ def _filter_citations_by_horizon(
 ) -> list[_EligibleCitation]:
     """Filter citations to those that have enough post-citation context.
 
-    For each unique ``(kind, real_id)``, finds the **earliest** occurrence
-    in the window (maximizes follow-up turns) and decides:
+    For each unique reflection citation key, finds the **earliest**
+    occurrence in the window (maximizes follow-up turns) and decides:
 
     - ``after_count >= post_horizon_size`` → eligible, ``has_full_horizon=True``.
     - ``position < stride_size`` → eligible (last-chance, about to fall
@@ -833,15 +844,22 @@ def _filter_citations_by_horizon(
         list[_EligibleCitation]: Citations to send to the LLM, each
         paired with its window position and horizon flag.
     """
-    seen: dict[tuple[str, str], int] = {}
+    seen: dict[tuple[Literal["playbook", "profile"], str], int] = {}
     for idx, interaction in enumerate(window):
         if interaction.role != "Assistant":
             continue
         for c in interaction.citations:
-            key = (c.kind, c.real_id)
+            key = _reflection_citation_key(c)
+            if key is None:
+                continue
             seen.setdefault(key, idx)  # earliest occurrence only
 
-    citation_by_key = {(c.kind, c.real_id): c for c in citations}
+    citation_by_key: dict[tuple[Literal["playbook", "profile"], str], Citation] = {}
+    for citation in citations:
+        key = _reflection_citation_key(citation)
+        if key is None:
+            continue
+        citation_by_key.setdefault(key, citation)
 
     out: list[_EligibleCitation] = []
     for key, position in seen.items():

--- a/reflexio/server/services/storage/sqlite_storage/_extras.py
+++ b/reflexio/server/services/storage/sqlite_storage/_extras.py
@@ -25,7 +25,14 @@ from ._base import (
     _row_to_interaction,
 )
 
-type _CitationKind = Literal["playbook", "profile"]
+type _CitationKind = Literal["playbook", "profile", "user_playbook", "agent_playbook"]
+
+_SUPPORTED_CITATION_KINDS: tuple[_CitationKind, ...] = (
+    "playbook",
+    "profile",
+    "user_playbook",
+    "agent_playbook",
+)
 
 
 class ExtrasMixin:
@@ -291,7 +298,7 @@ class ExtrasMixin:
                     continue
                 kind = c.get("kind")
                 real_id = c.get("real_id")
-                if kind not in ("playbook", "profile") or not real_id:
+                if kind not in _SUPPORTED_CITATION_KINDS or not real_id:
                     continue
                 key: tuple[_CitationKind, str] = (
                     cast(_CitationKind, kind),
@@ -453,12 +460,12 @@ class ExtrasMixin:
                         continue
                     kind = citation.get("kind")
                     real_id = citation.get("real_id")
-                    if kind and real_id:
+                    if kind in _SUPPORTED_CITATION_KINDS and real_id:
                         out.append(
                             SessionCitation(
                                 user_id=row["user_id"],
                                 session_id=row["session_id"],
-                                kind=str(kind),
+                                kind=cast(_CitationKind, kind),
                                 real_id=str(real_id),
                                 title=str(citation.get("title") or ""),
                             )

--- a/reflexio/server/services/storage/storage_base/_retrieval_log.py
+++ b/reflexio/server/services/storage/storage_base/_retrieval_log.py
@@ -7,7 +7,9 @@ class RetrievalLogMixin:
     These methods are optional retrieval-capture storage hooks. They are
     intentionally concrete (not ``@abstractmethod``) so concrete storage classes
     remain instantiable; each raises ``NotImplementedError`` until a backend
-    provides a real implementation.
+    provides a real implementation. Stored item rows may use either the legacy
+    ``agent_playbook_id`` field or the explicit ``target_kind`` / ``target_id``
+    pair; readers should preserve backward compatibility for both.
     """
 
     def save_playbook_retrieval_log(self, log: PlaybookRetrievalLog) -> int:

--- a/tests/server/services/reflection/test_post_horizon_filter.py
+++ b/tests/server/services/reflection/test_post_horizon_filter.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 
 from reflexio.models.api_schema.domain.entities import Citation, Interaction
 from reflexio.server.services.reflection.service import (
+    _collect_citations,
     _filter_citations_by_horizon,
 )
 
@@ -122,3 +123,35 @@ def test_filter_ignores_citations_on_non_assistant_turns():
         stride_size=5,
     )
     assert eligible == []
+
+
+def test_filter_canonicalizes_legacy_and_explicit_playbook_keys_and_ignores_agent():
+    """Legacy and explicit user-playbook citations for the same id share one
+    reflection key, and agent-playbook citations are ignored entirely."""
+    explicit = Citation(kind="user_playbook", real_id="42")
+    legacy = Citation(kind="playbook", real_id="42")
+    agent = Citation(kind="agent_playbook", real_id="42")
+    window = [
+        _interaction(0, citations=[explicit]),
+        _interaction(1, citations=[agent]),
+        _interaction(2),
+        _interaction(3, citations=[legacy]),
+        _interaction(4),
+        _interaction(5),
+    ]
+
+    citations = _collect_citations(window)
+    eligible = _filter_citations_by_horizon(
+        citations=citations,
+        window=window,
+        post_horizon_size=3,
+        stride_size=2,
+    )
+
+    assert [(citation.kind, citation.real_id) for citation in citations] == [
+        ("user_playbook", "42")
+    ]
+    assert len(eligible) == 1
+    assert eligible[0].citation.kind == "user_playbook"
+    assert eligible[0].position == 0
+    assert eligible[0].has_full_horizon is True

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -333,6 +333,41 @@ class TestReplaceProfile:
 
 
 class TestReplacePlaybook:
+    def test_user_playbook_citation_is_eligible_and_agent_playbook_is_ignored(
+        self, request_context, service, llm_client
+    ):
+        _set_config(request_context)
+        storage = request_context.storage
+        _seed_playbook(storage, 1, "u1")
+
+        _seed_request_with_interactions(
+            storage,
+            "u1",
+            "r1",
+            [
+                _make_interaction("u1", "r1", "User", "hi"),
+                _make_interaction(
+                    "u1",
+                    "r1",
+                    "Assistant",
+                    "hello",
+                    citations=[
+                        Citation(kind="user_playbook", real_id="1"),
+                        Citation(kind="agent_playbook", real_id="1"),
+                    ],
+                ),
+            ],
+        )
+
+        result = service.run(ReflectionServiceRequest(user_id="u1"))
+
+        assert result.gate_open is True
+        assert result.cited_count == 1
+        assert result.considered_count == 1
+        assert result.skipped_count == 0
+        assert result.ran is True
+        llm_client.generate_chat_response.assert_called_once()
+
     def test_replace_archives_cited_and_inserts_new_current(
         self, request_context, service, llm_client
     ):

--- a/tests/server/services/storage/test_sqlite_storage_bc_extras.py
+++ b/tests/server/services/storage/test_sqlite_storage_bc_extras.py
@@ -179,7 +179,8 @@ def test_get_citations_by_session_ids_extracts_cited_rows(
         session_id="s1",
         request_id="req_s1",
         assistant_citations=[
-            Citation(kind="playbook", real_id="42", title="Keep it short"),
+            Citation(kind="user_playbook", real_id="42", title="Keep it short"),
+            Citation(kind="agent_playbook", real_id="77", title="Escalate sooner"),
             Citation(kind="profile", real_id="p9", title="Prefers email"),
         ],
     )
@@ -228,7 +229,8 @@ def test_get_citations_by_session_ids_extracts_cited_rows(
         by_session.setdefault(citation.session_id, []).append(citation)
     assert set(by_session) == {"s1", "s2"}
     assert [(c.kind, c.real_id, c.title) for c in by_session["s1"]] == [
-        ("playbook", "42", "Keep it short"),
+        ("user_playbook", "42", "Keep it short"),
+        ("agent_playbook", "77", "Escalate sooner"),
         ("profile", "p9", "Prefers email"),
     ]
     assert [(c.kind, c.real_id) for c in by_session["s2"]] == [

--- a/tests/server/services/storage/test_storage_contract_extras.py
+++ b/tests/server/services/storage/test_storage_contract_extras.py
@@ -137,6 +137,52 @@ class TestPlaybookApplicationStats:
         assert len(stats) == 1
         assert stats[0].applied_count == 1
 
+    def test_accepts_explicit_user_and_agent_playbook_kinds(self, storage):
+        if not _backend_supports_application_stats(storage):
+            pytest.skip("Backend does not implement get_playbook_application_stats")
+        now = int(datetime.now(tz=UTC).timestamp())
+        storage._insert_interaction(
+            _make_interaction(
+                "r1",
+                now - 10,
+                [
+                    Citation(
+                        kind="user_playbook",
+                        real_id="42",
+                        tag="u1-42",
+                        title="timeline",
+                    )
+                ],
+            )
+        )
+        storage._insert_interaction(
+            _make_interaction(
+                "r2",
+                now,
+                [
+                    Citation(
+                        kind="user_playbook",
+                        real_id="42",
+                        tag="u1-42",
+                        title="timeline",
+                    ),
+                    Citation(
+                        kind="agent_playbook",
+                        real_id="7",
+                        tag="a1-7",
+                        title="org rule",
+                    ),
+                ],
+            )
+        )
+
+        stats = storage.get_playbook_application_stats(days_back=30)
+
+        assert [(row.kind, row.real_id, row.applied_count) for row in stats] == [
+            ("user_playbook", "42", 2),
+            ("agent_playbook", "7", 1),
+        ]
+
 
 def _backend_supports_application_stats(storage) -> bool:
     """True when the storage backend has a real (non-default) implementation.


### PR DESCRIPTION
## Summary
- Add explicit playbook citation provenance so citations can distinguish user and agent playbook targets.
- Extend retrieval-log item contracts and storage persistence with explicit target metadata and source-window snapshot fields.
- Keep legacy citation and retrieval-log compatibility while making new provenance fields available to enterprise offline tuner flows.

## Changes
- API/schema: explicit citation kind/real_id handling and retrieval-log item target fields.
- Reflection/storage: canonical citation key handling plus SQLite storage support for explicit retrieval-log targets.
- Tests: coverage for citation canonicalization, retrieval-log persistence, and explicit target compatibility.

## Test Plan
- `uv run pytest --no-cov tests/server/services/reflection/test_post_horizon_filter.py tests/server/services/reflection/test_reflection_service.py tests/server/services/storage/test_sqlite_storage_bc_extras.py tests/server/services/storage/test_storage_contract_extras.py -q`
- Enterprise integration gates were run from the parent PR with `REFLEXIO_GOVERNANCE_REF_SECRET=test-governance-ref-secret`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded citation support to recognize more specific playbook citation types.
  * Improved handling of playbook references so explicit playbook sources are preserved in outputs and reports.

* **Bug Fixes**
  * Fixed citation normalization so mixed legacy and explicit playbook references are handled consistently.
  * Improved filtering and deduplication so unsupported playbook-like citations are ignored where appropriate.

* **Documentation**
  * Updated schema and storage guidance to reflect backward-compatible playbook reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->