### PR TITLE
feat(scheduling): Workstream B Phase 1 — leader-gate seam, bounded org fan-out, shared callback executor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,6 +86,10 @@ REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED=false
 # Max interactions re-embedded per org per sweep tick (bounds embedding cost and
 # log volume). (optional; default 200; values <= 0 fall back to the default)
 REFLEXIO_MISSING_VECTOR_BACKFILL_CAP=200
+# Bounded per-tick org fan-out width for the lineage-GC / expiry-reclamation
+# scheduler. SQLite storage is pinned to serial (1) regardless of this value.
+# (optional; default 8; non-numeric or <=0 falls back to default)
+REFLEXIO_SCHEDULER_ORG_WORKERS=
 
 # =============================================================================
 # 5. TESTING & LOGGING

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -16,7 +16,6 @@ iterates (e.g. the QPS billable-endpoint scan over ``core_router.routes``).
 
 import inspect
 import logging
-import os
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
@@ -85,13 +84,19 @@ def _log_multi_worker_daemons() -> None:
     ``--workers N`` (N>1) runs the full daemon set in every worker process
     (duplicate ticking). Safe by the concurrent-tick invariant — every daemon
     tick is concurrent-safe — but worth one visible line (design D3).
+
+    Reuses ``embedder_warmup._detected_worker_count`` (checks
+    ``REFLEXIO_SERVER_WORKERS`` then falls back to ``WEB_CONCURRENCY``)
+    instead of re-implementing a narrower env read here. When the count is
+    undetectable (``None``), this logs nothing — it cannot verify the count,
+    so it must not assume a single worker.
     """
-    raw = os.environ.get("REFLEXIO_SERVER_WORKERS", "1")
-    try:
-        workers = int(raw)
-    except ValueError:
-        return
-    if workers > 1:
+    from reflexio.server.llm.providers.embedder_warmup import (
+        _detected_worker_count,
+    )
+
+    workers = _detected_worker_count()
+    if workers is not None and workers > 1:
         logger.warning(
             "event=multi_worker_daemons workers=%d — background daemons tick in "
             "every worker process (duplicate ticking; safe: ticks are "

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -16,6 +16,7 @@ iterates (e.g. the QPS billable-endpoint scan over ``core_router.routes``).
 
 import inspect
 import logging
+import os
 from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
@@ -76,6 +77,28 @@ __all__ = [
     "default_get_org_id",
     "limiter",
 ]
+
+
+def _log_multi_worker_daemons() -> None:
+    """Warn once at startup when multiple worker processes will run daemons.
+
+    ``--workers N`` (N>1) runs the full daemon set in every worker process
+    (duplicate ticking). Safe by the concurrent-tick invariant — every daemon
+    tick is concurrent-safe — but worth one visible line (design D3).
+    """
+    raw = os.environ.get("REFLEXIO_SERVER_WORKERS", "1")
+    try:
+        workers = int(raw)
+    except ValueError:
+        return
+    if workers > 1:
+        logger.warning(
+            "event=multi_worker_daemons workers=%d — background daemons tick in "
+            "every worker process (duplicate ticking; safe: ticks are "
+            "concurrent-safe by design)",
+            workers,
+        )
+
 
 # ``core_router`` stays an aggregator: it ``include_router``s every domain
 # sub-router so ``core_router.routes`` still enumerates all data-plane handlers
@@ -389,6 +412,7 @@ def create_app(
         run_startup_config_guards()
         maybe_start_embedder_warmup()
         if mounts_data_plane:
+            _log_multi_worker_daemons()
             log_publish_hardware_capacity()
             validate_llm_availability()
             from reflexio.server.llm.rerank import prewarm as _prewarm_cross_encoder

--- a/reflexio/server/callback_executor.py
+++ b/reflexio/server/callback_executor.py
@@ -17,6 +17,7 @@ import threading
 import time
 from collections import deque
 from collections.abc import Callable
+from typing import NamedTuple
 
 from reflexio.server.tracing import capture_anomaly
 
@@ -26,6 +27,19 @@ _WORKERS = 16
 _QUEUE_SIZE = 256
 _DROP_RATE_PER_MINUTE = 10
 _DROP_ANOMALY_THROTTLE_SECONDS = 3600.0
+
+
+class _DropFacts(NamedTuple):
+    """Facts about one drop, collected while ``_cond`` is held.
+
+    Carries everything :meth:`BoundedCallbackExecutor._emit_drop` needs to log
+    + escalate AFTER the lock is released, so the contended lock is never held
+    across a logging/anomaly call.
+    """
+
+    dropped_name: str
+    drops_last_minute: int
+    fire_anomaly: bool
 
 
 class BoundedCallbackExecutor:
@@ -58,28 +72,59 @@ class BoundedCallbackExecutor:
             name: Short label for logs (e.g. the scheduler key).
             fn: Zero-arg callback to run on a worker.
         """
+        drop_facts: _DropFacts | None = None
         with self._cond:
             if len(self._queue) >= self._queue_size:
                 dropped_name, _ = self._queue.popleft()
-                self._record_drop_locked(dropped_name)
+                drop_facts = self._record_drop_locked(dropped_name)
             self._queue.append((name, fn))
             self._cond.notify()
+        if drop_facts is not None:
+            self._emit_drop(drop_facts)
 
-    def _record_drop_locked(self, dropped_name: str) -> None:
-        """Log one drop and escalate a throttled anomaly on sustained overflow."""
+    def _record_drop_locked(self, dropped_name: str) -> _DropFacts:
+        """Collect the facts of one drop while ``self._cond`` is held.
+
+        Only bookkeeping happens under the lock (all 16 workers + all
+        producers contend on it): pruning the rolling drop-time window and
+        deciding — and, if firing, committing — the throttle state
+        (``_last_drop_anomaly``) so the decision stays race-free. Logging and
+        anomaly emission are the caller's job, done AFTER the lock is
+        released (see :meth:`_emit_drop`).
+        """
         now = time.monotonic()
-        logger.warning("event=callback_executor_drop_oldest dropped=%s", dropped_name)
         self._drop_times.append(now)
         while self._drop_times and now - self._drop_times[0] > 60.0:
             self._drop_times.popleft()
-        if (
-            len(self._drop_times) > _DROP_RATE_PER_MINUTE
+        drops_last_minute = len(self._drop_times)
+        fire_anomaly = (
+            drops_last_minute > _DROP_RATE_PER_MINUTE
             and now - self._last_drop_anomaly > _DROP_ANOMALY_THROTTLE_SECONDS
-        ):
+        )
+        if fire_anomaly:
             self._last_drop_anomaly = now
+        return _DropFacts(
+            dropped_name=dropped_name,
+            drops_last_minute=drops_last_minute,
+            fire_anomaly=fire_anomaly,
+        )
+
+    def _emit_drop(self, facts: _DropFacts) -> None:
+        """Log one drop and (if decided under the lock) escalate the anomaly.
+
+        Called with ``self._cond`` NOT held — logging and ``capture_anomaly``
+        never happen while the contended lock is owned. References the
+        module-level ``capture_anomaly`` name (not a bound attribute) so
+        tests that ``monkeypatch.setattr(module, "capture_anomaly", ...)``
+        still intercept the call.
+        """
+        logger.warning(
+            "event=callback_executor_drop_oldest dropped=%s", facts.dropped_name
+        )
+        if facts.fire_anomaly:
             capture_anomaly(
                 "callback_executor.drop_rate_exceeded",
-                drops_last_minute=len(self._drop_times),
+                drops_last_minute=facts.drops_last_minute,
             )
 
     def _worker_loop(self) -> None:
@@ -90,7 +135,11 @@ class BoundedCallbackExecutor:
                 name, fn = self._queue.popleft()
             try:
                 fn()
-            except Exception:  # noqa: BLE001 — one callback never kills a worker
+            except BaseException:  # noqa: BLE001 — daemon worker threads must
+                # survive anything a callback raises (including a callback
+                # that itself raises SystemExit); KeyboardInterrupt is only
+                # ever delivered to the main thread, so swallowing it here is
+                # safe. The fixed 16-worker pool must never silently shrink.
                 logger.exception(
                     "event=callback_executor_callback_failed name=%s", name
                 )

