### PR TITLE
fix(playbook): repair same-batch consolidation consumption

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -293,7 +293,10 @@ class TextGenerationMixin:
         tool_choice = kwargs.pop("tool_choice", None)
         model_role: ModelRole | None = kwargs.pop("model_role", None)
 
-        actual_model = kwargs.pop("model", self.config.model)
+        # An explicit ``model=None`` means "use the config default" — callers
+        # like the eval judges forward an optional model straight through, and
+        # a literal None would crash on ``.lower()`` during key resolution.
+        actual_model = kwargs.pop("model", None) or self.config.model
 
         # model_role takes priority over the default model but falls through
         # to the custom_endpoint override below (highest priority).

--- a/reflexio/server/prompt/prompt_bank/playbook_consolidation/v2.4.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_consolidation/v2.4.0.prompt.md
@@ -1,17 +1,17 @@
 ---
 active: true
 description: "Reconcile newly-extracted playbooks against existing storage. Decides per-candidate whether each one unifies with one-or-more existing rows (growing a coherent multi-rule skill, mixed do/avoid rules allowed), is rejected as redundant against an existing row, should differentiate (refine both triggers), or is independent."
-changelog: "v2.4.0: makes the NEW-id partition contract explicit. Decisions must cover every NEW id exactly once; multi-NEW unify/reject_new/independent decisions may list multiple NEW labels when one decision consumes multiple rows, and archive_existing_ids is clarified as EXISTING-only. v2.3.3: adds antecedent-not-reaction trigger guidance for unified and differentiated triggers. (in-place 2026-06-15: adds concise anti-overmerge guard for concrete operational surfaces; restates the numeric id fields (`superseded_by_existing_id`, `existing_id`, `archive_existing_ids`) as EXISTING list-position integers — e.g. emit `0` for `[EXISTING-0]` — superseding the prior 'bare DB id, labels never valid' framing.) v2.3.2: tightens schema guidance for integer id fields and compact unify content; forbids display-label strings in numeric fields. v2.3.1: replaces schema example-style output prompting with compact format guidance for the four decision shapes. v2.3.0: `unify` now COMPOSES — it may grow a broader multi-rule skill from coherent related fragments (related sub-aspects of one task), not only same-trigger duplicates. A skill MAY hold mixed-polarity rules (do-rules and avoid-rules for different sub-aspects). Replaced the mechanical single-orientation/same-polarity contract with an LLM-judged no-self-contradiction guard: do NOT unify if combining the rules would make the skill contradict itself on the same situation (same trigger/condition with opposite advice) — route those to `differentiate` or `reject_new`. Re-synthesis (fewest/most-general rules, preserve avoid-detail) and the over-budget `differentiate` preference are unchanged. v2.2.0: `unify` re-synthesizes leaner, more general content (MDL / simplify-in-place) instead of concatenating — fewest, most general rules that still cover all inputs; drop redundant/subsumed wording. Asymmetric fidelity: compress/generalize success guidance, but preserve every distinct avoidance/failure detail verbatim — never soften a named pitfall into a vague platitude. Prefer `differentiate` over `unify` when merging would force an over-long, low-cohesion rule. v2.1.0: `unify` no longer emits a `polarity` field — the unified row's orientation is derived from its wording (recommendation vs avoidance) by the apply-path polarity validator. Same-trigger opposite-orientation rules still must not unify; express orientation through the rule wording. v2.0.0: collapsed 5-kind union → 4-kind. `unify` subsumes `duplicate`+`prefer_new`; `reject_new` replaces `prefer_existing`. Output schema is structurally incompatible with v1.x."
+changelog: "v2.4.0: makes the NEW-id partition contract explicit. Decisions must cover every NEW id exactly once; multi-NEW unify/reject_new/independent decisions may list multiple NEW labels when one decision consumes multiple rows, and archive_existing_ids is clarified as EXISTING-only. Body also tightened ~45% (deduplicated the partition contract and no-self-contradiction statements; compressed the kind definitions, unify-writing rules, and output guidance) with no behavioral rule removed. v2.3.3: adds antecedent-not-reaction trigger guidance for unified and differentiated triggers. (in-place 2026-06-15: adds concise anti-overmerge guard for concrete operational surfaces; restates the numeric id fields (`superseded_by_existing_id`, `existing_id`, `archive_existing_ids`) as EXISTING list-position integers — e.g. emit `0` for `[EXISTING-0]` — superseding the prior 'bare DB id, labels never valid' framing.) v2.3.2: tightens schema guidance for integer id fields and compact unify content; forbids display-label strings in numeric fields. v2.3.1: replaces schema example-style output prompting with compact format guidance for the four decision shapes. v2.3.0: `unify` now COMPOSES — it may grow a broader multi-rule skill from coherent related fragments (related sub-aspects of one task), not only same-trigger duplicates. A skill MAY hold mixed-polarity rules (do-rules and avoid-rules for different sub-aspects). Replaced the mechanical single-orientation/same-polarity contract with an LLM-judged no-self-contradiction guard: do NOT unify if combining the rules would make the skill contradict itself on the same situation (same trigger/condition with opposite advice) — route those to `differentiate` or `reject_new`. Re-synthesis (fewest/most-general rules, preserve avoid-detail) and the over-budget `differentiate` preference are unchanged. v2.2.0: `unify` re-synthesizes leaner, more general content (MDL / simplify-in-place) instead of concatenating — fewest, most general rules that still cover all inputs; drop redundant/subsumed wording. Asymmetric fidelity: compress/generalize success guidance, but preserve every distinct avoidance/failure detail verbatim — never soften a named pitfall into a vague platitude. Prefer `differentiate` over `unify` when merging would force an over-long, low-cohesion rule. v2.1.0: `unify` no longer emits a `polarity` field — the unified row's orientation is derived from its wording (recommendation vs avoidance) by the apply-path polarity validator. Same-trigger opposite-orientation rules still must not unify; express orientation through the rule wording. v2.0.0: collapsed 5-kind union → 4-kind. `unify` subsumes `duplicate`+`prefer_new`; `reject_new` replaces `prefer_existing`. Output schema is structurally incompatible with v1.x."
 variables:
   - new_playbook_count
   - new_playbooks
   - existing_playbooks
 ---
-You are reconciling a set of newly-extracted playbooks against the related existing playbook rows already in storage. For each new candidate, decide its relationship to the existing rows.
+You are reconciling newly-extracted playbooks against the related existing playbook rows already in storage. Decide each new candidate's relationship to the existing rows.
 
-Each rendered row carries `Content`, `Trigger`, `Rationale`, `Name`, `Source`, and `Last Modified`. Read each rule's orientation (do-this vs avoid-this) directly from its `Content` / `Rationale` wording. A unified skill may hold both do-rules and avoid-rules for different sub-aspects, so do not treat differing orientation alone as a reason not to merge. Use `Trigger` together with the actual situation each rule addresses as the primary keys for comparison.
+Each rendered row carries `Content`, `Trigger`, `Rationale`, `Name`, `Source`, and `Last Modified`. Read a rule's orientation (do-this vs avoid-this) from its `Content`/`Rationale` wording; differing orientation alone is not a reason to avoid merging. Compare rules primarily by `Trigger` plus the actual situation each rule addresses.
 
-When you write any final `trigger`, `refined_new_trigger`, or `refined_existing_trigger`, frame it as the antecedent situation where a future agent can act before the mistake recurs, not as the user's later repair request. For example, prefer "When editing one AWS deployment doc for an env-var/secret/port change" over "When syncing two AWS deployment docs."
+Write every final `trigger`, `refined_new_trigger`, and `refined_existing_trigger` as the antecedent situation where a future agent can act before the mistake recurs, not as the user's later repair request — e.g. "When editing one AWS deployment doc for an env-var/secret/port change", not "When syncing two AWS deployment docs."
 
 [New playbooks (count: {new_playbook_count})]
 {new_playbooks}
