### PR TITLE
feat(embedding): guard inprocess-overrides-service-host + test internal_service quadrant (D4a)

### DIFF
--- a/reflexio/server/llm/providers/embedder_warmup.py
+++ b/reflexio/server/llm/providers/embedder_warmup.py
@@ -14,8 +14,9 @@ Three concerns live here:
   yet warm, so the load balancer does not route embedding traffic at a worker
   that would pay the ~2-8s cold-load on its first request.
 - **D8 config guards** — loud startup warnings for foot-guns of the in-process
-  topology: multiple uvicorn workers (each loads its own model copy) and a
-  half-configured daemon-disable / provider pair.
+  topology: multiple uvicorn workers (each loads its own model copy), a
+  half-configured daemon-disable / provider pair, and an in-process provider set
+  alongside a configured service endpoint (which the provider silently overrides).
 
 The gate is intentionally cheap to evaluate (no network probe, no provider
 auto-detection) because ``/health`` is the ALB + container health target and is
@@ -40,6 +41,11 @@ _WARM_RETRY_BACKOFF_S = 2.0
 
 _ENV_PROVIDER = "REFLEXIO_EMBEDDING_PROVIDER"
 _ENV_DISABLE_DAEMON = "REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON"
+# Service-endpoint envs, named to match embedding_service_provider.py exactly. An
+# in-process provider takes precedence over both, so either being set alongside
+# PROVIDER=inprocess silently strands the configured service host.
+_ENV_SERVICE_URL = "REFLEXIO_EMBEDDING_SERVICE_URL"
+_ENV_DAEMON_HOST = "REFLEXIO_EMBEDDING_DAEMON_HOST"
 # Recorded by ``reflexio.server.__main__`` before ``uvicorn.run`` so the guard
 # can read the configured worker count from inside a worker process, where
 # uvicorn exposes no worker-count env of its own.
@@ -96,7 +102,9 @@ def inprocess_local_gate_active() -> bool:
     except Exception:  # noqa: BLE001
         # An invalid REFLEXIO_EMBEDDING_PROVIDER must not turn /health (polled on
         # every ALB probe) into a 500 — treat unresolvable config as gate-off.
-        _LOGGER.debug("Embedding provider mode unresolvable; gate inactive", exc_info=True)
+        _LOGGER.debug(
+            "Embedding provider mode unresolvable; gate inactive", exc_info=True
+        )
         return False
     if mode != _INPROCESS:
         return False
@@ -272,10 +280,43 @@ def _guard_daemon_disable_half_pair() -> None:
         )
 
 
+def _guard_inprocess_overrides_service_host() -> None:
+    """D8(c): warn when in-process mode is set alongside a configured service host.
+
+    ``REFLEXIO_EMBEDDING_PROVIDER=inprocess`` wins the provider-precedence race in
+    ``embedding_provider_mode`` outright, so a co-configured
+    ``REFLEXIO_EMBEDDING_SERVICE_URL`` / ``REFLEXIO_EMBEDDING_DAEMON_HOST`` is
+    silently ignored and this process loads its own in-process local model instead
+    of routing to the service. On a GPU-service / self-host fleet that means an
+    unintended per-instance CPU model load. Warn-only: the intended in-process
+    flip leaves both endpoint envs unset, so this stays silent there.
+    """
+    if _provider() != _INPROCESS:
+        return
+    configured = [
+        name
+        for name in (_ENV_SERVICE_URL, _ENV_DAEMON_HOST)
+        if os.environ.get(name, "").strip()
+    ]
+    if not configured:
+        return
+    _LOGGER.warning(
+        "%s=%s takes precedence and loads an in-process local model, silently "
+        "ignoring the configured service endpoint(s): %s. Unset the endpoint(s) "
+        "to keep the in-process embedder, or unset %s to route embeddings to the "
+        "service.",
+        _ENV_PROVIDER,
+        _INPROCESS,
+        ", ".join(configured),
+        _ENV_PROVIDER,
+    )
+
+
 def run_startup_config_guards() -> None:
     """Run the D8 config guards once at server startup (idempotent, warn-only)."""
     _guard_workers_multiply_model()
     _guard_daemon_disable_half_pair()
