### PR TITLE
feat(storage): retention deletes tombstones before oldest live rows

### DIFF
--- a/reflexio/server/services/storage/retention.py
+++ b/reflexio/server/services/storage/retention.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 DEFAULT_ROW_RETENTION_LIMIT = 250_000
 ROW_RETENTION_DELETE_FRACTION = 0.20
+TOMBSTONE_STATUSES = ("archived", "merged", "superseded", "expired")
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,17 +19,32 @@ class RetentionTarget:
     table_name: str
     order_column: str
     id_columns: tuple[str, ...]
+    priority_statuses: tuple[str, ...] = ()
 
 
 RETENTION_TARGETS: tuple[RetentionTarget, ...] = (
-    RetentionTarget("profiles", "profiles", "created_at", ("profile_id",)),
+    RetentionTarget(
+        "profiles",
+        "profiles",
+        "created_at",
+        ("profile_id",),
+        priority_statuses=TOMBSTONE_STATUSES,
+    ),
     RetentionTarget("interactions", "interactions", "created_at", ("interaction_id",)),
     RetentionTarget("requests", "requests", "created_at", ("request_id",)),
     RetentionTarget(
-        "user_playbooks", "user_playbooks", "created_at", ("user_playbook_id",)
+        "user_playbooks",
+        "user_playbooks",
+        "created_at",
+        ("user_playbook_id",),
+        priority_statuses=TOMBSTONE_STATUSES,
     ),
     RetentionTarget(
-        "agent_playbooks", "agent_playbooks", "created_at", ("agent_playbook_id",)
+        "agent_playbooks",
+        "agent_playbooks",
+        "created_at",
+        ("agent_playbook_id",),
+        priority_statuses=TOMBSTONE_STATUSES,
     ),
     RetentionTarget(
         "agent_success_evaluation_result",

--- a/reflexio/server/services/storage/retention_mixin.py
+++ b/reflexio/server/services/storage/retention_mixin.py
@@ -98,11 +98,39 @@ class RetentionMixin(ABC):
         target = get_retention_target(target_name)
         if not self._retention_table_exists(target.table_name):
             return 0
-        keys = self._retention_select_oldest_keys(target, count)
+        keys = self._retention_select_keys(target, count)
         if not keys:
             return 0
         self._retention_perform_delete(target, keys)
         return len(keys)
+
+    def _retention_select_keys(
+        self, target: RetentionTarget, count: int
+    ) -> list[tuple[Any, ...]]:
+        """Select tombstones first, then oldest rows when a target opts in.
+
+        The tombstone pass can never under-delete: the fallback select returns
+        ``min(count, table_rows)`` keys and ``seen`` only ever holds tombstones
+        already counted, so the union still reaches ``count`` whenever the
+        table holds that many rows.
+        """
+        if not target.priority_statuses:
+            return self._retention_select_oldest_keys(target, count)
+
+        keys = self._retention_select_oldest_keys(
+            target, count, statuses=target.priority_statuses
+        )
+        if len(keys) >= count:
+            return keys
+
+        seen = set(keys)
+        for key in self._retention_select_oldest_keys(target, count):
+            if key not in seen:
+                keys.append(key)
+                seen.add(key)
+            if len(keys) == count:
+                break
+        return keys
 
     def _retention_perform_delete(
         self, target: RetentionTarget, keys: list[tuple[Any, ...]]
@@ -130,13 +158,23 @@ class RetentionMixin(ABC):
 
     @abstractmethod
     def _retention_select_oldest_keys(
-        self, target: RetentionTarget, count: int
+        self,
+        target: RetentionTarget,
+        count: int,
+        statuses: tuple[str, ...] | None = None,
     ) -> list[tuple[Any, ...]]:
         """Return up to ``count`` oldest key tuples for ``target``.
 
         Each key tuple contains values aligned with ``target.id_columns``.
         Ordering is by ``target.order_column`` ascending with the id
         columns as a stable tiebreaker.
+
+        Args:
+            target (RetentionTarget): Target whose keys are being selected.
+            count (int): Maximum number of key tuples to return.
+            statuses (tuple[str, ...] | None): When not None, restrict the
+                select to rows whose ``status`` is one of these values. An
+                empty tuple matches nothing (never every row).
         """
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/sqlite_storage/base/_deletion.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_deletion.py
@@ -46,14 +46,25 @@ class SQLiteDeletionMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def _retention_select_oldest_keys(
-        self, target: RetentionTarget, count: int
+        self,
+        target: RetentionTarget,
+        count: int,
+        statuses: tuple[str, ...] | None = None,
     ) -> list[tuple[Any, ...]]:
+        if statuses is not None and not statuses:
+            return []
         id_sql = ", ".join(target.id_columns)
-        tiebreak_sql = id_sql
+        where_sql = ""
+        params: list[Any] = []
+        if statuses:
+            placeholders = ", ".join("?" for _ in statuses)
+            where_sql = f"WHERE status IN ({placeholders}) "
+            params.extend(statuses)
+        params.append(count)
         rows = self._fetchall(
-            f"SELECT {id_sql} FROM {target.table_name} "  # noqa: S608
-            f"ORDER BY {target.order_column} ASC, {tiebreak_sql} ASC LIMIT ?",
-            (count,),
+            f"SELECT {id_sql} FROM {target.table_name} {where_sql}"  # noqa: S608
+            f"ORDER BY {target.order_column} ASC, {id_sql} ASC LIMIT ?",
+            tuple(params),
         )
         return [tuple(row[col] for col in target.id_columns) for row in rows]
 

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -9,6 +9,7 @@ from reflexio.models.api_schema.service_schemas import (
     Interaction,
     ProfileTimeToLive,
     Request,
+    Status,
     UserActionType,
     UserPlaybook,
     UserProfile,
@@ -214,6 +215,103 @@ def _make_agent_playbook(agent_playbook_id: int) -> AgentPlaybook:
         content=f"content-{agent_playbook_id}",
         created_at=agent_playbook_id,
     )
+
+
+def _seed_status_retention_rows(
+    storage: BaseStorage, target: str, statuses: list[Status]
+) -> tuple[str, str, list[str | int]]:
+    """Seed one row per status and return their IDs in insertion order."""
+    conn = storage.conn  # type: ignore[attr-defined]
+    if target == "profiles":
+        ids: list[str | int] = [f"retention-profile-{i}" for i in range(len(statuses))]
+        storage.add_user_profile(
+            "u1", [_make_profile(str(profile_id)) for profile_id in ids]
+        )
+        table_name, id_column = "profiles", "profile_id"
+    elif target == "user_playbooks":
+        storage.save_user_playbooks(
+            [_make_user_playbook(i + 1) for i in range(len(statuses))]
+        )
+        table_name, id_column = "user_playbooks", "user_playbook_id"
+        ids = [
+            row[id_column]
+            for row in conn.execute(
+                f"SELECT {id_column} FROM {table_name} ORDER BY {id_column}"  # noqa: S608
+            ).fetchall()
+        ]
+    else:
+        storage.save_agent_playbooks(
+            [_make_agent_playbook(i + 1) for i in range(len(statuses))]
+        )
+        table_name, id_column = "agent_playbooks", "agent_playbook_id"
+        ids = [
+            row[id_column]
+            for row in conn.execute(
+                f"SELECT {id_column} FROM {table_name} ORDER BY {id_column}"  # noqa: S608
+            ).fetchall()
+        ]
+
+    for created_at, (row_id, status) in enumerate(zip(ids, statuses, strict=True), 1):
+        conn.execute(
+            f"UPDATE {table_name} SET created_at = ?, status = ? "  # noqa: S608
+            f"WHERE {id_column} = ?",
+            (created_at, status.value, row_id),
+        )
+    conn.commit()
+    return table_name, id_column, ids
+
+
+@pytest.mark.parametrize("target", ["profiles", "user_playbooks", "agent_playbooks"])
+def test_retention_prioritizes_terminal_tombstones(
+    storage: BaseStorage, target: str
+) -> None:
+    statuses = [
+        Status.CURRENT,
+        Status.PENDING,
+        Status.ARCHIVE_IN_PROGRESS,
+        Status.ARCHIVED,
+        Status.MERGED,
+        Status.SUPERSEDED,
+        Status.EXPIRED,
+    ]
+    table_name, id_column, ids = _seed_status_retention_rows(storage, target, statuses)
+
+    deleted = storage.delete_oldest_retention_target_rows(target, 4)  # type: ignore[attr-defined]
+
+    assert deleted == 4
+    remaining_ids = {
+        row[id_column]
+        for row in storage.conn.execute(  # type: ignore[attr-defined]
+            f"SELECT {id_column} FROM {table_name}"  # noqa: S608
+        ).fetchall()
+    }
+    assert remaining_ids == set(ids[:3])
+
+
+@pytest.mark.parametrize("target", ["profiles", "user_playbooks", "agent_playbooks"])
+def test_retention_falls_back_to_oldest_rows_after_tombstones(
+    storage: BaseStorage, target: str
+) -> None:
+    statuses = [
+        Status.CURRENT,
+        Status.PENDING,
+        Status.ARCHIVE_IN_PROGRESS,
+        Status.ARCHIVED,
+        Status.MERGED,
+        Status.SUPERSEDED,
+    ]
+    table_name, id_column, ids = _seed_status_retention_rows(storage, target, statuses)
+
+    deleted = storage.delete_oldest_retention_target_rows(target, 5)  # type: ignore[attr-defined]
+
+    assert deleted == 5
+    remaining_ids = {
+        row[id_column]
+        for row in storage.conn.execute(  # type: ignore[attr-defined]
+            f"SELECT {id_column} FROM {table_name}"  # noqa: S608
+        ).fetchall()
+    }
+    assert remaining_ids == {ids[2]}
 
 
 def test_retention_user_playbook_delete_cleans_fts(storage: BaseStorage) -> None:


### PR DESCRIPTION
## Summary

Row retention trims a table strictly oldest-first by `created_at`. For `profiles`, `user_playbooks` and `agent_playbooks` that is the wrong order: a freshly-created **tombstone** (a row already superseded, merged, expired, or archived — dead weight nothing reads) survives, while an older row that is still live gets deleted.

Those three targets now opt into `priority_statuses`. Retention selects tombstones first (`archived`, `merged`, `superseded`, `expired`), then falls back to oldest-first for whatever count remains. Every other retention target is unchanged.

## Changes

- **`retention.py`** — new `TOMBSTONE_STATUSES`; `RetentionTarget` gains `priority_statuses` (defaults to `()`, so all other targets keep today's behavior). `profiles`, `user_playbooks`, `agent_playbooks` opt in.
- **`retention_mixin.py`** — `_retention_select_keys` runs the tombstone pass, then tops up from the oldest-first select, de-duplicating rows that appear in both.
- **`sqlite_storage/base/_deletion.py`** — the SQLite select gains the optional status filter.

### On the hook shape

Rather than add a *second* abstract hook alongside `_retention_select_oldest_keys`, the existing one gains an optional `statuses` param. The mixin's abstract surface is therefore **unchanged** (no new abstract method to break existing backends), and each backend keeps a single select method instead of two near-identical ones. An empty `statuses` tuple matches **nothing** rather than falling through to every row — the safe direction, since the unsafe one silently deletes live data.

### Why the fallback cannot under-delete

The oldest-first select returns `min(count, table_rows)` keys, and the dedup set only ever holds tombstones already counted, so the union still reaches `count` whenever the table holds that many rows. Retention never leaves a table above its high-water mark because of the tombstone pass.

## Test plan

New contract tests in `test_storage_contract_retention.py`, parametrized across `profiles`, `user_playbooks`, and `agent_playbooks`:

- `test_retention_prioritizes_terminal_tombstones` — tombstones are deliberately seeded **newer** than every live row, so an implementation that regressed to plain oldest-first would delete the live rows and fail.
- `test_retention_falls_back_to_oldest_rows_after_tombstones` — once tombstones are exhausted, the remaining budget comes off the oldest rows.

Verified the tests have teeth rather than assuming: setting `TOMBSTONE_STATUSES = ()` makes them fail; restoring it makes them pass.

```
pytest tests/server/services/storage/   →  1021 passed
ruff check / pyright                    →  clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Retention cleanup now prioritizes terminal records—such as archived, merged, superseded, and expired entries—before deleting older active records.
  - Cleanup falls back to the oldest remaining records when prioritized entries are exhausted.
  - Retention selection now applies status-based filtering consistently for SQLite storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->