### PR TITLE
feat(metering): per-record event_key seam for BYOC event-model

### DIFF
--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -9,6 +9,7 @@ wrapper over the ``record_usage_event`` hook (which only enqueues). No DB I/O.
 from __future__ import annotations
 
 import logging
+import uuid
 from collections.abc import Mapping
 from typing import Any
 
@@ -85,7 +86,15 @@ def record_learnings_generated(
 ) -> None:
     """Emit the Learning value facet — number of profiles/playbooks generated.
 
-    No-op when ``count <= 0``.
+    Documented FALLBACK for callers that genuinely lack a per-record id list
+    (e.g. dedup/consolidation can reduce the persisted count below the raw
+    extracted count, so there is no safe 1:1 id per unit of ``count``). Prefer
+    :func:`record_learnings_generated_records` whenever the caller has the
+    durable learning ids in scope. No-op when ``count <= 0``.
+
+    Emits a single event carrying a synthesized ``event_key=f"learn-batch:{uuid4()}"``
+    (distinct per call) so this aggregate event still has a dedup key, even
+    though it is not entity-backed.
 
     Args:
         org_id: Organisation identifier.
@@ -116,12 +125,81 @@ def record_learnings_generated(
         agent_version=agent_version,
         playbook_name=playbook_name,
         entity_type=entity_type,
+        event_key=f"learn-batch:{uuid.uuid4()}",
         count_value=count,
         platform_llm=platform_llm,
         platform_storage=platform_storage,
         caller_type=_INTERNAL,
         metadata=metadata,
     )
+
+
+def record_learnings_generated_records(
+    *,
+    org_id: str,
+    learning_ids: list[str],
+    platform_llm: bool | None,
+    platform_storage: bool | None,
+    pipeline: str | None = None,
+    user_id: str | None = None,
+    request_id: str | None = None,
+    session_id: str | None = None,
+    source: str | None = None,
+    agent_version: str | None = None,
+    playbook_name: str | None = None,
+    entity_type: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    """Emit the Learning value facet — one event per generated learning record.
+
+    Entity-backed alternative to :func:`record_learnings_generated`: emits one
+    ``learnings_generated`` event per id in ``learning_ids`` (``count_value=1``,
+    ``event_key=f"learn:{id}"``, ``entity_id=id``) instead of a single
+    aggregate event, so downstream dedup can key on the learning id. The
+    summed ``count_value`` across the emitted events equals
+    ``len(learning_ids)`` — unchanged from the total a caller would have
+    passed as ``count`` to :func:`record_learnings_generated`.
+
+    Callers must pass real, durable ids — never fabricate one to pad the
+    list. No-op when ``learning_ids`` is empty.
+
+    Args:
+        org_id: Organisation identifier.
+        learning_ids: Ids of the learnings durably generated in this run
+            (e.g. ``profile_id`` / ``user_playbook_id`` / ``agent_playbook_id``).
+        platform_llm: True iff the platform supplies the LLM for this org.
+        platform_storage: True iff the platform supplies storage; None defers to rollup.
+        pipeline: Optional pipeline tag (e.g. ``"playbook"``).
+        user_id: Optional user ID tied to the generated learning.
+        request_id: Optional request correlation ID.
+        session_id: Optional session ID.
+        source: Optional metering source/path label.
+        agent_version: Optional agent version tied to the generated learning.
+        playbook_name: Optional playbook name for playbook learnings.
+        entity_type: Optional entity type (e.g. ``"profile"``).
+        metadata: Optional path-specific usage metadata (shared across events).
+    """
+    for learning_id in learning_ids:
+        record_usage_event(
+            org_id=org_id,
+            event_name="learnings_generated",
+            event_category="learning",
+            pipeline=pipeline,
+            user_id=user_id,
+            request_id=request_id,
+            session_id=session_id,
+            source=source,
+            agent_version=agent_version,
+            playbook_name=playbook_name,
+            entity_type=entity_type,
+            entity_id=learning_id,
+            event_key=f"learn:{learning_id}",
+            count_value=1,
+            platform_llm=platform_llm,
+            platform_storage=platform_storage,
+            caller_type=_INTERNAL,
+            metadata=metadata,
+        )
 
 
 def emit_learnings_generated(
@@ -186,6 +264,73 @@ def emit_learnings_generated(
         logger.warning(
             "emit_learnings_generated failed for source=%s org=%s; "
             "learnings_generated event not emitted",
+            source,
+            org_id,
+            exc_info=True,
+        )
+
+
+def emit_learnings_generated_records(
+    *,
+    org_id: str,
+    configurator: Any,
+    learning_ids: list[str],
+    source: str,
+    pipeline: str | None = None,
+    user_id: str | None = None,
+    request_id: str | None = None,
+    agent_version: str | None = None,
+    playbook_name: str | None = None,
+    entity_type: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> None:
+    """Resolve ``platform_llm`` from config and emit one event per learning id.
+
+    Entity-backed counterpart to :func:`emit_learnings_generated` for the
+    non-extraction learning-mutation paths (reflection, resumable-extraction
+    finalization, aggregation, offline-tuner auto-apply) when the caller has
+    the durable learning ids in scope. Same guard semantics: config resolution
+    and emission are wrapped and any exception is logged and swallowed — the
+    product path must never fail because metering failed. No-op when
+    ``learning_ids`` is empty.
+
+    Args:
+        org_id: Organisation identifier.
+        configurator: Object exposing ``get_config()`` for platform-LLM resolution.
+        learning_ids: Ids of the learnings durably produced by this path.
+        source: Metering source/path label (e.g. ``"reflection"``).
+        pipeline: Optional pipeline tag (e.g. ``"playbook"``).
+        user_id: Optional user ID tied to the generated learning.
+        request_id: Optional request correlation ID.
+        agent_version: Optional agent version tied to the generated learning.
+        playbook_name: Optional playbook name for playbook learnings.
+        entity_type: Optional entity type (e.g. ``"profile"``).
+        metadata: Optional path-specific usage metadata (shared across events).
+    """
+    if not learning_ids:
+        return
+    try:
+        from reflexio.server.billing_signals import platform_llm_from_config
+
+        config = configurator.get_config()
+        record_learnings_generated_records(
+            org_id=org_id,
+            learning_ids=learning_ids,
+            platform_llm=platform_llm_from_config(config),
+            platform_storage=None,
+            pipeline=pipeline,
+            user_id=user_id,
+            request_id=request_id,
+            source=source,
+            agent_version=agent_version,
+            playbook_name=playbook_name,
+            entity_type=entity_type,
+            metadata=metadata,
+        )
+    except Exception:
+        logger.warning(
+            "emit_learnings_generated_records failed for source=%s org=%s; "
+            "learnings_generated events not emitted",
             source,
             org_id,
             exc_info=True,

--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -158,11 +158,19 @@ def record_learnings_generated_records(
 
     Entity-backed alternative to :func:`record_learnings_generated`: emits one
     ``learnings_generated`` event per id in ``learning_ids`` (``count_value=1``,
-    ``event_key=f"learn:{id}"``, ``entity_id=id``) instead of a single
-    aggregate event, so downstream dedup can key on the learning id. The
-    summed ``count_value`` across the emitted events equals
-    ``len(learning_ids)`` — unchanged from the total a caller would have
-    passed as ``count`` to :func:`record_learnings_generated`.
+    ``event_key=f"learn:{entity_type}:{id}"``, ``entity_id=id``) instead of a
+    single aggregate event, so downstream dedup can key on the learning id.
+    The ``entity_type`` segment is required for collision-freedom: entity-backed
+    callers draw ids from separate autoincrement primary keys in separate
+    tables (e.g. ``user_playbook_id`` and ``agent_playbook_id`` both start at
+    1), so the same integer id can legitimately occur in two tables — without
+    the entity-type segment those would mint the same ``event_key`` and
+    collapse into one event downstream. When ``entity_type`` is falsy, a
+    stable ``"_"`` placeholder is used (``learn:_:{id}``) rather than emitting
+    ``entity_type=None`` literally into the key. The summed ``count_value``
+    across the emitted events equals ``len(learning_ids)`` — unchanged from
+    the total a caller would have passed as ``count`` to
+    :func:`record_learnings_generated`.
 
     Callers must pass real, durable ids — never fabricate one to pad the
     list. No-op when ``learning_ids`` is empty.
@@ -183,6 +191,7 @@ def record_learnings_generated_records(
         entity_type: Optional entity type (e.g. ``"profile"``).
         metadata: Optional path-specific usage metadata (shared across events).
     """