+    _guard_inprocess_overrides_service_host()
 
 
 __all__ = [

--- a/tests/server/llm/test_embedder_warmup.py
+++ b/tests/server/llm/test_embedder_warmup.py
@@ -118,7 +118,7 @@ def test_warmup_starts_and_marks_ready_under_gate(
     monkeypatch.setattr(
         embedder_warmup,
         "_resolve_local_embedder_loader",
-        lambda: (lambda: load_calls.append(1)),
+        lambda: lambda: load_calls.append(1),
     )
 
     assert is_embedder_ready() is False
@@ -174,16 +174,22 @@ def test_warm_target_follows_resolved_model(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(
         nomic_embedding_provider.NomicEmbedder,
         "get",
-        staticmethod(lambda: type("N", (), {"_load": lambda _self: warmed.append("nomic")})()),
+        staticmethod(
+            lambda: type("N", (), {"_load": lambda _self: warmed.append("nomic")})()
+        ),
     )
     monkeypatch.setattr(
         local_embedding_provider.LocalEmbedder,
         "get",
-        staticmethod(lambda: type("L", (), {"_load": lambda _self: warmed.append("minilm")})()),
+        staticmethod(
+            lambda: type("L", (), {"_load": lambda _self: warmed.append("minilm")})()
+        ),
     )
 
     monkeypatch.setattr(
-        model_defaults, "resolve_model_name", lambda _role: "local/nomic-embed-text-v1.5"
+        model_defaults,
+        "resolve_model_name",
+        lambda _role: "local/nomic-embed-text-v1.5",
     )
     embedder_warmup._resolve_local_embedder_loader()()  # type: ignore[misc]
     assert warmed == ["nomic"]
@@ -291,6 +297,68 @@ def test_half_pair_guard_silent_when_neither_set(
     monkeypatch.delenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", raising=False)
     with caplog.at_level(logging.WARNING):
         embedder_warmup._guard_daemon_disable_half_pair()
+    assert caplog.records == []
+
+
+# --------------------------------------------------------------------------- #
+# D8(c): inprocess-overrides-service-host guard                               #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("env_var", "value"),
+    [
+        ("REFLEXIO_EMBEDDING_SERVICE_URL", "http://embedding.internal:8089"),
+        ("REFLEXIO_EMBEDDING_DAEMON_HOST", "embedding.internal"),
+    ],
+)
+def test_inprocess_override_guard_warns_when_service_endpoint_set(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    env_var: str,
+    value: str,
+) -> None:
+    """inprocess + a configured service endpoint → one warning naming the var."""
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_DAEMON_HOST", raising=False)
+    monkeypatch.setenv(env_var, value)
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_inprocess_overrides_service_host()
+    warnings = [r for r in caplog.records if "takes precedence" in r.message]
+    assert len(warnings) == 1
+    assert env_var in warnings[0].getMessage()
+
+
+def test_inprocess_override_guard_silent_for_intended_step_b_config(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The intended flip (inprocess + disable-daemon, NO service endpoints) is silent.
+
+    This is the exact Step B config the in-process rollout ships, so the guard
+    must not false-positive on it.
+    """
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "inprocess")
+    monkeypatch.setenv("REFLEXIO_DISABLE_LOCAL_EMBEDDING_DAEMON", "true")
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_SERVICE_URL", raising=False)
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_DAEMON_HOST", raising=False)
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_inprocess_overrides_service_host()
+    assert caplog.records == []
+
+
+def test_inprocess_override_guard_silent_when_not_inprocess(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A service host without PROVIDER=inprocess is the normal service topology.
+
+    That routes to the service (no in-process load), so the guard stays scoped to
+    the in-process path and says nothing.
+    """
+    monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_DAEMON_HOST", "embedding.internal")
+    with caplog.at_level(logging.WARNING):
+        embedder_warmup._guard_inprocess_overrides_service_host()
     assert caplog.records == []
 
 

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -756,10 +756,16 @@ def test_nomic_inprocess_fallback_does_not_use_minilm(monkeypatch) -> None:
 
 
 class TestRemoteServiceNoLocalFallback:
-    """Design item D4a / test-matrix row 8: a deployment configured for the REMOTE
-    embedding service (``REFLEXIO_EMBEDDING_DAEMON_HOST`` set → authoritative
-    ``local_service`` mode, no probe) must NEVER silently load an in-process
-    embedder (``NomicEmbedder`` / ``LocalEmbedder``) as a hidden fallback.
+    """Design item D4a / test-matrix row 8: a deployment configured for a REMOTE
+    embedding service must NEVER silently load an in-process embedder
+    (``NomicEmbedder`` / ``LocalEmbedder``) as a hidden fallback.
+
+    Both remote-service quadrants are covered:
+
+    - ``local_service`` — ``REFLEXIO_EMBEDDING_DAEMON_HOST`` set (authoritative
+      daemon-host branch, no ``/health`` probe).
+    - ``internal_service`` — ``REFLEXIO_EMBEDDING_SERVICE_URL`` set (the
+      horizontally-scaled cloud / GPU-service topology).
 
     When the remote service fails, the call must raise
     ``EmbeddingUnavailableError`` (which upstream turns into store-fail-loud /
@@ -786,6 +792,31 @@ class TestRemoteServiceNoLocalFallback:
         monkeypatch.delenv("EMBEDDING_PORT", raising=False)
         # A stale probe cache must not influence the authoritative daemon-host path.
         monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+
+    @staticmethod
+    def _configure_internal_service(monkeypatch) -> None:
+        """Set env so any model resolves to ``internal_service``.
+
+        ``REFLEXIO_EMBEDDING_SERVICE_URL`` set with no explicit provider,
+        ``CLAUDE_SMART_USE_LOCAL_EMBEDDING`` or ``DAEMON_HOST`` takes the
+        service-URL branch in ``embedding_provider_mode``, which resolves to
+        ``internal_service`` with no ``/health`` probe — so it can never
+        re-resolve to ``inprocess``.
+        """
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_PROVIDER", raising=False)
+        monkeypatch.delenv("CLAUDE_SMART_USE_LOCAL_EMBEDDING", raising=False)
+        monkeypatch.delenv("REFLEXIO_EMBEDDING_DAEMON_HOST", raising=False)
+        monkeypatch.setenv(
+            "REFLEXIO_EMBEDDING_SERVICE_URL", "http://embedding.internal:8089"
+        )
+        monkeypatch.setattr(esp, "_local_service_probe_cache", None)
+
+    # (configure_fn, expected_mode) for each remote-service quadrant. Both must
+    # fail loud on a service error and never load an in-process embedder.
+    _QUADRANTS = [
+        pytest.param(_configure_remote_service, "local_service", id="daemon_host"),
+        pytest.param(_configure_internal_service, "internal_service", id="service_url"),
+    ]
 
     def _guard_local_embedders(self, monkeypatch) -> list[MagicMock]:
         """Patch every in-process-embedder entry point to fail loudly if reached.
@@ -827,18 +858,19 @@ class TestRemoteServiceNoLocalFallback:
 
         monkeypatch.setattr(esp, "_http_client", lambda: _Client())
 
+    @pytest.mark.parametrize(("configure", "expected_mode"), _QUADRANTS)
     def test_batch_remote_failure_raises_and_never_loads_local(
-        self, monkeypatch
+        self, monkeypatch, configure, expected_mode
     ) -> None:
         """``get_embeddings`` (batch): a remote connection failure must surface as
         ``EmbeddingUnavailableError`` without ever touching a local embedder.
         """
-        self._configure_remote_service(monkeypatch)
+        configure(monkeypatch)
         model = "local/nomic-embed-text-v1.5"
 
         # Assert the precondition: mode is the authoritative service mode, NOT
         # inprocess — so the test cannot silently degrade into testing nothing.
-        assert embedding_provider_mode(model) == "local_service"
+        assert embedding_provider_mode(model) == expected_mode
 
         guards = self._guard_local_embedders(monkeypatch)
         # No backoff sleep needed — keep the retry loop fast.
@@ -856,14 +888,17 @@ class TestRemoteServiceNoLocalFallback:
         for guard in guards:
             guard.assert_not_called()
 
-    def test_single_remote_5xx_raises_and_never_loads_local(self, monkeypatch) -> None:
+    @pytest.mark.parametrize(("configure", "expected_mode"), _QUADRANTS)
+    def test_single_remote_5xx_raises_and_never_loads_local(
+        self, monkeypatch, configure, expected_mode
+    ) -> None:
         """``get_embedding`` (single-text): a remote 5xx must surface as
         ``EmbeddingUnavailableError`` without ever touching a local embedder.
         """
-        self._configure_remote_service(monkeypatch)
+        configure(monkeypatch)
         model = "local/nomic-embed-text-v1.5"
 
-        assert embedding_provider_mode(model) == "local_service"
+        assert embedding_provider_mode(model) == expected_mode
 
         guards = self._guard_local_embedders(monkeypatch)
 

--- a/tests/server/llm/test_nomic_embedding_realmodel_concurrency.py
+++ b/tests/server/llm/test_nomic_embedding_realmodel_concurrency.py
@@ -1,0 +1,169 @@
+"""Real-model concurrency proof for the Step A encode-lock fix (design §6 row 6ii).
+
+The fake-model concurrency tests
+(``test_embedding_service_concurrency.py``,
+``test_nomic_embedding_provider.py::_ReentrancyDetectingModel``) prove that
+``NomicEmbedder._model_lock`` is *acquired* — they serialize a stub ``encode()``.
+They cannot prove it *fixes the real race*, because a stub does not run the
+nomic-bert rotary cache (``_cos_cached`` / ``_sin_cached``) whose mid-forward
+resize is what actually corrupts concurrent encodes in prod. This test closes
+that gap with the REAL ``nomic-embed-text-v1.5`` model.
+
+Invariant under test (positive only)
+------------------------------------
+With ``_model_lock`` intact, N threads embedding a mixed-length burst — with the
+rotary cache reset to COLD before every round, reproducing the prod boot-window
+state where ``_update_cos_sin_cache`` must rebuild the shared buffers — produce
+ZERO exceptions and vectors byte-for-byte close (``atol=1e-4``) to a single-thread
+serial baseline. The cold-cache reset is essential: pre-warming the cache to the
+max length hides the race, because the resize (the window a concurrent reader
+corrupts) never fires again.
+
+Why the negative control is NOT asserted here
+----------------------------------------------
+Neutralizing ``_model_lock`` (swap it for ``contextlib.nullcontext()``) and
+re-running this exact harness reproduces the prod signature
+``RuntimeError: The size of tensor a (N) must match the size of tensor b (M)``.
+Verified 2026-07-09 via the standalone proof harness: 12 workers × 40 rounds gave
+0 errors locked vs 67 errors unlocked over 480 concurrent embeds. That control is
+deliberately left OUT of the committed assertions — its timing/torch-version
+fragility makes it a flaky gate — but a future reader can re-confirm the test
+genuinely bites by monkeypatching ``embedder._model_lock = contextlib.nullcontext()``
+before the concurrent phase and watching it go red.
+
+This test is heavy (loads torch + the ~550 MB real model) and keyless (local
+embeddings, no paid API), so it is opt-in: ``@skip_low_priority`` keeps it out of
+the default/fast/unit tier (run it with ``RUN_LOW_PRIORITY=1``), and
+``@skip_in_precommit`` also excludes it from the pre-commit hook — reusing the
+repo's heaviest-opt-in-test convention even though nothing here costs money.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures as cf
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
+from tests.server.test_utils import skip_in_precommit, skip_low_priority
+
+# Keep each forward single-threaded so the Python threads — not torch intra-op
+# threads — are the concurrency, and a constrained box is not oversubscribed.
+torch.set_num_threads(1)
+
+_N_WORKERS = 12
+_ROUNDS = 20
+_ATOL = 1e-4  # inference is deterministic; a race corrupts grossly, not by 1e-4
+
+# Mixed lengths are the trigger: the rotary cache is (re)sized whenever a longer
+# sequence than any seen so far arrives, and that resize is the window a concurrent
+# reader corrupts. A length-ASCENDING burst makes several threads hit the resize
+# at once.
+_LONG = " ".join(["the quick brown fox jumps over the lazy dog"] * 12)  # ~120 tok
+_TEXTS = [
+    "hi",
+    "short phrase here now",
+    "a medium length sentence that carries a bit more token weight than its peers",
+    "user asked about billing and the agent explained the invoice line items here " * 2,
+    _LONG,
+    _LONG[: len(_LONG) * 2 // 3],
+]
+
+
+def _reset_rotary(model: Any) -> None:
+    """Reset every rotary submodule's cache to cold.
+
+    Reproduces the prod boot-window state where the next forwards must rebuild
+    ``_cos_cached`` / ``_sin_cached`` — the racy resize the lock must serialize.
+
+    Args:
+        model (Any): The loaded sentence-transformers model.
+    """
+    for module in model.modules():
+        if hasattr(module, "_seq_len_cached"):
+            module._seq_len_cached = 0
+            module._cos_cached = None
+            module._sin_cached = None
+
+
+def _embed_one(embedder: NomicEmbedder, text: str) -> np.ndarray:
+    """Embed a single text and return its vector as float64 for comparison.
+
+    Args:
+        embedder (NomicEmbedder): The embedder under test.
+        text (str): Input to encode.
+
+    Returns:
+        np.ndarray: The embedding vector as ``float64``.
+    """
+    return np.asarray(embedder.embed([text])[0], dtype=np.float64)
+
+
+@pytest.fixture
+def real_embedder() -> NomicEmbedder:
+    """Return a fresh ``NomicEmbedder`` with the real model loaded.
+
+    Uses a fresh instance (not the process-wide singleton) so cache/state does
+    not bleed across tests. Skips — rather than fails — when the model cannot be
+    loaded (no network on a cold cache, or ``sentence-transformers`` missing).
+
+    Returns:
+        NomicEmbedder: An embedder whose real model is loaded and ready.
+    """
+    pytest.importorskip(
+        "sentence_transformers",
+        reason="sentence-transformers is required for the real-model concurrency test",
+    )
+    embedder = NomicEmbedder()
+    try:
+        embedder._load()
+    except Exception as exc:  # noqa: BLE001 — any load failure is a skip, not a fail
+        pytest.skip(f"real Nomic model unavailable (no network / not cached): {exc}")
+    return embedder
+
+
+@skip_in_precommit
+@skip_low_priority
+def test_model_lock_holds_under_real_concurrency(real_embedder: NomicEmbedder) -> None:
+    """The Step A ``_model_lock`` keeps real concurrent encodes uncorrupted.
+
+    For ``_ROUNDS`` rounds: reset every rotary cache to cold, then fire one embed
+    per worker concurrently over a length-ascending mixed burst. Assert zero
+    exceptions and that every concurrent vector matches its single-thread serial
+    baseline within ``_ATOL``.
+    """
+    model = real_embedder._load()
+
+    # Single-thread, one text at a time — the uncorrupted reference vectors.
+    baseline = {text: _embed_one(real_embedder, text) for text in _TEXTS}
+
+    # Ascending lengths so worker k's forward may trigger a resize while workers
+    # k-1 / k+1 are mid-forward reading the shared cache.
+    burst = sorted((_TEXTS * (_N_WORKERS // len(_TEXTS) + 1))[:_N_WORKERS], key=len)
+
+    errors: list[str] = []
+    mismatches: list[str] = []
+
+    def task(text: str) -> None:
+        try:
+            vec = _embed_one(real_embedder, text)
+        except Exception as exc:  # noqa: BLE001 — capturing the race is the point
+            errors.append(f"{type(exc).__name__}: {exc}")
+            return
+        base = baseline[text]
+        if vec.shape != base.shape or not np.allclose(vec, base, atol=_ATOL):
+            mismatches.append(f"len={len(text)} shape={vec.shape} vs {base.shape}")
+
+    for _ in range(_ROUNDS):
+        _reset_rotary(model)
+        with cf.ThreadPoolExecutor(max_workers=_N_WORKERS) as pool:
+            list(pool.map(task, burst))
+
+    assert errors == [], f"{len(errors)} concurrent embed(s) raised: {errors[:5]}"
+    assert mismatches == [], (
+        f"{len(mismatches)} concurrent vector(s) diverged from the serial "
+        f"baseline: {mismatches[:5]}"
+    )

--- a/tests/server/llm/test_nomic_embedding_realmodel_concurrency.py
+++ b/tests/server/llm/test_nomic_embedding_realmodel_concurrency.py
@@ -50,10 +50,6 @@ import torch
 from reflexio.server.llm.providers.nomic_embedding_provider import NomicEmbedder
 from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
-# Keep each forward single-threaded so the Python threads — not torch intra-op
-# threads — are the concurrency, and a constrained box is not oversubscribed.
-torch.set_num_threads(1)
-
 _N_WORKERS = 12
 _ROUNDS = 20
 _ATOL = 1e-4  # inference is deterministic; a race corrupts grossly, not by 1e-4
@@ -73,7 +69,7 @@ _TEXTS = [
 ]
 
 
-def _reset_rotary(model: Any) -> None:
+def _reset_rotary(model: Any) -> int:
     """Reset every rotary submodule's cache to cold.
 
     Reproduces the prod boot-window state where the next forwards must rebuild
@@ -81,12 +77,21 @@ def _reset_rotary(model: Any) -> None:
 
     Args:
         model (Any): The loaded sentence-transformers model.
+
+    Returns:
+        int: How many rotary modules were reset. Zero means the cache attribute
+            was renamed upstream and this reset is a silent no-op — the caller
+            MUST assert this is non-zero, or the test passes on a warm cache that
+            never opens the race window (a false green).
     """
+    reset = 0
     for module in model.modules():
         if hasattr(module, "_seq_len_cached"):
             module._seq_len_cached = 0
             module._cos_cached = None
             module._sin_cached = None
+            reset += 1
+    return reset
 
 
 def _embed_one(embedder: NomicEmbedder, text: str) -> np.ndarray:
@@ -135,6 +140,12 @@ def test_model_lock_holds_under_real_concurrency(real_embedder: NomicEmbedder) -
     exceptions and that every concurrent vector matches its single-thread serial
     baseline within ``_ATOL``.
     """
+    # Keep each forward single-threaded so the Python threads — not torch intra-op
+    # threads — are the concurrency, and a constrained box is not oversubscribed.
+    # Set here (not at module scope) so it only runs when the test actually runs,
+    # never mutating the process-global thread count during collection of skipped
+    # runs in other tiers.
+    torch.set_num_threads(1)
     model = real_embedder._load()
 
     # Single-thread, one text at a time — the uncorrupted reference vectors.
@@ -157,8 +168,14 @@ def test_model_lock_holds_under_real_concurrency(real_embedder: NomicEmbedder) -
         if vec.shape != base.shape or not np.allclose(vec, base, atol=_ATOL):
             mismatches.append(f"len={len(text)} shape={vec.shape} vs {base.shape}")
 
-    for _ in range(_ROUNDS):
-        _reset_rotary(model)
+    for round_idx in range(_ROUNDS):
+        n_reset = _reset_rotary(model)
+        if round_idx == 0:
+            assert n_reset > 0, (
+                "_reset_rotary matched no rotary modules — the cache attribute was "
+                "likely renamed upstream, so the reset is a no-op and this test no "
+                "longer opens the race window it exists to guard."
+            )
         with cf.ThreadPoolExecutor(max_workers=_N_WORKERS) as pool:
             list(pool.map(task, burst))
 


### PR DESCRIPTION
## What

Closes the D4a "resolved service mode never silently loads a local model" invariant gap that the v4 embedding-stability design re-review surfaced. The existing invariant test (#317) only covers the `DAEMON_HOST`-alone quadrant — it `delenv`s `REFLEXIO_EMBEDDING_PROVIDER` before asserting.

## Two gaps closed

1. **Config footgun (was unguarded + untested).** `REFLEXIO_EMBEDDING_PROVIDER=inprocess` wins the precedence race in `embedding_provider_mode()` outright (precedence-1), so a co-configured `REFLEXIO_EMBEDDING_SERVICE_URL` / `REFLEXIO_EMBEDDING_DAEMON_HOST` is **silently ignored** and the process loads its own in-process CPU model instead of routing to the service. On a GPU-service / self-host fleet (e.g. creao, which routes via `DAEMON_HOST` → `local_service`) that's an unintended per-instance CPU load → fleet-wide stampede risk. New **warn-only** `D8(c)` guard `_guard_inprocess_overrides_service_host()` fires when `inprocess` is set alongside either endpoint var. Matches the style of the existing D8 guards; the intended in-process flip leaves both endpoint envs unset, so it stays silent there (covered by a test).

2. **`internal_service` quadrant untested.** Extended `TestRemoteServiceNoLocalFallback` to parametrize over **both** service quadrants (`DAEMON_HOST`→`local_service` and `SERVICE_URL`→`internal_service`), proving each resolves to a real service mode, a service failure raises `EmbeddingUnavailableError`, and no in-process embedder (`NomicEmbedder`/`LocalEmbedder`) is ever loaded.

## Scope notes

- Warn-only (no refuse/raise) — consistent with the two existing D8 guards; avoids breaking startup.
- `CLAUDE_SMART_USE_LOCAL_EMBEDDING` is intentionally **not** in the guard: it selects local→local (no remote endpoint is bypassed), so it carries no silent-service-bypass / stampede risk.
- No new env var — both endpoint vars are already read + documented in `embedding_service_provider.py`, so the `.env.template` drift guard is not triggered.

## Tests

`uv run pytest tests/server/llm/test_embedder_warmup.py tests/server/llm/test_embedding_service_provider.py` → **63 passed**. `ruff` + `pyright` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup warnings when in-process embedding is enabled alongside remote embedding endpoint environment variables, clarifying precedence.
  * Ensured remote embedding failures no longer fall back to in-process embedders across both remote service endpoint configurations.
* **Tests**
  * Expanded in-process override warning coverage with new guard-test cases.
  * Broadened assertions that remote failures raise the correct error without invoking local fallbacks.
  * Added an opt-in real-model concurrency regression test for Nomic rotary cache resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->