### PR TITLE
feat(evaluations): simplify SHADOW_OFF gate + tighten hero trend semantics

### DIFF
--- a/reflexio/server/services/evaluation_overview/components/hero_state.py
+++ b/reflexio/server/services/evaluation_overview/components/hero_state.py
@@ -11,7 +11,6 @@ from enum import StrEnum
 
 _FULL_MIN_DAYS = 14
 _FULL_MIN_SHADOW_N = 500
-_SHADOW_OFF_MIN_DAYS = 7
 
 
 class HeroState(StrEnum):
@@ -50,7 +49,7 @@ def compute_hero_state(
             migration pair in supabase/data/supabase/migrations/. The
             per-turn shadow grade in F1 lives on a different surface.)
         total_results (int): Total AgentSuccessEvaluationResult rows in the
-            trend window (used only to differentiate EMPTY from SHADOW_OFF).
+            trend window, used to distinguish EMPTY from states with data.
 
     Returns:
         HeroState: The single applicable state. Empty wins over everything;
@@ -59,15 +58,7 @@ def compute_hero_state(
     if total_results == 0:
         return HeroState.EMPTY
     if not shadow_enabled:
-        if (
-            days_since_first_eval is not None
-            and days_since_first_eval >= _SHADOW_OFF_MIN_DAYS
-        ):
-            return HeroState.SHADOW_OFF
-        # <7 days since first eval AND shadow off → still onboarding;
-        # render as EMPTY so the frontend shows onboarding rather than a
-        # partly-formed trend.
-        return HeroState.EMPTY
+        return HeroState.SHADOW_OFF
     if days_since_first_eval is None or days_since_first_eval < _FULL_MIN_DAYS:
         return HeroState.EARLY
     if n_shadow_in_window < _FULL_MIN_SHADOW_N:

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -47,6 +47,7 @@ from reflexio.server.services.evaluation_overview.components.hero_state import (
     compute_hero_state,
 )
 from reflexio.server.services.evaluation_overview.components.rule_attribution import (
+    CitationKey,
     compute_net_sessions,
 )
 from reflexio.server.services.evaluation_overview.components.shadow_aggregation import (
@@ -80,14 +81,14 @@ class EvaluationOverviewService:
         Time windows used here:
           - ``[request.from_ts, request.to_ts]`` is the *trend* window. The hero
             chart, rule attribution, and the rule-attribution session set are
-            all computed over it. The frontend sends an 8-week range so the
-            trend chart has shape.
+            all computed over it. The frontend defaults to a 7-day range but
+            the user can widen it via the date pickers.
           - The *tile baseline* and *distribution baseline* are tighter:
             ``last_7d`` (≤ to_ts) vs ``prior_7d`` (the 7d before that).
-            Tying these to ``request.from_ts`` is wrong — with an 8-week
-            request, ``prior`` would land 9 weeks back and always be empty,
-            so every tile would display "no baseline" regardless of how much
-            data the org has.
+            Tying these to ``request.from_ts`` is wrong — for any window wider
+            than 7 days ``prior`` would land before the requested window and
+            always be empty, so every tile would display "no baseline"
+            regardless of how much data the org has.
         """
         # Tile + distribution baselines are always last-7d-vs-prior-7d,
         # anchored to ``request.to_ts`` (which is "now" from the frontend's
@@ -206,6 +207,9 @@ class EvaluationOverviewService:
         results: list[AgentSuccessEvaluationResult],
         earliest_eval_ts: int | None,
     ) -> HeroBlock:
+        # days_since only feeds the EARLY-vs-FULL gate, which is reachable only
+        # when shadow_enabled is True. Shadow is hardcoded off below, so this is
+        # currently inert — retained for the (pending) shadow re-enable.
         if earliest_eval_ts is None:
             days_since = None
         else:
@@ -264,8 +268,8 @@ class EvaluationOverviewService:
     def _build_attribution(
         self,
         results: list[AgentSuccessEvaluationResult],
-        citations_by_session: dict[ResultKey, list[tuple[str, str]]],
-        rule_titles: dict[tuple[str, str], str],
+        citations_by_session: dict[ResultKey, list[CitationKey]],
+        rule_titles: dict[CitationKey, str],
     ) -> list[RuleAttributionRow]:
         is_success_by_session = {
             (r.user_id, r.session_id): r.is_success for r in results
@@ -291,7 +295,7 @@ class EvaluationOverviewService:
 
     def _load_citations(
         self, result_keys: list[ResultKey]
-    ) -> tuple[dict[ResultKey, list[tuple[str, str]]], dict[tuple[str, str], str]]:
+    ) -> tuple[dict[ResultKey, list[CitationKey]], dict[CitationKey, str]]:
         """Pull `Interaction.citations` keyed by user/session, with title lookup.
 
         Falls back to empty data when the underlying storage method returns
@@ -300,8 +304,8 @@ class EvaluationOverviewService:
         """
         wanted = set(result_keys)
         session_ids = sorted({session_id for _, session_id in result_keys})
-        citations_by_session: dict[ResultKey, list[tuple[str, str]]] = defaultdict(list)
-        rule_titles: dict[tuple[str, str], str] = {}
+        citations_by_session: dict[ResultKey, list[CitationKey]] = defaultdict(list)
+        rule_titles: dict[CitationKey, str] = {}
         for citation in self.storage.get_citations_by_session_ids(session_ids):  # type: ignore[attr-defined]
             result_key = (citation.user_id, citation.session_id)
             if result_key not in wanted:
@@ -369,8 +373,8 @@ class EvaluationOverviewService:
         previous: list[AgentSuccessEvaluationResult],
         session_sources: dict[ResultKey, str],
         bucket: BucketLiteral,
-        citations_by_session: dict[ResultKey, list[tuple[str, str]]],
-        rule_titles: dict[tuple[str, str], str],
+        citations_by_session: dict[ResultKey, list[CitationKey]],
+        rule_titles: dict[CitationKey, str],
         current_scores: list[ImportedScore],
         prior_scores: list[ImportedScore],
     ) -> SourceSetComparison:

--- a/tests/server/services/evaluation_overview/test_hero_state.py
+++ b/tests/server/services/evaluation_overview/test_hero_state.py
@@ -18,12 +18,12 @@ def test_empty_when_no_evaluated_sessions_ever() -> None:
 
 
 def test_shadow_off_when_disabled_and_some_data() -> None:
-    """State 3: shadow off, >=7 days of trend → shadow_off."""
+    """State 3: shadow off with any data → shadow_off."""
     state = compute_hero_state(
         shadow_enabled=False,
-        days_since_first_eval=10,
+        days_since_first_eval=0,
         n_shadow_in_window=0,
-        total_results=42,
+        total_results=1,
     )
     assert state == HeroState.SHADOW_OFF
 

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -141,28 +141,29 @@ def test_service_reports_single_recent_success_as_100_percent() -> None:
     assert response.context_tiles.success.current == 100.0
 
 
-def test_service_uses_first_ever_eval_for_hero_age() -> None:
-    """A narrow window should not make a mature org look newly onboarded."""
+def test_service_shows_recent_evaluations_immediately() -> None:
+    """A new org with results should render its available trend immediately."""
     now = int(time.time())
     storage = _storage_with_results(
         [
             _eval_result(
                 result_id=1,
-                session_id="old",
+                session_id="recent",
                 is_success=True,
-                created_at=now - 10 * 24 * 60 * 60,
-            ),
-            _eval_result(
-                result_id=2, session_id="current", is_success=True, created_at=now
-            ),
+                created_at=now,
+            )
         ]
     )
     config = Config(storage_config=StorageConfigSQLite())
 
     svc = EvaluationOverviewService(storage=storage, config=config)
-    response = svc.run(GetEvaluationOverviewRequest(from_ts=now - 60, to_ts=now))
+    response = svc.run(
+        GetEvaluationOverviewRequest(from_ts=now - 3600, to_ts=now, bucket="day")
+    )
 
     assert response.hero.state == "shadow_off"
+    assert response.hero.regular_success_rate_pp == 100.0
+    assert sum(bucket.regular_n for bucket in response.hero.buckets) == 1
 
 
 def test_service_honors_day_bucket_for_hero_trend() -> None:
@@ -193,6 +194,7 @@ def test_service_honors_day_bucket_for_hero_trend() -> None:
 
     assert [bucket.ts for bucket in response.hero.buckets] == [day, 2 * day]
     assert [bucket.regular_n for bucket in response.hero.buckets] == [2, 1]
+    assert [bucket.regular_rate for bucket in response.hero.buckets] == [0.5, 1.0]
 
 
 def test_service_uses_bulk_storage_methods_without_per_session_reads() -> None:


### PR DESCRIPTION
## Summary

Tightens the evaluation-overview hero-block backend to pair with a frontend change that surfaces the **latest daily** success rate and defaults the trend window to 7 days.

## Changes

- **`hero_state.py`** — Remove the `<7 days since first eval` onboarding gate. With shadow disabled, any available data now renders `SHADOW_OFF` immediately instead of being masked as `EMPTY`. `total_results` now only differentiates `EMPTY` from states that have data.
- **`service.py`** — Document that the frontend defaults to a 7-day trend window (previously 8 weeks) while tile/distribution baselines stay anchored to `request.to_ts` (last-7d-vs-prior-7d). Add a `CitationKey` type alias for the citation/rule-title dicts. Note that `days_since` only feeds the inert EARLY-vs-FULL gate (shadow is hardcoded off).
- **Tests** — Cover the simplified `SHADOW_OFF` path (any data → `SHADOW_OFF`), immediate rendering of a single recent evaluation, and per-bucket `regular_rate`.

## Test Plan

- `pytest tests/server/services/evaluation_overview/test_hero_state.py tests/server/services/evaluation_overview/test_service_integration.py` — 16 passed
- `ruff check` / `ruff format --check` — clean
- `pyright` — 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated evaluation overview behavior so shadow-disabled evaluations consistently display the “Shadow Off” state, including immediately after the first evaluation.
  * Improved trend reporting for newly active evaluations, including accurate success rates and bucket counts.
  * Refined hero-state and trend-window handling for more consistent overview results.

* **Bug Fixes**
  * Corrected inconsistent hero status and trend data during the earliest evaluation period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->