### PR TITLE
fix(llm): drop local/* in-process embedding models from generation fallbacks

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -325,8 +325,16 @@ class TextGenerationMixin:
         }
 
         # Drop any fallback entry that points back at the primary — sending the
-        # same broken endpoint twice never helps.
-        fallback_models = [m for m in fallback_models_raw if m != actual_model]
+        # same broken endpoint twice never helps. Also drop in-process ``local/*``
+        # embedding models: they have no litellm completion route (they are served
+        # in-process by ``_litellm_embedding.py``), so litellm would raise
+        # ``BadRequestError: LLM Provider NOT provided`` deep inside its fallback
+        # ladder if one ever landed in this list (Sentry PYTHON-FASTAPI-CV).
+        fallback_models = [
+            m
+            for m in fallback_models_raw
+            if m != actual_model and not m.startswith("local/")
+        ]
 
         temperature = kwargs.pop("temperature", self.config.temperature)
         if self._is_temperature_restricted_model(actual_model):

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2267,6 +2267,24 @@ class TestBuildCompletionParamsEdgeCases:
         assert params["model"] == "claude-3-5-sonnet"
         assert params["api_key"] == "ant-key"
 
+    def test_local_embedding_model_is_dropped_from_fallbacks(self):
+        """A ``local/*`` in-process embedding model must be filtered out of the
+        fallback list: it has no litellm completion route (it is served
+        in-process), so handing it to litellm's fallback ladder raises
+        ``BadRequestError: LLM Provider NOT provided`` (Sentry PYTHON-FASTAPI-CV).
+        Valid generation fallbacks are preserved."""
+        config = LiteLLMConfig(
+            model="gpt-4o",
+            fallback_models=["local/nomic-embed-text-v1.5", "gpt-5-mini"],
+        )
+        client = LiteLLMClient(config)
+
+        _, _, _, _, fallbacks = client._build_completion_params(
+            [{"role": "user", "content": "hi"}],
+        )
+        assert "local/nomic-embed-text-v1.5" not in fallbacks
+        assert fallbacks == ["gpt-5-mini"]
+
 
 class TestConfigDefaults:
     def test_max_retries_default_is_three(self):

--- a/tests/server/llm/test_model_defaults.py
+++ b/tests/server/llm/test_model_defaults.py
@@ -12,6 +12,7 @@ from reflexio.models.config_schema import (
 )
 from reflexio.server.llm.model_defaults import (
     _PROVIDER_DEFAULTS,
+    GENERATION_CAPABLE_PROVIDERS,
     ModelRole,
     detect_available_providers,
     resolve_model_name,
@@ -397,6 +398,21 @@ class TestProviderDefaults:
                 ):
                     value = getattr(defaults, role.value)
                     assert value, f"{provider}.{role.value} is empty"
+
+    def test_local_provider_is_embedding_only(self) -> None:
+        """Pin the contract the generation-fallback filter relies on.
+
+        ``_build_completion_params`` (in ``_litellm_text_generation``) drops every
+        ``local/*`` model from text-generation fallback lists on the assumption
+        that ``local`` is an in-process EMBEDDING provider with no litellm
+        completion route (that blanket filter is what fixes Sentry
+        PYTHON-FASTAPI-CV). If a local *generation* model is ever added, this
+        assertion fails loudly so that filter — and the whole ``local/`` naming
+        scheme — is revisited before a legitimate local generation fallback gets
+        silently dropped.
+        """
+        assert _PROVIDER_DEFAULTS["local"].generation is None
+        assert "local" not in GENERATION_CAPABLE_PROVIDERS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Filters `local/*` in-process embedding models out of text-generation fallback lists so they can never be handed to litellm's completion fallback ladder.

## Problem

`local/*` models (e.g. `local/nomic-embed-text-v1.5`) are **in-process ONNX embedding** models — `_litellm_embedding.py` routes them to `NomicEmbedder`/`LocalEmbedder` and they have **no litellm completion route**. If such a model ends up in a text-generation `fallback_models` list, `_build_completion_params` passes it straight into litellm's `fallbacks`, and when the primary model fails, litellm tries the embedding model via `async_completion_with_fallbacks` → `get_llm_provider` → **`BadRequestError: LLM Provider NOT provided. You passed model=local/nomic-embed-text-v1.5`**.

This surfaced in production as **Sentry PYTHON-FASTAPI-CV (~1,290 events)**. The existing filter at `_build_completion_params` only deduped the primary model (`m != actual_model`); there was no guard against non-generation model names.

## Fix

`_build_completion_params` now drops `local/*` entries alongside the existing primary-model dedup:

```python
fallback_models = [
    m for m in fallback_models_raw
    if m != actual_model and not m.startswith("local/")
]
```

`local/` is the sole in-process embedding prefix (`embedding_service.py`), and no generation model uses it, so this is safe and targeted — a stray embedding model in the fallback list is now skipped instead of crashing the call.

## Test

Added `test_local_embedding_model_is_dropped_from_fallbacks`: a `local/nomic-embed-text-v1.5` + `gpt-5-mini` fallback list resolves to `["gpt-5-mini"]`. All existing fallback tests still pass (10 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-generation fallback handling by excluding `local/*` embedding models from the fallback ladder, avoiding provider routing errors when mixed with valid generation models.

* **Tests**
  * Added unit coverage to confirm `local/*` models are filtered out while valid fallbacks are preserved.
  * Added a regression/contract test to ensure the `local` provider is embedding-only and excluded from generation-capable provider defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->