### PR TITLE
fix: dedup embedding model mismatch + MiniMax default max_tokens cap

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -889,7 +889,7 @@ class Config(BaseModel):
     # Skip the LLM pre-extraction eligibility check (always run extraction)
     skip_should_run_check: bool = False
     # Enable storage-time document expansion for improved FTS recall
-    enable_document_expansion: bool = True
+    enable_document_expansion: bool = False
     # Whether this org has opted into shadow-mode runs. Drives /healthz/eval
     # liveness derivation and the /api/get_evaluation_overview hero state
     # machine. When True, each publish optionally schedules a parallel

--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -53,7 +53,11 @@ from reflexio.server.llm.image_utils import (
     encode_image_to_base64 as _encode_image_to_base64,
 )
 from reflexio.server.llm.llm_utils import is_pydantic_model
-from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
+from reflexio.server.llm.model_defaults import (
+    ModelRole,
+    default_max_tokens_for_model,
+    resolve_model_name,
+)
 
 if TYPE_CHECKING:
     from reflexio.server.llm._litellm_types import LiteLLMConfig
@@ -398,6 +402,10 @@ class TextGenerationMixin:
             params["temperature"] = 0.0
 
         max_tokens = kwargs.pop("max_tokens", self.config.max_tokens)
+        if max_tokens is None:
+            # Provider-level guard: some providers (MiniMax-M3) stall into the
+            # request timeout when max_tokens is omitted. See model_defaults.
+            max_tokens = default_max_tokens_for_model(actual_model)
         if max_tokens:
             params["max_tokens"] = max_tokens
         if self.config.top_p != 1.0:

--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -267,6 +267,34 @@ _PROVIDER_DEFAULTS: dict[str, ProviderDefaults] = {
 }
 
 
+# Output-token cap applied when neither the call site nor the client config
+# sets max_tokens. MiniMax-M3 misbehaves with unbounded output: omitting
+# max_tokens (especially combined with a strict json_schema response_format)
+# deterministically stalls generation into litellm's 120s timeout (reproduced
+# 2026-07; observed in prod as consolidator/document-expansion timeouts).
+# Sizing (measured in prod, 2026-07-14): M3's reasoning tokens count against
+# this budget, so too small a cap starves the visible output — at 4096 the
+# model regularly spent the whole budget thinking and returned empty/truncated
+# content (structured-output parse failures ran ~10-20x the 8192-era rate,
+# breaking extraction). 8192 was the healthiest measured setting. The 120s
+# provider stalls occur at every cap value (provider-side; mitigate with
+# fallback models, not here). Providers absent from this map stay unbounded.
+_PROVIDER_DEFAULT_MAX_TOKENS: dict[str, int] = {"minimax": 8192}
+
+
+def default_max_tokens_for_model(model: str) -> int | None:
+    """Return the provider-level default output-token cap for ``model``.
+
+    Args:
+        model (str): Full model name, e.g. ``"minimax/MiniMax-M3"``.
+
+    Returns:
+        int | None: Cap to apply when the caller set none, or None (no cap).
+    """
+    provider = model.split("/", 1)[0] if "/" in model else ""
+    return _PROVIDER_DEFAULT_MAX_TOKENS.get(provider)
+
+
 EMBEDDING_CAPABLE_PROVIDERS: frozenset[str] = frozenset(
     p for p, d in _PROVIDER_DEFAULTS.items() if d.embedding is not None
 )

