### PR TITLE
feat: run shadow comparisons at publish time

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -914,7 +914,7 @@ class Config(BaseModel):
         ),
     )
     shadow_comparison_judge_prompt_version: NonEmptyStr = Field(
-        default="v1.0.0",
+        default="v1.1.0",
         description=(
             "F1: pinned judge prompt version for per-turn shadow comparison. "
             "Verdicts are stored with the version that produced them; the "

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -427,7 +427,7 @@ Key files:
 
 **Tool Context**: Reads `tool_can_use` from root `Config` level (shared with playbook extraction).
 
-**Shadow Comparison**: Session-level shadow comparison was retracted in F1 because multi-turn shadow content suffers from trajectory contamination (turn 2+ user messages react to the regular response, not the shadow). The `regular_vs_shadow` field on `AgentSuccessEvaluationResult` is preserved as a nullable historical column but is always `None` on newly produced rows. Per-turn shadow comparison lives in a dedicated `services/shadow_comparison/` judge that writes its verdicts to a separate table — see the F1 spec.
+**Shadow Comparison**: Session-level shadow comparison was retracted in F1 because multi-turn shadow content suffers from trajectory contamination (turn 2+ user messages react to the regular response, not the shadow). The `regular_vs_shadow` field on `AgentSuccessEvaluationResult` is preserved as a nullable historical column but is always `None` on newly produced rows. Per-turn shadow comparison is scheduled from the publish path whenever an assistant interaction carries `shadow_content`; it lives in a dedicated `services/shadow_comparison/` judge that writes verdicts to a separate table, independent of session-level evaluation sampling.
 
 ### Durable Learning Queue
 
@@ -459,7 +459,8 @@ Key files:
 **Directories**: `services/shadow_comparison/`, `services/evaluation_overview/`
 
 Key files:
-- `shadow_comparison/judge.py`: Per-turn regular-vs-shadow judge that writes shadow verdicts through storage
+- `shadow_comparison/judge.py`: Per-turn regular-vs-shadow judge
+- `shadow_comparison/dispatcher.py` and `shadow_comparison/worker.py`: Publish-time dispatch and bounded background execution for shadow verdict writes
 - `shadow_comparison/outcome.py`: Verdict outcome model helpers
 - `evaluation_overview/service.py`: Aggregates evaluation-page metrics
 - `evaluation_overview/components/hero_state.py`, `evaluation_overview/components/distribution.py`, `evaluation_overview/components/rule_attribution.py`, `evaluation_overview/components/shadow_aggregation.py`: Focused aggregation helpers

--- a/reflexio/server/prompt/prompt_bank/shadow_comparison/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/shadow_comparison/v1.0.0.prompt.md
@@ -1,5 +1,5 @@
 ---
-active: true
+active: false
 description: "F1 per-turn comparison of two candidate AI responses against the same user message"
 variables:
   - user_message

--- a/reflexio/server/prompt/prompt_bank/shadow_comparison/v1.1.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/shadow_comparison/v1.1.0.prompt.md
@@ -1,0 +1,43 @@
+---
+active: true
+description: "F1 per-turn comparison of two candidate AI responses against request-local transcript context"
+variables:
+  - conversation_context
+  - request_1_response
+  - request_2_response
+---
+
+You are evaluating two candidate AI assistant responses to the same conversation
+context. Determine which response is better, or if they are roughly equivalent.
+
+Judgment criteria, in order of importance:
+1. Correctness — does the response accurately answer the user's latest need?
+2. Completeness — does the response cover what the user actually needs?
+3. Actionability — does it give the user a clear next step where applicable?
+4. Style and format — clarity, concision, structure.
+
+Important constraints:
+- Judge only on the transcript context and the two responses below. Do NOT
+  assume prior conversation history beyond the provided transcript or invent
+  missing context.
+- Length does not equal quality. A shorter response that fully answers is
+  better than a longer one that meanders.
+- Position (Request 1 vs Request 2) is arbitrary — the labels do not encode any
+  prior knowledge. Evaluate purely on content.
+
+CONVERSATION CONTEXT
+--------------------
+{conversation_context}
+
+REQUEST 1
+---------
+{request_1_response}
+
+REQUEST 2
+---------
+{request_2_response}
+
+Output a JSON object with exactly these fields:
+  better_request: "1" | "2" | "tie"
+  is_significantly_better: true | false  (false ↔ "they're close but 1/2 edges it")
+  comparison_reason: 1-2 sentences explaining the choice.

--- a/reflexio/server/services/agent_success_evaluation/README.md
+++ b/reflexio/server/services/agent_success_evaluation/README.md
@@ -5,7 +5,7 @@ Session-level agent success evaluation module.
 ## Module Shape
 
 - `service.py`: `AgentSuccessEvaluationService`, the request-path service that runs configured evaluators and saves result rows.
-- `runner.py`: `run_group_evaluation(...)`, the background/manual workflow entry point that loads a session, runs the service, dispatches shadow comparison, and marks operation state.
+- `runner.py`: `run_group_evaluation(...)`, the background/manual workflow entry point that loads a session, runs the service, and marks operation state.
 - `scheduler.py`: `GroupEvaluationScheduler`, the deferred inactivity scheduler.
 - `components/evaluator.py`: `AgentSuccessEvaluator`, the LLM evaluator component.
 - `regen_jobs.py`: regeneration job planning and execution; remains root-level because API/admin regenerate flows import it directly.

--- a/reflexio/server/services/agent_success_evaluation/runner.py
+++ b/reflexio/server/services/agent_success_evaluation/runner.py
@@ -5,11 +5,9 @@ checks completion status, runs evaluation, and marks the group as evaluated.
 """
 
 import logging
-import random
 from collections import defaultdict
 from datetime import UTC, datetime
 
-from reflexio.models.api_schema.domain.entities import Interaction
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
@@ -25,7 +23,6 @@ from reflexio.server.services.agent_success_evaluation.service import (
     AgentSuccessEvaluationService,
 )
 from reflexio.server.services.extractor_config_utils import get_extractor_name
-from reflexio.server.services.shadow_comparison.judge import ShadowComparisonJudge
 
 logger = logging.getLogger(__name__)
 
@@ -217,20 +214,6 @@ def run_group_evaluation(
         )
         return
 
-    # F1: per-turn shadow comparison. Dispatched only AFTER the regular
-    # success eval succeeds — a session whose success grade is unreliable
-    # would yield noisy verdicts that mislead the headline metric. The
-    # dispatch loop swallows per-interaction failures so one judge call
-    # cannot abort an entire batch.
-    _dispatch_shadow_comparison_judge(
-        storage=storage,
-        interactions=all_interactions,
-        session_id=session_id,
-        agent_version=agent_version,
-        request_context=request_context,
-        llm_client=llm_client,
-    )
-
     # 6. New rows saved successfully — now safe to remove the captured prior
     # rows. New rows have fresh auto-increment result_ids that do not overlap
     # with old_result_ids, so this cannot delete the regenerated verdict.
@@ -253,86 +236,3 @@ def run_group_evaluation(
         {"evaluated": True, "evaluated_at": evaluated_at},
     )
     logger.info("Marked session %s as evaluated at %d", session_id, evaluated_at)
-
-
-def _dispatch_shadow_comparison_judge(
-    *,
-    storage,  # noqa: ANN001 — BaseStorage; imported lazily to avoid cycles
-    interactions: list[Interaction],
-    session_id: str,
-    agent_version: str,
-    request_context: RequestContext,
-    llm_client: LiteLLMClient,
-) -> None:
-    """F1: grade each shadow-bearing interaction with the per-turn judge.
-
-    Iterates the session's interactions, skips any without ``shadow_content``,
-    invokes :class:`ShadowComparisonJudge.judge_turn`, and persists each
-    returned verdict via ``storage.save_shadow_comparison_verdict``. Per-
-    interaction exceptions are logged and the loop continues — partial
-    verdict sets are strictly better than nothing for the headline metric.
-
-    Args:
-        storage: The session storage. Must implement
-            ``save_shadow_comparison_verdict`` (currently SQLite + Supabase
-            + disk; backends without it surface ``NotImplementedError`` at
-            save time and the loop logs+continues).
-        interactions (list[Interaction]): Every interaction in the session,
-            in chronological order. Only those with non-empty
-            ``shadow_content`` are graded.
-        session_id (str): Denormalized onto each verdict.
-        agent_version (str): Denormalized onto each verdict.
-        request_context (RequestContext): Provides the configurator (for
-            the pinned ``shadow_comparison_judge_prompt_version``) and the
-            shared ``prompt_manager``.
-        llm_client (LiteLLMClient): The unified LLM client the judge uses
-            for the structured-output call.
-
-    Returns:
-        None: Verdicts are persisted as a side effect; the caller does not
-            need the count for control flow.
-    """
-    config = request_context.configurator.get_config()  # type: ignore[reportOptionalMemberAccess]
-    judge = ShadowComparisonJudge(
-        llm_client=llm_client,
-        prompt_manager=request_context.prompt_manager,  # type: ignore[reportOptionalMemberAccess]
-        prompt_version=config.shadow_comparison_judge_prompt_version,
-    )
-    rng = random.Random()  # noqa: S311 — position randomization, not crypto
-    saved_count = 0
-
-    for interaction in interactions:
-        if not interaction.shadow_content:
-            continue
-        try:
-            verdict = judge.judge_turn(
-                interaction=interaction,
-                session_id=session_id,
-                agent_version=agent_version,
-                rng=rng,
-            )
-        except Exception as exc:  # noqa: BLE001 — judge failure must not abort batch
-            logger.warning(
-                "F1 shadow_comparison dispatch failed for interaction %s: %s",
-                interaction.interaction_id,
-                exc,
-            )
-            continue
-        if verdict is None:
-            continue
-        try:
-            storage.save_shadow_comparison_verdict(verdict)
-            saved_count += 1
-        except Exception as exc:  # noqa: BLE001 — single-row save failure must not abort batch
-            logger.warning(
-                "F1 shadow_comparison verdict save failed for interaction %s: %s",
-                interaction.interaction_id,
-                exc,
-            )
-
-    if saved_count:
-        logger.info(
-            "F1: saved %d shadow_comparison verdict(s) for session=%s",
-            saved_count,
-            session_id,
-        )

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -48,6 +48,10 @@ from reflexio.server.services.reflection.reflection_service_utils import (
     ReflectionServiceRequest,
 )
 from reflexio.server.services.reflection.service import ReflectionService
+from reflexio.server.services.shadow_comparison.worker import (
+    ShadowComparisonJob,
+    enqueue_shadow_comparison,
+)
 from reflexio.server.services.storage.retention import (
     delete_count_for_retention,
     get_row_retention_limits,
@@ -276,8 +280,9 @@ class GenerationService:
                     self.storage.add_user_interactions_bulk(  # type: ignore[reportOptionalMemberAccess]
                         user_id=user_id, interactions=new_interactions
                     )
-                self._schedule_group_evaluation_if_needed(
+                self._schedule_post_publish_evaluations(
                     new_request=new_request,
+                    interactions=new_interactions,
                     user_id=user_id,
                     agent_version=agent_version,
                     source=source,
@@ -314,6 +319,13 @@ class GenerationService:
                     )
                 result.warnings.append(stall_warning)
                 logger.warning("%s; skipping automatic extraction", stall_warning)
+                self._schedule_post_publish_evaluations(
+                    new_request=new_request,
+                    interactions=new_interactions,
+                    user_id=user_id,
+                    agent_version=agent_version,
+                    source=source,
+                )
                 record_usage_event(
                     org_id=self.org_id,
                     user_id=user_id,
@@ -352,8 +364,9 @@ class GenerationService:
                             force_extraction=publish_user_interaction_request.force_extraction,
                             skip_aggregation=publish_user_interaction_request.skip_aggregation,
                         )
-                    self._schedule_group_evaluation_if_needed(
+                    self._schedule_post_publish_evaluations(
                         new_request=new_request,
+                        interactions=new_interactions,
                         user_id=user_id,
                         agent_version=agent_version,
                         source=source,
@@ -384,8 +397,9 @@ class GenerationService:
                     enqueue_publish_learning,
                 )
 
-                self._schedule_group_evaluation_if_needed(
+                self._schedule_post_publish_evaluations(
                     new_request=new_request,
+                    interactions=new_interactions,
                     user_id=user_id,
                     agent_version=agent_version,
                     source=source,
@@ -447,30 +461,30 @@ class GenerationService:
                     result=result,
                 )
 
-                # Schedule delayed group evaluation for the required session.
-                self._schedule_group_evaluation_if_needed(
-                    new_request=new_request,
-                    user_id=user_id,
-                    agent_version=agent_version,
-                    source=source,
-                )
+            self._schedule_post_publish_evaluations(
+                new_request=new_request,
+                interactions=new_interactions,
+                user_id=user_id,
+                agent_version=agent_version,
+                source=source,
+            )
 
-                record_usage_event(
-                    org_id=self.org_id,
-                    user_id=user_id,
-                    request_id=request_id,
-                    session_id=new_request.session_id,
-                    source=source,
-                    agent_version=agent_version,
-                    backend="classic",
-                    event_name="publish_request_succeeded",
-                    event_category="publish",
-                    outcome="success",
-                    count_value=len(new_interactions),
-                    duration_ms=int((time.perf_counter() - publish_start) * 1000),
-                    metadata={"warning_count": len(result.warnings)},
-                )
-                return result
+            record_usage_event(
+                org_id=self.org_id,
+                user_id=user_id,
+                request_id=request_id,
+                session_id=new_request.session_id,
+                source=source,
+                agent_version=agent_version,
+                backend="classic",
+                event_name="publish_request_succeeded",
+                event_category="publish",
+                outcome="success",
+                count_value=len(new_interactions),
+                duration_ms=int((time.perf_counter() - publish_start) * 1000),
+                metadata={"warning_count": len(result.warnings)},
+            )
+            return result
 
         except Exception as e:
             record_usage_event(
@@ -678,6 +692,39 @@ class GenerationService:
                 "Failed to schedule tagging for publish request %s",
                 request_id,
             )
+
+    def _schedule_post_publish_evaluations(
+        self,
+        *,
+        new_request: Request,
+        interactions: list[Interaction],
+        user_id: str,
+        agent_version: str,
+        source: str | None,
+    ) -> None:
+        """Schedule all best-effort evaluation work after publish persistence."""
+        if any(interaction.shadow_content for interaction in interactions):
+            try:
+                enqueue_shadow_comparison(
+                    ShadowComparisonJob(
+                        org_id=self.org_id,
+                        interactions=interactions,
+                        session_id=new_request.session_id,
+                        agent_version=agent_version,
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue shadow comparison for session %s",
+                    new_request.session_id,
+                )
+
+        self._schedule_group_evaluation_if_needed(
+            new_request=new_request,
+            user_id=user_id,
+            agent_version=agent_version,
+            source=source,
+        )
 
     def _schedule_group_evaluation_if_needed(
         self,

--- a/reflexio/server/services/shadow_comparison/dispatcher.py
+++ b/reflexio/server/services/shadow_comparison/dispatcher.py
@@ -1,0 +1,139 @@
+"""Publish-time dispatch for per-turn shadow comparisons."""
+
+from __future__ import annotations
+
+import logging
+import random
+
+from reflexio.models.api_schema.domain.entities import Interaction
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.services.shadow_comparison.judge import ShadowComparisonJudge
+
+logger = logging.getLogger(__name__)
+
+_ASSISTANT_ROLES = {"agent", "assistant"}
+
+
+def dispatch_shadow_comparison_judge(
+    *,
+    storage,  # noqa: ANN001 - BaseStorage; concrete type would create import cycles
+    interactions: list[Interaction],
+    session_id: str,
+    agent_version: str,
+    request_context: RequestContext,
+    llm_client: LiteLLMClient,
+) -> None:
+    """Judge each shadow-bearing assistant turn in a single publish request."""
+    if not interactions:
+        return
+
+    supports_verdicts = getattr(
+        storage, "supports_shadow_comparison_verdicts", lambda: False
+    )
+    if not supports_verdicts():
+        logger.info(
+            "Skipping shadow comparison for session=%s because %s does not support verdict storage",
+            session_id,
+            type(storage).__name__,
+        )
+        return
+
+    sorted_interactions = sorted(interactions, key=lambda i: i.created_at)
+    shadow_interactions = [
+        interaction
+        for interaction in sorted_interactions
+        if interaction.shadow_content
+        and interaction.role.strip().lower() in _ASSISTANT_ROLES
+    ]
+    if not shadow_interactions:
+        return
+
+    config = request_context.configurator.get_config()  # type: ignore[reportOptionalMemberAccess]
+    judge = ShadowComparisonJudge(
+        llm_client=llm_client,
+        prompt_manager=request_context.prompt_manager,  # type: ignore[reportOptionalMemberAccess]
+        prompt_version=config.shadow_comparison_judge_prompt_version,
+    )
+    rng = random.Random()  # noqa: S311 - position randomization, not crypto
+    saved_count = 0
+
+    for interaction in shadow_interactions:
+        conversation_context = _format_request_transcript_before(
+            sorted_interactions=sorted_interactions,
+            target=interaction,
+        )
+        try:
+            verdict = judge.judge_turn(
+                interaction=interaction,
+                session_id=session_id,
+                agent_version=agent_version,
+                rng=rng,
+                conversation_context=conversation_context,
+            )
+        except Exception as exc:  # noqa: BLE001 - one judge failure must not abort the batch
+            logger.warning(
+                "shadow_comparison dispatch failed for interaction %s: %s",
+                interaction.interaction_id,
+                exc,
+            )
+            continue
+        if verdict is None:
+            continue
+        try:
+            storage.save_shadow_comparison_verdict(verdict)
+            saved_count += 1
+        except NotImplementedError:
+            logger.info(
+                "Stopping shadow comparison for session=%s because %s does not support verdict storage",
+                session_id,
+                type(storage).__name__,
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 - single-row save failure must not abort batch
+            logger.warning(
+                "shadow_comparison verdict save failed for interaction %s: %s",
+                interaction.interaction_id,
+                exc,
+            )
+
+    if saved_count:
+        logger.info(
+            "Saved %d shadow_comparison verdict(s) for session=%s",
+            saved_count,
+            session_id,
+        )
+
+
+def _format_request_transcript_before(
+    *, sorted_interactions: list[Interaction], target: Interaction
+) -> str:
+    """Format prior turns in the same publish request as judge context.
+
+    ``sorted_interactions`` must already be ordered by ``created_at`` — the
+    caller sorts once and passes the shared list so this runs O(n) per turn.
+    """
+    prior_turns: list[Interaction] = []
+    for interaction in sorted_interactions:
+        if interaction is target or (
+            interaction.interaction_id
+            and interaction.interaction_id == target.interaction_id
+        ):
+            break
+        if interaction.content:
+            prior_turns.append(interaction)
+    if not prior_turns:
+        return ""
+    return "\n\n".join(
+        f"{_display_role(interaction.role)}:\n{interaction.content}"
+        for interaction in prior_turns
+    )
+
+
+def _display_role(role: str) -> str:
+    normalized = role.strip().lower()
+    if normalized in {"user", "human"}:
+        return "User"
+    if normalized in _ASSISTANT_ROLES:
+        return "Assistant"
+    return role.strip() or "Unknown"

--- a/reflexio/server/services/shadow_comparison/judge.py
+++ b/reflexio/server/services/shadow_comparison/judge.py
@@ -77,14 +77,16 @@ class ShadowComparisonJudge:
         agent_version: str,
         rng: random.Random,
         user_message: str = "",
+        conversation_context: str | None = None,
     ) -> ShadowComparisonVerdict | None:
         """
         Grade one interaction; return ``None`` when the LLM fails or the
         interaction has no shadow response to compare against.
 
-        Returning ``None`` (rather than raising) lets the regen worker
-        skip this turn and continue with the rest of the session — one
-        rate-limit blip should not abort an entire batch.
+        Returning ``None`` (rather than raising) lets the publish-time
+        dispatcher skip this turn and continue with the rest of the
+        request's shadow-bearing turns — one rate-limit blip should not
+        abort an entire batch.
 
         Args:
             interaction (Interaction): The agent-side interaction. Its
@@ -98,9 +100,11 @@ class ShadowComparisonJudge:
                 Production callers pass a fresh ``random.Random()`` per
                 judge call; tests inject a seeded ``Random`` for
                 reproducibility.
-            user_message (str): The user turn this interaction responds
-                to. Optional — empty string is rendered into the prompt
-                if the caller does not provide a value.
+            user_message (str): Backward-compatible single-turn context used
+                by the v1.0 prompt.
+            conversation_context (str | None): Request-local transcript context
+                used by v1.1+ prompts. Defaults to ``user_message`` so explicit
+                v1.0 prompt-version overrides keep working.
 
         Returns:
             ShadowComparisonVerdict | None: The constructed verdict, or
@@ -118,7 +122,13 @@ class ShadowComparisonJudge:
         prompt = self._prompt_manager.render_prompt(
             prompt_id=_PROMPT_ID,
             variables={
+                # ``user_message`` is retained only for explicit v1.0.0
+                # prompt-version overrides; the active v1.1+ template reads
+                # ``conversation_context`` instead. Do not drop it as "unused".
                 "user_message": user_message,
+                "conversation_context": conversation_context
+                if conversation_context is not None
+                else user_message,
                 "request_1_response": request_1,
                 "request_2_response": request_2,
             },

--- a/reflexio/server/services/shadow_comparison/worker.py
+++ b/reflexio/server/services/shadow_comparison/worker.py
@@ -1,0 +1,137 @@
+"""Bounded background worker for publish-time shadow comparison."""
+
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from dataclasses import dataclass
+
+from reflexio.models.api_schema.domain.entities import Interaction
+from reflexio.server.services.shadow_comparison.dispatcher import (
+    dispatch_shadow_comparison_judge,
+)
+from reflexio.server.usage_metrics import record_usage_event
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_WORKER_COUNT = 2
+_DEFAULT_QUEUE_SIZE = 1000
+
+
+@dataclass(frozen=True)
+class ShadowComparisonJob:
+    """Metadata needed to judge one publish request's shadow-bearing turns.
+
+    Carries only ``org_id`` plus request-scoped data — never the live
+    ``storage`` / ``request_context`` / ``llm_client`` objects. Those are
+    re-resolved via ``get_reflexio(org_id)`` inside the worker so a job that
+    waits in the queue across a config reload / cache eviction runs against
+    the *current* per-org instance rather than a stale one.
+    """
+
+    org_id: str
+    interactions: list[Interaction]
+    session_id: str
+    agent_version: str
+
+
+class ShadowComparisonWorker:
+    """Small process-local daemon worker pool for shadow comparison jobs."""
+
+    def __init__(
+        self,
+        *,
+        worker_count: int = _DEFAULT_WORKER_COUNT,
+        queue_size: int = _DEFAULT_QUEUE_SIZE,
+    ) -> None:
+        self.worker_count = max(1, worker_count)
+        self._queue: queue.Queue[ShadowComparisonJob] = queue.Queue(
+            maxsize=max(1, queue_size)
+        )
+        self._threads: list[threading.Thread] = []
+        self._start_lock = threading.Lock()
+        self._started = False
+
+    def start(self) -> None:
+        with self._start_lock:
+            if self._started:
+                return
+            self._threads = [
+                threading.Thread(
+                    target=self._worker_loop,
+                    name=f"shadow-comparison-worker-{idx}",
+                    daemon=True,
+                )
+                for idx in range(self.worker_count)
+            ]
+            for thread in self._threads:
+                thread.start()
+            self._started = True
+            logger.info(
+                "event=shadow_comparison_worker_started workers=%d queue_size=%d",
+                self.worker_count,
+                self._queue.maxsize,
+            )
+
+    def enqueue(self, job: ShadowComparisonJob) -> bool:
+        self.start()
+        try:
+            self._queue.put_nowait(job)
+        except queue.Full:
+            logger.warning(
+                "event=shadow_comparison_queue_full org_id=%s session_id=%s queue_size=%d",
+                job.org_id,
+                job.session_id,
+                self._queue.maxsize,
+            )
+            record_usage_event(
+                org_id=job.org_id,
+                user_id=None,
+                request_id=None,
+                session_id=job.session_id,
+                source=None,
+                agent_version=job.agent_version,
+                event_name="shadow_comparison_dropped",
+                event_category="shadow_comparison",
+                outcome="dropped",
+                metadata={"queue_size": self._queue.maxsize},
+            )
+            return False
+        return True
+
+    def _worker_loop(self) -> None:
+        # Imported lazily to break the import cycle generation_service ->
+        # shadow_comparison.worker -> reflexio_cache -> reflexio_lib ->
+        # generation_service (the publish_learning_worker does the same).
+        from reflexio.server.cache.reflexio_cache import get_reflexio
+
+        while True:
+            job = self._queue.get()
+            try:
+                reflexio = get_reflexio(org_id=job.org_id)
+                request_context = reflexio.request_context
+                dispatch_shadow_comparison_judge(
+                    storage=request_context.storage,
+                    interactions=job.interactions,
+                    session_id=job.session_id,
+                    agent_version=job.agent_version,
+                    request_context=request_context,
+                    llm_client=reflexio.llm_client,
+                )
+            except Exception:
+                logger.exception(
+                    "event=shadow_comparison_job_failed org_id=%s session_id=%s",
+                    job.org_id,
+                    job.session_id,
+                )
+            finally:
+                self._queue.task_done()
+
+
+_worker = ShadowComparisonWorker()
+
+
+def enqueue_shadow_comparison(job: ShadowComparisonJob) -> bool:
+    """Enqueue a shadow comparison job, dropping it when the local queue is full."""
+    return _worker.enqueue(job)

--- a/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/sqlite_storage/_shadow_verdicts.py
@@ -74,6 +74,10 @@ class ShadowVerdictsMixin:
     _fetchone: Any
     _fetchall: Any
 
+    def supports_shadow_comparison_verdicts(self) -> bool:
+        """Return whether this backend can persist shadow comparison verdicts."""
+        return True
+
     @SQLiteStorageBase.handle_exceptions
     def save_shadow_comparison_verdict(
         self, verdict: ShadowComparisonVerdict

--- a/reflexio/server/services/storage/storage_base/_shadow_verdicts.py
+++ b/reflexio/server/services/storage/storage_base/_shadow_verdicts.py
@@ -34,6 +34,10 @@ class ShadowVerdictsMixin:
     clear error message naming the backend rather than ``AttributeError``.
     """
 
+    def supports_shadow_comparison_verdicts(self) -> bool:
+        """Return whether this backend can persist shadow comparison verdicts."""
+        return False
+
     def save_shadow_comparison_verdict(
         self, verdict: ShadowComparisonVerdict
     ) -> ShadowComparisonVerdict:

--- a/tests/models/test_config_f1_fields.py
+++ b/tests/models/test_config_f1_fields.py
@@ -10,9 +10,9 @@ def _minimal(**overrides) -> Config:
     return Config(storage_config=StorageConfigSQLite(), **overrides)
 
 
-def test_shadow_comparison_judge_prompt_version_defaults_to_v1_0_0():
+def test_shadow_comparison_judge_prompt_version_defaults_to_v1_1_0():
     c = _minimal()
-    assert c.shadow_comparison_judge_prompt_version == "v1.0.0"
+    assert c.shadow_comparison_judge_prompt_version == "v1.1.0"
 
 
 def test_shadow_comparison_judge_prompt_version_rejects_empty_string():

--- a/tests/server/prompt/test_shadow_comparison_prompt_present.py
+++ b/tests/server/prompt/test_shadow_comparison_prompt_present.py
@@ -12,30 +12,38 @@ _PROMPT_ROOT = (
 )
 
 
-def test_shadow_comparison_v1_0_0_prompt_file_exists():
+def test_shadow_comparison_v1_1_0_prompt_file_exists():
+    assert (_PROMPT_ROOT / "v1.1.0.prompt.md").is_file()
+
+
+def test_shadow_comparison_v1_0_0_prompt_file_remains_for_history():
     assert (_PROMPT_ROOT / "v1.0.0.prompt.md").is_file()
 
 
-def test_shadow_comparison_v1_0_0_prompt_is_active():
-    content = (_PROMPT_ROOT / "v1.0.0.prompt.md").read_text()
+def test_shadow_comparison_v1_1_0_prompt_is_active():
+    content = (_PROMPT_ROOT / "v1.1.0.prompt.md").read_text()
     assert "active: true" in content
 
 
-def test_shadow_comparison_v1_0_0_prompt_declares_all_variables():
+def test_shadow_comparison_v1_0_0_prompt_is_inactive():
     content = (_PROMPT_ROOT / "v1.0.0.prompt.md").read_text()
-    for var in ("user_message", "request_1_response", "request_2_response"):
+    assert "active: false" in content
+
+
+def test_shadow_comparison_v1_1_0_prompt_declares_all_variables():
+    content = (_PROMPT_ROOT / "v1.1.0.prompt.md").read_text()
+    for var in ("conversation_context", "request_1_response", "request_2_response"):
         assert var in content, f"missing variable {var}"
 
 
-def test_shadow_comparison_v1_0_0_prompt_warns_against_position_weighting():
+def test_shadow_comparison_v1_1_0_prompt_warns_against_position_weighting():
     """The criterion-list in the prompt body must include a 'position
     is arbitrary' instruction so the judge doesn't blindly trust 1 or 2."""
-    content = (_PROMPT_ROOT / "v1.0.0.prompt.md").read_text()
+    content = (_PROMPT_ROOT / "v1.1.0.prompt.md").read_text()
     assert "Position" in content or "position" in content
 
 
-def test_shadow_comparison_v1_0_0_prompt_warns_against_assuming_prior_history():
-    """Q2-1 MVP constraint: the judge sees current-turn-only and must
-    not invent prior context."""
-    content = (_PROMPT_ROOT / "v1.0.0.prompt.md").read_text()
+def test_shadow_comparison_v1_1_0_prompt_warns_against_assuming_missing_history():
+    """The judge receives request-local context and must not invent history."""
+    content = (_PROMPT_ROOT / "v1.1.0.prompt.md").read_text()
     assert "prior" in content.lower() or "history" in content.lower()

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_shadow_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_shadow_integration.py
@@ -1,31 +1,15 @@
-"""F1 integration: runner dispatches the per-turn shadow judge.
-
-When session interactions carry ``shadow_content`` and the regular success
-eval succeeds, the runner must invoke
-:class:`ShadowComparisonJudge.judge_turn` per shadow-bearing interaction and
-persist a verdict via ``storage.save_shadow_comparison_verdict``. When the
-regular eval fails, the dispatch is skipped to avoid noisy verdicts on
-sessions whose success grade is unreliable.
-
-Uses a real :class:`SQLiteStorage` in a temp dir so the verdict save lands
-in real storage; the LLM judge call is stubbed to a deterministic verdict.
-"""
+"""Regression tests for group evaluation no longer dispatching shadow comparison."""
 
 from __future__ import annotations
 
 import tempfile
 from collections.abc import Generator
-from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from reflexio.models.api_schema.domain.entities import Interaction, Request
-from reflexio.models.api_schema.eval_overview_schema import (
-    ShadowComparisonOutput,
-    ShadowComparisonVerdict,
-)
 from reflexio.models.config_schema import Config, StorageConfigSQLite
 from reflexio.server.services.agent_success_evaluation.runner import (
     run_group_evaluation,
@@ -37,11 +21,6 @@ pytestmark = pytest.mark.integration
 
 @pytest.fixture
 def storage() -> Generator[SQLiteStorage]:
-    """Fresh SQLite store in a temp dir with embedding stubbed.
-
-    Stubbing ``_get_embedding`` avoids the test depending on a real
-    embedding provider during ``add_user_interaction``.
-    """
     with (
         tempfile.TemporaryDirectory() as tmp_dir,
         patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512),
@@ -52,69 +31,47 @@ def storage() -> Generator[SQLiteStorage]:
         )
 
 
-def _seed_session_with_shadow_interactions(
-    storage: SQLiteStorage,
-    *,
-    session_id: str = "sess-1",
-    user_id: str = "u1",
-    agent_version: str = "v1",
-) -> list[Interaction]:
-    """Seed one Request + 3 Interactions; 2 have shadow_content, 1 doesn't.
-
-    Uses a request ``created_at`` deep in the past so the runner's
-    completion-delay gate would also accept it — but the tests pass
-    ``force_regenerate=True`` anyway to bypass that gate explicitly.
-    """
+def _seed_session_with_shadow_interaction(storage: SQLiteStorage) -> None:
     ts = 1_700_000_000
     storage.add_request(
         Request(
             request_id="req-1",
-            user_id=user_id,
-            session_id=session_id,
+            user_id="u1",
+            session_id="sess-1",
             created_at=ts,
             source="test",
-            agent_version=agent_version,
+            agent_version="v1",
         )
     )
-    interactions: list[Interaction] = []
-    for i in range(3):
-        inter = Interaction(
-            user_id=user_id,
+    storage.add_user_interaction(
+        "u1",
+        Interaction(
+            user_id="u1",
             request_id="req-1",
-            created_at=ts + i,
-            role="agent",
-            content=f"REGULAR-{i}",
-            shadow_content=f"SHADOW-{i}" if i < 2 else "",
-        )
-        storage.add_user_interaction(user_id, inter)
-        interactions.append(inter)
-    return interactions
+            created_at=ts + 1,
+            role="assistant",
+            content="REGULAR",
+            shadow_content="SHADOW",
+        ),
+    )
 
 
-def _make_request_context(storage: SQLiteStorage, config: Config) -> SimpleNamespace:
-    """Build the minimal request_context the runner reads.
-
-    The runner accesses ``.storage`` and the helper accesses
-    ``.configurator.get_config()`` and ``.prompt_manager``. A
-    SimpleNamespace stand-in keeps the test independent of the heavy
-    BaseConfigurator stack.
-    """
+def _make_request_context(storage: SQLiteStorage) -> SimpleNamespace:
     return SimpleNamespace(
         storage=storage,
-        configurator=SimpleNamespace(get_config=lambda: config),
+        configurator=SimpleNamespace(
+            get_config=lambda: Config(storage_config=StorageConfigSQLite())
+        ),
         prompt_manager=MagicMock(),
     )
 
 
-def test_runner_writes_verdicts_for_interactions_with_shadow_content(
-    monkeypatch: pytest.MonkeyPatch, storage: SQLiteStorage
+def test_run_group_evaluation_no_longer_writes_shadow_verdicts(
+    monkeypatch: pytest.MonkeyPatch,
+    storage: SQLiteStorage,
 ) -> None:
-    """3 interactions, 2 carry shadow_content -> 2 verdicts saved."""
-    _seed_session_with_shadow_interactions(storage)
-
-    # Stub the regular success-eval service so it claims success without
-    # touching an LLM. The runner reads .has_run_failures() and
-    # .last_run_saved_result_count to decide whether to mark evaluated.
+    """Regen/session evaluation must not duplicate publish-time shadow verdicts."""
+    _seed_session_with_shadow_interaction(storage)
     fake_service = MagicMock()
     fake_service.has_run_failures.return_value = False
     fake_service.last_run_saved_result_count = 1
@@ -124,205 +81,29 @@ def test_runner_writes_verdicts_for_interactions_with_shadow_content(
         "runner.AgentSuccessEvaluationService",
         MagicMock(return_value=fake_service),
     )
+    judge_cls = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.dispatcher.ShadowComparisonJudge",
+        judge_cls,
+    )
 
-    # Stub the F1 judge to return a deterministic verdict per call. Capture
-    # the interaction_ids the judge was asked about so the test can assert
-    # the runner filtered to shadow-bearing rows.
-    seen_interaction_ids: list[int] = []
+    run_group_evaluation(
+        org_id="0",
+        user_id="u1",
+        session_id="sess-1",
+        agent_version="v1",
+        source=None,
+        request_context=_make_request_context(storage),  # type: ignore[arg-type]
+        llm_client=MagicMock(),
+        force_regenerate=True,
+    )
 
-    def fake_judge(
-        self,
-        *,
-        interaction: Interaction,
-        session_id: str,
-        agent_version: str,
-        rng,  # noqa: ANN001 — random.Random, kept loose to match the real signature
-        user_message: str = "",
-    ) -> ShadowComparisonVerdict:
-        seen_interaction_ids.append(interaction.interaction_id)
-        return ShadowComparisonVerdict(
-            verdict_id=0,
-            interaction_id=str(interaction.interaction_id),
-            session_id=session_id,
-            agent_version=agent_version,
-            reflexio_is_request_1=True,
-            output=ShadowComparisonOutput(
-                better_request="1",
-                is_significantly_better=True,
-            ),
-            judge_prompt_version="v1.0.0",
-            created_at=datetime.now(UTC),
+    judge_cls.assert_not_called()
+    assert (
+        storage.get_shadow_comparison_verdicts(
+            from_ts=0,
+            to_ts=2_000_000_000,
+            judge_prompt_version="v1.1.0",
         )
-
-    monkeypatch.setattr(
-        "reflexio.server.services.shadow_comparison.judge."
-        "ShadowComparisonJudge.judge_turn",
-        fake_judge,
+        == []
     )
-
-    config = Config(storage_config=StorageConfigSQLite())
-    request_context = _make_request_context(storage, config)
-
-    run_group_evaluation(
-        org_id="0",
-        user_id="u1",
-        session_id="sess-1",
-        agent_version="v1",
-        source=None,
-        request_context=request_context,  # type: ignore[arg-type]
-        llm_client=MagicMock(),
-        force_regenerate=True,
-    )
-
-    # 2 of the 3 interactions had shadow_content; expect 2 verdicts saved.
-    verdicts = storage.get_shadow_comparison_verdicts(
-        from_ts=0,
-        to_ts=2_000_000_000,
-        judge_prompt_version="v1.0.0",
-    )
-    assert len(verdicts) == 2, (
-        f"Expected 2 verdicts for the 2 shadow-bearing interactions, "
-        f"got {len(verdicts)}"
-    )
-
-    # And the judge was only invoked on the shadow-bearing interactions.
-    assert len(seen_interaction_ids) == 2
-    # SQLite assigns interaction_ids starting at 1 in this fresh db. The
-    # first two inserted carry shadow; the third does not.
-    saved_interaction_ids = {v.interaction_id for v in verdicts}
-    assert saved_interaction_ids == {
-        str(seen_interaction_ids[0]),
-        str(seen_interaction_ids[1]),
-    }
-
-
-def test_runner_does_not_dispatch_judge_when_success_eval_failed(
-    monkeypatch: pytest.MonkeyPatch, storage: SQLiteStorage
-) -> None:
-    """When the regular eval reports failures, skip F1 to avoid noisy verdicts."""
-    _seed_session_with_shadow_interactions(storage)
-
-    fake_service = MagicMock()
-    fake_service.has_run_failures.return_value = True  # failures present
-    fake_service.last_run_saved_result_count = 0
-    fake_service.last_run_save_failed = False
-    monkeypatch.setattr(
-        "reflexio.server.services.agent_success_evaluation."
-        "runner.AgentSuccessEvaluationService",
-        MagicMock(return_value=fake_service),
-    )
-
-    judge_call_count = 0
-
-    def fake_judge(self, **kwargs) -> None:  # noqa: ANN003 — loose match
-        nonlocal judge_call_count
-        judge_call_count += 1
-        return
-
-    monkeypatch.setattr(
-        "reflexio.server.services.shadow_comparison.judge."
-        "ShadowComparisonJudge.judge_turn",
-        fake_judge,
-    )
-
-    config = Config(storage_config=StorageConfigSQLite())
-    request_context = _make_request_context(storage, config)
-
-    run_group_evaluation(
-        org_id="0",
-        user_id="u1",
-        session_id="sess-1",
-        agent_version="v1",
-        source=None,
-        request_context=request_context,  # type: ignore[arg-type]
-        llm_client=MagicMock(),
-        force_regenerate=True,
-    )
-
-    assert judge_call_count == 0, (
-        "F1 judge should NOT be dispatched when the regular eval reported failures"
-    )
-    # And no verdicts written.
-    verdicts = storage.get_shadow_comparison_verdicts(
-        from_ts=0,
-        to_ts=2_000_000_000,
-        judge_prompt_version="v1.0.0",
-    )
-    assert verdicts == []
-
-
-def test_runner_continues_when_individual_judge_call_raises(
-    monkeypatch: pytest.MonkeyPatch, storage: SQLiteStorage
-) -> None:
-    """A failing judge call on one interaction must not abort the batch.
-
-    Seed 2 shadow-bearing interactions; make the first call raise. The
-    runner should log+continue and persist the second verdict.
-    """
-    _seed_session_with_shadow_interactions(storage)
-
-    fake_service = MagicMock()
-    fake_service.has_run_failures.return_value = False
-    fake_service.last_run_saved_result_count = 1
-    fake_service.last_run_save_failed = False
-    monkeypatch.setattr(
-        "reflexio.server.services.agent_success_evaluation."
-        "runner.AgentSuccessEvaluationService",
-        MagicMock(return_value=fake_service),
-    )
-
-    calls: list[int] = []
-
-    def fake_judge(
-        self,
-        *,
-        interaction: Interaction,
-        session_id: str,
-        agent_version: str,
-        rng,  # noqa: ANN001
-        user_message: str = "",
-    ) -> ShadowComparisonVerdict | None:
-        calls.append(interaction.interaction_id)
-        if len(calls) == 1:
-            raise RuntimeError("simulated transient judge failure")
-        return ShadowComparisonVerdict(
-            verdict_id=0,
-            interaction_id=str(interaction.interaction_id),
-            session_id=session_id,
-            agent_version=agent_version,
-            reflexio_is_request_1=False,
-            output=ShadowComparisonOutput(
-                better_request="2",
-                is_significantly_better=False,
-            ),
-            judge_prompt_version="v1.0.0",
-            created_at=datetime.now(UTC),
-        )
-
-    monkeypatch.setattr(
-        "reflexio.server.services.shadow_comparison.judge."
-        "ShadowComparisonJudge.judge_turn",
-        fake_judge,
-    )
-
-    config = Config(storage_config=StorageConfigSQLite())
-    request_context = _make_request_context(storage, config)
-
-    run_group_evaluation(
-        org_id="0",
-        user_id="u1",
-        session_id="sess-1",
-        agent_version="v1",
-        source=None,
-        request_context=request_context,  # type: ignore[arg-type]
-        llm_client=MagicMock(),
-        force_regenerate=True,
-    )
-
-    assert len(calls) == 2, "Both shadow-bearing interactions should be tried"
-    verdicts = storage.get_shadow_comparison_verdicts(
-        from_ts=0,
-        to_ts=2_000_000_000,
-        judge_prompt_version="v1.0.0",
-    )
-    assert len(verdicts) == 1, "Only the second (non-raising) call should persist"

--- a/tests/server/services/shadow_comparison/test_dispatcher.py
+++ b/tests/server/services/shadow_comparison/test_dispatcher.py
@@ -1,0 +1,273 @@
+"""Tests for publish-time shadow comparison dispatch."""
+
+from __future__ import annotations
+
+import queue
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from reflexio.models.api_schema.domain.entities import Interaction
+from reflexio.models.api_schema.eval_overview_schema import (
+    ShadowComparisonOutput,
+    ShadowComparisonVerdict,
+)
+from reflexio.models.config_schema import Config, StorageConfigSQLite
+from reflexio.server.services.shadow_comparison.dispatcher import (
+    dispatch_shadow_comparison_judge,
+)
+from reflexio.server.services.shadow_comparison.worker import (
+    ShadowComparisonJob,
+    ShadowComparisonWorker,
+)
+
+
+def _request_context() -> SimpleNamespace:
+    return SimpleNamespace(
+        configurator=SimpleNamespace(
+            get_config=lambda: Config(storage_config=StorageConfigSQLite())
+        ),
+        prompt_manager=MagicMock(),
+    )
+
+
+def _interaction(
+    *,
+    interaction_id: int,
+    role: str,
+    content: str,
+    shadow_content: str = "",
+) -> Interaction:
+    return Interaction(
+        interaction_id=interaction_id,
+        user_id="u1",
+        request_id="r1",
+        created_at=1_700_000_000 + interaction_id,
+        role=role,
+        content=content,
+        shadow_content=shadow_content,
+    )
+
+
+def _verdict(interaction: Interaction) -> ShadowComparisonVerdict:
+    return ShadowComparisonVerdict(
+        verdict_id=0,
+        interaction_id=str(interaction.interaction_id),
+        session_id="s1",
+        agent_version="v1",
+        reflexio_is_request_1=True,
+        output=ShadowComparisonOutput(
+            better_request="1",
+            is_significantly_better=True,
+            comparison_reason="Request 1 wins.",
+        ),
+        judge_prompt_version="v1.1.0",
+        created_at=datetime.now(UTC),
+    )
+
+
+def test_dispatcher_skips_unsupported_storage_without_judge_call(
+    monkeypatch,
+) -> None:
+    judge_cls = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.dispatcher.ShadowComparisonJudge",
+        judge_cls,
+    )
+
+    dispatch_shadow_comparison_judge(
+        storage=object(),
+        interactions=[
+            _interaction(
+                interaction_id=1,
+                role="assistant",
+                content="regular",
+                shadow_content="shadow",
+            )
+        ],
+        session_id="s1",
+        agent_version="v1",
+        request_context=_request_context(),  # type: ignore[arg-type]
+        llm_client=MagicMock(),
+    )
+
+    judge_cls.assert_not_called()
+
+
+def test_dispatcher_judges_shadow_assistant_turns_with_request_context(
+    monkeypatch,
+) -> None:
+    storage = MagicMock()
+    storage.supports_shadow_comparison_verdicts.return_value = True
+    contexts: list[str] = []
+
+    def fake_judge_turn(self, *, interaction, conversation_context, **_kwargs):
+        contexts.append(conversation_context)
+        return _verdict(interaction)
+
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.judge."
+        "ShadowComparisonJudge.judge_turn",
+        fake_judge_turn,
+    )
+
+    dispatch_shadow_comparison_judge(
+        storage=storage,
+        interactions=[
+            _interaction(interaction_id=1, role="user", content="Please compare A"),
+            _interaction(
+                interaction_id=2,
+                role="assistant",
+                content="regular answer",
+                shadow_content="shadow answer",
+            ),
+            _interaction(
+                interaction_id=3,
+                role="assistant",
+                content="regular no-shadow",
+            ),
+        ],
+        session_id="s1",
+        agent_version="v1",
+        request_context=_request_context(),  # type: ignore[arg-type]
+        llm_client=MagicMock(),
+    )
+
+    storage.save_shadow_comparison_verdict.assert_called_once()
+    assert contexts == ["User:\nPlease compare A"]
+
+
+def test_dispatcher_continues_after_individual_failures(monkeypatch) -> None:
+    storage = MagicMock()
+    storage.supports_shadow_comparison_verdicts.return_value = True
+    calls: list[int] = []
+
+    def fake_judge_turn(self, *, interaction, **_kwargs):
+        calls.append(interaction.interaction_id)
+        if len(calls) == 1:
+            raise RuntimeError("judge failed")
+        return _verdict(interaction)
+
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.judge."
+        "ShadowComparisonJudge.judge_turn",
+        fake_judge_turn,
+    )
+
+    dispatch_shadow_comparison_judge(
+        storage=storage,
+        interactions=[
+            _interaction(
+                interaction_id=1,
+                role="assistant",
+                content="regular one",
+                shadow_content="shadow one",
+            ),
+            _interaction(
+                interaction_id=2,
+                role="assistant",
+                content="regular two",
+                shadow_content="shadow two",
+            ),
+        ],
+        session_id="s1",
+        agent_version="v1",
+        request_context=_request_context(),  # type: ignore[arg-type]
+        llm_client=MagicMock(),
+    )
+
+    assert calls == [1, 2]
+    storage.save_shadow_comparison_verdict.assert_called_once()
+
+
+def _job(interactions: list[Interaction]) -> ShadowComparisonJob:
+    return ShadowComparisonJob(
+        org_id="org_test",
+        interactions=interactions,
+        session_id="s1",
+        agent_version="v1",
+    )
+
+
+def test_shadow_worker_drops_when_queue_full(monkeypatch) -> None:
+    worker = ShadowComparisonWorker(worker_count=1, queue_size=1)
+    monkeypatch.setattr(worker._queue, "put_nowait", MagicMock(side_effect=queue.Full))
+    dropped = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.worker.record_usage_event",
+        dropped,
+    )
+
+    accepted = worker.enqueue(_job([]))
+
+    assert accepted is False
+    dropped.assert_called_once()
+    assert dropped.call_args.kwargs["event_name"] == "shadow_comparison_dropped"
+
+
+def test_shadow_worker_loop_resolves_reflexio_and_dispatches(monkeypatch) -> None:
+    """The worker loop must re-resolve get_reflexio(org_id) and dispatch the job."""
+    reflexio = SimpleNamespace(
+        request_context=SimpleNamespace(storage=MagicMock()),
+        llm_client=MagicMock(),
+    )
+    # get_reflexio is imported lazily inside _worker_loop, so patch the source.
+    monkeypatch.setattr(
+        "reflexio.server.cache.reflexio_cache.get_reflexio",
+        lambda *, org_id: reflexio,  # noqa: ARG005 - matches get_reflexio kwarg signature
+    )
+    dispatched: list[dict] = []
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.worker.dispatch_shadow_comparison_judge",
+        lambda **kwargs: dispatched.append(kwargs),
+    )
+
+    worker = ShadowComparisonWorker(worker_count=1, queue_size=4)
+    worker.enqueue(
+        _job(
+            [
+                _interaction(
+                    interaction_id=1,
+                    role="assistant",
+                    content="regular",
+                    shadow_content="shadow",
+                )
+            ]
+        )
+    )
+    worker._queue.join()
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["storage"] is reflexio.request_context.storage
+    assert dispatched[0]["llm_client"] is reflexio.llm_client
+    assert dispatched[0]["session_id"] == "s1"
+
+
+def test_dispatcher_skips_non_assistant_shadow_turn(monkeypatch) -> None:
+    """A shadow-bearing non-assistant turn must not be judged."""
+    storage = MagicMock()
+    storage.supports_shadow_comparison_verdicts.return_value = True
+    judge_cls = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.shadow_comparison.dispatcher.ShadowComparisonJudge",
+        judge_cls,
+    )
+
+    dispatch_shadow_comparison_judge(
+        storage=storage,
+        interactions=[
+            _interaction(
+                interaction_id=1,
+                role="user",
+                content="regular",
+                shadow_content="shadow",
+            )
+        ],
+        session_id="s1",
+        agent_version="v1",
+        request_context=_request_context(),  # type: ignore[arg-type]
+        llm_client=MagicMock(),
+    )
+
+    judge_cls.assert_not_called()
+    storage.save_shadow_comparison_verdict.assert_not_called()

--- a/tests/server/services/test_generation_service_scheduling.py
+++ b/tests/server/services/test_generation_service_scheduling.py
@@ -6,11 +6,18 @@ silently bypassed the scheduler call, leaving /evaluations permanently empty.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
+from reflexio.models.api_schema.domain.entities import (
+    Interaction,
+    InteractionData,
+    Request,
+)
+from reflexio.models.api_schema.service_schemas import PublishUserInteractionRequest
 from reflexio.models.config_schema import (
     AgentSuccessConfig,
     Config,
@@ -31,6 +38,7 @@ def service() -> GenerationService:
     svc.org_id = "org_test"
     svc.request_context = MagicMock(name="request_context")
     svc.client = MagicMock(name="llm_client")
+    svc.storage = MagicMock(name="storage")
     svc.configurator = MagicMock(name="configurator")
     svc.configurator.get_config.return_value = Config(
         storage_config=StorageConfigSQLite(),
@@ -117,3 +125,167 @@ def test_evaluation_only_does_not_bypass_sampling_rate(
     )
 
     scheduler.schedule.assert_not_called()
+
+
+def test_shadow_content_bypasses_sampling_for_shadow_only(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shadow comparison enqueues even when session-level eval sampling is 0%."""
+    cast(Any, service.configurator.get_config).return_value = Config(
+        storage_config=StorageConfigSQLite(),
+        agent_success_config=AgentSuccessConfig(
+            success_definition_prompt="Evaluate whether the agent succeeded.",
+            sampling_rate=0.0,
+        ),
+    )
+    scheduler = MagicMock()
+    shadow_enqueue = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
+        lambda: scheduler,
+    )
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.enqueue_shadow_comparison",
+        shadow_enqueue,
+    )
+
+    service._schedule_post_publish_evaluations(
+        new_request=Request(
+            request_id="req", user_id="user_test", session_id="sess_42"
+        ),
+        interactions=[
+            Interaction(
+                user_id="user_test",
+                request_id="req",
+                role="assistant",
+                content="regular",
+                shadow_content="shadow",
+            )
+        ],
+        user_id="user_test",
+        agent_version="v_test",
+        source="ide",
+    )
+
+    shadow_enqueue.assert_called_once()
+    scheduler.schedule.assert_not_called()
+
+
+def test_no_shadow_and_zero_sampling_schedules_nothing(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cast(Any, service.configurator.get_config).return_value = Config(
+        storage_config=StorageConfigSQLite(),
+        agent_success_config=AgentSuccessConfig(
+            success_definition_prompt="Evaluate whether the agent succeeded.",
+            sampling_rate=0.0,
+        ),
+    )
+    scheduler = MagicMock()
+    shadow_enqueue = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
+        lambda: scheduler,
+    )
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.enqueue_shadow_comparison",
+        shadow_enqueue,
+    )
+
+    service._schedule_post_publish_evaluations(
+        new_request=Request(
+            request_id="req", user_id="user_test", session_id="sess_42"
+        ),
+        interactions=[
+            Interaction(user_id="user_test", request_id="req", role="assistant")
+        ],
+        user_id="user_test",
+        agent_version="v_test",
+        source="ide",
+    )
+
+    shadow_enqueue.assert_not_called()
+    scheduler.schedule.assert_not_called()
+
+
+def test_shadow_content_and_full_sampling_schedule_both(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scheduler = MagicMock()
+    shadow_enqueue = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.GroupEvaluationScheduler.get_instance",
+        lambda: scheduler,
+    )
+    monkeypatch.setattr(
+        "reflexio.server.services.generation_service.enqueue_shadow_comparison",
+        shadow_enqueue,
+    )
+
+    service._schedule_post_publish_evaluations(
+        new_request=Request(
+            request_id="req", user_id="user_test", session_id="sess_42"
+        ),
+        interactions=[
+            Interaction(
+                user_id="user_test",
+                request_id="req",
+                role="assistant",
+                content="regular",
+                shadow_content="shadow",
+            )
+        ],
+        user_id="user_test",
+        agent_version="v_test",
+        source="ide",
+    )
+
+    shadow_enqueue.assert_called_once()
+    scheduler.schedule.assert_called_once()
+
+
+def test_learning_stall_path_calls_post_publish_helper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = MagicMock(name="storage")
+    storage.get_request.return_value = None
+    storage.get_stall_state.return_value = SimpleNamespace(
+        stalled=True,
+        reason="auth_error",
+    )
+    request_context = SimpleNamespace(
+        storage=storage,
+        org_id="org_test",
+        configurator=MagicMock(name="configurator"),
+    )
+    service = GenerationService(
+        llm_client=MagicMock(name="llm_client"),
+        request_context=cast(Any, request_context),
+    )
+    service._cleanup_storage_tables_if_needed = MagicMock()  # type: ignore[method-assign]
+    post_publish = MagicMock()
+    monkeypatch.setattr(
+        GenerationService,
+        "_schedule_post_publish_evaluations",
+        post_publish,
+    )
+
+    result = service.run(
+        PublishUserInteractionRequest(
+            user_id="user_test",
+            session_id="sess_42",
+            interaction_data_list=[
+                InteractionData(
+                    role="assistant",
+                    content="regular",
+                    shadow_content="shadow",
+                )
+            ],
+        ),
+        use_publish_limiter=False,
+    )
+
+    assert result.request_id is not None
+    storage.add_request.assert_called_once()
+    storage.add_user_interactions_bulk.assert_called_once()
+    post_publish.assert_called_once()

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -67,7 +67,7 @@ PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     # F1 — per-turn shadow comparison judge. Produces structured
     # ShadowComparisonOutput; the mock dispatch lives in the integration
     # tests rather than the global heuristic mock, so no registry key.
-    "shadow_comparison": ("v1.0.0", None),
+    "shadow_comparison": ("v1.1.0", None),
 }
 
 


