### PR TITLE
fix(cli): detect bound-but-not-listening port holders in services stop/start

### DIFF
--- a/reflexio/cli/utils.py
+++ b/reflexio/cli/utils.py
@@ -42,21 +42,44 @@ def get_env_port(name: str, default: int) -> int:
 
 
 def find_pids_on_port(port: int) -> list[int]:
-    """Find process IDs listening on the given port using lsof."""
+    """
+    Find process IDs with a TCP socket bound to the given port using lsof.
+
+    Matches listeners and bound-but-not-listening sockets (e.g. an orphaned
+    uvicorn --reload worker holding the port in CLOSED state, which blocks
+    rebinding but is invisible to a LISTEN-only check). Client connections to
+    the port (sockets with a peer address) are excluded so unrelated processes
+    that merely connected to the service are never reported or killed.
+
+    Args:
+        port (int): TCP port to inspect
+
+    Returns:
+        list[int]: Sorted, de-duplicated PIDs holding a socket bound to the port
+    """
     try:
         result = subprocess.run(
-            ["lsof", "-nP", "-t", f"-iTCP:{port}", "-sTCP:LISTEN"],
+            ["lsof", "-nP", "-Fpn", f"-iTCP:{port}"],
             capture_output=True,
             text=True,
             check=False,
         )
-        if result.returncode == 0 and result.stdout.strip():
-            return [
-                int(p) for p in result.stdout.strip().split("\n") if p.strip().isdigit()
-            ]
     except FileNotFoundError:
-        pass
-    return []
+        return []
+    if result.returncode != 0 or not result.stdout.strip():
+        return []
+
+    pids: set[int] = set()
+    current_pid: int | None = None
+    suffix = f":{port}"
+    for line in result.stdout.splitlines():
+        if line.startswith("p") and line[1:].isdigit():
+            current_pid = int(line[1:])
+        elif line.startswith("n") and current_pid is not None:
+            name = line[1:]
+            if "->" not in name and name.endswith(suffix):
+                pids.add(current_pid)
+    return sorted(pids)
 
 
 def find_pids_by_pattern(pattern: str) -> list[int]:

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import io
+import os
+import shutil
 import signal
+import socket
 import tempfile
 import threading
 from pathlib import Path
@@ -75,8 +78,21 @@ def test_pidfile_path_uses_platform_temp_dir() -> None:
     assert path.name.startswith("reflexio_services_")
 
 
-def test_find_pids_on_port_queries_tcp_listeners_only(monkeypatch) -> None:
+def test_find_pids_on_port_reports_bound_sockets_not_clients(monkeypatch) -> None:
     calls: list[list[str]] = []
+    # One listener (123), one orphaned bound-but-not-listening socket (456),
+    # and one client merely connected to the port (789) which must be excluded.
+    lsof_output = (
+        "p123\n"
+        "f13\n"
+        "n*:8090\n"
+        "p456\n"
+        "f3\n"
+        "n127.0.0.1:8090\n"
+        "p789\n"
+        "f91\n"
+        "n127.0.0.1:55006->127.0.0.1:8090\n"
+    )
 
     def fake_run(
         cmd: list[str],
@@ -89,12 +105,32 @@ def test_find_pids_on_port_queries_tcp_listeners_only(monkeypatch) -> None:
         assert capture_output is True
         assert text is True
         assert check is False
-        return CompletedProcess(cmd, 0, stdout="123\nnot-a-pid\n456\n")
+        return CompletedProcess(cmd, 0, stdout=lsof_output)
 
     monkeypatch.setattr(utils.subprocess, "run", fake_run)
 
     assert utils.find_pids_on_port(8090) == [123, 456]
-    assert calls == [["lsof", "-nP", "-t", "-iTCP:8090", "-sTCP:LISTEN"]]
+    assert calls == [["lsof", "-nP", "-Fpn", "-iTCP:8090"]]
+
+
+def test_find_pids_on_port_ignores_other_ports_with_same_suffix(monkeypatch) -> None:
+    def fake_run(cmd: list[str], **_kwargs) -> CompletedProcess[str]:
+        return CompletedProcess(cmd, 0, stdout="p123\nn*:18090\n")
+
+    monkeypatch.setattr(utils.subprocess, "run", fake_run)
+
+    assert utils.find_pids_on_port(8090) == []
+
+
+@pytest.mark.skipif(shutil.which("lsof") is None, reason="lsof not available")
+def test_find_pids_on_port_detects_bound_socket_without_listen() -> None:
+    # Regression: an orphaned process can hold a port bound without listening
+    # (e.g. a leaked uvicorn --reload worker); it must still be detected.
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+
+        assert os.getpid() in utils.find_pids_on_port(port)
 
 
 def test_requested_port_conflicts_detect_duplicate_service_ports(


### PR DESCRIPTION
## Problem

`reflexio services stop` can report a service as "not running" while the very next `services start` fails with `[Errno 48] Address already in use` on the same port.

Root cause (observed live): an orphaned multiprocessing child from a previous uvicorn `--reload` backend run (reparented to PID 1) kept the backend socket **bound** in `CLOSED` state:

```
python3.1 67521 yilu 3u IPv4 ... TCP *:8091 (CLOSED)
```

`find_pids_on_port()` queried `lsof ... -sTCP:LISTEN`, which only sees listeners — so stop couldn't find or kill the orphan, start's preflight didn't flag the conflict, and uvicorn crashed mid-startup instead.

## Fix

Rewrite `find_pids_on_port()` to use a state-agnostic `lsof -nP -Fpn -iTCP:<port>` query and report any PID with a socket **bound** to the port — a socket name with no peer address (`->`) ending in `:<port>`. This covers listeners and orphaned bound sockets while excluding client connections, so a Jupyter kernel or browser that merely connected to the service is never reported or killed.

All three consumers of the shared helper are fixed at once:

- `stop_services()` — now finds and kills the orphan
- `ensure_requested_ports_available()` — start now exits with a clear "port ... already in use by PID(s)" message instead of a mid-start bind crash
- enterprise `_verify_ports_released()` — post-stop verification now catches leftover bound sockets

## Tests

- Parsing test: listener + bound-CLOSED orphan reported, client connection excluded
- Suffix test: `:18090` does not match a query for `:8090`
- Real-socket regression test: `bind()` without `listen()` is detected (the exact orphan signature)

## Verification

Reproduced the failure shape end-to-end on a scratch port: spawned a process that binds 18999 without listening, then

- `reflexio services stop --only backend --backend-port 18999` → `Stopped backend (port 18999)` (previously "not running"), orphan killed, port freed
- start preflight against the re-spawned orphan → `backend port 18999 is already in use by PID(s): <pid>`
- live-stack sanity check: real listeners on 8090/8091 reported; a stale Jupyter *client* socket to 8091 correctly excluded

`ruff check`, `ruff format --check`, `pyright`, and `tests/cli/test_utils.py` (16 passed) all green.

Enterprise companion PR follows (warning-wording tweak + submodule pointer bump); merge this first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of processes using a TCP port, including sockets that are bound but not actively listening.
  * Excluded unrelated client connections and ports with similar numeric suffixes.
  * Improved handling when the required system utility is unavailable or returns no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->