--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -430,14 +430,22 @@ def _post_embedding_batch(
             last_error = exc
             break
 
+    # For HTTP-status failures the response body carries the actionable
+    # detail (e.g. the daemon's 409 "already owns model X" message) — without
+    # it the log reads as a connectivity problem when it is a config conflict.
+    error_detail = str(last_error)
+    if isinstance(last_error, httpx.HTTPStatusError):
+        body = last_error.response.text.strip()
+        if body:
+            error_detail = f"{last_error} — response body: {body[:300]}"
     _LOGGER.warning(
         "Embedding service unavailable at %s: %s",
         url,
-        last_error,
+        error_detail,
         extra={"mode": mode},
     )
     raise EmbeddingUnavailableError(
-        f"Embedding service unavailable at {url}: {last_error}"
+        f"Embedding service unavailable at {url}: {error_detail}"
     ) from last_error
 
 

--- a/reflexio/server/services/deduplication_utils.py
+++ b/reflexio/server/services/deduplication_utils.py
@@ -8,13 +8,85 @@ ProfileConsolidator and PlaybookConsolidator.
 import logging
 from abc import ABC
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
+from reflexio.server.services.embedding_text import embedding_input
 from reflexio.server.site_var.site_var_manager import SiteVarManager
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_dedup_query_embeddings(
+    storage: Any,
+    client: LiteLLMClient,
+    query_texts: list[str],
+    *,
+    entity_label: str,
+) -> list[list[float] | None]:
+    """Embed dedup-search queries with the model that indexed the store.
+
+    Prefers the storage's own embedding path (correct model + "query" prefix);
+    falls back to ``client`` pinned to the storage's model/dimensions. Letting
+    the client resolve its default embedding model would be wrong here: it
+    picks the OSS default, which the enterprise embedding daemon rejects
+    (409 model conflict) and which would not match the indexed vectors anyway.
+
+    Args:
+        storage: Storage backend (duck-typed: ``_get_embedding`` preferred,
+            else ``embedding_model_name`` / ``embedding_dimensions``).
+        client: Shared LLM client, used only in the fallback path.
+        query_texts: Query strings to embed.
+        entity_label: Log prefix identifying the caller, e.g. "Profile".
+
+    Returns:
+        One embedding (or None) per query text, in input order. On any
+        failure, all entries are None so the caller degrades to text-only
+        search. A backend that signals embedding-service unavailability with
+        an empty vector (e.g. the Supabase query path) is normalized to None
+        so search falls back to its own embedding/FTS path instead of sending
+        an empty vector to the database.
+    """
+    try:
+        get_storage_embedding = getattr(storage, "_get_embedding", None)
+        if callable(get_storage_embedding):
+            logger.info(
+                "%s dedup query embeddings: source=storage model=%s",
+                entity_label,
+                getattr(storage, "embedding_model_name", "unknown"),
+            )
+            embeddings = [
+                cast(
+                    "list[float] | None",
+                    get_storage_embedding(query_text, purpose="query"),
+                )
+                for query_text in query_texts
+            ]
+        else:
+            embedding_model_name = storage.embedding_model_name
+            embedding_dimensions = storage.embedding_dimensions
+            logger.info(
+                "%s dedup query embeddings: source=llm_client model=%s",
+                entity_label,
+                embedding_model_name,
+            )
+            embeddings = list(
+                client.get_embeddings(
+                    [
+                        embedding_input(query_text, purpose="query")
+                        for query_text in query_texts
+                    ],
+                    model=embedding_model_name,
+                    dimensions=embedding_dimensions,
+                )
+            )
+    except Exception as e:
+        logger.warning("Failed to generate embeddings for dedup search: %s", e)
+        return [None] * len(query_texts)
+    return [emb or None for emb in embeddings]
+
 
 # Format used for "Last Modified" timestamps shown to deduplication LLMs.
 # Includes hours and minutes so same-day contradictions (morning vs evening)

--- a/reflexio/server/services/playbook/components/consolidator.py
+++ b/reflexio/server/services/playbook/components/consolidator.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from reflexio.models.api_schema.retriever_schema import SearchUserPlaybookRequest
 from reflexio.models.api_schema.service_schemas import UserPlaybook
 from reflexio.models.config_schema import (
-    EMBEDDING_DIMENSIONS,
     DeduplicationConfig,
     SearchOptions,
 )
@@ -23,6 +22,7 @@ from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
+    resolve_dedup_query_embeddings,
 )
 from reflexio.server.services.profile.profile_generation_service_utils import (
     check_string_token_overlap,
@@ -561,15 +561,12 @@ class PlaybookConsolidator(BaseDeduplicator):
         if not query_texts:
             return []
 
-        # Batch-generate embeddings
-        try:
-            embeddings = self.client.get_embeddings(
-                query_texts, dimensions=EMBEDDING_DIMENSIONS
-            )
-        except Exception as e:
-            logger.warning("Failed to generate embeddings for dedup search: %s", e)
-            # Fall back to text-only search
-            embeddings = [None] * len(query_texts)
+        # Embed dedup queries with the same model that indexed the store —
+        # see resolve_dedup_query_embeddings for why the client's default
+        # embedding model must not be used here.
+        embeddings = resolve_dedup_query_embeddings(
+            storage, self.client, query_texts, entity_label="Playbook"
+        )
 
         # Search for each new entry
         seen_ids: set[int] = set()

--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -7,7 +7,6 @@ import logging
 import os
 import uuid
 from datetime import UTC, datetime
-from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -20,8 +19,8 @@ from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
     parse_item_id,
+    resolve_dedup_query_embeddings,
 )
-from reflexio.server.services.embedding_text import embedding_input
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileTimeToLive,
     calculate_expiration_timestamp,