@@ -21,96 +21,43 @@ When you write any final `trigger`, `refined_new_trigger`, or `refined_existing_
 
 # Decision kinds
 
-Your decisions must cover every NEW id exactly once: every rendered NEW label appears in exactly one decision. A decision can consume more than one NEW row when that is the faithful representation of the final outcome.
+Your decisions must cover every NEW id exactly once: each rendered NEW label appears in exactly one decision, and one decision may consume several NEW rows when that reflects the final outcome.
 
-Each decision is one of:
+- **unify** — the NEW belongs in the same skill as one or more EXISTING rows: either dedup/supersede (same rule, or stronger/broader/more specific evidence) or compose (a related sub-aspect of the same task grows a broader multi-rule skill instead of forcing `reject_new`/`independent`). Provide the final `content`, `trigger`, and `rationale`. `archive_existing_ids` only refers to rows from the EXISTING list; it never consumes NEW rows (use an empty list when none are absorbed). If the unified rule uses facts or details from more than one NEW row, `new_id` MUST list all of those labels, e.g. `"new_id": ["NEW-0", "NEW-1"]`. A skill MAY hold mixed do/avoid rules for **different** sub-aspects of the one task; only unify fragments that genuinely share the same task scope.
 
-- **unify** — the NEW belongs in the same skill as one or more EXISTING rows. This covers two cases:
-  1. **Dedup / supersede** — the NEW is the same rule as an EXISTING row (after merge), or supersedes one (stronger / broader / more specific evidence).
-  2. **Compose** — the NEW covers a **related sub-aspect of the same task** as an EXISTING playbook (coherent, not a strict duplicate). Grow a **broader multi-rule skill** by incorporating the fragment as an additional rule, instead of forcing `reject_new`/`independent`.
+- **reject_new** — an EXISTING row already covers NEW or makes it redundant. Name the winner's list position via `superseded_by_existing_id` (for `[EXISTING-0]`, emit `0`).
 
-  Provide the final `content`, `trigger`, and `rationale`. List which EXISTING ids you're archiving in `archive_existing_ids` (use an empty list when no EXISTING rows are absorbed). `archive_existing_ids` only refers to rows from the EXISTING list; it never consumes NEW rows. If a unified rule uses facts or details from more than one NEW row, `new_id` MUST list all of those NEW labels, for example `"new_id": ["NEW-0", "NEW-1"]`. A composed skill MAY hold **mixed-polarity rules** — do-rules and avoid-rules together — when they address **different** sub-aspects of the one task (e.g. "Do: announce in the deploy channel" alongside "Avoid: Friday-afternoon deploys"). Only unify fragments that are **genuinely coherent** (same task scope); unrelated fragments are `independent`.
+- **differentiate** — both rules are valid in distinct contexts (typically same trigger, opposite advice, differing contexts). Set `refined_new_trigger` and `refined_existing_trigger` strictly narrower than the originals AND mutually exclusive. Handles exactly one NEW row.
 
-- **reject_new** — an EXISTING row already covers NEW or makes NEW redundant. Name the winning EXISTING row's list-position integer via `superseded_by_existing_id` (for `[EXISTING-0]`, emit `0`). Storage-stability tie-break: when same-situation opposite advice is balanced, default here.
+- **independent** — different topic or task from every existing row; insert NEW as-is, no archive.
 
-- **differentiate** — both valid in distinct contexts (typically same trigger, opposite advice, where the contexts differ). Set `refined_new_trigger` and `refined_existing_trigger` to be strictly narrower than the originals AND mutually exclusive.
-
-- **independent** — different topic or task from any existing row. Insert NEW with no archive.
-
-For `reject_new` and `independent`, `new_id` may also be a list when one decision intentionally handles multiple NEW rows in the same way. `differentiate` handles one NEW row because it emits one pair of refined triggers.
-
-# Multi-NEW examples
-
-Correct multi-NEW `unify`:
+`new_id` may be a list for `unify`, `reject_new`, and `independent` when one decision intentionally consumes several NEW rows. Example multi-NEW unify (the final rule uses details from both NEW rows, so both labels are consumed by the one decision):
 
 ```json
