### PR TITLE
feat(llm): per-provider bounded fail-open concurrency cap (Workstream C phase 3)

### DIFF
--- a/reflexio/server/llm/_litellm_embedding.py
+++ b/reflexio/server/llm/_litellm_embedding.py
@@ -31,6 +31,7 @@ import litellm
 import tiktoken
 
 from reflexio.server.llm._litellm_types import LiteLLMClientError
+from reflexio.server.llm._provider_concurrency import provider_slot
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
@@ -408,11 +409,12 @@ class EmbeddingMixin:
             if api_version:
                 params["api_version"] = api_version
 
-            response = litellm.embedding(
-                **params,
-                timeout=self.config.timeout,
-                num_retries=self.config.max_retries,
-            )
+            with provider_slot(params["model"]):
+                response = litellm.embedding(
+                    **params,
+                    timeout=self.config.timeout,
+                    num_retries=self.config.max_retries,
+                )
             # Response data may not be in order, sort by index to ensure correct ordering
             sorted_data = sorted(response.data, key=lambda x: x["index"])
             return [item["embedding"] for item in sorted_data]

--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -45,6 +45,7 @@ from reflexio.server.llm._litellm_types import (
     StructuredOutputParseError,
     ToolCallingChatResponse,
 )
+from reflexio.server.llm._provider_concurrency import provider_slot
 from reflexio.server.llm.image_utils import (
     SUPPORTED_IMAGE_MIME_TYPES,
     ImageEncodingError,
@@ -791,7 +792,8 @@ class TextGenerationMixin:
         )
 
         def _call_and_parse() -> str | BaseModel | ToolCallingChatResponse:
-            response = self._completion_with_hard_timeout(params, hard_timeout)
+            with provider_slot(params["model"]):
+                response = self._completion_with_hard_timeout(params, hard_timeout)
             self._emit_fallback_observability(response, params)
             message = response.choices[0].message  # type: ignore[reportAttributeAccessIssue]
             content = message.content

--- a/reflexio/server/llm/_provider_concurrency.py
+++ b/reflexio/server/llm/_provider_concurrency.py
@@ -1,0 +1,74 @@
+"""Per-provider, per-instance concurrency cap for remote LLM calls.
+
+A bounded, fail-open semaphore keyed by LLM provider. Acquired in the PARENT
+process around a provider call so N tasks don't fan into a provider-429 storm.
+On saturation it fails OPEN (proceeds without a permit) after a bounded wait,
+never blocking unboundedly — that would re-open the hung-provider stall class
+(Sentry PYTHON-FASTAPI-62) through the limiter. Part of Scalability Workstream C
+(design §5). 429 recovery stays with the fallback ladder (Decision A).
+"""
+
+import logging
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import litellm
+
+from reflexio.server.llm.llm_utils import positive_int_env
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_CONCURRENCY = 8
+REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY = positive_int_env(
+    "REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY", _DEFAULT_MAX_CONCURRENCY, logger
+)
+# Bounded wait before failing open. Long enough to queue a burst, short enough
+# to never park a request thread near the ~hard-timeout ceiling. Module constant
+# (not an env var) to keep C3 to a single knob.
+_ACQUIRE_TIMEOUT_SECONDS = 30.0
+
+_semaphores: dict[str, threading.BoundedSemaphore] = {}
+_registry_lock = threading.Lock()
+
+
+def _provider_key(model: str) -> str | None:
+    """Resolve the litellm provider for ``model``; None if unresolvable."""
+    try:
+        return litellm.get_llm_provider(model)[1]
+    except Exception:  # noqa: BLE001 — unknown model must not be capped or raise
+        return None
+
+
+def _get_semaphore(provider: str) -> threading.BoundedSemaphore:
+    with _registry_lock:
+        sem = _semaphores.get(provider)
+        if sem is None:
+            sem = threading.BoundedSemaphore(REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY)
+            _semaphores[provider] = sem
+        return sem
+
+
+@contextmanager
+def provider_slot(model: str) -> Iterator[None]:
+    """Cap concurrent in-flight calls to ``model``'s provider (fail-open)."""
+    provider = _provider_key(model)
+    if provider is None:
+        yield  # unknown provider → do not cap
+        return
+    sem = _get_semaphore(provider)
+    acquired = sem.acquire(timeout=_ACQUIRE_TIMEOUT_SECONDS)
+    if not acquired:
+        logger.warning(
+            "event=llm_provider_cap_saturated provider=%s cap=%d "
+            "timeout=%.1fs — proceeding without permit (fail-open)",
+            provider,
+            REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY,
+            _ACQUIRE_TIMEOUT_SECONDS,
+        )
+        yield
+        return
+    try:
+        yield
+    finally:
+        sem.release()

--- a/tests/server/llm/test_provider_concurrency.py
+++ b/tests/server/llm/test_provider_concurrency.py
@@ -40,6 +40,18 @@ def test_second_provider_independent(monkeypatch):
     assert a is not b
 
 
+def test_generation_seam_imports_provider_slot():
+    import reflexio.server.llm._litellm_text_generation as tg
+
+    assert hasattr(tg, "provider_slot")
+
+
+def test_embedding_seam_imports_provider_slot():
+    import reflexio.server.llm._litellm_embedding as emb
+
+    assert hasattr(emb, "provider_slot")
+
+
 def test_unknown_provider_not_capped(monkeypatch):
     monkeypatch.setattr(pc, "_provider_key", lambda _m: None)
     # Should be a no-op context (never blocks, never raises).

