### PR TITLE
fix(search): degrade to FTS on query-embedding failure (stop storage re-embed) + visible degraded flag

### DIFF
--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -757,6 +757,14 @@ class UnifiedSearchResponse(BaseModel):
         msg (str, optional): Additional message
         agent_answer (str, optional): LLM-synthesised answer populated by the agentic backend;
             None for classic backend.
+        degraded (bool): True when the search silently fell back from the
+            requested vector/hybrid mode to full-text search because query
+            embedding generation failed. Results are still returned (via FTS),
+            but relevance may be lower than a healthy vector/hybrid run.
+            Defaults to False.
+        search_mode_effective (str, optional): The search mode actually used
+            when it differs from the requested mode — currently ``"fts"`` on
+            the degrade path. None when the requested mode was honored.
     """
 
     success: bool
@@ -768,6 +776,8 @@ class UnifiedSearchResponse(BaseModel):
     agent_answer: str | None = None
     agent_trace: str | None = None
     rehydrated_text: str | None = None
+    degraded: bool = False
+    search_mode_effective: str | None = None
 
 
 # ===============================

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -165,7 +165,7 @@ def run_unified_search(
     recency_on = bool(recency and recency.enabled)
 
     # --- Phase A: query reformulation (+ temporal signals) + embedding ---
-    reformulation, embedding = _run_phase_a(
+    reformulation, embedding, embedding_failed = _run_phase_a(
         query=request.query,
         storage=storage,
         llm_client=llm_client,
@@ -177,6 +177,23 @@ def run_unified_search(
         search_mode=request.search_mode,
     )
     reformulated_query = reformulation.standalone_query
+
+    # Degrade-to-FTS: when embedding GENERATION failed (distinct from the
+    # benign None cases), force the effective mode to FTS for the entire
+    # Phase B fan-out. Storage then takes the zero-placeholder branch and
+    # never re-embeds — closing the historical second-embed leak where a
+    # None embedding + a vector/hybrid mode caused the storage layer to retry
+    # the embed and raise unguarded. Benign None (FTS-only, unsupported)
+    # leaves the requested mode untouched.
+    effective_search_mode = request.search_mode
+    if embedding_failed:
+        effective_search_mode = SearchMode.FTS
+        logger.warning(
+            "event=search_degraded_to_fts reason=embedding_generation_failed "
+            "backend=%s requested_mode=%s",
+            _storage_backend_name(storage),
+            request.search_mode.value,
+        )
     window_start, window_end = window_bounds(
         reformulation.start_days_ago, reformulation.end_days_ago
     )
@@ -216,6 +233,7 @@ def run_unified_search(
         recency_on=recency_on,
         start_time=window_start,
         end_time=window_end,
+        search_mode=effective_search_mode,
     )
 
     if profiles is None:
@@ -287,6 +305,8 @@ def run_unified_search(
         reformulated_query=reformulated_query
         if reformulated_query != request.query
         else None,
+        degraded=embedding_failed,
+        search_mode_effective=effective_search_mode.value if embedding_failed else None,
     )
     if session_id:
         session_seen_cache.record(org_id, session_id, _served_entity_keys(response))
@@ -328,7 +348,7 @@ def _run_phase_a(
     enable_reformulation: bool = False,
     pre_retrieval_model_name: str | None = None,
     search_mode: SearchMode = SearchMode.HYBRID,
-) -> tuple[ReformulationResult, list[float] | None]:
+) -> tuple[ReformulationResult, list[float] | None, bool]:
     """Run query reformulation and embedding generation sequentially.
 
     Args:
@@ -344,11 +364,16 @@ def _run_phase_a(
         search_mode (SearchMode): Search mode; FTS-only mode skips embedding generation entirely
 
     Returns:
-        tuple[ReformulationResult, Optional[list[float]]]: The reformulation
-            result (standalone query + temporal signals; signal-free
-            pass-through of the original query when reformulation is
-            disabled) and the query embedding (None when unsupported or on
-            failure).
+        tuple[ReformulationResult, Optional[list[float]], bool]: The
+            reformulation result (standalone query + temporal signals;
+            signal-free pass-through of the original query when reformulation
+            is disabled), the query embedding (None when unsupported, when the
+            mode is FTS-only, or when generation failed), and
+            ``embedding_failed`` — True *only* when an embedding attempt was
+            made and raised. The benign None cases (FTS-only mode,
+            ``supports_embedding`` False) leave ``embedding_failed`` False so
+            callers can distinguish a real failure from a mode that never
+            needed an embedding.
     """
     reformulator = QueryReformulator(
         llm_client=llm_client,
@@ -370,6 +395,7 @@ def _run_phase_a(
     # Embedding generation (uses reformulated query for semantic accuracy).
     # FTS-only search has no use for an embedding, so skip the call entirely.
     embedding = None
+    embedding_failed = False
     if supports_embedding and search_mode != SearchMode.FTS:
         with profile_step(
             "search.embedding",
@@ -383,9 +409,10 @@ def _run_phase_a(
                 span.set_data("embedding_generated", embedding is not None)
             except Exception as e:
                 span.set_data("embedding_generated", False)
+                embedding_failed = True
                 logger.error("Embedding generation failed: %s", e)
 
-    return reformulation, embedding
+    return reformulation, embedding, embedding_failed
 
 
 def _run_phase_b(
@@ -399,6 +426,7 @@ def _run_phase_b(
     recency_on: bool = False,
     start_time: datetime | None = None,
     end_time: datetime | None = None,
+    search_mode: SearchMode = SearchMode.HYBRID,
 ) -> tuple[
     list[Any] | None,
     list[Any] | None,
@@ -418,11 +446,15 @@ def _run_phase_b(
             (from reformulation temporal signals); forces the per-arm fan-out
             path since the combined single RPC has no time parameters.
         end_time (Optional[datetime]): Query-derived time-window upper bound.
+        search_mode (SearchMode): The EFFECTIVE search mode for this fan-out —
+            equal to ``request.search_mode`` normally, but forced to FTS by the
+            caller when embedding generation failed (degrade-to-FTS). Threaded
+            into every arm so storage never re-embeds a failed query.
 
     Returns:
         tuple: (profiles, agent_playbooks, user_playbooks) — all None on timeout/failure
     """
-    options = SearchOptions(query_embedding=embedding, search_mode=request.search_mode)
+    options = SearchOptions(query_embedding=embedding, search_mode=search_mode)
 
     entity_types = set(request.entity_types or _DEFAULT_ENTITY_TYPES)
     allowed_agent_statuses = request.agent_playbook_status_filter
@@ -463,6 +495,7 @@ def _run_phase_b(
                     entity_types=entity_types,
                     allowed_agent_statuses=allowed_agent_statuses,
                     recency_on=recency_on,
+                    search_mode=search_mode,
                 )
                 if combined is not None:
                     profiles, agent_playbooks, user_playbooks = combined
@@ -487,7 +520,7 @@ def _run_phase_b(
                     threshold,
                     request.user_id,
                     embedding,
-                    request.search_mode,
+                    search_mode,
                     start_time,
                     end_time,
                 )
@@ -521,7 +554,7 @@ def _run_phase_b(
                     status_filter=None,
                     threshold=threshold,
                     top_k=top_k,
-                    search_mode=request.search_mode,
+                    search_mode=search_mode,
                     start_time=start_time,
                     end_time=end_time,
                 )
@@ -580,6 +613,7 @@ def _run_phase_b_single_rpc(
     entity_types: set[str],
     allowed_agent_statuses: list[PlaybookStatus] | None,
     recency_on: bool = False,
+    search_mode: SearchMode = SearchMode.HYBRID,
 ) -> tuple[list[Any], list[Any], list[Any]] | None:
     """Run all Phase B arms through one combined storage round trip.
 
@@ -624,7 +658,7 @@ def _run_phase_b_single_rpc(
         agent_version=request.agent_version,
         playbook_name=request.playbook_name,
         agent_playbook_statuses=statuses,
-        search_mode=request.search_mode,
+        search_mode=search_mode,
         include_profiles="profiles" in entity_types and bool(request.user_id),
         include_agent_playbooks="agent_playbooks" in entity_types,
         include_user_playbooks="user_playbooks" in entity_types,

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -410,7 +410,7 @@ def _run_phase_a(
             except Exception as e:
                 span.set_data("embedding_generated", False)
                 embedding_failed = True
-                logger.error("Embedding generation failed: %s", e)
+                logger.exception("Embedding generation failed: %s", e)
 
     return reformulation, embedding, embedding_failed
 

--- a/tests/server/services/test_unified_search_floor.py
+++ b/tests/server/services/test_unified_search_floor.py
@@ -46,7 +46,7 @@ def test_floor_applied_per_arm(monkeypatch):
     monkeypatch.setattr(
         uss,
         "_run_phase_a",
-        lambda **_kw: (ReformulationResult(standalone_query="q"), None),
+        lambda **_kw: (ReformulationResult(standalone_query="q"), None, False),
     )
     monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], pbs))
 
@@ -81,7 +81,7 @@ def test_floor_recency_applied_after_logits(monkeypatch):
     monkeypatch.setattr(
         uss,
         "_run_phase_a",
-        lambda **_kw: (ReformulationResult(standalone_query="q"), None),
+        lambda **_kw: (ReformulationResult(standalone_query="q"), None, False),
     )
     monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], [old, fresh]))
 
@@ -116,7 +116,7 @@ def test_floor_recency_does_not_overtake_clearly_more_relevant(monkeypatch):
     monkeypatch.setattr(
         uss,
         "_run_phase_a",
-        lambda **_kw: (ReformulationResult(standalone_query="q"), None),
+        lambda **_kw: (ReformulationResult(standalone_query="q"), None, False),
     )
     monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], [old, fresh]))
 
@@ -152,7 +152,7 @@ def test_floor_recency_falls_back_to_combined_score_when_unavailable(monkeypatch
     monkeypatch.setattr(
         uss,
         "_run_phase_a",
-        lambda **_kw: (ReformulationResult(standalone_query="q"), None),
+        lambda **_kw: (ReformulationResult(standalone_query="q"), None, False),
     )
     monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], [old, fresh]))
 
@@ -183,7 +183,7 @@ def test_floor_disabled_returns_all(monkeypatch):
     monkeypatch.setattr(
         uss,
         "_run_phase_a",
-        lambda **_kw: (ReformulationResult(standalone_query="q"), None),
+        lambda **_kw: (ReformulationResult(standalone_query="q"), None, False),
     )
     monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([], [], pbs))
 

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -17,7 +17,11 @@ from reflexio.models.api_schema.domain.entities import (
 from reflexio.models.api_schema.retriever_schema import (
     UnifiedSearchRequest,
 )
-from reflexio.models.config_schema import RetrievalFloorConfig, SearchOptions
+from reflexio.models.config_schema import (
+    RetrievalFloorConfig,
+    SearchMode,
+    SearchOptions,
+)
 from reflexio.server.services.pre_retrieval import ReformulationResult
 from reflexio.server.services.retrieval.recency import RecencyConfig, ScoredItem
 from reflexio.server.services.storage.storage_base import BaseStorage
@@ -372,7 +376,7 @@ class TestRunUnifiedSearch(unittest.TestCase):
         with (
             patch(
                 "reflexio.server.services.unified_search_service._run_phase_a",
-                return_value=(ReformulationResult(standalone_query="q"), None),
+                return_value=(ReformulationResult(standalone_query="q"), None, False),
             ),
             patch(
                 "reflexio.server.services.unified_search_service._run_phase_b_single_rpc",
@@ -506,6 +510,163 @@ class TestEntityTypesFiltering(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.agent_playbooks, [])
         self.assertEqual(result.user_playbooks, [])
+
+
+_SERVICE_LOGGER = "reflexio.server.services.unified_search_service"
+
+
+def _fanout_storage(embedding=None):
+    """Mock storage pinned to the per-arm fan-out (single-RPC disabled).
+
+    Lets a test inspect the per-leg storage requests (and their
+    ``search_mode``) directly instead of the opaque combined RPC.
+    """
+    storage = _mock_storage(embedding)
+    storage.supports_embedding = True
+    storage.supports_unified_hybrid_search = False
+    return storage
+
+
+def _leg_search_modes(storage):
+    """The ``search_mode`` each fan-out leg was invoked with."""
+    return {
+        "profiles": storage.search_user_profile.call_args.args[0].search_mode,
+        "agent_playbooks": storage.search_agent_playbooks.call_args.args[0].search_mode,
+        "user_playbooks": storage.search_user_playbooks.call_args.args[0].search_mode,
+    }
+
+
+class TestEmbeddingFailureDegradesToFTS(unittest.TestCase):
+    """D2/D3: embedding-generation failure degrades the whole search to FTS."""
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_embedding_failure_degrades_to_fts_visibly_and_counted(
+        self, _reformulator_cls
+    ):
+        """A raising query-embedder must (a) still return results via FTS,
+        (b) surface degraded=True / effective mode fts, (c) drive every storage
+        leg with FTS so storage takes the placeholder branch and never
+        re-embeds, and (d) emit the counted degrade signal."""
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="test query"
+        )
+        storage = _fanout_storage()
+        storage._get_embedding.side_effect = RuntimeError("Embedding API down")
+
+        request = UnifiedSearchRequest(query="test query", user_id="user-1")
+        with self.assertLogs(_SERVICE_LOGGER, level="WARNING") as logs:
+            result = run_unified_search(
+                request=request,
+                org_id="test-org",
+                storage=storage,
+                llm_client=MagicMock(),
+                prompt_manager=MagicMock(),
+            )
+
+        # (a) success via FTS, not an exception
+        self.assertTrue(result.success)
+        # (b) caller-visible degrade
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.search_mode_effective, SearchMode.FTS.value)
+        # (c) every leg driven with FTS; the embedder was hit exactly once
+        # (the failed Phase-A attempt) — storage never re-embeds.
+        self.assertEqual(
+            _leg_search_modes(storage),
+            {
+                "profiles": SearchMode.FTS,
+                "agent_playbooks": SearchMode.FTS,
+                "user_playbooks": SearchMode.FTS,
+            },
+        )
+        self.assertEqual(storage._get_embedding.call_count, 1)
+        # profile leg received no embedding to force a re-embed downstream
+        self.assertIsNone(
+            storage.search_user_profile.call_args.kwargs["query_embedding"]
+        )
+        # (d) counted signal fired with a stable event key
+        self.assertTrue(
+            any("event=search_degraded_to_fts" in line for line in logs.output),
+            logs.output,
+        )
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_successful_embedding_is_not_degraded(self, _reformulator_cls):
+        """Healthy embedding: no degrade, requested mode honored, vector path
+        used (embedding threaded into the profile leg)."""
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="test query"
+        )
+        embedding = [0.42] * 1536
+        storage = _fanout_storage(embedding=embedding)
+
+        request = UnifiedSearchRequest(query="test query", user_id="user-1")
+        with self.assertNoLogs(_SERVICE_LOGGER, level="WARNING"):
+            result = run_unified_search(
+                request=request,
+                org_id="test-org",
+                storage=storage,
+                llm_client=MagicMock(),
+                prompt_manager=MagicMock(),
+            )
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.degraded)
+        self.assertIsNone(result.search_mode_effective)
+        self.assertEqual(
+            _leg_search_modes(storage),
+            {
+                "profiles": SearchMode.HYBRID,
+                "agent_playbooks": SearchMode.HYBRID,
+                "user_playbooks": SearchMode.HYBRID,
+            },
+        )
+        self.assertEqual(
+            storage.search_user_profile.call_args.kwargs["query_embedding"], embedding
+        )
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_fts_mode_from_start_is_not_degraded(self, _reformulator_cls):
+        """A request that asks for FTS outright never embedded, so it is a
+        benign None — not a degrade."""
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="test query"
+        )
+        storage = _fanout_storage()
+
+        request = UnifiedSearchRequest(
+            query="test query", user_id="user-1", search_mode=SearchMode.FTS
+        )
+        result = run_unified_search(
+            request=request,
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.degraded)
+        self.assertIsNone(result.search_mode_effective)
+        # FTS-only mode skips the embedder entirely.
+        storage._get_embedding.assert_not_called()
+        self.assertEqual(_leg_search_modes(storage)["agent_playbooks"], SearchMode.FTS)
+
+    def test_empty_query_guard_is_not_degraded(self):
+        """The empty-query early return is a benign no-op, never a degrade."""
+        # query is NonEmptyStr at the API boundary; construct past validation to
+        # exercise the defensive guard inside run_unified_search.
+        request = UnifiedSearchRequest.model_construct(query="")
+        result = run_unified_search(
+            request=request,
+            org_id="test-org",
+            storage=_fanout_storage(),
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        self.assertFalse(result.degraded)
+        self.assertIsNone(result.search_mode_effective)
 
 
 if __name__ == "__main__":

--- a/tests/server/services/test_unified_search_temporal.py
+++ b/tests/server/services/test_unified_search_temporal.py
@@ -195,6 +195,7 @@ def test_wants_current_composes_with_relevance_floor(monkeypatch):
         lambda **_kw: (
             ReformulationResult(standalone_query="q", wants_current=True),
             None,
+            False,
         ),
     )
     monkeypatch.setattr(uss, "_run_phase_b", lambda **_kw: ([stale, fresh], [], []))


### PR DESCRIPTION
## What
When query-embedding **generation** fails in `unified_search_service._run_phase_a`, degrade the *effective* search mode to FTS for the rest of the request, so the storage layer never performs a second (unguarded) embed. Surface the degrade to callers + ops.

Design items D2 + D3 of the embedding-stability redesign (Phase 1 follow-up to the #311 lock + #312 observability PRs).

## Why
Phase A caught embedding exceptions and set `embedding=None` but left `search_mode` unchanged (e.g. HYBRID). Storage's `_query_embedding_or_placeholder` re-embeds when `query_embedding is None AND mode != FTS` — a second embed on the hot search path that could raise unguarded (historical `/api/search` leak, PYTHON-FASTAPI-1N). Fixing it upstream in the search service (force FTS on generation failure) covers **all** storage backends at one layer.

Note: #311's encode lock already removed the acute (concurrent-encode) cause, so this is the robustness + observability layer.

## Changes
- `_run_phase_a` returns `(reformulation, embedding, embedding_failed)`; `embedding_failed` is set **only** in the embedding-call `except` (never for benign None: FTS-from-start, no embedding support, empty query).
- `run_unified_search` computes `effective_search_mode = FTS if embedding_failed else request.search_mode` and threads it into **both** `_run_phase_b` and `_run_phase_b_single_rpc` (every leg + `SearchOptions` + single-RPC arg).
- `UnifiedSearchResponse` gains `degraded: bool = False` + `search_mode_effective: str | None = None` (backward-compatible defaults) — **new public response fields (docs follow-up needed)**.
- Counted signal: `event=search_degraded_to_fts` WARNING (module idiom), once per degraded search.

## Tests
4 new through-`run_unified_search` tests: degrade-visible-and-counted (asserts `_get_embedding.call_count == 1` — no re-embed — all legs FTS, `degraded=True`); healthy-not-degraded; FTS-from-start-not-degraded; empty-query-not-degraded. `tests/server/` search/retriever suites = 224 passed; ruff + pyright clean. OSS-only, no output semantics changed on the success path.

## Known follow-up (not in this PR)
The `EmbeddingUnavailableError` outage mode (provider disabled/routing) returns `[]` from the query embed and is not yet flagged `degraded` — no leak, pre-existing; a candidate for the standing embedding-observability follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified search now reports when it falls back to full-text search after an embedding failure.
  * Search responses can now indicate the effective search mode used during fallback.

* **Bug Fixes**
  * Improved search behavior so a failed embedding attempt no longer retries the original mode and instead completes with a safe fallback.
  * Added coverage for fallback, non-fallback, and empty-query scenarios to keep search responses consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->