### PR TITLE
fix(search): flag empty query embedding as degraded (L1 follow-up)

### DIFF
--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -406,6 +406,14 @@ def _run_phase_a(
                 embedding = _get_cached_query_embedding(
                     storage, reformulation.standalone_query
                 )
+                # A falsy result (None or []) means the embedder produced no
+                # usable query vector — e.g. a storage backend that swallows
+                # EmbeddingUnavailableError and returns [] on a provider outage.
+                # Treat it the same as a raised failure: degrade to FTS rather
+                # than run a vector search with an empty embedding.
+                if not embedding:
+                    embedding = None
+                    embedding_failed = True
                 span.set_data("embedding_generated", embedding is not None)
             except Exception as e:
                 span.set_data("embedding_generated", False)

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -91,6 +91,31 @@ class TestRunUnifiedSearch(unittest.TestCase):
         assert sent_filters == [[PlaybookStatus.APPROVED, PlaybookStatus.PENDING]]
 
     @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_empty_embedding_degrades_to_fts(self, _reformulator_cls):
+        """An empty embedding result (e.g. a storage backend that swallows
+        EmbeddingUnavailableError and returns []) degrades to FTS and is flagged
+        as degraded — not run as a vector search with an empty embedding."""
+        storage = _mock_storage()
+        storage._get_embedding.return_value = []  # no usable query vector
+
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="test query"
+        )
+
+        request = UnifiedSearchRequest(query="test query")
+        result = run_unified_search(
+            request=request,
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        self.assertTrue(result.degraded)
+        self.assertEqual(result.search_mode_effective, "fts")
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
     def test_local_storage_without_get_embedding(self, _reformulator_cls):
         """Storage without _get_embedding should not crash and should use text-only search."""
         storage = _mock_storage()


### PR DESCRIPTION
Follow-up to #313 (closes the L1 gap the review flagged). When query-embedding generation returns a falsy result — None or `[]` (e.g. a storage backend swallowing `EmbeddingUnavailableError` on a provider outage and returning `[]`) — the search previously ran a vector search with an empty embedding and was NOT flagged `degraded`. Now a falsy result degrades to FTS and sets `degraded`/`search_mode_effective` + the counted signal, identical to a raised embedding failure. OSS-only; +1 test (`test_empty_embedding_degrades_to_fts`). 19 unified-search tests pass, ruff+pyright clean.