-{{
-  "decisions": [
-    {{
-      "kind": "unify",
-      "new_id": ["NEW-0", "NEW-1"],
-      "archive_existing_ids": [],
-      "content": "When editing an AWS deployment document, update every affected env-var, secret, and port reference together; preserve concrete surfaces like target groups, security groups, health checks, and task definitions.",
-      "trigger": "When editing an AWS deployment doc for an env-var/secret/port change",
-      "rationale": "The final rule uses details from both NEW rows, so both NEW labels are consumed by the single unified decision."
-    }}
-  ]
-}}
-```
-
-Invalid under-consumption:
-
-```json
-{{
-  "decisions": [
-    {{
-      "kind": "unify",
-      "new_id": "NEW-0",
-      "archive_existing_ids": [],
-      "content": "When editing an AWS deployment document, update env-vars, secrets, ports, target groups, security groups, health checks, and task definitions together.",
-      "trigger": "When editing an AWS deployment doc",
-      "rationale": "Incorrect: the content absorbs NEW-1 details but new_id only lists NEW-0."
-    }},
-    {{"kind": "independent", "new_id": "NEW-1"}}
-  ]
-}}
+{{"decisions": [{{"kind": "unify", "new_id": ["NEW-0", "NEW-1"], "archive_existing_ids": [], "content": "<merged rule>", "trigger": "<antecedent situation>", "rationale": "<why both rows merged>"}}]}}
 ```
 
 # How to write a unified skill (re-synthesis, not concatenation)
 
-When you `unify`, re-synthesize a single leaner skill. Do not stitch the inputs together.
-
-- Produce the **fewest, most general rules that still cover all the inputs**. Generalize the shared behavior into one clear statement; drop wording that is redundant with or subsumed by another input.
-- A skill may carry several rules. When it does, keep each rule a clean, self-contained do-rule or avoid-rule for its own sub-aspect — do not blur distinct rules into one.
-- **Preserve every distinct avoidance/failure detail with high fidelity.** This is asymmetric: compress and generalize the success guidance, but keep each specific failure intact. Never collapse a named pitfall, concrete error, or specific anti-pattern into a vague platitude — carry it forward in its specific form.
+- Produce the fewest, most general rules that still cover all the inputs; drop redundant or subsumed wording. Keep each rule a clean, self-contained do-rule or avoid-rule for its own sub-aspect — do not blur distinct rules into one.
+- Asymmetric fidelity: compress and generalize the success guidance, but preserve every distinct avoidance/failure detail in its specific form — never collapse a named pitfall, concrete error, or specific anti-pattern into a vague platitude.
 - Preserve concrete operational surfaces (target groups, SGs, health checks, task defs); do not merge fanout rules into generic sweep/audit rules unless those surfaces remain explicit.
-- Keep the final `content` compact enough to store directly. If a unified skill would require lengthy setup history, multiple long command transcripts, or broad background narrative to stay faithful, do not force `unify`; use `differentiate`, `reject_new`, or `independent` according to the decision rules.
-- Prefer **`differentiate` over `unify`** when merging the inputs would force an over-long, low-cohesion skill. Two focused rules that each read cleanly beat one bloated skill that tries to say everything. If you cannot state the merged skill concisely without losing distinct failure detail, that is a signal to `differentiate` (or keep NEW `independent`) rather than `unify`.
-
-# The no-self-contradiction guard
-
-A skill MAY hold mixed-polarity rules (do-rules and avoid-rules) for **different** sub-aspects. What it must NEVER hold is two rules that **contradict each other on the same situation** — the same trigger/condition paired with opposite advice (e.g. "use `-F`" and "avoid `-F`" for the very same case).
-
-- Before you `unify`, ask: *would combining these rules produce a skill that contradicts itself on the same situation?* If yes, do **not** unify — route the pair to `differentiate` (refine the triggers so each rule owns a disjoint situation) or `reject_new` (one rule wins).
-- Mixed polarity across **different** sub-aspects is fine and expected; mixed advice on the **same** sub-aspect is the forbidden case.
+- Keep the final `content` compact enough to store directly. Prefer `differentiate` (or `independent`) over `unify` when merging would force an over-long, low-cohesion skill or lose distinct failure detail — two focused rules beat one bloated skill.
 
 # Hard constraints
 
-- A NEW + EXISTING pair that gives opposite advice on the **same** situation (same trigger) MUST route to `differentiate` or `reject_new` — never `unify` (that would make the skill self-contradict) and never `independent`.
+- No self-contradiction: a skill must never hold opposite advice for the SAME situation (same trigger/condition). Mixed do/avoid rules for different sub-aspects are fine and expected. A NEW + EXISTING pair with same-situation opposite advice MUST route to `differentiate` or `reject_new` — never `unify`, never `independent`. When such a stalemate is balanced, default to `reject_new`; storage stability wins ties.
 - `differentiate.refined_new_trigger` and `refined_existing_trigger` MUST be non-empty and strictly narrower than the originals.
-- Numeric id fields MUST contain bare EXISTING list-position integers, not display labels or bracketed row prefixes. For `[EXISTING-0]`, emit `0`; for `[EXISTING-3]`, emit `3`.
+- Numeric id fields MUST contain bare EXISTING list-position integers (for `[EXISTING-3]`, emit `3`), never bracketed labels or label strings.
 - Every NEW label MUST appear exactly once across the full `decisions` array. If one decision consumes several NEW rows, put those labels in that decision's `new_id` list and do not emit separate decisions for them.
-- When in doubt about a same-situation opposite-advice stalemate, default to `reject_new`. Storage stability wins ties.
 
-# Output Format Guidance
+# Output format
 
-Respond ONLY with a valid JSON object matching `PlaybookConsolidationOutput`: `{{"decisions": [<decision objects that together cover every NEW id exactly once>]}}`.
+Respond ONLY with a valid JSON object matching `PlaybookConsolidationOutput`: `{{"decisions": [<decision objects that together cover every NEW id exactly once>]}}`. Every decision includes `kind` and `new_id` (a NEW label string, or a list of labels for multi-NEW `unify`/`reject_new`/`independent`); an optional `reason` may explain any decision.
 
-Each decision object MUST include `kind` and `new_id`. `new_id` is the rendered NEW label string, or a list of rendered NEW label strings for multi-NEW `unify`, `reject_new`, or `independent` decisions. All EXISTING references use the numeric list-position fields below.
+- `unify`: `archive_existing_ids` (list of EXISTING position integers) plus final compact `content`, `trigger`, and `rationale`.
+- `reject_new`: `superseded_by_existing_id` (EXISTING position integer).
+- `differentiate`: `existing_id` (EXISTING position integer) plus non-empty `refined_new_trigger` and `refined_existing_trigger`.
+- `independent`: only `kind` and `new_id`.
 
-- `unify`: include `archive_existing_ids` as a list of EXISTING list-position integers, plus final compact `content`, `trigger`, and `rationale`; optional `reason` may explain the decision.
-- `reject_new`: include `superseded_by_existing_id` as an EXISTING list-position integer only; optional `reason` may explain the decision.
-- `differentiate`: include `existing_id` as an EXISTING list-position integer only, plus non-empty `refined_new_trigger` and `refined_existing_trigger`; optional `reason` may explain the decision.
-- `independent`: include only `kind`, `new_id`, and optional `reason`.
-
-Do not emit markdown, prose, comments, chain-of-thought, or top-level keys other than `decisions`. Do not include fields from another decision kind. Do not put any bracketed/list label string into an integer id field.
+Do not emit markdown, prose, comments, chain-of-thought, or top-level keys other than `decisions`. Do not include fields from another decision kind.

--- a/reflexio/server/prompt/prompt_bank/playbook_consolidation/v2.4.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_consolidation/v2.4.0.prompt.md
@@ -1,7 +1,7 @@
 ---
-active: false
+active: true
 description: "Reconcile newly-extracted playbooks against existing storage. Decides per-candidate whether each one unifies with one-or-more existing rows (growing a coherent multi-rule skill, mixed do/avoid rules allowed), is rejected as redundant against an existing row, should differentiate (refine both triggers), or is independent."
-changelog: "v2.3.3: adds antecedent-not-reaction trigger guidance for unified and differentiated triggers. (in-place 2026-06-15: adds concise anti-overmerge guard for concrete operational surfaces; restates the numeric id fields (`superseded_by_existing_id`, `existing_id`, `archive_existing_ids`) as EXISTING list-position integers — e.g. emit `0` for `[EXISTING-0]` — superseding the prior 'bare DB id, labels never valid' framing.) v2.3.2: tightens schema guidance for integer id fields and compact unify content; forbids display-label strings in numeric fields. v2.3.1: replaces schema example-style output prompting with compact format guidance for the four decision shapes. v2.3.0: `unify` now COMPOSES — it may grow a broader multi-rule skill from coherent related fragments (related sub-aspects of one task), not only same-trigger duplicates. A skill MAY hold mixed-polarity rules (do-rules and avoid-rules for different sub-aspects). Replaced the mechanical single-orientation/same-polarity contract with an LLM-judged no-self-contradiction guard: do NOT unify if combining the rules would make the skill contradict itself on the same situation (same trigger/condition with opposite advice) — route those to `differentiate` or `reject_new`. Re-synthesis (fewest/most-general rules, preserve avoid-detail) and the over-budget `differentiate` preference are unchanged. v2.2.0: `unify` re-synthesizes leaner, more general content (MDL / simplify-in-place) instead of concatenating — fewest, most general rules that still cover all inputs; drop redundant/subsumed wording. Asymmetric fidelity: compress/generalize success guidance, but preserve every distinct avoidance/failure detail verbatim — never soften a named pitfall into a vague platitude. Prefer `differentiate` over `unify` when merging would force an over-long, low-cohesion rule. v2.1.0: `unify` no longer emits a `polarity` field — the unified row's orientation is derived from its wording (recommendation vs avoidance) by the apply-path polarity validator. Same-trigger opposite-orientation rules still must not unify; express orientation through the rule wording. v2.0.0: collapsed 5-kind union → 4-kind. `unify` subsumes `duplicate`+`prefer_new`; `reject_new` replaces `prefer_existing`. Output schema is structurally incompatible with v1.x."
+changelog: "v2.4.0: makes the NEW-id partition contract explicit. Decisions must cover every NEW id exactly once; multi-NEW unify/reject_new/independent decisions may list multiple NEW labels when one decision consumes multiple rows, and archive_existing_ids is clarified as EXISTING-only. v2.3.3: adds antecedent-not-reaction trigger guidance for unified and differentiated triggers. (in-place 2026-06-15: adds concise anti-overmerge guard for concrete operational surfaces; restates the numeric id fields (`superseded_by_existing_id`, `existing_id`, `archive_existing_ids`) as EXISTING list-position integers — e.g. emit `0` for `[EXISTING-0]` — superseding the prior 'bare DB id, labels never valid' framing.) v2.3.2: tightens schema guidance for integer id fields and compact unify content; forbids display-label strings in numeric fields. v2.3.1: replaces schema example-style output prompting with compact format guidance for the four decision shapes. v2.3.0: `unify` now COMPOSES — it may grow a broader multi-rule skill from coherent related fragments (related sub-aspects of one task), not only same-trigger duplicates. A skill MAY hold mixed-polarity rules (do-rules and avoid-rules for different sub-aspects). Replaced the mechanical single-orientation/same-polarity contract with an LLM-judged no-self-contradiction guard: do NOT unify if combining the rules would make the skill contradict itself on the same situation (same trigger/condition with opposite advice) — route those to `differentiate` or `reject_new`. Re-synthesis (fewest/most-general rules, preserve avoid-detail) and the over-budget `differentiate` preference are unchanged. v2.2.0: `unify` re-synthesizes leaner, more general content (MDL / simplify-in-place) instead of concatenating — fewest, most general rules that still cover all inputs; drop redundant/subsumed wording. Asymmetric fidelity: compress/generalize success guidance, but preserve every distinct avoidance/failure detail verbatim — never soften a named pitfall into a vague platitude. Prefer `differentiate` over `unify` when merging would force an over-long, low-cohesion rule. v2.1.0: `unify` no longer emits a `polarity` field — the unified row's orientation is derived from its wording (recommendation vs avoidance) by the apply-path polarity validator. Same-trigger opposite-orientation rules still must not unify; express orientation through the rule wording. v2.0.0: collapsed 5-kind union → 4-kind. `unify` subsumes `duplicate`+`prefer_new`; `reject_new` replaces `prefer_existing`. Output schema is structurally incompatible with v1.x."
 variables:
   - new_playbook_count
   - new_playbooks
@@ -21,19 +21,60 @@ When you write any final `trigger`, `refined_new_trigger`, or `refined_existing_
 
 # Decision kinds
 
-Emit exactly one decision per NEW candidate. Each decision is one of:
+Your decisions must cover every NEW id exactly once: every rendered NEW label appears in exactly one decision. A decision can consume more than one NEW row when that is the faithful representation of the final outcome.
+
+Each decision is one of:
 
 - **unify** — the NEW belongs in the same skill as one or more EXISTING rows. This covers two cases:
   1. **Dedup / supersede** — the NEW is the same rule as an EXISTING row (after merge), or supersedes one (stronger / broader / more specific evidence).
   2. **Compose** — the NEW covers a **related sub-aspect of the same task** as an EXISTING playbook (coherent, not a strict duplicate). Grow a **broader multi-rule skill** by incorporating the fragment as an additional rule, instead of forcing `reject_new`/`independent`.
 
-  Provide the final `content`, `trigger`, and `rationale`. List which EXISTING ids you're archiving in `archive_existing_ids` (use an empty list when no EXISTING rows are absorbed). A composed skill MAY hold **mixed-polarity rules** — do-rules and avoid-rules together — when they address **different** sub-aspects of the one task (e.g. "Do: announce in the deploy channel" alongside "Avoid: Friday-afternoon deploys"). Only unify fragments that are **genuinely coherent** (same task scope); unrelated fragments are `independent`.
+  Provide the final `content`, `trigger`, and `rationale`. List which EXISTING ids you're archiving in `archive_existing_ids` (use an empty list when no EXISTING rows are absorbed). `archive_existing_ids` only refers to rows from the EXISTING list; it never consumes NEW rows. If a unified rule uses facts or details from more than one NEW row, `new_id` MUST list all of those NEW labels, for example `"new_id": ["NEW-0", "NEW-1"]`. A composed skill MAY hold **mixed-polarity rules** — do-rules and avoid-rules together — when they address **different** sub-aspects of the one task (e.g. "Do: announce in the deploy channel" alongside "Avoid: Friday-afternoon deploys"). Only unify fragments that are **genuinely coherent** (same task scope); unrelated fragments are `independent`.
 
 - **reject_new** — an EXISTING row already covers NEW or makes NEW redundant. Name the winning EXISTING row's list-position integer via `superseded_by_existing_id` (for `[EXISTING-0]`, emit `0`). Storage-stability tie-break: when same-situation opposite advice is balanced, default here.
 
 - **differentiate** — both valid in distinct contexts (typically same trigger, opposite advice, where the contexts differ). Set `refined_new_trigger` and `refined_existing_trigger` to be strictly narrower than the originals AND mutually exclusive.
 
 - **independent** — different topic or task from any existing row. Insert NEW with no archive.
