### PR TITLE
feat(evaluation): judge retrieved learnings against their original rows

### DIFF
--- a/reflexio/server/services/agent_success_evaluation/components/retrieved_learning_evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/components/retrieved_learning_evaluator.py
@@ -22,10 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import ConfigDict, Field
 
-from reflexio.models.api_schema.domain import (
-    PlaybookStatus,
-    RetrievedLearningEvaluationResult,
-)
+from reflexio.models.api_schema.domain import RetrievedLearningEvaluationResult
 from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.services.service_utils import (
@@ -121,9 +118,9 @@ class RetrievedLearningImpactOutput(StrictStructuredOutput):
 
 @dataclass
 class LearningCandidate:
-    """One resolved retrieval-eligible learning.
+    """One resolved historically attached learning.
 
-    ``title`` comes from the resolved live row (playbook name; empty for
+    ``title`` comes from the resolved original row (playbook name; empty for
     profiles) and is shown to the judges only — it is never persisted.
     """
 
@@ -204,7 +201,7 @@ class RetrievedLearningEvaluator:
         agent_version: str,
         snapshot: BoundedRetrievedLearningSnapshot,
     ) -> RetrievedLearningEvaluationRun:
-        """Evaluate every attached, retrieval-eligible learning in a session.
+        """Evaluate every attached learning whose original row still exists.
 
         Args:
             user_id (str): Session owner.
@@ -356,10 +353,17 @@ class RetrievedLearningEvaluator:
         refs: dict[tuple[str, str], None],
         diagnostics: dict[str, Any],
     ) -> list[LearningCandidate]:
-        """Resolve refs to live retrieval-eligible rows; skip the rest.
+        """Resolve attached refs to their original rows; skip missing rows.
 
-        Learning content/trigger/title come from the resolved live row.
-        Unresolvable or ineligible refs are counted, never raised.
+        Lifecycle status and agent-playbook approval do not affect historical
+        evaluation. Learning content/trigger/title come from the original row;
+        unresolvable refs are skipped, never followed to a successor.
+
+        Resolution is best-effort, not a durability guarantee: row retention
+        (``RETENTION_TARGETS``) evicts tombstoned rows first and
+        ``gc_expired_tombstones`` hard-deletes aged ones, so a learning that was
+        genuinely served can age out and then resolve to nothing. That is a
+        silent skip by design — an old session simply judges fewer learnings.
         """
         storage = self.request_context.storage
         if storage is None:
@@ -386,7 +390,7 @@ class RetrievedLearningEvaluator:
         resolved: dict[tuple[str, str], LearningCandidate] = {}
         if profile_ids:
             for profile in storage.get_profiles_by_ids(
-                user_id, profile_ids, status_filter=[None]
+                user_id, profile_ids, include_inactive=True
             ):
                 resolved[("profile", profile.profile_id)] = LearningCandidate(
                     kind="profile",
@@ -397,7 +401,7 @@ class RetrievedLearningEvaluator:
                 )
         if user_playbook_ids:
             for playbook in storage.get_user_playbooks_by_ids(
-                user_id, user_playbook_ids, status_filter=[None]
+                user_id, user_playbook_ids, include_inactive=True
             ):
                 key = ("user_playbook", str(playbook.user_playbook_id))
                 resolved[key] = LearningCandidate(
@@ -409,8 +413,7 @@ class RetrievedLearningEvaluator:
                 )
         for playbook in storage.get_agent_playbooks_by_ids(
             agent_playbook_ids,
-            status_filter=[None],
-            playbook_status_filter=[PlaybookStatus.APPROVED],
+            include_inactive=True,
         ):
             key = ("agent_playbook", str(playbook.agent_playbook_id))
             resolved[key] = LearningCandidate(

--- a/reflexio/server/services/storage/lifecycle_filters.py
+++ b/reflexio/server/services/storage/lifecycle_filters.py
@@ -1,0 +1,54 @@
+"""Shared validation for the lifecycle filters on bulk by-id getters.
+
+``include_inactive=True`` returns every owned row regardless of lifecycle
+status, expiry, or approval — it is the historical-resolution mode used by the
+retrieved-learning evaluator. Combining it with an explicit status filter is
+contradictory: the filter would be silently discarded and the caller would get
+back rows it asked to exclude. Fail loud instead.
+"""
+
+from __future__ import annotations
+
+from reflexio.models.api_schema.domain import PlaybookStatus, Status
+from reflexio.server.services.storage.error import StorageError
+
+
+def validate_include_inactive(
+    *,
+    include_inactive: bool,
+    status_filter: list[Status | None] | None = None,
+    playbook_status_filter: list[PlaybookStatus] | None = None,
+) -> None:
+    """Reject ``include_inactive=True`` combined with an explicit status filter.
+
+    Raises ``StorageError`` rather than ``ValueError`` so the behavior is uniform
+    across backends: both ``handle_exceptions`` decorators re-raise ``StorageError``
+    untouched, whereas any other exception type is swallowed, wrapped, and (on
+    Supabase) reported to Sentry — turning a caller bug into noise.
+
+    Args:
+        include_inactive (bool): Whether the caller asked for all rows regardless
+            of lifecycle status.
+        status_filter (list[Status | None] | None): Explicit lifecycle statuses
+            the caller asked for, if any.
+        playbook_status_filter (list[PlaybookStatus] | None): Explicit approval
+            statuses the caller asked for, if any.
+
+    Raises:
+        StorageError: If ``include_inactive`` is True and either filter is set.
+    """
+    if not include_inactive:
+        return
+    conflicting = [
+        name
+        for name, value in (
+            ("status_filter", status_filter),
+            ("playbook_status_filter", playbook_status_filter),
+        )
+        if value is not None
+    ]
+    if conflicting:
+        raise StorageError(
+            f"include_inactive=True cannot be combined with {' and '.join(conflicting)}"
+            " — include_inactive ignores lifecycle filters. Pass one or the other."
+        )

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -19,6 +19,9 @@ from reflexio.models.api_schema.service_schemas import (
     Status,
 )
 from reflexio.models.config_schema import SearchMode, SearchOptions
+from reflexio.server.services.storage.lifecycle_filters import (
+    validate_include_inactive,
+)
 from reflexio.server.services.storage.storage_base._playbook import (
     AGGREGATE_REASON_PREFIX,
 )
@@ -351,7 +354,13 @@ class AgentPlaybookStoreMixin:
         *,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
+        include_inactive: bool = False,
     ) -> list[AgentPlaybook]:
+        validate_include_inactive(
+            include_inactive=include_inactive,
+            status_filter=status_filter,
+            playbook_status_filter=playbook_status_filter,
+        )
         if not agent_playbook_ids:
             return []
         unique_ids = list(dict.fromkeys(agent_playbook_ids))
@@ -364,16 +373,17 @@ class AgentPlaybookStoreMixin:
                 f"WHERE agent_playbook_id IN ({placeholders})"
             )
             params: list[Any] = list(chunk)
-            if status_filter is not None:
-                fragment, status_params = _build_status_sql(status_filter)
-                query += f" AND {fragment}"
-                params.extend(status_params)
-            else:
-                query += " AND status IS NULL"
-            if playbook_status_filter:
-                status_placeholders = ",".join("?" for _ in playbook_status_filter)
-                query += f" AND playbook_status IN ({status_placeholders})"
-                params.extend(status.value for status in playbook_status_filter)
+            if not include_inactive:
+                if status_filter is not None:
+                    fragment, status_params = _build_status_sql(status_filter)
+                    query += f" AND {fragment}"
+                    params.extend(status_params)
+                else:
+                    query += " AND status IS NULL"
+                if playbook_status_filter:
+                    status_placeholders = ",".join("?" for _ in playbook_status_filter)
+                    query += f" AND playbook_status IN ({status_placeholders})"
+                    params.extend(status.value for status in playbook_status_filter)
             rows.extend(self._fetchall(query, params))
         return [_row_to_agent_playbook(row) for row in rows]
 

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
@@ -268,24 +268,22 @@ class AgentEvaluationResultStoreMixin:
             attached.update(_parse_attachment_refs(row["retrieved_learnings"]))
         return attached
 
-    def _rle_eligible_refs(
+    def _rle_resolvable_refs(
         self, user_id: str, results: list[RetrievedLearningEvaluationResult]
     ) -> set[tuple[str, str]]:
-        """Recheck source rows for retrieval eligibility (in-transaction)."""
+        """Recheck original source rows for historical resolution (in-transaction)."""
         by_kind: dict[str, list[str]] = {}
         for r in results:
             by_kind.setdefault(r.kind, []).append(r.learning_id)
-        eligible: set[tuple[str, str]] = set()
-        now_epoch = int(self._current_epoch())
+        resolvable: set[tuple[str, str]] = set()
         for chunk in _chunked(by_kind.get("profile", [])):
             ph = ",".join("?" for _ in chunk)
             cur = self.conn.execute(
                 f"""SELECT profile_id FROM profiles
-                    WHERE user_id = ? AND profile_id IN ({ph})
-                      AND status IS NULL AND expiration_timestamp > ?""",
-                (user_id, *chunk, now_epoch),
+                    WHERE user_id = ? AND profile_id IN ({ph})""",
+                (user_id, *chunk),
             )
-            eligible.update(("profile", str(row[0])) for row in cur.fetchall())
+            resolvable.update(("profile", str(row[0])) for row in cur.fetchall())
         user_playbook_ids = [
             i for i in (_as_int(x) for x in by_kind.get("user_playbook", [])) if i
         ]
@@ -293,11 +291,10 @@ class AgentEvaluationResultStoreMixin:
             ph = ",".join("?" for _ in chunk)
             cur = self.conn.execute(
                 f"""SELECT user_playbook_id FROM user_playbooks
-                    WHERE user_id = ? AND user_playbook_id IN ({ph})
-                      AND status IS NULL""",
+                    WHERE user_id = ? AND user_playbook_id IN ({ph})""",
                 (user_id, *chunk),
             )
-            eligible.update(("user_playbook", str(row[0])) for row in cur.fetchall())
+            resolvable.update(("user_playbook", str(row[0])) for row in cur.fetchall())
         agent_playbook_ids = [
             i for i in (_as_int(x) for x in by_kind.get("agent_playbook", [])) if i
         ]
@@ -305,12 +302,11 @@ class AgentEvaluationResultStoreMixin:
             ph = ",".join("?" for _ in chunk)
             cur = self.conn.execute(
                 f"""SELECT agent_playbook_id FROM agent_playbooks
-                    WHERE agent_playbook_id IN ({ph})
-                      AND status IS NULL AND playbook_status = 'approved'""",
+                    WHERE agent_playbook_id IN ({ph})""",
                 chunk,
             )
-            eligible.update(("agent_playbook", str(row[0])) for row in cur.fetchall())
-        return eligible
+            resolvable.update(("agent_playbook", str(row[0])) for row in cur.fetchall())
+        return resolvable
 
     @SQLiteStorageBase.handle_exceptions
     def begin_retrieved_learning_evaluation_run(
@@ -457,16 +453,16 @@ class AgentEvaluationResultStoreMixin:
                     self.conn.rollback()
                     return RetrievedLearningCommitResult(disposition="stale")
                 # Persist only records that are still attached to the live
-                # session AND retrieval-eligible. A duplicate identity is left
+                # session AND whose original row still exists. A duplicate identity is left
                 # to trip the UNIQUE index and roll back the commit — caller
                 # bugs fail loud rather than silently dropping data.
                 attached = self._rle_attached_refs(user_id, session_id)
-                eligible = self._rle_eligible_refs(user_id, results)
+                resolvable = self._rle_resolvable_refs(user_id, results)
                 kept = [
                     r
                     for r in results
                     if (r.kind, r.learning_id) in attached
-                    and (r.kind, r.learning_id) in eligible
+                    and (r.kind, r.learning_id) in resolvable
                 ]
                 final_status = proposed_status if kept else "not_applicable"
                 self.conn.execute(
@@ -503,7 +499,7 @@ class AgentEvaluationResultStoreMixin:
                         "generation": generation,
                         "status": final_status,
                         "session_fingerprint": session_fingerprint,
-                        "eligible_count": len(eligible),
+                        "resolvable_count": len(resolvable),
                         "committed_count": len(kept),
                         "completed_at": int(self._current_epoch()),
                     }

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -10,6 +10,9 @@ from reflexio.models.api_schema.common import BlockingIssue
 from reflexio.models.api_schema.retriever_schema import SearchUserPlaybookRequest
 from reflexio.models.api_schema.service_schemas import Status, UserPlaybook
 from reflexio.models.config_schema import SearchMode, SearchOptions
+from reflexio.server.services.storage.lifecycle_filters import (
+    validate_include_inactive,
+)
 
 from .._base import (
     _TOMBSTONE_STATUS_VALUES,
@@ -544,13 +547,25 @@ class UserPlaybookStoreMixin:
         user_id: str,
         user_playbook_ids: list[int],
         status_filter: list[Status | None] | None = None,
+        *,
+        include_inactive: bool = False,
     ) -> list[UserPlaybook]:
+        validate_include_inactive(
+            include_inactive=include_inactive, status_filter=status_filter
+        )
         if not user_playbook_ids:
             return []
+        ph = ",".join("?" for _ in user_playbook_ids)
+        if include_inactive:
+            rows = self._fetchall(
+                "SELECT * FROM user_playbooks "
+                f"WHERE user_id = ? AND user_playbook_id IN ({ph})",
+                (user_id, *user_playbook_ids),
+            )
+            return [_row_to_user_playbook(r) for r in rows]
         if status_filter is None:
             status_filter = [None]
         frag, sparams = _build_status_sql(status_filter)
-        ph = ",".join("?" for _ in user_playbook_ids)
         sql = (
             f"SELECT * FROM user_playbooks "
             f"WHERE user_id = ? AND user_playbook_id IN ({ph}) AND {frag}"

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_profile_store.py
@@ -16,6 +16,9 @@ from reflexio.models.api_schema.service_schemas import (
     Status,
     UserProfile,
 )
+from reflexio.server.services.storage.lifecycle_filters import (
+    validate_include_inactive,
+)
 
 from .._base import (
     _PROFILE_TOMBSTONE_STATUS_VALUES,
@@ -660,14 +663,25 @@ class ProfileStoreMixin:
         user_id: str,
         profile_ids: list[str],
         status_filter: list[Status | None] | None = None,
+        *,
+        include_inactive: bool = False,
     ) -> list[UserProfile]:
+        validate_include_inactive(
+            include_inactive=include_inactive, status_filter=status_filter
+        )
         if not profile_ids:
             return []
+        ph = ",".join("?" for _ in profile_ids)
+        if include_inactive:
+            rows = self._fetchall(
+                f"SELECT * FROM profiles WHERE user_id = ? AND profile_id IN ({ph})",
+                (user_id, *profile_ids),
+            )
+            return [_row_to_profile(r) for r in rows]
         if status_filter is None:
             status_filter = [None]
         current_ts = _epoch_now()
         frag, sparams = _build_status_sql(status_filter)
-        ph = ",".join("?" for _ in profile_ids)
         sql = (
             f"SELECT * FROM profiles "
             f"WHERE user_id = ? AND profile_id IN ({ph}) "

--- a/reflexio/server/services/storage/storage_base/playbook/_agent.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_agent.py
@@ -168,8 +168,35 @@ class AgentPlaybookStoreMixin:
         *,
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
+        include_inactive: bool = False,
     ) -> list[AgentPlaybook]:
-        """Fetch agent playbooks in bulk with lifecycle filters."""
+        """Fetch agent playbooks in bulk with lifecycle filters.
+
+        Args:
+            agent_playbook_ids (list[int]): Playbook ids to fetch. Empty list
+                returns ``[]`` without hitting storage.
+            status_filter (list[Status | None] | None): Lifecycle statuses to
+                include. ``None`` (default) means CURRENT only.
+            playbook_status_filter (list[PlaybookStatus] | None): Approval
+                statuses to include. ``None`` (default) means no approval filter.
+            include_inactive (bool): Return every matching row regardless of
+                lifecycle status *or* approval status. This is the *historical
+                resolution* mode (see ``RetrievedLearningEvaluator``): it answers
+                "what did this id point at", not "what is retrievable now", so an
+                archived or never-approved playbook that was actually served is
+                still returned. It is a strict superset of ``include_tombstones``
+                on ``get_agent_playbook_by_id``, which only unhides
+                MERGED/SUPERSEDED for lineage walks. The default preserves
+                retrieval behavior.
+
+        Returns:
+            list[AgentPlaybook]: Matching playbooks. Order is unspecified.
+
+        Raises:
+            StorageError: If ``include_inactive`` is combined with an explicit
+                ``status_filter`` or ``playbook_status_filter`` — the two are
+                contradictory.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/reflexio/server/services/storage/storage_base/playbook/_user.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_user.py
@@ -220,6 +220,8 @@ class UserPlaybookStoreMixin:
         user_id: str,
         user_playbook_ids: list[int],
         status_filter: list[Status | None] | None = None,
+        *,
+        include_inactive: bool = False,
     ) -> list[UserPlaybook]:
         """Fetch the subset of a user's playbooks whose ids are in the list.
 
@@ -234,11 +236,23 @@ class UserPlaybookStoreMixin:
             status_filter (list[Status | None] | None): Statuses to
                 include. ``None`` (default) means CURRENT only — same
                 default as ``get_user_playbooks`` for consistency.
+            include_inactive (bool): Return matching owned rows regardless of
+                lifecycle status. This is the *historical resolution* mode (see
+                ``RetrievedLearningEvaluator``): it answers "what did this id
+                point at", not "what is retrievable now". It is a strict superset
+                of ``include_tombstones`` on ``get_user_playbook_by_id``, which
+                only unhides MERGED/SUPERSEDED for lineage walks —
+                ``include_inactive`` also returns ARCHIVED rows. ``user_id``
+                scoping still applies. The default preserves retrieval behavior.
 
         Returns:
             list[UserPlaybook]: Matching playbooks. Order is unspecified.
                 Ids that do not exist (or do not match the user / status
                 filter) are silently omitted.
+
+        Raises:
+            StorageError: If ``include_inactive`` is combined with an explicit
+                ``status_filter`` — the two are contradictory.
         """
         raise NotImplementedError
 

--- a/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
+++ b/reflexio/server/services/storage/storage_base/profiles/_profile_store.py
@@ -210,6 +210,8 @@ class ProfileStoreMixin:
         user_id: str,
         profile_ids: list[str],
         status_filter: list[Status | None] | None = None,
+        *,
+        include_inactive: bool = False,
     ) -> list[UserProfile]:
         """Fetch the subset of a user's profiles whose ids are in the list.
 
@@ -224,11 +226,24 @@ class ProfileStoreMixin:
             status_filter (list[Status | None] | None): Statuses to
                 include. ``None`` (default) means CURRENT only — same
                 default as ``get_user_profile`` for consistency.
+            include_inactive (bool): Return matching owned rows regardless of
+                lifecycle status or expiry. This is the *historical resolution*
+                mode (see ``RetrievedLearningEvaluator``): it answers "what did
+                this id point at", not "what is retrievable now". It is a strict
+                superset of ``include_tombstones`` on ``get_profile_by_id``,
+                which only unhides MERGED/SUPERSEDED for lineage walks —
+                ``include_inactive`` also returns ARCHIVED and EXPIRED rows.
+                ``user_id`` scoping still applies. The default preserves
+                retrieval behavior.
 
         Returns:
             list[UserProfile]: Matching profiles. Order is unspecified.
                 Ids that do not exist (or do not match the user / status
                 filter) are silently omitted.
+
+        Raises:
+            StorageError: If ``include_inactive`` is combined with an explicit
+                ``status_filter`` — the two are contradictory.
         """
         raise NotImplementedError
 

--- a/tests/server/services/agent_success_evaluation/test_retrieved_learning_evaluator.py
+++ b/tests/server/services/agent_success_evaluation/test_retrieved_learning_evaluator.py
@@ -11,6 +11,7 @@ import pytest
 
 from reflexio.models.api_schema.domain import (
     AgentPlaybook,
+    LineageContext,
     PlaybookStatus,
     UserPlaybook,
     UserProfile,
@@ -162,9 +163,10 @@ def _echoing_llm() -> MagicMock:
     return llm
 
 
-def test_resolution_skips_missing_and_ineligible(storage: SQLiteStorage) -> None:
+def test_resolution_preserves_archived_attached_id(storage: SQLiteStorage) -> None:
     profile_id, upb_id, apb_id = _seed_all_kinds(storage)
-    # Archive the user playbook — no longer retrieval-eligible.
+    # Archive the user playbook after publication. It is no longer retrievable,
+    # but it remains the exact learning that was injected into the response.
     assert storage.archive_user_playbook_by_id(USER, upb_id)
     llm = _echoing_llm()
     evaluator = _make_evaluator(storage, llm)
@@ -189,6 +191,7 @@ def test_resolution_skips_missing_and_ineligible(storage: SQLiteStorage) -> None
     assert run.proposed_status == "complete"
     assert {(r.kind, r.learning_id) for r in run.rows} == {
         ("profile", profile_id),
+        ("user_playbook", str(upb_id)),
         ("agent_playbook", str(apb_id)),
     }
     assert run.diagnostics["invalid_ref_count"] == 1
@@ -199,7 +202,9 @@ def test_resolution_skips_missing_and_ineligible(storage: SQLiteStorage) -> None
     bulk_agent_lookup.assert_called_once()
 
 
-def test_unapproved_agent_playbook_is_ineligible(storage: SQLiteStorage) -> None:
+def test_unapproved_agent_playbook_is_evaluated_when_attached(
+    storage: SQLiteStorage,
+) -> None:
     storage.save_agent_playbooks(
         [
             AgentPlaybook(
@@ -217,7 +222,127 @@ def test_unapproved_agent_playbook_is_ineligible(storage: SQLiteStorage) -> None
         USER, SESSION, "v1", _snapshot({1: [("agent_playbook", str(apb_id))]})
     )
     assert run.outcome == "evaluated"
-    assert run.rows == []
+    assert [(row.kind, row.learning_id) for row in run.rows] == [
+        ("agent_playbook", str(apb_id))
+    ]
+
+
+def test_expired_profile_is_evaluated_when_attached(storage: SQLiteStorage) -> None:
+    profile_id, _, _ = _seed_all_kinds(storage)
+    storage.conn.execute(
+        "UPDATE profiles SET expiration_timestamp = 1 WHERE profile_id = ?",
+        (profile_id,),
+    )
+    storage.conn.commit()
+    assert storage.expire_active_profiles(now=2) == 1
+
+    run = _make_evaluator(storage, _echoing_llm()).evaluate(
+        USER, SESSION, "v1", _snapshot({1: [("profile", profile_id)]})
+    )
+
+    assert [(row.kind, row.learning_id) for row in run.rows] == [
+        ("profile", profile_id)
+    ]
+
+
+def test_resolution_uses_original_superseded_ids_and_content(
+    storage: SQLiteStorage,
+) -> None:
+    profile_id, upb_id, apb_id = _seed_all_kinds(storage)
+    storage.add_user_profile(
+        USER,
+        [
+            UserProfile(
+                profile_id="prof-successor",
+                user_id=USER,
+                content="successor profile content",
+                last_modified_timestamp=2,
+                generated_from_request_id="r2",
+            )
+        ],
+    )
+    storage.save_user_playbooks(
+        [
+            UserPlaybook(
+                user_id=USER,
+                playbook_name="successor checklist",
+                request_id="r2",
+                agent_version="v1",
+                content="successor user playbook content",
+            )
+        ]
+    )
+    successor_upb_id = next(
+        playbook.user_playbook_id
+        for playbook in storage.get_user_playbooks(user_id=USER, limit=10)
+        if playbook.user_playbook_id != upb_id
+    )
+    storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="successor deploy",
+                agent_version="v1",
+                content="successor agent playbook content",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )
+    successor_apb_id = next(
+        playbook.agent_playbook_id
+        for playbook in storage.get_agent_playbooks(limit=10)
+        if playbook.agent_playbook_id != apb_id
+    )
+    context = LineageContext(op_kind="revise", actor="test", request_id="r2")
+    assert storage.supersede_record(
+        entity_type="profile",
+        incumbent_id=profile_id,
+        successor_id="prof-successor",
+        context=context,
+    )
+    assert storage.supersede_record(
+        entity_type="user_playbook",
+        incumbent_id=str(upb_id),
+        successor_id=str(successor_upb_id),
+        context=context,
+    )
+    assert storage.supersede_record(
+        entity_type="agent_playbook",
+        incumbent_id=str(apb_id),
+        successor_id=str(successor_apb_id),
+        context=context,
+    )
+
+    llm = _echoing_llm()
+    run = _make_evaluator(storage, llm).evaluate(
+        USER,
+        SESSION,
+        "v1",
+        _snapshot(
+            {
+                1: [
+                    ("profile", profile_id),
+                    ("user_playbook", str(upb_id)),
+                    ("agent_playbook", str(apb_id)),
+                ]
+            }
+        ),
+    )
+
+    assert {(row.kind, row.learning_id) for row in run.rows} == {
+        ("profile", profile_id),
+        ("user_playbook", str(upb_id)),
+        ("agent_playbook", str(apb_id)),
+    }
+    judge_payloads = "\n".join(
+        call.kwargs["messages"][0]["content"]
+        for call in llm.generate_chat_response.call_args_list
+    )
+    assert "prefers concise answers" in judge_payloads
+    assert "always produce a checklist" in judge_payloads
+    assert "verify before deploy" in judge_payloads
+    assert "successor profile content" not in judge_payloads
+    assert "successor user playbook content" not in judge_payloads
+    assert "successor agent playbook content" not in judge_payloads
 
 
 def test_empty_candidates_make_zero_llm_calls(storage: SQLiteStorage) -> None:

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -249,6 +249,37 @@ class TestGetUserPlaybooksByIds:
         assert len(result) == 1
         assert result[0].user_playbook_id == upid
 
+    def test_include_inactive_returns_archived(self, storage):
+        storage.save_user_playbooks([_make_user_playbook(1, "u1", "fb", "v1")])
+        upid = storage.get_user_playbooks(user_id="u1", status_filter=[None])[
+            0
+        ].user_playbook_id
+        storage.archive_user_playbook_by_id("u1", upid)
+        result = storage.get_user_playbooks_by_ids("u1", [upid], include_inactive=True)
+        assert [p.user_playbook_id for p in result] == [upid]
+
+    def test_include_inactive_still_filters_by_user_id(self, storage):
+        """user_id is the only predicate left standing under include_inactive."""
+        storage.save_user_playbooks([_make_user_playbook(1, "u2", "fb", "v1")])
+        upid = storage.get_user_playbooks(user_id="u2", status_filter=[None])[
+            0
+        ].user_playbook_id
+        storage.archive_user_playbook_by_id("u2", upid)
+        assert (
+            storage.get_user_playbooks_by_ids("u1", [upid], include_inactive=True) == []
+        )
+
+    def test_include_inactive_with_status_filter_is_rejected(self, storage):
+        """The two are contradictory — fail loud rather than drop the filter."""
+        storage.save_user_playbooks([_make_user_playbook(1, "u1", "fb", "v1")])
+        upid = storage.get_user_playbooks(user_id="u1", status_filter=[None])[
+            0
+        ].user_playbook_id
+        with pytest.raises(StorageError):
+            storage.get_user_playbooks_by_ids(
+                "u1", [upid], status_filter=[Status.ARCHIVED], include_inactive=True
+            )
+
 
 class TestArchiveUserPlaybookById:
     """Contract tests for archive_user_playbook_by_id (used by ReflectionService)."""

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -15,6 +15,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserActionType,
     UserProfile,
 )
+from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.storage_base import BaseStorage
 
 pytestmark = pytest.mark.integration
@@ -296,6 +297,30 @@ class TestGetProfilesByIds:
         )
         assert len(result) == 1
         assert result[0].profile_id == "p1"
+
+    def test_include_inactive_returns_archived(self, storage: BaseStorage) -> None:
+        storage.add_user_profile("u1", [_make_profile("u1", "p1", "x")])
+        storage.archive_profile_by_id("u1", "p1")
+        result = storage.get_profiles_by_ids("u1", ["p1"], include_inactive=True)
+        assert [p.profile_id for p in result] == ["p1"]
+
+    def test_include_inactive_still_filters_by_user_id(
+        self, storage: BaseStorage
+    ) -> None:
+        """user_id is the only predicate left standing under include_inactive."""
+        storage.add_user_profile("u2", [_make_profile("u2", "p2", "b")])
+        storage.archive_profile_by_id("u2", "p2")
+        assert storage.get_profiles_by_ids("u1", ["p2"], include_inactive=True) == []
+
+    def test_include_inactive_with_status_filter_is_rejected(
+        self, storage: BaseStorage
+    ) -> None:
+        """The two are contradictory — fail loud rather than drop the filter."""
+        storage.add_user_profile("u1", [_make_profile("u1", "p1", "x")])
+        with pytest.raises(StorageError):
+            storage.get_profiles_by_ids(
+                "u1", ["p1"], status_filter=[Status.ARCHIVED], include_inactive=True
+            )
 
 
 class TestArchiveProfileById:

--- a/tests/server/services/storage/test_storage_contract_retrieved_learning_evals.py
+++ b/tests/server/services/storage/test_storage_contract_retrieved_learning_evals.py
@@ -5,7 +5,7 @@ Covers the two core invariants:
 1. Round-trip parity — ``retrieved_learnings`` survives publish/storage/read
    identically on every locally-testable backend.
 2. Exact evaluation set — replacement persists exactly the attached AND
-   retrieval-eligible identities, atomically, fenced by generation +
+   historically resolvable identities, atomically, fenced by generation +
    session fingerprint.
 """
 
@@ -177,7 +177,7 @@ def test_content_only_edit_invalidates_fingerprint(storage) -> None:
     assert commit.disposition == "stale"
 
 
-def test_replace_persists_exact_eligible_set(storage) -> None:
+def test_replace_persists_exact_resolvable_set(storage) -> None:
     playbook_id = _seed_eligible_learnings(storage)
     _seed_session(
         storage,
@@ -218,11 +218,43 @@ def test_replace_persists_exact_eligible_set(storage) -> None:
     assert state["committed_count"] == 2
 
 
+def test_replace_keeps_attached_source_that_becomes_inactive(storage) -> None:
+    """A lifecycle change during judging must not discard the historical verdict."""
+    playbook_id = _seed_eligible_learnings(storage)
+    _seed_session(
+        storage,
+        refs=[RetrievedLearning(kind="user_playbook", learning_id=str(playbook_id))],
+    )
+    snapshot = storage.load_bounded_retrieved_learning_snapshot(USER, SESSION)
+    fingerprint = session_fingerprint(snapshot)
+    generation = storage.begin_retrieved_learning_evaluation_run(USER, SESSION)
+
+    # Simulate aggregation or consolidation completing while the LLM judges run.
+    assert storage.archive_user_playbook_by_id(USER, playbook_id)
+    commit = storage.replace_retrieved_learning_evaluation_results(
+        USER,
+        SESSION,
+        generation,
+        fingerprint,
+        "complete",
+        {},
+        [_result("user_playbook", str(playbook_id))],
+    )
+
+    assert commit.disposition == "applied"
+    assert commit.status == "complete"
+    assert commit.committed_count == 1
+    rows = storage.get_retrieved_learning_evaluation_results(session_id=SESSION)
+    assert [(row.kind, row.learning_id) for row in rows] == [
+        ("user_playbook", str(playbook_id))
+    ]
+
+
 def test_replace_drops_eligible_but_unattached(storage) -> None:
     """Commit keeps only records attached to the live session.
 
-    Guards the ``attached AND retrieval-eligible`` contract at the storage
-    layer: an otherwise-eligible ref that was never attached to the session
+    Guards the ``attached AND historically resolvable`` contract at the storage
+    layer: an otherwise-resolvable ref that was never attached to the session
     must be dropped rather than persisted.
     """
     _seed_eligible_learnings(storage)
@@ -253,8 +285,8 @@ def test_replace_drops_eligible_but_unattached(storage) -> None:
         "complete",
         {},
         [
-            _result("profile", "prof-1"),  # attached + eligible
-            _result("profile", "prof-2"),  # eligible but never attached
+            _result("profile", "prof-1"),  # attached + resolvable
+            _result("profile", "prof-2"),  # resolvable but never attached
         ],
     )
     assert commit.disposition == "applied"
@@ -263,7 +295,7 @@ def test_replace_drops_eligible_but_unattached(storage) -> None:
     assert [(r.kind, r.learning_id) for r in rows] == [("profile", "prof-1")]
 
 
-def test_replace_with_no_eligible_rows_clears_and_records_not_applicable(
+def test_replace_with_no_resolvable_rows_clears_and_records_not_applicable(
     storage,
 ) -> None:
     _seed_eligible_learnings(storage)
@@ -284,7 +316,7 @@ def test_replace_with_no_eligible_rows_clears_and_records_not_applicable(
     )
     assert commit.disposition == "applied" and commit.committed_count == 1
 
-    # A later run whose candidates all became ineligible clears prior rows.
+    # A later run whose candidates no longer exist clears prior rows.
     generation = storage.begin_retrieved_learning_evaluation_run(USER, SESSION)
     commit = storage.replace_retrieved_learning_evaluation_results(
         USER,


### PR DESCRIPTION
## Summary

Retrieved-learning evaluation (RLE) judged only learnings that were still **retrieval-eligible** at judge time — `status IS NULL`, unexpired, and (for agent playbooks) `approved`. That asks the wrong question.

A learning that was injected into a response and *then* archived, expired, or un-approved is still the exact learning the agent saw. Filtering it out silently discards a verdict about work that actually happened. It also created a race: a lifecycle change landing mid-run — aggregation or consolidation completing while the LLM judges are in flight — could make an in-flight verdict vanish at commit time.

This reframes the invariant from *"is it still retrievable?"* to *"does the original row still exist?"*.

## Changes

**`include_inactive` on the three bulk by-id getters** (`get_profiles_by_ids`, `get_user_playbooks_by_ids`, `get_agent_playbooks_by_ids`). Returns every matching owned row regardless of lifecycle status, expiry, or approval.

It is a strict **superset** of the existing `include_tombstones` flag on the *singular* by-id getters, which only unhides MERGED/SUPERSEDED for lineage walks. Both flags now cross-reference each other in the `storage_base` docstrings so the next caller can tell them apart. `user_id` scoping still applies, and the default preserves existing retrieval behavior.

**`_rle_eligible_refs` → `_rle_resolvable_refs`** on the commit path. It still locks (`FOR SHARE`) and rechecks the source rows in-transaction, but the lifecycle predicates are gone — it now verifies row *existence* only. The `attached AND resolvable` commit contract is otherwise unchanged.

**Resolution never follows a lineage pointer to a successor.** The judge sees the original content, never the row that replaced it.

**A contradictory-argument guard.** Passing `include_inactive=True` *and* an explicit `status_filter` is a caller bug: the filter would be silently dropped and the caller would get back rows it explicitly asked to exclude. `validate_include_inactive` rejects the combination.

It raises `StorageError` rather than `ValueError` for a specific reason: both `handle_exceptions` decorators re-raise `StorageError` untouched, but *wrap* any other exception type — and on the Supabase path also report it to Sentry. Raising `ValueError` made a pure caller bug surface as an opaque `StorageError` on one backend and a `ValueError` on another, with Sentry noise attached. It now fails loud and identically on every backend.

## Notes

Resolution is **best-effort by design**, not a durability guarantee. Row retention evicts tombstoned rows first, so a genuinely-served learning can age out and then resolve to nothing. That is a silent skip — an old session simply judges fewer learnings. Documented on `_resolve_candidates`.

## Test Plan

- Contract tests for `include_inactive` on all three getters, covering that an archived row is returned, that **`user_id` remains the only surviving tenant wall** under the flag (it strips every other predicate, so this is now the one thing standing between tenants on that path), and that the contradictory filter combination is rejected.
- Evaluator tests that an archived, expired, or never-approved *attached* learning is still judged.
- A superseded learning is judged on its **original** content — asserted negatively, i.e. that the successor's content never reaches the judge payload.
- `109 passed` across the evaluator and storage-contract suites (up from 103). Ruff and Pyright clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical learning evaluations now continue to resolve attached archived, expired, or unapproved records when their original data remains available.
  * Evaluation results now retain verdicts for sources that become inactive during judging.
  * Historical lookups can include inactive records while preserving ownership and identity boundaries.

* **Bug Fixes**
  * Superseded records now resolve to their original content rather than successor data.

* **Validation**
  * Conflicting lifecycle filters are rejected with a clear error when inactive-record lookup is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->