### PR TITLE
feat(search): session-scoped result dedup keyed by session_id

### DIFF
--- a/docs/lib/methods/unified-search.ts
+++ b/docs/lib/methods/unified-search.ts
@@ -90,6 +90,13 @@ export const unifiedSearchMethods: MethodDef[] = [
           "Search mode: vector (embedding similarity), fts (full-text search), or hybrid (combined with RRF)",
         enumValues: ["vector", "fts", "hybrid"],
       },
+      {
+        name: "session_id",
+        type: "string",
+        required: false,
+        description:
+          "Agent session this search serves. When set, results already returned to the same session are skipped and next-best matches backfilled; searches without it neither read nor record session dedup state",
+      },
     ],
   },
 ];

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -737,6 +737,9 @@ class UnifiedSearchRequest(BaseModel):
     search_mode: SearchMode = SearchMode.HYBRID
     # Caller correlation IDs for billing attribution on the Application line.
     # Optional; consumed by _meter_applied_learnings in server/api.py.
+    # ``session_id`` additionally enables session-scoped result dedup: items
+    # already served to the same (org, session) are skipped and the next-best
+    # matches backfilled (see server/services/retrieval/session_dedup.py).
     request_id: str | None = None
     session_id: str | None = None
     interaction_id: int | None = Field(default=None, gt=0)