### PR DESCRIPTION
## Summary
- Decouples shadow head-to-head judging from sampled session-level group evaluation.
- Runs publish-time, interaction-level shadow comparisons for persisted assistant turns with `shadow_content`.
- Keeps session metrics such as success rate and correction count gated by the existing sampling and delayed scheduler.
- Bumps the pinned shadow comparison prompt to `v1.1.0` to include request-local transcript context and intentionally start a new dashboard epoch.

## Changes
- Added `shadow_comparison.dispatcher` and a bounded background worker for immediate best-effort per-request judging.
- Replaced scattered scheduling with `GenerationService._schedule_post_publish_evaluations(...)`, including the learning-stall path.
- Removed shadow dispatch from `run_group_evaluation(...)` so regen/session evaluation no longer duplicates verdict writes.
- Added storage capability checks before judge calls and support methods for storage backends.
- Added prompt `shadow_comparison/v1.1.0`, deactivated `v1.0.0`, and updated tests/docs.

## Test Plan
- `uv run pytest open_source/reflexio/tests/server/services/test_generation_service_scheduling.py -o 'addopts=' -v`
- `uv run pytest open_source/reflexio/tests/server/services/shadow_comparison open_source/reflexio/tests/server/services/agent_success_evaluation/test_group_evaluation_shadow_integration.py -o 'addopts=' -v`
- `uv run pytest open_source/reflexio/tests/models/test_config_f1_fields.py open_source/reflexio/tests/server/prompt/test_shadow_comparison_prompt_present.py open_source/reflexio/tests/server/services/test_prompt_model_mapping.py -o 'addopts=' -v`
- `uv run ruff check ...` and `uv run pyright ...` on staged Python files
- Local real-LLM E2E on backend `http://localhost:18091` with MiniMax and Supabase: verified zero-sampling shadow verdict creation, no-shadow no-op, and sampled group evaluation + shadow verdict rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated shadow comparison to use the newer evaluation prompt version.
  * Added publish-time shadow comparison for assistant turns that include shadow content, with background processing for smoother handling.

* **Bug Fixes**
  * Session-level shadow comparison is no longer triggered during group evaluation, preventing duplicate or unexpected verdict writes.
  * New shadow comparison results are now stored reliably in supported backends.

* **Documentation**
  * Clarified how shadow comparison is scheduled and recorded, and updated the related overview and component list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->