### PR TITLE
fix(embedding): move encode serialization into the embedder singletons (prod race fix)

### DIFF
--- a/reflexio/server/llm/embedding_service.py
+++ b/reflexio/server/llm/embedding_service.py
@@ -34,29 +34,19 @@ _SUPPORTED_MODELS = {
 _ACTIVE_MODEL: str | None = None
 _ACTIVE_MODEL_LOCK = threading.Lock()
 
-# The underlying sentence-transformers / ONNX embedders share internal buffers
-# and are NOT thread-safe: concurrent ``.embed()`` calls interleave and corrupt
-# each other's padding/attention tensors (observed under concurrent publishes as
-# ``RuntimeError: The size of tensor a (62) must match the size of tensor b (61)
-# at non-singleton dimension 1``). The ``_ENCODE_SEMAPHORE`` below only caps how
-# many requests run at once (for memory), it does NOT serialize them, so this
-# lock guards the actual model inference. Throughput comes from micro-batch
-# coalescing (many texts per encode), not from parallel encodes on one model.
-_MODEL_ENCODE_LOCK = threading.Lock()
-
 DEFAULT_OSS_EMBEDDING_MODEL = MINILM_MODEL
 
-# Bound how many embed/encode calls run at once. The endpoint is a sync ``def``
-# served from Starlette's threadpool, so without a guard a burst of requests
-# would run that many model.encode() calls in parallel, stacking their
-# activation memory and OOM-killing the daemon. The semaphore caps simultaneous
-# encodes; excess requests block on acquire() and are picked up when a slot
-# frees — they queue, they are never rejected. Pair with a small encode
-# batch_size so each in-flight encode stays cheap.
+# Bound how many micro-batch processor threads run at once. The endpoint is a
+# sync ``def`` served from Starlette's threadpool, so without a cap a burst of
+# requests would spawn a processor per request and stack their activation
+# memory, OOM-killing the daemon. This caps concurrent processors; excess
+# requests queue on the micro-batch condition and are picked up when a slot
+# frees — they are never rejected. The embedder singletons (NomicEmbedder /
+# LocalEmbedder) serialize the actual model.encode() internally — the shared
+# models are not thread-safe — so no encode lock or semaphore is needed here.
+# Pair with a small encode batch_size so each in-flight encode stays cheap.
 _DEFAULT_MAX_CONCURRENCY = 4
 _ENV_MAX_CONCURRENCY = "REFLEXIO_EMBED_MAX_CONCURRENCY"
-_ENCODE_SEMAPHORE: threading.BoundedSemaphore | None = None
-_ENCODE_SEMAPHORE_LOCK = threading.Lock()
 
 # Opportunistically coalesce concurrent small requests before calling
 # model.encode(). This keeps request concurrency thread-based while giving the
@@ -109,16 +99,6 @@ def _micro_batch_max_texts() -> int:
     return positive_int_env(
         _ENV_MICRO_BATCH_MAX_TEXTS, _DEFAULT_MICRO_BATCH_MAX_TEXTS, logger
     )
-
-
-def _encode_semaphore() -> threading.BoundedSemaphore:
-    """Return the process-wide encode semaphore, building it on first use."""
-    global _ENCODE_SEMAPHORE
-    if _ENCODE_SEMAPHORE is None:
-        with _ENCODE_SEMAPHORE_LOCK:
-            if _ENCODE_SEMAPHORE is None:
-                _ENCODE_SEMAPHORE = threading.BoundedSemaphore(_max_concurrency())
-    return _ENCODE_SEMAPHORE
 
 
 class EmbeddingRequest(BaseModel):
@@ -313,29 +293,16 @@ def _process_micro_batch(jobs: list[_EmbeddingJob]) -> None:
 
 
 def _encode_texts_now(model: str, texts: list[str]) -> list[list[float]]:
-    semaphore = _encode_semaphore()
-    # Non-blocking probe purely for observability: if no slot is free, this
-    # request will have to wait. The real acquire below blocks until a slot
-    # opens, so the request queues and is picked up later — never rejected.
-    if not semaphore.acquire(blocking=False):
-        logger.info(
-            "Embedding request queued; all %d encode slots busy",
-            _max_concurrency(),
-        )
-        semaphore.acquire()
-    try:
-        # Serialize the actual inference: the shared embedder models are not
-        # thread-safe, so concurrent encodes race and produce tensor-shape
-        # errors. The semaphore (above) bounds memory; this lock bounds the
-        # model to one in-flight encode at a time.
-        with _MODEL_ENCODE_LOCK:
-            if is_nomic_model(model):
-                return NomicEmbedder.get().embed(texts)
-            if model == MINILM_MODEL:
-                return LocalEmbedder.get().embed(texts)
-        raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
-    finally:
-        semaphore.release()
+    # The embedder singletons serialize their own model.encode() internally
+    # (the shared sentence-transformers / ONNX models are not thread-safe — see
+    # NomicEmbedder / LocalEmbedder). Concurrency is already bounded by the
+    # micro-batch processor cap (``_max_concurrency``), so no extra encode
+    # lock/semaphore is needed here.
+    if is_nomic_model(model):
+        return NomicEmbedder.get().embed(texts)
+    if model == MINILM_MODEL:
+        return LocalEmbedder.get().embed(texts)
+    raise HTTPException(status_code=400, detail=f"Unsupported model: {model}")
 
 
 def _activate_model(model: str) -> None:

--- a/reflexio/server/llm/providers/local_embedding_provider.py
+++ b/reflexio/server/llm/providers/local_embedding_provider.py
@@ -74,7 +74,17 @@ class LocalEmbedder:
 
     def __init__(self) -> None:
         self._ef: Any | None = None
+        # Guards lazy construction / cache-recovery swaps of ``self._ef``.
         self._ef_lock = threading.Lock()
+        # Serializes the actual encode call. The shared ONNX embedding function
+        # is NOT thread-safe — concurrent ``ef(...)`` calls interleave and
+        # corrupt each other's padding/attention buffers (observed in prod as
+        # tensor-shape mismatches). ``threading.Lock`` is non-reentrant, so this
+        # is a SEPARATE lock from ``_ef_lock`` (the recovery path re-acquires
+        # ``_ef_lock`` while we hold this one): fixed order is ``_encode_lock``
+        # outer, ``_ef_lock`` inner, which cannot deadlock. NOTE: this lock is
+        # not FIFO-fair — do not turn it into a fairness queue without measuring.
+        self._encode_lock = threading.Lock()
 
     @classmethod
     def get(cls) -> LocalEmbedder:
@@ -121,12 +131,17 @@ class LocalEmbedder:
                 ``_TARGET_DIM`` (512) floats with the last 128 positions
                 zero-padded.
         """
-        ef = self._load()
         safe_inputs = [(text or "")[:_MAX_CHARS] for text in texts]
-        try:
-            raw = ef(safe_inputs)
-        except Exception as exc:  # noqa: BLE001 - Chroma raises varied cache errors.
-            raw = self._retry_embed_after_cache_clear(ef, exc, safe_inputs)
+        # Serialize the encode: the shared ONNX embedder is not thread-safe.
+        # ``_load()`` and ``_retry_embed_after_cache_clear()`` both acquire
+        # ``_ef_lock`` internally; running them under ``_encode_lock`` fixes the
+        # lock order (``_encode_lock`` outer) so recovery can never deadlock.
+        with self._encode_lock:
+            ef = self._load()
+            try:
+                raw = ef(safe_inputs)
+            except Exception as exc:  # noqa: BLE001 - Chroma raises varied cache errors.
+                raw = self._retry_embed_after_cache_clear(ef, exc, safe_inputs)
         return [_pad(vec) for vec in raw]
 
     def _retry_embed_after_cache_clear(

--- a/reflexio/server/llm/providers/nomic_embedding_provider.py
+++ b/reflexio/server/llm/providers/nomic_embedding_provider.py
@@ -157,15 +157,30 @@ class NomicEmbedder:
         """
         model = self._load()
         safe = [(t or "")[:_MAX_CHARS] for t in texts]
-        # show_progress_bar=False so server logs stay clean during ingest
-        # batches. convert_to_numpy=True returns a numpy ndarray; we slice
-        # and renormalise per-row before converting to plain Python lists.
-        raw = model.encode(
-            safe,
-            batch_size=_encode_batch_size(),
-            show_progress_bar=False,
-            convert_to_numpy=True,
-        )
+        # The sentence-transformers model is NOT thread-safe: nomic-bert's
+        # rotary-embedding code mutates instance attrs (``_cos_cached`` /
+        # ``_sin_cached``) on every forward pass, so two concurrent
+        # ``encode()`` calls on this shared singleton corrupt each other's
+        # buffers (observed in prod as "size of tensor a (N) must match tensor
+        # b (M)" and "'NoneType' object is not subscriptable"). Serialize the
+        # encode so every caller — daemon, in-process fallback, prewarm,
+        # regeneration — is safe by construction. ``_load()`` acquires and
+        # releases ``_model_lock`` and returns before we re-acquire it here, so
+        # there is no nesting/deadlock. NOTE: ``threading.Lock`` is not FIFO-fair
+        # — do not "improve" this into a fairness queue without measuring; the
+        # micro-batch coalescing in ``embedding_service`` is where throughput
+        # comes from, not parallel encodes on one model.
+        with self._model_lock:
+            # show_progress_bar=False so server logs stay clean during ingest
+            # batches. convert_to_numpy=True returns a numpy ndarray; we slice
+            # and renormalise per-row (below, outside the lock) before
+            # converting to plain Python lists.
+            raw = model.encode(
+                safe,
+                batch_size=_encode_batch_size(),
+                show_progress_bar=False,
+                convert_to_numpy=True,
+            )
         return [_truncate_and_renormalise(vec.tolist()) for vec in raw]
 
 

--- a/tests/server/llm/test_embedding_service_concurrency.py
+++ b/tests/server/llm/test_embedding_service_concurrency.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 import threading
 import time
 
+import numpy as np
 import pytest
 
 from reflexio.server.llm import embedding_service as es
 
 
-class _ConcurrencyRecorder:
-    """Stand-in embedder that records the peak number of simultaneous calls."""
+class _ConcurrencyModel:
+    """Fake sentence-transformers model recording peak simultaneous encodes.
+
+    Injected into a real ``NomicEmbedder`` so the assertions exercise the
+    embedder-level ``_model_lock`` — the invariant that survives after the
+    daemon's own ``_MODEL_ENCODE_LOCK`` was removed (the embedder, not the
+    daemon, now owns serialization of the non-thread-safe model).
+    """
 
     def __init__(self, hold: float = 0.1) -> None:
         self._hold = hold
@@ -19,40 +26,30 @@ class _ConcurrencyRecorder:
         self.current = 0
         self.peak = 0
         self.calls = 0
+        self.encode_calls: list[list[str]] = []
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
+    def encode(self, texts: list[str], **_kwargs: object) -> np.ndarray:
         with self._lock:
             self.current += 1
             self.calls += 1
             self.peak = max(self.peak, self.current)
-        # Hold the slot so concurrent callers actually overlap.
+            self.encode_calls.append(list(texts))
+        # Hold the slot so concurrent callers would overlap if unserialized.
         time.sleep(self._hold)
         with self._lock:
             self.current -= 1
-        return [[0.0] * 512 for _ in texts]
-
-
-class _BatchRecorder:
-    """Stand-in embedder that records each encode call's texts."""
-
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self.calls: list[list[str]] = []
-
-    def embed(self, texts: list[str]) -> list[list[float]]:
-        with self._lock:
-            self.calls.append(list(texts))
-        return [[float(index)] * 512 for index, _text in enumerate(texts)]
+        return np.array([[0.1] * 768 for _ in texts])
 
 
 def _reset_service_state(
-    monkeypatch: pytest.MonkeyPatch, recorder: _ConcurrencyRecorder | _BatchRecorder
+    monkeypatch: pytest.MonkeyPatch, model: _ConcurrencyModel
 ) -> None:
-    monkeypatch.setattr(es, "_ENCODE_SEMAPHORE", None)
     monkeypatch.setattr(es, "_ACTIVE_MODEL", None)
     monkeypatch.setattr(es, "_MICRO_BATCH_QUEUE", [])
     monkeypatch.setattr(es, "_ACTIVE_BATCH_PROCESSORS", 0)
-    monkeypatch.setattr(es.NomicEmbedder, "get", classmethod(lambda _cls: recorder))
+    embedder = es.NomicEmbedder()
+    embedder._model = model  # pre-load so _load() is a no-op fast path
+    monkeypatch.setattr(es.NomicEmbedder, "get", classmethod(lambda _cls: embedder))
 
 
 def test_max_concurrency_defaults_to_4(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -81,12 +78,12 @@ def test_micro_batch_max_texts_respects_env(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 def test_embed_texts_caps_and_queues(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Excess concurrent requests queue (never reject) and the cap is honored."""
+    """Excess concurrent requests queue (never reject) and encodes serialize."""
     monkeypatch.setenv("REFLEXIO_EMBED_MAX_CONCURRENCY", "2")
     monkeypatch.setenv("REFLEXIO_EMBED_MICRO_BATCH_DELAY_MS", "1")
     monkeypatch.setenv("REFLEXIO_EMBED_MICRO_BATCH_MAX_TEXTS", "1")
-    recorder = _ConcurrencyRecorder(hold=0.1)
-    _reset_service_state(monkeypatch, recorder)
+    fake_model = _ConcurrencyModel(hold=0.1)
+    _reset_service_state(monkeypatch, fake_model)
 
     model = "local/nomic-embed-text-v1.5"
     errors: list[Exception] = []
@@ -101,17 +98,18 @@ def test_embed_texts_caps_and_queues(monkeypatch: pytest.MonkeyPatch) -> None:
     for thread in threads:
         thread.start()
     for thread in threads:
-        thread.join()
+        thread.join(timeout=10)
 
     # All six requests completed — they queued, none were rejected.
+    assert all(not thread.is_alive() for thread in threads)
     assert errors == []
-    assert recorder.calls == 6
-    # Model inference itself is serialized by _MODEL_ENCODE_LOCK (see PR #153:
-    # concurrent .embed() calls on the shared, non-thread-safe model corrupt each
-    # other's tensors). The semaphore only bounds how many requests sit waiting
-    # for that lock; the recorder counts time inside embed(), which the lock
-    # makes mutually exclusive, so the peak simultaneous-encode count is exactly 1.
-    assert recorder.peak == 1
+    assert fake_model.calls == 6
+    # Model inference is serialized by the embedder's own ``_model_lock`` (see
+    # PR #153: concurrent encodes on the shared, non-thread-safe model corrupt
+    # each other's tensors). The daemon no longer holds a redundant lock — the
+    # embedder owns serialization by construction. The fake model counts time
+    # inside encode(), so the peak simultaneous-encode count must be exactly 1.
+    assert fake_model.peak == 1
 
 
 def test_micro_batches_concurrent_requests(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -119,8 +117,8 @@ def test_micro_batches_concurrent_requests(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setenv("REFLEXIO_EMBED_MAX_CONCURRENCY", "1")
     monkeypatch.setenv("REFLEXIO_EMBED_MICRO_BATCH_DELAY_MS", "50")
     monkeypatch.setenv("REFLEXIO_EMBED_MICRO_BATCH_MAX_TEXTS", "8")
-    recorder = _BatchRecorder()
-    _reset_service_state(monkeypatch, recorder)
+    fake_model = _ConcurrencyModel(hold=0.0)
+    _reset_service_state(monkeypatch, fake_model)
 
     model = "local/nomic-embed-text-v1.5"
     barrier = threading.Barrier(2)
@@ -141,9 +139,9 @@ def test_micro_batches_concurrent_requests(monkeypatch: pytest.MonkeyPatch) -> N
     for thread in threads:
         thread.start()
     for thread in threads:
-        thread.join()
+        thread.join(timeout=10)
 
     assert errors == []
     assert len(results) == 2
-    assert len(recorder.calls) == 1
-    assert set(recorder.calls[0]) == {"first", "second"}
+    assert len(fake_model.encode_calls) == 1
+    assert set(fake_model.encode_calls[0]) == {"first", "second"}

--- a/tests/server/llm/test_local_embedding_provider.py
+++ b/tests/server/llm/test_local_embedding_provider.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import sys
 import tarfile
+import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
@@ -491,6 +493,161 @@ class TestEmbedPadding:
 
         with pytest.raises(lep.LocalEmbedderError, match="chromadb"):
             LocalEmbedder.get().embed(["hi"])
+
+
+class TestEncodeSerialization:
+    """The shared ONNX embedding function is not thread-safe.
+
+    ``LocalEmbedder.embed()`` must serialize the actual encode call so
+    concurrent publishes can't interleave and corrupt shared buffers.
+    """
+
+    def test_encode_is_serialized_across_threads(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """8 threads on ONE embedder never enter the encode callable at once.
+
+        Reverting the ``self._encode_lock`` guard in ``embed()`` makes this
+        fail: the stub records/raises on concurrent entry.
+        """
+        state = {"active": False, "reentered": False, "calls": 0}
+        guard = threading.Lock()
+
+        def encode(docs: list[str]) -> list[list[float]]:
+            with guard:
+                if state["active"]:
+                    state["reentered"] = True
+                    raise AssertionError("embedder entered by two threads at once")
+                state["active"] = True
+                state["calls"] += 1
+            try:
+                time.sleep(0.02)  # widen the race window
+            finally:
+                with guard:
+                    state["active"] = False
+            return [[0.1] * 384 for _ in docs]
+
+        ef_instance = MagicMock()
+        ef_instance.side_effect = encode
+        ef_class = MagicMock(return_value=ef_instance)
+        ef_class.MODEL_NAME = "all-MiniLM-L6-v2"
+        ef_class.DOWNLOAD_PATH = "/fake/cache"
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = ef_class
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+
+        embedder = LocalEmbedder.get()
+        payloads = [
+            ["short"],
+            ["x" * 500],
+            ["a", "b", "c"],
+            ["", "y" * 50],
+            ["one"],
+            ["p", "q"],
+            ["z" * 700],
+            ["m", "n", "o", "p"],
+        ]
+        results: list[list[list[float]]] = []
+        errors: list[BaseException] = []
+        results_lock = threading.Lock()
+
+        def worker(texts: list[str]) -> None:
+            try:
+                out = embedder.embed(texts)
+            except BaseException as exc:  # noqa: BLE001
+                with results_lock:
+                    errors.append(exc)
+                return
+            with results_lock:
+                results.append(out)
+
+        threads = [threading.Thread(target=worker, args=(p,)) for p in payloads]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert errors == []
+        assert state["reentered"] is False
+        assert state["calls"] == len(payloads)
+        assert len(results) == len(payloads)
+        assert all(len(vec) == 512 for out in results for vec in out)
+
+    def test_concurrent_cache_recovery_does_not_deadlock(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """Recovery path (``_ef_lock``) nests safely inside ``_encode_lock``.
+
+        The recovery path re-embeds while holding ``_ef_lock``; because it runs
+        under the outer ``_encode_lock``, no encode call ever overlaps and the
+        two locks never deadlock. Drives it concurrently to prove both.
+        """
+        cache_dir = tmp_path / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
+        cache_dir.mkdir(parents=True)
+        (cache_dir / "partial-download").write_text("corrupt")
+
+        guard = threading.Lock()
+        state = {"active": False, "reentered": False, "attempts": 0}
+
+        class FlakyMiniLM:
+            MODEL_NAME = "all-MiniLM-L6-v2"
+            DOWNLOAD_PATH = str(cache_dir)
+            EXTRACTED_FOLDER_NAME = "onnx"
+            ARCHIVE_FILENAME = "onnx.tar.gz"
+
+            def __call__(self, docs: list[str]) -> list[list[float]]:
+                with guard:
+                    if state["active"]:
+                        state["reentered"] = True
+                        raise AssertionError("encode entered by two threads at once")
+                    state["active"] = True
+                    state["attempts"] += 1
+                    first = state["attempts"] == 1
+                try:
+                    time.sleep(0.01)
+                    if first:
+                        raise tarfile.ReadError("bad checksum")
+                finally:
+                    with guard:
+                        state["active"] = False
+                return [[0.2] * 384 for _ in docs]
+
+        fake = MagicMock()
+        fake.ONNXMiniLM_L6_V2 = FlakyMiniLM
+        monkeypatch.setitem(sys.modules, "chromadb", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils", MagicMock())
+        monkeypatch.setitem(sys.modules, "chromadb.utils.embedding_functions", fake)
+
+        embedder = LocalEmbedder.get()
+        results: list[list[list[float]]] = []
+        errors: list[BaseException] = []
+        results_lock = threading.Lock()
+
+        def worker() -> None:
+            try:
+                out = embedder.embed(["hello", "world"])
+            except BaseException as exc:  # noqa: BLE001
+                with results_lock:
+                    errors.append(exc)
+                return
+            with results_lock:
+                results.append(out)
+
+        threads = [threading.Thread(target=worker) for _ in range(6)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=15)
+
+        # No thread is stuck: the _encode_lock/_ef_lock ordering can't deadlock.
+        assert all(not thread.is_alive() for thread in threads)
+        assert errors == []
+        assert state["reentered"] is False
+        assert len(results) == 6
+        assert all(len(vec) == 512 for out in results for vec in out)
 
 
 class TestLiteLLMClientShortCircuit:

--- a/tests/server/llm/test_nomic_embedding_provider.py
+++ b/tests/server/llm/test_nomic_embedding_provider.py
@@ -2,12 +2,46 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
 
 from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
+
+
+class _ReentrancyDetectingModel:
+    """Fake sentence-transformers model that flags concurrent ``encode()``.
+
+    The real ``nomic-bert`` model mutates instance-level rotary caches
+    (``_cos_cached``/``_sin_cached``) on every forward pass, so two threads
+    inside ``encode()`` at once corrupt each other. This stub makes that
+    corruption observable: it raises (and records a flag) the moment a second
+    thread enters while the first has not yet exited.
+    """
+
+    def __init__(self, hold: float = 0.02) -> None:
+        self._hold = hold
+        self._guard = threading.Lock()
+        self._active = False
+        self.reentered = False
+        self.calls = 0
+
+    def encode(self, texts: list[str], **_kwargs: object) -> np.ndarray:
+        with self._guard:
+            if self._active:
+                self.reentered = True
+                raise AssertionError("model.encode() entered by two threads at once")
+            self._active = True
+            self.calls += 1
+        try:
+            time.sleep(self._hold)  # widen the race window
+        finally:
+            with self._guard:
+                self._active = False
+        return np.array([[0.1] * 768 for _ in texts])
 
 
 def _embedder_with_fake_model() -> tuple[NomicEmbedder, MagicMock]:
@@ -50,3 +84,53 @@ def test_embed_ignores_invalid_batch_size_env(monkeypatch: pytest.MonkeyPatch) -
     embedder.embed(["hello"])
 
     assert model.encode.call_args.kwargs["batch_size"] == 4
+
+
+def test_encode_is_serialized_across_threads() -> None:
+    """Concurrent ``embed()`` calls on ONE embedder never overlap in encode().
+
+    Regression for the prod race: the shared singleton model is not
+    thread-safe, so the embedder must serialize ``model.encode()`` itself.
+    Reverting the ``self._model_lock`` guard in ``embed()`` makes this fail.
+    """
+    embedder = NomicEmbedder()
+    model = _ReentrancyDetectingModel(hold=0.02)
+    embedder._model = model  # pre-load so _load() is a no-op fast path
+
+    # Mixed-length payloads: differing text counts and differing char lengths.
+    payloads = [
+        ["short"],
+        ["x" * 500],
+        ["a", "b", "c"],
+        ["", "y" * 50],
+        ["only-one-longer-input " * 10],
+        ["p", "q"],
+        ["z" * 2000],
+        ["m", "n", "o", "p"],
+    ]
+    results: list[list[list[float]]] = []
+    errors: list[BaseException] = []
+    results_lock = threading.Lock()
+
+    def worker(texts: list[str]) -> None:
+        try:
+            out = embedder.embed(texts)
+        except BaseException as exc:  # noqa: BLE001
+            with results_lock:
+                errors.append(exc)
+            return
+        with results_lock:
+            results.append(out)
+
+    threads = [threading.Thread(target=worker, args=(p,)) for p in payloads]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert model.reentered is False
+    assert model.calls == len(payloads)
+    assert len(results) == len(payloads)
+    assert all(len(vec) == 512 for out in results for vec in out)


### PR DESCRIPTION
## What
Move the `model.encode()` serialization lock **into** the embedder singletons (`NomicEmbedder`, `LocalEmbedder`) so every caller is thread-safe by construction. Delete the daemon's now-redundant `_MODEL_ENCODE_LOCK` and its vestigial `_ENCODE_SEMAPHORE`.

## Why
The shared `SentenceTransformer` singletons are **not thread-safe** — nomic-bert's rotary-embedding code mutates instance attrs (`_cos_cached`/`_sin_cached`) per forward pass, so concurrent `encode()` calls corrupt each other. Prod hit this as 5 Sentry issue classes (176 tensor-race events: `size of tensor a (N) must match tensor b (M)`, `'NoneType' object is not subscriptable`). The daemon guarded encode with a module lock, but the **in-process fallback path** (used whenever the daemon `/health` probe flaps) called the model **unlocked**. Fixing only the daemon left every fallback/prewarm/regeneration caller racing — so the fix belongs in the singleton, not the daemon (fix-by-class).

Full analysis + the broader plan: enterprise `docs/superpowers/specs/2026-07-08-embedding-service-stability-redesign.md` (3-round reviewed). This PR is **Phase 1a only** — the urgent, self-contained lock fix. Follow-ups (separate PRs): search-path degrade threading (D2), caller-visible `degraded` flag (D3), fallback observability (1c), and dedup cleanups.

## Changes
- `NomicEmbedder.embed()` — wrap only `model.encode(...)` in `self._model_lock` (post-processing stays outside, on thread-local data). `_load()` releases the lock before re-acquire — no nesting.
- `LocalEmbedder.embed()` — new dedicated `self._encode_lock` (outer) ordered against the recovery path's `_ef_lock` (inner); non-reentrant-safe.
- `embedding_service.py` — delete `_MODEL_ENCODE_LOCK` + `_ENCODE_SEMAPHORE` machinery; micro-batch coalescing, processor-thread cap (`_max_concurrency`), and job-count guard intact.

## Tests
Fail-before/pass-after concurrency regression tests (fake model detects concurrent `encode()` entry, 8 threads × mixed lengths) for both embedders, plus a LocalEmbedder concurrent-cache-recovery deadlock test. Updated the daemon concurrency test to assert the invariant via the embedder lock. `tests/server/llm/` = 507 passed; ruff + pyright clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent embedding requests so model encoding is safely serialized and no longer overlaps across threads.
  * Preserved batching behavior while reducing contention during embedding generation.
  * Strengthened recovery handling when cached embedding data is corrupted, avoiding deadlocks under load.

* **Tests**
  * Added regression coverage for concurrent embedding calls and serialization behavior.
  * Expanded test coverage for both local and Nomic embedding paths, including cache recovery and micro-batching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->