### PR TITLE
fix(storage): preserve evaluation embeddings

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
@@ -36,11 +36,12 @@ class AgentEvaluationResultStoreMixin:
         self, results: list[AgentSuccessEvaluationResult]
     ) -> None:
         for result in results:
-            embedding_text = f"{result.failure_type} {result.failure_reason}"
-            if embedding_text.strip():
-                result.embedding = self._get_embedding(embedding_text)
-            else:
-                result.embedding = []
+            if not result.embedding:
+                embedding_text = f"{result.failure_type} {result.failure_reason}"
+                if embedding_text.strip():
+                    result.embedding = self._get_embedding(embedding_text)
+                else:
+                    result.embedding = []
 
             created_at_iso = _epoch_to_iso(result.created_at)
             subject_ref = self._subject_ref_for_user_id(result.user_id)


### PR DESCRIPTION
## Summary
- Preserve precomputed `AgentSuccessEvaluationResult.embedding` values when saving SQLite evaluation results.
- Keep local tau/offline-tuner evidence imports aligned with Supabase behavior when campaign evidence already carries embeddings.

## Test Plan
- `uv run ruff check reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how evaluation results are saved so existing embedding values are preserved instead of being overwritten.
  * When no embedding is provided, the app now generates one only when there is meaningful text available; otherwise, it stores an empty value safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->