### PR TITLE
feat(durable): oldest-pending-age + status-count learning-job queries

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -16,7 +16,7 @@ iterates (e.g. the QPS billable-endpoint scan over ``core_router.routes``).
 
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -269,6 +269,7 @@ def create_app(
     capabilities: "CapabilityRegistry | None" = None,
     app_context_factory: "Callable[[], AppContext] | None" = None,
     profile: "DeploymentProfile | None" = None,
+    durable_org_ids_provider: Callable[[], Iterable[str]] | None = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -310,6 +311,16 @@ def create_app(
             provided it is the single source for router-group mounting, auth, and
             data-plane lifespan gating (the legacy knobs still populate the derived
             profile, so callers may pass either — they express the same thing).
+        durable_org_ids_provider: Optional zero-arg callable returning the org_ids
+            with actionable durable-learning work, threaded straight through to
+            ``maybe_start_durable_learning(org_ids_provider=...)``. When None
+            (default) the single-ref bootstrap default is used, so behaviour is
+            byte-identical to before this parameter existed. It is a plain
+            injectable seam so a deployment (e.g. enterprise cross-ref fan-out) can
+            supply its own discovery WITHOUT this factory importing deployment
+            logic. It is only consulted when ``REFLEXIO_DURABLE_LEARNING_QUEUE`` is
+            on — when the flag is off ``maybe_start_durable_learning`` returns None
+            without ever calling the provider.
 
     Returns:
         Configured FastAPI application.
@@ -382,11 +393,13 @@ def create_app(
             )
             # Durable learning drains the learning_jobs queue per org. Gated on
             # REFLEXIO_DURABLE_LEARNING_QUEUE; the default provider discovers
-            # orgs-with-work via the bootstrap storage (single-ref). Enterprise
-            # cross-ref fan-out is a deferred follow-up.
+            # orgs-with-work via the bootstrap storage (single-ref). A deployment
+            # may inject its own discovery via ``durable_org_ids_provider`` (e.g.
+            # enterprise cross-ref fan-out); when None the single-ref default runs.
             durable_learning_scheduler = maybe_start_durable_learning(
                 lambda org_id: RequestContext(org_id=org_id),
                 bootstrap_org_id=bootstrap_org_id,
+                org_ids_provider=durable_org_ids_provider,
             )
         try:
             if capabilities is not None:

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -332,9 +332,7 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
             """,
             (),
         )
-        if not row or row[0]["age_seconds"] is None:
-            return None
-        return float(row[0]["age_seconds"])
+        return None if row[0]["age_seconds"] is None else float(row[0]["age_seconds"])
 
     @SQLiteStorageBase.handle_exceptions
     def count_learning_jobs_by_status(self, status: str) -> int:
@@ -343,8 +341,6 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
             "SELECT COUNT(*) AS cnt FROM learning_jobs WHERE status = ?",
             (status,),
         )
-        if not row:
-            return 0
         return int(row[0]["cnt"])
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
+++ b/reflexio/server/services/storage/sqlite_storage/_learning_jobs.py
@@ -317,6 +317,37 @@ class SQLiteLearningJobStoreMixin(LearningJobStoreABC):
         return [str(row["org_id"]) for row in rows]
 
     @SQLiteStorageBase.handle_exceptions
+    def get_oldest_pending_learning_job_age_seconds(self) -> float | None:
+        """Age in seconds of the oldest pending job, or None if none pending.
+
+        Computes the age entirely in SQLite using ``strftime('%s','now')`` to
+        avoid app/DB clock skew.  The table is accessed without a schema prefix
+        (SQLite has no schema routing — the local DB file is the ref).
+        """
+        row = self._fetchall(
+            """
+            SELECT (strftime('%s', 'now') - strftime('%s', MIN(created_at))) AS age_seconds
+            FROM learning_jobs
+            WHERE status = 'pending'
+            """,
+            (),
+        )
+        if not row or row[0]["age_seconds"] is None:
+            return None
+        return float(row[0]["age_seconds"])
+
+    @SQLiteStorageBase.handle_exceptions
+    def count_learning_jobs_by_status(self, status: str) -> int:
+        """Count of learning jobs with the given status on this storage ref."""
+        row = self._fetchall(
+            "SELECT COUNT(*) AS cnt FROM learning_jobs WHERE status = ?",
+            (status,),
+        )
+        if not row:
+            return 0
+        return int(row[0]["cnt"])
+
+    @SQLiteStorageBase.handle_exceptions
     def get_learning_status_for_request(
         self,
         *,

--- a/reflexio/server/services/storage/storage_base/_learning_jobs.py
+++ b/reflexio/server/services/storage/storage_base/_learning_jobs.py
@@ -180,6 +180,36 @@ class LearningJobStoreABC(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def get_oldest_pending_learning_job_age_seconds(self) -> float | None:
+        """Age in seconds of the oldest ``status='pending'`` job on this storage ref.
+
+        Returns:
+            The age in seconds (``now - created_at``) of the oldest pending job,
+            or ``None`` if there are no pending jobs.
+
+        Resolves the table via the same placement resolver used by
+        ``list_org_ids_with_pending_learning_jobs`` — never hardcodes
+        ``public.`` or ``reflexio_ops.``.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def count_learning_jobs_by_status(self, status: str) -> int:
+        """Count of learning jobs with the given ``status`` on this storage ref.
+
+        Args:
+            status: One of ``'pending'``, ``'claimed'``, ``'done'``,
+                ``'failed'``, or ``'dead'``.
+
+        Returns:
+            The integer count of matching rows (0 if none).
+
+        Resolves the table via the same placement resolver used by the other
+        query methods — never hardcodes schema prefix.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def get_learning_status_for_request(
         self,
         *,

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -473,6 +473,144 @@ class TestOrgDiscovery:
         assert storage.org_id in storage.list_org_ids_with_pending_learning_jobs()
 
 
+class TestQueueAlarmQueries:
+    """Contract tests for the queue-alarm query methods (Task 1 of durable XRef)."""
+
+    def test_oldest_pending_age_none_when_no_pending(self, storage) -> None:
+        """Returns None when there are no pending jobs."""
+        assert storage.get_oldest_pending_learning_job_age_seconds() is None
+
+    def test_oldest_pending_age_returns_float_when_pending(self, storage) -> None:
+        """Returns a non-negative float when at least one pending job exists."""
+        _enqueue(storage, "u-age1", "r-age1", 1000.0)
+        age = storage.get_oldest_pending_learning_job_age_seconds()
+        assert age is not None
+        assert isinstance(age, float)
+        assert age >= 0.0
+
+    def test_oldest_pending_age_ignores_non_pending(self, storage) -> None:
+        """A claimed, done, failed, or dead job does not contribute to oldest-pending age."""
+        # Enqueue and immediately claim the job → status becomes 'claimed', not 'pending'.
+        _enqueue(storage, "u-age-np", "r-age-np", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-age-np"
+        ]
+        assert job.status == "claimed"
+        # No pending jobs → must return None.
+        assert storage.get_oldest_pending_learning_job_age_seconds() is None
+
+    def test_oldest_pending_age_picks_oldest(self, storage) -> None:
+        """When there are multiple pending jobs the method returns the age of the oldest.
+
+        We inject the created_at directly (bypassing enqueue) so we can control
+        the timestamp precisely.
+        """
+        import time
+        import uuid as _uuid
+        from datetime import UTC, datetime
+
+        now = time.time()
+        older_ts = now - 100  # 100 seconds ago
+        newer_ts = now - 10  # 10 seconds ago
+
+        # Insert two pending rows with controlled created_at values.
+        older_iso = datetime.fromtimestamp(older_ts, tz=UTC).strftime(
+            "%Y-%m-%dT%H:%M:%S.000Z"
+        )
+        newer_iso = datetime.fromtimestamp(newer_ts, tz=UTC).strftime(
+            "%Y-%m-%dT%H:%M:%S.000Z"
+        )
+
+        storage.conn.execute(
+            """
+            INSERT INTO learning_jobs
+                (job_id, org_id, user_id, job_type, latest_request_id,
+                 covers_through, status, force_extraction, skip_aggregation,
+                 created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, 0, ?, ?)
+            """,
+            (
+                str(_uuid.uuid4()),
+                storage.org_id,
+                "u-old",
+                "learning",
+                "r-old",
+                older_iso,
+                older_iso,
+                older_iso,
+            ),
+        )
+        storage.conn.execute(
+            """
+            INSERT INTO learning_jobs
+                (job_id, org_id, user_id, job_type, latest_request_id,
+                 covers_through, status, force_extraction, skip_aggregation,
+                 created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'pending', 0, 0, ?, ?)
+            """,
+            (
+                str(_uuid.uuid4()),
+                storage.org_id,
+                "u-new",
+                "learning",
+                "r-new",
+                newer_iso,
+                newer_iso,
+                newer_iso,
+            ),
+        )
+        storage.conn.commit()
+
+        age = storage.get_oldest_pending_learning_job_age_seconds()
+        assert age is not None
+        # The oldest pending job was created ~100 s ago; allow +/-5 s clock tolerance.
+        assert 95.0 <= age <= 105.0, f"Expected ~100 s, got {age}"
+
+    def test_count_by_status_zero_when_empty(self, storage) -> None:
+        """count_learning_jobs_by_status returns 0 for all statuses when empty."""
+        for status in ("pending", "claimed", "done", "failed", "dead"):
+            assert storage.count_learning_jobs_by_status(status) == 0
+
+    def test_count_by_status_pending(self, storage) -> None:
+        """Counts pending jobs correctly."""
+        _enqueue(storage, "u-cnt1", "r-cnt1", 1000.0)
+        _enqueue(storage, "u-cnt2", "r-cnt2", 2000.0)
+        assert storage.count_learning_jobs_by_status("pending") == 2
+
+    def test_count_by_status_dead(self, storage) -> None:
+        """Counts dead jobs correctly (including 'dead' which is terminal)."""
+        _enqueue(storage, "u-cntd", "r-cntd", 1000.0)
+        [job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-cntd"
+        ]
+        storage.fail_learning_job(
+            job_id=job.job_id, claim_token=job.claim_token, dead=True
+        )
+        assert storage.count_learning_jobs_by_status("dead") == 1
+        assert storage.count_learning_jobs_by_status("pending") == 0
+
+    def test_count_by_status_mixed(self, storage) -> None:
+        """Count is scoped correctly across multiple statuses."""
+        _enqueue(storage, "u-mix1", "r-mix1", 1000.0)
+        _enqueue(storage, "u-mix2", "r-mix2", 1000.0)
+        # Claim only one of the two pending jobs (limit=1).
+        claimed = storage.claim_learning_jobs(
+            claimed_by="w1", limit=1, lease_seconds=300
+        )
+        assert len(claimed) == 1
+        assert storage.count_learning_jobs_by_status("pending") == 1
+        assert storage.count_learning_jobs_by_status("claimed") == 1
+        assert storage.count_learning_jobs_by_status("done") == 0
+
+
 class TestRetrySemantics:
     def test_failed_job_is_reclaimable(self, storage) -> None:
         """A failed (not dead) job must be re-claimable without manual status reset.

--- a/tests/server/services/storage/test_storage_contract_learning_jobs.py
+++ b/tests/server/services/storage/test_storage_contract_learning_jobs.py
@@ -489,18 +489,52 @@ class TestQueueAlarmQueries:
         assert age >= 0.0
 
     def test_oldest_pending_age_ignores_non_pending(self, storage) -> None:
-        """A claimed, done, failed, or dead job does not contribute to oldest-pending age."""
+        """Non-pending jobs (claimed, done, failed, dead) do not contribute to oldest-pending age."""
         # Enqueue and immediately claim the job → status becomes 'claimed', not 'pending'.
-        _enqueue(storage, "u-age-np", "r-age-np", 1000.0)
-        [job] = [
+        _enqueue(storage, "u-age-np-cl", "r-age-np-cl", 1000.0)
+        [claimed_job] = [
             j
             for j in storage.claim_learning_jobs(
                 claimed_by="w1", limit=10, lease_seconds=300
             )
-            if j.user_id == "u-age-np"
+            if j.user_id == "u-age-np-cl"
         ]
-        assert job.status == "claimed"
+        assert claimed_job.status == "claimed"
         # No pending jobs → must return None.
+        assert storage.get_oldest_pending_learning_job_age_seconds() is None
+
+        # Complete the claimed job → 'done'; still no pending.
+        storage.complete_learning_job(
+            job_id=claimed_job.job_id, claim_token=claimed_job.claim_token
+        )
+        assert storage.get_oldest_pending_learning_job_age_seconds() is None
+
+        # Enqueue, claim, and fail (dead=False) → 'failed'; still no pending.
+        _enqueue(storage, "u-age-np-fail", "r-age-np-fail", 1000.0)
+        [failed_job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-age-np-fail"
+        ]
+        storage.fail_learning_job(
+            job_id=failed_job.job_id, claim_token=failed_job.claim_token, dead=False
+        )
+        assert storage.get_oldest_pending_learning_job_age_seconds() is None
+
+        # Enqueue, claim, and kill (dead=True) → 'dead'; still no pending.
+        _enqueue(storage, "u-age-np-dead", "r-age-np-dead", 1000.0)
+        [dead_job] = [
+            j
+            for j in storage.claim_learning_jobs(
+                claimed_by="w1", limit=10, lease_seconds=300
+            )
+            if j.user_id == "u-age-np-dead"
+        ]
+        storage.fail_learning_job(
+            job_id=dead_job.job_id, claim_token=dead_job.claim_token, dead=True
+        )
         assert storage.get_oldest_pending_learning_job_age_seconds() is None
 
     def test_oldest_pending_age_picks_oldest(self, storage) -> None:
@@ -509,6 +543,10 @@ class TestQueueAlarmQueries:
         We inject the created_at directly (bypassing enqueue) so we can control
         the timestamp precisely.
         """
+        if not hasattr(storage, "conn"):
+            pytest.skip(
+                "direct-insert controlled-created_at test requires a SQLite connection"
+            )
         import time
         import uuid as _uuid
         from datetime import UTC, datetime


### PR DESCRIPTION
## What

Two read-only `LearningJobStore` query methods for durable-learning-queue observability:

- `get_oldest_pending_learning_job_age_seconds() -> float | None` — age (epoch seconds) of the oldest `status='pending'` learning job on this ref; `None` when none pending.
- `count_learning_jobs_by_status(status: str) -> int` — count of jobs in a given status (e.g. `'dead'`).

## Why

The enterprise durable-learning scheduler is being made cross-ref-aware for a safe production activation. These queries back the per-ref **queue-age** and **dead-letter** alarms the rollout gates require. Adding them to the `LearningJobStore` ABC keeps every backend contract-covered.

## Notes

- Added to the ABC + the SQLite mixin; both resolve the table the same way as the sibling `list_org_ids_with_pending_learning_jobs` (no schema hardcoding — enterprise routes to `reflexio_ops` via the resolver).
- 8 new contract tests in `TestQueueAlarmQueries` (oldest-of-multiple, None-when-empty, ignores every non-pending status, dead-count, mixed-status). The controlled-`created_at` test skips cleanly on non-SQLite backends (direct-connection insert).
- **Downstream sequencing:** the enterprise Supabase/Postgres impls of these two abstract methods land together with the enterprise repin — do not bump the enterprise submodule pointer to this commit before those impls exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking learning-job queue health, including the age of the oldest pending job and counts by job status.
  * Improved durable-learning startup configuration so deployments can supply organization IDs when the feature is enabled.

* **Tests**
  * Added coverage for queue-health queries across empty, pending, claimed, done, failed, and dead job states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
