### PR TITLE
fix(embedding): observable in-process fallback + mode-tagged errors; dedup get_embedding

### DIFF
--- a/reflexio/server/llm/_litellm_embedding.py
+++ b/reflexio/server/llm/_litellm_embedding.py
@@ -197,6 +197,24 @@ def _truncate_for_embedding(
     return encoding.decode(tokens[:max_tokens])
 
 
+def _embedding_error(message: str, mode: str) -> LiteLLMClientError:
+    """Build a ``LiteLLMClientError`` and log it tagged with the resolved mode.
+
+    Attaching ``mode`` (daemon-path vs in-process-path vs cloud) to the log makes
+    embedding failures attributable to a routing decision. The exception message
+    itself is unchanged so existing callers/tests keep matching on it.
+
+    Args:
+        message (str): The exception message (also logged).
+        mode (str): The resolved embedding provider mode.
+
+    Returns:
+        LiteLLMClientError: The exception to raise (``raise ... from e``).
+    """
+    _LOGGER.warning("%s (mode=%s)", message, mode, extra={"mode": mode})
+    return LiteLLMClientError(message)
+
+
 class EmbeddingMixin:
     """Embedding dispatch (service / Nomic / local ONNX / litellm) for ``LiteLLMClient``.
 
@@ -251,6 +269,10 @@ class EmbeddingMixin:
         """
         Get embedding vector for the given text.
 
+        Thin wrapper over ``get_embeddings`` — the single- and batch-text paths
+        share one dispatch body so their routing, truncation, and error handling
+        cannot drift.
+
         Args:
             text: The text to get embedding for.
             model: Optional embedding model. When omitted, the model is
@@ -265,73 +287,7 @@ class EmbeddingMixin:
         Raises:
             LiteLLMClientError: If embedding generation fails.
         """
-        embedding_model = model or self._resolve_default_embedding_model()
-        mode = embedding_provider_mode(embedding_model)
-        if mode == "off":
-            raise EmbeddingUnavailableError("Embedding provider is disabled")
-        if should_use_embedding_service(embedding_model):
-            return get_service_embeddings(
-                [text], model=embedding_model, dimensions=dimensions
-            )[0]
-
-        # local/nomic-embed-* must stay on the Nomic provider (137M params,
-        # 768d Matryoshka-truncated to 512). Falling through to MiniLM would
-        # mix embedding models inside existing vector stores.
-        if _is_nomic_model(embedding_model):
-            _reject_cloud_mode(embedding_model, mode)
-            try:
-                return NomicEmbedder.get().embed([text])[0]
-            except Exception as e:
-                raise LiteLLMClientError(
-                    f"Nomic embedding generation failed: {str(e)}"
-                ) from e
-
-        # local/* models route through the in-process ONNX embedder — no
-        # network call, no litellm API, no tiktoken truncation (the embedder
-        # applies its own token cap). The dispatch is gated solely on
-        # ``chromadb`` being importable; the env-var opt-in (claude-smart's
-        # ``CLAUDE_SMART_USE_LOCAL_EMBEDDING``) is enforced earlier in the
-        # auto-detection layer (see ``model_defaults._auto_detect_model``).
-        if embedding_model.startswith("local/"):
-            _reject_cloud_mode(embedding_model, mode)
-            if not _is_chromadb_importable():
-                raise LiteLLMClientError(
-                    f"Embedding model {embedding_model!r} requires chromadb. "
-                    "Run `pip install chromadb`."
-                )
-            try:
-                return LocalEmbedder.get().embed([text])[0]
-            except Exception as e:
-                raise LiteLLMClientError(
-                    f"Local embedding generation failed: {str(e)}"
-                ) from e
-
-        text = _truncate_for_embedding(text, embedding_model)
-
-        try:
-            params = {"model": embedding_model, "input": [text]}
-            if dimensions:
-                params["dimensions"] = dimensions
-
-            # Resolve and add API key configuration if provided (overrides env vars)
-            api_key, api_base, api_version = self._resolve_api_key(
-                embedding_model, for_embedding=True
-            )
-            if api_key:
-                params["api_key"] = api_key
-            if api_base:
-                params["api_base"] = api_base
-            if api_version:
-                params["api_version"] = api_version
-
-            response = litellm.embedding(
-                **params,
-                timeout=self.config.timeout,
-                num_retries=self.config.max_retries,
-            )
-            return response.data[0]["embedding"]
-        except Exception as e:
-            raise LiteLLMClientError(f"Embedding generation failed: {str(e)}") from e
+        return self._embed_texts([text], model, dimensions, batch=False)[0]
 
     def get_embeddings(
         self,
@@ -358,44 +314,86 @@ class EmbeddingMixin:
         """
         if not texts:
             return []
+        return self._embed_texts(list(texts), model, dimensions, batch=True)
 
+    def _embed_texts(
+        self,
+        texts: list[str],
+        model: str | None,
+        dimensions: int | None,
+        *,
+        batch: bool,
+    ) -> list[list[float]]:
+        """Shared embedding dispatch for ``get_embedding`` and ``get_embeddings``.
+
+        ``get_embedding`` passes a single-element list and unwraps ``[0]``;
+        ``get_embeddings`` passes the whole list. Behavior is identical between
+        the two callers except the error-message wording, which ``batch``
+        selects ("batch" wording matches the historical batch-path messages).
+
+        Args:
+            texts: Non-empty list of texts to embed (caller guarantees non-empty).
+            model: Optional embedding model; auto-detected when ``None``.
+            dimensions: Optional embedding dimensions.
+            batch: Selects the batch vs single error-message wording.
+
+        Returns:
+            One embedding vector per input text, in input order.
+
+        Raises:
+            EmbeddingUnavailableError: If the embedding provider is disabled.
+            LiteLLMClientError: If embedding generation fails.
+        """
         embedding_model = model or self._resolve_default_embedding_model()
         mode = embedding_provider_mode(embedding_model)
         if mode == "off":
             raise EmbeddingUnavailableError("Embedding provider is disabled")
         if should_use_embedding_service(embedding_model):
             return get_service_embeddings(
-                list(texts), model=embedding_model, dimensions=dimensions
+                texts, model=embedding_model, dimensions=dimensions
             )
 
-        # See matching short-circuits in get_embedding above.
+        # local/nomic-embed-* must stay on the Nomic provider (137M params,
+        # 768d Matryoshka-truncated to 512). Falling through to MiniLM would
+        # mix embedding models inside existing vector stores.
         if _is_nomic_model(embedding_model):
             _reject_cloud_mode(embedding_model, mode)
             try:
-                return NomicEmbedder.get().embed(list(texts))
+                return NomicEmbedder.get().embed(texts)
             except Exception as e:
-                raise LiteLLMClientError(
-                    f"Nomic batch embedding generation failed: {str(e)}"
+                raise _embedding_error(
+                    f"Nomic{' batch' if batch else ''} embedding generation "
+                    f"failed: {str(e)}",
+                    mode,
                 ) from e
 
+        # local/* models route through the in-process ONNX embedder — no
+        # network call, no litellm API, no tiktoken truncation (the embedder
+        # applies its own token cap). The dispatch is gated solely on
+        # ``chromadb`` being importable; the env-var opt-in (claude-smart's
+        # ``CLAUDE_SMART_USE_LOCAL_EMBEDDING``) is enforced earlier in the
+        # auto-detection layer (see ``model_defaults._auto_detect_model``).
         if embedding_model.startswith("local/"):
             _reject_cloud_mode(embedding_model, mode)
             if not _is_chromadb_importable():
-                raise LiteLLMClientError(
+                raise _embedding_error(
                     f"Embedding model {embedding_model!r} requires chromadb. "
-                    "Run `pip install chromadb`."
+                    "Run `pip install chromadb`.",
+                    mode,
                 )
             try:
-                return LocalEmbedder.get().embed(list(texts))
+                return LocalEmbedder.get().embed(texts)
             except Exception as e:
-                raise LiteLLMClientError(
-                    f"Local batch embedding generation failed: {str(e)}"
+                raise _embedding_error(
+                    f"Local{' batch' if batch else ''} embedding generation "
+                    f"failed: {str(e)}",
+                    mode,
                 ) from e
 
-        texts = [_truncate_for_embedding(t, embedding_model) for t in texts]
+        truncated = [_truncate_for_embedding(t, embedding_model) for t in texts]
 
         try:
-            params = {"model": embedding_model, "input": texts}
+            params = {"model": embedding_model, "input": truncated}
             if dimensions:
                 params["dimensions"] = dimensions
 
@@ -419,6 +417,8 @@ class EmbeddingMixin:
             sorted_data = sorted(response.data, key=lambda x: x["index"])
             return [item["embedding"] for item in sorted_data]
         except Exception as e:
-            raise LiteLLMClientError(
-                f"Batch embedding generation failed: {str(e)}"
+            raise _embedding_error(
+                f"{'Batch embedding' if batch else 'Embedding'} generation "
+                f"failed: {str(e)}",
+                mode,
             ) from e

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -54,9 +54,19 @@ _LOCAL_SERVICE_PROBE_FAILURE_CACHE_SECONDS = 5.0
 # never hands out a connection the load balancer already closed.
 _HTTP_KEEPALIVE_EXPIRY_SECONDS = 50.0
 _EMBEDDING_RETRY_BACKOFF_SECONDS = 0.1
+# ``embedding_provider_mode`` is called on every embedding request (often several
+# times per request), and a down daemon resolves to ``inprocess`` every time, so
+# an unconditional warning would flood the logs. Emit the fallback WARNING at most
+# once per this interval per process.
+_INPROCESS_FALLBACK_WARN_INTERVAL_SECONDS = 60.0
 _SERVICE_MODES = {"local_service", "internal_service"}
 _VALID_MODES = {"cloud", *_SERVICE_MODES, "inprocess", "off"}
 _local_service_probe_cache: tuple[float, bool, str | None] | None = None
+# Reason the most recent *fresh* /health probe failed (populated by
+# ``_local_service_status``), surfaced in the inprocess-fallback WARNING.
+_last_probe_failure_reason: str | None = None
+# Monotonic timestamp of the last inprocess-fallback WARNING, for rate limiting.
+_last_inprocess_fallback_warn_at: float | None = None
 _http_client_lock = threading.Lock()
 _http_client_instance: httpx.Client | None = None
 _http_client_pid: int | None = None
@@ -154,7 +164,7 @@ def _http_client() -> httpx.Client:
 
 
 def _local_service_status() -> tuple[bool, str | None]:
-    global _local_service_probe_cache
+    global _local_service_probe_cache, _last_probe_failure_reason
     now = time.monotonic()
     if _local_service_probe_cache is not None:
         cached_at, cached_reachable, cached_model = _local_service_probe_cache
@@ -166,6 +176,7 @@ def _local_service_status() -> tuple[bool, str | None]:
         if now - cached_at < ttl:
             return cached_reachable, cached_model
 
+    reason: str | None = None
     try:
         response = _http_client().get(
             f"{_local_service_url()}/health",
@@ -175,19 +186,53 @@ def _local_service_status() -> tuple[bool, str | None]:
         active_model = response.json().get("active_model") if reachable else None
         if not isinstance(active_model, str):
             active_model = None
-    except httpx.HTTPError:
+        if not reachable:
+            reason = f"/health returned HTTP {response.status_code}"
+    except httpx.HTTPError as exc:
         reachable = False
         active_model = None
-    except ValueError:
+        reason = f"{type(exc).__name__}: {exc}"
+    except ValueError as exc:
         reachable = False
         active_model = None
+        reason = f"invalid /health response: {exc}"
+    _last_probe_failure_reason = reason
     _local_service_probe_cache = (now, reachable, active_model)
     return reachable, active_model
 
 
-def _local_service_supports_model(model: str | None) -> bool:
-    reachable, active_model = _local_service_status()
-    return reachable and (active_model is None or active_model == model)
+def _warn_inprocess_fallback(model: str | None, reason: str | None) -> None:
+    """Warn (rate-limited) that a ``local/*`` model fell back to the in-process embedder.
+
+    Emitted only when daemon-mode resolution for a ``local/*`` model fails the
+    ``/health`` probe (or the daemon serves a different model) and routing falls
+    back to ``inprocess`` — NOT when ``inprocess`` was configured explicitly. The
+    fallback loads a second copy of the embedding model into this worker process,
+    so operators need to distinguish it from an intentional in-process config.
+
+    Args:
+        model (str | None): The ``local/*`` embedding model being resolved.
+        reason (str | None): Why the daemon path was rejected, if known.
+    """
+    global _last_inprocess_fallback_warn_at
+    now = time.monotonic()
+    if (
+        _last_inprocess_fallback_warn_at is not None
+        and now - _last_inprocess_fallback_warn_at
+        < _INPROCESS_FALLBACK_WARN_INTERVAL_SECONDS
+    ):
+        return
+    _last_inprocess_fallback_warn_at = now
+    _LOGGER.warning(
+        "Embedding daemon probe at %s failed for model %r; falling back to an "
+        "in-process embedding model copy (a second model is loaded into this "
+        "worker process). Probe failure: %s. Further fallback warnings are "
+        "suppressed for %.0fs.",
+        _local_service_url(),
+        model,
+        reason or "unknown",
+        _INPROCESS_FALLBACK_WARN_INTERVAL_SECONDS,
+    )
 
 
 def _ordered_embeddings_from_response(
@@ -260,7 +305,18 @@ def embedding_provider_mode(model: str | None = None) -> EmbeddingProviderMode:
         return "local_service"
 
     if _is_local_model(model):
-        return "local_service" if _local_service_supports_model(model) else "inprocess"
+        reachable, active_model = _local_service_status()
+        if reachable and (active_model is None or active_model == model):
+            return "local_service"
+        if reachable:
+            reason = (
+                f"daemon is reachable but serves active_model={active_model!r}, "
+                f"not {model!r}"
+            )
+        else:
+            reason = _last_probe_failure_reason
+        _warn_inprocess_fallback(model, reason)
+        return "inprocess"
     return "cloud"
 
 
@@ -311,7 +367,12 @@ def get_service_embeddings(
         chunk = texts[start : start + chunk_size]
         embeddings.extend(
             _post_embedding_batch(
-                url, model=model, texts=chunk, dimensions=dimensions, timeout=timeout
+                url,
+                model=model,
+                texts=chunk,
+                dimensions=dimensions,
+                timeout=timeout,
+                mode=mode,
             )
         )
     return embeddings
@@ -324,6 +385,7 @@ def _post_embedding_batch(
     texts: list[str],
     dimensions: int | None,
     timeout: float,
+    mode: EmbeddingProviderMode,
 ) -> list[list[float]]:
     """POST one bounded batch of texts to the embedding service."""
     payload: dict[str, Any] = {"model": model, "input": texts}
@@ -368,7 +430,12 @@ def _post_embedding_batch(
             last_error = exc
             break
 
-    _LOGGER.warning("Embedding service unavailable at %s: %s", url, last_error)
+    _LOGGER.warning(
+        "Embedding service unavailable at %s: %s",
+        url,
+        last_error,
+        extra={"mode": mode},
+    )
     raise EmbeddingUnavailableError(
         f"Embedding service unavailable at {url}: {last_error}"
     ) from last_error

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import time
 from contextlib import contextmanager
 from unittest.mock import patch
@@ -71,6 +72,75 @@ def test_local_model_without_opt_in_preserves_inprocess_mode(monkeypatch) -> Non
     monkeypatch.setattr(esp, "_http_client", lambda: _UnreachableHttpClient())
 
     assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+
+
+def test_inprocess_fallback_warns_once_then_rate_limits(monkeypatch, caplog) -> None:
+    """A failed daemon probe for a ``local/*`` model warns once about the
+    in-process fallback, then suppresses repeats within the 60s window."""
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_DAEMON_HOST", raising=False)
+    monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+    monkeypatch.setattr(esp, "_last_probe_failure_reason", None)
+    monkeypatch.setattr(esp, "_last_inprocess_fallback_warn_at", None)
+    monkeypatch.setattr(esp, "_http_client", lambda: _UnreachableHttpClient())
+
+    with caplog.at_level(logging.WARNING, logger=esp.__name__):
+        assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+        assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+
+    fallbacks = [r for r in caplog.records if "falling back to an" in r.getMessage()]
+    assert len(fallbacks) == 1
+    message = fallbacks[0].getMessage()
+    assert "in-process embedding model copy" in message
+    assert "127.0.0.1:8072" in message  # the probe target
+    assert "RequestError" in message  # the probe failure reason
+
+
+def test_explicit_inprocess_config_does_not_warn(monkeypatch, caplog) -> None:
+    """An explicit ``REFLEXIO_EMBEDDING_PROVIDER=inprocess`` is intentional, not a
+    fallback, so it must not emit the fallback WARNING."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.setattr(esp, "_last_inprocess_fallback_warn_at", None)
+
+    with caplog.at_level(logging.WARNING, logger=esp.__name__):
+        assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+
+    assert not [r for r in caplog.records if "falling back" in r.getMessage()]
+
+
+def test_reachable_mismatched_daemon_warns_with_model_reason(
+    monkeypatch, caplog
+) -> None:
+    """A reachable daemon serving a different model also falls back in-process,
+    and the warning names the model mismatch as the reason."""
+
+    class _HealthResponse:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"active_model": "local/nomic-embed-text-v1.5"}
+
+    class _Client:
+        def get(self, *_args, **_kwargs) -> _HealthResponse:
+            return _HealthResponse()
+
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_DAEMON_HOST", raising=False)
+    monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+    monkeypatch.setattr(esp, "_last_probe_failure_reason", None)
+    monkeypatch.setattr(esp, "_last_inprocess_fallback_warn_at", None)
+    monkeypatch.setattr(esp, "_http_client", lambda: _Client())
+
+    with caplog.at_level(logging.WARNING, logger=esp.__name__):
+        assert embedding_provider_mode("local/minilm-l6-v2") == "inprocess"
+
+    fallbacks = [r for r in caplog.records if "falling back to an" in r.getMessage()]
+    assert len(fallbacks) == 1
+    assert "active_model=" in fallbacks[0].getMessage()
 
 
 def test_local_model_auto_uses_reachable_matching_daemon(monkeypatch) -> None:

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -689,6 +689,74 @@ class TestGetEmbeddings:
 
 
 # ===================================================================
+# Single/batch parity + error-mode tagging
+# ===================================================================
+
+
+class TestEmbeddingSingleBatchParity:
+    """``get_embedding`` is a thin wrapper over ``get_embeddings`` — the two
+    must agree, and embedding failures must be tagged with the resolved mode."""
+
+    @staticmethod
+    def _route_local_inprocess(monkeypatch, *, embed):
+        """Force the in-process LocalEmbedder branch with a fake embedder."""
+        from reflexio.server.llm import _litellm_embedding
+
+        monkeypatch.setattr(
+            _litellm_embedding, "embedding_provider_mode", lambda _m: "inprocess"
+        )
+        monkeypatch.setattr(
+            _litellm_embedding, "should_use_embedding_service", lambda _m: False
+        )
+        monkeypatch.setattr(_litellm_embedding, "_is_chromadb_importable", lambda: True)
+
+        class _FakeEmbedder:
+            @staticmethod
+            def get():
+                return _FakeEmbedder()
+
+            def embed(self, texts):
+                return embed(texts)
+
+        monkeypatch.setattr(_litellm_embedding, "LocalEmbedder", _FakeEmbedder)
+
+    def test_get_embedding_matches_get_embeddings_first_element(self, monkeypatch):
+        """get_embedding(t) == get_embeddings([t])[0] on the local-embedder path."""
+        self._route_local_inprocess(
+            monkeypatch,
+            embed=lambda texts: [[float(len(t)), 1.0, 2.0] for t in texts],
+        )
+        client = _build_client()
+
+        single = client.get_embedding("hello", model="local/minilm-l6-v2")
+        batch = client.get_embeddings(["hello"], model="local/minilm-l6-v2")
+
+        assert single == batch[0]
+        assert single == [5.0, 1.0, 2.0]
+
+    def test_inprocess_embedding_failure_is_tagged_with_mode(self, monkeypatch, caplog):
+        """A local (in-process) embedding failure logs a record tagged mode=inprocess."""
+
+        def _boom(_texts):
+            raise RuntimeError("boom")
+
+        self._route_local_inprocess(monkeypatch, embed=_boom)
+        client = _build_client()
+
+        with (
+            caplog.at_level(logging.WARNING),
+            pytest.raises(
+                LiteLLMClientError, match="Local embedding generation failed"
+            ),
+        ):
+            client.get_embedding("hello", model="local/minilm-l6-v2")
+
+        tagged = [r for r in caplog.records if getattr(r, "mode", None) == "inprocess"]
+        assert tagged, "expected a log record carrying the resolved mode"
+        assert "mode=inprocess" in tagged[0].getMessage()
+
+
+# ===================================================================
 # Default embedding-model resolution tests
 # ===================================================================
 


### PR DESCRIPTION
## What
Two OSS-only quality items from the embedding-stability redesign (Phase 1, non-urgent follow-ups to the #311 lock fix):

1. **Fallback observability (1c).** When a `local/*` model's daemon `/health` probe fails, mode resolution silently returns `inprocess` and loads a *second* in-process model copy — invisible to operators. Now emits a **rate-limited (≤1/60s)** WARNING naming the probe target, the failure reason, and the second-copy implication. Fires **only** on the model-driven fallback, never on an explicit `REFLEXIO_EMBEDDING_PROVIDER=inprocess` (intentional, returns earlier). Adds a `mode=<resolved_mode>` tag on embedding-error log/exception context so failures are attributable to the daemon vs in-process path. Exception types/messages/control-flow unchanged.

2. **Dedup `get_embedding`/`get_embeddings`.** Extracted a shared private `_embed_texts(..., batch=)`; the two public methods now delegate (single passes `[text]`, returns `[0]`). Signatures preserved. Note: extracted-to-helper rather than a plain `get_embeddings([t])[0]` collapse because the single/batch error-message wording differs and is asserted verbatim by existing tests — the `batch=` flag selects the wording, so no message regression and no output change.

Out of scope (different semantics — not a safe dedup): unifying `_truncate_and_renormalise` / `_pad` / `_resize_embedding`.

## Tests
New: fallback-warns-once-then-rate-limits, explicit-inprocess-does-not-warn, mismatched-daemon-warns-with-model-reason; get_embedding==get_embeddings[0] parity; in-process failure carries `mode=`. `tests/server/llm/` = 515 passed (baseline 507); ruff + pyright clean. No enterprise files, no embedding output semantics changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding fallback handling when a local service is unreachable or serving a different model.
  * Reduced repeated fallback warnings so logs stay cleaner during ongoing outages.
  * Made single-text and batch embedding results behave consistently for local embeddings.
  * Added clearer embedding error messages with mode-aware logging for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->