### PR TITLE
fix(llm): treat provider-prefix drift as primary, not a fallback

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -109,6 +109,33 @@ def _is_expected_transient_llm_error(exc: BaseException) -> bool:
     return type(exc).__name__ in _TRANSIENT_LLM_ERROR_NAMES
 
 
+def _same_observed_model(primary_model: Any, served_model: Any) -> bool:
+    """Return True when the served model is the primary model modulo provider-prefix drift.
+
+    Some providers echo back the bare model name (e.g. ``MiniMax-M3``) even when
+    LiteLLM was called through the provider-prefixed name (``minimax/MiniMax-M3``).
+    Treat those as the same model so fallback observability does not misreport the
+    primary as a fallback. The match is anchored on a ``/`` boundary in either
+    direction, so ``gpt-4`` never matches ``gpt-40``.
+
+    Args:
+        primary_model: The originally requested model name (may be ``None``).
+        served_model: The model LiteLLM reports as having served the call (may be ``None``).
+
+    Returns:
+        bool: True if the names are equal or differ only by a provider prefix.
+    """
+    if not primary_model or not served_model:
+        return False
+    primary = str(primary_model)
+    served = str(served_model)
+    return (
+        primary == served
+        or primary.endswith(f"/{served}")
+        or served.endswith(f"/{primary}")
+    )
+
+
 class TextGenerationMixin:
     """Chat/response generation, completion-param build, hard-timeout, cost, multimodal.
 
@@ -696,7 +723,7 @@ class TextGenerationMixin:
                 or getattr(response, "model", None)
             )
 
-            if not served_model or served_model == primary_model:
+            if not served_model or _same_observed_model(primary_model, served_model):
                 return
 
             self.logger.info(

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -2890,6 +2890,23 @@ class TestFallbackObservability:
 
         assert "llm.fallback_used" not in tags
 
+    def test_sentry_tag_not_set_when_provider_strips_prefix(self, monkeypatch):
+        tags = self._install_fake_sentry(monkeypatch)
+        client = LiteLLMClient(LiteLLMConfig(model="minimax/MiniMax-M3"))
+
+        # MiniMax returns the bare model name even when LiteLLM was called
+        # through the provider-prefixed name. That is still the primary model,
+        # not a fallback.
+        response = _make_completion_response("ok")
+        response._hidden_params = {"model_id": "MiniMax-M3"}
+        response.model = "MiniMax-M3"
+
+        monkeypatch.setattr("litellm.completion", lambda **_p: response)
+
+        client.generate_chat_response([{"role": "user", "content": "hi"}])
+
+        assert "llm.fallback_used" not in tags
+
 
 class TestEmbeddingRetries:
     """Embedding calls get num_retries parity with chat. Cross-model


### PR DESCRIPTION
## Problem

The LLM fallback-observability check detects a fallback by comparing the model that actually served the call against the requested primary model. It used exact string equality, but some providers (e.g. MiniMax) echo back the **bare** model name (`MiniMax-M3`) even when LiteLLM was called through the provider-prefixed name (`minimax/MiniMax-M3`).

As a result, a normal call served by the primary model was misclassified as a fallback and fired a spurious `llm.fallback_used` Sentry tag (plus `llm.primary_model` / `llm.fallback_model`), polluting fallback observability.

## Fix

Add `_same_observed_model(primary, served)`, which treats the two as the same model when they are equal or differ only by a provider prefix. The suffix match is anchored on a `/` boundary in both directions, so token-prefix collisions like `gpt-4` vs `gpt-40` do not falsely match. Use it in place of the exact-equality guard in `_emit_fallback_observability`.

This only *broadens* the "same model" set, so it can suppress spurious tags but cannot fire new ones — the true-positive path (a genuine cross-model fallback) is unchanged and still covered by the existing test.

## Tests

Added `test_sentry_tag_not_set_when_provider_strips_prefix`, which drives the full `generate_chat_response` path with a forged response echoing the bare model name and asserts no fallback tag is emitted. The existing "real fallback fires" and "exact match stays silent" tests remain green.

- `ruff check` ✅  ·  `pyright` ✅  ·  `TestFallbackObservability` (3 tests) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback reporting when model providers normalize or remove model-name prefixes.
  * Prevented false fallback alerts and telemetry tags when the same primary model is represented with different provider routing formats.

* **Tests**
  * Added coverage for normalized model names to ensure fallback indicators are reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->