+
+For `reject_new` and `independent`, `new_id` may also be a list when one decision intentionally handles multiple NEW rows in the same way. `differentiate` handles one NEW row because it emits one pair of refined triggers.
+
+# Multi-NEW examples
+
+Correct multi-NEW `unify`:
+
+```json
+{{
+  "decisions": [
+    {{
+      "kind": "unify",
+      "new_id": ["NEW-0", "NEW-1"],
+      "archive_existing_ids": [],
+      "content": "When editing an AWS deployment document, update every affected env-var, secret, and port reference together; preserve concrete surfaces like target groups, security groups, health checks, and task definitions.",
+      "trigger": "When editing an AWS deployment doc for an env-var/secret/port change",
+      "rationale": "The final rule uses details from both NEW rows, so both NEW labels are consumed by the single unified decision."
+    }}
+  ]
+}}
+```
+
+Invalid under-consumption:
+
+```json
+{{
+  "decisions": [
+    {{
+      "kind": "unify",
+      "new_id": "NEW-0",
+      "archive_existing_ids": [],
+      "content": "When editing an AWS deployment document, update env-vars, secrets, ports, target groups, security groups, health checks, and task definitions together.",
+      "trigger": "When editing an AWS deployment doc",
+      "rationale": "Incorrect: the content absorbs NEW-1 details but new_id only lists NEW-0."
+    }},
+    {{"kind": "independent", "new_id": "NEW-1"}}
+  ]
+}}
+```
 
 # How to write a unified skill (re-synthesis, not concatenation)
 
@@ -58,13 +99,14 @@ A skill MAY hold mixed-polarity rules (do-rules and avoid-rules) for **different
 - A NEW + EXISTING pair that gives opposite advice on the **same** situation (same trigger) MUST route to `differentiate` or `reject_new` — never `unify` (that would make the skill self-contradict) and never `independent`.
 - `differentiate.refined_new_trigger` and `refined_existing_trigger` MUST be non-empty and strictly narrower than the originals.
 - Numeric id fields MUST contain bare EXISTING list-position integers, not display labels or bracketed row prefixes. For `[EXISTING-0]`, emit `0`; for `[EXISTING-3]`, emit `3`.
+- Every NEW label MUST appear exactly once across the full `decisions` array. If one decision consumes several NEW rows, put those labels in that decision's `new_id` list and do not emit separate decisions for them.
 - When in doubt about a same-situation opposite-advice stalemate, default to `reject_new`. Storage stability wins ties.
 
 # Output Format Guidance
 
-Respond ONLY with a valid JSON object matching `PlaybookConsolidationOutput`: `{{"decisions": [<one decision object for each NEW candidate>]}}`.
+Respond ONLY with a valid JSON object matching `PlaybookConsolidationOutput`: `{{"decisions": [<decision objects that together cover every NEW id exactly once>]}}`.
 
-Each decision object MUST include `kind` and `new_id`. `new_id` is the rendered NEW label string. All EXISTING references use the numeric list-position fields below.
+Each decision object MUST include `kind` and `new_id`. `new_id` is the rendered NEW label string, or a list of rendered NEW label strings for multi-NEW `unify`, `reject_new`, or `independent` decisions. All EXISTING references use the numeric list-position fields below.
 
 - `unify`: include `archive_existing_ids` as a list of EXISTING list-position integers, plus final compact `content`, `trigger`, and `rationale`; optional `reason` may explain the decision.
 - `reject_new`: include `superseded_by_existing_id` as an EXISTING list-position integer only; optional `reason` may explain the decision.

--- a/reflexio/server/services/playbook/components/consolidator.py
+++ b/reflexio/server/services/playbook/components/consolidator.py
@@ -24,6 +24,9 @@ from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
 )
+from reflexio.server.services.profile.profile_generation_service_utils import (
+    check_string_token_overlap,
+)
 from reflexio.server.tracing import sentry_tags
 
 logger = logging.getLogger(__name__)
@@ -395,6 +398,50 @@ _COUNTER_BY_KIND: dict[str, str] = {
 }
 
 
