### PR TITLE
fix: retain offline tuner reward cleanup metadata

### DIFF
--- a/reflexio/server/services/storage/governance_validation.py
+++ b/reflexio/server/services/storage/governance_validation.py
@@ -34,6 +34,8 @@ _CANONICAL_DELETE_TARGET_NAMES = (
     "profile",
     "user_playbook",
     "agent_success_evaluation_result",
+    "offline_tuner_reward_label",
+    "offline_tuner_reward_label_target_by_target_owner",
     "profile_purge",
     "user_playbook_purge",
 )
@@ -52,6 +54,8 @@ _ALLOWED_PURGE_TARGET_NAMES = frozenset(
         "profile",
         "user_playbook",
         "agent_success_evaluation_result",
+        "offline_tuner_reward_label",
+        "offline_tuner_reward_label_target_by_target_owner",
         "agent_playbook",
         "profile_purge",
         "user_playbook_purge",
@@ -157,6 +161,8 @@ _ALLOWED_DELETED_COUNTS_KEYS = frozenset(
         "profiles",
         "requests",
         "agent_success_evaluation_results",
+        "offline_tuner_reward_labels",
+        "offline_tuner_reward_label_targets_by_target_owner",
         "purged_profiles",
         "purged_user_playbooks",
     }

--- a/reflexio/server/services/storage/retention.py
+++ b/reflexio/server/services/storage/retention.py
@@ -36,6 +36,12 @@ RETENTION_TARGETS: tuple[RetentionTarget, ...] = (
         "created_at",
         ("result_id",),
     ),
+    RetentionTarget(
+        "offline_tuner_reward_label",
+        "offline_tuner_reward_label",
+        "label_created_at",
+        ("reward_label_id",),
+    ),
     RetentionTarget("share_links", "share_links", "created_at", ("id",)),
     RetentionTarget(
         "agent_playbook_source_user_playbooks",
@@ -116,6 +122,9 @@ RETENTION_CASCADES: dict[str, tuple[CascadeRef, ...]] = {
     ),
     "playbook_retrieval_logs": (
         CascadeRef("playbook_retrieval_log_items", "retrieval_log_id"),
+    ),
+    "offline_tuner_reward_label": (
+        CascadeRef("offline_tuner_reward_label_target", "reward_label_id"),
     ),
 }
 


### PR DESCRIPTION
## Summary
- Add offline tuner reward label bookkeeping to OSS governance retention/validation so enterprise storage cleanup targets remain recognized by shared storage utilities.
- Preserve reward-label retention target and cascade definitions for local proof/storage contract parity.

## Changes
- Extend governance validation allowed target/count keys for offline tuner reward labels and target-owner cleanup.
- Add `offline_tuner_reward_label` retention target and cascade to `offline_tuner_reward_label_target`.

## Test Plan
- `uv run pytest open_source/reflexio/tests/server/services/storage/test_storage_contract_retention.py open_source/reflexio/tests/server/services/governance/test_governance_refs.py -q -o 'addopts='`
- `uv run ruff check open_source/reflexio/reflexio/server/services/storage/retention.py open_source/reflexio/reflexio/server/services/storage/governance_validation.py open_source/reflexio/tests/server/services/storage/test_storage_contract_retention.py open_source/reflexio/tests/server/services/governance/test_governance_refs.py`
- `uv run pyright open_source/reflexio/reflexio/server/services/storage/retention.py open_source/reflexio/reflexio/server/services/storage/governance_validation.py`
