### PR TITLE
refactor: clarify playbook request provenance

### DIFF
--- a/reflexio/server/services/playbook/components/consolidator.py
+++ b/reflexio/server/services/playbook/components/consolidator.py
@@ -921,8 +921,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         existing_by_position: dict[str, UserPlaybook],
         archive_ids: list[int],
         seen_archive: set[int],
-        generation_request_id: str | None = None,
-        request_id: str | None = None,
+        generation_request_id: str,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Dispatch a single decision to its kind-specific apply method.
 
@@ -948,10 +947,6 @@ class PlaybookConsolidator(BaseDeduplicator):
             either archive nothing or split into multiple rows with no single
             survivor.
         """
-        generation_request_id = _normalize_generation_request_id(
-            generation_request_id, request_id=request_id
-        )
-
         if isinstance(decision, UnifyDecision):
             return self._apply_unify(
                 decision,
@@ -994,8 +989,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         existing_by_position: dict[str, UserPlaybook],
         archive_ids: list[int],
         seen_archive: set[int],
-        generation_request_id: str | None = None,
-        request_id: str | None = None,
+        generation_request_id: str,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Collapse / compose NEW (+ 0..N EXISTING) into one row.
 
@@ -1030,10 +1024,6 @@ class PlaybookConsolidator(BaseDeduplicator):
             ValueError: If an ``archive_existing_ids`` entry has no matching
                 ``EXISTING-{idx}`` row in the position map.
         """
-        generation_request_id = _normalize_generation_request_id(
-            generation_request_id, request_id=request_id
-        )
-
         new_ids = decision.new_ids
         candidates: list[UserPlaybook] = []
         for new_id in new_ids:
@@ -1166,8 +1156,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         existing_by_position: dict[str, UserPlaybook],
         archive_ids: list[int],
         seen_archive: set[int],
-        generation_request_id: str | None = None,
-        request_id: str | None = None,
+        generation_request_id: str,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Archive the existing row and emit two refined rows in its place.
 
@@ -1191,10 +1180,6 @@ class PlaybookConsolidator(BaseDeduplicator):
             is archived but maps to no single survivor, so it produces NO merge
             group (its archived id is a pure-delete leftover for the caller).
         """
-        generation_request_id = _normalize_generation_request_id(
-            generation_request_id, request_id=request_id
-        )
-
         candidate = candidates_by_id.get(decision.new_id)
         if candidate is None:
             raise KeyError(
@@ -1240,8 +1225,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         decision: IndependentDecision,
         *,
         candidates_by_id: dict[str, UserPlaybook],
-        generation_request_id: str | None = None,
-        request_id: str | None = None,
+        generation_request_id: str,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Insert the new candidate unchanged; no archive.
 
@@ -1253,10 +1237,6 @@ class PlaybookConsolidator(BaseDeduplicator):
             Tuple of ``([candidate row], [consumed NEW-N id], [])`` — no archive,
             so never a merge group.
         """
-        generation_request_id = _normalize_generation_request_id(
-            generation_request_id, request_id=request_id
-        )
-
         rows: list[UserPlaybook] = []
         for new_id in decision.new_ids:
             candidate = candidates_by_id.get(new_id)

--- a/reflexio/server/services/playbook/components/consolidator.py
+++ b/reflexio/server/services/playbook/components/consolidator.py
@@ -191,6 +191,22 @@ def _existing_id_log_label(value: ExistingIdField) -> str:
     return str(value)
 
 