@@ -306,42 +305,9 @@ class ProfileConsolidator(BaseDeduplicator):
 
         # Generate embeddings with the request storage backend so dedup search
         # uses the same model/prefix/routing as normal profile search.
-        embeddings: list[list[float] | None]
-        try:
-            get_storage_embedding = getattr(storage, "_get_embedding", None)
-            if callable(get_storage_embedding):
-                logger.info(
-                    "Profile dedup query embeddings: source=storage model=%s",
-                    getattr(storage, "embedding_model_name", "unknown"),
-                )
-                embeddings = [
-                    cast(
-                        list[float],
-                        get_storage_embedding(query_text, purpose="query"),
-                    )
-                    for query_text in query_texts
-                ]
-            else:
-                storage_with_embeddings = cast(Any, storage)
-                embedding_model_name = storage_with_embeddings.embedding_model_name
-                embedding_dimensions = storage_with_embeddings.embedding_dimensions
-                logger.info(
-                    "Profile dedup query embeddings: source=llm_client model=%s",
-                    embedding_model_name,
-                )
-                embeddings = list(
-                    self.client.get_embeddings(
-                        [
-                            embedding_input(query_text, purpose="query")
-                            for query_text in query_texts
-                        ],
-                        model=embedding_model_name,
-                        dimensions=embedding_dimensions,
-                    )
-                )
-        except Exception as e:
-            logger.warning("Failed to generate embeddings for dedup search: %s", e)
-            embeddings = [None] * len(query_texts)
+        embeddings = resolve_dedup_query_embeddings(
+            storage, self.client, query_texts, entity_label="Profile"
+        )
 
         # Search for each new profile.
         #

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -1809,6 +1809,43 @@ class TestBuildCompletionParams:
         assert call_kwargs["max_tokens"] == 100
 
     @patch("reflexio.server.llm.litellm_client.litellm.completion")
+    def test_minimax_gets_default_max_tokens_cap(self, mock_completion):
+        """Unset max_tokens on a MiniMax model applies the provider cap.
+
+        MiniMax-M3 with unbounded output deterministically stalls into the
+        120s litellm timeout (prod consolidator/document-expansion outage,
+        2026-07-14). The provider-level default in model_defaults bounds it.
+        """
+        mock_completion.return_value = _make_completion_response("ok")
+        client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
+
+        client.generate_response("hi")
+
+        assert mock_completion.call_args.kwargs["max_tokens"] == 8192
+
+    @patch("reflexio.server.llm.litellm_client.litellm.completion")
+    def test_minimax_explicit_max_tokens_beats_provider_cap(self, mock_completion):
+        """Config/call-site max_tokens overrides the provider default cap."""
+        mock_completion.return_value = _make_completion_response("ok")
+        client = LiteLLMClient(
+            LiteLLMConfig(model="minimax/MiniMax-M3", max_tokens=100)
+        )
+
+        client.generate_response("hi")
+
+        assert mock_completion.call_args.kwargs["max_tokens"] == 100
+
+    @patch("reflexio.server.llm.litellm_client.litellm.completion")
+    def test_unmapped_provider_stays_unbounded(self, mock_completion):
+        """Providers without a default cap keep omitting max_tokens."""
+        mock_completion.return_value = _make_completion_response("ok")
+        client = LiteLLMClient(LiteLLMConfig(model="gpt-4o"))
+
+        client.generate_response("hi")
+
+        assert "max_tokens" not in mock_completion.call_args.kwargs
+
+    @patch("reflexio.server.llm.litellm_client.litellm.completion")
     def test_top_p_non_default(self, mock_completion):
         mock_completion.return_value = _make_completion_response("ok")
         config = LiteLLMConfig(model="gpt-4o", top_p=0.9)

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -212,32 +212,56 @@ class TestRetrieveExistingPlaybooks:
     """Tests for _retrieve_existing_playbooks."""
 
     def test_with_embeddings(self, mock_consolidator):
-        """Test retrieval using embeddings for vector search."""
+        """Test retrieval embeds queries via the storage's own embedding path."""
         new_fb = _make_user_playbook(0, trigger="user asks about billing")
         existing_fb = _make_user_playbook(
             1, user_playbook_id=100, trigger="billing inquiry"
         )
 
-        mock_consolidator.client.get_embeddings.return_value = [[0.1, 0.2, 0.3]]
-        mock_consolidator.request_context.storage.search_user_playbooks.return_value = [
-            existing_fb
-        ]
+        storage = mock_consolidator.request_context.storage
+        storage._get_embedding.return_value = [0.1, 0.2, 0.3]
+        storage.search_user_playbooks.return_value = [existing_fb]
 
         result = mock_consolidator._retrieve_existing_playbooks([new_fb])
 
         assert len(result) == 1
         assert result[0].user_playbook_id == 100
