### PR TITLE
feat(search): raise default unified-search threshold 0.3 -> 0.45

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2517,7 +2517,7 @@ class ReflexioClient:
             request (Optional[UnifiedSearchRequest]): The search request object (alternative to kwargs)
             query (str): Search query text
             top_k (Optional[int]): Maximum results per entity type (default: 5)
-            threshold (Optional[float]): Similarity threshold for vector search (default: 0.3)
+            threshold (Optional[float]): Similarity threshold for vector search (default: 0.45)
             agent_version (Optional[str]): Filter by agent version (agent_playbooks, user_playbooks)
             playbook_name (Optional[str]): Filter by playbook name (agent_playbooks, user_playbooks)
             user_id (Optional[str]): Filter by user ID (profiles, user_playbooks)

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -741,7 +741,7 @@ class UnifiedSearchRequest(BaseModel):
     Args:
         query (str): Search query text
         top_k (int, optional): Maximum results per entity type. Defaults to 5
-        threshold (float, optional): Similarity threshold for vector search. Defaults to 0.3
+        threshold (float, optional): Similarity threshold for vector search. Defaults to 0.45
         agent_version (str, optional): Filter by agent version (agent_playbooks, user_playbooks)
         playbook_name (str, optional): Filter by playbook name (agent_playbooks, user_playbooks)
         user_id (str, optional): Filter by user ID (profiles, user_playbooks)
@@ -757,7 +757,7 @@ class UnifiedSearchRequest(BaseModel):
 
     query: NonEmptyStr
     top_k: int | None = Field(default=5, gt=0)
-    threshold: float | None = Field(default=0.3, ge=0.0, le=1.0)
+    threshold: float | None = Field(default=0.45, ge=0.0, le=1.0)
     agent_version: str | None = None
     playbook_name: str | None = None
     user_id: str | None = None

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -144,7 +144,7 @@ def run_unified_search(
         return UnifiedSearchResponse(success=True, msg="No query provided")
 
     top_k = request.top_k if request.top_k is not None else 5
-    threshold = request.threshold if request.threshold is not None else 0.3
+    threshold = request.threshold if request.threshold is not None else 0.45
 
     floor_cfg = retrieval_floor or RetrievalFloorConfig()
     floor_on = floor_cfg.enabled


### PR DESCRIPTION
## What

Raise the default unified-search retrieval threshold from **0.3 → 0.45**.

Updates the source of truth (`UnifiedSearchRequest.threshold` schema
default), the service-layer fallback in `run_unified_search`, and the
`ReflexioClient.search()` docstring. The per-entity search endpoints
(`SearchUserProfileRequest` etc., default `0.4`) are intentionally left
unchanged.

## Why

A retrieval-eval harness — 275 LLM-generated queries (standard + a harder
oblique/terse tier) over a 276-row corpus of real production rows plus 212
synthetic negatives, with the offline simulator faithfulness-verified
against the live hybrid-search RPC and the full `run_unified_search` path
(cosine drift ≤ 2.8e-07) — showed:

- recall@5 is **flat from threshold 0.0 through 0.5** on this corpus and
  only degrades past 0.5, so the old 0.3 default was effectively a no-op
  that rarely trimmed noise;
- 0.45 preserves recall while giving a slightly tighter similarity floor.

## Test

`threshold` resolves to `0.45` at both the schema-default and
instance level; existing unified-search unit tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated search threshold documentation to reflect the new default value of 0.45.

- **Bug Fixes**
  - Increased the default similarity threshold for searches from 0.3 to 0.45, improving result relevance when no threshold is specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->