### PR TITLE
fix(llm): reset inherited litellm HTTP client cache in forked completion worker

### DIFF
--- a/reflexio/server/llm/_litellm_subprocess.py
+++ b/reflexio/server/llm/_litellm_subprocess.py
@@ -141,9 +141,37 @@ def _picklable_completion_result(response: Any) -> Any:
     return response
 
 
+def _reset_llm_client_state_after_fork() -> None:
+    """Drop litellm's module-level HTTP client cache in the forked CHILD.
+
+    ``_litellm_completion_worker`` runs in a ``multiprocessing`` fork child, which
+    inherits a *copy* of the parent's ``litellm.in_memory_llm_clients_cache`` —
+    including any warm keep-alive HTTPS connection the parent held. Reusing such
+    an inherited socket in the child shares one TLS/HTTP connection across two
+    processes and corrupts the child's first completion (surfaces as
+    ``[SSL] record layer failure`` / ``Server disconnected`` / a garbled request
+    the provider rejects as missing auth). Clearing the cache here forces the
+    child to build a fresh client (and socket) for its one completion. Best-effort
+    and fully guarded: a litellm build without these attributes is a no-op, never
+    a crash. Only the child's copy is mutated, so the parent cache is untouched.
+    """
+    try:
+        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+        if cache is not None:
+            flush = getattr(cache, "flush_cache", None)
+            if callable(flush):
+                flush()
+            cache_dict = getattr(cache, "cache_dict", None)
+            if isinstance(cache_dict, dict):
+                cache_dict.clear()
+    except Exception:  # noqa: BLE001, S110 — a reset failure must never break the call
+        pass
+
+
 def _litellm_completion_worker(
     params: dict[str, Any], result_queue: multiprocessing.Queue
 ) -> None:
+    _reset_llm_client_state_after_fork()
     try:
         result_queue.put(
             ("ok", _picklable_completion_result(litellm.completion(**params)))

--- a/tests/server/llm/test_litellm_subprocess_fork_reset.py
+++ b/tests/server/llm/test_litellm_subprocess_fork_reset.py
@@ -1,0 +1,120 @@
+"""Fork-safety of the isolated-completion worker.
+
+A forked ``_litellm_completion_worker`` child inherits the parent's litellm
+module-level HTTP client cache (``litellm.in_memory_llm_clients_cache``). If the
+parent ever holds a warm client, the child would reuse an inherited — and now
+cross-process-shared — socket, corrupting the very first completion in that
+child (observed as ``[SSL] record layer failure`` / ``Server disconnected`` /
+a garbled request the provider rejects as missing auth). The worker must reset
+that inherited client state in the child *before* any completion runs, without
+touching the parent's cache.
+
+These tests fork real children (default ``fork`` start method on Linux) and
+report the child-observed cache state back over a ``Queue``.
+"""
+
+import multiprocessing
+
+import litellm
+
+from reflexio.server.llm._litellm_subprocess import (
+    _litellm_completion_worker,
+    _reset_llm_client_state_after_fork,
+)
+
+_SENTINEL_KEY = "reflexio-fork-reset-sentinel"
+
+
+def _child_report_cache_state(result_queue: multiprocessing.Queue) -> None:
+    """Run the child-side reset, then report whether the inherited cache is
+    empty (from the child's point of view)."""
+    _reset_llm_client_state_after_fork()
+    cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+    cache_dict = getattr(cache, "cache_dict", None)
+    result_queue.put(
+        ("child_cache_size", len(cache_dict) if cache_dict is not None else -1)
+    )
+
+
+def _child_report_via_worker(result_queue: multiprocessing.Queue) -> None:
+    """Drive the real worker entrypoint (with ``litellm.completion`` stubbed so
+    no network happens) and report the inherited cache size the child sees
+    *after* the worker's built-in reset but as observed via a side channel."""
+
+    def _fake_completion(**_params):
+        cache = getattr(litellm, "in_memory_llm_clients_cache", None)
+        cache_dict = getattr(cache, "cache_dict", None)
+        # Report the cache size the worker left us with, then return a minimal
+        # picklable object so the worker's "ok" path succeeds.
+        result_queue.put(
+            ("worker_saw_cache_size", len(cache_dict) if cache_dict is not None else -1)
+        )
+
+        class _Resp:
+            choices: list = []
+
+        return _Resp()
+
+    litellm.completion = _fake_completion  # type: ignore[assignment]
+    worker_queue: multiprocessing.Queue = multiprocessing.get_context().Queue(maxsize=1)
+    _litellm_completion_worker({"model": "gpt-5-mini"}, worker_queue)
+
+
+def test_forked_child_resets_inherited_llm_client_cache():
+    """The child clears the inherited cache; the PARENT keeps its entry."""
+    cache = litellm.in_memory_llm_clients_cache
+    cache.cache_dict[_SENTINEL_KEY] = "warm-client-placeholder"
+    try:
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue(maxsize=1)
+        proc = ctx.Process(target=_child_report_cache_state, args=(result_queue,))
+        proc.start()
+        try:
+            label, child_cache_size = result_queue.get(timeout=10.0)
+        finally:
+            proc.join(timeout=5.0)
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=5.0)
+            result_queue.close()
+            result_queue.join_thread()
+
+        # Child exited cleanly — a crash or hung child must not pass or leak.
+        assert proc.exitcode == 0
+        # Child ran the reset -> inherited cache is empty in the child.
+        assert label == "child_cache_size"
+        assert child_cache_size == 0
+        # Parent is unaffected -> its sentinel survives.
+        assert _SENTINEL_KEY in cache.cache_dict
+    finally:
+        cache.cache_dict.pop(_SENTINEL_KEY, None)
+
+
+def test_worker_entry_resets_cache_before_completion():
+    """The reset runs inside ``_litellm_completion_worker`` itself, before the
+    completion call — so a stubbed completion in the child sees an empty cache
+    even though the parent seeded a sentinel."""
+    cache = litellm.in_memory_llm_clients_cache
+    cache.cache_dict[_SENTINEL_KEY] = "warm-client-placeholder"
+    try:
+        ctx = multiprocessing.get_context("fork")
+        result_queue = ctx.Queue(maxsize=1)
+        proc = ctx.Process(target=_child_report_via_worker, args=(result_queue,))
+        proc.start()
+        try:
+            label, worker_saw = result_queue.get(timeout=10.0)
+        finally:
+            proc.join(timeout=5.0)
+            if proc.is_alive():
+                proc.terminate()
+                proc.join(timeout=5.0)
+            result_queue.close()
+            result_queue.join_thread()
+
+        # Child exited cleanly — a crash or hung child must not pass or leak.
+        assert proc.exitcode == 0
+        assert label == "worker_saw_cache_size"
+        assert worker_saw == 0
+        assert _SENTINEL_KEY in cache.cache_dict
+    finally:
+        cache.cache_dict.pop(_SENTINEL_KEY, None)


