### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -132,7 +132,7 @@ client (Python SDK)
 - **`api_endpoints/`**: Request handling, `RequestContext` (bundles storage/config/prompts), auth
 - **`routes/`**: Domain route modules (`system.py`, `interactions.py`, `profiles.py`, `playbooks.py`, `search.py`, `provenance.py`, `evaluation.py`, `braintrust.py`, `config.py`) included into `api.py`'s `core_router`
 - **`db/`**: Auth & config storage only (SQLite) - NOT for profiles/interactions
-- **`llm/`**: Unified LLM client (auto-detects OpenAI/Claude from model name)
+- **`llm/`**: Unified LiteLLM client, provider adapters, local rerank helpers, structured-output repair, and fail-open per-provider concurrency caps
 - **`prompt/`**: Versioned prompt templates in `prompt_bank/`
 - **`services/`**: Core business logic
   - `generation_service.py` - Orchestrator (runs profile/playbook/success services)

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -117,7 +117,7 @@ Description: FastAPI backend server that processes user interactions to generate
 Key files:
 - `litellm_client.py`: Stable import surface, client config/credential resolution, and `LiteLLMClient` facade
 - `_litellm_text_generation.py`, `_litellm_embedding.py`, `_litellm_structured_output.py`: Completion/tool-call, embedding, and structured-output mixins
-- `_litellm_json_extraction.py`, `_litellm_subprocess.py`, `_litellm_types.py`: JSON parsing, hard-timeout subprocess snapshots/workers, and shared public types/errors
+- `_litellm_json_extraction.py`, `_litellm_subprocess.py`, `_provider_concurrency.py`, `_litellm_types.py`: JSON parsing, hard-timeout subprocess snapshots/workers, per-provider fail-open concurrency caps, and shared public types/errors
 - `providers/`: Optional local/provider adapters (`claude-code/`, OpenClaw, local embedding, Nomic embedding); registration is opt-in via environment/config
 - `openai_client.py`: OpenAI implementation (legacy, do not use directly)
 - `claude_client.py`: Claude implementation (legacy, do not use directly)
@@ -134,6 +134,7 @@ Key files:
 - **Structured-output repair**: `generate_chat_response(..., response_format=..., structured_output_validator=...)` opts a call into bounded corrective repair. The validator receives the parsed Pydantic object and returns semantic errors; an empty list means valid. Opted-in calls repair malformed, blank, and semantically invalid outputs with one same-model corrective follow-up. If that still fails and `REFLEXIO_LLM_FALLBACK_MODELS` has an eligible network fallback, one final corrective turn is sent to the first eligible fallback model. Exhaustion raises `StructuredOutputRepairError` with the latest raw response and validation errors for programmatic handling; `parsed_output` is the most recent attempt that parsed at all, which may be an earlier attempt when the final response fails parsing — do not treat it as metadata of the latest raw response. Exception text does not include raw output.
 - **Two-level retry model**: transport failures/timeouts use LiteLLM's fallback ladder within a generation turn (`num_retries=0`, primary then configured fallbacks). Structured-output repair is across turns and is opt-in via `structured_output_validator`; callers without a validator keep the legacy one-shot blind parse retry.
 - **Fallback model dual role**: `REFLEXIO_LLM_FALLBACK_MODELS` now controls both transport availability and the optional final structured-output repair escalation. Entries are comma-separated LiteLLM model names; `local/*` entries and self-references are ignored for chat fallback. Operators should order the first eligible network model as the preferred repair escalation target. A smaller fallback is acceptable because escalated output must still pass schema parsing and the caller's semantic validator.
+- **Provider concurrency cap**: `_provider_concurrency.py` wraps remote provider calls with a bounded, fail-open semaphore keyed by LiteLLM provider. Tune with `REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY` when parallel extraction/search workloads trigger provider 429 storms; saturation logs and proceeds rather than parking request threads indefinitely.
 - Return types: `str` for text, or `BaseModel` for Pydantic models
 
 **Usage**:


### PR DESCRIPTION
## Summary
- Updated OSS code-map README entries for the current LLM client layout.
- Documented `_provider_concurrency.py` and the `REFLEXIO_LLM_PROVIDER_MAX_CONCURRENCY` fail-open provider cap.

## Repositories/submodules reviewed
- Parent: `ReflexioAI/reflexio-enterprise`
- Submodules: `ReflexioAI/reflexio`, `ReflexioAI/claude-smart`

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/README.md reflexio/server/README.md`

## Notes/Risks
- Updates follow `/root/reflexio-enterprise/how_to_write_readme.md` for model-facing code-map READMEs.
- `open_source/reflexio/README.md` was intentionally left untouched because it is the public/user-facing README excluded by the guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to describe the unified LiteLLM client and its provider adapters.
  * Documented local reranking helpers, structured-output repair, and fail-open behavior.
  * Added details about per-provider concurrency caps, configuration, logging, and continued operation during provider saturation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->