### PR TITLE
fix: make extraction prefilter Unicode-aware

### DIFF
--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -5,6 +5,7 @@ Base class for generation services
 import logging
 import re
 import time
+import unicodedata
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -42,10 +43,11 @@ class ExtractorExecutionError(RuntimeError):
 logger = logging.getLogger(__name__)
 
 
-# Cheap-signal thresholds for the pre-LLM should_run filter. Tuned for
+# Cheap-signal threshold for the pre-LLM should_run filter. Tuned for
 # coding-assistant traffic where most turns are either slash commands
 # or tool scaffolding, and where the LLM should_run gate costs 5–7s
-# even when it ultimately votes False.
+# even when it ultimately votes False. Non-Latin letters and numbers
+# count twice because many scripts carry more meaning per character.
 _MIN_USER_CONTENT_LEN = 30
 # Heuristic match for reflexio's own extractor system prompts that
 # sometimes leak into the corpus via the claude-code LLM provider's
@@ -91,6 +93,31 @@ def _iter_user_contents(
     return out
 
 
+def _weighted_content_length(content: str) -> int:
+    """Count original non-Latin letters and numbers twice.
+
+    Normalize each code point only for script classification so compatibility
+    forms such as full-width Latin stay unweighted without changing the
+    original content length.
+    """
+    stripped = content.strip()
+
+    def is_non_latin_letter_or_number(char: str) -> bool:
+        normalized_chars = [
+            normalized_char
+            for normalized_char in unicodedata.normalize("NFKC", char)
+            if unicodedata.category(normalized_char)[0] in {"L", "N"}
+        ]
+        return bool(normalized_chars) and all(
+            not normalized_char.isascii()
+            and "LATIN" not in unicodedata.name(normalized_char, "")
+            for normalized_char in normalized_chars
+        )
+
+    non_latin_bonus = sum(1 for char in stripped if is_non_latin_letter_or_number(char))
+    return len(stripped) + non_latin_bonus
+
+
 def _cheap_should_run_reject(
     session_data_models: list[RequestInteractionDataModel],
 ) -> str | None:
@@ -102,8 +129,9 @@ def _cheap_should_run_reject(
     should run.
 
     Rejection rules:
-        - No user message at least ``_MIN_USER_CONTENT_LEN`` chars long
-          (purely short commands / confirmations).
+        - No user message reaches ``_MIN_USER_CONTENT_LEN`` weighted
+          characters (purely short commands / confirmations). Non-Latin
+          letters and numbers count twice.
         - Every user message is a bare slash-command dispatch with no
           substantive trailing text (e.g. ``/commit``, ``/review``,
           ``/claude-smart:tag``). Slash commands that carry user text
@@ -127,7 +155,10 @@ def _cheap_should_run_reject(
         if any(lowered.startswith(p) for p in _EXTRACTOR_PROMPT_PREFIXES):
             return "extractor_prompt_echo"
 
-    if not any(len(c.strip()) >= _MIN_USER_CONTENT_LEN for c in user_contents):
+    if not any(
+        _weighted_content_length(content) >= _MIN_USER_CONTENT_LEN
+        for content in user_contents
+    ):
         return "all_user_turns_too_short"
 
     if all(_is_pure_slash_command(c) for c in user_contents):

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -156,7 +156,8 @@ def _cheap_should_run_reject(
             return "extractor_prompt_echo"
 
     if not any(
-        _weighted_content_length(content) >= _MIN_USER_CONTENT_LEN
+        len(content.strip()) >= _MIN_USER_CONTENT_LEN
+        or _weighted_content_length(content) >= _MIN_USER_CONTENT_LEN
         for content in user_contents
     ):
         return "all_user_turns_too_short"

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -2190,6 +2190,16 @@ class TestCheapShouldRunReject:
         assert _weighted_content_length(content) == length
         assert _cheap_should_run_reject(self._batch(content)) == expected
 
+    def test_long_content_skips_weighted_length(self, monkeypatch):
+        def fail_if_called(_content):
+            pytest.fail("weighted length should only run below the base threshold")
+
+        monkeypatch.setattr(
+            "reflexio.server.services.base_generation_service._weighted_content_length",
+            fail_if_called,
+        )
+        assert _cheap_should_run_reject(self._batch("a" * 30)) is None
+
     @pytest.mark.parametrize("character", ["汉", "あ", "한", "م", "я", "١"])
     def test_non_latin_letters_and_numbers_count_twice(self, character):
         assert _weighted_content_length(character * 14) == 28

--- a/tests/server/services/test_base_generation_service.py
+++ b/tests/server/services/test_base_generation_service.py
@@ -27,6 +27,7 @@ from reflexio.server.services.base_generation_service import (
     StatusChangeOperation,
     _cheap_should_run_reject,
     _is_pure_slash_command,
+    _weighted_content_length,
 )
 from reflexio.server.services.extraction.outcome import ExtractionOutcome
 from reflexio.server.services.storage.storage_base import AgentRunStatus
@@ -2139,7 +2140,7 @@ class TestPureSlashCommand:
 
 
 class TestCheapShouldRunReject:
-    """Regression tests for the ``all_slash_commands`` rule after the /btw fix."""
+    """Regression tests for the cheap pre-LLM signal filter."""
 
     @staticmethod
     def _batch(*contents: str) -> list[RequestInteractionDataModel]:
@@ -2180,6 +2181,58 @@ class TestCheapShouldRunReject:
 
     def test_mixed_bare_and_content_bearing_passes(self):
         batch = self._batch("/learn", "/btw actually keep this whole batch around")
+        assert _cheap_should_run_reject(batch) is None
+
+    @pytest.mark.parametrize("length", [29, 30])
+    def test_latin_boundary_is_unchanged(self, length):
+        content = "a" * length
+        expected = "all_user_turns_too_short" if length == 29 else None
+        assert _weighted_content_length(content) == length
+        assert _cheap_should_run_reject(self._batch(content)) == expected
+
+    @pytest.mark.parametrize("character", ["汉", "あ", "한", "م", "я", "١"])
+    def test_non_latin_letters_and_numbers_count_twice(self, character):
+        assert _weighted_content_length(character * 14) == 28
+        assert _cheap_should_run_reject(self._batch(character * 14)) == (
+            "all_user_turns_too_short"
+        )
+        assert _weighted_content_length(character * 15) == 30
+        assert _cheap_should_run_reject(self._batch(character * 15)) is None
+
+    def test_mixed_latin_and_non_latin_content_uses_weighted_length(self):
+        content = "a" * 10 + "汉" * 10
+        assert _weighted_content_length(content) == 30
+        assert _cheap_should_run_reject(self._batch(content)) is None
+
+    def test_full_width_latin_normalizes_without_non_latin_bonus(self):
+        content = "Ａ" * 29
+        assert _weighted_content_length(content) == 29
+        assert _cheap_should_run_reject(self._batch(content)) == (
+            "all_user_turns_too_short"
+        )
+
+    @pytest.mark.parametrize("character", ["ﬃ", "Ⅷ"])
+    def test_latin_compatibility_forms_do_not_expand_the_length(self, character):
+        content = character * 29
+        assert _weighted_content_length(content) == 29
+        assert _cheap_should_run_reject(self._batch(content)) == (
+            "all_user_turns_too_short"
+        )
+
+    def test_decomposed_latin_accents_preserve_the_original_length(self):
+        content = "e\u0301" * 15
+        assert len(content) == 30
+        assert _weighted_content_length(content) == 30
+        assert _cheap_should_run_reject(self._batch(content)) is None
+
+    def test_chinese_memory_request_is_not_rejected_as_too_short(self):
+        batch = self._batch(
+            "现在你需要叫我蜘蛛侠",
+            "请记住这个名字，写入到memory",
+            "我是谁",
+            "我是谁",
+            "现在请你记住，我现在就叫蜘蛛侠，无论哪个对话，我都叫蜘蛛侠",
+        )
         assert _cheap_should_run_reject(batch) is None
 
 


### PR DESCRIPTION
## Summary

Short interactions written in Chinese and other non-Latin scripts could be rejected by the cheap pre-LLM extraction filter before profile and playbook generation. This change makes that threshold script-aware while preserving existing Roman-script behavior.

## Changes

- Count non-Latin Unicode letters and numbers twice when applying the 30-character prefilter threshold.
- Short-circuit on the raw threshold so Unicode scoring is bounded to inputs under 30 characters.
- Preserve original string length for Latin compatibility forms and decomposed Latin accents.
- Add boundary coverage for Latin, Chinese, Japanese, Korean, Arabic, Cyrillic, mixed-script, full-width, compatibility, and decomposed text.
- Add a regression fixture based on the reported Chinese memory interaction batch.

## Test plan

- `uv run ruff check reflexio/server/services/base_generation_service.py tests/server/services/test_base_generation_service.py`
- `uv run pyright reflexio/server/services/base_generation_service.py tests/server/services/test_base_generation_service.py`
- `uv run pytest tests/server/services/test_base_generation_service.py -q -o 'addopts='` (101 passed)
- Local service reproduction: publishing the supplied Chinese interaction sequence generated one profile and one playbook.

## Follow-ups

- Addressed review feedback that whole-string NFKC normalization could change Roman-script thresholds; normalization is now used only to classify each original code point.
- Addressed CodeRabbit feedback by bypassing weighted scoring when raw stripped length already meets the threshold.
- Merged as `1ae88e1d`; downstream submodule consumers should pin this merged `main` commit rather than the feature-branch tip.