+def _normalize_generation_request_id(
+    generation_request_id: str | None,
+    *,
+    request_id: str | None = None,
+) -> str:
+    if generation_request_id is not None:
+        if request_id is not None and request_id != generation_request_id:
+            raise TypeError(
+                "generation_request_id and request_id must match when both are provided"
+            )
+        return generation_request_id
+    if request_id is not None:
+        return request_id
+    raise TypeError("generation_request_id is required")
+
+
 class UnifyDecision(BaseModel):
     """Collapse NEW (+ 0..N EXISTING) into one row with LLM-supplied content.
 
@@ -653,16 +669,18 @@ class PlaybookConsolidator(BaseDeduplicator):
     def deduplicate(
         self,
         results: list[list[UserPlaybook]],
-        request_id: str,
-        agent_version: str,
+        generation_request_id: str | None = None,
+        agent_version: str | None = None,
         user_id: str | None = None,
+        *,
+        request_id: str | None = None,
     ) -> tuple[list[UserPlaybook], list[int], list[tuple[int, list[int]]]]:
         """
         Consolidate user playbook entries across extractors and against existing entries in DB.
 
         Args:
             results: List of entry lists from extractors (each extractor returns list[UserPlaybook])
-            request_id: Request ID for context
+            generation_request_id: Request ID for context
             agent_version: Agent version for context
             user_id: Optional user ID to scope the existing entry search
 
@@ -680,6 +698,12 @@ class PlaybookConsolidator(BaseDeduplicator):
             non-merge archives such as ``differentiate``'s split source); the
             caller subtracts the merge-covered ids to find pure-delete leftovers.
         """
+        generation_request_id = _normalize_generation_request_id(
+            generation_request_id, request_id=request_id
+        )
+        if agent_version is None:
+            raise TypeError("agent_version is required")
+
         # Check if mock mode is enabled
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
             logger.info("Mock mode: skipping consolidation")
@@ -714,7 +738,7 @@ class PlaybookConsolidator(BaseDeduplicator):
                 op="identify_duplicates",
                 org_id=self.request_context.org_id,
                 user_id=user_id,
-                request_id=request_id,
+                request_id=generation_request_id,
                 agent_version=agent_version,
                 error_type=type(e).__name__,
             ):
@@ -723,14 +747,15 @@ class PlaybookConsolidator(BaseDeduplicator):
 
         if not dedup_output.decisions:
             logger.info(
-                "No consolidation decisions returned for request %s", request_id
+                "No consolidation decisions returned for request %s",
+                generation_request_id,
             )
             return new_playbooks, [], []
 
         logger.info(
             "Received %d consolidation decisions for request %s",
             len(dedup_output.decisions),
-            request_id,
+            generation_request_id,
         )
 
         # Build consolidated result via the discriminated-union apply path
@@ -738,7 +763,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             new_playbooks=new_playbooks,
             existing_playbooks=existing_playbooks,
             dedup_output=dedup_output,
-            request_id=request_id,
+            generation_request_id=generation_request_id,
             agent_version=agent_version,
         )
 
@@ -751,8 +776,10 @@ class PlaybookConsolidator(BaseDeduplicator):
         new_playbooks: list[UserPlaybook],
         existing_playbooks: list[UserPlaybook],
         dedup_output: PlaybookConsolidationOutput,
-        request_id: str,
-        agent_version: str,  # noqa: ARG002
+        generation_request_id: str | None = None,
+        agent_version: str | None = None,  # noqa: ARG002
+        *,
+        request_id: str | None = None,
     ) -> tuple[list[UserPlaybook], list[int], list[tuple[int, list[int]]]]:
         """
         Build the deduplicated entry list from LLM decisions.
@@ -766,7 +793,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             new_playbooks: Flattened list of new (candidate) entries.
             existing_playbooks: List of existing entries from the DB.
             dedup_output: LLM decisions output (discriminated union).
-            request_id: Request ID stamped onto newly-built rows.
+            generation_request_id: Request ID stamped onto newly-built rows.
             agent_version: Agent version (currently unused, kept for symmetry).
 
         Returns:
