### PR TITLE
test: cover populated evaluation hero state

### DIFF
--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -137,6 +137,7 @@ def test_service_reports_single_recent_success_as_100_percent() -> None:
         GetEvaluationOverviewRequest(from_ts=now - 3600, to_ts=now, bucket="day")
     )
 
+    assert response.hero.state == "shadow_off"
     assert response.hero.regular_success_rate_pp == 100.0
     assert response.context_tiles.success.current == 100.0
 


### PR DESCRIPTION
## Summary

- Lock in the evaluation-overview behavior where a single recent scored session produces a populated `shadow_off` hero instead of the empty state.

## Changes

- Add an integration assertion for the hero state alongside the existing success-rate assertions.

## Test Plan

- `uv run ruff check tests/server/services/evaluation_overview/test_service_integration.py`
- `uv run pyright tests/server/services/evaluation_overview/test_service_integration.py`
- `uv run pytest tests/server/services/evaluation_overview/test_service_integration.py --no-cov -q` (11 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage to verify the expected hero state for a recent successful evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->