-        mock_consolidator.client.get_embeddings.assert_called_once()
+        storage._get_embedding.assert_called_once_with(
+            "user asks about billing", purpose="query"
+        )
+        # The dedup path must never use the client's default embedding model:
+        # it resolves the OSS default, which does not match the indexed vectors
+        # (and the enterprise embedding daemon rejects it with 409).
+        mock_consolidator.client.get_embeddings.assert_not_called()
+
+    def test_fallback_embeddings_use_storage_model_and_query_prefix(
+        self, mock_consolidator
+    ):
+        """Without a storage embedding path, pin the client to the storage's model."""
+        storage = mock_consolidator.request_context.storage
+        storage._get_embedding = None
+        storage.embedding_model_name = "local/test-embedding-model"
+        storage.embedding_dimensions = 768
+        storage.search_user_playbooks.return_value = []
+        mock_consolidator.client.get_embeddings.return_value = [[0.1] * 768]
+
+        new_fb = _make_user_playbook(0, trigger="user asks about billing")
+        mock_consolidator._retrieve_existing_playbooks([new_fb])
+
+        mock_consolidator.client.get_embeddings.assert_called_once_with(
+            ["search_query: user asks about billing"],
+            model="local/test-embedding-model",
+            dimensions=768,
+        )
 
     def test_fallback_to_text_search(self, mock_consolidator):
         """Test fallback to text-only search when embedding generation fails."""
         new_fb = _make_user_playbook(0)
         existing_fb = _make_user_playbook(1, user_playbook_id=200)
 
-        mock_consolidator.client.get_embeddings.side_effect = Exception("embed error")
-        mock_consolidator.request_context.storage.search_user_playbooks.return_value = [
-            existing_fb
-        ]
+        storage = mock_consolidator.request_context.storage
+        storage._get_embedding.side_effect = Exception("embed error")
+        storage.search_user_playbooks.return_value = [existing_fb]
 
         result = mock_consolidator._retrieve_existing_playbooks([new_fb])
 


### PR DESCRIPTION
## Summary

Fixes two bugs in how dedup search and MiniMax generation calls are made, improves an error message, and changes a config default.

## Changes

- **Consolidator dedup embeddings** — the playbook consolidator let the LLM client resolve its *default* embedding model for dedup query embeddings instead of the model that indexed the store. Against a single-model embedding daemon this fails with 409 (`_activate_model` rejects any model other than the daemon's active one), and the query vectors would not be comparable with the indexed vectors anyway (nor match their dimensions). Extracted the profile consolidator's storage-first pattern into a shared `resolve_dedup_query_embeddings()` helper in `deduplication_utils`, now used by both consolidators. The helper also normalizes an empty-vector unavailability signal to `None` so search degrades to its own embedding/FTS path instead of passing an empty vector to the backend.
- **MiniMax default max_tokens cap** — MiniMax-M3 with omitted `max_tokens` (especially with a strict `json_schema` response_format) can stall generation into litellm's request timeout. Added a provider-level default cap (8192) in `model_defaults`, applied in `_build_completion_params` only when neither the call site nor the client config sets one. The value is sized to leave room for M3's reasoning tokens, which count against the output budget — smaller caps starve the visible output and produce empty/truncated structured JSON. Other providers stay unbounded.
- **Embedding-service error detail** — HTTP failures from the embedding service now include the response body (capped at 300 chars) in the warning and raised error, so a 4xx config conflict no longer reads as a connectivity problem.
- **Config default** — `enable_document_expansion` now defaults to `False`. Expansion adds an LLM call per stored document for FTS-recall synonyms; orgs can opt back in via config.

## Test Plan

- [x] New unit tests: MiniMax default cap applied / explicit value wins / other providers stay unbounded
- [x] Updated playbook consolidator tests: storage-first embedding path, storage-model-pinned fallback, text-only degradation on embedding failure
- [x] `pytest tests/server/services/playbook tests/server/services/profile tests/server/llm` — 786 passed
- [x] ruff + pyright clean on changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-specific output limits when no maximum token setting is provided.
  * Improved deduplication searches by using the configured storage embedding method, with a client-based fallback.
  * Enhanced embedding error messages with relevant response details.

* **Behavior Changes**
  * Document expansion is now disabled by default.

* **Tests**
  * Added coverage for token limits, embedding fallbacks, and storage-based search embeddings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->