--- a/tests/server/llm/test_provider_concurrency.py
+++ b/tests/server/llm/test_provider_concurrency.py
@@ -1,0 +1,68 @@
+import time
+
+import reflexio.server.llm._provider_concurrency as pc
+
+
+def _hold(model, started, release, results, idx):
+    with pc.provider_slot(model):
+        started.set()
+        results[idx] = True
+        release.wait(timeout=5)
+
+
+def test_caps_concurrent_holders_per_provider(monkeypatch):
+    # Force a small cap and a short acquire timeout via reload.
+    monkeypatch.setenv("REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY", "2")
+    import importlib
+
+    importlib.reload(pc)
+    monkeypatch.setattr(pc, "_ACQUIRE_TIMEOUT_SECONDS", 0.3)
+    # Force a deterministic provider key (avoid network/model lookups).
+    monkeypatch.setattr(pc, "_provider_key", lambda _m: "openai")
+
+    sem = pc._get_semaphore("openai")
+    assert sem._value == 2  # BoundedSemaphore initial permits
+    # Hold both permits.
+    with pc.provider_slot("gpt-x"), pc.provider_slot("gpt-x"):
+        assert sem._value == 0
+        # A third acquire must FAIL OPEN after the bounded timeout (not block forever).
+        t0 = time.monotonic()
+        with pc.provider_slot("gpt-x"):
+            waited = time.monotonic() - t0
+        assert waited >= 0.3  # waited the bounded timeout, then proceeded
+    importlib.reload(pc)
+
+
+def test_second_provider_independent(monkeypatch):
+    monkeypatch.setattr(pc, "_provider_key", lambda m: m)  # model name == provider
+    a = pc._get_semaphore("prov_a")
+    b = pc._get_semaphore("prov_b")
+    assert a is not b
+
+
+def test_unknown_provider_not_capped(monkeypatch):
+    monkeypatch.setattr(pc, "_provider_key", lambda _m: None)
+    # Should be a no-op context (never blocks, never raises).
+    with pc.provider_slot("whatever"):
+        pass
+
+
+def test_fail_open_emits_log(monkeypatch, caplog):
+    monkeypatch.setattr(pc, "_provider_key", lambda _m: "openai")
+    monkeypatch.setattr(pc, "_ACQUIRE_TIMEOUT_SECONDS", 0.2)
+    monkeypatch.setattr(pc, "REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY", 1)
+    # rebuild the semaphore registry to pick up cap=1
+    pc._semaphores.clear()
+    # Enter left-to-right: the first slot takes the lone permit, then the
+    # second slot saturates and fails open (emitting the WARNING).
+    with (
+        pc.provider_slot("gpt-x"),
+        caplog.at_level("WARNING"),
+        pc.provider_slot("gpt-x"),  # saturated → fail open
+    ):
+        pass
+    assert any(
+        "provider_cap_saturated" in r.message or "saturat" in r.message.lower()
+        for r in caplog.records
+    )
+    pc._semaphores.clear()


### PR DESCRIPTION
## What

Per-provider, per-instance **bounded fail-open concurrency cap** for remote LLM calls
(`REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY`, default 8). Part of Scalability **Workstream C** (C3).

## Why

At 4–8 tasks, a publish burst fans N tasks' LLM calls at one provider with no local ceiling →
provider-429 storms. This caps concurrent in-flight calls **per provider per instance**.

## Design (per the enterprise design doc §5, reviewed 2 rounds)

- New `reflexio/server/llm/_provider_concurrency.py`: a lazily-built per-provider
  `BoundedSemaphore` + `provider_slot(model)` context manager.
- **Parent placement** (required): generation wraps `self._completion_with_hard_timeout(...)` in
  `_call_and_parse` — the subprocess spawns *inside* that call, so the permit is held in the
  parent (a child-side semaphore would cap nothing). Embedding wraps the in-process
  `litellm.embedding(...)`. Two distinct seams.
- **Bounded acquire + fail-open**: `acquire(timeout=30s)`; on timeout it proceeds WITHOUT a
  permit + logs `llm_provider_cap_saturated` — never blocks unboundedly (that would re-open the
  hung-provider stall class PYTHON-FASTAPI-62 through the limiter).
- **No 429/retry logic** (Decision A): 429 recovery stays with the existing fallback ladder;
  `num_retries` untouched.
- **Out of scope** (§5.2): the remote GPU/CPU embedding cell (httpx, not litellm) and local ONNX
  embedders — bounded by their own knob.
- Primary-provider approximation: a fallback-provider call counts against the primary's cap.

## Tests

- Deterministic unit tests: cap enforced per provider, fail-open after the bounded timeout,
  per-provider isolation, unknown-provider uncapped, saturation logs.
- Wiring: both seams import/enter `provider_slot`. Parent placement is structural (wrap around
  `_completion_with_hard_timeout`, outside the fork).
- `560 passed` across `tests/server/llm/` (4 unrelated errors need an LLM API key at fixture setup).

`.env.template` doc + the deployment-doctrine 3-knob disambiguation land in the paired enterprise PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-provider concurrency limits for remote language-model and embedding requests.
  * Added configurable handling for busy providers, allowing requests to continue after a bounded wait.

* **Reliability**
  * Prevented excessive simultaneous requests to the same provider while keeping unknown providers available.
  * Added warning visibility when provider capacity is temporarily saturated.

* **Tests**
  * Added coverage for provider limits, independent provider handling, timeout behavior, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->