### PR TITLE
feat(embedding): Phase 2 prep — warm-before-ready /health + torch pin + config guards (dormant)

### DIFF
--- a/reflexio/server/__main__.py
+++ b/reflexio/server/__main__.py
@@ -15,6 +15,7 @@ Flags mirror the subset of ``uvicorn`` CLI options that
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 import uvicorn
@@ -99,6 +100,11 @@ def main(argv: list[str] | None = None) -> None:
             file=sys.stderr,
         )
         raise SystemExit(2)
+
+    # Record the configured worker count so per-worker startup guards can read
+    # it (uvicorn exposes no worker-count env inside a worker process). See
+    # ``embedder_warmup._detected_worker_count``.
+    os.environ["REFLEXIO_SERVER_WORKERS"] = str(1 if args.reload else args.workers)
 
     if args.reload:
         uvicorn.run(

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -372,6 +372,19 @@ def create_app(
         gc_scheduler = None
         durable_learning_scheduler = None
         started_caps: list = []
+        # D8 config guards + D5 warm-before-ready. Both are dormant unless the
+        # deployment has flipped to the in-process local embedder
+        # (REFLEXIO_EMBEDDING_PROVIDER=inprocess + local/* default); pre-flip
+        # this is a no-op and /health stays byte-for-byte unchanged. Run before
+        # the data-plane block so a gated deployment warms regardless of the
+        # mount profile (otherwise /health could 503 forever).
+        from reflexio.server.llm.providers.embedder_warmup import (
+            maybe_start_embedder_warmup,
+            run_startup_config_guards,
+        )
+
+        run_startup_config_guards()
+        maybe_start_embedder_warmup()
         if mounts_data_plane:
             log_publish_hardware_capacity()
             validate_llm_availability()

--- a/reflexio/server/llm/providers/embedder_warmup.py
+++ b/reflexio/server/llm/providers/embedder_warmup.py
@@ -1,0 +1,222 @@
+"""Warm-before-ready readiness gate for the in-process local embedder.
+
+Phase 2 preparation for the embedding-stability redesign. Everything here is
+**dormant** until a future config flip sets ``REFLEXIO_EMBEDDING_PROVIDER=inprocess``
+with a ``local/*`` default embedding model. Pre-flip (the current daemon-mode
+prod state, or any cloud/off/OSS-dev deployment) none of this changes ``/health``
+or startup behaviour.
+
+Three concerns live here:
+
+- **D5 warm-before-ready** — a process-level ``threading.Event`` set once the
+  in-process embedder has loaded, plus a non-blocking startup thread that loads
+  it. ``/health`` reports 503 while the gate is active and the embedder is not
+  yet warm, so the load balancer does not route embedding traffic at a worker
+  that would pay the ~2-8s cold-load on its first request.
+- **D8 config guards** — loud startup warnings for foot-guns of the in-process
+  topology: multiple uvicorn workers (each loads its own model copy) and a
+  half-configured daemon-disable / provider pair.
+
+The gate is intentionally cheap to evaluate (no network probe, no provider
+auto-detection) because ``/health`` is the ALB + container health target and is
+polled frequently.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+
+_LOGGER = logging.getLogger(__name__)
+
+_ENV_PROVIDER = "REFLEXIO_EMBEDDING_PROVIDER"
+_ENV_DISABLE_DAEMON = "REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON"
+# Recorded by ``reflexio.server.__main__`` before ``uvicorn.run`` so the guard
+# can read the configured worker count from inside a worker process, where
+# uvicorn exposes no worker-count env of its own.
+_ENV_WORKERS = "REFLEXIO_SERVER_WORKERS"
+_ENV_WEB_CONCURRENCY = "WEB_CONCURRENCY"
+
+_INPROCESS = "inprocess"
+
+# Process-level readiness signal: set once the in-process embedder is loaded.
+_ready = threading.Event()
+
+
+def mark_embedder_ready() -> None:
+    """Mark the in-process embedder as loaded/warm for this process."""
+    _ready.set()
+
+
+def is_embedder_ready() -> bool:
+    """Return True once the in-process embedder has been warmed in this process."""
+    return _ready.is_set()
+
+
+def reset_warmup_state_for_test() -> None:
+    """Clear the readiness signal. Test-only hygiene helper."""
+    _ready.clear()
+
+
+def _provider() -> str:
+    return os.environ.get(_ENV_PROVIDER, "").strip().lower()
+
+
+def inprocess_local_gate_active() -> bool:
+    """Return True iff this deployment serves embeddings via the in-process local path.
+
+    The gate is active only when BOTH hold:
+
+    - ``REFLEXIO_EMBEDDING_PROVIDER == "inprocess"`` (explicit config flip), and
+    - the resolved default embedding model is a ``local/*`` model.
+
+    Any other configuration (cloud, off, daemon-mode ``local_service`` /
+    ``internal_service``, or no explicit provider at all) returns False, keeping
+    the warm-before-ready behaviour dormant. Cheap by construction: neither
+    branch performs a network probe or provider auto-detection.
+
+    Returns:
+        bool: True when warm-before-ready ``/health`` gating should apply.
+    """
+    from reflexio.server.llm.providers.embedding_service_provider import (
+        embedding_provider_mode,
+    )
+
+    if embedding_provider_mode() != _INPROCESS:
+        return False
+
+    from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
+
+    try:
+        model = resolve_model_name(ModelRole.EMBEDDING)
+    except Exception:  # noqa: BLE001
+        # No embedding-capable provider resolvable — cannot be the in-process
+        # local path, so the gate stays inactive rather than wedging /health.
+        _LOGGER.debug("Embedding model resolution failed; gate inactive", exc_info=True)
+        return False
+    return model.startswith("local/")
+
+
+def _warm_embedder() -> None:
+    """Load the in-process embedder, then flip the readiness signal.
+
+    Fire-and-forget; runs in a daemon thread so a slow model load never blocks
+    startup. On failure the readiness signal stays clear and ``/health`` keeps
+    reporting not-ready, which is the intended fail-safe.
+    """
+    from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
+
+    try:
+        NomicEmbedder.get()._load()
+        mark_embedder_ready()
+        _LOGGER.info("In-process embedder warm; /health now reports ready.")
+    except Exception:  # noqa: BLE001
+        _LOGGER.exception("In-process embedder warmup failed; /health stays not-ready.")
+
+
+def maybe_start_embedder_warmup() -> bool:
+    """Spawn the non-blocking warm-before-ready thread when the gate is active.
+
+    Returns:
+        bool: True when a warmup thread was started (gate active), else False.
+    """
+    if not inprocess_local_gate_active():
+        return False
+    threading.Thread(target=_warm_embedder, daemon=True, name="embedder-warmup").start()
+    return True
+
+
+def _detected_worker_count() -> int | None:
+    """Best-effort read of the configured uvicorn worker count.
+
+    uvicorn exposes no worker-count env inside a worker process, so
+    ``reflexio.server.__main__`` records it in ``REFLEXIO_SERVER_WORKERS``. A
+    ``WEB_CONCURRENCY`` fallback covers gunicorn-style entrypoints. Returns
+    ``None`` when neither is set (custom entrypoint) — the guard then warns that
+    it could not verify the count rather than refusing.
+
+    Returns:
+        int | None: The detected worker count, or None if undetectable.
+    """
+    for name in (_ENV_WORKERS, _ENV_WEB_CONCURRENCY):
+        raw = os.environ.get(name)
+        if raw:
+            try:
+                return int(raw)
+            except ValueError:
+                continue
+    return None
+
+
+def _guard_workers_multiply_model() -> None:
+    """D8(a): warn when in-process mode runs under multiple workers.
+
+    In-process embedding loads one model copy per worker process, so a
+    memory-bounded host that is fine with 1 worker can OOM at N. Warn-only: the
+    worker count is not always reliably detectable from inside a worker.
+    """
+    if _provider() != _INPROCESS:
+        return
+    count = _detected_worker_count()
+    if count is not None and count > 1:
+        _LOGGER.warning(
+            "%s=%s with %d uvicorn workers: the in-process embedder loads one "
+            "model copy PER worker process, multiplying memory on a "
+            "memory-bounded task. Prefer 1 worker for in-process embedding, or "
+            "run the shared embedding daemon.",
+            _ENV_PROVIDER,
+            _INPROCESS,
+            count,
+        )
+    elif count is None:
+        _LOGGER.warning(
+            "%s=%s but the uvicorn worker count could not be verified (neither "
+            "%s nor %s is set). If this deployment runs multiple workers, each "
+            "loads its own in-process model copy.",
+            _ENV_PROVIDER,
+            _INPROCESS,
+            _ENV_WORKERS,
+            _ENV_WEB_CONCURRENCY,
+        )
+
+
+def _guard_daemon_disable_half_pair() -> None:
+    """D8(b): warn when the daemon-disable flag and provider disagree.
+
+    ``REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON`` (truthy) and
+    ``REFLEXIO_EMBEDDING_PROVIDER=inprocess`` describe the same intent from two
+    angles and are meant to be flipped together. If exactly one is set the
+    topology is half-configured (e.g. the daemon is disabled but requests still
+    route to daemon mode, or vice-versa).
+    """
+    from reflexio.server.env_utils import env_truthy
+
+    daemon_disabled = env_truthy(os.environ.get(_ENV_DISABLE_DAEMON, ""))
+    inprocess = _provider() == _INPROCESS
+    if daemon_disabled != inprocess:
+        _LOGGER.warning(
+            "Half-configured in-process embedding: %s=%s and %s=%s disagree. "
+            "Set them together (disable the daemon AND select the in-process "
+            "provider) or neither.",
+            _ENV_DISABLE_DAEMON,
+            daemon_disabled,
+            _ENV_PROVIDER,
+            _provider() or "<unset>",
+        )
+
+
+def run_startup_config_guards() -> None:
+    """Run the D8 config guards once at server startup (idempotent, warn-only)."""
+    _guard_workers_multiply_model()
+    _guard_daemon_disable_half_pair()
+
+
+__all__ = [
+    "inprocess_local_gate_active",
+    "is_embedder_ready",
+    "mark_embedder_ready",
+    "maybe_start_embedder_warmup",
+    "reset_warmup_state_for_test",
+    "run_startup_config_guards",
+]

--- a/reflexio/server/llm/providers/embedder_warmup.py
+++ b/reflexio/server/llm/providers/embedder_warmup.py
@@ -27,8 +27,16 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import time
+from collections.abc import Callable
 
 _LOGGER = logging.getLogger(__name__)
+
+# Warm-before-ready retry: cold model load is ~2-8s and reliable in prod, but a
+# bounded retry absorbs a transient blip before giving up (a give-up leaves
+# /health at 503, forcing a full ECS task replacement).
+_WARM_MAX_ATTEMPTS = 3
+_WARM_RETRY_BACKOFF_S = 2.0
 
 _ENV_PROVIDER = "REFLEXIO_EMBEDDING_PROVIDER"
 _ENV_DISABLE_DAEMON = "REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON"
@@ -83,7 +91,14 @@ def inprocess_local_gate_active() -> bool:
         embedding_provider_mode,
     )
 
-    if embedding_provider_mode() != _INPROCESS:
+    try:
+        mode = embedding_provider_mode()
+    except Exception:  # noqa: BLE001
+        # An invalid REFLEXIO_EMBEDDING_PROVIDER must not turn /health (polled on
+        # every ALB probe) into a 500 — treat unresolvable config as gate-off.
+        _LOGGER.debug("Embedding provider mode unresolvable; gate inactive", exc_info=True)
+        return False
+    if mode != _INPROCESS:
         return False
 
     from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
@@ -98,21 +113,72 @@ def inprocess_local_gate_active() -> bool:
     return model.startswith("local/")
 
 
-def _warm_embedder() -> None:
-    """Load the in-process embedder, then flip the readiness signal.
+def _resolve_local_embedder_loader() -> Callable[[], object] | None:
+    """Return a zero-arg loader for the embedder matching the resolved local model.
 
-    Fire-and-forget; runs in a daemon thread so a slow model load never blocks
-    startup. On failure the readiness signal stays clear and ``/health`` keeps
-    reporting not-ready, which is the intended fail-safe.
+    Dispatches on the SAME model the gate resolved so readiness reflects the
+    embedder that will actually serve: ``local/nomic-*`` -> ``NomicEmbedder``
+    (sentence-transformers), any other ``local/*`` -> ``LocalEmbedder`` (chromadb
+    ONNX, e.g. the OSS ``local/minilm-l6-v2`` default). Returns None when no
+    in-process local model resolves.
+
+    Returns:
+        Callable[[], object] | None: A loader that warms the correct singleton,
+            or None if the resolved model is not an in-process local one.
     """
-    from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
+    from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 
     try:
-        NomicEmbedder.get()._load()
-        mark_embedder_ready()
-        _LOGGER.info("In-process embedder warm; /health now reports ready.")
+        model = resolve_model_name(ModelRole.EMBEDDING)
     except Exception:  # noqa: BLE001
-        _LOGGER.exception("In-process embedder warmup failed; /health stays not-ready.")
+        return None
+    if not model.startswith("local/"):
+        return None
+    if "nomic" in model:
+        from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
+
+        return lambda: NomicEmbedder.get()._load()
+    from reflexio.server.llm.providers.local_embedding_provider import LocalEmbedder
+
+    return lambda: LocalEmbedder.get()._load()
+
+
+def _warm_embedder() -> None:
+    """Load the resolved in-process local embedder, then flip the readiness signal.
+
+    Warms whichever embedder the gate's resolved ``local/*`` model maps to (see
+    :func:`_resolve_local_embedder_loader`), so readiness reflects the model that
+    will actually serve — not a hardcoded one. Fire-and-forget in a daemon thread
+    so a slow load never blocks startup; a bounded retry absorbs a transient blip.
+    On final failure the readiness signal stays clear and ``/health`` keeps
+    reporting not-ready — the intended fail-safe (deploy fails loud, old rev serves).
+    """
+    loader = _resolve_local_embedder_loader()
+    if loader is None:
+        _LOGGER.warning(
+            "Warmup gate active but no in-process local embedder resolved; "
+            "/health stays not-ready."
+        )
+        return
+    for attempt in range(1, _WARM_MAX_ATTEMPTS + 1):
+        try:
+            loader()
+            mark_embedder_ready()
+            _LOGGER.info("In-process embedder warm; /health now reports ready.")
+            return
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning(
+                "In-process embedder warmup attempt %d/%d failed.",
+                attempt,
+                _WARM_MAX_ATTEMPTS,
+                exc_info=True,
+            )
+            if attempt < _WARM_MAX_ATTEMPTS:
+                time.sleep(_WARM_RETRY_BACKOFF_S * attempt)
+    _LOGGER.error(
+        "In-process embedder warmup exhausted %d attempts; /health stays not-ready.",
+        _WARM_MAX_ATTEMPTS,
+    )
 
 
 def maybe_start_embedder_warmup() -> bool:

--- a/reflexio/server/llm/providers/nomic_embedding_provider.py
+++ b/reflexio/server/llm/providers/nomic_embedding_provider.py
@@ -65,8 +65,10 @@ _ENV_BATCH_SIZE = "REFLEXIO_EMBED_BATCH_SIZE"
 
 # D7 (Phase 2 prep): optionally pin torch intra-op thread count so the embedder
 # does not oversubscribe CPU under bounded concurrency. Unset (the default) =
-# leave torch untouched, i.e. zero behaviour change. Applies at model load so it
-# covers both the in-process path and the shared daemon.
+# leave torch untouched, i.e. zero behaviour change. Applies at Nomic model load
+# (both the in-process fallback and the shared daemon run NomicEmbedder). Note the
+# chromadb/minilm LocalEmbedder path uses onnxruntime, not torch, so this knob does
+# not affect it.
 _ENV_TORCH_THREADS = "REFLEXIO_EMBED_TORCH_THREADS"
 _torch_threads_pinned = False
 _torch_threads_lock = threading.Lock()

--- a/reflexio/server/llm/providers/nomic_embedding_provider.py
+++ b/reflexio/server/llm/providers/nomic_embedding_provider.py
@@ -63,10 +63,60 @@ _MAX_CHARS = 32_000
 _DEFAULT_ENCODE_BATCH_SIZE = 4
 _ENV_BATCH_SIZE = "REFLEXIO_EMBED_BATCH_SIZE"
 
+# D7 (Phase 2 prep): optionally pin torch intra-op thread count so the embedder
+# does not oversubscribe CPU under bounded concurrency. Unset (the default) =
+# leave torch untouched, i.e. zero behaviour change. Applies at model load so it
+# covers both the in-process path and the shared daemon.
+_ENV_TORCH_THREADS = "REFLEXIO_EMBED_TORCH_THREADS"
+_torch_threads_pinned = False
+_torch_threads_lock = threading.Lock()
+
 
 def _encode_batch_size() -> int:
     """Resolve the encode mini-batch size from env, defaulting to 4."""
     return positive_int_env(_ENV_BATCH_SIZE, _DEFAULT_ENCODE_BATCH_SIZE, _LOGGER)
+
+
+def _maybe_pin_torch_threads() -> None:
+    """Pin torch intra-op threads to ``REFLEXIO_EMBED_TORCH_THREADS`` if set.
+
+    Dormant by default: when the env var is unset (or blank) this is a no-op and
+    ``torch.set_num_threads`` is never called, so torch keeps its default
+    autodetected thread count. When set to a positive int it is applied exactly
+    once per process (guarded against re-calling). A non-positive or non-integer
+    value is ignored with a warning.
+    """
+    global _torch_threads_pinned
+    if _torch_threads_pinned:
+        return
+    raw = os.environ.get(_ENV_TORCH_THREADS)
+    if not raw:
+        return
+    try:
+        n = int(raw)
+    except ValueError:
+        _LOGGER.warning(
+            "%s must be a positive integer; got %r — leaving torch threads at "
+            "their default.",
+            _ENV_TORCH_THREADS,
+            raw,
+        )
+        return
+    if n < 1:
+        _LOGGER.warning(
+            "%s must be >= 1; got %d — leaving torch threads at their default.",
+            _ENV_TORCH_THREADS,
+            n,
+        )
+        return
+    with _torch_threads_lock:
+        if _torch_threads_pinned:
+            return
+        import torch
+
+        torch.set_num_threads(n)
+        _torch_threads_pinned = True
+        _LOGGER.info("Pinned torch intra-op threads to %d (%s)", n, _ENV_TORCH_THREADS)
 
 
 class NomicEmbedderError(RuntimeError):
@@ -118,6 +168,7 @@ class NomicEmbedder:
                     "sentence-transformers is required for the Nomic local "
                     "embedder. Install with `uv add sentence-transformers`."
                 ) from exc
+            _maybe_pin_torch_threads()
             _LOGGER.info(
                 "Loading Nomic embedding model %s — first call may download "
                 "~550 MB to %s",

--- a/reflexio/server/routes/system.py
+++ b/reflexio/server/routes/system.py
@@ -13,6 +13,7 @@ from fastapi import (
     Request,
     status,
 )
+from fastapi.responses import JSONResponse
 
 from reflexio.models.api_schema.retriever_schema import (
     GetDashboardStatsRequest,
@@ -55,9 +56,27 @@ def root() -> dict[str, str]:
     }
 
 
-@router.get("/health")
-async def health_check() -> dict[str, str]:
-    """Health check endpoint for ECS/container orchestration."""
+@router.get("/health", response_model=None)
+async def health_check() -> dict[str, str] | JSONResponse:
+    """Health check endpoint for ECS/container orchestration.
+
+    When the in-process-embedder warm-before-ready gate is active (a future
+    ``REFLEXIO_EMBEDDING_PROVIDER=inprocess`` + ``local/*`` deployment) and the
+    embedder has not finished loading, return HTTP 503 so the load balancer
+    holds traffic until the model is warm. In every other configuration — the
+    current daemon-mode prod state included — the gate is inactive and this
+    returns exactly the historical 200 body.
+    """
+    from reflexio.server.llm.providers.embedder_warmup import (
+        inprocess_local_gate_active,
+        is_embedder_ready,
+    )
+
+    if inprocess_local_gate_active() and not is_embedder_ready():
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"status": "starting"},
+        )
     return {"status": "healthy"}
 
 

--- a/tests/server/llm/test_embedder_warmup.py
+++ b/tests/server/llm/test_embedder_warmup.py
@@ -1,0 +1,260 @@
+"""Unit tests for the in-process embedder warm-before-ready gate (D5/D8).
+
+These prove the Phase-2 dormancy invariant: nothing here activates unless a
+deployment has explicitly flipped ``REFLEXIO_EMBEDDING_PROVIDER=inprocess`` with
+a ``local/*`` default embedding model.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from reflexio.server.llm.providers import embedder_warmup
+from reflexio.server.llm.providers.embedder_warmup import (
+    inprocess_local_gate_active,
+    is_embedder_ready,
+    maybe_start_embedder_warmup,
+    reset_warmup_state_for_test,
+    run_startup_config_guards,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    """Clear the process-global readiness signal before every test."""
+    reset_warmup_state_for_test()
+
+
+# --------------------------------------------------------------------------- #
+# Gate: dormant unless inprocess + local/*                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_inactive_when_provider_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No REFLEXIO_EMBEDDING_PROVIDER → gate inactive (current prod state)."""
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    assert inprocess_local_gate_active() is False
+
+
+@pytest.mark.parametrize("mode", ["cloud", "off", "local_service", "internal_service"])
+def test_gate_inactive_for_non_inprocess_modes(
+    monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """Any explicit non-inprocess provider keeps the gate dormant."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", mode)
+    if mode in {"local_service", "internal_service"}:
+        # These modes require a service URL to resolve; the gate must short out
+        # on the provider check before touching URL resolution.
+        monkeypatch.setenv("REFLEXIO_EMBEDDING_SERVICE_URL", "http://127.0.0.1:8072")
+    assert inprocess_local_gate_active() is False
+
+
+def test_gate_active_when_inprocess_and_local_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """inprocess + the default local embedding model → gate active."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    assert inprocess_local_gate_active() is True
+
+
+def test_gate_inactive_when_inprocess_but_model_not_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """inprocess but the resolved default is a cloud model → gate inactive.
+
+    Proves the gate is a genuine AND of provider AND model, not provider alone.
+    """
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.setattr(
+        embedder_warmup,
+        "_provider",
+        lambda: "inprocess",
+    )
+
+    from reflexio.server.llm import model_defaults
+
+    monkeypatch.setattr(
+        model_defaults,
+        "resolve_model_name",
+        lambda *_a, **_k: "text-embedding-3-small",
+    )
+    assert inprocess_local_gate_active() is False
+
+
+# --------------------------------------------------------------------------- #
+# D5 warm-before-ready thread                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_warmup_not_started_when_gate_inactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gate inactive → no thread spawned, readiness stays clear."""
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    assert maybe_start_embedder_warmup() is False
+    assert is_embedder_ready() is False
+
+
+def test_warmup_starts_and_marks_ready_under_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Gate active → a daemon thread loads a (fake) embedder and flips ready.
+
+    Uses a fast fake so the real ~550MB model never loads. Startup itself must
+    not block: ``maybe_start_embedder_warmup`` returns immediately while the
+    load happens on the background thread.
+    """
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+
+    load_calls: list[int] = []
+
+    class _FakeEmbedder:
+        def _load(self) -> None:
+            load_calls.append(1)
+
+    from reflexio.server.llm.providers import nomic_embedding_provider
+
+    monkeypatch.setattr(
+        nomic_embedding_provider.NomicEmbedder,
+        "get",
+        staticmethod(lambda: _FakeEmbedder()),
+    )
+
+    assert is_embedder_ready() is False
+    started = maybe_start_embedder_warmup()
+    assert started is True
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and not is_embedder_ready():
+        time.sleep(0.01)
+
+    assert is_embedder_ready() is True
+    assert load_calls == [1]
+
+
+def test_warmup_failure_leaves_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A load failure must NOT mark ready — /health stays 503 (fail-safe)."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+
+    class _BoomEmbedder:
+        def _load(self) -> None:
+            raise RuntimeError("boom")
+
+    from reflexio.server.llm.providers import nomic_embedding_provider
+
+    monkeypatch.setattr(
+        nomic_embedding_provider.NomicEmbedder,
+        "get",
+        staticmethod(lambda: _BoomEmbedder()),
+    )
+
+    assert maybe_start_embedder_warmup() is True
+    time.sleep(0.2)
+    assert is_embedder_ready() is False
+
+
+# --------------------------------------------------------------------------- #
+# D8(a): workers-multiply-model guard                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_workers_guard_warns_on_multiworker_inprocess(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "2")
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_workers_multiply_model()
+    assert any("model copy PER worker" in r.message for r in caplog.records)
+
+
+def test_workers_guard_silent_on_single_worker(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "1")
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_workers_multiply_model()
+    assert caplog.records == []
+
+
+def test_workers_guard_warns_when_undetectable(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.delenv("REFLEXIO_SERVER_WORKERS", raising=False)
+    monkeypatch.delenv("WEB_CONCURRENCY", raising=False)
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_workers_multiply_model()
+    assert any("could not be verified" in r.message for r in caplog.records)
+
+
+def test_workers_guard_silent_when_not_inprocess(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Even with many workers, the guard is silent off the in-process path."""
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "8")
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_workers_multiply_model()
+    assert caplog.records == []
+
+
+# --------------------------------------------------------------------------- #
+# D8(b): half-pair daemon-disable / provider guard                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_half_pair_guard_warns_when_provider_set_alone(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.delenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", raising=False)
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_daemon_disable_half_pair()
+    assert any("Half-configured" in r.message for r in caplog.records)
+
+
+def test_half_pair_guard_warns_when_disable_set_alone(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.setenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", "1")
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_daemon_disable_half_pair()
+    assert any("Half-configured" in r.message for r in caplog.records)
+
+
+def test_half_pair_guard_silent_when_both_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.setenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", "1")
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_daemon_disable_half_pair()
+    assert caplog.records == []
+
+
+def test_half_pair_guard_silent_when_neither_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", raising=False)
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_daemon_disable_half_pair()
+    assert caplog.records == []
+
+
+def test_run_startup_config_guards_is_silent_when_dormant(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The whole guard pass emits nothing in the default (pre-flip) state."""
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.delenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", raising=False)
+    monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "1")
+    with caplog.at_level(logging.WARNING):
+        run_startup_config_guards()
+    assert caplog.records == []

--- a/tests/server/llm/test_embedder_warmup.py
+++ b/tests/server/llm/test_embedder_warmup.py
@@ -111,16 +111,14 @@ def test_warmup_starts_and_marks_ready_under_gate(
 
     load_calls: list[int] = []
 
-    class _FakeEmbedder:
-        def _load(self) -> None:
-            load_calls.append(1)
+    from reflexio.server.llm.providers import embedder_warmup
 
-    from reflexio.server.llm.providers import nomic_embedding_provider
-
+    # Patch the loader seam so the test controls warm success regardless of which
+    # local embedder (nomic vs minilm/LocalEmbedder) the default model resolves to.
     monkeypatch.setattr(
-        nomic_embedding_provider.NomicEmbedder,
-        "get",
-        staticmethod(lambda: _FakeEmbedder()),
+        embedder_warmup,
+        "_resolve_local_embedder_loader",
+        lambda: (lambda: load_calls.append(1)),
     )
 
     assert is_embedder_ready() is False
@@ -136,24 +134,72 @@ def test_warmup_starts_and_marks_ready_under_gate(
 
 
 def test_warmup_failure_leaves_not_ready(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A load failure must NOT mark ready — /health stays 503 (fail-safe)."""
+    """A load failure (all retries) must NOT mark ready — /health stays 503 (fail-safe)."""
     monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
 
-    class _BoomEmbedder:
-        def _load(self) -> None:
-            raise RuntimeError("boom")
+    from reflexio.server.llm.providers import embedder_warmup
 
-    from reflexio.server.llm.providers import nomic_embedding_provider
+    # Fast, deterministic retry for the test.
+    monkeypatch.setattr(embedder_warmup, "_WARM_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(embedder_warmup, "_WARM_RETRY_BACKOFF_S", 0.0)
+
+    attempts: list[int] = []
+
+    def _boom() -> None:
+        attempts.append(1)
+        raise RuntimeError("boom")
 
     monkeypatch.setattr(
-        nomic_embedding_provider.NomicEmbedder,
-        "get",
-        staticmethod(lambda: _BoomEmbedder()),
+        embedder_warmup, "_resolve_local_embedder_loader", lambda: _boom
     )
 
     assert maybe_start_embedder_warmup() is True
     time.sleep(0.2)
     assert is_embedder_ready() is False
+    # Bounded retry actually retried before giving up.
+    assert attempts == [1, 1]
+
+
+def test_warm_target_follows_resolved_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The warmed embedder matches the resolved local model (nomic vs minilm),
+    not a hardcoded class — so readiness reflects the model that will serve."""
+    from reflexio.server.llm import model_defaults
+    from reflexio.server.llm.providers import (
+        embedder_warmup,
+        local_embedding_provider,
+        nomic_embedding_provider,
+    )
+
+    warmed: list[str] = []
+    monkeypatch.setattr(
+        nomic_embedding_provider.NomicEmbedder,
+        "get",
+        staticmethod(lambda: type("N", (), {"_load": lambda _self: warmed.append("nomic")})()),
+    )
+    monkeypatch.setattr(
+        local_embedding_provider.LocalEmbedder,
+        "get",
+        staticmethod(lambda: type("L", (), {"_load": lambda _self: warmed.append("minilm")})()),
+    )
+
+    monkeypatch.setattr(
+        model_defaults, "resolve_model_name", lambda _role: "local/nomic-embed-text-v1.5"
+    )
+    embedder_warmup._resolve_local_embedder_loader()()  # type: ignore[misc]
+    assert warmed == ["nomic"]
+
+    warmed.clear()
+    monkeypatch.setattr(
+        model_defaults, "resolve_model_name", lambda _role: "local/minilm-l6-v2"
+    )
+    embedder_warmup._resolve_local_embedder_loader()()  # type: ignore[misc]
+    assert warmed == ["minilm"]
+
+    # A non-local resolved model yields no loader (gate would be inactive too).
+    monkeypatch.setattr(
+        model_defaults, "resolve_model_name", lambda _role: "text-embedding-3-small"
+    )
+    assert embedder_warmup._resolve_local_embedder_loader() is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/server/llm/test_nomic_torch_threads.py
+++ b/tests/server/llm/test_nomic_torch_threads.py
@@ -1,0 +1,66 @@
+"""D7: torch intra-op thread pinning is dormant unless explicitly configured."""
+
+from __future__ import annotations
+
+import pytest
+
+from reflexio.server.llm.providers import nomic_embedding_provider
+from reflexio.server.llm.providers.nomic_embedding_provider import (
+    _maybe_pin_torch_threads,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_pinned_flag() -> None:
+    """Reset the once-per-process pin guard so each test starts fresh."""
+    nomic_embedding_provider._torch_threads_pinned = False
+
+
+def _patch_torch(monkeypatch: pytest.MonkeyPatch) -> list[int]:
+    """Patch ``torch.set_num_threads`` and return the list it records into."""
+    import torch
+
+    calls: list[int] = []
+    monkeypatch.setattr(torch, "set_num_threads", lambda n: calls.append(n))
+    return calls
+
+
+def test_unset_does_not_touch_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default (unset) → torch.set_num_threads is never called."""
+    monkeypatch.delenv("REFLEXIO_EMBED_TORCH_THREADS", raising=False)
+    calls = _patch_torch(monkeypatch)
+    _maybe_pin_torch_threads()
+    assert calls == []
+
+
+def test_set_pins_threads_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A positive value pins exactly once, even across repeated calls."""
+    monkeypatch.setenv("REFLEXIO_EMBED_TORCH_THREADS", "1")
+    calls = _patch_torch(monkeypatch)
+    _maybe_pin_torch_threads()
+    _maybe_pin_torch_threads()  # second call must be a no-op (already pinned)
+    assert calls == [1]
+
+
+def test_set_two_threads(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tested alternative (2) is applied verbatim."""
+    monkeypatch.setenv("REFLEXIO_EMBED_TORCH_THREADS", "2")
+    calls = _patch_torch(monkeypatch)
+    _maybe_pin_torch_threads()
+    assert calls == [2]
+
+
+def test_invalid_value_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-integer value leaves torch untouched (no crash)."""
+    monkeypatch.setenv("REFLEXIO_EMBED_TORCH_THREADS", "not-a-number")
+    calls = _patch_torch(monkeypatch)
+    _maybe_pin_torch_threads()
+    assert calls == []
+
+
+def test_non_positive_value_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-positive value leaves torch untouched."""
+    monkeypatch.setenv("REFLEXIO_EMBED_TORCH_THREADS", "0")
+    calls = _patch_torch(monkeypatch)
+    _maybe_pin_torch_threads()
+    assert calls == []

--- a/tests/server/routes/test_health_warm_gate.py
+++ b/tests/server/routes/test_health_warm_gate.py
@@ -1,0 +1,75 @@
+"""``/health`` warm-before-ready behaviour and its dormancy anti-regression.
+
+The 200 path is the ALB + container health target and MUST stay byte-for-byte
+identical to the pre-Phase-2 response whenever the in-process gate is inactive.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from reflexio.server.api import create_app
+from reflexio.server.llm.providers.embedder_warmup import (
+    mark_embedder_ready,
+    reset_warmup_state_for_test,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> None:
+    reset_warmup_state_for_test()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(create_app())
+
+
+def test_health_200_unchanged_when_gate_inactive(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default (no provider) → exactly the historical 200 body.
+
+    This is the dormancy anti-regression: a change that makes the pre-flip
+    ``/health`` anything other than ``200 {"status": "healthy"}`` fails here.
+    """
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+@pytest.mark.parametrize("mode", ["cloud", "off"])
+def test_health_200_when_non_inprocess_provider(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    """A non-inprocess provider keeps /health on the unchanged 200 path."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", mode)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_health_503_when_gate_active_and_not_warm(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Gate active + embedder not yet loaded → 503 not-ready."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    response = client.get("/health")
+    assert response.status_code == 503
+    assert response.json() == {"status": "starting"}
+
+
+def test_health_200_after_ready_event_set(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Once the embedder is warm, /health returns to the unchanged 200 body."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    assert client.get("/health").status_code == 503
+
+    mark_embedder_ready()  # simulate warmup completion (no real model loaded)
+
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}

--- a/tests/server/test_app_route_inventory.py
+++ b/tests/server/test_app_route_inventory.py
@@ -82,7 +82,10 @@ FULL_ROUTES = [
     (
         "/health",
         ("GET",),
-        "dict",
+        # response_model is None: the handler may return a JSONResponse (503,
+        # not-ready) when the in-process warm gate is active, so the route
+        # cannot declare a Pydantic response model. The 200 body is unchanged.
+        None,
         None,
         (),
         "health_check",


### PR DESCRIPTION
## What
Phase 2 preparation for the embedding-stability redesign: the code that makes a future **config-only** topology flip (drop the co-located daemon, embed in-process) safe. **Everything here is dormant until `REFLEXIO_EMBEDDING_PROVIDER=inprocess` is set with a `local/*` default model** — pre-flip (current daemon-mode prod, or any cloud/off/OSS-dev deployment) `/health` and startup are byte-for-byte unchanged.

- **D5 warm-before-ready** — a startup daemon thread warms the in-process embedder; `/health` returns 503 (not-ready) only while the gate is active and the embedder hasn't loaded, so the LB doesn't route embedding traffic at a worker that would pay the ~2–8s cold-load. Warms the embedder the gate **resolved** (nomic→`NomicEmbedder`, else minilm→`LocalEmbedder`), with a bounded retry; on final failure `/health` stays 503 (fail-loud → deploy fails, old rev serves).
- **D7 torch pin** — `REFLEXIO_EMBED_TORCH_THREADS` (default unset = no torch change) pins `torch.set_num_threads(n)` at Nomic model load.
- **D8 config guards** — loud startup warnings for in-process foot-guns: uvicorn workers>1 (per-worker model copy) and a half-configured daemon-disable/provider pair.

## Safety
The dormancy invariant is the whole point and is proven by tests: `/health` returns the identical `200 {"status":"healthy"}` when the gate is inactive; torch is never touched with the env unset; guards are silent. Reviewed (SAFE TO MERGE) — the review's one Important finding (warm-target mismatch: hardcoded Nomic vs the minilm default) is fixed in this PR, so an OSS/self-host inprocess flip can't wedge `/health`.

## Tests
36 new tests (gate AND-logic, dormant `/health`, warm dispatch by resolved model, retry, torch dormancy, guards). `tests/server/` relevant tier = 344 passed; ruff + pyright clean. OSS-only.

Follow-up at enterprise bump: document `REFLEXIO_EMBED_TORCH_THREADS` in the enterprise `.env.template` (drift-guard doesn't scan OSS, but per env-var policy). Config flip + deploy are separate, explicitly-gated steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness checks for the server’s health endpoint so it can report “starting” until embedding support is ready.
  * Improved startup handling for embedding setup and worker configuration, with clearer warnings for common misconfigurations.

* **Bug Fixes**
  * Reduced the chance of serving requests before local embedding is fully warmed up.
  * Added safer thread settings for local embedding to improve stability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->