### PR TITLE
fix: keep client per-call headers scoped

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -313,9 +313,8 @@ class ReflexioClient:
         if headers:
             request_headers.update(headers)
 
-        self.session.headers.update(request_headers)
         kwargs.setdefault("timeout", self.timeout)
-        response = self.session.request(method, url, **kwargs)
+        response = self.session.request(method, url, headers=request_headers, **kwargs)
         response.raise_for_status()
 
         # Empty body on a successful response (e.g. 204 No Content).

--- a/tests/client/test_request_headers.py
+++ b/tests/client/test_request_headers.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from reflexio.client import ReflexioClient
+
+
+def _json_response(payload: dict[str, object]) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.content = b'{"success": true}'
+    response.headers = {"Content-Type": "application/json"}
+    return response
+
+
+@patch("reflexio.client.client.requests.Session")
+def test_make_request_does_not_persist_per_call_headers(mock_session_class) -> None:
+    mock_session = MagicMock()
+    mock_session.headers = {}
+    mock_session_class.return_value = mock_session
+    mock_session.request.return_value = _json_response({"success": True})
+
+    client = ReflexioClient(api_key="normal-key", url_endpoint="http://localhost:8000")
+    client.session.headers.update({"User-Agent": "reflexio-test"})
+
+    client._make_request(  # noqa: SLF001 - client header regression guard
+        "POST",
+        "/api/admin/offline_tuner/run",
+        headers={"Authorization": "Bearer admin-key"},
+        json={},
+    )
+    client._make_request("GET", "/api/whoami")  # noqa: SLF001
+
+    first_call = mock_session.request.call_args_list[0]
+    second_call = mock_session.request.call_args_list[1]
+    assert first_call.kwargs["headers"]["Authorization"] == "Bearer admin-key"
+    assert second_call.kwargs["headers"]["Authorization"] == "Bearer normal-key"
+    assert client.session.headers == {"User-Agent": "reflexio-test"}


### PR DESCRIPTION
## Summary
- Fixes the Reflexio client request path so per-call headers stay scoped to a single HTTP request.
- Prevents an admin Authorization override from contaminating later normal client calls on the same `ReflexioClient` instance.
- Adds a regression test that sends an admin bearer for one request and verifies the next request uses the original client bearer.

## Changes
- Pass merged headers directly to `session.request(...)` instead of mutating `self.session.headers`.
- Add `tests/client/test_request_headers.py` coverage for per-call header isolation.

## Test Plan
- `uv run pytest open_source/reflexio/tests/client/test_request_headers.py --no-cov`
- `uv run ruff check open_source/reflexio/reflexio/client/client.py open_source/reflexio/tests/client/test_request_headers.py`
- `uv run pyright open_source/reflexio/reflexio/client/client.py open_source/reflexio/tests/client/test_request_headers.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP header handling so request-specific headers are applied only to the current call and no longer carry over to later requests.
  * Preserved existing session headers while keeping per-request authentication overrides isolated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->