### PR TITLE
docs(developer): document isolation rule for future self-bootstrapping test harnesses

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -179,10 +179,10 @@ Today the E2E suite runs `Reflexio` in-process with `StorageConfigSQLite` config
 If you add a future harness that boots services from a clean checkout — analogous to claude-smart's `tests/integration/integration.sh` — it must:
 
 1. Sandbox storage: point `LOCAL_STORAGE_PATH` (or the SQLite `db_path`) at a temp dir, never the default `~/.reflexio/data/`.
-2. Use non-default ports: `BACKEND_PORT=19061`, `DOCS_PORT=19062` (or higher), and refuse production ports (`8061`, `8062`) unless the user explicitly opts in.
-3. Refuse to use the real `$HOME` as the integration home; create a temp `INTEG_HOME` and export it before launching services.
+2. Use non-default ports: pick a `1XXXX` form that mirrors the production `8061`/`8062` while staying clear of common dev ranges (e.g. `BACKEND_PORT=19061`, `DOCS_PORT=19062`, or higher), and refuse production ports (`8061`, `8062`) unless the user explicitly opts in.
+3. Never use the real `$HOME` as the integration home; create a temp `INTEG_HOME` and export `HOME=$INTEG_HOME` before launching services so every subprocess inherits the isolated home.
 
-Rationale: claude-smart learned this the hard way when its harness bound production ports (`8071`/`8072`/`3001`) and either failed or replaced the user's installed instance — see [claude-smart PR #125](https://github.com/ReflexioAI/claude-smart/pull/125) (`test: isolate integration harness runtime`). OSS avoids the hazard today only because no such harness exists yet; the above rule prevents reintroducing it when one is added.
+Rationale: claude-smart encountered this when its harness bound production ports (`8071`/`8072`/`3001`) and either failed or replaced the user's installed instance. OSS avoids the hazard today only because no such harness exists yet; the above rule prevents reintroducing it when one is added.
 
 ## Commit & PR Conventions
 

--- a/developer.md
+++ b/developer.md
@@ -172,6 +172,18 @@ uv run pytest -k "test_name"           # by name
 - Use markers: `@pytest.mark.unit` (no network), `@pytest.mark.integration` (needs services), `@pytest.mark.e2e` (full stack), `@pytest.mark.requires_credentials` (needs API keys)
 - Keep tests independent — no shared mutable state between tests
 
+### Self-bootstrapping test harnesses
+
+Today the E2E suite runs `Reflexio` in-process with `StorageConfigSQLite` configured against a `tmp_path` fixture (`tests/e2e_tests/conftest.py`), so tests neither bind production ports nor write to `~/.reflexio`.
+
+If you add a future harness that boots services from a clean checkout — analogous to claude-smart's `tests/integration/integration.sh` — it must:
+
+1. Sandbox storage: point `LOCAL_STORAGE_PATH` (or the SQLite `db_path`) at a temp dir, never the default `~/.reflexio/data/`.
+2. Use non-default ports: `BACKEND_PORT=19061`, `DOCS_PORT=19062` (or higher), and refuse production ports (`8061`, `8062`) unless the user explicitly opts in.
+3. Refuse to use the real `$HOME` as the integration home; create a temp `INTEG_HOME` and export it before launching services.
+
+Rationale: claude-smart learned this the hard way when its harness bound production ports (`8071`/`8072`/`3001`) and either failed or replaced the user's installed instance — see [claude-smart PR #125](https://github.com/ReflexioAI/claude-smart/pull/125) (`test: isolate integration harness runtime`). OSS avoids the hazard today only because no such harness exists yet; the above rule prevents reintroducing it when one is added.
+
 ## Commit & PR Conventions
 
 **Commit messages** — use conventional prefixes:

--- a/developer.md
+++ b/developer.md
@@ -176,13 +176,13 @@ uv run pytest -k "test_name"           # by name
 
 Today the E2E suite runs `Reflexio` in-process with `StorageConfigSQLite` configured against a `tmp_path` fixture (`tests/e2e_tests/conftest.py`), so tests neither bind production ports nor write to `~/.reflexio`.
 
-If you add a future harness that boots services from a clean checkout — analogous to claude-smart's `tests/integration/integration.sh` — it must:
+If you add a future harness that boots services from a clean checkout, it must:
 
 1. Sandbox storage: point `LOCAL_STORAGE_PATH` (or the SQLite `db_path`) at a temp dir, never the default `~/.reflexio/data/`.
 2. Use non-default ports: pick a `1XXXX` form that mirrors the production `8061`/`8062` while staying clear of common dev ranges (e.g. `BACKEND_PORT=19061`, `DOCS_PORT=19062`, or higher), and refuse production ports (`8061`, `8062`) unless the user explicitly opts in.
 3. Never use the real `$HOME` as the integration home; create a temp `INTEG_HOME` and export `HOME=$INTEG_HOME` before launching services so every subprocess inherits the isolated home.
 
-Rationale: claude-smart encountered this when its harness bound production ports (`8071`/`8072`/`3001`) and either failed or replaced the user's installed instance. OSS avoids the hazard today only because no such harness exists yet; the above rule prevents reintroducing it when one is added.
+Without these guards the harness binds `8061`/`8062` (already taken by a developer's running `reflexio services`) or writes to `~/.reflexio/data/`, clobbering the developer's installed state.
 
 ## Commit & PR Conventions
 


### PR DESCRIPTION
### Why

`claude-smart` recently added isolation guards (PR #125) to its self-bootstrapping integration harness because that harness boots services on the production ports (`8071`/`8072`/`3001`) from a clean checkout — risking clobbering a developer's installed instance.

Reflexio OSS has the same potential hazard: `reflexio services start` defaults to ports `8061`/`8062`, and a future CI harness or contributor script could bind those ports and replace a developer's local production instance.

Today the E2E suite avoids the problem by running `Reflexio` in-process with a `tmp_path` SQLite fixture (see `tests/e2e_tests/conftest.py`), so no port binding and no `~/.reflexio` writes occur.

### What

Document the rule for any *future* self-bootstrapping harness: sandbox storage, use non-default ports, refuse real `$HOME`. This is documentation only — no behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for building self-bootstrapping end-to-end test harnesses.
  * Documented safe sandboxing requirements, including isolated storage, non-default ports, and avoiding the real home directory.
  * Included context for preventing test harnesses from interfering with production services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->