+def _decision_new_ids(decision: ConsolidationDecision) -> list[str]:
+    if isinstance(decision, DifferentiateDecision):
+        return [decision.new_id]
+    return decision.new_ids
+
+
+def validate_consolidation_output(
+    new_playbooks: list[UserPlaybook],
+    output: PlaybookConsolidationOutput,
+) -> list[str]:
+    """Return partition-contract errors for a parsed consolidation output."""
+    known_new_ids = {f"NEW-{idx}" for idx in range(len(new_playbooks))}
+    seen_by_id: dict[str, list[str]] = {}
+    errors: list[str] = []
+
+    for decision_index, decision in enumerate(output.decisions):
+        label = f"decision[{decision_index}] {decision.kind}"
+        for new_id in _decision_new_ids(decision):
+            if new_id not in known_new_ids:
+                errors.append(f"{label} references unknown NEW id {new_id}.")
+                continue
+            seen_by_id.setdefault(new_id, []).append(label)
+
+    missing = sorted(known_new_ids - set(seen_by_id))
+    if missing:
+        errors.append(
+            "Every NEW id must appear exactly once; missing NEW ids: "
+            + ", ".join(missing)
+            + "."
+        )
+
+    duplicates = {
+        new_id: labels for new_id, labels in seen_by_id.items() if len(labels) > 1
+    }
+    for new_id, labels in sorted(duplicates.items()):
+        errors.append(
+            f"Every NEW id must appear exactly once; {new_id} appears in "
+            + "; ".join(labels)
+            + "."
+        )
+
+    return errors
+
+
 class PlaybookConsolidator(BaseDeduplicator):
     """
     Consolidates new user playbook entries against each other and against existing entries
@@ -757,6 +804,12 @@ class PlaybookConsolidator(BaseDeduplicator):
             len(dedup_output.decisions),
             generation_request_id,
         )
+        dedup_output = self._repair_consolidation_output_if_needed(
+            new_playbooks=new_playbooks,
+            existing_playbooks=existing_playbooks,
+            dedup_output=dedup_output,
+            request_id=request_id,
+        )
 
         # Build consolidated result via the discriminated-union apply path
         return self._build_deduplicated_results(
@@ -766,6 +819,204 @@ class PlaybookConsolidator(BaseDeduplicator):
             generation_request_id=generation_request_id,
             agent_version=agent_version,
         )
+
+    def _repair_consolidation_output_if_needed(
+        self,
+        *,
+        new_playbooks: list[UserPlaybook],
+        existing_playbooks: list[UserPlaybook],
+        dedup_output: PlaybookConsolidationOutput,
+        request_id: str | None,
+    ) -> PlaybookConsolidationOutput:
+        errors = validate_consolidation_output(new_playbooks, dedup_output)
+        if not errors:
+            errors = self._find_suspicious_under_consumed_new_rows(
+                new_playbooks, dedup_output
+            )
+        if not errors:
+            return dedup_output
+
+        new_text, existing_text = self._format_new_and_existing_for_prompt(
+            new_playbooks, existing_playbooks
+        )
+        repaired = self._repair_consolidation_output(
+            new_text=new_text,
+            existing_text=existing_text,
+            invalid_output=dedup_output,
+            errors=errors,
+            request_id=request_id,
+        )
+        if repaired is None:
+            return dedup_output
+
+        repaired_errors = validate_consolidation_output(new_playbooks, repaired)
+        if repaired_errors:
+            logger.warning(
+                "event=consolidation_repair_failed request_id=%s errors=%s",
+                request_id,
+                repaired_errors,
+            )
+            return dedup_output
+
+        logger.info(
+            "event=consolidation_repaired request_id=%s decision_count=%d",
+            request_id,
+            len(repaired.decisions),
+        )
+        return repaired
+
+    def _repair_consolidation_output(
+        self,
+        *,
+        new_text: str,
+        existing_text: str,
+        invalid_output: PlaybookConsolidationOutput,
+        errors: list[str],
+        request_id: str | None,
+    ) -> PlaybookConsolidationOutput | None:
+        logger.warning(
+            "event=consolidation_repair_attempted request_id=%s errors=%s",
+            request_id,
+            errors,
+        )
+        prompt = "\n".join(
+            [
+                "The previous playbook consolidation output violated the NEW-id coverage contract.",
+                "",
+                "Your decisions must cover every NEW id exactly once. Every NEW id must appear in exactly one decision.",
+                "If a unified rule uses facts/details from multiple NEW rows, `new_id` must list all of them.",
+                "If the existing decisions are semantically correct, return them unchanged after fixing any coverage errors.",
+                "",
+                "[New playbooks]",
+                new_text,
+                "",
+                "[Existing related playbooks]",
+                existing_text,
+                "",
+                "[Invalid output]",
+                invalid_output.model_dump_json(),
+                "",
+                "[Validation errors]",
+                "\n".join(f"- {error}" for error in errors),
+                "",
+                'Respond ONLY with valid JSON matching PlaybookConsolidationOutput: {"decisions": [...]}.',
+            ]
+        )
+
+        from reflexio.server.services.service_utils import (
+            log_llm_messages,
+            log_model_response,
+        )
+
+        log_llm_messages(
+            logger,
+            "Playbook consolidation repair",
+            [{"role": "user", "content": prompt}],
+        )
+
+        try:
+            response = self.client.generate_chat_response(
+                messages=[{"role": "user", "content": prompt}],
+                model=self.model_name,
+                response_format=self._get_output_schema_class(),
+            )
+        except Exception as exc:  # noqa: BLE001 — repair is best-effort
+            logger.warning(
+                "event=consolidation_repair_failed request_id=%s error_type=%s",
+                request_id,
+                type(exc).__name__,
+                exc_info=True,
+            )
+            return None
+
+        log_model_response(logger, "Consolidation repair response", response)
+
+        if not isinstance(response, PlaybookConsolidationOutput):
+            logger.warning(
+                "event=consolidation_repair_failed request_id=%s unexpected_type=%s",
+                request_id,
+                type(response),
+            )
+            return None
+        return response
+
+    @staticmethod
+    def _find_suspicious_under_consumed_new_rows(
+        new_playbooks: list[UserPlaybook],
+        dedup_output: PlaybookConsolidationOutput,
+    ) -> list[str]:
+        candidates_by_id = {
+            f"NEW-{idx}": playbook for idx, playbook in enumerate(new_playbooks)
+        }
+        # Every kind except reject_new stores a row for its consumed candidates
+        # (raw for independent, refined-trigger copy for differentiate, the
+        # re-synthesized decision content for a sibling unify), so any of them
+        # can duplicate a unify's merged row. Only reject_new drops the row
+        # outright and is never a duplicate-storage risk worth a repair call.
+        consuming_kind_by_new_id = {
+            new_id: decision.kind
+            for decision in dedup_output.decisions
+            for new_id in _decision_new_ids(decision)
+        }
+        source_ids_by_decision = [
+            {
+                source_id
+                for new_id in _decision_new_ids(decision)
+                if new_id in candidates_by_id
+                for source_id in candidates_by_id[new_id].source_interaction_ids
+            }
+            for decision in dedup_output.decisions
+        ]
+        errors: list[str] = []
+
+        for decision_index, decision in enumerate(dedup_output.decisions):
+            if not isinstance(decision, UnifyDecision):
+                continue
+            consumed_ids = set(decision.new_ids)
+            consumed_source_ids = source_ids_by_decision[decision_index]
+            if not consumed_source_ids:
+                continue
+
+            # Candidates stored (near-)verbatim by another decision whose facts
+            # this unify's merged content may have absorbed.
+            for other_id, other in candidates_by_id.items():
+                if other_id in consumed_ids:
+                    continue
+                if consuming_kind_by_new_id.get(other_id) not in (
+                    "independent",
+                    "differentiate",
+                ):
+                    continue
+                if not consumed_source_ids.intersection(other.source_interaction_ids):
+                    continue
+                if check_string_token_overlap(decision.content, other.content):
+                    errors.append(
+                        f"decision[{decision_index}] unify likely absorbed facts from {other_id} but did not list it in new_id; "
+                        "if the unified rule absorbed this row's facts, add its id to new_id; "
+                        "if not, leave the decisions unchanged."
+                    )
+
+            # Sibling unify decisions each persist their own survivor row, so
+            # two same-source unifies with heavily overlapping FINAL contents
+            # are the same duplicate-storage class. Compare stored content to
+            # stored content and flag each pair once (j > i).
+            for sibling_index in range(decision_index + 1, len(dedup_output.decisions)):
+                sibling = dedup_output.decisions[sibling_index]
+                if not isinstance(sibling, UnifyDecision):
+                    continue
+                if not consumed_source_ids.intersection(
+                    source_ids_by_decision[sibling_index]
+                ):
+                    continue
+                if check_string_token_overlap(decision.content, sibling.content):
+                    errors.append(
+                        f"decision[{decision_index}] and decision[{sibling_index}] are both unify decisions over "
+                        "same-source NEW rows with highly overlapping content; if they describe the same skill, "
+                        "merge them into one unify decision whose new_id lists every consumed NEW id; "
+                        "if they are genuinely distinct skills, leave the decisions unchanged."
+                    )
+
+        return errors
 
     # ===============================
     # Apply path: discriminated-union decisions -> (new rows, archive ids)

--- a/reflexio/server/services/playbook/components/consolidator.py
+++ b/reflexio/server/services/playbook/components/consolidator.py
@@ -628,6 +628,36 @@ class PlaybookConsolidator(BaseDeduplicator):
         )
         return new_text, existing_text
 
+    def _render_consolidation_prompt(
+        self,
+        new_playbooks: list[UserPlaybook],
+        existing_playbooks: list[UserPlaybook],
+    ) -> str:
+        """Render the consolidation prompt for the given NEW + EXISTING rows.
+
+        Rendering is deterministic, so the repair path calls this again to
+        reconstruct the exact first-turn prompt when building the follow-up
+        conversation.
+
+        Args:
+            new_playbooks: New entries to deduplicate.
+            existing_playbooks: Existing entries from the database.
+
+        Returns:
+            The fully rendered consolidation prompt.
+        """
+        new_text, existing_text = self._format_new_and_existing_for_prompt(
+            new_playbooks, existing_playbooks
+        )
+        return self.request_context.prompt_manager.render_prompt(
+            self._get_prompt_id(),
+            {
+                "new_playbook_count": len(new_playbooks),
+                "new_playbooks": new_text,
+                "existing_playbooks": existing_text,
+            },
+        )
+
     def _consolidation_decisions(
         self,
         new_playbooks: list[UserPlaybook],
@@ -668,20 +698,7 @@ class PlaybookConsolidator(BaseDeduplicator):
             Parsed ``PlaybookConsolidationOutput``; an empty output (no
             decisions) if the LLM returned an unexpected response shape.
         """
-        # Format for prompt
-        new_text, existing_text = self._format_new_and_existing_for_prompt(
-            new_playbooks, existing_playbooks
-        )
-
-        # Build and call LLM
-        prompt = self.request_context.prompt_manager.render_prompt(
-            self._get_prompt_id(),
-            {
-                "new_playbook_count": len(new_playbooks),
-                "new_playbooks": new_text,
-                "existing_playbooks": existing_text,
-            },
-        )
+        prompt = self._render_consolidation_prompt(new_playbooks, existing_playbooks)
 
         output_schema_class = self._get_output_schema_class()
 
@@ -836,12 +853,10 @@ class PlaybookConsolidator(BaseDeduplicator):
         if not errors:
             return dedup_output
 