--- a/reflexio/server/services/retrieval/session_dedup.py
+++ b/reflexio/server/services/retrieval/session_dedup.py
@@ -1,0 +1,127 @@
+"""In-memory record of search results already served to a session.
+
+When a unified search request carries a ``session_id``, results returned for
+that ``(org_id, session_id)`` are remembered here so later searches in the
+same session can skip items the session has already received and surface the
+next-best matches instead. The session is the dedup scope: concurrent
+sessions never affect each other, and a request without a ``session_id``
+neither reads nor writes this cache.
+
+The cache is deliberately process-local and best-effort. Losing it (restart,
+another replica) only means an item may be served to a session twice — the
+pre-dedup behavior. The time- and size-based limits below are memory bounds,
+not dedup semantics: within a live session an item stays suppressed for the
+session's lifetime.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+# Entity key: (entity_kind, entity_id) with entity_kind one of
+# "profile" | "user_playbook" | "agent_playbook" and entity_id stringified.
+EntityKey = tuple[str, str]
+
+_MAX_SESSIONS = 1024
+_MAX_ENTRIES_PER_SESSION = 2000
+_IDLE_EVICTION_SECONDS = 12 * 60 * 60
+
+
+@dataclass
+class _SessionEntry:
+    last_access: float
+    # OrderedDict used as an insertion-ordered set for FIFO eviction.
+    entries: OrderedDict[EntityKey, None] = field(default_factory=OrderedDict)
+
+
+class SessionSeenCache:
+    """Bounded per-(org, session) set of entity keys already served.
+
+    Bounds: least-recently-used session eviction beyond ``max_sessions``,
+    FIFO entry eviction beyond ``max_entries_per_session``, and lazy removal
+    of sessions idle longer than ``idle_eviction_seconds``.
+    """
+
+    def __init__(
+        self,
+        max_sessions: int = _MAX_SESSIONS,
+        max_entries_per_session: int = _MAX_ENTRIES_PER_SESSION,
+        idle_eviction_seconds: float = _IDLE_EVICTION_SECONDS,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._max_sessions = max_sessions
+        self._max_entries_per_session = max_entries_per_session
+        self._idle_eviction_seconds = idle_eviction_seconds
+        self._sessions: OrderedDict[tuple[str, str], _SessionEntry] = OrderedDict()
+
+    def seen(self, org_id: str, session_id: str) -> frozenset[EntityKey]:
+        """Return the entity keys already served to this org's session.
+
+        Args:
+            org_id (str): Organization the session belongs to
+            session_id (str): Session identifier from the search request
+
+        Returns:
+            frozenset[EntityKey]: Keys previously recorded for the session
+        """
+        now = time.monotonic()
+        key = (org_id, session_id)
+        with self._lock:
+            self._evict_idle(now)
+            entry = self._sessions.get(key)
+            if entry is None:
+                return frozenset()
+            entry.last_access = now
+            self._sessions.move_to_end(key)
+            return frozenset(entry.entries)
+
+    def record(self, org_id: str, session_id: str, keys: Iterable[EntityKey]) -> None:
+        """Record entity keys as served to this org's session.
+
+        Args:
+            org_id (str): Organization the session belongs to
+            session_id (str): Session identifier from the search request
+            keys (Iterable[EntityKey]): Entity keys returned to the caller
+        """
+        now = time.monotonic()
+        session_key = (org_id, session_id)
+        entity_keys = list(keys)
+        with self._lock:
+            self._evict_idle(now)
+            entry = self._sessions.get(session_key)
+            if entry is None:
+                if not entity_keys:
+                    # Nothing to remember: don't let empty results consume a
+                    # session slot and evict a live session's seen-state.
+                    return
+                entry = _SessionEntry(last_access=now)
+                self._sessions[session_key] = entry
+            entry.last_access = now
+            self._sessions.move_to_end(session_key)
+            for entity_key in entity_keys:
+                entry.entries[entity_key] = None
+            while len(entry.entries) > self._max_entries_per_session:
+                entry.entries.popitem(last=False)
+            while len(self._sessions) > self._max_sessions:
+                self._sessions.popitem(last=False)
+
+    def clear(self) -> None:
+        """Drop all sessions (test hook)."""
+        with self._lock:
+            self._sessions.clear()
+
+    def _evict_idle(self, now: float) -> None:
+        # Sessions are LRU-ordered, so idle ones cluster at the front.
+        while self._sessions:
+            _, entry = next(iter(self._sessions.items()))
+            if now - entry.last_access <= self._idle_eviction_seconds:
+                break
+            self._sessions.popitem(last=False)
+
+
+# Process-wide instance used by the unified search service.
+session_seen_cache = SessionSeenCache()

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -51,6 +51,10 @@ from reflexio.server.services.retrieval.recency import (
     multiplicative_factor,
 )
 from reflexio.server.services.retrieval.relevance_floor import apply_relevance_floors
+from reflexio.server.services.retrieval.session_dedup import (
+    EntityKey,
+    session_seen_cache,
+)
 from reflexio.server.services.retrieval.temporal import (
     freshness_collapse,
     sort_by_recency,
@@ -86,6 +90,16 @@ _ENV_SINGLE_RPC = "REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC"
 # sort): matches the RecencyConfig default pool so the fresh version of a
 # fact can be promoted even when it ranks below top_k on text relevance.
 _TEMPORAL_POOL_SIZE = 20
+# Session dedup widens the fetch pool so filtered-out (already served) items
+# can be backfilled, but never by more than this many extra candidates.
+_SESSION_DEDUP_FETCH_BUMP_CAP = 50
+# Singular dedup kinds (session_dedup EntityKey vocabulary) — deliberately
+# distinct from the plural request-level ``entity_types`` values.
+_ENTITY_ID_ATTRS = {
+    "profile": "profile_id",
+    "user_playbook": "user_playbook_id",
+    "agent_playbook": "agent_playbook_id",
+}
 _EMBEDDING_CACHE_TTL_SECONDS = max(
     0, int(os.getenv("REFLEXIO_QUERY_EMBEDDING_CACHE_TTL_SECONDS", "300") or "300")
 )
@@ -181,6 +195,15 @@ def run_unified_search(
     )
     result_cap = max(top_k, _TEMPORAL_POOL_SIZE) if temporal_reorder else top_k
 
+    # Session dedup: a request that carries a session_id skips items already
+    # served to that (org, session) and backfills from a widened pool.
+    session_id = (request.session_id or "").strip()
+    seen_keys = (
+        session_seen_cache.seen(org_id, session_id) if session_id else frozenset()
+    )
+    if seen_keys:
+        fetch_k += min(len(seen_keys), _SESSION_DEDUP_FETCH_BUMP_CAP)
+
     # --- Phase B: parallel searches across all entity types ---
     profiles, agent_playbooks, user_playbooks = _run_phase_b(
         request=request,
@@ -197,6 +220,16 @@ def run_unified_search(
 
     if profiles is None:
         return UnifiedSearchResponse(success=False, msg="Search failed")
+
+    if seen_keys:
+        # Drop before the floors so seen items spend no cross-encoder budget.
+        profiles = _drop_seen_items(profiles or [], "profile", seen_keys)
+        agent_playbooks = _drop_seen_items(
+            agent_playbooks or [], "agent_playbook", seen_keys
+        )
+        user_playbooks = _drop_seen_items(
+            user_playbooks or [], "user_playbook", seen_keys
+        )
 
     if floor_on:
         profiles, agent_playbooks, user_playbooks = _apply_floors(
@@ -255,6 +288,8 @@ def run_unified_search(
         if reformulated_query != request.query
         else None,
     )
+    if session_id:
+        session_seen_cache.record(org_id, session_id, _served_entity_keys(response))
     _maybe_capture_final_response(
         request=request,
         response=response,
@@ -722,6 +757,34 @@ def _unwrap_item(item: Any) -> Any:
 
 def _unwrap_items(items: list[Any]) -> list[Any]:
     return [_unwrap_item(item) for item in items]
+
+
+def _entity_key(kind: str, item: Any) -> EntityKey | None:
+    """Return the session-dedup key for a (possibly score-wrapped) item."""
+    raw_id = getattr(_unwrap_item(item), _ENTITY_ID_ATTRS[kind], None)
+    if raw_id in (None, "", 0):
+        return None
+    return (kind, str(raw_id))
+
+
+def _drop_seen_items(
+    items: list[Any], kind: str, seen: frozenset[EntityKey]
+) -> list[Any]:
+    return [item for item in items if _entity_key(kind, item) not in seen]
+
+
+def _served_entity_keys(response: UnifiedSearchResponse) -> list[EntityKey]:
+    arms: tuple[tuple[str, list[Any]], ...] = (
+        ("profile", response.profiles or []),
+        ("user_playbook", response.user_playbooks or []),
+        ("agent_playbook", response.agent_playbooks or []),
+    )
+    return [
+        key
+        for kind, items in arms
+        for item in items
+        if (key := _entity_key(kind, item)) is not None
+    ]
 
 
 def _suppress_source_user_playbooks(

--- a/tests/e2e_tests/test_session_dedup_e2e.py
+++ b/tests/e2e_tests/test_session_dedup_e2e.py
@@ -1,0 +1,76 @@
+"""E2E: session-scoped search dedup through real SQLite storage.
+
+Drives ``Reflexio.unified_search`` (the same path the ``/api/search`` route
+calls) against a real per-test SQLite database: a search carrying a
+``session_id`` never re-returns rows already served to that session and
+backfills next-best matches; other sessions and session-less searches are
+unaffected.
+"""
+
+from reflexio.models.api_schema.retriever_schema import UnifiedSearchRequest
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+
+
+def _seed_playbooks(reflexio_instance, count: int = 5) -> None:
+    storage = reflexio_instance.request_context.storage
+    assert storage is not None
+    storage.save_user_playbooks(
+        [
+            UserPlaybook(
+                user_id="dedup-user",
+                agent_version="dedup-agent",
+                request_id=f"dedup-req-{i}",
+                content=f"When refunding an order always verify the receipt id variant {i}",
+                trigger="refund order receipt",
+            )
+            for i in range(1, count + 1)
+        ]
+    )
+
+
+def _search_ids(reflexio_instance, org_id: str, session_id: str | None) -> set[int]:
+    response = reflexio_instance.unified_search(
+        UnifiedSearchRequest(
+            query="how to refund an order",
+            user_id="dedup-user",
+            agent_version="dedup-agent",
+            entity_types=["user_playbooks"],
+            top_k=2,
+            session_id=session_id,
+        ),
+        org_id=org_id,
+    )
+    assert response.success
+    return {p.user_playbook_id for p in response.user_playbooks or []}
+
+
+def test_session_dedup_end_to_end(
+    reflexio_instance_playbook_only, test_org_id, cleanup_playbook_only
+):
+    instance = reflexio_instance_playbook_only
+    _seed_playbooks(instance)
+    session_a = f"{test_org_id}-dedup-a"
+    session_b = f"{test_org_id}-dedup-b"
+
+    first = _search_ids(instance, test_org_id, session_a)
+    assert len(first) == 2
+
+    # Same session: previously served rows skipped, next-best backfilled.
+    second = _search_ids(instance, test_org_id, session_a)
+    assert len(second) == 2
+    assert first.isdisjoint(second)
+
+    # A concurrent session sees the full result set.
+    other = _search_ids(instance, test_org_id, session_b)
+    assert other == first
+
+    # Pool exhausts: the last remaining row, then nothing.
+    third = _search_ids(instance, test_org_id, session_a)
+    assert len(third) == 1
+    assert third.isdisjoint(first | second)
+    assert _search_ids(instance, test_org_id, session_a) == set()
+
+    # Session-less searches are unaffected and never consume any session.
+    assert _search_ids(instance, test_org_id, None) == first
+    assert _search_ids(instance, test_org_id, None) == first
+    assert _search_ids(instance, test_org_id, session_b) == second

--- a/tests/server/services/retrieval/test_session_dedup.py
+++ b/tests/server/services/retrieval/test_session_dedup.py
@@ -1,0 +1,102 @@
+"""Unit tests for the per-session seen-cache used by unified search dedup."""
+
+import unittest
+
+from reflexio.server.services.retrieval.session_dedup import SessionSeenCache
+
+
+class TestSessionSeenCache(unittest.TestCase):
+    def test_seen_record_round_trip(self):
+        cache = SessionSeenCache()
+        self.assertEqual(cache.seen("org", "s1"), frozenset())
+
+        cache.record("org", "s1", [("profile", "p1"), ("user_playbook", "7")])
+        self.assertEqual(
+            cache.seen("org", "s1"),
+            frozenset({("profile", "p1"), ("user_playbook", "7")}),
+        )
+
+    def test_sessions_are_isolated(self):
+        cache = SessionSeenCache()
+        cache.record("org", "s1", [("profile", "p1")])
+
+        self.assertEqual(cache.seen("org", "s2"), frozenset())
+        self.assertEqual(cache.seen("org", "s1"), frozenset({("profile", "p1")}))
+
+    def test_orgs_are_isolated(self):
+        cache = SessionSeenCache()
+        cache.record("org-a", "s1", [("profile", "p1")])
+
+        self.assertEqual(cache.seen("org-b", "s1"), frozenset())
+
+    def test_per_session_entry_cap_evicts_oldest_first(self):
+        cache = SessionSeenCache(max_entries_per_session=3)
+        cache.record("org", "s1", [("profile", f"p{i}") for i in range(5)])
+
+        self.assertEqual(
+            cache.seen("org", "s1"),
+            frozenset({("profile", "p2"), ("profile", "p3"), ("profile", "p4")}),
+        )
+
+    def test_session_cap_evicts_least_recently_used(self):
+        cache = SessionSeenCache(max_sessions=2)
+        cache.record("org", "s1", [("profile", "p1")])
+        cache.record("org", "s2", [("profile", "p2")])
+        # Touch s1 so s2 becomes the least recently used.
+        cache.seen("org", "s1")
+        cache.record("org", "s3", [("profile", "p3")])
+
+        self.assertEqual(cache.seen("org", "s2"), frozenset())
+        self.assertEqual(cache.seen("org", "s1"), frozenset({("profile", "p1")}))
+        self.assertEqual(cache.seen("org", "s3"), frozenset({("profile", "p3")}))
+
+    def test_idle_sessions_evicted(self):
+        cache = SessionSeenCache(idle_eviction_seconds=0.0)
+        cache.record("org", "s1", [("profile", "p1")])
+
+        # Any later access observes the zero-idle session as expired.
+        self.assertEqual(cache.seen("org", "s1"), frozenset())
+
+    def test_clear_drops_everything(self):
+        cache = SessionSeenCache()
+        cache.record("org", "s1", [("profile", "p1")])
+        cache.clear()
+
+        self.assertEqual(cache.seen("org", "s1"), frozenset())
+
+    def test_empty_record_does_not_allocate_a_session_slot(self):
+        cache = SessionSeenCache(max_sessions=2)
+        cache.record("org", "s1", [("profile", "p1")])
+        cache.record("org", "s2", [("profile", "p2")])
+        # Empty recordings for new sessions must not evict live sessions.
+        cache.record("org", "empty-1", [])
+        cache.record("org", "empty-2", [])
+
+        self.assertEqual(cache.seen("org", "s1"), frozenset({("profile", "p1")}))
+        self.assertEqual(cache.seen("org", "s2"), frozenset({("profile", "p2")}))
+
+    def test_empty_record_still_refreshes_an_existing_session(self):
+        cache = SessionSeenCache(max_sessions=2)
+        cache.record("org", "s1", [("profile", "p1")])
+        cache.record("org", "s2", [("profile", "p2")])
+        # Empty record on s1 marks it most recently used...
+        cache.record("org", "s1", [])
+        # ...so adding a third session evicts s2, not s1.
+        cache.record("org", "s3", [("profile", "p3")])
+
+        self.assertEqual(cache.seen("org", "s1"), frozenset({("profile", "p1")}))
+        self.assertEqual(cache.seen("org", "s2"), frozenset())
+
+    def test_re_recording_same_key_is_idempotent(self):
+        cache = SessionSeenCache(max_entries_per_session=2)
+        cache.record("org", "s1", [("profile", "p1")])
+        cache.record("org", "s1", [("profile", "p1"), ("profile", "p2")])
+
+        self.assertEqual(
+            cache.seen("org", "s1"),
+            frozenset({("profile", "p1"), ("profile", "p2")}),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/services/test_unified_search_session_dedup.py
+++ b/tests/server/services/test_unified_search_session_dedup.py
@@ -1,0 +1,206 @@
+"""Session-scoped result dedup in unified search.
+
+A request that carries a ``session_id`` must not re-return items already
+served to that (org, session); the widened fetch pool backfills next-best
+matches instead. Requests without a ``session_id`` are unaffected and record
+nothing. Covered on both Phase B routing paths (per-arm fan-out and the
+combined single RPC).
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from reflexio.models.api_schema.domain.entities import (
+    AgentPlaybook,
+    UserPlaybook,
+    UserProfile,
+)
+from reflexio.models.api_schema.retriever_schema import UnifiedSearchRequest
+from reflexio.server.services.pre_retrieval import ReformulationResult
+from reflexio.server.services.retrieval.session_dedup import session_seen_cache
+from reflexio.server.services.unified_search_service import (
+    configure_retrieval_capture_hook,
+    run_unified_search,
+)
+
+_ORG = "test-org"
+
+
+def _profiles(count: int) -> list[UserProfile]:
+    return [
+        UserProfile(
+            profile_id=f"p{i}",
+            user_id="u1",
+            content=f"profile {i}",
+            last_modified_timestamp=1000 + i,
+            generated_from_request_id="req-1",
+        )
+        for i in range(1, count + 1)
+    ]
+
+
+def _user_playbooks(count: int) -> list[UserPlaybook]:
+    return [
+        UserPlaybook(
+            user_playbook_id=10 + i,
+            user_id="u1",
+            agent_version="agent-v1",
+            request_id="req-1",
+            content=f"user playbook {10 + i}",
+        )
+        for i in range(1, count + 1)
+    ]
+
+
+def _agent_playbooks(count: int) -> list[AgentPlaybook]:
+    return [
+        AgentPlaybook(
+            agent_playbook_id=i,
+            agent_version="agent-v1",
+            content=f"agent playbook {i}",
+        )
+        for i in range(1, count + 1)
+    ]
+
+
+def _mock_storage(*, single_rpc: bool) -> MagicMock:
+    storage = MagicMock()
+    storage._get_embedding.return_value = [0.1] * 8
+    storage.supports_unified_hybrid_search = single_rpc
+    storage.search_user_profile.return_value = _profiles(5)
+    storage.search_agent_playbooks.return_value = _agent_playbooks(5)
+    storage.search_user_playbooks.return_value = _user_playbooks(5)
+    storage.unified_hybrid_search.return_value = (
+        _profiles(5),
+        _agent_playbooks(5),
+        _user_playbooks(5),
+    )
+    # The source-playbook suppression lookup must return a real mapping.
+    storage.get_source_user_playbook_ids_for_agent_playbooks.return_value = {}
+    return storage
+
+
+def _search(storage: MagicMock, session_id: str | None) -> tuple:
+    request = UnifiedSearchRequest(
+        query="how to refund",
+        user_id="u1",
+        top_k=2,
+        session_id=session_id,
+    )
+    response = run_unified_search(
+        request=request,
+        org_id=_ORG,
+        storage=storage,
+        llm_client=MagicMock(),
+        prompt_manager=MagicMock(),
+    )
+    assert response.success
+    return (
+        [p.profile_id for p in response.profiles or []],
+        [p.agent_playbook_id for p in response.agent_playbooks or []],
+        [p.user_playbook_id for p in response.user_playbooks or []],
+    )
+
+
+@patch("reflexio.server.services.unified_search_service.QueryReformulator")
+class TestUnifiedSearchSessionDedup(unittest.TestCase):
+    def setUp(self):
+        session_seen_cache.clear()
+        configure_retrieval_capture_hook(None)
+
+    def tearDown(self):
+        session_seen_cache.clear()
+
+    def _prep(self, reformulator_cls) -> None:
+        reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="how to refund"
+        )
+
+    def _assert_dedup_behavior(self, reformulator_cls, storage: MagicMock) -> None:
+        self._prep(reformulator_cls)
+
+        first = _search(storage, "s1")
+        self.assertEqual(first, (["p1", "p2"], [1, 2], [11, 12]))
+
+        # Same session: previously served items skipped, next-best backfilled.
+        second = _search(storage, "s1")
+        self.assertEqual(second, (["p3", "p4"], [3, 4], [13, 14]))
+
+        # A concurrent session is unaffected by s1's history.
+        other = _search(storage, "s2")
+        self.assertEqual(other, (["p1", "p2"], [1, 2], [11, 12]))
+
+        # Exhausted pool: everything remaining, then nothing.
+        third = _search(storage, "s1")
+        self.assertEqual(third, (["p5"], [5], [15]))
+        fourth = _search(storage, "s1")
+        self.assertEqual(fourth, ([], [], []))
+
+    @patch.dict(os.environ, {"REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC": "0"})
+    def test_dedup_and_backfill_fanout_path(self, reformulator_cls):
+        self._assert_dedup_behavior(reformulator_cls, _mock_storage(single_rpc=False))
+
+    @patch.dict(os.environ, {"REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC": "1"})
+    def test_dedup_and_backfill_single_rpc_path(self, reformulator_cls):
+        storage = _mock_storage(single_rpc=True)
+        self._assert_dedup_behavior(reformulator_cls, storage)
+        storage.unified_hybrid_search.assert_called()
+
+    @patch.dict(os.environ, {"REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC": "0"})
+    def test_no_session_id_is_unaffected_and_records_nothing(self, reformulator_cls):
+        self._prep(reformulator_cls)
+        storage = _mock_storage(single_rpc=False)
+
+        self.assertEqual(_search(storage, None), (["p1", "p2"], [1, 2], [11, 12]))
+        self.assertEqual(_search(storage, None), (["p1", "p2"], [1, 2], [11, 12]))
+        self.assertEqual(len(session_seen_cache._sessions), 0)
+
+        # Whitespace-only session ids are treated as absent.
+        self.assertEqual(_search(storage, "   "), (["p1", "p2"], [1, 2], [11, 12]))
+        self.assertEqual(len(session_seen_cache._sessions), 0)
+
+    @patch.dict(os.environ, {"REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC": "0"})
+    def test_items_with_default_ids_are_never_filtered_or_recorded(
+        self, reformulator_cls
+    ):
+        """Rows carrying model-default ids (0 / "") have no stable identity.
+
+        They must pass through dedup untouched on every call and must not be
+        recorded — otherwise all id-0 rows would count as mutually "seen".
+        """
+        self._prep(reformulator_cls)
+        storage = _mock_storage(single_rpc=False)
+        unidentified = UserPlaybook(
+            user_playbook_id=0,
+            user_id="u1",
+            agent_version="agent-v1",
+            request_id="req-1",
+            content="user playbook without a stable id",
+        )
+        storage.search_user_playbooks.return_value = [unidentified]
+        storage.search_user_profile.return_value = []
+        storage.search_agent_playbooks.return_value = []
+
+        for _ in range(2):
+            _, _, user_playbook_ids = _search(storage, "s1")
+            self.assertEqual(user_playbook_ids, [0])
+        self.assertEqual(session_seen_cache.seen(_ORG, "s1"), frozenset())
+
+    @patch.dict(os.environ, {"REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC": "0"})
+    def test_fetch_pool_widens_by_seen_count(self, reformulator_cls):
+        self._prep(reformulator_cls)
+        storage = _mock_storage(single_rpc=False)
+
+        _search(storage, "s1")
+        first_top_k = storage.search_user_playbooks.call_args.args[0].top_k
+        self.assertEqual(first_top_k, 2)
+
+        _search(storage, "s1")
+        # 6 items (2 per arm) were recorded, so the pool widens by 6.
+        second_top_k = storage.search_user_playbooks.call_args.args[0].top_k
+        self.assertEqual(second_top_k, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds session-scoped result dedup to unified search: a request that carries a `session_id` no longer re-returns items already served to that `(org, session)` — the fetch pool widens so the next-best matches backfill instead. Repeated searches within one agent session (e.g. hook-driven searches firing on every prompt/tool call) stop injecting the same rules over and over and surface new ones.

Dedup activates **only** when `session_id` is present on the request. Searches without a session id behave exactly as before and neither read nor record any dedup state.

## Changes

- **New `SessionSeenCache`** (`server/services/retrieval/session_dedup.py`): bounded, process-local, best-effort in-memory store keyed `(org_id, session_id)` — LRU cap of 1024 sessions, FIFO cap of 2000 entries per session, 12h idle eviction (memory bounds, not dedup semantics). Empty recordings never allocate a session slot, so zero-result searches can't evict live sessions' seen-state.
- **`run_unified_search` wiring** (`unified_search_service.py`): when `session_id` is set, widen `fetch_k` by the seen count (capped at +50), drop seen `(kind, id)` pairs right after Phase B — before the cross-encoder floors, and after both routing paths (single-RPC and per-arm fan-out) converge, so the filter is path-agnostic — then record only the finally returned items. Items with model-default ids (`0` / `""`) are never filtered or recorded.
- **Schema/docs**: comment on `UnifiedSearchRequest.session_id` and the `unified-search` method-registry entry updated to document the dedup semantics. No wire changes — `session_id` already existed (previously metering-only).

## Behavior notes

- Existing callers that already pass `session_id` will start getting session-dedup'd results — this is the intended semantic ("this search serves that session's context").
- The cache is per-process: restarts or multi-worker deployments (`--workers 2` default) can serve an item once per worker before suppression. Losing the cache only reverts to pre-dedup behavior.
- Pipeline revisions (reflection insert-then-archive, consolidation supersede) create new row ids, so revised content re-qualifies automatically. In-place manual edits keep their id and stay suppressed for the session (accepted edge).

## Test Plan

- [x] 10 unit tests for `SessionSeenCache` (round-trip, per-session FIFO cap, session LRU cap, idle eviction, org/session isolation, empty-record guards, idempotent re-record)
- [x] 5 service tests for `run_unified_search`: dedup + backfill + exhaustion on **both** Phase B paths (single-RPC and fan-out), concurrent-session isolation, no-session no-op (including whitespace-only ids, asserting nothing is recorded), default-id passthrough, fetch-pool widening
- [x] E2E test on real SQLite storage (`tests/e2e_tests/test_session_dedup_e2e.py`): serve → dedup → backfill → exhaust → session isolation → session-less neutrality
- [x] All 65 pre-existing unified-search tests pass; ruff / pyright clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified search now supports an optional `session_id` so repeated searches in the same session avoid returning the same items again and backfill with the next-best matches.
  * Session-less searches continue to work normally and are not tracked for deduplication.

* **Bug Fixes**
  * Search results are now more consistent across repeated requests within the same session, reducing duplicate results and improving result variety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->