### PR TITLE
fix(llm): log expected transient upstream failures at WARNING, not ERROR

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -74,6 +74,36 @@ _MODEL_TIMEOUT_FLOOR_SECONDS: dict[str, int] = {
 }
 
 
+# Upstream-provider errors that are EXPECTED and transient. By the time one of
+# these reaches the request handler the fallback ladder is already exhausted,
+# but the caller — not the client — owns fatality, and many callers degrade
+# gracefully (FTS fallback for document expansion, skip-dedup for profile
+# consolidation). Log these at WARNING so a flaky provider (e.g. minimax
+# timeouts / 529 overload) can't flood ERROR-level alerts for handled failures;
+# genuinely-unexpected errors (bugs, auth, malformed structured output) stay
+# ERROR. Classified by exception TYPE NAME to avoid importing the heavy
+# ``litellm``/``openai`` exception hierarchies at module import.
+_TRANSIENT_LLM_ERROR_NAMES: frozenset[str] = frozenset(
+    {
+        "Timeout",
+        "APITimeoutError",
+        "APIConnectionError",
+        "RateLimitError",
+        "InternalServerError",
+        "ServiceUnavailableError",
+    }
+)
+
+
+def _is_expected_transient_llm_error(exc: BaseException) -> bool:
+    """True for expected transient upstream failures (timeout / connection /
+    rate-limit / overload), including our own ``LLMHardTimeoutError`` (a
+    ``TimeoutError`` subclass raised when a provider hang is killed)."""
+    if isinstance(exc, TimeoutError):  # incl. LLMHardTimeoutError
+        return True
+    return type(exc).__name__ in _TRANSIENT_LLM_ERROR_NAMES
+
+
 class TextGenerationMixin:
     """Chat/response generation, completion-param build, hard-timeout, cost, multimodal.
 
@@ -826,7 +856,15 @@ class TextGenerationMixin:
                 )
                 return _call_and_parse()
         except Exception as e:
-            self.logger.error(
+            # Expected transient upstream failures (provider timeout / connection
+            # / rate-limit / overload) log at WARNING — callers own fatality and
+            # most degrade gracefully; only genuinely-unexpected errors are ERROR.
+            log = (
+                self.logger.warning
+                if _is_expected_transient_llm_error(e)
+                else self.logger.error
+            )
+            log(
                 "event=llm_request_end model=%s elapsed_seconds=%.3f success=False error_type=%s error=%s",
                 params.get("model"),
                 time.perf_counter() - request_start,

--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -465,7 +465,14 @@ class ProfileConsolidator(BaseDeduplicator):
 
             dedup_output = response
         except Exception as e:
-            logger.error("Failed to identify duplicates: %s", str(e))
+            # Graceful degradation: dedup is best-effort — on any failure
+            # (commonly a transient minimax timeout/overload) keep the profiles
+            # un-deduped rather than failing the caller. WARNING, not ERROR, so a
+            # flaky provider doesn't flood error alerts for a handled fallback.
+            logger.warning(
+                "Failed to identify duplicates (%s); keeping profiles un-deduped",
+                str(e),
+            )
             return _strip_deletion_markers(new_profiles), [], []
 
         if not dedup_output.duplicate_groups and not dedup_output.deletions:

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1468,6 +1468,64 @@ class TestStructuredOutputRetry:
 
         assert call_count == 1
 
+    def _request_end_failure_records(self, caplog):
+        return [
+            r
+            for r in caplog.records
+            if "event=llm_request_end" in r.getMessage()
+            and "success=False" in r.getMessage()
+        ]
+
+    def test_transient_upstream_error_logged_at_warning(self, caplog):
+        """A transient upstream failure (provider timeout / connection / 529
+        overload) logs the request-end failure at WARNING, not ERROR — callers
+        own fatality and most degrade gracefully — but still raises."""
+
+        def fake_completion(**kwargs):
+            raise TimeoutError("provider hung")  # incl. our LLMHardTimeoutError
+
+        client = _build_client(
+            LiteLLMConfig(model="minimax/MiniMax-M3", max_retries=1, retry_delay=0)
+        )
+        with (
+            patch("litellm.completion", side_effect=fake_completion),
+            caplog.at_level(logging.DEBUG),
+            pytest.raises(LiteLLMClientError),
+        ):
+            client.generate_chat_response(
+                messages=[{"role": "user", "content": "test"}],
+                response_format=SampleResponse,
+            )
+
+        ends = self._request_end_failure_records(caplog)
+        assert ends, "expected a request-end failure log record"
+        assert all(r.levelno == logging.WARNING for r in ends)
+        assert not any(r.levelno == logging.ERROR for r in ends)
+
+    def test_unexpected_error_still_logged_at_error(self, caplog):
+        """A genuinely-unexpected error (not a known transient upstream type)
+        stays at ERROR."""
+
+        def fake_completion(**kwargs):
+            raise RuntimeError("boom")
+
+        client = _build_client(
+            LiteLLMConfig(model="gpt-4o-mini", max_retries=1, retry_delay=0)
+        )
+        with (
+            patch("litellm.completion", side_effect=fake_completion),
+            caplog.at_level(logging.DEBUG),
+            pytest.raises(LiteLLMClientError),
+        ):
+            client.generate_chat_response(
+                messages=[{"role": "user", "content": "test"}],
+                response_format=SampleResponse,
+            )
+
+        ends = self._request_end_failure_records(caplog)
+        assert ends, "expected a request-end failure log record"
+        assert all(r.levelno == logging.ERROR for r in ends)
+
 
 # ===================================================================
 # _extract_json_from_string tests


### PR DESCRIPTION
## Log expected transient upstream LLM failures at WARNING, not ERROR

**Problem.** A batch Sentry alert fired on ERROR-log volume traced to minimax API
instability — intermittent `529` (server overloaded) + ~25s timeouts in the
document-expansion and profile-dedup paths. Both paths **already degrade
gracefully** (FTS fallback for expansion; keep profiles un-deduped for
consolidation), so there is **no user-facing failure** — but the underlying
timeout was logged at **ERROR** in the LiteLLM client's catch-all and in the
consolidator, flooding error alerts for handled fallbacks.

**Fix (log-level only — no behavior change).**
- `_litellm_text_generation.py`: the request-end failure handler now classifies
  the caught exception. Expected transient upstream errors — `Timeout`,
  `APITimeoutError`, `APIConnectionError`, `RateLimitError`,
  `InternalServerError`, `ServiceUnavailableError`, and our own
  `LLMHardTimeoutError` (a `TimeoutError` subclass raised when a provider hang is
  killed) — log at **WARNING**; everything else (bugs, auth, malformed structured
  output) stays **ERROR**. It **still raises `LiteLLMClientError`**, so callers
  continue to own fatality. Classified by exception type name to avoid importing
  the heavy `litellm`/`openai` exception hierarchies at module import.
- `consolidator.py`: the best-effort dedup failure (returns profiles un-deduped)
  is a graceful degradation → **WARNING**, not ERROR.

**Tests.** New unit tests assert a transient upstream error (`TimeoutError`) logs
the request-end failure at WARNING while a genuinely-unexpected error
(`RuntimeError`) stays ERROR; both still raise. Full `test_litellm_client_unit.py`
+ profile suite green (258 passed); ruff + pyright clean.

**Not in scope (documented in the investigation):** the document-expansion 25s
timeout is intentionally short (latency-sensitive; FTS fallback by design) and is
**not** extended here. If minimax overload becomes chronic, demoting it from
primary for these ops is a separate cost/quality decision.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logging for temporary upstream AI service failures by reporting them as warnings instead of errors.
  - Unexpected failures continue to be reported as errors for visibility.
  - Profile deduplication now gracefully falls back to retaining incoming profiles when processing fails, while preserving deletion markers.

- **Tests**
  - Added coverage verifying log severity for transient and unexpected request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->