### PR DESCRIPTION
## fix(llm): reset inherited litellm HTTP client cache in the forked completion worker

### The hazard
`_litellm_completion_worker` runs in a `multiprocessing` **fork** child, which inherits a *copy* of the parent's `litellm.in_memory_llm_clients_cache`. If the parent ever holds a warm keep-alive HTTPS client, the fork child reuses an inherited socket **now shared across two processes**, corrupting the child's first completion — it surfaces as `[SSL] record layer failure` / `Server disconnected` / a garbled request the provider rejects (e.g. a spurious auth-missing 401 on the very first call, then success on every later call).

Currently **dormant** in production (completions only ever run in short-lived children, so the parent holds no warm client) — but a landmine if a future change adds a parent-side provider call or litellm starts keeping a module-level client. Surfaced during a metering-health investigation that reproduced the exact "first-call-fails, same-key-succeeds-after" signature 100% reliably by artificially warming a parent-held live TLS connection before forking.

### The fix
A guarded `_reset_llm_client_state_after_fork()` called at the **top of `_litellm_completion_worker`** (runs in the child, before any completion): flush + clear `litellm.in_memory_llm_clients_cache` so the child always builds a fresh client + socket. Best-effort and fully guarded — a litellm build lacking those attributes is a no-op, never a crash. Only the child's copy is mutated; the parent cache is untouched.

Chose a **worker-entry reset over `os.register_at_fork`**: the worker is the module's only fork path, so a top-of-worker reset is self-contained and adds no process-wide fork hooks.

### Test
`tests/server/llm/test_litellm_subprocess_fork_reset.py` — real fork-based tests: seed the parent cache with a sentinel, fork a child, assert the **child sees an empty cache** (reset ran) while the **parent's sentinel survives** (parent unaffected). Verified failing→passing (child inherited the sentinel with a no-op stub; empty after the real reset). Full OSS llm suite: 551 passed, no regressions.

Hosted-runner CI may be billing-infra-red (self-hosted CI is the real gate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of isolated LLM completions by preventing forked worker processes from reusing inherited LiteLLM client/socket state.
  * Ensured completion workers reset any inherited in-memory client cache before starting requests.

* **Tests**
  * Added fork-safety tests to confirm the child clears inherited client cache while the parent’s state remains intact.
  * Added coverage validating the cache reset occurs before invoking completion in the worker process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->