### PR TITLE
feat: trigger aggregation after user playbook successors

### DIFF
--- a/reflexio/server/services/playbook/aggregation_trigger.py
+++ b/reflexio/server/services/playbook/aggregation_trigger.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -18,6 +20,7 @@ from reflexio.server.services.playbook.playbook_service_utils import (
 logger = logging.getLogger(__name__)
 
 AggregationTriggerStatus = Literal[
+    "queued",
     "triggered",
     "skipped_no_config",
     "skipped_saturated",
@@ -60,6 +63,55 @@ def has_user_playbook_aggregation_config(request_context: RequestContext) -> boo
     return bool(playbook_config and playbook_config.aggregation_config)
 
 
+def _run_aggregation_task(
+    *,
+    request_context: RequestContext,
+    aggregator: PlaybookAggregator,
+    request: PlaybookAggregatorRequest,
+    reason: str,
+) -> AggregationTriggerResult:
+    agent_version = request.agent_version
+    try:
+        run_with_operation_limit(
+            org_id=request_context.org_id,
+            operation="aggregation",
+            fn=lambda: aggregator.run(request),
+        )
+    except TimeoutError:
+        logger.info(
+            "Skipping background aggregation for agent_version=%s reason=%s: aggregation limiter is saturated",
+            agent_version,
+            reason,
+        )
+        return AggregationTriggerResult(
+            status="skipped_saturated",
+            reason=reason,
+            agent_version=agent_version,
+            error_type="TimeoutError",
+        )
+    except Exception as exc:  # noqa: BLE001
+        return _failed_result(
+            exc=exc,
+            reason=reason,
+            agent_version=agent_version,
+            message="User playbook aggregation failed after successor commit",
+        )
+    return AggregationTriggerResult(
+        status="triggered",
+        reason=reason,
+        agent_version=agent_version,
+    )
+
+
+def _start_aggregation_thread(task: Callable[[], AggregationTriggerResult]) -> None:
+    thread = threading.Thread(
+        target=task,
+        name="reflexio-user-playbook-aggregation",
+        daemon=True,
+    )
+    thread.start()
+
+
 def maybe_trigger_user_playbook_aggregation(
     *,
     request_context: RequestContext,
@@ -95,29 +147,20 @@ def maybe_trigger_user_playbook_aggregation(
         )
         request = PlaybookAggregatorRequest(agent_version=agent_version)
         try:
-            run_with_operation_limit(
-                org_id=request_context.org_id,
-                operation="aggregation",
-                fn=lambda: aggregator.run(request),
-            )
-        except TimeoutError:
-            logger.info(
-                "Skipping inline aggregation for agent_version=%s reason=%s: aggregation limiter is saturated",
-                agent_version,
-                reason,
-            )
-            return AggregationTriggerResult(
-                status="skipped_saturated",
-                reason=reason,
-                agent_version=agent_version,
-                error_type="TimeoutError",
+            _start_aggregation_thread(
+                lambda: _run_aggregation_task(
+                    request_context=request_context,
+                    aggregator=aggregator,
+                    request=request,
+                    reason=reason,
+                )
             )
         except Exception as exc:  # noqa: BLE001
             return _failed_result(
                 exc=exc,
                 reason=reason,
                 agent_version=agent_version,
-                message="User playbook aggregation failed after successor commit",
+                message="User playbook aggregation dispatch failed after successor commit",
             )
     except Exception as exc:  # noqa: BLE001
         return _failed_result(
@@ -128,7 +171,7 @@ def maybe_trigger_user_playbook_aggregation(
         )
 
     return AggregationTriggerResult(
-        status="triggered",
+        status="queued",
         reason=reason,
         agent_version=agent_version,
     )

--- a/reflexio/server/services/playbook/aggregation_trigger.py
+++ b/reflexio/server/services/playbook/aggregation_trigger.py
@@ -33,6 +33,27 @@ class AggregationTriggerResult:
     error_type: str | None = None
 
 
+def _failed_result(
+    *,
+    exc: Exception,
+    reason: str,
+    agent_version: str,
+    message: str,
+) -> AggregationTriggerResult:
+    logger.exception(
+        "%s agent_version=%s reason=%s",
+        message,
+        agent_version,
+        reason,
+    )
+    return AggregationTriggerResult(
+        status="failed",
+        reason=reason,
+        agent_version=agent_version,
+        error_type=type(exc).__name__,
+    )
+
+
 def maybe_trigger_user_playbook_aggregation(
     *,
     request_context: RequestContext,
@@ -40,61 +61,66 @@ def maybe_trigger_user_playbook_aggregation(
     agent_version: str,
     reason: str,
 ) -> AggregationTriggerResult:
-    root_config = request_context.configurator.get_config()
-    playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
-    if not playbook_config or not playbook_config.aggregation_config:
-        return AggregationTriggerResult(
-            status="skipped_no_config",
-            reason=reason,
-            agent_version=agent_version,
-        )
-
-    logger.info(
-        "Triggering user playbook aggregation agent_version=%s reason=%s",
-        agent_version,
-        reason,
-    )
-    aggregator_kwargs: dict[str, Any] = {}
-    aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
-    if aggregation_prompt_processor is not None:
-        aggregator_kwargs["aggregation_prompt_processor"] = aggregation_prompt_processor
-
-    aggregator = PlaybookAggregator(
-        llm_client=llm_client,
-        request_context=request_context,
-        agent_version=agent_version,
-        **aggregator_kwargs,
-    )
-    request = PlaybookAggregatorRequest(agent_version=agent_version)
     try:
-        run_with_operation_limit(
-            org_id=request_context.org_id,
-            operation="aggregation",
-            fn=lambda: aggregator.run(request),
-        )
-    except TimeoutError:
+        root_config = request_context.configurator.get_config()
+        playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
+        if not playbook_config or not playbook_config.aggregation_config:
+            return AggregationTriggerResult(
+                status="skipped_no_config",
+                reason=reason,
+                agent_version=agent_version,
+            )
+
         logger.info(
-            "Skipping inline aggregation for agent_version=%s reason=%s: aggregation limiter is saturated",
+            "Triggering user playbook aggregation agent_version=%s reason=%s",
             agent_version,
             reason,
         )
-        return AggregationTriggerResult(
-            status="skipped_saturated",
-            reason=reason,
+        aggregator_kwargs: dict[str, Any] = {}
+        aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
+        if aggregation_prompt_processor is not None:
+            aggregator_kwargs["aggregation_prompt_processor"] = (
+                aggregation_prompt_processor
+            )
+
+        aggregator = PlaybookAggregator(
+            llm_client=llm_client,
+            request_context=request_context,
             agent_version=agent_version,
-            error_type="TimeoutError",
+            **aggregator_kwargs,
         )
+        request = PlaybookAggregatorRequest(agent_version=agent_version)
+        try:
+            run_with_operation_limit(
+                org_id=request_context.org_id,
+                operation="aggregation",
+                fn=lambda: aggregator.run(request),
+            )
+        except TimeoutError:
+            logger.info(
+                "Skipping inline aggregation for agent_version=%s reason=%s: aggregation limiter is saturated",
+                agent_version,
+                reason,
+            )
+            return AggregationTriggerResult(
+                status="skipped_saturated",
+                reason=reason,
+                agent_version=agent_version,
+                error_type="TimeoutError",
+            )
+        except Exception as exc:  # noqa: BLE001
+            return _failed_result(
+                exc=exc,
+                reason=reason,
+                agent_version=agent_version,
+                message="User playbook aggregation failed after successor commit",
+            )
     except Exception as exc:  # noqa: BLE001
-        logger.exception(
-            "User playbook aggregation failed after successor commit agent_version=%s reason=%s",
-            agent_version,
-            reason,
-        )
-        return AggregationTriggerResult(
-            status="failed",
+        return _failed_result(
+            exc=exc,
             reason=reason,
             agent_version=agent_version,
-            error_type=type(exc).__name__,
+            message="User playbook aggregation setup failed",
         )
 
     return AggregationTriggerResult(

--- a/reflexio/server/services/playbook/aggregation_trigger.py
+++ b/reflexio/server/services/playbook/aggregation_trigger.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.extensions import get_service
+from reflexio.server.operation_limiter import run_with_operation_limit
+from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
+)
+from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
+from reflexio.server.services.playbook.playbook_service_utils import (
+    PlaybookAggregatorRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+AggregationTriggerStatus = Literal[
+    "triggered",
+    "skipped_no_config",
+    "skipped_saturated",
+    "failed",
+]
+
+
+@dataclass(frozen=True)
+class AggregationTriggerResult:
+    status: AggregationTriggerStatus
+    reason: str
+    agent_version: str
+    error_type: str | None = None
+
+
+def maybe_trigger_user_playbook_aggregation(
+    *,
+    request_context: RequestContext,
+    llm_client: Any,
+    agent_version: str,
+    reason: str,
+) -> AggregationTriggerResult:
+    root_config = request_context.configurator.get_config()
+    playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
+    if not playbook_config or not playbook_config.aggregation_config:
+        return AggregationTriggerResult(
+            status="skipped_no_config",
+            reason=reason,
+            agent_version=agent_version,
+        )
+
+    logger.info(
+        "Triggering user playbook aggregation agent_version=%s reason=%s",
+        agent_version,
+        reason,
+    )
+    aggregator_kwargs: dict[str, Any] = {}
+    aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
+    if aggregation_prompt_processor is not None:
+        aggregator_kwargs["aggregation_prompt_processor"] = aggregation_prompt_processor
+
+    aggregator = PlaybookAggregator(
+        llm_client=llm_client,
+        request_context=request_context,
+        agent_version=agent_version,
+        **aggregator_kwargs,
+    )
+    request = PlaybookAggregatorRequest(agent_version=agent_version)
+    try:
+        run_with_operation_limit(
+            org_id=request_context.org_id,
+            operation="aggregation",
+            fn=lambda: aggregator.run(request),
+        )
+    except TimeoutError:
+        logger.info(
+            "Skipping inline aggregation for agent_version=%s reason=%s: aggregation limiter is saturated",
+            agent_version,
+            reason,
+        )
+        return AggregationTriggerResult(
+            status="skipped_saturated",
+            reason=reason,
+            agent_version=agent_version,
+            error_type="TimeoutError",
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception(
+            "User playbook aggregation failed after successor commit agent_version=%s reason=%s",
+            agent_version,
+            reason,
+        )
+        return AggregationTriggerResult(
+            status="failed",
+            reason=reason,
+            agent_version=agent_version,
+            error_type=type(exc).__name__,
+        )
+
+    return AggregationTriggerResult(
+        status="triggered",
+        reason=reason,
+        agent_version=agent_version,
+    )

--- a/reflexio/server/services/playbook/aggregation_trigger.py
+++ b/reflexio/server/services/playbook/aggregation_trigger.py
@@ -54,6 +54,12 @@ def _failed_result(
     )
 
 
+def has_user_playbook_aggregation_config(request_context: RequestContext) -> bool:
+    root_config = request_context.configurator.get_config()
+    playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
+    return bool(playbook_config and playbook_config.aggregation_config)
+
+
 def maybe_trigger_user_playbook_aggregation(
     *,
     request_context: RequestContext,
@@ -62,9 +68,7 @@ def maybe_trigger_user_playbook_aggregation(
     reason: str,
 ) -> AggregationTriggerResult:
     try:
-        root_config = request_context.configurator.get_config()
-        playbook_config = getattr(root_config, "user_playbook_extractor_config", None)
-        if not playbook_config or not playbook_config.aggregation_config:
+        if not has_user_playbook_aggregation_config(request_context):
             return AggregationTriggerResult(
                 status="skipped_no_config",
                 reason=reason,

--- a/reflexio/server/services/playbook/service.py
+++ b/reflexio/server/services/playbook/service.py
@@ -22,22 +22,18 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
 )
 from reflexio.models.config_schema import PlaybookConfig
-from reflexio.server.extensions import get_service
-from reflexio.server.operation_limiter import run_with_operation_limit
 from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     StatusChangeOperation,
 )
-from reflexio.server.services.playbook.aggregation_prompt_processing import (
-    AGGREGATION_PROMPT_PROCESSOR,
+from reflexio.server.services.playbook.aggregation_trigger import (
+    maybe_trigger_user_playbook_aggregation,
 )
-from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
 from reflexio.server.services.playbook.components.extractor import PlaybookExtractor
 from reflexio.server.services.playbook.playbook_service_constants import (
     PlaybookServiceConstants,
 )
 from reflexio.server.services.playbook.playbook_service_utils import (
-    PlaybookAggregatorRequest,
     PlaybookGenerationRequest,
     format_expert_comparison_pairs,
     has_expert_content,
@@ -528,42 +524,12 @@ class PlaybookGenerationService(
         Trigger playbook aggregation for playbook types that have aggregator config.
         This is called after raw user playbook entries are saved to check if aggregation should run.
         """
-        playbook_config = self._configured_playbook_config()
-        if not playbook_config or not playbook_config.aggregation_config:
-            return
-
-        logger.info("Triggering aggregation")
-
-        # Create aggregator request. Aggregation is singleton — it operates on the
-        # user's whole playbook set, so no name selector is threaded.
-        aggregator_request = PlaybookAggregatorRequest(
-            agent_version=self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
-        )
-
-        # Initialize and run aggregator (synchronous)
-        aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
-        aggregator_kwargs = {}
-        if aggregation_prompt_processor is not None:
-            aggregator_kwargs["aggregation_prompt_processor"] = (
-                aggregation_prompt_processor
-            )
-        aggregator = PlaybookAggregator(
-            llm_client=self.client,
+        maybe_trigger_user_playbook_aggregation(
             request_context=self.request_context,
+            llm_client=self.client,
             agent_version=self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
-            **aggregator_kwargs,
+            reason="playbook_generation",
         )
-        try:
-            run_with_operation_limit(
-                org_id=self.request_context.org_id,
-                operation="aggregation",
-                fn=lambda: aggregator.run(aggregator_request),
-            )
-        except TimeoutError:
-            logger.info(
-                "Skipping inline aggregation for agent_version=%s: aggregation limiter is saturated",
-                self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
-            )
 
     # ===============================
     # Rerun hook implementations (override base class methods)

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -20,6 +20,9 @@ from reflexio.models.api_schema.domain.entities import LineageContext
 from reflexio.models.config_schema import PlaybookOptimizerConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.playbook.aggregation_trigger import (
+    maybe_trigger_user_playbook_aggregation,
+)
 from reflexio.server.tracing import sentry_tags
 
 from .assistant_webhook import AssistantCallable, LocalScriptAssistant, WebhookAssistant
@@ -488,13 +491,21 @@ class PlaybookOptimizer:
         # the rule wording, so writing ``best_content`` is sufficient — there
         # is no derived polarity label or separate polarity field to keep in
         # sync.
-        return _supersede_user_playbook(
+        successor_id = _supersede_user_playbook(
             self.storage,
             current_user,
             best_content,
             "playbook_optimizer",
             request_id=run_request_id,
         )
+        if successor_id is not None:
+            maybe_trigger_user_playbook_aggregation(
+                request_context=self.request_context,
+                llm_client=self.llm_client,
+                agent_version=current_user.agent_version,
+                reason="playbook_optimizer",
+            )
+        return successor_id
 
 
 def _agent_like_playbook(playbook: UserPlaybook) -> AgentPlaybook:

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -499,13 +499,19 @@ class PlaybookOptimizer:
             request_id=run_request_id,
         )
         if successor_id is not None:
-            successor = self.storage.get_user_playbook_by_id(successor_id)
-            if successor is not None and successor.agent_version:
-                maybe_trigger_user_playbook_aggregation(
-                    request_context=self.request_context,
-                    llm_client=self.llm_client,
-                    agent_version=successor.agent_version,
-                    reason="playbook_optimizer",
+            try:
+                successor = self.storage.get_user_playbook_by_id(successor_id)
+                if successor is not None and successor.agent_version:
+                    maybe_trigger_user_playbook_aggregation(
+                        request_context=self.request_context,
+                        llm_client=self.llm_client,
+                        agent_version=successor.agent_version,
+                        reason="playbook_optimizer",
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "playbook_optimizer aggregation trigger failed after successor commit",
+                    extra={"successor_id": successor_id},
                 )
         return successor_id
 

--- a/reflexio/server/services/playbook_optimizer/optimizer.py
+++ b/reflexio/server/services/playbook_optimizer/optimizer.py
@@ -499,12 +499,14 @@ class PlaybookOptimizer:
             request_id=run_request_id,
         )
         if successor_id is not None:
-            maybe_trigger_user_playbook_aggregation(
-                request_context=self.request_context,
-                llm_client=self.llm_client,
-                agent_version=current_user.agent_version,
-                reason="playbook_optimizer",
-            )
+            successor = self.storage.get_user_playbook_by_id(successor_id)
+            if successor is not None and successor.agent_version:
+                maybe_trigger_user_playbook_aggregation(
+                    request_context=self.request_context,
+                    llm_client=self.llm_client,
+                    agent_version=successor.agent_version,
+                    reason="playbook_optimizer",
+                )
         return successor_id
 
 

--- a/reflexio/server/services/reflection/service.py
+++ b/reflexio/server/services/reflection/service.py
@@ -40,6 +40,9 @@ from reflexio.models.api_schema.domain.entities import (
 )
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.operation_state_utils import OperationStateManager
+from reflexio.server.services.playbook.aggregation_trigger import (
+    maybe_trigger_user_playbook_aggregation,
+)
 from reflexio.server.services.playbook.playbook_edit_apply import apply_playbook_edit
 from reflexio.server.services.reflection.components.extractor import (
     ReflectionExtractor,
@@ -655,6 +658,13 @@ class ReflectionService:
                     new_playbook.user_playbook_id,
                 )
             return True
+        if archived > 0:
+            maybe_trigger_user_playbook_aggregation(
+                request_context=self.request_context,
+                llm_client=self.client,
+                agent_version=new_playbook.agent_version,
+                reason="reflection",
+            )
         if archived < 0:
             with sentry_tags(
                 subsystem="reflection",

--- a/reflexio/server/services/reflection/service.py
+++ b/reflexio/server/services/reflection/service.py
@@ -659,12 +659,21 @@ class ReflectionService:
                 )
             return True
         if archived > 0:
-            maybe_trigger_user_playbook_aggregation(
-                request_context=self.request_context,
-                llm_client=self.client,
-                agent_version=new_playbook.agent_version,
-                reason="reflection",
-            )
+            try:
+                successor = storage.get_user_playbook_by_id(archived)
+                if successor is not None and successor.agent_version:
+                    maybe_trigger_user_playbook_aggregation(
+                        request_context=self.request_context,
+                        llm_client=self.client,
+                        agent_version=successor.agent_version,
+                        reason="reflection",
+                    )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "event=reflection_aggregation_trigger_failed kind=playbook "
+                    "successor_id=%s",
+                    archived,
+                )
         if archived < 0:
             with sentry_tags(
                 subsystem="reflection",

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -1,5 +1,6 @@
 import datetime
 import tempfile
+from contextlib import nullcontext
 from datetime import UTC
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -286,6 +287,89 @@ def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising
 
     assert result.status == "failed"
     assert result.error_type == "RuntimeError"
+
+
+def test_maybe_trigger_user_playbook_aggregation_reports_timeout_saturation():
+    from reflexio.server.services.playbook.aggregation_trigger import (
+        maybe_trigger_user_playbook_aggregation,
+    )
+
+    configurator = MagicMock()
+    configurator.get_config.return_value = _aggregation_enabled_config()
+    ctx = MagicMock(configurator=configurator, org_id="test-org")
+
+    with patch(
+        "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
+        side_effect=TimeoutError("aggregation limiter saturated"),
+    ):
+        result = maybe_trigger_user_playbook_aggregation(
+            request_context=ctx,
+            llm_client=MagicMock(),
+            agent_version="v1",
+            reason="post_commit",
+        )
+
+    assert result.status == "skipped_saturated"
+    assert result.error_type == "TimeoutError"
+
+
+@pytest.mark.parametrize(
+    ("patch_target", "error_type"),
+    [
+        (None, "RuntimeError"),
+        (
+            "reflexio.server.services.playbook.aggregation_trigger.get_service",
+            "LookupError",
+        ),
+        (
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
+            "ValueError",
+        ),
+        (
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregatorRequest",
+            "TypeError",
+        ),
+    ],
+)
+def test_maybe_trigger_user_playbook_aggregation_reports_setup_failure_without_raising(
+    patch_target: str | None, error_type: str
+):
+    from reflexio.server.services.playbook.aggregation_trigger import (
+        maybe_trigger_user_playbook_aggregation,
+    )
+
+    configurator = MagicMock()
+    configurator.get_config.return_value = _aggregation_enabled_config()
+    ctx = MagicMock(configurator=configurator, org_id="test-org")
+
+    expected_error = {
+        "RuntimeError": RuntimeError("config failed"),
+        "LookupError": LookupError("processor failed"),
+        "ValueError": ValueError("aggregator failed"),
+        "TypeError": TypeError("request failed"),
+    }[error_type]
+    if patch_target is None:
+        configurator.get_config.side_effect = expected_error
+        failure_context = nullcontext()
+    else:
+        failure_context = patch(patch_target, side_effect=expected_error)
+
+    with (
+        failure_context,
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit"
+        ) as limiter,
+    ):
+        result = maybe_trigger_user_playbook_aggregation(
+            request_context=ctx,
+            llm_client=MagicMock(),
+            agent_version="v1",
+            reason="post_commit",
+        )
+
+    assert result.status == "failed"
+    assert result.error_type == error_type
+    limiter.assert_not_called()
 
 
 @pytest.fixture

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -104,6 +104,10 @@ def test_inline_aggregation_default_path_does_not_inject_processor():
             "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
             side_effect=lambda **kwargs: kwargs["fn"](),
         ),
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
+            side_effect=lambda task: task(),
+        ),
     ):
         service._trigger_playbook_aggregation()
 
@@ -193,6 +197,7 @@ def test_maybe_trigger_user_playbook_aggregation_uses_limiter_and_processor():
     llm_client = MagicMock()
     created_kwargs: list[dict[str, Any]] = []
     requests: list[Any] = []
+    task_results: list[Any] = []
 
     class FakeAggregator:
         def __init__(self, **kwargs: Any) -> None:
@@ -211,6 +216,10 @@ def test_maybe_trigger_user_playbook_aggregation_uses_limiter_and_processor():
             "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
             side_effect=lambda **kwargs: kwargs["fn"](),
         ) as limiter,
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
+            side_effect=lambda task: task_results.append(task()),
+        ),
     ):
         result = maybe_trigger_user_playbook_aggregation(
             request_context=ctx,
@@ -219,9 +228,10 @@ def test_maybe_trigger_user_playbook_aggregation_uses_limiter_and_processor():
             reason="unit_test",
         )
 
-    assert result.status == "triggered"
+    assert result.status == "queued"
     assert result.reason == "unit_test"
     assert result.agent_version == "v1"
+    assert task_results[0].status == "triggered"
     assert limiter.call_args.kwargs["org_id"] == "test-org"
     assert limiter.call_args.kwargs["operation"] == "aggregation"
     assert created_kwargs[0]["llm_client"] is llm_client
@@ -260,6 +270,7 @@ def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
     ctx = MagicMock(configurator=configurator, org_id="test-org")
+    task_results: list[Any] = []
 
     class FailingAggregator:
         def __init__(self, **_kwargs: Any) -> None:
@@ -277,6 +288,10 @@ def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising
             "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
             side_effect=lambda **kwargs: kwargs["fn"](),
         ),
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
+            side_effect=lambda task: task_results.append(task()),
+        ),
     ):
         result = maybe_trigger_user_playbook_aggregation(
             request_context=ctx,
@@ -285,8 +300,9 @@ def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising
             reason="post_commit",
         )
 
-    assert result.status == "failed"
-    assert result.error_type == "RuntimeError"
+    assert result.status == "queued"
+    assert task_results[0].status == "failed"
+    assert task_results[0].error_type == "RuntimeError"
 
 
 def test_maybe_trigger_user_playbook_aggregation_reports_timeout_saturation():
@@ -297,10 +313,14 @@ def test_maybe_trigger_user_playbook_aggregation_reports_timeout_saturation():
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
     ctx = MagicMock(configurator=configurator, org_id="test-org")
+    task_results: list[Any] = []
 
     with patch(
         "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
         side_effect=TimeoutError("aggregation limiter saturated"),
+    ), patch(
+        "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
+        side_effect=lambda task: task_results.append(task()),
     ):
         result = maybe_trigger_user_playbook_aggregation(
             request_context=ctx,
@@ -309,8 +329,9 @@ def test_maybe_trigger_user_playbook_aggregation_reports_timeout_saturation():
             reason="post_commit",
         )
 
-    assert result.status == "skipped_saturated"
-    assert result.error_type == "TimeoutError"
+    assert result.status == "queued"
+    assert task_results[0].status == "skipped_saturated"
+    assert task_results[0].error_type == "TimeoutError"
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -96,11 +96,11 @@ def test_inline_aggregation_default_path_does_not_inject_processor():
 
     with (
         patch(
-            "reflexio.server.services.playbook.service.PlaybookAggregator",
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
             FakeAggregator,
         ),
         patch(
-            "reflexio.server.services.playbook.service.run_with_operation_limit",
+            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
             side_effect=lambda **kwargs: kwargs["fn"](),
         ),
     ):
@@ -128,11 +128,11 @@ def test_inline_aggregation_injects_registered_processor():
 
     with (
         patch(
-            "reflexio.server.services.playbook.service.PlaybookAggregator",
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
             FakeAggregator,
         ),
         patch(
-            "reflexio.server.services.playbook.service.run_with_operation_limit",
+            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
             side_effect=lambda **kwargs: kwargs["fn"](),
         ),
     ):
@@ -161,11 +161,11 @@ def test_inline_aggregation_does_not_thread_processor_prompt_text_separately():
 
     with (
         patch(
-            "reflexio.server.services.playbook.service.PlaybookAggregator",
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
             FakeAggregator,
         ),
         patch(
-            "reflexio.server.services.playbook.service.run_with_operation_limit",
+            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
             side_effect=lambda **kwargs: kwargs["fn"](),
         ),
     ):
@@ -174,6 +174,118 @@ def test_inline_aggregation_does_not_thread_processor_prompt_text_separately():
     assert len(created_kwargs) == 1
     assert created_kwargs[0]["aggregation_prompt_processor"] is processor
     assert "aggregation_prompt_extra_instructions" not in created_kwargs[0]
+
+
+def test_maybe_trigger_user_playbook_aggregation_uses_limiter_and_processor():
+    from reflexio.server.services.playbook.aggregation_trigger import (
+        maybe_trigger_user_playbook_aggregation,
+    )
+
+    processor = PassthroughPromptProcessor()
+    register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
+
+    configurator = MagicMock()
+    configurator.get_config.return_value = _aggregation_enabled_config()
+    ctx = MagicMock()
+    ctx.configurator = configurator
+    ctx.org_id = "test-org"
+    llm_client = MagicMock()
+    created_kwargs: list[dict[str, Any]] = []
+    requests: list[Any] = []
+
+    class FakeAggregator:
+        def __init__(self, **kwargs: Any) -> None:
+            created_kwargs.append(kwargs)
+
+        def run(self, request: Any) -> dict[str, int]:
+            requests.append(request)
+            return {"playbooks_generated": 0}
+
+    with (
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
+            FakeAggregator,
+        ),
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
+            side_effect=lambda **kwargs: kwargs["fn"](),
+        ) as limiter,
+    ):
+        result = maybe_trigger_user_playbook_aggregation(
+            request_context=ctx,
+            llm_client=llm_client,
+            agent_version="v1",
+            reason="unit_test",
+        )
+
+    assert result.status == "triggered"
+    assert result.reason == "unit_test"
+    assert result.agent_version == "v1"
+    assert limiter.call_args.kwargs["org_id"] == "test-org"
+    assert limiter.call_args.kwargs["operation"] == "aggregation"
+    assert created_kwargs[0]["llm_client"] is llm_client
+    assert created_kwargs[0]["request_context"] is ctx
+    assert created_kwargs[0]["agent_version"] == "v1"
+    assert created_kwargs[0]["aggregation_prompt_processor"] is processor
+    assert requests[0].agent_version == "v1"
+
+
+def test_maybe_trigger_user_playbook_aggregation_reports_no_config():
+    from reflexio.server.services.playbook.aggregation_trigger import (
+        maybe_trigger_user_playbook_aggregation,
+    )
+
+    configurator = MagicMock()
+    configurator.get_config.return_value = Config(storage_config=StorageConfigSQLite())
+    ctx = MagicMock(configurator=configurator, org_id="test-org")
+
+    result = maybe_trigger_user_playbook_aggregation(
+        request_context=ctx,
+        llm_client=MagicMock(),
+        agent_version="v1",
+        reason="missing_config",
+    )
+
+    assert result.status == "skipped_no_config"
+    assert result.reason == "missing_config"
+    assert result.agent_version == "v1"
+
+
+def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising():
+    from reflexio.server.services.playbook.aggregation_trigger import (
+        maybe_trigger_user_playbook_aggregation,
+    )
+
+    configurator = MagicMock()
+    configurator.get_config.return_value = _aggregation_enabled_config()
+    ctx = MagicMock(configurator=configurator, org_id="test-org")
+
+    class FailingAggregator:
+        def __init__(self, **_kwargs: Any) -> None:
+            pass
+
+        def run(self, _request: Any) -> dict[str, int]:
+            raise RuntimeError("boom")
+
+    with (
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
+            FailingAggregator,
+        ),
+        patch(
+            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
+            side_effect=lambda **kwargs: kwargs["fn"](),
+        ),
+    ):
+        result = maybe_trigger_user_playbook_aggregation(
+            request_context=ctx,
+            llm_client=MagicMock(),
+            agent_version="v1",
+            reason="post_commit",
+        )
+
+    assert result.status == "failed"
+    assert result.error_type == "RuntimeError"
 
 
 @pytest.fixture

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -679,7 +679,9 @@ def test_optimizer_skips_when_winner_cannot_be_adopted(
     assert jobs == []
 
 
-def test_user_playbook_optimizer_successor_triggers_aggregation(tmp_path):
+def test_user_playbook_optimizer_successor_triggers_aggregation_with_successor_version(
+    tmp_path,
+):
     storage = _sqlite_storage(tmp_path)
     config = Config(
         storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
@@ -691,7 +693,7 @@ def test_user_playbook_optimizer_successor_triggers_aggregation(tmp_path):
     user_playbook = UserPlaybook(
         user_playbook_id=0,
         user_id="u1",
-        agent_version="v1",
+        agent_version="v-incumbent",
         request_id="req-1",
         content="old",
         trigger="when old",
@@ -700,11 +702,27 @@ def test_user_playbook_optimizer_successor_triggers_aggregation(tmp_path):
     target = PlaybookOptimizationTarget(
         kind="user_playbook", target_id=user_playbook.user_playbook_id
     )
+    original_supersede_record = storage.supersede_record
 
-    with patch(
-        "reflexio.server.services.playbook_optimizer.optimizer."
-        "maybe_trigger_user_playbook_aggregation",
-    ) as trigger:
+    def supersede_and_update_successor(*args, **kwargs):
+        ok = original_supersede_record(*args, **kwargs)
+        if ok:
+            storage.conn.execute(
+                "UPDATE user_playbooks SET agent_version = ? WHERE user_playbook_id = ?",
+                ("v-successor", int(kwargs["successor_id"])),
+            )
+            storage.conn.commit()
+        return ok
+
+    with (
+        patch.object(
+            storage, "supersede_record", side_effect=supersede_and_update_successor
+        ),
+        patch(
+            "reflexio.server.services.playbook_optimizer.optimizer."
+            "maybe_trigger_user_playbook_aggregation",
+        ) as trigger,
+    ):
         successor_id = optimizer._commit_if_allowed(  # noqa: SLF001
             target,
             _agent_like_playbook(user_playbook),
@@ -715,7 +733,7 @@ def test_user_playbook_optimizer_successor_triggers_aggregation(tmp_path):
 
     assert successor_id is not None
     trigger.assert_called_once()
-    assert trigger.call_args.kwargs["agent_version"] == "v1"
+    assert trigger.call_args.kwargs["agent_version"] == "v-successor"
     assert trigger.call_args.kwargs["reason"] == "playbook_optimizer"
 
 

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -777,6 +777,53 @@ def test_agent_playbook_optimizer_successor_does_not_trigger_aggregation(tmp_pat
     trigger.assert_not_called()
 
 
+def test_user_playbook_optimizer_successor_reload_failure_does_not_fail_commit(
+    tmp_path,
+):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            auto_update_user_playbooks=True
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    user_playbook = UserPlaybook(
+        user_playbook_id=0,
+        user_id="u1",
+        agent_version="v1",
+        request_id="req-1",
+        content="old",
+        trigger="when old",
+    )
+    storage.save_user_playbooks([user_playbook])
+    target = PlaybookOptimizationTarget(
+        kind="user_playbook", target_id=user_playbook.user_playbook_id
+    )
+
+    with (
+        patch.object(
+            storage,
+            "get_user_playbook_by_id",
+            side_effect=[user_playbook, RuntimeError("reload failed")],
+        ),
+        patch(
+            "reflexio.server.services.playbook_optimizer.optimizer."
+            "maybe_trigger_user_playbook_aggregation",
+        ) as trigger,
+    ):
+        successor_id = optimizer._commit_if_allowed(  # noqa: SLF001
+            target,
+            _agent_like_playbook(user_playbook),
+            "new",
+            config.playbook_optimizer_config,
+            "run-1",
+        )
+
+    assert successor_id is not None
+    trigger.assert_not_called()
+
+
 def test_optimizer_runs_single_window_when_commit_threshold_is_one(tmp_path):
     storage = _sqlite_storage(tmp_path)
     config = Config(

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -47,6 +47,7 @@ from reflexio.server.services.playbook_optimizer.models import (
 )
 from reflexio.server.services.playbook_optimizer.optimizer import (
     PlaybookOptimizer,
+    _agent_like_playbook,
     _split_train_validation_windows,
 )
 from reflexio.server.services.playbook_optimizer.rollout import MultiTurnRollout
@@ -676,6 +677,86 @@ def test_optimizer_skips_when_winner_cannot_be_adopted(
     optimizer._run_gepa.assert_not_called()  # type: ignore[attr-defined]
     jobs = storage.conn.execute("SELECT * FROM playbook_optimization_jobs").fetchall()
     assert jobs == []
+
+
+def test_user_playbook_optimizer_successor_triggers_aggregation(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            auto_update_user_playbooks=True
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    user_playbook = UserPlaybook(
+        user_playbook_id=0,
+        user_id="u1",
+        agent_version="v1",
+        request_id="req-1",
+        content="old",
+        trigger="when old",
+    )
+    storage.save_user_playbooks([user_playbook])
+    target = PlaybookOptimizationTarget(
+        kind="user_playbook", target_id=user_playbook.user_playbook_id
+    )
+
+    with patch(
+        "reflexio.server.services.playbook_optimizer.optimizer."
+        "maybe_trigger_user_playbook_aggregation",
+    ) as trigger:
+        successor_id = optimizer._commit_if_allowed(  # noqa: SLF001
+            target,
+            _agent_like_playbook(user_playbook),
+            "new",
+            config.playbook_optimizer_config,
+            "run-1",
+        )
+
+    assert successor_id is not None
+    trigger.assert_called_once()
+    assert trigger.call_args.kwargs["agent_version"] == "v1"
+    assert trigger.call_args.kwargs["reason"] == "playbook_optimizer"
+
+
+def test_agent_playbook_optimizer_successor_does_not_trigger_aggregation(tmp_path):
+    storage = _sqlite_storage(tmp_path)
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "reflexio.db")),
+        playbook_optimizer_config=PlaybookOptimizerConfig(
+            auto_update_pending_agent_playbooks=True
+        ),
+    )
+    optimizer = _optimizer_for_test(storage, config)
+    [agent_playbook] = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="support",
+                agent_version="v1",
+                content="old",
+                trigger="when old",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+    target = PlaybookOptimizationTarget(
+        kind="agent_playbook", target_id=agent_playbook.agent_playbook_id
+    )
+
+    with patch(
+        "reflexio.server.services.playbook_optimizer.optimizer."
+        "maybe_trigger_user_playbook_aggregation",
+    ) as trigger:
+        successor_id = optimizer._commit_if_allowed(  # noqa: SLF001
+            target,
+            agent_playbook,
+            "new",
+            config.playbook_optimizer_config,
+            "run-1",
+        )
+
+    assert successor_id is not None
+    trigger.assert_not_called()
 
 
 def test_optimizer_runs_single_window_when_commit_threshold_is_one(tmp_path):

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -457,6 +457,96 @@ class TestReplacePlaybook:
         assert len(current) == 1
         assert current[0].source_interaction_ids == [10, 11]
 
+    def test_successful_playbook_successor_triggers_aggregation(
+        self, request_context, service, llm_client
+    ):
+        _set_config(request_context)
+        storage = request_context.storage
+        _seed_playbook(storage, 1, "user-1")
+
+        cite = Citation(kind="playbook", real_id="1")
+        _seed_request_with_interactions(
+            storage,
+            "user-1",
+            "req-1",
+            [
+                _make_interaction("user-1", "req-1", "User", "hi"),
+                _make_interaction(
+                    "user-1", "req-1", "Assistant", "hello", citations=[cite]
+                ),
+            ],
+        )
+
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="playbook",
+                    target_id="1",
+                    new_content="new rule",
+                    new_rationale="rewritten because Y was wrong",
+                    reason="rule was wrong",
+                )
+            ]
+        )
+
+        with patch(
+            "reflexio.server.services.reflection.service."
+            "maybe_trigger_user_playbook_aggregation",
+        ) as trigger:
+            service.run(ReflectionServiceRequest(request_id="req-1", user_id="user-1"))
+
+        trigger.assert_called_once()
+        assert trigger.call_args.kwargs["request_context"] is request_context
+        assert trigger.call_args.kwargs["llm_client"] is llm_client
+        assert trigger.call_args.kwargs["agent_version"] == "v1"
+        assert trigger.call_args.kwargs["reason"] == "reflection"
+
+    def test_lost_cas_playbook_successor_does_not_trigger_aggregation(
+        self, request_context, service, llm_client
+    ):
+        _set_config(request_context)
+        storage = request_context.storage
+        _seed_playbook(storage, 1, "user-1")
+
+        cite = Citation(kind="playbook", real_id="1")
+        _seed_request_with_interactions(
+            storage,
+            "user-1",
+            "req-1",
+            [
+                _make_interaction("user-1", "req-1", "User", "hi"),
+                _make_interaction(
+                    "user-1", "req-1", "Assistant", "hello", citations=[cite]
+                ),
+            ],
+        )
+
+        llm_client.generate_chat_response.return_value = ReflectionOutput(
+            decisions=[
+                ReflectionDecision(
+                    target_kind="playbook",
+                    target_id="1",
+                    new_content="new rule",
+                    new_rationale="rewritten because Y was wrong",
+                    reason="rule was wrong",
+                )
+            ]
+        )
+
+        with (
+            patch(
+                "reflexio.server.services.reflection.service.apply_playbook_edit",
+                return_value=-1,
+            ),
+            patch(
+                "reflexio.server.services.reflection.service."
+                "maybe_trigger_user_playbook_aggregation",
+            ) as trigger,
+        ):
+            service.run(ReflectionServiceRequest(request_id="req-1", user_id="user-1"))
+
+        trigger.assert_not_called()
+
 
 class TestNoChange:
     def test_no_change_does_not_mutate_storage(

--- a/tests/server/services/reflection/test_reflection_service.py
+++ b/tests/server/services/reflection/test_reflection_service.py
@@ -547,6 +547,48 @@ class TestReplacePlaybook:
 
         trigger.assert_not_called()
 
+    def test_playbook_successor_reload_failure_does_not_fail_reflection(
+        self, request_context, service
+    ):
+        cited = UserPlaybook(
+            user_playbook_id=1,
+            user_id="user-1",
+            agent_version="v1",
+            request_id="req-1",
+            content="old rule",
+            trigger="when old",
+        )
+        decision = ReflectionDecision(
+            target_kind="playbook",
+            target_id="1",
+            new_content="new rule",
+            reason="rule was wrong",
+        )
+
+        with (
+            patch(
+                "reflexio.server.services.reflection.service.apply_playbook_edit",
+                return_value=2,
+            ),
+            patch.object(
+                request_context.storage,
+                "get_user_playbook_by_id",
+                side_effect=RuntimeError("reload failed"),
+            ),
+            patch(
+                "reflexio.server.services.reflection.service."
+                "maybe_trigger_user_playbook_aggregation",
+            ) as trigger,
+        ):
+            replaced = service._replace_playbook(  # noqa: SLF001
+                ReflectionServiceRequest(request_id="req-1", user_id="user-1"),
+                decision,
+                cited,
+            )
+
+        assert replaced is True
+        trigger.assert_not_called()
+
 
 class TestNoChange:
     def test_no_change_does_not_mutate_storage(


### PR DESCRIPTION
## Summary
- Ensure user-playbook successor creation re-checks the aggregation gate so agent playbooks stay consistent after durable user playbook replacements.
- Centralize best-effort aggregation triggering behind a shared helper that respects missing config, operation saturation, setup failures, and run failures.
- Cover reflection and optimizer successor flows with persisted-successor reload tests so aggregation uses committed row state.

## Changes
- Added `maybe_trigger_user_playbook_aggregation` and `has_user_playbook_aggregation_config` in the playbook service layer.
- Reused the helper from playbook extraction, reflection, and playbook optimizer successor paths.
- Added focused regression coverage for successful triggers, skipped config, saturated limiter, reload failures, and best-effort failures.

## Test Plan
- `uv run ruff check reflexio_ext/server/services/offline_tuner/runner.py reflexio_ext/tests/server/services/offline_tuner/test_runner.py open_source/reflexio/reflexio/server/services/playbook/aggregation_trigger.py open_source/reflexio/reflexio/server/services/playbook/service.py open_source/reflexio/reflexio/server/services/reflection/service.py open_source/reflexio/reflexio/server/services/playbook_optimizer/optimizer.py open_source/reflexio/tests/server/services/playbook/test_playbook_generation_service.py open_source/reflexio/tests/server/services/reflection/test_reflection_service.py open_source/reflexio/tests/server/services/playbook_optimizer/test_playbook_optimizer.py`
- `uv run pyright reflexio_ext/server/services/offline_tuner/runner.py reflexio_ext/tests/server/services/offline_tuner/test_runner.py open_source/reflexio/reflexio/server/services/playbook/aggregation_trigger.py`
- `REFLEXIO_TEST_MODE=1 uv run pytest open_source/reflexio/tests/server/services/playbook/test_playbook_generation_service.py open_source/reflexio/tests/server/services/reflection/test_reflection_service.py open_source/reflexio/tests/server/services/playbook_optimizer/test_playbook_optimizer.py reflexio_ext/tests/server/services/offline_tuner/test_rollback.py reflexio_ext/tests/server/services/offline_tuner/test_runner.py -q --no-cov`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter background aggregation for playbook-related updates, now queued when configuration is available.
  * Aggregation can be skipped when prerequisites are missing or the system is saturated, without impacting the main workflow.

* **Bug Fixes**
  * Improved resilience so aggregation issues don’t interfere with playbook generation, optimization, or reflection.
  * Aggregation is triggered only for the appropriate successor scenarios and won’t break successor processing.

* **Tests**
  * Expanded automated coverage for queueing behavior, missing-config skipping, timeout saturation handling, and successor-based reflection/optimization flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->