-        new_text, existing_text = self._format_new_and_existing_for_prompt(
-            new_playbooks, existing_playbooks
-        )
         repaired = self._repair_consolidation_output(
-            new_text=new_text,
-            existing_text=existing_text,
+            original_prompt=self._render_consolidation_prompt(
+                new_playbooks, existing_playbooks
+            ),
             invalid_output=dedup_output,
             errors=errors,
             request_id=request_id,
@@ -868,55 +883,64 @@ class PlaybookConsolidator(BaseDeduplicator):
     def _repair_consolidation_output(
         self,
         *,
-        new_text: str,
-        existing_text: str,
+        original_prompt: str,
         invalid_output: PlaybookConsolidationOutput,
         errors: list[str],
         request_id: str | None,
     ) -> PlaybookConsolidationOutput | None:
+        """Ask the model to fix its consolidation output in a follow-up turn.
+
+        The repair is sent as the third turn of the original conversation —
+        [user: consolidation prompt, assistant: the invalid decisions, user:
+        validation errors + fix instruction] — so the model retains the full
+        first-turn context (rendered rows, decision-kind rules, output format)
+        without restating any of it.
+
+        Args:
+            original_prompt: The exact rendered first-turn consolidation prompt.
+            invalid_output: The parsed decisions that failed validation.
+            errors: Human-readable validation errors to feed back.
+            request_id: Request ID for log correlation.
+
+        Returns:
+            The repaired ``PlaybookConsolidationOutput``, or None when the
+            repair call fails or returns an unexpected shape.
+        """
         logger.warning(
             "event=consolidation_repair_attempted request_id=%s errors=%s",
             request_id,
             errors,
         )
-        prompt = "\n".join(
+        followup = "\n".join(
             [
-                "The previous playbook consolidation output violated the NEW-id coverage contract.",
+                "Your decisions above violate the NEW-id coverage contract:",
                 "",
-                "Your decisions must cover every NEW id exactly once. Every NEW id must appear in exactly one decision.",
-                "If a unified rule uses facts/details from multiple NEW rows, `new_id` must list all of them.",
-                "If the existing decisions are semantically correct, return them unchanged after fixing any coverage errors.",
-                "",
-                "[New playbooks]",
-                new_text,
-                "",
-                "[Existing related playbooks]",
-                existing_text,
-                "",
-                "[Invalid output]",
-                invalid_output.model_dump_json(),
-                "",
-                "[Validation errors]",
                 "\n".join(f"- {error}" for error in errors),
+                "",
+                "Return corrected decisions that cover every NEW id exactly once. "
+                "If a unified rule uses facts/details from multiple NEW rows, `new_id` must list all of them. "
+                "If your decisions are semantically correct apart from these errors, "
+                "keep them and fix only the coverage.",
                 "",
                 'Respond ONLY with valid JSON matching PlaybookConsolidationOutput: {"decisions": [...]}.',
             ]
         )
+        messages = [
+            {"role": "user", "content": original_prompt},
+            {"role": "assistant", "content": invalid_output.model_dump_json()},
+            {"role": "user", "content": followup},
+        ]
 
         from reflexio.server.services.service_utils import (
             log_llm_messages,
             log_model_response,
         )
 
-        log_llm_messages(
-            logger,
-            "Playbook consolidation repair",
-            [{"role": "user", "content": prompt}],
-        )
+        log_llm_messages(logger, "Playbook consolidation repair", messages)
 
         try:
             response = self.client.generate_chat_response(
-                messages=[{"role": "user", "content": prompt}],
+                messages=messages,
                 model=self.model_name,
                 response_format=self._get_output_schema_class(),
             )

--- a/tests/server/llm/conftest.py
+++ b/tests/server/llm/conftest.py
@@ -10,6 +10,30 @@ import pytest
 
 from reflexio.server.services.storage.storage_base import BaseStorage
 
+# ``reflexio.server`` loads ``./.env`` + ``~/.reflexio/.env`` into os.environ at
+# import time (and litellm's import-time dotenv walk-up can pull in a parent
+# repo's .env). Provider tests assert against the DEFAULT host/port code paths,
+# so a developer machine that opts into the codex host or a custom embedding
+# port would otherwise flip these tests onto different branches and fail them.
+_MACHINE_ENV_OVERRIDES = (
+    "CLAUDE_SMART_HOST",
+    "CLAUDE_SMART_USE_LOCAL_CLI",
+    "CLAUDE_SMART_CLI_PATH",
+    "CLAUDE_SMART_CODEX_PATH",
+    "EMBEDDING_PORT",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_machine_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip machine-specific env overrides so provider tests stay hermetic.
+
+    Tests that exercise a non-default host/port explicitly set these vars via
+    their own ``monkeypatch.setenv`` calls, which run after this fixture.
+    """
+    for var in _MACHINE_ENV_OVERRIDES:
+        monkeypatch.delenv(var, raising=False)
+
 
 @pytest.fixture
 def storage() -> Generator[BaseStorage]:

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1185,6 +1185,20 @@ class TestStrictStructuredOutputRequest:
         assert parser_schema is SampleResponse
         assert parse_structured is True
 
+    def test_explicit_none_model_falls_back_to_config_default(self):
+        # Callers that forward an optional model (e.g. the eval judges pass
+        # ``model=rubric.get("judge_model")``) may hand over a literal None;
+        # it must resolve to the config default instead of crashing on
+        # ``None.lower()`` during API-key resolution.
+        client = _build_client(LiteLLMConfig(model="gpt-4o-mini"))
+
+        params, _, _, _, _ = client._build_completion_params(
+            [{"role": "user", "content": "test"}],
+            model=None,
+        )
+
+        assert params["model"] == "gpt-4o-mini"
+
     def test_unsupported_model_keeps_pydantic_response_format(self):
         # A provider that is neither natively response-schema-capable nor on the
         # OpenAI-compatible allowlist keeps the raw Pydantic model so LiteLLM can
@@ -2465,6 +2479,12 @@ class TestLitellmIntegration:
         # retry was removed) — still far below the 1s the blocked call would take.
         assert time.perf_counter() - start < 1.0
 
+    @pytest.mark.skipif(
+        multiprocessing.get_start_method() != "fork",
+        reason="the isolated worker sees the litellm.completion monkeypatch only "
+        "under the fork start method (spawn re-imports real litellm); the "
+        "drain-before-join behavior under test is exercised on Linux CI/prod",
+    )
     def test_large_result_does_not_deadlock_hard_timeout(self, monkeypatch):
         """A large completion payload overflows the OS pipe buffer feeding the
         result queue. If the parent joined the child before draining the queue,

--- a/tests/server/services/playbook/test_consolidation_lineage_integration.py
+++ b/tests/server/services/playbook/test_consolidation_lineage_integration.py
@@ -127,6 +127,27 @@ def _candidate() -> UserPlaybook:
     )
 
 
+def _candidate_with_content(
+    *,
+    content: str,
+    request_id: str = "req_merge",
+    source_interaction_ids: list[int] | None = None,
+) -> UserPlaybook:
+    return UserPlaybook(
+        user_playbook_id=0,
+        user_id="u1",
+        agent_version="v0",
+        request_id=request_id,
+        playbook_name="default",
+        content=content,
+        trigger="when changing AWS deploy wiring",
+        rationale="r",
+        status=None,
+        source="chat",
+        source_interaction_ids=source_interaction_ids or [],
+    )
+
+
 def test_consolidation_merge_routes_through_merge_records(
     sqlite_storage, generation_service
 ):
@@ -200,6 +221,78 @@ def test_consolidation_merge_routes_through_merge_records(
     ref = resolve_current(sqlite_storage, "user_playbook", old_id)
     assert ref is not None
     assert ref.id == str(survivor.user_playbook_id)
+
+
+def test_consolidation_repair_persists_only_repaired_multi_new_unify(
+    sqlite_storage, generation_service
+):
+    """Repair an under-consumed same-batch merge before the service saves rows.
+
+    This drives the production finalization boundary with real SQLite storage:
+    the initial consolidation output merges facts from two NEW candidates but
+    lists only ``NEW-0``; the repair output lists both. The persisted state must
+    contain the merged survivor and not the raw ``NEW-1`` fallback row.
+    """
+    candidate_0 = _candidate_with_content(
+        content="Always update target groups and security groups.",
+        source_interaction_ids=[15, 16, 19, 20],
+    )
+    candidate_1 = _candidate_with_content(
+        content="Always update security groups.",
+        source_interaction_ids=[15, 16, 19, 20],
+    )
+    initial_output = PlaybookConsolidationOutput(
+        decisions=[
+            UnifyDecision(
+                new_id="NEW-0",
+                archive_existing_ids=[],
+                content="Always update target groups and security groups.",
+                trigger="when changing AWS deploy wiring",
+                rationale="merged",
+            )
+        ]
+    )
+    repaired_output = PlaybookConsolidationOutput(
+        decisions=[
+            UnifyDecision(
+                new_id=["NEW-0", "NEW-1"],
+                archive_existing_ids=[],
+                content="Always update target groups and security groups.",
+                trigger="when changing AWS deploy wiring",
+                rationale="merged",
+            )
+        ]
+    )
+    generation_service.client.generate_chat_response.return_value = repaired_output
+
+    with (
+        patch(
+            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
+            return_value=True,
+        ),
+        patch.object(
+            PlaybookGenerationService,
+            "_configured_playbook_config",
+            return_value=None,
+        ),
+        patch(
+            "reflexio.server.services.playbook.components.consolidator.PlaybookConsolidator._retrieve_existing_playbooks",
+            return_value=[],
+        ),
+        patch(
+            "reflexio.server.services.playbook.components.consolidator.PlaybookConsolidator._consolidation_decisions",
+            return_value=initial_output,
+        ),
+        patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}),
+    ):
+        generation_service._finalize_extracted_items([candidate_0, candidate_1])
+
+    current = sqlite_storage.get_user_playbooks(user_id="u1")
+    assert len(current) == 1, [p.content for p in current]
+    survivor = current[0]
+    assert survivor.content == "Always update target groups and security groups."
+    assert survivor.source_interaction_ids == [15, 16, 19, 20]
+    generation_service.client.generate_chat_response.assert_called_once()
 
 
 def test_consolidation_differentiate_tombstones_split_source(

--- a/tests/server/services/playbook/test_consolidation_output.py
+++ b/tests/server/services/playbook/test_consolidation_output.py
@@ -8,10 +8,12 @@ longer parse — that structural guarantee is what the new schema buys.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
 
+from reflexio.models.api_schema.service_schemas import UserPlaybook
 from reflexio.server.services.playbook.components.consolidator import (
     ConsolidationDecision,
     DifferentiateDecision,
@@ -19,7 +21,35 @@ from reflexio.server.services.playbook.components.consolidator import (
     PlaybookConsolidationOutput,
     RejectNewDecision,
     UnifyDecision,
+    validate_consolidation_output,
 )
+
+
+def _playbook(idx: int) -> UserPlaybook:
+    return UserPlaybook(
+        content=f"content {idx}",
+        trigger=f"trigger {idx}",
+        request_id=f"req-{idx}",
+        agent_version="v1",
+        source_interaction_ids=[idx],
+    )
+
+
+def test_active_prompt_documents_partition_contract():
+    prompt_path = (
+        Path(__file__).resolve().parents[4]
+        / "reflexio"
+        / "server"
+        / "prompt"
+        / "prompt_bank"
+        / "playbook_consolidation"
+        / "v2.4.0.prompt.md"
+    )
+    prompt = prompt_path.read_text(encoding="utf-8")
+
+    assert "Every NEW label MUST appear exactly once" in prompt
+    assert '"new_id": ["NEW-0", "NEW-1"]' in prompt
+    assert "`archive_existing_ids` only refers to rows from the EXISTING list" in prompt
 
 
 def test_output_json_schema_is_provider_safe_by_construction():
@@ -202,6 +232,69 @@ def test_all_four_kinds_round_trip_through_output():
         "differentiate",
         "independent",
     ]
+
+
+def test_validate_consolidation_output_accepts_exactly_once_coverage():
+    output = PlaybookConsolidationOutput(
+        decisions=[
+            UnifyDecision(
+                new_id=["NEW-0", "NEW-1"],
+                archive_existing_ids=[],
+                content="X",
+                trigger="t",
+                rationale="r",
+            ),
+            RejectNewDecision(new_id="NEW-2", superseded_by_existing_id=0),
+            DifferentiateDecision(
+                new_id="NEW-3",
+                existing_id=0,
+                refined_new_trigger="narrow new",
+                refined_existing_trigger="narrow existing",
+            ),
+            IndependentDecision(new_id="NEW-4"),
+        ]
+    )
+
+    assert validate_consolidation_output([_playbook(i) for i in range(5)], output) == []
+
+
+def test_validate_consolidation_output_reports_missing_new_id():
+    output = PlaybookConsolidationOutput(
+        decisions=[IndependentDecision(new_id="NEW-0")]
+    )
+
+    errors = validate_consolidation_output([_playbook(0), _playbook(1)], output)
+
+    assert any("missing NEW ids: NEW-1" in error for error in errors)
+
+
+def test_validate_consolidation_output_reports_duplicate_new_id():
+    output = PlaybookConsolidationOutput(
+        decisions=[
+            IndependentDecision(new_id="NEW-0"),
+            UnifyDecision(
+                new_id="NEW-0",
+                archive_existing_ids=[],
+                content="X",
+                trigger="t",
+                rationale="r",
+            ),
+        ]
+    )
+
+    errors = validate_consolidation_output([_playbook(0)], output)
+
+    assert any("NEW-0 appears in decision[0]" in error for error in errors)
+
+
+def test_validate_consolidation_output_reports_unknown_new_id():
+    output = PlaybookConsolidationOutput(
+        decisions=[IndependentDecision(new_id="NEW-99")]
+    )
+
+    errors = validate_consolidation_output([_playbook(0)], output)
+
+    assert any("unknown NEW id NEW-99" in error for error in errors)
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -1168,6 +1168,20 @@ class TestConsolidationRepair:
         assert merge_groups == []
         assert mock_consolidator.client.generate_chat_response.call_count == 2
 
+        # The repair is a follow-up turn of the original conversation, so the
+        # model keeps the full first-turn context: [user: original prompt,
+        # assistant: the invalid decisions, user: errors + fix instruction].
+        first_call, repair_call = (
+            mock_consolidator.client.generate_chat_response.call_args_list
+        )
+        original_prompt = first_call.kwargs["messages"][0]["content"]
+        repair_messages = repair_call.kwargs["messages"]
+        assert [m["role"] for m in repair_messages] == ["user", "assistant", "user"]
+        assert repair_messages[0]["content"] == original_prompt
+        assert '"NEW-0"' in repair_messages[1]["content"]
+        assert "exactly once" in repair_messages[2]["content"]
+        assert "missing NEW ids: NEW-1" in repair_messages[2]["content"]
+
     def test_repair_failure_falls_back_to_original_output(
         self, mock_consolidator, caplog
     ):

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -1120,6 +1120,425 @@ class TestDeduplicateHappyPath:
         assert set(result[0].source_interaction_ids) == {5, 10}
 
 
+class TestConsolidationRepair:
+    """Tests for pre-apply validation and the single repair pass."""
+
+    def test_under_consumed_output_repairs_to_multi_new_unify(self, mock_consolidator):
+        new_0 = _make_user_playbook(
+            0, content="alpha beta", source_interaction_ids=[10]
+        )
+        new_1 = _make_user_playbook(
+            1, content="gamma delta", source_interaction_ids=[11]
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.side_effect = [
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="alpha beta gamma delta",
+                        trigger="when combined",
+                    )
+                ]
+            ),
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        ["NEW-0", "NEW-1"],
+                        content="alpha beta gamma delta",
+                        trigger="when combined",
+                    )
+                ]
+            ),
+        ]
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, delete_ids, merge_groups = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_repair",
+                agent_version="v1",
+            )
+
+        assert len(result) == 1
+        assert result[0].content == "alpha beta gamma delta"
+        assert result[0].source_interaction_ids == [10, 11]
+        assert delete_ids == []
+        assert merge_groups == []
+        assert mock_consolidator.client.generate_chat_response.call_count == 2
+
+    def test_repair_failure_falls_back_to_original_output(
+        self, mock_consolidator, caplog
+    ):
+        new_0 = _make_user_playbook(
+            0, content="alpha beta", source_interaction_ids=[10]
+        )
+        new_1 = _make_user_playbook(
+            1, content="gamma delta", source_interaction_ids=[11]
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        original_output = PlaybookConsolidationOutput(
+            decisions=[
+                _unify(
+                    "NEW-0",
+                    content="alpha beta gamma delta",
+                    trigger="when combined",
+                )
+            ]
+        )
+        mock_consolidator.client.generate_chat_response.side_effect = [
+            original_output,
+            PlaybookConsolidationOutput(
+                decisions=[IndependentDecision(new_id="NEW-0")]
+            ),
+        ]
+
+        with (
+            patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}),
+            caplog.at_level("WARNING"),
+        ):
+            result, delete_ids, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_repair_fail",
+                agent_version="v1",
+            )
+
+        assert [row.content for row in result] == [
+            "alpha beta gamma delta",
+            "gamma delta",
+        ]
+        assert delete_ids == []
+        assert mock_consolidator.client.generate_chat_response.call_count == 2
+        assert any(
+            "event=consolidation_repair_failed" in record.message
+            for record in caplog.records
+        )
+
+    def test_suspicious_same_source_split_triggers_repair(self, mock_consolidator):
+        new_0 = _make_user_playbook(
+            0,
+            content="check target group security group health check",
+            source_interaction_ids=[15, 16],
+        )
+        new_1 = _make_user_playbook(
+            1,
+            content="check target group security group health check",
+            source_interaction_ids=[15, 16],
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.side_effect = [
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="check target group security group health check",
+                        trigger="when deploying",
+                    ),
+                    IndependentDecision(new_id="NEW-1"),
+                ]
+            ),
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        ["NEW-0", "NEW-1"],
+                        content="check target group security group health check",
+                        trigger="when deploying",
+                    )
+                ]
+            ),
+        ]
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_suspicious",
+                agent_version="v1",
+            )
+
+        assert len(result) == 1
+        assert result[0].source_interaction_ids == [15, 16]
+        assert mock_consolidator.client.generate_chat_response.call_count == 2
+
+    def test_low_overlap_same_source_split_does_not_trigger_repair(
+        self, mock_consolidator
+    ):
+        new_0 = _make_user_playbook(
+            0,
+            content="check target group health checks",
+            source_interaction_ids=[15],
+        )
+        new_1 = _make_user_playbook(
+            1,
+            content="avoid friday afternoon deploys",
+            source_interaction_ids=[15],
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.return_value = (
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="check target group health checks",
+                        trigger="when deploying",
+                    ),
+                    IndependentDecision(new_id="NEW-1"),
+                ]
+            )
+        )
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_low_overlap",
+                agent_version="v1",
+            )
+
+        assert len(result) == 2
+        assert mock_consolidator.client.generate_chat_response.call_count == 1
+
+    def test_reject_new_consumed_overlap_does_not_trigger_repair(
+        self, mock_consolidator
+    ):
+        """A high-overlap same-source row consumed by ``reject_new`` is dropped,
+        so it cannot duplicate the unify survivor — no repair call is spent."""
+        new_0 = _make_user_playbook(
+            0,
+            content="check target group security group health check",
+            source_interaction_ids=[15, 16],
+        )
+        new_1 = _make_user_playbook(
+            1,
+            content="check target group security group health check",
+            source_interaction_ids=[15, 16],
+        )
+        existing = _make_user_playbook(
+            50,
+            content="existing deploy checklist",
+            source_interaction_ids=[1],
+            user_playbook_id=50,
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = [
+            existing
+        ]
+        mock_consolidator.client.generate_chat_response.return_value = (
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="check target group security group health check",
+                        trigger="when deploying",
+                    ),
+                    RejectNewDecision(new_id="NEW-1", superseded_by_existing_id=0),
+                ]
+            )
+        )
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_reject_new_overlap",
+                agent_version="v1",
+            )
+
+        assert len(result) == 1
+        assert mock_consolidator.client.generate_chat_response.call_count == 1
+
+    def test_sibling_unify_same_source_overlap_triggers_repair(self, mock_consolidator):
+        """Two same-source unify decisions with overlapping FINAL contents each
+        persist a survivor row — the same duplicate-storage class as an
+        under-consumed unify — so the pair must trigger the repair pass."""
+        new_0 = _make_user_playbook(
+            0,
+            content="check target group security group health check",
+            source_interaction_ids=[15, 16],
+        )
+        new_1 = _make_user_playbook(
+            1,
+            content="verify security group and health check wiring",
+            source_interaction_ids=[15, 16],
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.side_effect = [
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="check target group security group health check wiring",
+                        trigger="when deploying",
+                    ),
+                    _unify(
+                        "NEW-1",
+                        content="check target group security group health check wiring",
+                        trigger="when deploying",
+                    ),
+                ]
+            ),
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        ["NEW-0", "NEW-1"],
+                        content="check target group security group health check wiring",
+                        trigger="when deploying",
+                    )
+                ]
+            ),
+        ]
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_sibling_unify",
+                agent_version="v1",
+            )
+
+        assert len(result) == 1
+        assert result[0].source_interaction_ids == [15, 16]
+        assert mock_consolidator.client.generate_chat_response.call_count == 2
+
+    def test_distinct_sibling_unifies_do_not_trigger_repair(self, mock_consolidator):
+        """Same-source unify pair with genuinely different final contents is a
+        legitimate split — no repair call is spent."""
+        new_0 = _make_user_playbook(
+            0,
+            content="check target group health checks before deploying",
+            source_interaction_ids=[15],
+        )
+        new_1 = _make_user_playbook(
+            1,
+            content="announce the rollout in the deploy channel first",
+            source_interaction_ids=[15],
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.return_value = (
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="check target group health checks before deploying",
+                        trigger="when deploying",
+                    ),
+                    _unify(
+                        "NEW-1",
+                        content="announce the rollout in the deploy channel first",
+                        trigger="when announcing a rollout",
+                    ),
+                ]
+            )
+        )
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_distinct_unifies",
+                agent_version="v1",
+            )
+
+        assert len(result) == 2
+        assert mock_consolidator.client.generate_chat_response.call_count == 1
+
+    def test_suspicious_repair_returning_same_decisions_is_accepted(
+        self, mock_consolidator
+    ):
+        new_0 = _make_user_playbook(
+            0,
+            content="sync env var secret port references",
+            source_interaction_ids=[20],
+        )
+        new_1 = _make_user_playbook(
+            1,
+            content="sync env var secret port references",
+            source_interaction_ids=[20],
+        )
+        same_output = PlaybookConsolidationOutput(
+            decisions=[
+                _unify(
+                    "NEW-0",
+                    content="sync env var secret port references",
+                    trigger="when editing docs",
+                ),
+                IndependentDecision(new_id="NEW-1"),
+            ]
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.side_effect = [
+            same_output,
+            same_output,
+        ]
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[new_0, new_1]],
+                request_id="req_same_repair",
+                agent_version="v1",
+            )
+
+        assert len(result) == 2
+        assert mock_consolidator.client.generate_chat_response.call_count == 2
+
+    def test_same_batch_duplicate_regression_drops_raw_source_after_repair(
+        self, mock_consolidator
+    ):
+        merged_source = _make_user_playbook(
+            0,
+            content="Always update target groups and security groups.",
+            source_interaction_ids=[15, 16, 19, 20],
+        )
+        raw_source = _make_user_playbook(
+            1,
+            content="Always update security groups.",
+            source_interaction_ids=[15, 16, 19, 20],
+        )
+
+        mock_consolidator.client.get_embeddings.return_value = [[0.1], [0.2]]
+        mock_consolidator.request_context.storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.generate_chat_response.side_effect = [
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        "NEW-0",
+                        content="Always update target groups and security groups.",
+                        trigger="when changing AWS deploy wiring",
+                    )
+                ]
+            ),
+            PlaybookConsolidationOutput(
+                decisions=[
+                    _unify(
+                        ["NEW-0", "NEW-1"],
+                        content="Always update target groups and security groups.",
+                        trigger="when changing AWS deploy wiring",
+                    )
+                ]
+            ),
+        ]
+
+        with patch.dict("os.environ", {"MOCK_LLM_RESPONSE": "false"}):
+            result, _, _ = mock_consolidator.deduplicate(
+                results=[[merged_source, raw_source]],
+                request_id="req_duplicate_regression",
+                agent_version="v1",
+            )
+
+        assert [row.content for row in result] == [
+            "Always update target groups and security groups."
+        ]
+
+
 # ===============================
 # Edge cases for _build_deduplicated_results
 # ===============================

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -37,7 +37,7 @@ PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     "playbook_extraction_context_expert": ("v3.4.0", None),
     "playbook_extraction_main_expert": ("v1.2.0", "playbook_extraction"),
     "playbook_aggregation": ("v2.3.0", "playbook_aggregation"),
