### PR TITLE
docs: repoint retired supabase/data/supabase/migrations comment to data/tenant

### DIFF
--- a/reflexio/server/services/evaluation_overview/components/hero_state.py
+++ b/reflexio/server/services/evaluation_overview/components/hero_state.py
@@ -46,7 +46,7 @@ def compute_hero_state(
             grade. (Note: the direct-grade `shadow_is_success` /
             `shadow_is_escalated` columns added briefly in May 2026 were
             retracted before any production deploy — see the deleted
-            migration pair in supabase/data/supabase/migrations/. The
+            migration pair in supabase/data/tenant/. The
             per-turn shadow grade in F1 lives on a different surface.)
         total_results (int): Total AgentSuccessEvaluationResult rows in the
             trend window, used to distinguish EMPTY from states with data.


### PR DESCRIPTION
One-line docstring fix following the enterprise migration-CLI-retirement (the CLI-globbed `supabase/data/supabase/migrations/` dir was retired; the data corpus collapsed into `supabase/data/{tenant,global}/`). Updates the stale `hero_state.py` docstring reference. No runtime effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated an internal reference to reflect the current database migration location.
  * No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->