@@ -781,6 +808,10 @@ class PlaybookConsolidator(BaseDeduplicator):
             two rows (no single survivor), so its archived id appears in the
             delete set but NOT in any merge group.
         """
+        generation_request_id = _normalize_generation_request_id(
+            generation_request_id, request_id=request_id
+        )
+
         candidates_by_id = {
             f"NEW-{idx}": playbook for idx, playbook in enumerate(new_playbooks)
         }
@@ -810,7 +841,7 @@ class PlaybookConsolidator(BaseDeduplicator):
                     existing_by_position=existing_by_position,
                     archive_ids=archive_ids,
                     seen_archive=seen_archive,
-                    request_id=request_id,
+                    generation_request_id=generation_request_id,
                 )
             except Exception as exc:  # noqa: BLE001 — per-decision isolation
                 result_counters.failed_count += 1
@@ -834,7 +865,7 @@ class PlaybookConsolidator(BaseDeduplicator):
                     subsystem="playbook_consolidator",
                     op="apply_decision",
                     org_id=self.request_context.org_id,
-                    request_id=request_id,
+                    request_id=generation_request_id,
                     kind=decision.kind,
                     new_id=new_id_str,
                     existing_id=existing_id_str,
@@ -890,7 +921,8 @@ class PlaybookConsolidator(BaseDeduplicator):
         existing_by_position: dict[str, UserPlaybook],
         archive_ids: list[int],
         seen_archive: set[int],
-        request_id: str,
+        generation_request_id: str | None = None,
+        request_id: str | None = None,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Dispatch a single decision to its kind-specific apply method.
 
@@ -904,7 +936,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             archive_ids: Accumulator list mutated with ids to archive/delete.
             seen_archive: Accumulator set guarding ``archive_ids`` against
                 duplicate ids.
-            request_id: Request ID stamped onto newly-built rows.
+            generation_request_id: Request ID stamped onto newly-built rows.
 
         Returns:
             Tuple of ``(rows_to_insert, handled_new_ids, merge_source_ids)``.
@@ -916,6 +948,10 @@ class PlaybookConsolidator(BaseDeduplicator):
             either archive nothing or split into multiple rows with no single
             survivor.
         """
+        generation_request_id = _normalize_generation_request_id(
+            generation_request_id, request_id=request_id
+        )
+
         if isinstance(decision, UnifyDecision):
             return self._apply_unify(
                 decision,
@@ -923,7 +959,7 @@ class PlaybookConsolidator(BaseDeduplicator):
                 existing_by_position=existing_by_position,
                 archive_ids=archive_ids,
                 seen_archive=seen_archive,
-                request_id=request_id,
+                generation_request_id=generation_request_id,
             )
         if isinstance(decision, RejectNewDecision):
             return self._apply_reject_new(
@@ -940,10 +976,14 @@ class PlaybookConsolidator(BaseDeduplicator):
                 existing_by_position=existing_by_position,
                 archive_ids=archive_ids,
                 seen_archive=seen_archive,
-                request_id=request_id,
+                generation_request_id=generation_request_id,
             )
         if isinstance(decision, IndependentDecision):
