### PR TITLE
feat(cache): make REFLEXIO_CACHE_MAX_SIZE env-tunable (Workstream C phase 1)

### DIFF
--- a/reflexio/server/cache/reflexio_cache.py
+++ b/reflexio/server/cache/reflexio_cache.py
@@ -8,12 +8,13 @@ from typing import Any, Final
 from cachetools import TTLCache
 
 from reflexio.lib.reflexio_lib import Reflexio
+from reflexio.server.llm.llm_utils import positive_int_env
 from reflexio.server.tracing import profile_step
 
 logger = logging.getLogger(__name__)
 
 # Cache configuration
-REFLEXIO_CACHE_MAX_SIZE = 100
+REFLEXIO_CACHE_MAX_SIZE = positive_int_env("REFLEXIO_CACHE_MAX_SIZE", 100, logger)
 REFLEXIO_CACHE_TTL_SECONDS = 3600  # 1 hour safety net
 
 # Type alias for cache key: (org_id, storage_base_dir)

--- a/tests/server/cache/test_reflexio_cache.py
+++ b/tests/server/cache/test_reflexio_cache.py
@@ -11,6 +11,7 @@ Covers:
 7. Version-based auto-invalidation: stale entries are evicted on next get
 """
 
+import importlib
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -471,3 +472,33 @@ class TestVersionBasedInvalidation:
         c = get_reflexio("org-1")
         assert c is third
         assert mock_reflexio_cls.call_count == 3
+
+
+# =============================================================================
+# Env-tunable cache max size
+# =============================================================================
+
+
+def test_cache_max_size_env_override(monkeypatch: pytest.MonkeyPatch):
+    """REFLEXIO_CACHE_MAX_SIZE is read from the environment at import time."""
+    import reflexio.server.cache.reflexio_cache as cache_mod
+
+    monkeypatch.setenv("REFLEXIO_CACHE_MAX_SIZE", "400")
+    try:
+        cache_mod = importlib.reload(cache_mod)
+        assert cache_mod.REFLEXIO_CACHE_MAX_SIZE == 400
+        assert cache_mod.get_cache_stats()["max_size"] == 400
+    finally:
+        # Restore the module-global cache to its default sizing so the
+        # resized cache doesn't leak into other tests.
+        monkeypatch.delenv("REFLEXIO_CACHE_MAX_SIZE", raising=False)
+        importlib.reload(cache_mod)
+
+
+def test_cache_max_size_defaults_to_100(monkeypatch: pytest.MonkeyPatch):
+    """Without the env var set, the max size falls back to 100."""
+    import reflexio.server.cache.reflexio_cache as cache_mod
+
+    monkeypatch.delenv("REFLEXIO_CACHE_MAX_SIZE", raising=False)
+    cache_mod = importlib.reload(cache_mod)
+    assert cache_mod.REFLEXIO_CACHE_MAX_SIZE == 100


### PR DESCRIPTION
## What

Make the Reflexio instance-cache max size operator-tunable via a new env var
`REFLEXIO_CACHE_MAX_SIZE` (default **100**, unchanged behavior until set).

## Why

Part of the Scalability-Readiness **Workstream C** (instance-aware limits & caches). The
in-process instance cache holds up to 100 warm per-org `Reflexio` instances; at ~300
concurrently-active orgs per task the LRU thrashes and every request cold-rebuilds. This lets
an operator size the cache to the active-org count. No behavior change until the var is set.

## Change

- `reflexio_cache.py`: read the size via the existing `positive_int_env("REFLEXIO_CACHE_MAX_SIZE", 100, logger)` (import-light helper; falls back to 100 on unset/blank/invalid/non-positive).
- Tests: env-override (via `importlib.reload`, since the value is read once at import) + default-when-unset; teardown restores the default cache.

Design: `docs/superpowers/specs/2026-07-14-workstream-c-instance-aware-limits-caches-design.md` §3 (in the enterprise repo).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache capacity can now be configured through the `REFLEXIO_CACHE_MAX_SIZE` environment setting.
  * Cache monitoring statistics accurately reflect the configured capacity.
  * The default cache capacity remains 100 when no setting is provided.

* **Tests**
  * Added coverage for configured and default cache capacity values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->