### PR TITLE
fix: validate normalized config payloads

### DIFF
--- a/reflexio/server/routes/config.py
+++ b/reflexio/server/routes/config.py
@@ -92,10 +92,10 @@ def set_config(
     # Create Reflexio instance to access the configurator through request_context
     reflexio = reflexio_cache.get_reflexio(org_id=org_id)
     configurator = reflexio.request_context.configurator
-    normalized_config = configurator.normalize_config_payload(config)
-    if not isinstance(normalized_config, dict):
-        normalized_config = config
     try:
+        normalized_config = configurator.normalize_config_payload(config)
+        if not isinstance(normalized_config, dict):
+            normalized_config = config
         Config.model_validate(normalized_config)
     except ValidationError as exc:
         raise HTTPException(


### PR DESCRIPTION
## Summary
- Make `/api/set_config` return the existing 422 validation response when configurator normalization raises a Pydantic `ValidationError`.
- Keeps enterprise overlay validation errors on the public config API path instead of surfacing as TestClient/server exceptions.

## Changes
- Moves `normalize_config_payload()` inside the existing validation `try` block in `reflexio/server/routes/config.py`.

## Test Plan
- Verified from the enterprise stack with:
  - `TMPDIR=/var/tmp/reflexio-review-loop REFLEXIO_GOVERNANCE_REF_SECRET=review-loop-secret uv run pytest -o 'addopts=' reflexio_ext/tests/server/services/offline_tuner/test_config.py reflexio_ext/tests/server/services/offline_tuner/test_linkage.py reflexio_ext/tests/server/services/offline_tuner/test_mode_b.py reflexio_ext/tests/server/services/offline_tuner/test_runner.py reflexio_ext/tests/server/services/offline_tuner/test_api.py -q`
  - `uv run ruff check ... open_source/reflexio/reflexio/server/routes/config.py`
  - `TMPDIR=/var/tmp/reflexio-review-loop REFLEXIO_GOVERNANCE_REF_SECRET=review-loop-secret uv run pyright ... open_source/reflexio/reflexio/server/routes/config.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration error handling so invalid configuration input is consistently returned as a validation error.
  * Configuration issues caught during normalization now surface the same way as other validation problems, reducing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->