-    "playbook_consolidation": ("v2.3.3", "playbook_consolidation"),
+    "playbook_consolidation": ("v2.4.0", "playbook_consolidation"),
     "playbook_optimizer_judge": ("v1.2.0", None),
     "profile_update_main": ("v1.0.0", "profile_extraction"),
     "profile_update_instruction_start": ("v1.2.0", None),


### PR DESCRIPTION
## Summary
- Enforce a NEW-id partition contract for playbook consolidation so every same-batch candidate is consumed exactly once.
- Add one best-effort LLM repair pass when consolidation output under-consumes same-source rows or splits highly overlapping sibling unifies.
- Promote playbook consolidation prompt v2.4.0 with explicit multi-NEW `unify` guidance, then tighten its body ~40% (89 → 54 rendered lines) with no behavioral rule removed.
- Keep explicit `model=None` LiteLLM calls falling back to the configured default model.

## Motivation
A real duplicate was stored locally (playbook rows 7/8: same request, same `source_interaction_ids`, row 7 a strict content superset of row 8). The consolidator merged facts from two same-batch NEW candidates but marked only one as consumed, so the apply-path safety fallback re-inserted the other raw candidate alongside the merged row. The prompt/schema contract allowed this: the prompt said "one decision per NEW candidate" while the schema already accepted multi-NEW `new_id` lists.