-            return self._apply_independent(decision, candidates_by_id=candidates_by_id)
+            return self._apply_independent(
+                decision,
+                candidates_by_id=candidates_by_id,
+                generation_request_id=generation_request_id,
+            )
         raise ValueError(f"unknown decision kind: {decision}")
 
     def _apply_unify(
@@ -954,7 +994,8 @@ class PlaybookConsolidator(BaseDeduplicator):
         existing_by_position: dict[str, UserPlaybook],
         archive_ids: list[int],
         seen_archive: set[int],
-        request_id: str,
+        generation_request_id: str | None = None,
+        request_id: str | None = None,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Collapse / compose NEW (+ 0..N EXISTING) into one row.
 
@@ -974,7 +1015,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             existing_by_position: Mapping ``"EXISTING-M"`` -> existing playbook.
             archive_ids: Accumulator mutated with EXISTING ids to archive.
             seen_archive: Dedup set for ``archive_ids``.
-            request_id: Request ID stamped on the unified row.
+            generation_request_id: Request ID stamped on the unified row.
 
         Returns:
             Tuple of ``([unified_row], [consumed NEW-N ids], merge_source_ids)``
@@ -989,6 +1030,10 @@ class PlaybookConsolidator(BaseDeduplicator):
             ValueError: If an ``archive_existing_ids`` entry has no matching
                 ``EXISTING-{idx}`` row in the position map.
         """
+        generation_request_id = _normalize_generation_request_id(
+            generation_request_id, request_id=request_id
+        )
+
         new_ids = decision.new_ids
         candidates: list[UserPlaybook] = []
         for new_id in new_ids:
@@ -1035,7 +1080,8 @@ class PlaybookConsolidator(BaseDeduplicator):
             user_playbook_id=0,
             user_id=primary_candidate.user_id,
             agent_version=primary_candidate.agent_version,
-            request_id=request_id,
+            # Legacy storage/API field; value may be synthetic for manual/rerun flows.
+            request_id=generation_request_id,
             playbook_name=primary_candidate.playbook_name,
             created_at=int(datetime.now(UTC).timestamp()),
             content=decision.content,
@@ -1120,7 +1166,8 @@ class PlaybookConsolidator(BaseDeduplicator):
         existing_by_position: dict[str, UserPlaybook],
         archive_ids: list[int],
         seen_archive: set[int],
-        request_id: str,
+        generation_request_id: str | None = None,
+        request_id: str | None = None,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Archive the existing row and emit two refined rows in its place.
 
@@ -1136,7 +1183,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             existing_by_position: Mapping ``"EXISTING-M"`` -> existing playbook.
             archive_ids: Accumulator mutated with the existing id to archive.
             seen_archive: Dedup set for ``archive_ids``.
-            request_id: Request ID stamped on both new rows.
+            generation_request_id: Request ID stamped on both new rows.
 
         Returns:
             Tuple of ``([refined_new_row, refined_existing_row], [NEW-N id],
@@ -1144,6 +1191,10 @@ class PlaybookConsolidator(BaseDeduplicator):
             is archived but maps to no single survivor, so it produces NO merge
             group (its archived id is a pure-delete leftover for the caller).
         """
+        generation_request_id = _normalize_generation_request_id(
+            generation_request_id, request_id=request_id
+        )
+
         candidate = candidates_by_id.get(decision.new_id)
         if candidate is None:
             raise KeyError(
@@ -1168,7 +1219,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         refined_candidate = candidate.model_copy(
             update={
                 "user_playbook_id": 0,
-                "request_id": request_id,
+                "request_id": generation_request_id,
                 "trigger": decision.refined_new_trigger,
                 "created_at": now_ts,
             }
@@ -1176,7 +1227,7 @@ class PlaybookConsolidator(BaseDeduplicator):
         refined_existing = existing.model_copy(
             update={
                 "user_playbook_id": 0,
-                "request_id": request_id,
+                "request_id": generation_request_id,
                 "trigger": decision.refined_existing_trigger,
                 "created_at": now_ts,
                 "source_interaction_ids": list(existing.source_interaction_ids),
@@ -1189,6 +1240,8 @@ class PlaybookConsolidator(BaseDeduplicator):
         decision: IndependentDecision,
         *,
         candidates_by_id: dict[str, UserPlaybook],
+        generation_request_id: str | None = None,
+        request_id: str | None = None,
     ) -> tuple[list[UserPlaybook], list[str], list[int]]:
         """Insert the new candidate unchanged; no archive.
 
@@ -1200,12 +1253,18 @@ class PlaybookConsolidator(BaseDeduplicator):
             Tuple of ``([candidate row], [consumed NEW-N id], [])`` — no archive,
             so never a merge group.
         """
+        generation_request_id = _normalize_generation_request_id(
+            generation_request_id, request_id=request_id
+        )
+
         rows: list[UserPlaybook] = []
         for new_id in decision.new_ids:
             candidate = candidates_by_id.get(new_id)
             if candidate is None:
                 raise KeyError(f"independent references unknown NEW id: {new_id}")
-            rows.append(candidate)
+            rows.append(
+                candidate.model_copy(update={"request_id": generation_request_id})
+            )
         return rows, decision.new_ids, []
 
     @staticmethod

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -643,6 +643,26 @@ class TestBuildDeduplicatedResults:
         assert delete_ids == []
         assert merge_groups == []
 
+    def test_unify_stamps_generation_request_id(self, mock_consolidator):
+        """``unify`` should stamp synthesized rows with the provenance id."""
+        new_playbooks = [_make_user_playbook(0, source_interaction_ids=[10])]
+
+        dedup_output = PlaybookConsolidationOutput(
+            decisions=[
+                _unify("NEW-0", content="merged", trigger="merged trigger"),
+            ],
+        )
+
+        result, _, _ = mock_consolidator._build_deduplicated_results(
+            new_playbooks=new_playbooks,
+            existing_playbooks=[],
+            dedup_output=dedup_output,
+            generation_request_id="rerun_playbook_unify_1",
+            agent_version="v1",
+        )
+
+        assert [row.request_id for row in result] == ["rerun_playbook_unify_1"]
+
     def test_unify_accepts_multiple_new_ids(self, mock_consolidator):
         """Multi-NEW ``unify`` emits one synthesized row and consumes all NEW ids."""
         new_playbooks = [
@@ -857,6 +877,35 @@ class TestBuildDeduplicatedResults:
         assert len(result) == 2
         assert delete_ids == [999]
 
+    def test_differentiate_stamps_generation_request_id(self, mock_consolidator):
+        """``differentiate`` should stamp both synthesized rows with provenance."""
+        new_playbooks = [_make_user_playbook(0, trigger="broad trigger")]
+        existing_playbooks = [_make_user_playbook(1, user_playbook_id=999)]
+
+        dedup_output = PlaybookConsolidationOutput(
+            decisions=[
+                DifferentiateDecision(
+                    new_id="NEW-0",
+                    existing_id=0,
+                    refined_new_trigger="narrow new trigger",
+                    refined_existing_trigger="narrow existing trigger",
+                ),
+            ],
+        )
+
+        result, _, _ = mock_consolidator._build_deduplicated_results(
+            new_playbooks=new_playbooks,
+            existing_playbooks=existing_playbooks,
+            dedup_output=dedup_output,
+            generation_request_id="rerun_playbook_diff_1",
+            agent_version="v1",
+        )
+
+        assert [row.request_id for row in result] == [
+            "rerun_playbook_diff_1",
+            "rerun_playbook_diff_1",
+        ]
+
     def test_existing_reference_ignores_out_of_range_position_key(
         self, mock_consolidator
     ):
@@ -907,6 +956,50 @@ class TestBuildDeduplicatedResults:
 
 class TestDeduplicateHappyPath:
     """Tests for the full deduplicate() flow with LLM mocks returning PlaybookConsolidationOutput."""
+
+    def test_deduplicate_stamps_generation_request_id(self, mock_consolidator):
+        """The main entry point should propagate ``generation_request_id``."""
+        fb0 = _make_user_playbook(0, content="playbook from extractor 1")
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.return_value = (
+            PlaybookConsolidationOutput(
+                decisions=[IndependentDecision(new_id="NEW-0")],
+            )
+        )
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, delete_ids, _ = mock_consolidator.deduplicate(
+                results=[[fb0]],
+                generation_request_id="rerun_playbook_dedup_1",
+                agent_version="v1",
+            )
+
+        assert [row.request_id for row in result] == ["rerun_playbook_dedup_1"]
+        assert delete_ids == []
+
+    def test_deduplicate_accepts_legacy_request_id_keyword(self, mock_consolidator):
+        """The main entry point should keep the legacy ``request_id=`` alias."""
+        fb0 = _make_user_playbook(0, content="playbook from extractor 1")
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.return_value = (
+            PlaybookConsolidationOutput(
+                decisions=[IndependentDecision(new_id="NEW-0")],
+            )
+        )
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, delete_ids, _ = mock_consolidator.deduplicate(
+                results=[[fb0]],
+                request_id="legacy_req_dedup_1",
+                agent_version="v1",
+            )
+
+        assert [row.request_id for row in result] == ["legacy_req_dedup_1"]
+        assert delete_ids == []
 
     def test_happy_path_with_unify(self, mock_consolidator):
         """Full happy path: LLM returns a ``unify`` decision and an ``independent``.

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -545,6 +545,52 @@ class TestBuildDeduplicatedResults:
 
         assert len(result) == 2
 
+    def test_build_deduplicated_results_stamps_generation_request_id(
+        self, mock_consolidator
+    ):
+        """Newly synthesized rows should carry the generation provenance id."""
+        new_playbooks = [
+            _make_user_playbook(0, content="Use the deployment checklist."),
+        ]
+        dedup_output = PlaybookConsolidationOutput(
+            decisions=[IndependentDecision(kind="independent", new_id="NEW-0")]
+        )
+
+        result, delete_ids, merge_groups = (
+            mock_consolidator._build_deduplicated_results(
+                new_playbooks=new_playbooks,
+                existing_playbooks=[],
+                dedup_output=dedup_output,
+                generation_request_id="rerun_playbook_ab12cd34",
+                agent_version="v1",
+            )
+        )
+
+        assert delete_ids == []
+        assert merge_groups == []
+        assert [row.request_id for row in result] == ["rerun_playbook_ab12cd34"]
+
+    def test_build_deduplicated_results_accepts_legacy_request_id_keyword(
+        self, mock_consolidator
+    ):
+        """The helper should keep the legacy ``request_id=`` alias working."""
+        new_playbooks = [
+            _make_user_playbook(0, content="Use the deployment checklist."),
+        ]
+        dedup_output = PlaybookConsolidationOutput(
+            decisions=[IndependentDecision(kind="independent", new_id="NEW-0")]
+        )
+
+        result, _, _ = mock_consolidator._build_deduplicated_results(
+            new_playbooks=new_playbooks,
+            existing_playbooks=[],
+            dedup_output=dedup_output,
+            request_id="legacy_req_1",
+            agent_version="v1",
+        )
+
+        assert [row.request_id for row in result] == ["legacy_req_1"]
+
     def test_independent_decision_accepts_multiple_new_ids(self, mock_consolidator):
         """A list-valued ``new_id`` inserts each named NEW candidate once."""
         new_playbooks = [

--- a/tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py
@@ -109,6 +109,43 @@ def _make_evaluation(
 
 
 # ---------------------------------------------------------------------------
+# get_user_playbooks
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserPlaybooks:
+    """Round-trip characterization for get_user_playbooks user_id filtering."""
+
+    def test_user_id_filter_includes_synthetic_generation_request_id(self, tmp_path):
+        """Synthetic manual/rerun request ids stay visible under user_id filtering."""
+        s = _store(tmp_path)
+        s.add_request(_make_request(request_id="req-real", user_id="user-1"))
+        real = _make_user_playbook(
+            user_id="user-1",
+            request_id="req-real",
+            content="real request playbook",
+        )
+        synthetic = _make_user_playbook(
+            user_id="user-1",
+            request_id="rerun_playbook_ab12cd34",
+            content="synthetic rerun playbook",
+        )
+        other_user = _make_user_playbook(
+            user_id="user-2",
+            request_id="manual_cd34ef56",
+            content="other user synthetic playbook",
+        )
+        s.save_user_playbooks([real, synthetic, other_user])
+
+        rows = s.get_user_playbooks(user_id="user-1", limit=10)
+
+        assert {row.request_id for row in rows} == {
+            "req-real",
+            "rerun_playbook_ab12cd34",
+        }
+
+
+# ---------------------------------------------------------------------------
 # count_user_playbooks_by_session
 # ---------------------------------------------------------------------------
 

--- a/tests/server/services/storage/sqlite_storage/test_user_playbook_search_synthetic_request_visibility.py
+++ b/tests/server/services/storage/sqlite_storage/test_user_playbook_search_synthetic_request_visibility.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from reflexio.models.api_schema.domain.entities import Request, UserPlaybook
+from reflexio.models.api_schema.retriever_schema import SearchUserPlaybookRequest
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _store(tmp_path) -> SQLiteStorage:
+    s = SQLiteStorage(org_id="org-char", db_path=str(tmp_path / "org-char.db"))
+    s.migrate()
+    return s
+
+
+def _make_request(
+    *, request_id: str, user_id: str, session_id: str = "session-1"
+) -> Request:
+    return Request(request_id=request_id, user_id=user_id, session_id=session_id)
+
+
+def _make_user_playbook(
+    *, user_id: str, request_id: str, content: str
+) -> UserPlaybook:
+    return UserPlaybook(
+        user_id=user_id,
+        agent_version="v1",
+        request_id=request_id,
+        playbook_name="deployment",
+        content=content,
+    )
+
+
+def test_search_user_playbooks_user_id_includes_synthetic_generation_request_id(
+    tmp_path,
+):
+    store = _store(tmp_path)
+    store.add_request(_make_request(request_id="req-real", user_id="user-1"))
+    store.save_user_playbooks(
+        [
+            _make_user_playbook(
+                user_id="user-1",
+                request_id="req-real",
+                content="real request playbook",
+            ),
+            _make_user_playbook(
+                user_id="user-1",
+                request_id="manual_ab12cd34",
+                content="manual generation playbook",
+            ),
+            _make_user_playbook(
+                user_id="user-2",
+                request_id="rerun_playbook_cd34ef56",
+                content="other user playbook",
+            ),
+        ]
+    )
+
+    rows = store.search_user_playbooks(
+        SearchUserPlaybookRequest(user_id="user-1", top_k=10)
+    )
+
+    assert {row.request_id for row in rows} == {"req-real", "manual_ab12cd34"}


### PR DESCRIPTION
## Summary
- Clarifies playbook consolidator internals so generated playbook rows use `generation_request_id` locally while preserving the legacy `request_id` storage/API field.
- Keeps `request_id=` as a compatibility alias and rejects ambiguous dual values.
- Adds SQLite regression coverage proving synthetic generated playbook IDs remain visible under user filters.

## Changes
- Refactors `PlaybookConsolidator` local parameter naming around generated playbook provenance.
- Adds compatibility and stamping tests for `generation_request_id` and legacy `request_id=` callers.
- Adds SQLite user-playbook retrieval/search regressions for synthetic IDs such as `rerun_playbook_*`.

## Test Plan
- `uv run pytest tests/server/services/playbook/test_playbook_consolidator.py tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py tests/server/services/storage/sqlite_storage/test_user_playbook_search_synthetic_request_visibility.py -q -o 'addopts='` -> 96 passed
- `uv run ruff check reflexio/server/services/playbook/components/consolidator.py tests/server/services/playbook/test_playbook_consolidator.py tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py tests/server/services/storage/sqlite_storage/test_user_playbook_search_synthetic_request_visibility.py` -> passed
- `uv run pyright reflexio/server/services/playbook/components/consolidator.py tests/server/services/playbook/test_playbook_consolidator.py tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py tests/server/services/storage/sqlite_storage/test_user_playbook_search_synthetic_request_visibility.py` -> 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request/provenance consistency during playbook consolidation so newly synthesized rows retain the correct request reference.
  * Search and listing for user playbooks now more reliably returns rows tied to the expected real or provided generation request, with synthetic/rerun cases handled correctly.
  * Playbook consolidation now accepts either legacy `request_id` or the newer generation-style `generation_request_id` input for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->