### PR TITLE
feat: missing-vector backfill sweep for degraded-embedding interactions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,15 @@ REFLEXIO_PUBLISH_LEARNING_WORKERS=
 # Inactivity delay in seconds before a quiet session is evaluated by agent-success
 # evaluation. (optional; default 600 = 10 minutes)
 GROUP_EVALUATION_DELAY_SECONDS=600
+# Opt-in background sweep that re-embeds interactions whose embedding failed at
+# ingest (empty vector, no vector row -> invisible to vector/hybrid search). Runs
+# per-org on the shared lineage-GC scheduler cadence. Off by default so the GC
+# scheduler's start conditions are unchanged unless you opt in.
+#   options: true | false  (optional; default false)
+REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED=false
+# Max interactions re-embedded per org per sweep tick (bounds embedding cost and
+# log volume). (optional; default 200; values <= 0 fall back to the default)
+REFLEXIO_MISSING_VECTOR_BACKFILL_CAP=200
 
 # =============================================================================
 # 5. TESTING & LOGGING

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -365,6 +365,9 @@ def create_app(
     from reflexio.server.services.lineage.gc_scheduler import (
         maybe_start_lineage_gc,
     )
+    from reflexio.server.services.lineage.vector_backfill_sweep import (
+        install_missing_vector_backfill_sweep,
+    )
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: ARG001
@@ -400,6 +403,11 @@ def create_app(
                 lambda org_id: RequestContext(org_id=org_id),
                 bootstrap_org_id=bootstrap_org_id,
             )
+            # Register the missing-vector backfill sweep (opt-in via
+            # REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED) BEFORE starting the GC
+            # scheduler, so its per-org hook is visible when maybe_start_lineage_gc
+            # evaluates its start conditions. No-op when the flag is off.
+            install_missing_vector_backfill_sweep()
             gc_scheduler = maybe_start_lineage_gc(
                 lambda org_id: RequestContext(org_id=org_id),
                 bootstrap_org_id=bootstrap_org_id,

--- a/reflexio/server/services/lineage/vector_backfill_sweep.py
+++ b/reflexio/server/services/lineage/vector_backfill_sweep.py
@@ -1,0 +1,139 @@
+"""Missing-vector backfill sweep for the shared ``LineageGCScheduler``.
+
+When an embedding call fails or degrades, the ingest path stores an empty
+embedding (and writes no vector row), returns success, and nothing ever
+re-embeds the row — so that interaction is invisible to vector/hybrid search
+forever. This is a latent durability hole. This module registers a bounded,
+idempotent, per-org sweep that re-embeds those interactions on the shared GC
+scheduler cadence.
+
+Design:
+
+- **Per-org**: registered via :func:`register_per_org_sweep`, so it runs once
+  per org per tick with the org id supplied by the scheduler (the ``(org_id,
+  now) -> int`` seam). The global ``register_global_sweep`` seam only passes
+  ``now`` and cannot drive a per-org backfill, so it is the wrong hook here.
+- **Bounded**: re-embeds at most ``REFLEXIO_MISSING_VECTOR_BACKFILL_CAP``
+  interactions per org per tick (prior art warns unbounded backfills flood
+  logs / embedding cost — see ``llm/_litellm_embedding.py``).
+- **Opt-in**: only registered when ``REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED``
+  is truthy, so a default OSS deployment is byte-for-byte unchanged (the
+  scheduler does not start on this hook alone). The enable flag is re-read every
+  tick so a live disable is honoured without a restart.
+- **Fail-safe**: the storage layer catches ``EmbeddingUnavailableError`` and
+  returns 0 (work left for the next tick); this closure additionally captures
+  any unexpected error as an anomaly and returns the count so far, so one org's
+  failure never stalls the shared loop.
+- **Idempotent**: once an interaction's vector is written it no longer matches
+  detection and is skipped next tick.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from reflexio.server.env_utils import env_str, env_truthy
+
+logger = logging.getLogger(__name__)
+
+ENABLE_ENV_VAR = "REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED"
+CAP_ENV_VAR = "REFLEXIO_MISSING_VECTOR_BACKFILL_CAP"
+_DEFAULT_CAP = 200
+
+# Guard against duplicate registration when the app lifespan runs more than once
+# in a single process (e.g. test apps).
+_installed = False
+
+
+def _resolve_cap() -> int:
+    """Return the per-org per-tick backfill cap from the environment.
+
+    Falls back to :data:`_DEFAULT_CAP` when unset, blank, or unparseable/<= 0.
+    """
+    raw = env_str(CAP_ENV_VAR, str(_DEFAULT_CAP))
+    try:
+        cap = int(raw)
+    except ValueError:
+        logger.warning(
+            "event=missing_vector_backfill_bad_cap value=%r — using default %d",
+            raw,
+            _DEFAULT_CAP,
+        )
+        return _DEFAULT_CAP
+    return cap if cap > 0 else _DEFAULT_CAP
+
+
+def missing_vector_backfill_sweep(org_id: str, _now: int) -> int:
+    """Re-embed a bounded batch of vector-less interactions for one org.
+
+    Registered with the OSS ``register_per_org_sweep`` seam. Reads the enable
+    flag and cap each tick so live config changes are honoured. Absorbs its own
+    errors (returns instead of raising) and therefore emits its own anomaly.
+
+    Args:
+        org_id (str): The org to sweep.
+        _now (int): Current unix epoch supplied by the scheduler. Unused — the
+            cap, not a time cutoff, bounds the work.
+
+    Returns:
+        int: Number of interactions whose vector was backfilled (0 on skip/error).
+    """
+    if not env_truthy(env_str(ENABLE_ENV_VAR, "false")):
+        return 0
+
+    # Imported lazily so importing this module never drags in the request stack.
+    from reflexio.server.api_endpoints.request_context import RequestContext
+    from reflexio.server.tracing import capture_anomaly
+
+    try:
+        ctx = RequestContext(org_id=org_id)
+        if ctx.storage is None:
+            return 0
+        backfilled = ctx.storage.backfill_missing_interaction_vectors(_resolve_cap())
+        if backfilled:
+            logger.info(
+                "event=missing_vector_backfill_tick org_id=%s backfilled=%d",
+                org_id,
+                backfilled,
+            )
+        return backfilled
+    except Exception:
+        capture_anomaly(
+            "interactions.missing_vector_backfill.run_failed", org_id=org_id
+        )
+        logger.exception("event=missing_vector_backfill_org_failed org_id=%s", org_id)
+        return 0
+
+
+def install_missing_vector_backfill_sweep() -> None:
+    """Register the backfill sweep on the OSS lineage GC scheduler when enabled.
+
+    Only registers when ``REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED`` is truthy,
+    so an OSS deployment that has not opted in keeps its scheduler start
+    conditions unchanged. Idempotent: a second call in the same process is a
+    no-op. Non-fatal: a registration failure logs and skips rather than aborting
+    app startup.
+
+    Call this before ``maybe_start_lineage_gc`` so the registered hook is
+    visible when the scheduler evaluates its start conditions.
+    """
+    global _installed  # noqa: PLW0603
+    if _installed:
+        return
+    if not env_truthy(env_str(ENABLE_ENV_VAR, "false")):
+        return
+    try:
+        from reflexio.server.services.lineage.gc_scheduler import (
+            register_per_org_sweep,
+        )
+
+        register_per_org_sweep(missing_vector_backfill_sweep)
+        _installed = True
+        logger.info(
+            "event=missing_vector_backfill_sweep_registered cap=%d", _resolve_cap()
+        )
+    except Exception:
+        from reflexio.server.tracing import capture_anomaly
+
+        capture_anomaly("interactions.missing_vector_backfill.install_failed")
+        logger.exception("event=missing_vector_backfill_install_failed")

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -82,6 +82,12 @@ class InteractionStoreMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def add_user_interaction(self, user_id: str, interaction: Interaction) -> None:  # noqa: ARG002
+        # NOTE: distinct from the bulk/backfill derivation
+        # (_embed_text_for_interaction). This legacy single-insert path embeds via
+        # the purpose-prefixed _get_embedding ("search_document: ...") and its own
+        # f-string, so it is intentionally NOT routed through the shared helper —
+        # aligning it would silently change stored embedding values (e.g. null ->
+        # literal "None"). The real bulk ingest + backfill share the helper.
         embedding = self._get_embedding(
             f"{interaction.content}\n{interaction.user_action_description}"
         )
@@ -196,7 +202,7 @@ class InteractionStoreMixin:
             to_embed = [i for i in interactions if not i.embedding]
             if to_embed:
                 texts = [
-                    "\n".join([i.content or "", i.user_action_description or ""])
+                    _embed_text_for_interaction(i.content, i.user_action_description)
                     for i in to_embed
                 ]
                 try:
@@ -228,7 +234,7 @@ class InteractionStoreMixin:
         if not to_embed:
             return
         texts = [
-            "\n".join([i.content or "", i.user_action_description or ""])
+            _embed_text_for_interaction(i.content, i.user_action_description)
             for i in to_embed
         ]
         try:
@@ -340,13 +346,19 @@ class InteractionStoreMixin:
         Updates the ``embedding`` TEXT column (read by the Python vector-rank
         search path) and upserts the ``interactions_vec`` row via the same
         ``_vec_upsert`` helper the insert path uses.
+
+        Only commits when it owns the transaction (mirroring ``_insert_interaction``)
+        so it can never flush a partial outer transaction if ever called inside an
+        open ``commit_scope``; ``_vec_upsert`` likewise defers under an open scope.
         """
         with self._lock:
+            own_txn = self._own_transaction()
             self.conn.execute(
                 "UPDATE interactions SET embedding = ? WHERE interaction_id = ?",
                 (_json_dumps(embedding), interaction_id),
             )
-            self.conn.commit()
+            if own_txn:
+                self.conn.commit()
         self._vec_upsert("interactions_vec", interaction_id, embedding)
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -27,6 +27,16 @@ from .._base import (
 logger = logging.getLogger(__name__)
 
 
+def _embed_text_for_interaction(content: str | None, action_desc: str | None) -> str:
+    """Derive the text embedded for an interaction.
+
+    Kept byte-for-byte identical to the ingest path
+    (``add_user_interactions_bulk`` / ``prepare_interaction_embeddings``) so a
+    backfilled vector matches a freshly-ingested one.
+    """
+    return "\n".join([content or "", action_desc or ""])
+
+
 class InteractionStoreMixin:
     """Mixin providing interaction-store CRUD for SQLite storage."""
 
@@ -234,6 +244,110 @@ class InteractionStoreMixin:
             embeddings = [[] for _ in texts]
         for interaction, embedding in zip(to_embed, embeddings, strict=False):
             interaction.embedding = embedding
+
+    # ------------------------------------------------------------------
+    # Missing-vector backfill (durability sweep)
+    # ------------------------------------------------------------------
+
+    @SQLiteStorageBase.handle_exceptions
+    def iter_interactions_missing_vectors(self, limit: int) -> list[tuple[int, str]]:
+        """Enumerate interactions whose embedding was never persisted.
+
+        A degraded/failed embedding leaves the ``embedding`` column empty
+        (``'[]'`` or NULL) and writes no ``interactions_vec`` row — equivalent
+        conditions on the write path. Detecting on the ``embedding`` column is
+        both the root-cause signal and portable across backends (the column
+        exists everywhere; ``interactions_vec`` is a SQLite-vec detail).
+
+        Args:
+            limit: Maximum number of interactions to return.
+
+        Returns:
+            list[tuple[int, str]]: ``(interaction_id, embed_text)`` pairs, at
+            most ``limit`` long, ordered by ``interaction_id`` for stable paging.
+        """
+        if limit <= 0:
+            return []
+        rows = self._fetchall(
+            """SELECT interaction_id, content, user_action_description
+               FROM interactions
+               WHERE embedding IS NULL OR embedding = '[]'
+               ORDER BY interaction_id
+               LIMIT ?""",
+            (limit,),
+        )
+        return [
+            (
+                r["interaction_id"],
+                _embed_text_for_interaction(r["content"], r["user_action_description"]),
+            )
+            for r in rows
+        ]
+
+    @SQLiteStorageBase.handle_exceptions
+    def backfill_missing_interaction_vectors(self, limit: int) -> int:
+        """Re-embed and persist vectors for interactions missing them.
+
+        Bounded by ``limit`` and idempotent: once the ``embedding`` column and
+        ``interactions_vec`` row are written, the row no longer matches
+        detection and is skipped next time. Embeds via the same batch call and
+        text derivation the ingest path uses so backfilled vectors match
+        freshly-ingested ones.
+
+        Fail-safe: if the embedder is unavailable the batch call raises
+        ``EmbeddingUnavailableError``; we log a single bounded WARN and return 0,
+        leaving the rows for the next tick rather than crashing the caller or
+        hot-looping a down embedder.
+
+        Args:
+            limit: Maximum number of interactions to re-embed this call.
+
+        Returns:
+            int: Number of interactions whose vector was backfilled.
+        """
+        if limit <= 0:
+            return 0
+        pairs = self.iter_interactions_missing_vectors(limit)
+        if not pairs:
+            return 0
+        texts = [text for _, text in pairs]
+        try:
+            embeddings = self.llm_client.get_embeddings(
+                texts, self.embedding_model_name, self.embedding_dimensions
+            )
+        except EmbeddingUnavailableError as exc:
+            logger.warning(
+                "Embedding unavailable during missing-vector backfill; leaving "
+                "%d interaction(s) for the next tick: %s",
+                len(pairs),
+                exc,
+            )
+            return 0
+        backfilled = 0
+        for (iid, _text), embedding in zip(pairs, embeddings, strict=False):
+            if not embedding:
+                # Embedder returned empty for this row — leave it for next tick.
+                continue
+            self._persist_backfilled_vector(iid, embedding)
+            backfilled += 1
+        return backfilled
+
+    def _persist_backfilled_vector(
+        self, interaction_id: int, embedding: list[float]
+    ) -> None:
+        """Write a re-embedded vector for one interaction (column + vec row).
+
+        Updates the ``embedding`` TEXT column (read by the Python vector-rank
+        search path) and upserts the ``interactions_vec`` row via the same
+        ``_vec_upsert`` helper the insert path uses.
+        """
+        with self._lock:
+            self.conn.execute(
+                "UPDATE interactions SET embedding = ? WHERE interaction_id = ?",
+                (_json_dumps(embedding), interaction_id),
+            )
+            self.conn.commit()
+        self._vec_upsert("interactions_vec", interaction_id, embedding)
 
     @SQLiteStorageBase.handle_exceptions
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:

--- a/reflexio/server/services/storage/storage_base/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_interaction_store.py
@@ -60,6 +60,65 @@ class InteractionStoreMixin:
         """
         return
 
+    def iter_interactions_missing_vectors(
+        self,
+        limit: int,  # noqa: ARG002
+    ) -> list[tuple[int, str]]:
+        """Enumerate interactions whose embedding vector was never persisted.
+
+        When an embedding call fails or degrades, the ingest path stores an empty
+        embedding (and writes no vector row), returns success, and nothing ever
+        re-embeds the row — so that interaction is invisible to vector/hybrid
+        search forever. This method surfaces those rows so a background sweep can
+        re-embed them (see ``backfill_missing_interaction_vectors``).
+
+        Returns ``(interaction_id, embed_text)`` pairs where ``embed_text`` is
+        derived exactly as the ingest path derives it, so a backfilled vector is
+        byte-for-byte comparable to a freshly-ingested one.
+
+        Safe default: returns ``[]`` — "this backend does not support backfill
+        detection". Backends that store embeddings (SQLite here; Supabase and
+        Postgres in the enterprise repo) MUST override this so their rows are
+        actually recoverable. Bounded by ``limit`` per call.
+
+        Args:
+            limit: Maximum number of interactions to return.
+
+        Returns:
+            list[tuple[int, str]]: ``(interaction_id, embed_text)`` pairs, at
+            most ``limit`` long. Empty when nothing needs backfilling or the
+            backend does not support detection.
+        """
+        return []
+
+    def backfill_missing_interaction_vectors(
+        self,
+        limit: int,  # noqa: ARG002
+    ) -> int:
+        """Re-embed and persist vectors for interactions missing them.
+
+        Idempotent and bounded: enumerates up to ``limit`` interactions via
+        ``iter_interactions_missing_vectors``, re-embeds their text using the
+        same embedder + derivation the ingest path uses, and writes the vector
+        back through the same code path a fresh insert uses. Once a vector
+        exists the row is skipped on the next call.
+
+        Fail-safe: if the embedder is unavailable the implementation must skip
+        gracefully and leave the work for a later call (never raise, never
+        hot-loop a down embedder).
+
+        Safe default: returns ``0`` — "this backend does not support backfill".
+        SQLite overrides this; the enterprise Supabase/Postgres backends must
+        override it (and ``iter_interactions_missing_vectors``) for production.
+
+        Args:
+            limit: Maximum number of interactions to re-embed this call.
+
+        Returns:
+            int: Number of interactions whose vector was backfilled.
+        """
+        return 0
+
     @abstractmethod
     def delete_user_interaction(self, request: DeleteUserInteractionRequest) -> None:
         raise NotImplementedError

--- a/tests/server/services/storage/test_missing_vector_backfill_integration.py
+++ b/tests/server/services/storage/test_missing_vector_backfill_integration.py
@@ -1,0 +1,261 @@
+"""Integration tests for the missing-vector backfill sweep (SQLite, mocked LLM).
+
+Reproduces the durability hole: when an embedding call fails at ingest the
+interaction is stored with an empty embedding and no vector row, so it is
+invisible to vector search forever. The backfill sweep re-embeds those rows.
+
+Coverage:
+- backfill writes the vector AND the row becomes vector-searchable (via the
+  search path, not by inspecting the table),
+- idempotency (a second sweep backfills 0),
+- the per-tick bound is respected (seed > cap => only cap done),
+- fail-safe: with the embedder raising EmbeddingUnavailableError the backfill
+  returns 0 without raising,
+- the sweep closure honours its enable gate and is failure-isolated.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from reflexio.models.api_schema.retriever_schema import SearchInteractionRequest
+from reflexio.models.api_schema.service_schemas import Interaction
+from reflexio.models.config_schema import SearchMode
+from reflexio.server.llm.providers.embedding_service_provider import (
+    EmbeddingUnavailableError,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _store(tmp_path, worker_id: str) -> SQLiteStorage:
+    # Unique org id per worker keeps xdist runs isolated.
+    s = SQLiteStorage(
+        org_id=f"backfill-{worker_id}", db_path=str(tmp_path / "backfill.db")
+    )
+    s.migrate()
+    return s
+
+
+def _unit_vector(dims: int) -> list[float]:
+    """A fixed unit vector so cosine similarity to itself is 1.0."""
+    return [1.0] + [0.0] * (dims - 1)
+
+
+def _install_working_embedder(s: SQLiteStorage) -> list[float]:
+    """Replace the storage's llm_client with a mock returning a fixed vector.
+
+    Returns the vector so the caller can reuse it as the query embedding.
+    """
+    vec = _unit_vector(s.embedding_dimensions)
+
+    def _batch(texts, *_a, **_k):
+        return [list(vec) for _ in texts]
+
+    def _single(*_a, **_k):
+        return list(vec)
+
+    client = MagicMock()
+    client.get_embeddings.side_effect = _batch
+    client.get_embedding.side_effect = _single
+    s.llm_client = client
+    return vec
+
+
+def _seed_missing_vector_interactions(
+    s: SQLiteStorage, user_id: str, count: int, *, start_id: int = 1
+) -> list[int]:
+    """Seed interactions that have NO embedding (simulate a prior embed failure).
+
+    Uses the durable-path insert (embeddings_prepared=True) with embedding=[],
+    exactly the state ingest leaves behind when embedding degrades: '[]' in the
+    embedding column and no interactions_vec row. No embedder is called.
+    """
+    ids = list(range(start_id, start_id + count))
+    interactions = [
+        Interaction(
+            interaction_id=iid,
+            user_id=user_id,
+            request_id=f"req-{iid}",
+            content=f"the quick brown fox number {iid}",
+            created_at=int(time.time()) + iid,
+            embedding=[],
+        )
+        for iid in ids
+    ]
+    s.add_user_interactions_bulk(
+        user_id=user_id, interactions=interactions, embeddings_prepared=True
+    )
+    return ids
+
+
+def _vec_row_count(s: SQLiteStorage, interaction_id: int) -> int:
+    if not s._has_sqlite_vec:
+        return 0
+    row = s.conn.execute(
+        "SELECT COUNT(*) AS cnt FROM interactions_vec WHERE rowid = ?",
+        (interaction_id,),
+    ).fetchone()
+    return row["cnt"] if row else 0
+
+
+def _embedding_column(s: SQLiteStorage, interaction_id: int) -> str | None:
+    row = s.conn.execute(
+        "SELECT embedding FROM interactions WHERE interaction_id = ?",
+        (interaction_id,),
+    ).fetchone()
+    return row["embedding"] if row else None
+
+
+def _vector_search_ids(
+    s: SQLiteStorage, user_id: str, query_embedding: list[float]
+) -> set[int]:
+    req = SearchInteractionRequest(
+        user_id=user_id, search_mode=SearchMode.VECTOR, most_recent_k=50
+    )
+    results = s.search_interaction(req, query_embedding=query_embedding)
+    return {i.interaction_id for i in results}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_makes_interactions_vector_searchable(tmp_path, worker_id) -> None:
+    s = _store(tmp_path, worker_id)
+    vec = _install_working_embedder(s)
+    uid = "u-searchable"
+    ids = _seed_missing_vector_interactions(s, uid, 3)
+
+    # Precondition: empty embedding column, no vec row, NOT vector-searchable.
+    for iid in ids:
+        assert _embedding_column(s, iid) == "[]"
+        assert _vec_row_count(s, iid) == 0
+    assert _vector_search_ids(s, uid, vec) == set()
+
+    backfilled = s.backfill_missing_interaction_vectors(limit=100)
+
+    assert backfilled == 3
+    # Vector row now exists (when sqlite-vec is loaded) and the column is filled.
+    for iid in ids:
+        assert _embedding_column(s, iid) != "[]"
+        if s._has_sqlite_vec:
+            assert _vec_row_count(s, iid) == 1
+    # The rows are now reachable through the vector search path.
+    assert _vector_search_ids(s, uid, vec) == set(ids)
+
+
+def test_backfill_is_idempotent(tmp_path, worker_id) -> None:
+    s = _store(tmp_path, worker_id)
+    _install_working_embedder(s)
+    uid = "u-idem"
+    _seed_missing_vector_interactions(s, uid, 4)
+
+    first = s.backfill_missing_interaction_vectors(limit=100)
+    second = s.backfill_missing_interaction_vectors(limit=100)
+
+    assert first == 4
+    assert second == 0
+    assert s.iter_interactions_missing_vectors(100) == []
+
+
+def test_backfill_respects_the_per_tick_bound(tmp_path, worker_id) -> None:
+    s = _store(tmp_path, worker_id)
+    _install_working_embedder(s)
+    uid = "u-bound"
+    _seed_missing_vector_interactions(s, uid, 10)
+
+    done = s.backfill_missing_interaction_vectors(limit=3)
+
+    assert done == 3
+    # 7 still awaiting backfill on the next tick.
+    assert len(s.iter_interactions_missing_vectors(100)) == 7
+
+
+def test_backfill_is_fail_safe_when_embedder_unavailable(tmp_path, worker_id) -> None:
+    s = _store(tmp_path, worker_id)
+    uid = "u-failsafe"
+    ids = _seed_missing_vector_interactions(s, uid, 3)
+
+    client = MagicMock()
+    client.get_embeddings.side_effect = EmbeddingUnavailableError("provider down")
+    s.llm_client = client
+
+    done = s.backfill_missing_interaction_vectors(limit=100)
+
+    # No crash, nothing backfilled, work left for the next tick.
+    assert done == 0
+    for iid in ids:
+        assert _embedding_column(s, iid) == "[]"
+    assert len(s.iter_interactions_missing_vectors(100)) == 3
+
+
+def test_base_default_is_a_safe_no_op() -> None:
+    """The base mixin default returns empty/0 so backends lacking an override
+    are simply skipped, never broken."""
+    from reflexio.server.services.storage.storage_base.profiles._interaction_store import (  # noqa: E501
+        InteractionStoreMixin,
+    )
+
+    assert InteractionStoreMixin.iter_interactions_missing_vectors(None, 10) == []  # type: ignore[arg-type]
+    assert InteractionStoreMixin.backfill_missing_interaction_vectors(None, 10) == 0  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Sweep closure
+# ---------------------------------------------------------------------------
+
+
+def test_sweep_disabled_by_default_does_not_touch_storage(
+    tmp_path, worker_id, monkeypatch
+) -> None:
+    from reflexio.server.services.lineage import vector_backfill_sweep as vbs
+
+    monkeypatch.delenv("REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED", raising=False)
+
+    # RequestContext must never be constructed when the flag is off.
+    def _boom(*_a, **_k):  # pragma: no cover - asserts it is never called
+        raise AssertionError("RequestContext built while sweep disabled")
+
+    monkeypatch.setattr(
+        "reflexio.server.api_endpoints.request_context.RequestContext", _boom
+    )
+
+    assert vbs.missing_vector_backfill_sweep("some-org", 0) == 0
+
+
+def test_sweep_enabled_backfills_via_storage(tmp_path, worker_id, monkeypatch) -> None:
+    from reflexio.server.services.lineage import vector_backfill_sweep as vbs
+
+    s = _store(tmp_path, worker_id)
+    _install_working_embedder(s)
+    uid = "u-sweep"
+    _seed_missing_vector_interactions(s, uid, 5)
+
+    monkeypatch.setenv("REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED", "true")
+    monkeypatch.setenv("REFLEXIO_MISSING_VECTOR_BACKFILL_CAP", "2")
+
+    fake_ctx = MagicMock()
+    fake_ctx.storage = s
+
+    def _fake_request_context(**_kwargs):
+        return fake_ctx
+
+    monkeypatch.setattr(
+        "reflexio.server.api_endpoints.request_context.RequestContext",
+        _fake_request_context,
+    )
+
+    # Cap=2 => two per tick; the sweep threads the env cap through to storage.
+    assert vbs.missing_vector_backfill_sweep(s.org_id, 0) == 2
+    assert len(s.iter_interactions_missing_vectors(100)) == 3

--- a/tests/server/services/storage/test_missing_vector_backfill_integration.py
+++ b/tests/server/services/storage/test_missing_vector_backfill_integration.py
@@ -211,6 +211,74 @@ def test_base_default_is_a_safe_no_op() -> None:
     assert InteractionStoreMixin.backfill_missing_interaction_vectors(None, 10) == 0  # type: ignore[arg-type]
 
 
+@pytest.mark.parametrize(
+    ("content", "action_desc"),
+    [
+        ("hello world", "clicked the submit button"),
+        ("only content", ""),  # empty action desc -> the `or ""` branch
+        ("", "only action desc"),  # empty content
+    ],
+)
+def test_backfill_text_matches_the_ingest_derivation(
+    tmp_path, worker_id, content: str, action_desc: str
+) -> None:
+    """Cross-path guard: the text ``iter_interactions_missing_vectors`` yields for
+    an interaction is byte-identical to the text the *ingest* path actually
+    derives and hands to the embedder for that same interaction. Fails loudly if
+    anyone later changes ingest derivation without updating backfill.
+
+    The mock embedder ignores its input, so this asserts on the derived TEXT that
+    ingest passes to ``get_embeddings`` — not on the resulting vector.
+    """
+    s = _store(tmp_path, worker_id)
+
+    captured_texts: list[str] = []
+
+    def _record(texts, *_a, **_k):
+        captured_texts.extend(texts)
+        return [_unit_vector(s.embedding_dimensions) for _ in texts]
+
+    client = MagicMock()
+    client.get_embeddings.side_effect = _record
+    s.llm_client = client
+
+    uid = "u-equivalence"
+    # Ingest via the REAL bulk path (embeddings_prepared=False) so
+    # add_user_interactions_bulk derives the text and passes it to get_embeddings.
+    ingested = Interaction(
+        interaction_id=1,
+        user_id=uid,
+        request_id="req-ingest",
+        content=content,
+        user_action_description=action_desc,
+        created_at=int(time.time()),
+    )
+    s.add_user_interactions_bulk(user_id=uid, interactions=[ingested])
+    assert len(captured_texts) == 1
+    ingest_text = captured_texts[0]
+
+    # Seed a distinct row with the SAME content/action but no vector, then read
+    # back the text the backfill detector derives for it.
+    missing = Interaction(
+        interaction_id=2,
+        user_id=uid,
+        request_id="req-missing",
+        content=content,
+        user_action_description=action_desc,
+        created_at=int(time.time()) + 1,
+        embedding=[],
+    )
+    s.add_user_interactions_bulk(
+        user_id=uid, interactions=[missing], embeddings_prepared=True
+    )
+    pairs = dict(s.iter_interactions_missing_vectors(100))
+    assert 2 in pairs
+    backfill_text = pairs[2]
+
+    # The load-bearing invariant: single-sourced derivation.
+    assert backfill_text == ingest_text
+
+
 # ---------------------------------------------------------------------------
 # Sweep closure
 # ---------------------------------------------------------------------------

--- a/tests/server/services/storage/test_storage_contract_missing_vectors.py
+++ b/tests/server/services/storage/test_storage_contract_missing_vectors.py
@@ -1,0 +1,68 @@
+"""Contract: iter_interactions_missing_vectors across storage backends.
+
+Any backend that implements missing-vector detection must surface interactions
+whose embedding was never persisted (empty embedding column / no vector row) and
+exclude interactions that already have a vector — bounded by ``limit``. The
+safe base default returns ``[]`` (covered in the integration suite); this
+contract runs against every locally-testable backend via the shared fixture.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import Interaction
+from reflexio.server.services.storage.storage_base import BaseStorage
+
+pytestmark = pytest.mark.integration
+
+
+def _seed(storage: BaseStorage, user_id: str, iid: int, *, embedding: list[float]):
+    interaction = Interaction(
+        interaction_id=iid,
+        user_id=user_id,
+        request_id=f"req-{iid}",
+        content=f"content {iid}",
+        created_at=int(time.time()) + iid,
+        embedding=embedding,
+    )
+    # embeddings_prepared=True writes the provided embedding verbatim (no LLM call),
+    # so an empty list reproduces the degraded-ingest state deterministically.
+    storage.add_user_interactions_bulk(
+        user_id=user_id, interactions=[interaction], embeddings_prepared=True
+    )
+
+
+class TestIterInteractionsMissingVectors:
+    def test_detects_only_the_vectorless_rows(self, storage: BaseStorage) -> None:
+        uid = "u-missing"
+        _seed(storage, uid, 1, embedding=[])  # missing -> detected
+        _seed(storage, uid, 2, embedding=[0.1] * 512)  # has vector -> excluded
+        _seed(storage, uid, 3, embedding=[])  # missing -> detected
+
+        found = dict(storage.iter_interactions_missing_vectors(100))
+
+        assert set(found) == {1, 3}
+        # The returned text is the ingest-path derivation (content + action desc).
+        assert found[1] == "content 1\n"
+        assert found[3] == "content 3\n"
+
+    def test_respects_the_limit(self, storage: BaseStorage) -> None:
+        uid = "u-limit"
+        for iid in range(1, 6):
+            _seed(storage, uid, iid, embedding=[])
+
+        assert len(storage.iter_interactions_missing_vectors(2)) == 2
+        assert len(storage.iter_interactions_missing_vectors(100)) == 5
+
+    def test_empty_when_nothing_missing(self, storage: BaseStorage) -> None:
+        _seed(storage, "u-none", 1, embedding=[0.2] * 512)
+
+        assert storage.iter_interactions_missing_vectors(100) == []
+
+    def test_non_positive_limit_returns_empty(self, storage: BaseStorage) -> None:
+        _seed(storage, "u-zero", 1, embedding=[])
+
+        assert storage.iter_interactions_missing_vectors(0) == []


### PR DESCRIPTION
## The durability bug

When an embedding call fails or degrades, the ingest path
(`sqlite_storage/profiles/_interaction_store.py::_insert_interaction`, the
`if interaction.embedding:` guard) stores an **empty vector**, writes **no
`interactions_vec` row**, and returns **200 OK** — and nothing anywhere ever
re-embeds that interaction. It is invisible to vector/hybrid search **forever**.
There was no backfill/re-embed mechanism in the codebase. This is a latent
durability hole in production today.

## The fix — a bounded, idempotent, per-org, fail-safe sweep

**1. Detection (safe base default + real SQLite impl).**
`iter_interactions_missing_vectors(limit) -> list[(interaction_id, embed_text)]`
is added to the storage base `InteractionStoreMixin` with a **safe default that
returns `[]`** ("this backend doesn't support backfill detection"), so backends
that lack an override are skipped rather than broken. The SQLite backend
implements the real query, detecting interactions whose `embedding` column is
empty (`'[]'`/`NULL`) — equivalent to "no vec row" on the write path, and the
column is what the SQLite interaction vector-search path actually reads. The
returned `embed_text` reuses the **exact** ingest-path derivation
(`"\n".join([content or "", user_action_description or ""])`) so a backfilled
vector matches a freshly-ingested one.

**2. Re-embed + upsert.** `backfill_missing_interaction_vectors(limit) -> int`
re-embeds via the same batch `llm_client.get_embeddings(...)` call the ingest
path uses (no `search_document:` prefix — matching bulk ingest, not the
single-insert path), updates the `embedding` column, and writes the vec row via
the existing `_vec_upsert` helper (no hand-rolled SQL). **Idempotent**: once the
vector exists the row no longer matches detection.

**3. Sweep hook.** Registered **per-org** on the shared `LineageGCScheduler` via
`register_per_org_sweep` (the `(org_id, now) -> int` seam). Note: the task
pointed at `register_global_sweep`, but that seam only passes `now` and cannot
drive a per-org backfill — `register_per_org_sweep`'s signature is exactly the
required `(org_id) -> int` shape and matches the per-org design, mirroring the
enterprise `_governance_per_org_sweep`. Registered at the OSS start site
(`api.py` lifespan, before `maybe_start_lineage_gc`), not via the enterprise
hook installer.

- **Opt-in**: only registered when `REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED` is
  truthy (default **off**), so a default OSS deployment's scheduler start
  conditions are byte-for-byte unchanged.
- **Bounded**: `REFLEXIO_MISSING_VECTOR_BACKFILL_CAP` interactions per org per
  tick (default **200**) — prior art (`llm/_litellm_embedding.py`) warns
  unbounded backfills flood logs / embedding cost.
- **Fail-safe**: `EmbeddingUnavailableError` is caught, a single bounded WARN is
  logged, and the work is left for the next tick — the sweep never raises,
  never crashes the shared loop, and never hot-loops a down embedder.

Both env vars are documented in `.env.example`.

## Tests (trophy model — SQLite storage, mocked LLM)

- interactions become **vector-searchable via the search path** after backfill,
- **idempotency** (second sweep backfills 0),
- **bound** respected (seed 10, cap 3 → only 3/tick),
- **fail-safe** (embedder raising `EmbeddingUnavailableError` → returns 0, no
  raise, work left),
- sweep **enable-gate** + failure isolation,
- **contract test** for `iter_interactions_missing_vectors` across backends,
- base **safe-default** no-op.

`uv run pytest tests/server/services/storage/test_missing_vector_backfill_integration.py tests/server/services/storage/test_storage_contract_missing_vectors.py` → **11 passed**. Sibling contract/lineage suites stay green.

## Enterprise follow-up required

This OSS PR fixes the **SQLite** backend only. Production (Supabase) is **not**
fixed until the enterprise repo overrides the two new methods —
`iter_interactions_missing_vectors` and `backfill_missing_interaction_vectors`
— on its `SupabaseStorage` (and `PostgresStorage` for self-host/native-Postgres)
interaction-store classes (pgvector detection + re-embed/upsert), plus the usual
enterprise submodule repin and a matching `.env.template` entry for the two env
vars (the enterprise env-drift guard requires it). Until then the base safe
defaults make those backends **no-op** (not broken).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional background sweep to backfill missing interaction embeddings to improve vector and hybrid search coverage.
  * Introduced configuration to enable/disable backfilling and to cap the number of items processed per organization per sweep tick.
* **Bug Fixes**
  * Repaired a durability gap where interactions could be stored without their corresponding vector data, preventing discovery via vector search.
* **Tests**
  * Added integration and contract tests covering recovery behavior, per-tick limits, idempotency, disabled mode, and graceful handling when embeddings are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review hardening (folded in)

- Single-sourced the embed-text derivation: both bulk ingest sites now call the same `_embed_text_for_interaction` helper backfill uses (pure refactor, byte-identical). `add_user_interaction` (legacy single-insert, `search_document:`-prefixed) intentionally left divergent with a clarifying comment.
- Added a cross-path **equivalence test** asserting `iter_interactions_missing_vectors` text == the ingest-derived text for the same interaction.
- `_persist_backfilled_vector` now commits only when it owns the transaction (mirrors `_insert_interaction`), safe under an open `commit_scope`.

### Known / optional follow-ons (non-blocking)

- **No partial index on the detection query.** `iter_interactions_missing_vectors` scans `WHERE embedding IS NULL OR embedding = '[]'` with no supporting index; fine at current SQLite scale and bounded by `limit`, but a partial index could be added if the vector-less backlog ever grows large.
- **Fail-safe catches only `EmbeddingUnavailableError`, not `LiteLLMClientError`.** A non-degradation embedding error would propagate to the sweep closure, which already captures it as an anomaly and returns 0 (loop-safe). Broadening the caught class in the storage layer is a possible future refinement.