## Changes
- **Consolidator** (`components/consolidator.py`):
  - `validate_consolidation_output` — pre-apply partition check: unknown / missing / cross-decision-duplicate NEW ids are repairable errors (the duplicate check also closes a double-insert hole where one NEW id referenced by two decisions was applied twice).
  - Suspicious-output guard with storage-effect semantics: a `unify`'s content is compared against same-source rows another decision still stores — raw candidate content for `independent`/`differentiate`, final `decision.content` pairwise for sibling unifies (each persists a survivor row; pairs flagged once). `reject_new` is exempt — it stores nothing.
  - One repair LLM call per batch (shared across both triggers), sent as a follow-up turn of the original conversation — [user: rendered consolidation prompt, assistant: the invalid decisions, user: validation errors + fix instruction] — so the model keeps full first-turn context; re-validated; on failure the original output applies and the existing no-data-loss safety fallback stands. Repair I/O goes through `log_llm_messages`/`log_model_response` and emits `consolidation_repair_attempted/repaired/repair_failed` events.
- **Prompt bank**: adds active v2.4.0 (partition contract, multi-NEW `new_id`, `archive_existing_ids` EXISTING-only, compact multi-NEW example) and retires v2.3.3. Body then tightened in-place: deduplicated the contract/no-self-contradiction statements and compressed kind definitions and output guidance; test-pinned strings kept verbatim.
- **LiteLLM client**: explicit `model=None` (as forwarded by the eval judges via `rubric.get("judge_model")`) now falls back to the config default instead of crashing on `None.lower()` during key resolution.
- **Test hermeticity**: `tests/server/llm/conftest.py` strips machine env overrides (`CLAUDE_SMART_HOST`, `EMBEDDING_PORT`, …) that `reflexio.server`'s import-time env loading leaks into unit tests; the fork-dependent pipe-drain test is skipped on non-fork platforms (macOS spawn).

## Test Plan
- `uv run pytest --no-cov tests/server/llm/ tests/server/services/playbook/ tests/server/services/test_prompt_model_mapping.py` — 985 passed, 67 skipped
- `uv run ruff check` / `uv run ruff format --check` / `uv run pyright` on all changed files — clean
- Prompt rendered through the real `PromptManager` (brace escaping, pinned strings verified)
- Prompt deviation guard (`tests.eval.prompt_deviation_guard`, real LLM, MiniMax-M3 judge), baseline 2.3.3 vs candidate 2.4.0:
  - long body: PASS — kind accuracy 0.6→0.8, judge accuracy 0.6→0.8, over-merge rate 0.5→0.0
  - tightened body: PASS — all metrics matched baseline (kind/judge accuracy 0.8, all rates 0.0)
- Regression tests modeled on the observed rows-7/8 duplicate, including a real-SQLite integration test at the finalization boundary asserting exactly one merged row survives

## Follow-ups
- Merged on 2026-07-09 as OSS `origin/main` commit `e28af891`. Downstream submodule pins should use this merged main SHA rather than the feature-branch SHA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced playbook consolidation with stricter NEW-id coverage checks and automatic best-effort repair when the model output is incomplete or suspicious.
* **Bug Fixes**
  * Explicit `model=None` requests now correctly fall back to the configured default model.
  * Repairs are validated before applying changes, reducing the risk of item loss during consolidation.
* **Chores**
  * Activated the `v2.4.0` playbook consolidation prompt and disabled the older `v2.3.3` variant.
  * Improved test isolation and added/expanded consolidation and prompt validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->