--- a/reflexio/server/callback_executor.py
+++ b/reflexio/server/callback_executor.py
@@ -1,0 +1,115 @@
+"""Process-wide bounded executor for deferred fire-and-forget callbacks.
+
+Replaces thread-per-fire in the debounce schedulers (tagging, group
+evaluation, playbook optimization) so thread count is O(1) instead of
+O(active keys) (spec section 6.2). Sizes are module constants, not env vars.
+
+Overflow policy: drop-oldest (a dropped fire is a stale debounced trigger —
+the next event for that key re-creates it) with one warning log per drop and
+a throttled anomaly when drops exceed ``_DROP_RATE_PER_MINUTE`` in a rolling
+minute (the "this is routine, resize it" signal).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+
+from reflexio.server.tracing import capture_anomaly
+
+logger = logging.getLogger(__name__)
+
+_WORKERS = 16
+_QUEUE_SIZE = 256
+_DROP_RATE_PER_MINUTE = 10
+_DROP_ANOMALY_THROTTLE_SECONDS = 3600.0
+
+
+class BoundedCallbackExecutor:
+    """Fixed worker pool + bounded FIFO queue with drop-oldest overflow.
+
+    Args:
+        workers: Number of daemon worker threads.
+        queue_size: Max queued callbacks before drop-oldest applies.
+    """
+
+    def __init__(
+        self, *, workers: int = _WORKERS, queue_size: int = _QUEUE_SIZE
+    ) -> None:
+        self._queue: deque[tuple[str, Callable[[], None]]] = deque()
+        self._queue_size = queue_size
+        self._cond = threading.Condition()
+        self._drop_times: deque[float] = deque()
+        self._last_drop_anomaly = 0.0
+        for i in range(workers):
+            threading.Thread(
+                target=self._worker_loop,
+                daemon=True,
+                name=f"callback-exec-{i}",
+            ).start()
+
+    def submit(self, name: str, fn: Callable[[], None]) -> None:
+        """Enqueue a callback; on a full queue, evict the oldest queued fire.
+
+        Args:
+            name: Short label for logs (e.g. the scheduler key).
+            fn: Zero-arg callback to run on a worker.
+        """
+        with self._cond:
+            if len(self._queue) >= self._queue_size:
+                dropped_name, _ = self._queue.popleft()
+                self._record_drop_locked(dropped_name)
+            self._queue.append((name, fn))
+            self._cond.notify()
+
+    def _record_drop_locked(self, dropped_name: str) -> None:
+        """Log one drop and escalate a throttled anomaly on sustained overflow."""
+        now = time.monotonic()
+        logger.warning("event=callback_executor_drop_oldest dropped=%s", dropped_name)
+        self._drop_times.append(now)
+        while self._drop_times and now - self._drop_times[0] > 60.0:
+            self._drop_times.popleft()
+        if (
+            len(self._drop_times) > _DROP_RATE_PER_MINUTE
+            and now - self._last_drop_anomaly > _DROP_ANOMALY_THROTTLE_SECONDS
+        ):
+            self._last_drop_anomaly = now
+            capture_anomaly(
+                "callback_executor.drop_rate_exceeded",
+                drops_last_minute=len(self._drop_times),
+            )
+
+    def _worker_loop(self) -> None:
+        while True:
+            with self._cond:
+                while not self._queue:
+                    self._cond.wait()
+                name, fn = self._queue.popleft()
+            try:
+                fn()
+            except Exception:  # noqa: BLE001 — one callback never kills a worker
+                logger.exception(
+                    "event=callback_executor_callback_failed name=%s", name
+                )
+
+
+_executor: BoundedCallbackExecutor | None = None
+_executor_lock = threading.Lock()
+
+
+def submit_callback(name: str, fn: Callable[[], None]) -> None:
+    """Submit to the lazily-created process-wide executor.
+
+    Args:
+        name: Short label for logs.
+        fn: Zero-arg callback.
+    """
+    global _executor  # noqa: PLW0603
+    if _executor is None:
+        with _executor_lock:
+            if _executor is None:
+                _executor = BoundedCallbackExecutor()
+    _executor.submit(name, fn)

--- a/reflexio/server/org_fanout.py
+++ b/reflexio/server/org_fanout.py
@@ -6,6 +6,19 @@ and abandoned (not joined) at the end so a stuck org cannot eat a slot across
 ticks; stragglers finish in the background. Python cannot kill threads —
 "timeout" means stop waiting + log, and the caller escalates repeats.
 
+Each org's actual start/end time is tracked, so timeout classification is
+honest about queue-wait vs. run-time: an org that never got a worker before
+its wait elapsed is STARVED (not counted as a timeout, not retried); an org
+that has run for less than the budget gets one more wait for the remaining
+budget; only an org that has genuinely run for >= the budget is reported as
+timed out. Each future is waited on for at most ~2x the budget.
+
+Abandonment is per-tick, not process-wide: ``ThreadPoolExecutor`` worker
+threads are non-daemon, so CPython still joins ALL of them at interpreter
+exit — a forever-hung ``fn`` can block graceful process shutdown until the
+orchestrator's kill grace expires; ``shutdown(wait=False)`` here only frees
+the NEXT tick's capacity, not exit-time joining.
+
 Error isolation is the caller's contract: ``fn`` must catch its own per-org
 exceptions (LineageGC's sweep body already does); this helper only
 backstop-logs unexpected escapes.
@@ -15,6 +28,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from collections.abc import Callable, Iterable
 from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
@@ -36,15 +50,21 @@ def iterate_orgs_bounded(
         org_ids (Iterable[str]): Orgs to process this tick.
         fn (Callable[[str], None]): Per-org work body; must handle its own errors.
         max_workers (int): Pool width; ``<= 1`` runs serially with no pool.
-        per_org_timeout_seconds (float): Max seconds to wait per org before
-            logging ``event=org_sweep_timeout`` and moving on (the straggler
-            thread keeps running in the background).
+        per_org_timeout_seconds (float): Run-time budget per org (not
+            queue-wait time). An org that never got a worker before its wait
+            elapsed is logged as ``event=org_sweep_starved`` and excluded
+            from the result (not timed out, not retried). An org that has
+            actually run for less than the budget is given one more wait for
+            the remaining budget; only once it has genuinely run for at
+            least the budget is it logged as ``event=org_sweep_timeout`` and
+            moved on (the straggler thread keeps running in the background).
         stop_event (threading.Event | None): When set, stop submitting new
             orgs; in-flight orgs finish (matches serial-loop shutdown semantics).
 
     Returns:
-        list[str]: Org ids that timed out this call (callers track repeats
-        across ticks and escalate).
+        list[str]: Org ids that genuinely timed out this call (ran for at
+        least the budget without finishing); starved orgs are excluded.
+        Callers track repeats across ticks and escalate.
     """
     timed_out: list[str] = []
     if max_workers <= 1:
@@ -54,6 +74,19 @@ def iterate_orgs_bounded(
             fn(org_id)
         return timed_out
 
+    starts: dict[str, float] = {}
+    ends: dict[str, float] = {}
+    record_lock = threading.Lock()
+
+    def _tracked(org_id: str) -> None:
+        with record_lock:
+            starts[org_id] = time.monotonic()
+        try:
+            fn(org_id)
+        finally:
+            with record_lock:
+                ends[org_id] = time.monotonic()
+
     executor = ThreadPoolExecutor(
         max_workers=max_workers, thread_name_prefix="org-fanout"
     )
@@ -62,23 +95,90 @@ def iterate_orgs_bounded(
         for org_id in org_ids:
             if stop_event is not None and stop_event.is_set():
                 break
-            futures.append((org_id, executor.submit(fn, org_id)))
+            futures.append((org_id, executor.submit(_tracked, org_id)))
         for org_id, future in futures:
-            try:
-                future.result(timeout=per_org_timeout_seconds)
-            except FuturesTimeoutError:
+            if _wait_for_org(
+                org_id,
+                future,
+                per_org_timeout_seconds=per_org_timeout_seconds,
+                starts=starts,
+                ends=ends,
+                lock=record_lock,
+            ):
                 timed_out.append(org_id)
-                logger.warning(
-                    "event=org_sweep_timeout org_id=%s timeout_seconds=%s",
-                    org_id,
-                    per_org_timeout_seconds,
-                )
-            except Exception:
-                # fn owns error isolation; anything escaping is a bug — log,
-                # never let one org's escape skip the remaining result waits.
-                logger.exception("event=org_fanout_unexpected_error org_id=%s", org_id)
     finally:
         # Per-tick pool, abandoned not joined (spec 6.1): stragglers finish in
         # the background; the NEXT tick gets a fresh pool and full width.
         executor.shutdown(wait=False)
     return timed_out
+
+
+def _wait_for_org(
+    org_id: str,
+    future: Future[None],
+    *,
+    per_org_timeout_seconds: float,
+    starts: dict[str, float],
+    ends: dict[str, float],
+    lock: threading.Lock,
+) -> bool:
+    """Wait for one org's future; return True iff it genuinely timed out.
+
+    Classifies a ``FuturesTimeoutError`` honestly instead of treating
+    queue-wait as run time: an org with no recorded start never got a
+    worker (STARVED — logged, not counted as a timeout, no further wait); an
+    org that has run for less than the budget gets one more wait for the
+    remaining budget. Total wait per org is bounded to ~2x the budget.
+
+    Args:
+        org_id (str): The org this future belongs to.
+        future (Future[None]): The submitted future for ``org_id``.
+        per_org_timeout_seconds (float): The run-time budget for this org.
+        starts (dict[str, float]): Monotonic start times, keyed by org id.
+        ends (dict[str, float]): Monotonic end times, keyed by org id.
+        lock (threading.Lock): Guards ``starts``/``ends``.
+
+    Returns:
+        bool: True if the org genuinely timed out (ran >= the budget without
+        finishing); False if it completed, was starved, or raised an
+        unexpected error.
+    """
+    try:
+        future.result(timeout=per_org_timeout_seconds)
+        return False
+    except FuturesTimeoutError:
+        pass
+    except Exception:
+        # fn owns error isolation; anything escaping is a bug — log, never
+        # let one org's escape skip the remaining result waits.
+        logger.exception("event=org_fanout_unexpected_error org_id=%s", org_id)
+        return False
+
+    with lock:
+        start = starts.get(org_id)
+        finished = org_id in ends
+    if finished:
+        # Completed between the timeout firing and this check — not a timeout.
+        return False
+    if start is None:
+        logger.warning("event=org_sweep_starved org_id=%s", org_id)
+        return False
+
+    elapsed_running = time.monotonic() - start
+    remaining = per_org_timeout_seconds - elapsed_running
+    if remaining > 0:
+        try:
+            future.result(timeout=remaining)
+            return False
+        except FuturesTimeoutError:
+            pass
+        except Exception:
+            logger.exception("event=org_fanout_unexpected_error org_id=%s", org_id)
+            return False
+
+    logger.warning(
+        "event=org_sweep_timeout org_id=%s timeout_seconds=%s",
+        org_id,
+        per_org_timeout_seconds,
+    )
+    return True

--- a/reflexio/server/org_fanout.py
+++ b/reflexio/server/org_fanout.py
@@ -1,0 +1,84 @@
+"""Bounded parallel org iteration for org-walking daemon ticks.
+
+Replaces serial ``for org_id in org_ids`` loops in daemon ticks with a
+bounded per-tick thread pool (spec section 6.1). The pool is created per call
+and abandoned (not joined) at the end so a stuck org cannot eat a slot across
+ticks; stragglers finish in the background. Python cannot kill threads —
+"timeout" means stop waiting + log, and the caller escalates repeats.
+
+Error isolation is the caller's contract: ``fn`` must catch its own per-org
+exceptions (LineageGC's sweep body already does); this helper only
+backstop-logs unexpected escapes.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable, Iterable
+from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+def iterate_orgs_bounded(
+    org_ids: Iterable[str],
+    fn: Callable[[str], None],
+    *,
+    max_workers: int,
+    per_org_timeout_seconds: float,
+    stop_event: threading.Event | None = None,
+) -> list[str]:
+    """Run ``fn(org_id)`` for each org with bounded concurrency and a per-org timeout.
+
+    Args:
+        org_ids (Iterable[str]): Orgs to process this tick.
+        fn (Callable[[str], None]): Per-org work body; must handle its own errors.
+        max_workers (int): Pool width; ``<= 1`` runs serially with no pool.
+        per_org_timeout_seconds (float): Max seconds to wait per org before
+            logging ``event=org_sweep_timeout`` and moving on (the straggler
+            thread keeps running in the background).
+        stop_event (threading.Event | None): When set, stop submitting new
+            orgs; in-flight orgs finish (matches serial-loop shutdown semantics).
+
+    Returns:
+        list[str]: Org ids that timed out this call (callers track repeats
+        across ticks and escalate).
+    """
+    timed_out: list[str] = []
+    if max_workers <= 1:
+        for org_id in org_ids:
+            if stop_event is not None and stop_event.is_set():
+                break
+            fn(org_id)
+        return timed_out
+
+    executor = ThreadPoolExecutor(
+        max_workers=max_workers, thread_name_prefix="org-fanout"
+    )
+    futures: list[tuple[str, Future[None]]] = []
+    try:
+        for org_id in org_ids:
+            if stop_event is not None and stop_event.is_set():
+                break
+            futures.append((org_id, executor.submit(fn, org_id)))
+        for org_id, future in futures:
+            try:
+                future.result(timeout=per_org_timeout_seconds)
+            except FuturesTimeoutError:
+                timed_out.append(org_id)
+                logger.warning(
+                    "event=org_sweep_timeout org_id=%s timeout_seconds=%s",
+                    org_id,
+                    per_org_timeout_seconds,
+                )
+            except Exception:
+                # fn owns error isolation; anything escaping is a bug — log,
+                # never let one org's escape skip the remaining result waits.
+                logger.exception("event=org_fanout_unexpected_error org_id=%s", org_id)
+    finally:
+        # Per-tick pool, abandoned not joined (spec 6.1): stragglers finish in
+        # the background; the NEXT tick gets a fresh pool and full width.
+        executor.shutdown(wait=False)
+    return timed_out

--- a/reflexio/server/scheduling.py
+++ b/reflexio/server/scheduling.py
@@ -19,6 +19,9 @@ set of hooks so no observable behaviour changes:
   ``start`` is a logged no-op when a feature gate is off).
 - :meth:`_on_started` / :meth:`_on_stopped` emit each scheduler's own start/stop
   log line (through its own module logger, so output is byte-identical).
+- ``leader_gate`` (optional): a fleet-coordination gate consulted before each
+  tick; ``None`` (the default and the OSS-local case) preserves today's
+  always-tick behavior byte-for-byte.
 
 A scheduler whose loop is materially different (e.g. a bounded-attempt retrier
 that waits *before* each attempt and exits on first success) may override
@@ -31,7 +34,28 @@ nothing from ``reflexio_ext``.
 
 from __future__ import annotations
 
+import logging
 import threading
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+# How long a non-leader waits before re-checking the gate. Fixed (no interval
+# memoization): a follower that becomes leader starts ticking within <=60s.
+_FOLLOWER_POLL_SECONDS: float = 60.0
+
+
+class LeaderGate(Protocol):
+    """Fleet-coordination gate consulted before each tick.
+
+    Implementations must NEVER raise from ``should_run`` — error handling
+    (including fail-open) lives inside the implementation, so the scheduler
+    base needs no error path (spec §4.1).
+    """
+
+    def should_run(self) -> bool:
+        """Return whether this instance should run the next tick."""
+        ...
 
 
 class ThreadedScheduler:
@@ -44,12 +68,17 @@ class ThreadedScheduler:
 
     Args:
         thread_name (str): OS thread name for the daemon (aids debugging / logs).
+        leader_gate (LeaderGate | None): Optional fleet-coordination gate
+            consulted before each tick. Defaults to None (always tick).
     """
 
-    def __init__(self, *, thread_name: str) -> None:
+    def __init__(
+        self, *, thread_name: str, leader_gate: LeaderGate | None = None
+    ) -> None:
         self._thread_name = thread_name
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
+        self._leader_gate = leader_gate
 
     def start(self) -> None:
         """Start the daemon thread, unless it is gated off or already running.
@@ -125,8 +154,22 @@ class ThreadedScheduler:
         """
         raise NotImplementedError
 
+    def _elected_interval(self) -> float:
+        """Run one gated iteration; return the seconds to wait before the next.
+
+        ``None`` gate -> tick (today's behavior). Gate ``True`` -> tick.
+        Gate ``False`` -> skip and wait the fixed follower poll.
+
+        Returns:
+            float: Seconds to wait before the next loop iteration.
+        """
+        if self._leader_gate is None or self._leader_gate.should_run():
+            return self._run_once()
+        logger.debug("event=%s_skip_not_leader", self._thread_name)
+        return _FOLLOWER_POLL_SECONDS
+
     def _run_loop(self) -> None:
-        """Drive :meth:`_run_once` until stopped, waiting its returned interval."""
+        """Drive gated iterations until stopped, waiting each returned interval."""
         while not self._stop_event.is_set():
-            interval = self._run_once()
+            interval = self._elected_interval()
             self._stop_event.wait(interval)

--- a/reflexio/server/scheduling.py
+++ b/reflexio/server/scheduling.py
@@ -49,8 +49,11 @@ class LeaderGate(Protocol):
     """Fleet-coordination gate consulted before each tick.
 
     Implementations must NEVER raise from ``should_run`` — error handling
-    (including fail-open) lives inside the implementation, so the scheduler
-    base needs no error path (spec §4.1).
+    (including fail-open) lives inside the implementation (spec §4.1). The
+    scheduler base nonetheless defends against a contract violation: if
+    ``should_run`` raises anyway, the base logs the error and fails open
+    (runs the tick) rather than trusting the contract blindly and letting the
+    daemon thread die silently.
     """
 
     def should_run(self) -> bool:
@@ -160,10 +163,25 @@ class ThreadedScheduler:
         ``None`` gate -> tick (today's behavior). Gate ``True`` -> tick.
         Gate ``False`` -> skip and wait the fixed follower poll.
 
+        The gate contract says ``should_run`` never raises (see
+        :class:`LeaderGate`), but this has zero defense of its own: an escaped
+        exception here would kill the daemon thread permanently and silently.
+        A raise is therefore caught defensively and treated as fail-open (tick
+        runs; duplicate work is safe, silence is not) rather than propagated.
+
         Returns:
             float: Seconds to wait before the next loop iteration.
         """
-        if self._leader_gate is None or self._leader_gate.should_run():
+        if self._leader_gate is None:
+            return self._run_once()
+        try:
+            should_run = self._leader_gate.should_run()
+        except Exception:
+            logger.exception(
+                "event=%s_leader_gate_error — failing open", self._thread_name
+            )
+            return self._run_once()
+        if should_run:
             return self._run_once()
         logger.debug("event=%s_skip_not_leader", self._thread_name)
         return _FOLLOWER_POLL_SECONDS

--- a/reflexio/server/services/agent_success_evaluation/scheduler.py
+++ b/reflexio/server/services/agent_success_evaluation/scheduler.py
@@ -13,7 +13,9 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from functools import partial
 
+from reflexio.server.callback_executor import submit_callback
 from reflexio.server.services.agent_success_evaluation import _eval_health
 
 logger = logging.getLogger(__name__)
@@ -135,14 +137,10 @@ class GroupEvaluationScheduler:
                         # Remove from scheduled map and fire
                         del self._scheduled[key]
 
-                        # Spawn daemon thread for the callback
-                        t = threading.Thread(
-                            target=self._run_callback,
-                            args=(key, callback),
-                            daemon=True,
-                            name=f"group-eval-{key[2][:20]}",
+                        submit_callback(
+                            f"group-eval-{key[2][:20]}",
+                            partial(self._run_callback, key, callback),
                         )
-                        t.start()
 
             except Exception:
                 logger.exception("Error in group evaluation scheduler loop")

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -86,9 +86,13 @@ _leader_gate_hook: LeaderGate | None = None
 def set_leader_gate(gate: LeaderGate | None) -> None:
     """Register the leader gate consulted by ``maybe_start_lineage_gc``.
 
+    Enterprise deployments call this at app-composition time so the scheduler
+    only ticks on the elected leader (``gate.should_run()`` wraps fleet leader
+    election, e.g. an advisory-lock gate). ``None`` (OSS default) preserves
+    always-tick behavior. Pass ``None`` to clear the hook (tests restore defaults).
+
     Args:
-        gate (LeaderGate | None): Fleet-coordination gate, or ``None`` to clear
-            (tests restore OSS defaults).
+        gate (LeaderGate | None): Fleet-coordination gate, or ``None`` to clear.
     """
     global _leader_gate_hook  # noqa: PLW0603
     _leader_gate_hook = gate
@@ -130,8 +134,8 @@ _per_org_sweep_hooks: list[Callable[[str, int], int]] = []
 def register_per_org_sweep(fn: Callable[[str, int], int]) -> None:
     """Register a per-org reclamation sweep.
 
-    The sweep is invoked once per org inside ``_gc_tick``'s org loop, after
-    the Class-B block, unconditionally (not gated on ``lineage_gc`` or
+    The sweep is invoked once per org inside ``_sweep_org``, after the
+    Class-B block, unconditionally (not gated on ``lineage_gc`` or
     ``expiry_reclamation`` — the real gate lives in the enterprise closure).
 
     Note: a registered sweep that absorbs its own exceptions (returns instead

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -28,13 +28,17 @@ import time
 from collections.abc import Callable
 
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.scheduling import ThreadedScheduler
+from reflexio.server.env_utils import env_str
+from reflexio.server.org_fanout import iterate_orgs_bounded
+from reflexio.server.scheduling import LeaderGate, ThreadedScheduler
 from reflexio.server.tracing import capture_anomaly
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_POLL_INTERVAL_SECONDS = 86400
 _MIN_POLL_SECONDS = 1
+_ORG_SWEEP_TIMEOUT_SECONDS = 60.0
+_DEFAULT_ORG_FANOUT_WORKERS = 8
 
 # Window-misconfiguration tripwire: if a single tick deletes more than this
 # many tombstones for one org, something is likely wrong with the grace window.
@@ -71,6 +75,23 @@ def set_org_id_provider(provider: Callable[[], list[str]] | None) -> None:
     """
     global _org_id_provider_hook  # noqa: PLW0603
     _org_id_provider_hook = provider
+
+
+# Injection seam: enterprise sets the fleet leader gate here at composition
+# time (spec 4.3), exactly like set_org_id_provider. None (OSS default) keeps
+# the always-tick behavior.
+_leader_gate_hook: LeaderGate | None = None
+
+
+def set_leader_gate(gate: LeaderGate | None) -> None:
+    """Register the leader gate consulted by ``maybe_start_lineage_gc``.
+
+    Args:
+        gate (LeaderGate | None): Fleet-coordination gate, or ``None`` to clear
+            (tests restore OSS defaults).
+    """
+    global _leader_gate_hook  # noqa: PLW0603
+    _leader_gate_hook = gate
 
 
 # Global sweeps run once per tick (for GLOBAL tables like invitation_codes),
@@ -138,8 +159,11 @@ class LineageGCScheduler(ThreadedScheduler):
         request_context_factory: Callable[[str], RequestContext],
         bootstrap_org_id: str,
         org_id_provider: Callable[[], list[str]] | None = None,
+        leader_gate: LeaderGate | None = None,
     ) -> None:
-        super().__init__(thread_name="reflexio-lineage-gc-scheduler")
+        super().__init__(
+            thread_name="reflexio-lineage-gc-scheduler", leader_gate=leader_gate
+        )
         self.request_context_factory = request_context_factory
         self.bootstrap_org_id = bootstrap_org_id
         # Optional injectable org-id source. When set (managed/multi-tenant mode),
@@ -149,6 +173,8 @@ class LineageGCScheduler(ThreadedScheduler):
         # raises NotImplementedError on Supabase. When None (OSS default),
         # discovery falls back to storage.list_org_ids() exactly as before.
         self.org_id_provider = org_id_provider
+        # Orgs that timed out on the PREVIOUS tick; a repeat escalates.
+        self._prior_timeout_orgs: set[str] = set()
 
     def _on_started(self) -> None:
         logger.info("event=lineage_gc_scheduler_started")
@@ -197,119 +223,163 @@ class LineageGCScheduler(ThreadedScheduler):
             org_ids = [bootstrap_ctx.org_id, *org_ids]
         return org_ids
 
-    def _gc_tick(self, org_ids: list[str]) -> None:
+    def _sweep_org(self, org_id: str) -> None:
+        """Run Class A, Class B, and per-org sweeps for a single org.
+
+        Extracted from ``_gc_tick``'s per-org loop body so it can be handed to
+        :func:`iterate_orgs_bounded` as the per-org work item; the stop-event
+        check that used to guard the loop iteration now lives in that helper.
+
+        Args:
+            org_id (str): The org to sweep this tick.
+        """
+        try:
+            ctx = self.request_context_factory(org_id)
+            if ctx.storage is None:
+                return
+            cfg = ctx.configurator.get_config()
+        except Exception:
+            capture_anomaly("lineage.gc.run_failed", org_id=org_id)
+            logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
+            return
+
+        # Class A: profile expiry sweep (requires PII/grace sign-off; gated on
+        # lineage_gc.enabled independently of Class B).
+        if cfg.lineage_gc.enabled:
+            try:
+                expired_tombstoned = ctx.storage.expire_active_profiles(
+                    now=int(time.time())
+                )
+                if expired_tombstoned:
+                    logger.info(
+                        "event=expiry_sweep org_id=%s profiles_tombstoned=%d",
+                        org_id,
+                        expired_tombstoned,
+                    )
+                if expired_tombstoned > _HIGH_VOLUME_THRESHOLD:
+                    capture_anomaly(
+                        "lineage.expiry_sweep.high_volume",
+                        org_id=org_id,
+                        count=expired_tombstoned,
+                    )
+            except Exception:
+                capture_anomaly("lineage.expiry_sweep.failed", org_id=org_id)
+                logger.exception("event=lineage_expiry_sweep_failed org_id=%s", org_id)
+
+            # Tombstone GC: each entity type is independent within the loop.
+            try:
+                older_than_epoch = (
+                    int(time.time())
+                    - cfg.lineage_gc.tombstone_grace_window_days * 86400
+                )
+                tombstone_deleted = 0
+                for entity_type in _ENTITY_TYPES:
+                    tombstone_deleted += ctx.storage.gc_expired_tombstones(
+                        entity_type=entity_type,
+                        older_than_epoch=older_than_epoch,
+                    )
+                if tombstone_deleted:
+                    logger.info(
+                        "event=lineage_gc_tick org_id=%s tombstone_deleted=%d",
+                        org_id,
+                        tombstone_deleted,
+                    )
+                if tombstone_deleted > _HIGH_VOLUME_THRESHOLD:
+                    capture_anomaly(
+                        "lineage.gc.high_volume",
+                        org_id=org_id,
+                        count=tombstone_deleted,
+                    )
+            except Exception:
+                capture_anomaly("lineage.gc.tombstone_gc_failed", org_id=org_id)
+                logger.exception(
+                    "event=lineage_gc_tombstone_gc_failed org_id=%s", org_id
+                )
+
+        # Class B: direct-delete of expired plain rows (no audit/grace
+        # obligation; independent of lineage_gc).  Each sweep is isolated so
+        # one failing method does not skip the rest.
+        if (
+            getattr(cfg, "expiry_reclamation", None) is not None
+            and cfg.expiry_reclamation.enabled
+        ):
+            now = int(time.time())
+            for method_name, grace, limit in _CLASS_B_SWEEPS:
+                method = getattr(ctx.storage, method_name, None)
+                if method is None:
+                    continue
+                try:
+                    deleted = method(now=now, grace_seconds=grace, limit=limit)
+                    if deleted:
+                        logger.info(
+                            "event=class_b_reclaim org_id=%s method=%s deleted=%d",
+                            org_id,
+                            method_name,
+                            deleted,
+                        )
+                except Exception:
+                    capture_anomaly(
+                        "lineage.class_b_reclaim.failed",
+                        org_id=org_id,
+                        method=method_name,
+                    )
+                    logger.exception(
+                        "event=class_b_reclaim_failed org_id=%s method=%s",
+                        org_id,
+                        method_name,
+                    )
+
+        # Per-org sweeps: invoked unconditionally once per org (the real gate
+        # lives in each enterprise closure). Extracted to keep _gc_tick's
+        # cyclomatic complexity in check and to mirror _run_global_sweeps.
+        self._run_per_org_sweeps(org_id)
+
+    def _gc_tick(self, org_ids: list[str], *, max_workers: int = 1) -> None:
         """Run one GC pass across the given org IDs.
 
         Factored out of ``_run_loop`` so tests can exercise it without threads.
+        Default ``max_workers=1`` is the serial path (used by existing tests);
+        ``_run_once`` passes the configured fan-out width.
 
         Args:
             org_ids (list[str]): Org IDs to process in this tick.
+            max_workers (int): Bounded fan-out width (1 = serial).
         """
-        for org_id in org_ids:
-            if self._stop_event.is_set():
-                break
-            try:
-                ctx = self.request_context_factory(org_id)
-                if ctx.storage is None:
-                    continue
-                cfg = ctx.configurator.get_config()
-            except Exception:
-                capture_anomaly("lineage.gc.run_failed", org_id=org_id)
-                logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
-                continue
+        timed_out = iterate_orgs_bounded(
+            org_ids,
+            self._sweep_org,
+            max_workers=max_workers,
+            per_org_timeout_seconds=_ORG_SWEEP_TIMEOUT_SECONDS,
+            stop_event=self._stop_event,
+        )
+        for org_id in set(timed_out) & self._prior_timeout_orgs:
+            capture_anomaly("lineage.gc.org_sweep_timeout_repeat", org_id=org_id)
+        self._prior_timeout_orgs = set(timed_out)
 
-            # Class A: profile expiry sweep (requires PII/grace sign-off; gated on
-            # lineage_gc.enabled independently of Class B).
-            if cfg.lineage_gc.enabled:
-                try:
-                    expired_tombstoned = ctx.storage.expire_active_profiles(
-                        now=int(time.time())
-                    )
-                    if expired_tombstoned:
-                        logger.info(
-                            "event=expiry_sweep org_id=%s profiles_tombstoned=%d",
-                            org_id,
-                            expired_tombstoned,
-                        )
-                    if expired_tombstoned > _HIGH_VOLUME_THRESHOLD:
-                        capture_anomaly(
-                            "lineage.expiry_sweep.high_volume",
-                            org_id=org_id,
-                            count=expired_tombstoned,
-                        )
-                except Exception:
-                    capture_anomaly("lineage.expiry_sweep.failed", org_id=org_id)
-                    logger.exception(
-                        "event=lineage_expiry_sweep_failed org_id=%s", org_id
-                    )
+    def _org_fanout_workers(self, bootstrap_ctx: RequestContext) -> int:
+        """Resolve the fan-out width: SQLite pins to 1; else env (default 8).
 
-                # Tombstone GC: each entity type is independent within the loop.
-                try:
-                    older_than_epoch = (
-                        int(time.time())
-                        - cfg.lineage_gc.tombstone_grace_window_days * 86400
-                    )
-                    tombstone_deleted = 0
-                    for entity_type in _ENTITY_TYPES:
-                        tombstone_deleted += ctx.storage.gc_expired_tombstones(
-                            entity_type=entity_type,
-                            older_than_epoch=older_than_epoch,
-                        )
-                    if tombstone_deleted:
-                        logger.info(
-                            "event=lineage_gc_tick org_id=%s tombstone_deleted=%d",
-                            org_id,
-                            tombstone_deleted,
-                        )
-                    if tombstone_deleted > _HIGH_VOLUME_THRESHOLD:
-                        capture_anomaly(
-                            "lineage.gc.high_volume",
-                            org_id=org_id,
-                            count=tombstone_deleted,
-                        )
-                except Exception:
-                    capture_anomaly("lineage.gc.tombstone_gc_failed", org_id=org_id)
-                    logger.exception(
-                        "event=lineage_gc_tombstone_gc_failed org_id=%s", org_id
-                    )
+        SQLite: each worker would construct a fresh storage (connection +
+        migrate()) against one shared DB file — contention the serial loop
+        never produces — and OSS-local is usually one org anyway (spec 6.1).
 
-            # Class B: direct-delete of expired plain rows (no audit/grace
-            # obligation; independent of lineage_gc).  Each sweep is isolated so
-            # one failing method does not skip the rest.
-            if (
-                getattr(cfg, "expiry_reclamation", None) is not None
-                and cfg.expiry_reclamation.enabled
-            ):
-                now = int(time.time())
-                for method_name, grace, limit in _CLASS_B_SWEEPS:
-                    method = getattr(ctx.storage, method_name, None)
-                    if method is None:
-                        continue
-                    try:
-                        deleted = method(now=now, grace_seconds=grace, limit=limit)
-                        if deleted:
-                            logger.info(
-                                "event=class_b_reclaim org_id=%s method=%s deleted=%d",
-                                org_id,
-                                method_name,
-                                deleted,
-                            )
-                    except Exception:
-                        capture_anomaly(
-                            "lineage.class_b_reclaim.failed",
-                            org_id=org_id,
-                            method=method_name,
-                        )
-                        logger.exception(
-                            "event=class_b_reclaim_failed org_id=%s method=%s",
-                            org_id,
-                            method_name,
-                        )
+        Args:
+            bootstrap_ctx (RequestContext): This tick's bootstrap context.
 
-            # Per-org sweeps: invoked unconditionally once per org (the real gate
-            # lives in each enterprise closure). Extracted to keep _gc_tick's
-            # cyclomatic complexity in check and to mirror _run_global_sweeps.
-            self._run_per_org_sweeps(org_id)
+        Returns:
+            int: The pool width for this tick.
+        """
+        storage = getattr(bootstrap_ctx, "storage", None)
+        if storage is not None and "sqlite" in type(storage).__name__.lower():
+            return 1
+        raw = env_str(
+            "REFLEXIO_SCHEDULER_ORG_WORKERS", str(_DEFAULT_ORG_FANOUT_WORKERS)
+        )
+        try:
+            value = int(raw)
+        except ValueError:
+            return _DEFAULT_ORG_FANOUT_WORKERS
+        return value if value > 0 else _DEFAULT_ORG_FANOUT_WORKERS
 
     def _run_per_org_sweeps(self, org_id: str) -> None:
         """Invoke each registered per-org sweep once for this org.
@@ -378,7 +448,7 @@ class LineageGCScheduler(ThreadedScheduler):
             cfg = bootstrap_ctx.configurator.get_config()
             poll_interval = cfg.lineage_gc.poll_interval_seconds
             org_ids = self._discover_org_ids(bootstrap_ctx)
-            self._gc_tick(org_ids)
+            self._gc_tick(org_ids, max_workers=self._org_fanout_workers(bootstrap_ctx))
             self._run_global_sweeps(cfg)
         except Exception:
             logger.exception("event=lineage_gc_scheduler_tick_failed")
@@ -390,6 +460,7 @@ def maybe_start_lineage_gc(
     *,
     bootstrap_org_id: str,
     org_id_provider: Callable[[], list[str]] | None = None,
+    leader_gate: LeaderGate | None = None,
 ) -> LineageGCScheduler | None:
     """Start the scheduler when bootstrap config enables tombstone GC or expiry reclamation.
 
@@ -429,6 +500,10 @@ def maybe_start_lineage_gc(
             (OSS default), falls back to the module-level provider hook set via
             :func:`set_org_id_provider`; when both are ``None`` discovery uses
             ``storage.list_org_ids()`` exactly as before.
+        leader_gate: Optional fleet-coordination gate. When ``None`` (OSS
+            default), falls back to the module-level hook set via
+            :func:`set_leader_gate`; when both are ``None`` the scheduler ticks
+            unconditionally (today's behavior).
 
     Returns:
         LineageGCScheduler: The started scheduler, or ``None`` if no start
@@ -495,6 +570,7 @@ def maybe_start_lineage_gc(
         org_id_provider=(
             org_id_provider if org_id_provider is not None else _org_id_provider_hook
         ),
+        leader_gate=leader_gate if leader_gate is not None else _leader_gate_hook,
     )
     scheduler.start()
     return scheduler

--- a/reflexio/server/services/playbook_optimizer/scheduler.py
+++ b/reflexio/server/services/playbook_optimizer/scheduler.py
@@ -5,6 +5,9 @@ import logging
 import threading
 import time
 from collections.abc import Callable
+from functools import partial
+
+from reflexio.server.callback_executor import submit_callback
 
 from .optimizer import PlaybookOptimizationRunStatus, PlaybookOptimizationTarget
 
@@ -110,12 +113,16 @@ class PlaybookOptimizationScheduler:
                             continue
                         _, callback, abort_threshold, cooldown_seconds = current
                         del self._scheduled[key]
-                        threading.Thread(
-                            target=self._run_callback,
-                            args=(key, callback, abort_threshold, cooldown_seconds),
-                            daemon=True,
-                            name=f"playbook-opt-{key[1]}-{key[2]}",
-                        ).start()
+                        submit_callback(
+                            f"playbook-opt-{key[1]}-{key[2]}",
+                            partial(
+                                self._run_callback,
+                                key,
+                                callback,
+                                abort_threshold,
+                                cooldown_seconds,
+                            ),
+                        )
             except Exception:
                 logger.exception("Playbook optimization scheduler loop failed")
                 time.sleep(1)

--- a/reflexio/server/services/tagging/tagging_scheduler.py
+++ b/reflexio/server/services/tagging/tagging_scheduler.py
@@ -20,8 +20,10 @@ import os
 import threading
 import time
 from collections.abc import Callable
+from functools import partial
 
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.callback_executor import submit_callback
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.tagging.service import TaggingService
 
@@ -101,13 +103,10 @@ class TaggingScheduler:
                             continue
 
                         del self._scheduled[key]
-                        t = threading.Thread(
-                            target=self._run_callback,
-                            args=(key, callback),
-                            daemon=True,
-                            name=f"tagging-{key[1][:20]}",
+                        submit_callback(
+                            f"tagging-{key[1][:20]}",
+                            partial(self._run_callback, key, callback),
                         )
-                        t.start()
             except Exception:
                 logger.exception("Error in tagging scheduler loop")
                 time.sleep(1)

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -15,6 +15,7 @@ from reflexio.server.scheduling import LeaderGate
 from reflexio.server.services.lineage import gc_scheduler
 from reflexio.server.services.lineage import gc_scheduler as gc_mod
 from reflexio.server.services.lineage.gc_scheduler import (
+    _DEFAULT_ORG_FANOUT_WORKERS,
     _ENTITY_TYPES,
     _HIGH_VOLUME_THRESHOLD,
     _MIN_POLL_SECONDS,
@@ -23,6 +24,7 @@ from reflexio.server.services.lineage.gc_scheduler import (
     clear_per_org_sweeps,
     maybe_start_lineage_gc,
     register_per_org_sweep,
+    set_leader_gate,
 )
 
 # ---------------------------------------------------------------------------
@@ -760,10 +762,83 @@ def test_repeat_timeout_escalates_anomaly(monkeypatch, gc_scheduler_factory) -> 
     assert [a for a in anomalies if a[0] == "lineage.gc.org_sweep_timeout_repeat"]
 
 
+def test_alternating_timeout_does_not_escalate_anomaly(
+    monkeypatch, gc_scheduler_factory
+) -> None:
+    """An org timing out, then ticking clean, then timing out again is NOT a
+    repeat — only STRICTLY CONSECUTIVE timeouts escalate. Guards against a
+    naive "seen it time out before" set that never gets cleared on a clean
+    tick.
+    """
+    anomalies: list[tuple] = []
+    monkeypatch.setattr(
+        gc_mod, "capture_anomaly", lambda name, **kw: anomalies.append((name, kw))
+    )
+    sched, _ = gc_scheduler_factory(org_ids=["x"])
+
+    # tick1: times out. tick2: clean. tick3: times out again (not consecutive).
+    results = iter([["x"], [], ["x"]])
+    monkeypatch.setattr(
+        gc_mod, "iterate_orgs_bounded", lambda *_args, **_kwargs: next(results)
+    )
+
+    sched._gc_tick(["x"], max_workers=2)  # tick1: first-ever timeout
+    sched._gc_tick(["x"], max_workers=2)  # tick2: clean tick resets the streak
+    sched._gc_tick(["x"], max_workers=2)  # tick3: timed out again, but not consecutive
+
+    assert not [
+        a for a in anomalies if a[0] == "lineage.gc.org_sweep_timeout_repeat"
+    ], "alternating timeouts must not escalate — only strictly consecutive ticks do"
+
+
 def test_sqlite_forces_serial(monkeypatch, gc_scheduler_factory) -> None:
     """SQLite storage pins the fan-out to max_workers=1 (spec 6.1)."""
     sched, _ = gc_scheduler_factory(org_ids=["a"], storage_class_name="SQLiteStorage")
     assert sched._org_fanout_workers(sched.request_context_factory("a")) == 1
+
+
+def test_org_fanout_workers_env_unset_defaults(
+    monkeypatch, gc_scheduler_factory
+) -> None:
+    """Non-SQLite storage + no env override resolves to the module default."""
+    monkeypatch.delenv("REFLEXIO_SCHEDULER_ORG_WORKERS", raising=False)
+    sched, _ = gc_scheduler_factory(org_ids=["a"])
+    assert (
+        sched._org_fanout_workers(sched.request_context_factory("a"))
+        == _DEFAULT_ORG_FANOUT_WORKERS
+    )
+
+
+def test_org_fanout_workers_env_valid_custom(monkeypatch, gc_scheduler_factory) -> None:
+    """A valid positive integer override is honored."""
+    monkeypatch.setenv("REFLEXIO_SCHEDULER_ORG_WORKERS", "3")
+    sched, _ = gc_scheduler_factory(org_ids=["a"])
+    assert sched._org_fanout_workers(sched.request_context_factory("a")) == 3
+
+
+def test_org_fanout_workers_env_non_numeric_falls_back(
+    monkeypatch, gc_scheduler_factory
+) -> None:
+    """A non-numeric override falls back to the module default."""
+    monkeypatch.setenv("REFLEXIO_SCHEDULER_ORG_WORKERS", "abc")
+    sched, _ = gc_scheduler_factory(org_ids=["a"])
+    assert (
+        sched._org_fanout_workers(sched.request_context_factory("a"))
+        == _DEFAULT_ORG_FANOUT_WORKERS
+    )
+
+
+@pytest.mark.parametrize("value", ["0", "-1"])
+def test_org_fanout_workers_env_non_positive_falls_back(
+    monkeypatch, gc_scheduler_factory, value
+) -> None:
+    """Zero or negative overrides fall back to the module default."""
+    monkeypatch.setenv("REFLEXIO_SCHEDULER_ORG_WORKERS", value)
+    sched, _ = gc_scheduler_factory(org_ids=["a"])
+    assert (
+        sched._org_fanout_workers(sched.request_context_factory("a"))
+        == _DEFAULT_ORG_FANOUT_WORKERS
+    )
 
 
 def test_leader_gate_forwarded(gc_scheduler_factory) -> None:
@@ -774,3 +849,30 @@ def test_leader_gate_forwarded(gc_scheduler_factory) -> None:
     gate = _Gate()
     sched, _ = gc_scheduler_factory(org_ids=["a"], leader_gate=gate)
     assert sched._leader_gate is gate
+
+
+def test_maybe_start_lineage_gc_reads_module_leader_gate_hook():
+    """maybe_start_lineage_gc picks up a leader gate set via set_leader_gate,
+    mirroring the module-hook fallback for set_org_id_provider (see
+    test_maybe_start_lineage_gc_reads_module_provider_hook in
+    test_gc_scheduler_multitenant_integration.py)."""
+
+    class _Gate:
+        def should_run(self) -> bool:
+            return True
+
+    gate = _Gate()
+    cfg = LineageGCConfig(enabled=True)
+    ctx = _make_ctx("org_1", lineage_gc=cfg)
+
+    set_leader_gate(gate)
+    sched = None
+    try:
+        sched = maybe_start_lineage_gc(lambda _: ctx, bootstrap_org_id="org_1")  # type: ignore[arg-type]
+        assert sched is not None
+        assert sched._leader_gate is gate
+    finally:
+        set_leader_gate(None)
+        if sched is not None:
+            sched.stop(timeout_seconds=1.0)
+    assert gc_mod._leader_gate_hook is None

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -10,7 +11,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from reflexio.models.config_schema import LineageGCConfig
+from reflexio.server.scheduling import LeaderGate
 from reflexio.server.services.lineage import gc_scheduler
+from reflexio.server.services.lineage import gc_scheduler as gc_mod
 from reflexio.server.services.lineage.gc_scheduler import (
     _ENTITY_TYPES,
     _HIGH_VOLUME_THRESHOLD,
@@ -61,6 +64,59 @@ def _scheduler(*, bootstrap_org_id: str = "org_bootstrap", factory=None):
         request_context_factory=factory,  # type: ignore[arg-type]
         bootstrap_org_id=bootstrap_org_id,
     )
+
+
+@pytest.fixture
+def gc_scheduler_factory():
+    """Return a factory building a ``LineageGCScheduler`` with a stubbed sweep.
+
+    The returned callable takes ``org_ids`` (used to build per-org contexts
+    and seed the bootstrap org), an optional ``storage_class_name`` (a
+    stand-in storage type name so ``_org_fanout_workers``'s SQLite check can
+    be exercised without a real ``SQLiteStorage``), and an optional
+    ``leader_gate``. ``_sweep_org`` is replaced with a stub that records the
+    org id into a shared list (thread-safely) instead of doing real storage
+    work, so fan-out tests can assert on which orgs were swept without
+    depending on ``lineage_gc``/``expiry_reclamation`` config gating.
+
+    Returns:
+        Callable[..., tuple[LineageGCScheduler, list[str]]]: Factory
+        returning ``(scheduler, swept_org_ids)``.
+    """
+
+    def _factory(
+        *,
+        org_ids: list[str],
+        storage_class_name: str | None = None,
+        leader_gate: LeaderGate | None = None,
+    ) -> tuple[LineageGCScheduler, list[str]]:
+        swept: list[str] = []
+        lock = threading.Lock()
+
+        def factory(org_id: str):
+            storage = (
+                type(storage_class_name, (), {})()
+                if storage_class_name is not None
+                else None
+            )
+            return _make_ctx(
+                org_id, lineage_gc=LineageGCConfig(enabled=False), storage=storage
+            )
+
+        sched = LineageGCScheduler(
+            request_context_factory=factory,  # type: ignore[arg-type]
+            bootstrap_org_id=org_ids[0] if org_ids else "org_bootstrap",
+            leader_gate=leader_gate,
+        )
+
+        def _stub_sweep_org(org_id: str) -> None:
+            with lock:
+                swept.append(org_id)
+
+        sched._sweep_org = _stub_sweep_org  # type: ignore[method-assign]
+        return sched, swept
+
+    return _factory
 
 
 # ---------------------------------------------------------------------------
@@ -667,3 +723,54 @@ def test_maybe_start_starts_when_a_per_org_sweep_is_registered_even_with_flags_o
         clear_global_sweeps()
         if sched is not None:
             sched.stop(timeout_seconds=1.0)
+
+
+# ---------------------------------------------------------------------------
+# Bounded org fan-out — _gc_tick(max_workers=...) + leader-gate forwarding
+# ---------------------------------------------------------------------------
+
+
+def test_gc_tick_parallel_processes_all_orgs(gc_scheduler_factory) -> None:
+    """max_workers>1 sweeps every org exactly once (same set as serial)."""
+    sched, swept = gc_scheduler_factory(org_ids=[f"o{i}" for i in range(10)])
+    sched._gc_tick([f"o{i}" for i in range(10)], max_workers=4)
+    assert sorted(swept) == sorted(f"o{i}" for i in range(10))
+
+
+def test_gc_tick_default_is_serial(gc_scheduler_factory) -> None:
+    """Default max_workers=1 preserves strict serial order (byte-compat)."""
+    sched, swept = gc_scheduler_factory(org_ids=["a", "b", "c"])
+    sched._gc_tick(["a", "b", "c"])
+    assert swept == ["a", "b", "c"]
+
+
+def test_repeat_timeout_escalates_anomaly(monkeypatch, gc_scheduler_factory) -> None:
+    """The same org timing out in two consecutive ticks fires capture_anomaly."""
+    anomalies: list[tuple] = []
+    monkeypatch.setattr(
+        gc_mod, "capture_anomaly", lambda name, **kw: anomalies.append((name, kw))
+    )
+    sched, _ = gc_scheduler_factory(org_ids=["x"])
+    monkeypatch.setattr(
+        gc_mod, "iterate_orgs_bounded", lambda *_args, **_kwargs: ["x"]
+    )  # every tick: org x times out
+    sched._gc_tick(["x"], max_workers=2)
+    assert not [a for a in anomalies if a[0] == "lineage.gc.org_sweep_timeout_repeat"]
+    sched._gc_tick(["x"], max_workers=2)
+    assert [a for a in anomalies if a[0] == "lineage.gc.org_sweep_timeout_repeat"]
+
+
+def test_sqlite_forces_serial(monkeypatch, gc_scheduler_factory) -> None:
+    """SQLite storage pins the fan-out to max_workers=1 (spec 6.1)."""
+    sched, _ = gc_scheduler_factory(org_ids=["a"], storage_class_name="SQLiteStorage")
+    assert sched._org_fanout_workers(sched.request_context_factory("a")) == 1
+
+
+def test_leader_gate_forwarded(gc_scheduler_factory) -> None:
+    class _Gate:
+        def should_run(self) -> bool:
+            return False
+
+    gate = _Gate()
+    sched, _ = gc_scheduler_factory(org_ids=["a"], leader_gate=gate)
+    assert sched._leader_gate is gate

--- a/tests/server/services/lineage/test_gc_scheduler_global_sweep.py
+++ b/tests/server/services/lineage/test_gc_scheduler_global_sweep.py
@@ -88,7 +88,11 @@ def test_run_once_invokes_global_sweeps(monkeypatch):
         bootstrap_org_id="org-boot",
     )
     monkeypatch.setattr(scheduler, "_discover_org_ids", lambda _ctx: [])
-    monkeypatch.setattr(scheduler, "_gc_tick", lambda _org_ids: None)
+    # Stub matches _gc_tick's real keyword-only max_workers param (added by
+    # the bounded org fan-out) so _run_once's real calling convention still
+    # resolves; the assertion below is unaffected — this stub is a no-op
+    # regardless of the value it's called with.
+    monkeypatch.setattr(scheduler, "_gc_tick", lambda _org_ids, **_kwargs: None)
 
     scheduler._run_once()
 

--- a/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
+++ b/tests/server/services/playbook_optimizer/test_playbook_optimizer.py
@@ -46,6 +46,7 @@ from reflexio.server.services.playbook_optimizer.models import (
     ScenarioWindow,
 )
 from reflexio.server.services.playbook_optimizer.optimizer import (
+    PlaybookOptimizationRunStatus,
     PlaybookOptimizer,
     _agent_like_playbook,
     _split_train_validation_windows,
@@ -1469,3 +1470,30 @@ def test_scheduler_applies_abort_cooldown():
         cooldown_after_aborts_seconds=60,
     )
     assert scheduler._scheduled == {}  # noqa: SLF001
+
+
+def test_scheduler_fires_callback_through_executor() -> None:
+    """Fire-path coverage: enqueue on a real scheduler and confirm the
+    callback actually runs through the real ``submit_callback`` /
+    ``BoundedCallbackExecutor`` path, analogous to
+    ``tests/server/services/tagging/test_tagging_scheduler.py::
+    test_scheduler_fires_scheduled_callback``.
+
+    Constructs a fresh ``PlaybookOptimizationScheduler`` instance directly
+    (bypassing ``get_instance``) so the class singleton is not polluted.
+    """
+    scheduler = PlaybookOptimizationScheduler()
+    fired = threading.Event()
+
+    def callback() -> PlaybookOptimizationRunStatus:
+        fired.set()
+        return "completed"
+
+    scheduler.enqueue(
+        org_id="org-fire-path",
+        target=PlaybookOptimizationTarget(kind="agent_playbook", target_id=99),
+        callback=callback,
+        jitter_seconds=0,
+    )
+
+    assert fired.wait(timeout=5), "scheduled callback never fired"

--- a/tests/server/test_callback_executor.py
+++ b/tests/server/test_callback_executor.py
@@ -5,13 +5,13 @@ from reflexio.server import callback_executor as ce_mod
 from reflexio.server.callback_executor import BoundedCallbackExecutor
 
 
-def _drain(executor: BoundedCallbackExecutor, timeout: float = 2.0) -> None:
+def _wait_until(predicate, timeout: float = 2.0) -> bool:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        with executor._cond:
-            if not executor._queue:
-                return
-        time.sleep(0.01)
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
 
 
 def test_callbacks_run() -> None:
@@ -29,17 +29,21 @@ def test_queue_bound_drops_oldest(monkeypatch) -> None:
     )
     ex = BoundedCallbackExecutor(workers=1, queue_size=2)
     gate = threading.Event()
-    ex.submit("blocker", lambda: gate.wait(timeout=5))  # occupies the 1 worker
-    time.sleep(0.05)
+    started = threading.Event()
+
+    def blocker() -> None:
+        started.set()
+        gate.wait(timeout=5)
+
+    ex.submit("blocker", blocker)  # occupies the 1 worker
+    assert started.wait(timeout=2.0), "blocker never started running"
     ran: list[str] = []
     ex.submit("old", lambda: ran.append("old"))
     ex.submit("mid", lambda: ran.append("mid"))
     ex.submit("new", lambda: ran.append("new"))  # queue full -> "old" dropped
     gate.set()
-    _drain(ex)
-    time.sleep(0.05)
+    assert _wait_until(lambda: ran == ["mid", "new"]), f"unexpected ran={ran}"
     assert "old" not in ran
-    assert ran == ["mid", "new"]
 
 
 def test_drop_rate_escalates_anomaly(monkeypatch) -> None:
@@ -51,12 +55,18 @@ def test_drop_rate_escalates_anomaly(monkeypatch) -> None:
     )
     ex = BoundedCallbackExecutor(workers=1, queue_size=1)
     gate = threading.Event()
-    ex.submit("blocker", lambda: gate.wait(timeout=5))
-    time.sleep(0.05)
+    started = threading.Event()
+
+    def blocker() -> None:
+        started.set()
+        gate.wait(timeout=5)
+
+    ex.submit("blocker", blocker)
+    assert started.wait(timeout=2.0), "blocker never started running"
     for i in range(ce_mod._DROP_RATE_PER_MINUTE + 3):
         ex.submit(f"cb{i}", lambda: None)  # each overflow drops the prior one
     gate.set()
-    assert "callback_executor.drop_rate_exceeded" in anomalies
+    assert _wait_until(lambda: "callback_executor.drop_rate_exceeded" in anomalies)
     assert anomalies.count("callback_executor.drop_rate_exceeded") == 1  # throttled
 
 

--- a/tests/server/test_callback_executor.py
+++ b/tests/server/test_callback_executor.py
@@ -1,0 +1,78 @@
+import threading
+import time
+
+from reflexio.server import callback_executor as ce_mod
+from reflexio.server.callback_executor import BoundedCallbackExecutor
+
+
+def _drain(executor: BoundedCallbackExecutor, timeout: float = 2.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with executor._cond:
+            if not executor._queue:
+                return
+        time.sleep(0.01)
+
+
+def test_callbacks_run() -> None:
+    ex = BoundedCallbackExecutor(workers=2, queue_size=8)
+    ran = threading.Event()
+    ex.submit("t", ran.set)
+    assert ran.wait(timeout=2.0)
+
+
+def test_queue_bound_drops_oldest(monkeypatch) -> None:
+    monkeypatch.setattr(
+        ce_mod,
+        "capture_anomaly",
+        lambda _, **__: None,  # noqa: ARG005
+    )
+    ex = BoundedCallbackExecutor(workers=1, queue_size=2)
+    gate = threading.Event()
+    ex.submit("blocker", lambda: gate.wait(timeout=5))  # occupies the 1 worker
+    time.sleep(0.05)
+    ran: list[str] = []
+    ex.submit("old", lambda: ran.append("old"))
+    ex.submit("mid", lambda: ran.append("mid"))
+    ex.submit("new", lambda: ran.append("new"))  # queue full -> "old" dropped
+    gate.set()
+    _drain(ex)
+    time.sleep(0.05)
+    assert "old" not in ran
+    assert ran == ["mid", "new"]
+
+
+def test_drop_rate_escalates_anomaly(monkeypatch) -> None:
+    anomalies: list[str] = []
+    monkeypatch.setattr(
+        ce_mod,
+        "capture_anomaly",
+        lambda name, **__: anomalies.append(name),  # noqa: ARG005
+    )
+    ex = BoundedCallbackExecutor(workers=1, queue_size=1)
+    gate = threading.Event()
+    ex.submit("blocker", lambda: gate.wait(timeout=5))
+    time.sleep(0.05)
+    for i in range(ce_mod._DROP_RATE_PER_MINUTE + 3):
+        ex.submit(f"cb{i}", lambda: None)  # each overflow drops the prior one
+    gate.set()
+    assert "callback_executor.drop_rate_exceeded" in anomalies
+    assert anomalies.count("callback_executor.drop_rate_exceeded") == 1  # throttled
+
+
+def test_callback_exception_does_not_kill_worker() -> None:
+    ex = BoundedCallbackExecutor(workers=1, queue_size=8)
+
+    def boom() -> None:
+        raise RuntimeError("boom")
+
+    ran = threading.Event()
+    ex.submit("boom", boom)
+    ex.submit("after", ran.set)
+    assert ran.wait(timeout=2.0)  # worker survived the exception
+
+
+def test_module_singleton_constants() -> None:
+    assert ce_mod._WORKERS == 16
+    assert ce_mod._QUEUE_SIZE == 256
+    assert ce_mod._DROP_RATE_PER_MINUTE == 10

--- a/tests/server/test_org_fanout.py
+++ b/tests/server/test_org_fanout.py
@@ -1,0 +1,82 @@
+import threading
+import time
+
+from reflexio.server.org_fanout import iterate_orgs_bounded
+
+
+def test_all_orgs_processed_and_no_timeouts() -> None:
+    seen: list[str] = []
+    lock = threading.Lock()
+
+    def fn(org_id: str) -> None:
+        with lock:
+            seen.append(org_id)
+
+    timed_out = iterate_orgs_bounded(
+        [f"org{i}" for i in range(20)], fn, max_workers=4, per_org_timeout_seconds=5.0
+    )
+    assert sorted(seen) == sorted(f"org{i}" for i in range(20))
+    assert timed_out == []
+
+
+def test_concurrency_is_bounded() -> None:
+    active = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def fn(org_id: str) -> None:
+        nonlocal active, peak
+        with lock:
+            active += 1
+            peak = max(peak, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+
+    iterate_orgs_bounded(
+        [str(i) for i in range(12)], fn, max_workers=3, per_org_timeout_seconds=5.0
+    )
+    assert peak <= 3
+
+
+def test_stuck_org_times_out_and_others_complete() -> None:
+    done: list[str] = []
+    release = threading.Event()
+
+    def fn(org_id: str) -> None:
+        if org_id == "stuck":
+            release.wait(timeout=10)  # far longer than the per-org timeout
+            return
+        done.append(org_id)
+
+    timed_out = iterate_orgs_bounded(
+        ["stuck", "a", "b"], fn, max_workers=3, per_org_timeout_seconds=0.2
+    )
+    release.set()  # unblock the straggler thread
+    assert timed_out == ["stuck"]
+    assert sorted(done) == ["a", "b"]
+
+
+def test_serial_when_max_workers_is_one() -> None:
+    order: list[str] = []
+    iterate_orgs_bounded(
+        ["a", "b", "c"],
+        order.append,
+        max_workers=1,
+        per_org_timeout_seconds=1.0,
+    )
+    assert order == ["a", "b", "c"]  # strict submission order == serial
+
+
+def test_stop_event_halts_submission() -> None:
+    stop = threading.Event()
+    seen: list[str] = []
+
+    def fn(org_id: str) -> None:
+        seen.append(org_id)
+        stop.set()  # first org requests shutdown
+
+    iterate_orgs_bounded(
+        ["a", "b", "c"], fn, max_workers=1, per_org_timeout_seconds=1.0, stop_event=stop
+    )
+    assert seen == ["a"]  # in-flight finishes; no new submissions

--- a/tests/server/test_org_fanout.py
+++ b/tests/server/test_org_fanout.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 import time
 
@@ -37,6 +38,10 @@ def test_concurrency_is_bounded() -> None:
         [str(i) for i in range(12)], fn, max_workers=3, per_org_timeout_seconds=5.0
     )
     assert peak <= 3
+    # Lower bound too: with 12 orgs and max_workers=3, at least 2 must have
+    # been active concurrently at some point — a serial regression (workers
+    # never overlapping) must fail this test.
+    assert peak >= 2
 
 
 def test_stuck_org_times_out_and_others_complete() -> None:
@@ -80,3 +85,96 @@ def test_stop_event_halts_submission() -> None:
         ["a", "b", "c"], fn, max_workers=1, per_org_timeout_seconds=1.0, stop_event=stop
     )
     assert seen == ["a"]  # in-flight finishes; no new submissions
+
+
+def test_stop_event_halts_submission_with_pool() -> None:
+    """The pooled path (max_workers > 1) has its own submission loop with its
+    own stop_event check — a separate code path from the serial loop that
+    test_stop_event_halts_submission exercises (max_workers <= 1 skips the
+    pool entirely). Uses a generator that sets ``stop`` deterministically on
+    the submitting thread (between yielding "b" and "c") so the assertion
+    does not depend on background-thread scheduling timing.
+    """
+    stop = threading.Event()
+    submitted: list[str] = []
+    lock = threading.Lock()
+
+    def fn(org_id: str) -> None:
+        with lock:
+            submitted.append(org_id)
+
+    def org_ids():
+        yield "a"
+        yield "b"
+        stop.set()  # deterministic: runs on the submitting thread before "c"
+        yield "c"
+        yield "d"
+
+    iterate_orgs_bounded(
+        org_ids(), fn, max_workers=2, per_org_timeout_seconds=1.0, stop_event=stop
+    )
+    assert sorted(submitted) == ["a", "b"]  # c, d never submitted once stop fired
+
+
+def test_starved_org_not_falsely_reported_as_timed_out() -> None:
+    """Regression for the queue-wait-counted-as-run-time bug (F001): with
+    max_workers < len(org_ids), an org that is merely queued (never started)
+    when its own wait window elapses must not be reported as timed out. Once
+    a worker frees up, the queued org still gets to run and finish normally.
+    """
+    budget = 0.2
+    stuck_duration = 0.5  # sits inside "fast"'s [2*budget, 3*budget) wait window
+    done: list[str] = []
+    lock = threading.Lock()
+
+    def fn(org_id: str) -> None:
+        if org_id in ("stuck1", "stuck2"):
+            time.sleep(stuck_duration)
+            return
+        with lock:
+            done.append(org_id)
+
+    timed_out = iterate_orgs_bounded(
+        ["stuck1", "stuck2", "fast"],
+        fn,
+        max_workers=2,
+        per_org_timeout_seconds=budget,
+    )
+    assert timed_out == ["stuck1", "stuck2"]
+    assert "fast" not in timed_out
+    assert done == ["fast"]  # "fast" got a freed worker and completed within the call
+
+
+def test_starved_org_when_never_scheduled(caplog) -> None:
+    """Starved classification (F001): when both workers stay occupied for the
+    entire call, the queued org never starts and must be logged/classified
+    as starved — excluded from timed_out, not merely "timed out but silent".
+    """
+    budget = 0.1
+    release = threading.Event()
+    done: list[str] = []
+    lock = threading.Lock()
+
+    def fn(org_id: str) -> None:
+        if org_id in ("stuck1", "stuck2"):
+            release.wait(timeout=10)  # far longer than the per-org timeout
+            return
+        with lock:
+            done.append(org_id)
+
+    with caplog.at_level(logging.WARNING, logger="reflexio.server.org_fanout"):
+        timed_out = iterate_orgs_bounded(
+            ["stuck1", "stuck2", "fast"],
+            fn,
+            max_workers=2,
+            per_org_timeout_seconds=budget,
+        )
+    release.set()  # unblock the straggler threads
+
+    assert timed_out == ["stuck1", "stuck2"]
+    assert "fast" not in timed_out
+    assert done == []  # "fast" never got a worker during the call — truly starved
+    assert any(
+        "org_sweep_starved" in record.message and "fast" in record.message
+        for record in caplog.records
+    ), f"Expected an org_sweep_starved warning for 'fast'; got {caplog.records}"

--- a/tests/server/test_scheduling.py
+++ b/tests/server/test_scheduling.py
@@ -172,3 +172,69 @@ def test_stop_timeout_keeps_thread_reference_and_blocks_double_start() -> None:
 
     assert sched.is_running() is False
     assert sched._thread is None
+
+
+class _TickCounter(ThreadedScheduler):
+    """Ticks fast; records tick count so tests can assert gating."""
+
+    def __init__(self, *, leader_gate=None) -> None:
+        super().__init__(thread_name="tick-counter", leader_gate=leader_gate)
+        self.ticks = 0
+
+    def _run_once(self) -> float:
+        self.ticks += 1
+        return 0.01
+
+
+class _StaticGate:
+    """LeaderGate stub returning a fixed answer; counts calls."""
+
+    def __init__(self, answer: bool) -> None:
+        self.answer = answer
+        self.calls = 0
+
+    def should_run(self) -> bool:
+        self.calls += 1
+        return self.answer
+
+
+class TestLeaderGate:
+    def test_no_gate_ticks_run(self) -> None:
+        s = _TickCounter()
+        s.start()
+        time.sleep(0.1)
+        s.stop()
+        assert s.ticks >= 2  # today's behavior, byte-for-byte
+
+    def test_gate_true_ticks_run(self) -> None:
+        gate = _StaticGate(True)
+        s = _TickCounter(leader_gate=gate)
+        s.start()
+        time.sleep(0.1)
+        s.stop()
+        assert s.ticks >= 2
+        assert gate.calls >= 2  # consulted once per tick
+
+    def test_gate_false_skips_and_waits_follower_poll(self) -> None:
+        gate = _StaticGate(False)
+        s = _TickCounter(leader_gate=gate)
+        s.start()
+        time.sleep(0.1)
+        s.stop(timeout_seconds=0.2)
+        assert s.ticks == 0  # follower never ticks
+        assert gate.calls == 1  # then waits _FOLLOWER_POLL_SECONDS (60s)
+        from reflexio.server.scheduling import _FOLLOWER_POLL_SECONDS
+
+        assert _FOLLOWER_POLL_SECONDS == 60.0
+
+    def test_follower_becomes_leader_next_poll(self) -> None:
+        from reflexio.server.scheduling import _FOLLOWER_POLL_SECONDS
+
+        gate = _StaticGate(False)
+        s = _TickCounter(leader_gate=gate)
+        # Drive _run_loop's decision helper directly to avoid waiting 60s.
+        assert s._elected_interval() == _FOLLOWER_POLL_SECONDS
+        assert s.ticks == 0
+        gate.answer = True
+        s._elected_interval()
+        assert s.ticks == 1

--- a/tests/server/test_scheduling.py
+++ b/tests/server/test_scheduling.py
@@ -198,22 +198,57 @@ class _StaticGate:
         return self.answer
 
 
+class _RaisingGate:
+    """LeaderGate stub whose ``should_run`` always raises.
+
+    Exercises the base's fail-open defense (spec: the gate contract says
+    ``should_run`` never raises, but the base must not trust that blindly).
+    """
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def should_run(self) -> bool:
+        self.calls += 1
+        raise RuntimeError("gate boom")
+
+
 class TestLeaderGate:
     def test_no_gate_ticks_run(self) -> None:
         s = _TickCounter()
         s.start()
-        time.sleep(0.1)
-        s.stop()
+        try:
+            assert _wait_until(lambda: s.ticks >= 2)
+        finally:
+            s.stop()
         assert s.ticks >= 2  # today's behavior, byte-for-byte
 
     def test_gate_true_ticks_run(self) -> None:
         gate = _StaticGate(True)
         s = _TickCounter(leader_gate=gate)
         s.start()
-        time.sleep(0.1)
-        s.stop()
+        try:
+            assert _wait_until(lambda: s.ticks >= 2)
+        finally:
+            s.stop()
         assert s.ticks >= 2
         assert gate.calls >= 2  # consulted once per tick
+
+    def test_gate_raises_fails_open_and_loop_survives(self, caplog) -> None:
+        gate = _RaisingGate()
+        s = _TickCounter(leader_gate=gate)
+        with caplog.at_level("ERROR"):
+            s.start()
+            try:
+                assert _wait_until(lambda: s.ticks >= 2), (
+                    "loop died after the gate raised instead of failing open"
+                )
+            finally:
+                s.stop()
+        assert gate.calls >= 2  # gate consulted again on the next iteration
+        assert any(
+            "tick-counter_leader_gate_error" in r.message for r in caplog.records
+        )
 
     def test_gate_false_skips_and_waits_follower_poll(self) -> None:
         gate = _StaticGate(False)
@@ -246,7 +281,9 @@ def test_multi_worker_daemon_log(monkeypatch, caplog) -> None:
     monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "3")
     with caplog.at_level("WARNING"):
         _log_multi_worker_daemons()
-    assert any("event=multi_worker_daemons workers=3" in r.message for r in caplog.records)
+    assert any(
+        "event=multi_worker_daemons workers=3" in r.message for r in caplog.records
+    )
 
     caplog.clear()
     monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "1")

--- a/tests/server/test_scheduling.py
+++ b/tests/server/test_scheduling.py
@@ -238,3 +238,18 @@ class TestLeaderGate:
         gate.answer = True
         s._elected_interval()
         assert s.ticks == 1
+
+
+def test_multi_worker_daemon_log(monkeypatch, caplog) -> None:
+    from reflexio.server.api import _log_multi_worker_daemons
+
+    monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "3")
+    with caplog.at_level("WARNING"):
+        _log_multi_worker_daemons()
+    assert any("event=multi_worker_daemons workers=3" in r.message for r in caplog.records)
+
+    caplog.clear()
+    monkeypatch.setenv("REFLEXIO_SERVER_WORKERS", "1")
+    with caplog.at_level("WARNING"):
+        _log_multi_worker_daemons()
+    assert not caplog.records


### PR DESCRIPTION
## Summary

Phase 1 (OSS half) of the Workstream B scheduler-coordination design (spec: `docs/superpowers/specs/2026-07-10-workstream-b-scheduler-coordination-design.md` in the enterprise repo; review-converged over 3 rounds). Prepares the daemon fleet for multi-instance deployments and 1,000-org scale:

1. **`LeaderGate` seam on `ThreadedScheduler`** (`scheduling.py`, stays stdlib-only): an optional injected fleet-coordination gate consulted per tick. `None` (OSS default) preserves today's always-tick behavior byte-for-byte; a follower waits a fixed 60s poll; a gate that violates its never-raise contract is caught and **fails open** (tick runs — duplicate work, never silence). The enterprise layer supplies the real advisory-lock gate in the follow-up PR via the new `set_leader_gate` module hook (mirrors `set_org_id_provider`).
2. **`iterate_orgs_bounded`** (`org_fanout.py`, new): bounded per-tick parallel org iteration with per-org timeout, adopted by `LineageGCScheduler` (`REFLEXIO_SCHEDULER_ORG_WORKERS`, default 8; SQLite pinned serial). Timeout classification is honest: only orgs that *started and exceeded* their run budget are `timed_out`; orgs starved behind stuck workers log `org_sweep_starved` and never poison the repeat-timeout anomaly (`lineage.gc.org_sweep_timeout_repeat`, fired only on strictly-consecutive repeats).
3. **`BoundedCallbackExecutor`** (`callback_executor.py`, new): one process-wide 16-worker pool with a 256-entry drop-oldest queue replacing thread-per-fire in the three debounce schedulers (tagging, group evaluation, playbook optimization). Thread count goes O(active keys) → O(1). Drop logging happens outside the lock; sustained overflow (>10 drops/min) escalates a throttled anomaly.
4. **Multi-worker visibility**: one WARNING at data-plane startup when the server runs >1 worker process (daemons tick in every worker; safe by the concurrent-tick invariant).

## Intended behavior change (reviewer note)

The three converted schedulers previously spawned an unbounded thread per fire. They now share the bounded executor: under a sustained 256-deep backlog, **drop-oldest evicts the oldest queued fire**, and a dropped fire for a key with no subsequent event is skipped. This is a design-accepted best-effort tradeoff (spec §6.2 — owned for all three families), swapping a silent-OOM failure mode for a bounded, alarmed one.

## Testing

- 3,568 unit tests pass; the 7 failures in `tests/server/services/governance/test_subject_write_barrier_sqlite.py` are **pre-existing and red on `origin/main`** (verified against the unmodified base twice; zero overlap with this diff).
- e2e tier: 43 passed. Ruff + Pyright clean on all changed files.
- New coverage: gate matrix (None/True/False/raise), fan-out concurrency bound (upper+lower), stuck/starved-org classification, pooled stop-event path, env-parsing fallbacks, alternating-tick non-escalation, module-hook fallback, executor drop-oldest/drop-rate/exception-survival, playbook-optimizer real fire path. Threading-heavy files re-run 5x, no flakes.
- Reviewed by a 5-lens review loop (correctness, security-resilience, architecture, verification-testing, docs-api): 18 findings fixed and independently verified in one iteration.

## Enterprise follow-up (do not merge out of order)

This PR is self-contained and inert without the enterprise half: no gate is injected (all daemons keep today's behavior except the LineageGC fan-out, the executor conversion, and the startup log). The enterprise PR (coordination module, leadership table, wiring, submodule repin) lands next per the design's §10.1 order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable bounded parallel processing for scheduled organization maintenance tasks.
  * Added leader coordination to prevent duplicate scheduler activity across worker processes.
  * Added resilient background callback execution with bounded queuing and overflow handling.
  * Added startup warnings for multi-worker daemon configurations.
  * Added optional scheduler worker-count configuration, with serial execution preserved for SQLite.

* **Bug Fixes**
  * Improved timeout classification and cancellation handling for maintenance tasks.
  * Prevented callback failures from stopping subsequent scheduled work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->