+    key_entity_type = entity_type or "_"
     for learning_id in learning_ids:
         record_usage_event(
             org_id=org_id,
@@ -197,7 +206,7 @@ def record_learnings_generated_records(
             playbook_name=playbook_name,
             entity_type=entity_type,
             entity_id=learning_id,
-            event_key=f"learn:{learning_id}",
+            event_key=f"learn:{key_entity_type}:{learning_id}",
             count_value=1,
             platform_llm=platform_llm,
             platform_storage=platform_storage,
@@ -290,13 +299,16 @@ def emit_learnings_generated_records(
 ) -> None:
     """Resolve ``platform_llm`` from config and emit one event per learning id.
 
-    Entity-backed counterpart to :func:`emit_learnings_generated` for the
-    non-extraction learning-mutation paths (reflection, resumable-extraction
-    finalization, aggregation, offline-tuner auto-apply) when the caller has
-    the durable learning ids in scope. Same guard semantics: config resolution
-    and emission are wrapped and any exception is logged and swallowed — the
-    product path must never fail because metering failed. No-op when
-    ``learning_ids`` is empty.
+    Entity-backed counterpart to :func:`emit_learnings_generated`, currently
+    adopted by two of the non-extraction learning-mutation paths —
+    resumable-extraction finalization and aggregation — the callers with
+    durable per-record ids in scope. Extraction, reflection, and offline-tuner
+    auto-apply do not have a safe 1:1 id per unit of count (see
+    :func:`record_learnings_generated_records`) and use the count-based
+    :func:`emit_learnings_generated` fallback instead. Same guard semantics:
+    config resolution and emission are wrapped and any exception is logged
+    and swallowed — the product path must never fail because metering
+    failed. No-op when ``learning_ids`` is empty.
 
     Args:
         org_id: Organisation identifier.

--- a/reflexio/server/billing_meter.py
+++ b/reflexio/server/billing_meter.py
@@ -36,7 +36,10 @@ def record_extraction_tokens(
 ) -> None:
     """Emit the Learning cost facet — call only when extraction fired.
 
-    No-op when ``billing_input_tokens <= 0``.
+    No-op when ``billing_input_tokens <= 0``. Each call mints a fresh
+    ``event_key=f"tok:{uuid4()}"`` so two token emits under the same
+    ``request_id`` (e.g. profile + playbook extraction in one request) never
+    collapse into one billed event downstream.
 
     Args:
         org_id: Organisation identifier.
@@ -58,6 +61,7 @@ def record_extraction_tokens(
         pipeline=pipeline,
         request_id=request_id,
         session_id=session_id,
+        event_key=f"tok:{uuid.uuid4()}",
         count_value=billing_input_tokens,
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
@@ -351,6 +355,8 @@ def record_applied_learnings(
     """Emit the Application line — surfaced top-K learnings.
 
     No-op unless ``caller_type == "production_agent"`` AND ``surfaced_count > 0``.
+    Each call mints a fresh ``event_key=f"applied:{uuid4()}"`` — a distinct
+    key per search-response moment, never collapsed by ``request_id``.
 
     Args:
         org_id: Organisation identifier.
@@ -371,6 +377,7 @@ def record_applied_learnings(
         pipeline=pipeline,
         request_id=request_id,
         session_id=session_id,
+        event_key=f"applied:{uuid.uuid4()}",
         count_value=surfaced_count,
         platform_llm=platform_llm,
         platform_storage=platform_storage,
@@ -389,7 +396,10 @@ def record_search_request(
 
     No-op unless ``caller_type == "production_agent"``. Unlike
     :func:`record_applied_learnings`, empty search responses still count because
-    this measures requests made, not learnings surfaced.
+    this measures requests made, not learnings surfaced. Each call mints a
+    fresh ``event_key=f"search:{uuid4()}"`` — a distinct key per request, so
+    two searches under the same ``request_id`` are never collapsed into one
+    billed event downstream.
 
     Args:
         org_id: Organisation identifier.
@@ -405,6 +415,7 @@ def record_search_request(
         event_category="application",
         request_id=request_id,
         session_id=session_id,
+        event_key=f"search:{uuid.uuid4()}",
         count_value=1,
         caller_type=caller_type,
     )

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -789,8 +789,54 @@ class ExtractionResumeWorker:
     def _record_finalized_learnings(
         self, run: AgentRunRecord, items: list[Any], *, entity_type: str
     ) -> None:
-        from reflexio.server.billing_meter import emit_learnings_generated
+        """Emit ``learnings_generated`` for a finalized resumable-extraction batch.
 
+        Prefers one event per learning id (``entity_id``/``profile_id`` for
+        profiles, ``user_playbook_id`` for playbooks) when every item in
+        ``items`` carries a durable id — the common case, since these ids are
+        assigned by the extractor (profile) or by ``save_user_playbooks``
+        in-place during ``_finalize_extracted_items`` (playbook), which has
+        already run by the time this is called. Falls back to the
+        count-based aggregate event when any item lacks one (e.g. dropped by
+        within-batch/consolidator dedup before persist, leaving a default
+        ``user_playbook_id=0``) — this avoids both fabricating an id for a row
+        that never persisted and colliding on the shared default-id key.
+        Totals are preserved either way: ``len(items)`` learnings are counted
+        whether via ``len(learning_ids)`` per-record events or one aggregate
+        ``count=len(items)`` event.
+        """
+        from reflexio.server.billing_meter import (
+            emit_learnings_generated,
+            emit_learnings_generated_records,
+        )
+
+        if not items:
+            return
+
+        id_attr = "profile_id" if entity_type == "profile" else "user_playbook_id"
+        learning_ids = [
+            str(getattr(item, id_attr))
+            for item in items
+            if getattr(item, id_attr, None)
+        ]
+        metadata = {
+            "run_id": run.id,
+            "extractor_kind": run.binding.extractor_kind,
+        }
+        if len(learning_ids) == len(items):
+            emit_learnings_generated_records(
+                org_id=self.request_context.org_id,
+                configurator=self.request_context.configurator,
+                learning_ids=learning_ids,
+                source="resumable_extraction",
+                pipeline=run.binding.extractor_kind,
+                user_id=run.binding.user_id,
+                request_id=run.binding.request_id,
+                agent_version=run.binding.agent_version,
+                entity_type=entity_type,
+                metadata=metadata,
+            )
+            return
         emit_learnings_generated(
             org_id=self.request_context.org_id,
             configurator=self.request_context.configurator,
@@ -801,10 +847,7 @@ class ExtractionResumeWorker:
             request_id=run.binding.request_id,
             agent_version=run.binding.agent_version,
             entity_type=entity_type,
-            metadata={
-                "run_id": run.id,
-                "extractor_kind": run.binding.extractor_kind,
-            },
+            metadata=metadata,
         )
 
     def _schedule_finalized_tagging(self, run: AgentRunRecord) -> None:

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -7,12 +7,12 @@ import os
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from contextlib import nullcontext
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from reflexio.defaults import resolve_agent_version
 from reflexio.models.api_schema.service_schemas import (
@@ -327,18 +327,14 @@ class GenerationService:
                     agent_version=agent_version,
                     source=source,
                 )
-                record_usage_event(
-                    org_id=self.org_id,
+                self._emit_publish_success_events(
+                    interactions=new_interactions,
                     user_id=user_id,
                     request_id=request_id,
                     session_id=new_request.session_id,
                     source=source,
                     agent_version=agent_version,
                     backend="evaluation_only",
-                    event_name="publish_request_succeeded",
-                    event_category="publish",
-                    outcome="success",
-                    count_value=len(new_interactions),
                     duration_ms=int((time.perf_counter() - publish_start) * 1000),
                     metadata={
                         "evaluation_only": True,
@@ -366,17 +362,13 @@ class GenerationService:
                     agent_version=agent_version,
                     source=source,
                 )
-                record_usage_event(
-                    org_id=self.org_id,
+                self._emit_publish_success_events(
+                    interactions=new_interactions,
                     user_id=user_id,
                     request_id=request_id,
                     session_id=new_request.session_id,
                     source=source,
                     agent_version=agent_version,
-                    event_name="publish_request_succeeded",
-                    event_category="publish",
-                    outcome="success",
-                    count_value=len(new_interactions),
                     duration_ms=int((time.perf_counter() - publish_start) * 1000),
                     metadata={"warning_count": len(result.warnings)},
                 )
@@ -411,18 +403,14 @@ class GenerationService:
                         agent_version=agent_version,
                         source=source,
                     )
-                    record_usage_event(
-                        org_id=self.org_id,
+                    self._emit_publish_success_events(
+                        interactions=new_interactions,
                         user_id=user_id,
                         request_id=request_id,
                         session_id=new_request.session_id,
                         source=source,
                         agent_version=agent_version,
                         backend="durable",
-                        event_name="publish_request_succeeded",
-                        event_category="publish",
-                        outcome="success",
-                        count_value=len(new_interactions),
                         duration_ms=int((time.perf_counter() - publish_start) * 1000),
                         metadata={
                             "defer_learning": True,
@@ -456,18 +444,14 @@ class GenerationService:
                         skip_aggregation=publish_user_interaction_request.skip_aggregation,
                     )
                 )
-                record_usage_event(
-                    org_id=self.org_id,
+                self._emit_publish_success_events(
+                    interactions=new_interactions,
                     user_id=user_id,
                     request_id=request_id,
                     session_id=new_request.session_id,
                     source=source,
                     agent_version=agent_version,
                     backend="classic",
-                    event_name="publish_request_succeeded",
-                    event_category="publish",
-                    outcome="success",
-                    count_value=len(new_interactions),
                     duration_ms=int((time.perf_counter() - publish_start) * 1000),
                     metadata={
                         "defer_learning": True,
@@ -509,18 +493,14 @@ class GenerationService:
                 source=source,
             )
 
-            record_usage_event(
-                org_id=self.org_id,
+            self._emit_publish_success_events(
+                interactions=new_interactions,
                 user_id=user_id,
                 request_id=request_id,
                 session_id=new_request.session_id,
                 source=source,
                 agent_version=agent_version,
                 backend="classic",
-                event_name="publish_request_succeeded",
-                event_category="publish",
-                outcome="success",
-                count_value=len(new_interactions),
                 duration_ms=int((time.perf_counter() - publish_start) * 1000),
                 metadata={"warning_count": len(result.warnings)},
             )
@@ -553,6 +533,47 @@ class GenerationService:
                     user_id,
                 )
             raise
+
+    def _emit_publish_success_events(
+        self,
+        *,
+        interactions: list[Interaction],
+        user_id: str,
+        request_id: str,
+        session_id: str,
+        source: str | None,
+        agent_version: str,
+        duration_ms: int,
+        metadata: Mapping[str, Any],
+        backend: str | None = None,
+    ) -> None:
+        """Emit one ``publish_request_succeeded`` event per interaction.
+
+        Replaces the old single aggregate event (``count_value=len(interactions)``)
+        with one entity-backed event per interaction (``count_value=1``,
+        ``event_key=f"pub:{interaction_id}"``, ``entity_id=interaction_id``) so
+        downstream dedup can key on the interaction id. The summed
+        ``count_value`` across the emitted events equals the old aggregate
+        count, so totals are unchanged.
+        """
+        for interaction in interactions:
+            record_usage_event(
+                org_id=self.org_id,
+                user_id=user_id,
+                request_id=request_id,
+                session_id=session_id,
+                source=source,
+                agent_version=agent_version,
+                backend=backend,
+                event_name="publish_request_succeeded",
+                event_category="publish",
+                outcome="success",
+                count_value=1,
+                event_key=f"pub:{interaction.interaction_id}",
+                entity_id=str(interaction.interaction_id),
+                duration_ms=duration_ms,
+                metadata=metadata,
+            )
 
     # ===============================
     # deferred learning

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -729,7 +729,9 @@ class PlaybookAggregator:
                 metadata=stats,
             )
             self._record_learnings_generated(
-                count=len(saved_playbook_list),
+                learning_ids=[
+                    str(saved.agent_playbook_id) for saved in saved_playbook_list
+                ],
                 playbook_name=playbook_name,
                 request_id=_run_id,
                 metadata=stats,
@@ -769,17 +771,17 @@ class PlaybookAggregator:
     def _record_learnings_generated(
         self,
         *,
-        count: int,
+        learning_ids: list[str],
         playbook_name: str,
         request_id: str,
         metadata: Mapping[str, Any],
     ) -> None:
-        from reflexio.server.billing_meter import emit_learnings_generated
+        from reflexio.server.billing_meter import emit_learnings_generated_records
 
-        emit_learnings_generated(
+        emit_learnings_generated_records(
             org_id=self.request_context.org_id,
             configurator=self.configurator,
-            count=count,
+            learning_ids=learning_ids,
             source="aggregation",
             pipeline="playbook",
             request_id=request_id,

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -730,11 +730,14 @@ class PlaybookAggregator:
             )
             self._record_learnings_generated(
                 learning_ids=[
-                    str(saved.agent_playbook_id) for saved in saved_playbook_list
+                    str(saved.agent_playbook_id)
+                    for saved in saved_playbook_list
+                    if getattr(saved, "agent_playbook_id", None)
                 ],
                 playbook_name=playbook_name,
                 request_id=_run_id,
                 metadata=stats,
+                total_count=len(saved_playbook_list),
             )
             return stats
 
@@ -775,13 +778,45 @@ class PlaybookAggregator:
         playbook_name: str,
         request_id: str,
         metadata: Mapping[str, Any],
+        total_count: int | None = None,
     ) -> None:
-        from reflexio.server.billing_meter import emit_learnings_generated_records
+        """Emit ``learnings_generated`` for a completed aggregation run.
 
-        emit_learnings_generated_records(
+        Prefers one event per learning id (entity-backed) when every saved
+        playbook in this run carries a durable ``agent_playbook_id`` — the
+        common case, since ``save_agent_playbook_with_aggregate_event``
+        raises rather than returning a partial row. Falls back to the
+        count-based aggregate event when ``learning_ids`` is short of
+        ``total_count`` (a falsy/unset id slipped through), mirroring
+        ``ExtractionResumeWorker._record_finalized_learnings`` — this avoids
+        emitting a colliding ``learn:agent_playbook:0`` key. ``total_count``
+        defaults to ``len(learning_ids)`` so callers that already guarantee a
+        complete id list (e.g. existing tests) are unaffected.
+        """
+        from reflexio.server.billing_meter import (
+            emit_learnings_generated,
+            emit_learnings_generated_records,
+        )
+
+        total = len(learning_ids) if total_count is None else total_count
+        if len(learning_ids) == total:
+            emit_learnings_generated_records(
+                org_id=self.request_context.org_id,
+                configurator=self.configurator,
+                learning_ids=learning_ids,
+                source="aggregation",
+                pipeline="playbook",
+                request_id=request_id,
+                agent_version=self.agent_version,
+                playbook_name=playbook_name,
+                entity_type="agent_playbook",
+                metadata=metadata,
+            )
+            return
+        emit_learnings_generated(
             org_id=self.request_context.org_id,
             configurator=self.configurator,
-            learning_ids=learning_ids,
+            count=total,
             source="aggregation",
             pipeline="playbook",
             request_id=request_id,

--- a/reflexio/server/usage_metrics.py
+++ b/reflexio/server/usage_metrics.py
@@ -27,6 +27,7 @@ class UsageEvent:
     pipeline: str | None = None
     entity_type: str | None = None
     entity_id: str | None = None
+    event_key: str | None = None
     extractor_name: str | None = None
     playbook_name: str | None = None
     source: str | None = None
@@ -72,6 +73,7 @@ def record_usage_event(
     pipeline: str | None = None,
     entity_type: str | None = None,
     entity_id: str | None = None,
+    event_key: str | None = None,
     extractor_name: str | None = None,
     playbook_name: str | None = None,
     source: str | None = None,
@@ -109,6 +111,7 @@ def record_usage_event(
                 pipeline=pipeline,
                 entity_type=entity_type,
                 entity_id=entity_id,
+                event_key=event_key,
                 extractor_name=extractor_name,
                 playbook_name=playbook_name,
                 source=source,

--- a/tests/server/services/test_generation_billing_events.py
+++ b/tests/server/services/test_generation_billing_events.py
@@ -1,0 +1,99 @@
+"""Tests for per-record ``publish_request_succeeded`` usage events.
+
+Task A2 of the BYOC metering redesign: the publish path must emit ONE
+``publish_request_succeeded`` event per published interaction (each
+``count_value=1``, keyed by ``event_key=f"pub:{interaction_id}"`` /
+``entity_id=interaction_id``) instead of a single aggregate event with
+``count_value=len(new_interactions)``. Totals must be preserved: the sum of
+``count_value`` across the per-interaction events must equal the old
+aggregate count.
+
+Uses a real ``GenerationService.run()`` call over a temp-dir SQLite storage
+(mirroring the pattern in ``test_generation_service.py`` /
+``test_generation_billing_emission.py``) with ``evaluation_only=True`` so the
+publish short-circuits before any LLM extraction (site: generation_service.py
+"evaluation_only" branch), keeping the test independent of LLM mocking.
+
+Note on ids: ``Interaction.interaction_id`` is a DB auto-increment ``int``
+(0 is a placeholder until insert) -- there is no caller-supplied interaction
+id. So unlike illustrative pseudocode that might use string labels like
+"i1"/"i2"/"i3" as literal ids, this test publishes 3 interactions into a
+fresh per-test SQLite db (autoincrement starts at 1, insertion order
+preserved) and asserts against the real assigned ids.
+"""
+
+from __future__ import annotations
+
+import datetime
+from datetime import UTC
+
+import pytest
+
+from reflexio.models.api_schema.service_schemas import (
+    InteractionData,
+    PublishUserInteractionRequest,
+)
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.server.services.generation_service import GenerationService
+from reflexio.server.usage_metrics import UsageEvent, configure_usage_event_recorder
+
+
+class _PublishFixture:
+    """Wraps a real ``GenerationService`` over temp-dir SQLite storage.
+
+    ``publish(interaction_ids=[...])`` publishes one interaction per label
+    (labels only vary interaction content -- see module docstring for why the
+    real ``event_key``/``entity_id`` won't literally equal the labels) and
+    returns every ``UsageEvent`` recorded during the call.
+    """
+
+    def __init__(self, tmp_path) -> None:
+        self.generation_service = GenerationService(
+            llm_client=LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini")),
+            request_context=RequestContext(
+                org_id="publish_events_test_org", storage_base_dir=str(tmp_path)
+            ),
+        )
+
+    def publish(self, interaction_ids: list[str]) -> list[UsageEvent]:
+        request = PublishUserInteractionRequest(
+            user_id="publish_events_test_user",
+            interaction_data_list=[
+                InteractionData(
+                    content=f"interaction {label}",
+                    created_at=int(datetime.datetime.now(UTC).timestamp()),
+                )
+                for label in interaction_ids
+            ],
+            session_id="publish_events_test_session",
+            evaluation_only=True,
+        )
+        events: list[UsageEvent] = []
+        configure_usage_event_recorder(events.append)
+        try:
+            self.generation_service.run(request)
+        finally:
+            configure_usage_event_recorder(None)
+        return events
+
+
+@pytest.fixture
+def publish_fixture(tmp_path):
+    return _PublishFixture(tmp_path)
+
+
+def test_publish_emits_one_event_per_interaction(publish_fixture):
+    events = publish_fixture.publish(interaction_ids=["i1", "i2", "i3"])
+    pub = [e for e in events if e.event_name == "publish_request_succeeded"]
+
+    assert len(pub) == 3
+
+    # Real ids are the DB auto-increment ints assigned in insertion order --
+    # fresh per-org sqlite db, so a first publish of 3 interactions is 1,2,3.
+    ids = sorted(int(e.entity_id) for e in pub)
+    assert ids == [1, 2, 3]
+    assert sorted(e.event_key for e in pub) == [f"pub:{i}" for i in ids]
+
+    assert all(e.count_value == 1 for e in pub)
+    assert sum(e.count_value for e in pub) == 3  # total unchanged vs old count_value=3

--- a/tests/server/services/test_non_extraction_learning_metering.py
+++ b/tests/server/services/test_non_extraction_learning_metering.py
@@ -168,6 +168,8 @@ def test_resumable_finalization_emits_one_event_per_profile_id() -> None:
         assert event.count_value == 1
         assert event.entity_type == "profile"
         assert event.source == "resumable_extraction"
+        # tie key<->entity together so a swapped association can't pass on sets alone
+        assert event.event_key == f"learn:{event.entity_type}:{event.entity_id}"
 
 
 def test_resumable_finalization_emits_one_event_per_playbook_id() -> None:
@@ -198,6 +200,9 @@ def test_resumable_finalization_emits_one_event_per_playbook_id() -> None:
         "learn:user_playbook:13",
     }
     assert {e.entity_id for e in events} == {"11", "12", "13"}
+    for event in events:
+        # tie key<->entity together so a swapped association can't pass on sets alone
+        assert event.event_key == f"learn:{event.entity_type}:{event.entity_id}"
 
 
 def test_resumable_finalization_falls_back_when_a_playbook_id_is_unset() -> None:
@@ -270,6 +275,8 @@ def test_aggregation_records_attributed_learnings_generated() -> None:
         assert event.entity_type == "agent_playbook"
         assert event.agent_version == "v1"
         assert event.playbook_name == "agent_rules"
+        # tie key<->entity together so a swapped association can't pass on sets alone
+        assert event.event_key == f"learn:{event.entity_type}:{event.entity_id}"
 
 
 def test_aggregation_falls_back_when_an_agent_playbook_id_is_falsy() -> None:

--- a/tests/server/services/test_non_extraction_learning_metering.py
+++ b/tests/server/services/test_non_extraction_learning_metering.py
@@ -88,18 +88,12 @@ def test_reflection_zero_revisions_records_nothing() -> None:
     assert events == []
 
 
-def test_resumable_finalization_records_learnings_generated() -> None:
-    events: list[UsageEvent] = []
-    configure_usage_event_recorder(events.append)
-    worker = ExtractionResumeWorker(
-        request_context=_request_context(),
-        llm_client=MagicMock(),
-    )
-    run = AgentRunRecord(
+def _agent_run(*, extractor_kind: str) -> AgentRunRecord:
+    return AgentRunRecord(
         id="run-1",
         binding=AgentBinding(
             org_id="org-1",
-            extractor_kind="profile",
+            extractor_kind=extractor_kind,
             user_id="user-1",
             request_id="req-1",
             agent_version="v1",
@@ -108,6 +102,20 @@ def test_resumable_finalization_records_learnings_generated() -> None:
         status=AgentRunStatus.FINALIZING,
         generation_request_snapshot={},
     )
+
+
+def test_resumable_finalization_falls_back_when_items_lack_ids() -> None:
+    """Items with no durable id (e.g. plain objects) fall back to the
+    count-based aggregate event -- Task A3's documented fallback, since there
+    is no safe per-record id to key a dedup event on.
+    """
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = ExtractionResumeWorker(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+    run = _agent_run(extractor_kind="profile")
 
     worker._record_finalized_learnings(
         run,
@@ -123,9 +131,107 @@ def test_resumable_finalization_records_learnings_generated() -> None:
     assert event.source == "resumable_extraction"
     assert event.entity_type == "profile"
     assert event.metadata == {"run_id": "run-1", "extractor_kind": "profile"}
+    assert event.event_key is not None and event.event_key.startswith("learn-batch:")
+
+
+def test_resumable_finalization_emits_one_event_per_profile_id() -> None:
+    """When every item carries a durable ``profile_id`` (the common case --
+    profile ids are assigned by the extractor before finalize runs), emit one
+    entity-backed event per profile instead of the count-only fallback.
+    """
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = ExtractionResumeWorker(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+    run = _agent_run(extractor_kind="profile")
+
+    class _FakeProfile:
+        def __init__(self, profile_id: str) -> None:
+            self.profile_id = profile_id
+
+    worker._record_finalized_learnings(
+        run,
+        [_FakeProfile("prof-1"), _FakeProfile("prof-2")],
+        entity_type="profile",
+    )
+
+    assert len(events) == 2
+    assert sum(e.count_value for e in events) == 2  # total unchanged vs old count=2
+    assert {e.event_key for e in events} == {"learn:prof-1", "learn:prof-2"}
+    assert {e.entity_id for e in events} == {"prof-1", "prof-2"}
+    for event in events:
+        assert event.count_value == 1
+        assert event.entity_type == "profile"
+        assert event.source == "resumable_extraction"
+
+
+def test_resumable_finalization_emits_one_event_per_playbook_id() -> None:
+    """Same as above for the playbook (``user_playbook_id``) kind."""
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = ExtractionResumeWorker(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+    run = _agent_run(extractor_kind="playbook")
+
+    class _FakePlaybook:
+        def __init__(self, user_playbook_id: int) -> None:
+            self.user_playbook_id = user_playbook_id
+
+    worker._record_finalized_learnings(
+        run,
+        [_FakePlaybook(11), _FakePlaybook(12), _FakePlaybook(13)],
+        entity_type="user_playbook",
+    )
+
+    assert len(events) == 3
+    assert sum(e.count_value for e in events) == 3  # total unchanged vs old count=3
+    assert {e.event_key for e in events} == {"learn:11", "learn:12", "learn:13"}
+    assert {e.entity_id for e in events} == {"11", "12", "13"}
+
+
+def test_resumable_finalization_falls_back_when_a_playbook_id_is_unset() -> None:
+    """A ``user_playbook_id=0`` (default, unset) mixed in with real ids means
+    dedup dropped that item before persist -- fall back to the count-based
+    aggregate rather than emit a colliding ``learn:0`` key or fabricate an id.
+    """
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    worker = ExtractionResumeWorker(
+        request_context=_request_context(),
+        llm_client=MagicMock(),
+    )
+    run = _agent_run(extractor_kind="playbook")
+
+    class _FakePlaybook:
+        def __init__(self, user_playbook_id: int) -> None:
+            self.user_playbook_id = user_playbook_id
+
+    worker._record_finalized_learnings(
+        run,
+        [_FakePlaybook(21), _FakePlaybook(0)],
+        entity_type="user_playbook",
+    )
+
+    assert len(events) == 1
+    assert events[0].count_value == 2  # total unchanged vs old count=2
+    assert events[0].event_key is not None and events[0].event_key.startswith(
+        "learn-batch:"
+    )
 
 
 def test_aggregation_records_attributed_learnings_generated() -> None:
+    """Aggregation emits one entity-backed event per generated playbook.
+
+    ``saved_playbook_list`` entries always carry a real ``agent_playbook_id``
+    (``save_agent_playbook_with_aggregate_event`` raises rather than
+    returning a partial row) -- aggregator.py is the one caller with a clean,
+    always-populated per-record id list, so it uses the entity-backed path
+    (Task A3) rather than the count-only fallback.
+    """
     events: list[UsageEvent] = []
     configure_usage_event_recorder(events.append)
     aggregator = PlaybookAggregator(
@@ -135,21 +241,24 @@ def test_aggregation_records_attributed_learnings_generated() -> None:
     )
 
     aggregator._record_learnings_generated(
-        count=3,
+        learning_ids=["101", "102", "103"],
         playbook_name="agent_rules",
         request_id="agg-run-1",
         metadata={"playbooks_generated": 3},
     )
 
-    assert len(events) == 1
-    event = events[0]
-    assert event.event_name == "learnings_generated"
-    assert event.count_value == 3
-    assert event.pipeline == "playbook"
-    assert event.source == "aggregation"
-    assert event.entity_type == "agent_playbook"
-    assert event.agent_version == "v1"
-    assert event.playbook_name == "agent_rules"
+    assert len(events) == 3
+    assert sum(e.count_value for e in events) == 3  # total unchanged vs old count=3
+    assert {e.event_key for e in events} == {"learn:101", "learn:102", "learn:103"}
+    assert {e.entity_id for e in events} == {"101", "102", "103"}
+    for event in events:
+        assert event.event_name == "learnings_generated"
+        assert event.count_value == 1
+        assert event.pipeline == "playbook"
+        assert event.source == "aggregation"
+        assert event.entity_type == "agent_playbook"
+        assert event.agent_version == "v1"
+        assert event.playbook_name == "agent_rules"
 
 
 def test_metering_failure_is_isolated_from_the_product_path() -> None:

--- a/tests/server/services/test_non_extraction_learning_metering.py
+++ b/tests/server/services/test_non_extraction_learning_metering.py
@@ -159,7 +159,10 @@ def test_resumable_finalization_emits_one_event_per_profile_id() -> None:
 
     assert len(events) == 2
     assert sum(e.count_value for e in events) == 2  # total unchanged vs old count=2
-    assert {e.event_key for e in events} == {"learn:prof-1", "learn:prof-2"}
+    assert {e.event_key for e in events} == {
+        "learn:profile:prof-1",
+        "learn:profile:prof-2",
+    }
     assert {e.entity_id for e in events} == {"prof-1", "prof-2"}
     for event in events:
         assert event.count_value == 1
@@ -189,7 +192,11 @@ def test_resumable_finalization_emits_one_event_per_playbook_id() -> None:
 
     assert len(events) == 3
     assert sum(e.count_value for e in events) == 3  # total unchanged vs old count=3
-    assert {e.event_key for e in events} == {"learn:11", "learn:12", "learn:13"}
+    assert {e.event_key for e in events} == {
+        "learn:user_playbook:11",
+        "learn:user_playbook:12",
+        "learn:user_playbook:13",
+    }
     assert {e.entity_id for e in events} == {"11", "12", "13"}
 
 
@@ -249,7 +256,11 @@ def test_aggregation_records_attributed_learnings_generated() -> None:
 
     assert len(events) == 3
     assert sum(e.count_value for e in events) == 3  # total unchanged vs old count=3
-    assert {e.event_key for e in events} == {"learn:101", "learn:102", "learn:103"}
+    assert {e.event_key for e in events} == {
+        "learn:agent_playbook:101",
+        "learn:agent_playbook:102",
+        "learn:agent_playbook:103",
+    }
     assert {e.entity_id for e in events} == {"101", "102", "103"}
     for event in events:
         assert event.event_name == "learnings_generated"
@@ -259,6 +270,37 @@ def test_aggregation_records_attributed_learnings_generated() -> None:
         assert event.entity_type == "agent_playbook"
         assert event.agent_version == "v1"
         assert event.playbook_name == "agent_rules"
+
+
+def test_aggregation_falls_back_when_an_agent_playbook_id_is_falsy() -> None:
+    """Whole-branch-review finding (2): a falsy/0 ``agent_playbook_id`` mixed
+    into the run must not mint a colliding ``learn:agent_playbook:0`` key --
+    fall back to the count-based aggregate event instead, matching
+    ``ExtractionResumeWorker``'s guard for the same failure mode.
+    """
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=_request_context(),
+        agent_version="v1",
+    )
+
+    aggregator._record_learnings_generated(
+        learning_ids=["201"],  # one id missing relative to total_count=2
+        playbook_name="agent_rules",
+        request_id="agg-run-2",
+        metadata={"playbooks_generated": 2},
+        total_count=2,
+    )
+
+    assert len(events) == 1
+    assert events[0].count_value == 2  # total unchanged vs old count=2
+    assert events[0].event_key is not None and events[0].event_key.startswith(
+        "learn-batch:"
+    )
+    assert events[0].entity_type == "agent_playbook"
+    assert events[0].source == "aggregation"
 
 
 def test_metering_failure_is_isolated_from_the_product_path() -> None:

--- a/tests/server/test_billing_meter_events.py
+++ b/tests/server/test_billing_meter_events.py
@@ -1,0 +1,206 @@
+"""Tests for per-record ``learnings_generated`` events (Task A3).
+
+Phase A of the BYOC metering redesign: ``learnings_generated`` gains an
+entity-backed emission path, ``record_learnings_generated_records`` /
+``emit_learnings_generated_records``, that emits ONE event per learning id
+(``count_value=1``, ``event_key=f"learn:{id}"``, ``entity_id=id``) instead of
+a single aggregate event with ``count_value=N``, so downstream dedup can key
+on the learning id.
+
+The existing count-based ``record_learnings_generated`` / ``emit_learnings_generated``
+remain as the documented FALLBACK for callers that genuinely lack a per-record
+id list (e.g. dedup/consolidation can reduce the persisted count below the raw
+extracted count, so there is no safe 1:1 id per unit of ``count``). The
+fallback path now also carries a synthesized ``event_key=f"learn-batch:{uuid4()}"``
+so every ``learnings_generated`` event -- record-backed or batch -- has a
+dedup key.
+
+Totals are preserved in both paths: the sum of ``count_value`` across the
+per-record events equals ``len(learning_ids)``; the fallback emits exactly
+``count_value=N`` in one event, unchanged from before.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+from reflexio.server.billing_meter import (
+    emit_learnings_generated_records,
+    record_learnings_generated,
+    record_learnings_generated_records,
+)
+
+HOOK = "reflexio.server.billing_meter.record_usage_event"
+
+_BATCH_KEY_RE = re.compile(r"^learn-batch:[0-9a-f-]{36}$")
+
+
+def test_records_emits_one_event_per_id():
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["p1", "p2", "p3"],
+            platform_llm=True,
+            platform_storage=None,
+            pipeline="profile",
+        )
+    assert hook.call_count == 3
+    for call, learning_id in zip(hook.call_args_list, ["p1", "p2", "p3"], strict=True):
+        kwargs = call.kwargs
+        assert kwargs["event_name"] == "learnings_generated"
+        assert kwargs["event_category"] == "learning"
+        assert kwargs["count_value"] == 1
+        assert kwargs["event_key"] == f"learn:{learning_id}"
+        assert kwargs["entity_id"] == learning_id
+
+
+def test_records_emits_distinct_keys():
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["a", "b", "c"],
+            platform_llm=True,
+            platform_storage=None,
+        )
+    keys = [call.kwargs["event_key"] for call in hook.call_args_list]
+    assert len(keys) == len(set(keys)) == 3
+
+
+def test_records_totals_preserved():
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["x1", "x2", "x3", "x4"],
+            platform_llm=True,
+            platform_storage=None,
+        )
+    total = sum(call.kwargs["count_value"] for call in hook.call_args_list)
+    assert total == 4  # == len(learning_ids), matching the old count semantics
+
+
+def test_records_noop_for_empty_list():
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=[],
+            platform_llm=True,
+            platform_storage=None,
+        )
+    hook.assert_not_called()
+
+
+def test_records_forwards_carried_fields():
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["pb1"],
+            platform_llm=False,
+            platform_storage=True,
+            pipeline="playbook",
+            user_id="user-1",
+            request_id="req-1",
+            session_id="sess-1",
+            source="aggregation",
+            agent_version="v9",
+            playbook_name="agent_rules",
+            entity_type="agent_playbook",
+            metadata={"k": "v"},
+        )
+    kwargs = hook.call_args.kwargs
+    assert kwargs["pipeline"] == "playbook"
+    assert kwargs["user_id"] == "user-1"
+    assert kwargs["request_id"] == "req-1"
+    assert kwargs["session_id"] == "sess-1"
+    assert kwargs["source"] == "aggregation"
+    assert kwargs["agent_version"] == "v9"
+    assert kwargs["playbook_name"] == "agent_rules"
+    assert kwargs["entity_type"] == "agent_playbook"
+    assert kwargs["platform_llm"] is False
+    assert kwargs["platform_storage"] is True
+    assert kwargs["caller_type"] == "internal"
+    assert kwargs["metadata"] == {"k": "v"}
+
+
+def test_fallback_emits_one_synthesized_key_event_with_count_value_n():
+    """The documented FALLBACK path: no ids, one event, count_value=N."""
+    with patch(HOOK) as hook:
+        record_learnings_generated(
+            org_id="org1",
+            count=5,
+            platform_llm=True,
+            platform_storage=None,
+        )
+    hook.assert_called_once()
+    kwargs = hook.call_args.kwargs
+    assert kwargs["event_name"] == "learnings_generated"
+    assert kwargs["count_value"] == 5
+    assert _BATCH_KEY_RE.match(kwargs["event_key"])
+
+
+def test_fallback_keys_are_unique_across_calls():
+    with patch(HOOK) as hook:
+        record_learnings_generated(
+            org_id="org1", count=2, platform_llm=True, platform_storage=None
+        )
+        record_learnings_generated(
+            org_id="org1", count=3, platform_llm=True, platform_storage=None
+        )
+    keys = [call.kwargs["event_key"] for call in hook.call_args_list]
+    assert len(keys) == len(set(keys)) == 2
+
+
+def test_fallback_still_noops_for_zero_count():
+    with patch(HOOK) as hook:
+        record_learnings_generated(
+            org_id="org1", count=0, platform_llm=True, platform_storage=None
+        )
+    hook.assert_not_called()
+
+
+def _configurator(config=None):
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    return configurator
+
+
+def test_emit_records_resolves_platform_llm_and_emits_per_id():
+    with patch(HOOK) as hook:
+        emit_learnings_generated_records(
+            org_id="org1",
+            configurator=_configurator(),
+            learning_ids=["r1", "r2"],
+            source="reflection",
+            pipeline="reflection",
+        )
+    assert hook.call_count == 2
+    assert all(call.kwargs["platform_llm"] is True for call in hook.call_args_list)
+    assert {call.kwargs["event_key"] for call in hook.call_args_list} == {
+        "learn:r1",
+        "learn:r2",
+    }
+
+
+def test_emit_records_noop_for_empty_ids():
+    with patch(HOOK) as hook:
+        emit_learnings_generated_records(
+            org_id="org1",
+            configurator=_configurator(),
+            learning_ids=[],
+            source="reflection",
+        )
+    hook.assert_not_called()
+
+
+def test_emit_records_swallows_exceptions():
+    configurator = MagicMock()
+    configurator.get_config.side_effect = RuntimeError("config boom")
+    with patch(HOOK) as hook:
+        # Must not raise despite get_config() blowing up mid-emit.
+        emit_learnings_generated_records(
+            org_id="org1",
+            configurator=configurator,
+            learning_ids=["r1"],
+            source="reflection",
+        )
+    hook.assert_not_called()

--- a/tests/server/test_billing_meter_events.py
+++ b/tests/server/test_billing_meter_events.py
@@ -1,4 +1,5 @@
-"""Tests for per-record ``learnings_generated`` events (Task A3).
+"""Tests for per-record ``learnings_generated`` events (Task A3) and
+synthesized-key event-moment counters (Task A4).
 
 Phase A of the BYOC metering redesign: ``learnings_generated`` gains an
 entity-backed emission path, ``record_learnings_generated_records`` /
@@ -18,6 +19,15 @@ dedup key.
 Totals are preserved in both paths: the sum of ``count_value`` across the
 per-record events equals ``len(learning_ids)``; the fallback emits exactly
 ``count_value=N`` in one event, unchanged from before.
+
+Task A4 covers the three "event-moment" counters -- ``record_extraction_tokens``,
+``record_applied_learnings``, ``record_search_request`` -- which have no
+durable per-record row to key on (a token batch, an applied-learnings
+response, a search request are all ephemeral moments, not entities). Each now
+mints a fresh ``uuid4()`` at the emit site as its ``event_key``
+(``tok:``/``applied:``/``search:`` prefixes) so two calls -- even with the
+exact same ``request_id`` -- produce two distinct keys and are never
+collapsed by downstream dedup. ``count_value`` is unchanged.
 """
 
 from __future__ import annotations
@@ -27,13 +37,19 @@ from unittest.mock import MagicMock, patch
 
 from reflexio.server.billing_meter import (
     emit_learnings_generated_records,
+    record_applied_learnings,
+    record_extraction_tokens,
     record_learnings_generated,
     record_learnings_generated_records,
+    record_search_request,
 )
 
 HOOK = "reflexio.server.billing_meter.record_usage_event"
 
 _BATCH_KEY_RE = re.compile(r"^learn-batch:[0-9a-f-]{36}$")
+_TOK_KEY_RE = re.compile(r"^tok:[0-9a-f-]{36}$")
+_APPLIED_KEY_RE = re.compile(r"^applied:[0-9a-f-]{36}$")
+_SEARCH_KEY_RE = re.compile(r"^search:[0-9a-f-]{36}$")
 
 
 def test_records_emits_one_event_per_id():
@@ -203,4 +219,172 @@ def test_emit_records_swallows_exceptions():
             learning_ids=["r1"],
             source="reflection",
         )
+    hook.assert_not_called()
+
+
+# --- Task A4: synthesized-key event-moment counters ------------------------
+
+
+def test_extraction_tokens_emits_synthesized_key():
+    with patch(HOOK) as hook:
+        record_extraction_tokens(
+            org_id="org1",
+            billing_input_tokens=100,
+            prompt_tokens=80,
+            completion_tokens=20,
+            platform_llm=True,
+            platform_storage=None,
+        )
+    hook.assert_called_once()
+    kwargs = hook.call_args.kwargs
+    assert kwargs["event_name"] == "extraction_tokens"
+    assert kwargs["count_value"] == 100  # unchanged: billing_input_tokens
+    assert _TOK_KEY_RE.match(kwargs["event_key"])
+
+
+def test_extraction_tokens_two_emits_under_one_request_id_get_distinct_keys():
+    """Two token emits under the SAME request_id must not collapse downstream."""
+    with patch(HOOK) as hook:
+        record_extraction_tokens(
+            org_id="org1",
+            billing_input_tokens=100,
+            prompt_tokens=80,
+            completion_tokens=20,
+            platform_llm=True,
+            platform_storage=None,
+            request_id="req-shared",
+        )
+        record_extraction_tokens(
+            org_id="org1",
+            billing_input_tokens=50,
+            prompt_tokens=40,
+            completion_tokens=10,
+            platform_llm=True,
+            platform_storage=None,
+            request_id="req-shared",
+        )
+    assert hook.call_count == 2
+    keys = [call.kwargs["event_key"] for call in hook.call_args_list]
+    assert len(keys) == len(set(keys)) == 2
+    for key in keys:
+        assert _TOK_KEY_RE.match(key)
+    counts = [call.kwargs["count_value"] for call in hook.call_args_list]
+    assert counts == [100, 50]  # both counted, unchanged
+
+
+def test_extraction_tokens_noop_for_zero_or_negative():
+    with patch(HOOK) as hook:
+        record_extraction_tokens(
+            org_id="org1",
+            billing_input_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
+            platform_llm=True,
+            platform_storage=None,
+        )
+    hook.assert_not_called()
+
+
+def test_applied_learnings_emits_synthesized_key():
+    with patch(HOOK) as hook:
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=3,
+            caller_type="production_agent",
+            platform_llm=True,
+            platform_storage=None,
+        )
+    hook.assert_called_once()
+    kwargs = hook.call_args.kwargs
+    assert kwargs["event_name"] == "learning_applied"
+    assert kwargs["count_value"] == 3  # unchanged: surfaced_count
+    assert _APPLIED_KEY_RE.match(kwargs["event_key"])
+
+
+def test_applied_learnings_two_calls_get_distinct_keys():
+    with patch(HOOK) as hook:
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=2,
+            caller_type="production_agent",
+            platform_llm=True,
+            platform_storage=None,
+            request_id="req-shared",
+        )
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=2,
+            caller_type="production_agent",
+            platform_llm=True,
+            platform_storage=None,
+            request_id="req-shared",
+        )
+    assert hook.call_count == 2
+    keys = [call.kwargs["event_key"] for call in hook.call_args_list]
+    assert len(keys) == len(set(keys)) == 2
+
+
+def test_applied_learnings_noop_guards_unchanged():
+    with patch(HOOK) as hook:
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=0,
+            caller_type="production_agent",
+            platform_llm=True,
+            platform_storage=None,
+        )
+        record_applied_learnings(
+            org_id="org1",
+            surfaced_count=3,
+            caller_type="dashboard",
+            platform_llm=True,
+            platform_storage=None,
+        )
+    hook.assert_not_called()
+
+
+def test_search_request_emits_synthesized_key():
+    with patch(HOOK) as hook:
+        record_search_request(
+            org_id="org1",
+            caller_type="production_agent",
+        )
+    hook.assert_called_once()
+    kwargs = hook.call_args.kwargs
+    assert kwargs["event_name"] == "search_request"
+    assert kwargs["count_value"] == 1  # unchanged
+    assert _SEARCH_KEY_RE.match(kwargs["event_key"])
+
+
+def test_search_request_two_calls_same_args_get_distinct_keys():
+    """The critical A4 guard: two identical-args search calls must produce
+    TWO events with DISTINCT search: keys -- this is what prevents the
+    request_id-collision under-count (two searches must never collapse into
+    one billed event downstream).
+    """
+    with patch(HOOK) as hook:
+        record_search_request(
+            org_id="org1",
+            caller_type="production_agent",
+            request_id="req-shared",
+            session_id="sess-shared",
+        )
+        record_search_request(
+            org_id="org1",
+            caller_type="production_agent",
+            request_id="req-shared",
+            session_id="sess-shared",
+        )
+    assert hook.call_count == 2
+    keys = [call.kwargs["event_key"] for call in hook.call_args_list]
+    assert len(keys) == len(set(keys)) == 2
+    for key in keys:
+        assert _SEARCH_KEY_RE.match(key)
+    counts = [call.kwargs["count_value"] for call in hook.call_args_list]
+    assert counts == [1, 1]  # both counted, unchanged
+
+
+def test_search_request_noop_for_non_production_agent():
+    with patch(HOOK) as hook:
+        record_search_request(org_id="org1", caller_type="dashboard")
     hook.assert_not_called()

--- a/tests/server/test_billing_meter_events.py
+++ b/tests/server/test_billing_meter_events.py
@@ -4,9 +4,13 @@ synthesized-key event-moment counters (Task A4).
 Phase A of the BYOC metering redesign: ``learnings_generated`` gains an
 entity-backed emission path, ``record_learnings_generated_records`` /
 ``emit_learnings_generated_records``, that emits ONE event per learning id
-(``count_value=1``, ``event_key=f"learn:{id}"``, ``entity_id=id``) instead of
-a single aggregate event with ``count_value=N``, so downstream dedup can key
-on the learning id.
+(``count_value=1``, ``event_key=f"learn:{entity_type}:{id}"``, ``entity_id=id``)
+instead of a single aggregate event with ``count_value=N``, so downstream
+dedup can key on the learning id. The ``entity_type`` segment is required for
+collision-freedom: ``user_playbook_id`` and ``agent_playbook_id`` are each an
+autoincrement primary key in a SEPARATE table, so the same integer id can
+legitimately occur in both -- without the entity-type segment those would
+mint the same ``event_key`` and collapse into one event downstream.
 
 The existing count-based ``record_learnings_generated`` / ``emit_learnings_generated``
 remain as the documented FALLBACK for callers that genuinely lack a per-record
@@ -60,6 +64,7 @@ def test_records_emits_one_event_per_id():
             platform_llm=True,
             platform_storage=None,
             pipeline="profile",
+            entity_type="profile",
         )
     assert hook.call_count == 3
     for call, learning_id in zip(hook.call_args_list, ["p1", "p2", "p3"], strict=True):
@@ -67,8 +72,46 @@ def test_records_emits_one_event_per_id():
         assert kwargs["event_name"] == "learnings_generated"
         assert kwargs["event_category"] == "learning"
         assert kwargs["count_value"] == 1
-        assert kwargs["event_key"] == f"learn:{learning_id}"
+        assert kwargs["event_key"] == f"learn:profile:{learning_id}"
         assert kwargs["entity_id"] == learning_id
+
+
+def test_records_key_uses_placeholder_when_entity_type_is_none():
+    """No entity_type -> stable '_' placeholder, never a literal 'None'."""
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["z1"],
+            platform_llm=True,
+            platform_storage=None,
+        )
+    assert hook.call_args.kwargs["event_key"] == "learn:_:z1"
+
+
+def test_records_key_disambiguates_same_id_across_entity_types():
+    """Regression guard for the cross-table collision finding: a
+    user_playbook id and an agent_playbook id that share the same integer
+    (both tables are separate AUTOINCREMENT PKs starting at 1) must produce
+    DISTINCT event_keys.
+    """
+    with patch(HOOK) as hook:
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["11"],
+            platform_llm=True,
+            platform_storage=None,
+            entity_type="user_playbook",
+        )
+        record_learnings_generated_records(
+            org_id="org1",
+            learning_ids=["11"],
+            platform_llm=True,
+            platform_storage=None,
+            entity_type="agent_playbook",
+        )
+    keys = [call.kwargs["event_key"] for call in hook.call_args_list]
+    assert keys == ["learn:user_playbook:11", "learn:agent_playbook:11"]
+    assert len(set(keys)) == 2
 
 
 def test_records_emits_distinct_keys():
@@ -188,12 +231,13 @@ def test_emit_records_resolves_platform_llm_and_emits_per_id():
             learning_ids=["r1", "r2"],
             source="reflection",
             pipeline="reflection",
+            entity_type="profile",
         )
     assert hook.call_count == 2
     assert all(call.kwargs["platform_llm"] is True for call in hook.call_args_list)
     assert {call.kwargs["event_key"] for call in hook.call_args_list} == {
-        "learn:r1",
-        "learn:r2",
+        "learn:profile:r1",
+        "learn:profile:r2",
     }
 
 

--- a/tests/server/test_usage_metrics.py
+++ b/tests/server/test_usage_metrics.py
@@ -7,8 +7,11 @@ def test_usage_event_carries_event_key():
     usage_metrics.configure_usage_event_recorder(captured.append)
     try:
         usage_metrics.record_usage_event(
-            org_id="7", event_name="search_request", event_category="application",
-            count_value=1, event_key="search:abc",
+            org_id="7",
+            event_name="search_request",
+            event_category="application",
+            count_value=1,
+            event_key="search:abc",
         )
     finally:
         usage_metrics.configure_usage_event_recorder(None)

--- a/tests/server/test_usage_metrics.py
+++ b/tests/server/test_usage_metrics.py
@@ -1,0 +1,19 @@
+from reflexio.server import usage_metrics
+from reflexio.server.usage_metrics import UsageEvent
+
+
+def test_usage_event_carries_event_key():
+    captured = []
+    usage_metrics.configure_usage_event_recorder(captured.append)
+    try:
+        usage_metrics.record_usage_event(
+            org_id="7", event_name="search_request", event_category="application",
+            count_value=1, event_key="search:abc",
+        )
+    finally:
+        usage_metrics.configure_usage_event_recorder(None)
+    assert captured and captured[0].event_key == "search:abc"
+
+
+def test_event_key_defaults_none():
+    assert UsageEvent(org_id="7", event_name="x", event_category="y").event_key is None


### PR DESCRIPTION
## What

Adds a **billing-agnostic per-record identity seam** to usage metering: usage events now carry an optional, stable `event_key`. This is the open-source half of an enterprise BYOC metering redesign that replaces a fragile positional-sequence protocol with idempotency-keyed dedup. **No billing, dedup, or WAL logic is added here** — only the ability for events to identify the record they measure.

## Why

The enterprise control plane needs a stable per-record key so a re-sent usage report deduplicates instead of colliding. That identity only exists at the moment usage is produced — i.e. at these OSS emit sites. So the sites stop pre-aggregating (one event with `count_value=N`) and instead emit one identified event per record. Totals are unchanged.

## Changes

- **`event_key` field** on `UsageEvent` + `record_usage_event` (optional, defaults `None`).
- **Publish** (`generation_service.py`): one event per interaction, `event_key=f"pub:{interaction_id}"`, via a shared `_emit_publish_success_events` helper across all 5 backend branches. Totals preserved.
- **Learnings generated**: per-learning events (`learn:{id}`) where durable ids exist (aggregator, resume_worker); a documented count-fallback (`learn-batch:{uuid4()}`, `count_value=N`) where a caller only has a pre-dedup count (extraction, reflection). Existing `pipeline`/`source` fields are preserved so the enterprise side can classify — no split logic added to OSS.
- **Event-moment counters** (tokens/search/applied): a fresh `uuid4` key minted per emit (`tok:`/`search:`/`applied:`), so two identical calls never collapse.

## Testing

- New tests: `test_usage_metrics.py`, `test_generation_billing_events.py`, `test_billing_meter_events.py`, `test_non_extraction_learning_metering.py` — assert per-record keys, **distinctness across calls**, and totals preserved.
- Metering test tier: 950 passed, 3 skipped; 4 snapshots passed (no prompt/mock drift). ruff + pyright clean on all changed files.

## Scope / safety

- Billing-agnostic: no dedup/WAL/billing/classification logic in this repo (verified by grep).
- Totals byte-for-byte unchanged for existing billing consumers (per-record split sums to the old aggregate).
- No new env vars.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Usage & Billing**
  - Enhanced billing/usage telemetry with per-activity event keys so multiple events under the same request are no longer merged.
  - Generated “learnings” metering can now emit one event per learning identifier (and per entity) when available.
  - Added count-based fallback events when durable record identifiers are missing.
  - Publish metering now records one success event per published interaction.
- **Tests**
  - Expanded coverage for per-interaction publish events, per-learning billing emissions, event key formatting, and fallback/no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->