### PR TITLE
refactor: make learning deduplication unconditional

### DIFF
--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -73,6 +73,8 @@ Consolidates newly extracted playbooks against existing playbooks in the databas
 
 The LLM call opts into the shared structured-output repair path: malformed, blank, or partition-invalid decisions get a corrective same-model follow-up, and deployments with `REFLEXIO_LLM_FALLBACK_MODELS` can use the first eligible fallback model for one final corrective turn. If repair exhausts, the consolidator applies the first parsed output through the defensive apply path; if nothing parsed, a safety fallback inserts every new candidate so extracted data is never silently dropped.
 
+Inline consolidation always runs during generation (the legacy `deduplicator` feature flag is retired). The enterprise repo additionally ships a **scheduled second-pass job** (`reflexio_ext/server/services/playbook_reconsolidation/`) that re-runs consolidation daily over already-persisted rows — user playbooks per `(user_id, agent_version)` and agent playbooks per `agent_version` — by rendering each duplicate group as NEW candidates against an empty EXISTING side via `_consolidation_decisions`, then tombstoning merged sources with `merge_records` lineage.
+
 ## Prompt IDs
 
 | Constant | Prompt ID | Used By |

--- a/reflexio/server/services/playbook/service.py
+++ b/reflexio/server/services/playbook/service.py
@@ -315,42 +315,35 @@ class PlaybookGenerationService(
                 all_playbooks.extend(result)
         all_playbooks = dedupe_and_drop_empty(all_playbooks)
 
-        # Deduplicate against existing entries in DB when deduplicator is enabled
-        existing_ids_to_delete: list[int] = []
-        merge_groups: list[tuple[int, list[int]]] = []
-        from reflexio.server.site_var.feature_flags import is_deduplicator_enabled
+        # Deduplicate against existing entries in DB
+        from reflexio.server.services.playbook.components.consolidator import (
+            PlaybookConsolidator,
+        )
 
-        if is_deduplicator_enabled(self.org_id):
-            from reflexio.server.services.playbook.components.consolidator import (
-                PlaybookConsolidator,
-            )
+        playbook_config = self._configured_playbook_config()
+        dedup_config = playbook_config.deduplication_config if playbook_config else None
 
-            playbook_config = self._configured_playbook_config()
-            dedup_config = (
-                playbook_config.deduplication_config if playbook_config else None
-            )
-
-            consolidator = PlaybookConsolidator(
-                request_context=self.request_context,
-                llm_client=self.client,
-                dedup_config=dedup_config,
-            )
-            (
-                deduplicated_playbooks,
-                existing_ids_to_delete,
-                merge_groups,
-            ) = consolidator.deduplicate(
-                [all_playbooks],
-                generation_request_id,
-                self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
-                user_id=self.service_config.user_id,  # type: ignore[reportOptionalMemberAccess]
-            )
-            logger.info(
-                "User playbook entries after deduplication: %d",
-                len(deduplicated_playbooks),
-            )
-            if deduplicated_playbooks:
-                all_playbooks = deduplicated_playbooks
+        consolidator = PlaybookConsolidator(
+            request_context=self.request_context,
+            llm_client=self.client,
+            dedup_config=dedup_config,
+        )
+        (
+            deduplicated_playbooks,
+            existing_ids_to_delete,
+            merge_groups,
+        ) = consolidator.deduplicate(
+            [all_playbooks],
+            generation_request_id,
+            self.service_config.agent_version,  # type: ignore[reportOptionalMemberAccess]
+            user_id=self.service_config.user_id,  # type: ignore[reportOptionalMemberAccess]
+        )
+        logger.info(
+            "User playbook entries after deduplication: %d",
+            len(deduplicated_playbooks),
+        )
+        if deduplicated_playbooks:
+            all_playbooks = deduplicated_playbooks
 
         # Set status and source for all entries
         for playbook in all_playbooks:

--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -169,30 +169,27 @@ class ProfileGenerationService(
         all_new_profiles = [p for result in results if result for p in result]
         existing_ids_to_delete: list[str] = []
 
-        # Always run deduplicator when enabled and there are new profiles
+        # Always run deduplicator when there are new profiles
         if all_new_profiles:
-            from reflexio.server.site_var.feature_flags import is_deduplicator_enabled
+            from reflexio.server.services.profile.components.consolidator import (
+                ProfileConsolidator,
+            )
 
-            if is_deduplicator_enabled(self.org_id):
-                from reflexio.server.services.profile.components.consolidator import (
-                    ProfileConsolidator,
+            consolidator = ProfileConsolidator(
+                request_context=self.request_context,
+                llm_client=self.client,
+                output_pending_status=self.output_pending_status,
+            )
+            all_new_profiles, existing_ids_to_delete, _superseded_profiles = (
+                consolidator.deduplicate(
+                    all_new_profiles, user_id, generation_request_id
                 )
-
-                consolidator = ProfileConsolidator(
-                    request_context=self.request_context,
-                    llm_client=self.client,
-                    output_pending_status=self.output_pending_status,
-                )
-                all_new_profiles, existing_ids_to_delete, _superseded_profiles = (
-                    consolidator.deduplicate(
-                        all_new_profiles, user_id, generation_request_id
-                    )
-                )
-                logger.info(
-                    "Profile updates after deduplication: %d profiles, %d existing to delete",
-                    len(all_new_profiles),
-                    len(existing_ids_to_delete),
-                )
+            )
+            logger.info(
+                "Profile updates after deduplication: %d profiles, %d existing to delete",
+                len(all_new_profiles),
+                len(existing_ids_to_delete),
+            )
 
         # Set source and status for all profiles
         for profile in all_new_profiles:

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -281,6 +281,7 @@ class AgentPlaybookStoreMixin:
         query: str | None = None,
         start_time: int | None = None,
         end_time: int | None = None,
+        offset: int = 0,
     ) -> list[AgentPlaybook]:
         sql = "SELECT * FROM agent_playbooks WHERE 1=1"
         params: list[Any] = []
@@ -326,8 +327,8 @@ class AgentPlaybookStoreMixin:
             sql += f" AND {tag_frag}"
             params.extend(tag_params)
 
-        sql += " ORDER BY created_at DESC LIMIT ?"
-        params.append(limit)
+        sql += " ORDER BY created_at DESC, agent_playbook_id DESC LIMIT ? OFFSET ?"
+        params.extend([limit, offset])
         rows = self._fetchall(sql, params)
         return [_row_to_agent_playbook(r) for r in rows]
 

--- a/reflexio/server/services/storage/storage_base/playbook/_agent.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_agent.py
@@ -124,6 +124,7 @@ class AgentPlaybookStoreMixin:
         query: str | None = None,
         start_time: int | None = None,
         end_time: int | None = None,
+        offset: int = 0,
     ) -> list[AgentPlaybook]:
         """Get agent playbooks from storage.
 
@@ -139,6 +140,7 @@ class AgentPlaybookStoreMixin:
             playbook_status_filter (Optional[list[PlaybookStatus]]): List of PlaybookStatus values to filter by.
                 If None, returns all playbook statuses.
             tags (list[str], optional): Match playbooks having any of these tags.
+            offset (int): Number of matching rows to skip. Defaults to 0.
 
         Returns:
             list[AgentPlaybook]: List of agent playbook objects

--- a/reflexio/server/site_var/README.md
+++ b/reflexio/server/site_var/README.md
@@ -26,14 +26,14 @@ Per-org feature gating with fail-open defaults. Each flag supports global enable
 ```python
 from reflexio.server.site_var.feature_flags import is_feature_enabled, get_all_feature_flags
 
-is_feature_enabled(org_id, "deduplicator")  # Single flag check
+is_feature_enabled(org_id, "resumable_extraction_agent")  # Single flag check
 get_all_feature_flags(org_id)               # All flags as dict[str, bool]
 ```
 
 **Config format** (`feature_flags.json`):
 ```json
 {
-    "deduplicator": {
+    "resumable_extraction_agent": {
         "enabled": true,
         "enabled_org_ids": []
     }
@@ -42,7 +42,7 @@ get_all_feature_flags(org_id)               # All flags as dict[str, bool]
 
 **Resolution logic**: Enabled if `enabled=True` (global) OR `org_id` in `enabled_org_ids`. Unknown flags default to enabled (fail-open).
 
-**Current flags**: `invitation_only` (global, gates registration), `deduplicator` (gates playbook deduplication).
+**Current flags**: `invitation_only` (global, gates registration), `resumable_extraction_agent`, `lineage_dual_read_diff`.
 
 ## Usage
 

--- a/reflexio/server/site_var/feature_flags.py
+++ b/reflexio/server/site_var/feature_flags.py
@@ -40,7 +40,7 @@ def is_feature_enabled(org_id: str, feature_name: str) -> bool:
 
     Args:
         org_id (str): The organization ID to check
-        feature_name (str): The feature flag name (e.g. "deduplicator")
+        feature_name (str): The feature flag name (e.g. "resumable_extraction_agent")
 
     Returns:
         bool: True if the feature is enabled for this org
@@ -88,19 +88,6 @@ def is_invitation_only_enabled() -> bool:
     if invitation_config is None:
         return False
     return invitation_config.get("enabled", False)
-
-
-def is_deduplicator_enabled(org_id: str) -> bool:
-    """
-    Convenience check for whether the deduplicator is enabled for an org.
-
-    Args:
-        org_id (str): The organization ID to check
-
-    Returns:
-        bool: True if deduplicator is enabled
-    """
-    return is_feature_enabled(org_id, "deduplicator")
 
 
 def _is_fail_closed_flag_enabled(org_id: str, feature_key: str) -> bool:

--- a/reflexio/server/site_var/site_var_sources/feature_flags.json
+++ b/reflexio/server/site_var/site_var_sources/feature_flags.json
@@ -2,10 +2,6 @@
     "invitation_only": {
         "enabled": true
     },
-    "deduplicator": {
-        "enabled": true,
-        "enabled_org_ids": []
-    },
     "resumable_extraction_agent": {
         "enabled": true,
         "enabled_org_ids": []

--- a/tests/e2e_tests/test_resumable_extraction_e2e.py
+++ b/tests/e2e_tests/test_resumable_extraction_e2e.py
@@ -388,10 +388,12 @@ def test_resumable_extraction_resumes_after_human_answer(
         with (
             patch("litellm.completion", side_effect=[response]),
             patch(
-                "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-                return_value=False,
-            ),
+                "reflexio.server.services.profile.components.consolidator.ProfileConsolidator",
+            ) as mock_consolidator_cls,
         ):
+            mock_consolidator_cls.return_value.deduplicate.side_effect = (
+                lambda profiles, _user_id, _request_id: (profiles, [], [])
+            )
             resumed = worker.drain(max_runs=1)
 
         run = storage.get_agent_run("run_1")

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -175,10 +175,12 @@ def test_resume_worker_resumes_profile_run_and_consumes_dependency(
     with (
         patch("litellm.completion", side_effect=[response]),
         patch(
-            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-            return_value=False,
-        ),
+            "reflexio.server.services.profile.components.consolidator.ProfileConsolidator",
+        ) as mock_consolidator_cls,
     ):
+        mock_consolidator_cls.return_value.deduplicate.side_effect = (
+            lambda profiles, _user_id, _request_id: (profiles, [], [])
+        )
         resumed = worker.drain(max_runs=1)
 
     assert resumed == 1

--- a/tests/server/services/playbook/test_consolidation_lineage_integration.py
+++ b/tests/server/services/playbook/test_consolidation_lineage_integration.py
@@ -174,10 +174,6 @@ def test_consolidation_merge_routes_through_merge_records(
     )
 
     with (
-        patch(
-            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-            return_value=True,
-        ),
         patch.object(
             PlaybookGenerationService,
             "_configured_playbook_config",
@@ -274,10 +270,6 @@ def test_consolidation_repair_persists_only_repaired_multi_new_unify(
     )
 
     with (
-        patch(
-            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-            return_value=True,
-        ),
         patch.object(
             PlaybookGenerationService,
             "_configured_playbook_config",
@@ -324,10 +316,6 @@ def test_consolidation_differentiate_tombstones_split_source(
     )
 
     with (
-        patch(
-            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-            return_value=True,
-        ),
         patch.object(
             PlaybookGenerationService,
             "_configured_playbook_config",
@@ -369,10 +357,6 @@ def test_consolidation_differentiate_propagates_tombstone_failure(
     )
 
     with (
-        patch(
-            "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-            return_value=True,
-        ),
         patch.object(
             PlaybookGenerationService,
             "_configured_playbook_config",

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -681,9 +681,8 @@ def test_finalize_drops_empty_and_same_batch_duplicates_with_dedup_flag_off():
 
         with (
             patch(
-                "reflexio.server.site_var.feature_flags.is_deduplicator_enabled",
-                return_value=False,
-            ),
+                "reflexio.server.services.playbook.components.consolidator.PlaybookConsolidator",
+            ) as mock_dedup_cls,
             patch.object(
                 _storage(playbook_generation_service), "save_user_playbooks"
             ) as save_user_playbooks,
@@ -691,6 +690,13 @@ def test_finalize_drops_empty_and_same_batch_duplicates_with_dedup_flag_off():
                 playbook_generation_service, "_enqueue_user_playbook_optimization"
             ),
         ):
+            mock_dedup_cls.return_value.deduplicate.side_effect = (
+                lambda results, *_args, **_kwargs: (
+                    [p for r in results for p in r],
+                    [],
+                    [],
+                )
+            )
             playbook_generation_service._finalize_extracted_items(
                 [first, duplicate, blank]
             )

--- a/tests/server/services/profile/test_dedup_always_soft_integration.py
+++ b/tests/server/services/profile/test_dedup_always_soft_integration.py
@@ -43,7 +43,6 @@ from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 
 pytestmark = pytest.mark.integration
 
-_DEDUP_FLAG = "reflexio.server.site_var.feature_flags.is_deduplicator_enabled"
 _DEDUP_CLS = (
     "reflexio.server.services.profile.components.consolidator.ProfileConsolidator"
 )
@@ -106,15 +105,14 @@ def _build_service(
 
 
 def _patch_dedup(*, all_new, existing_ids, superseded):
-    """Patch is_deduplicator_enabled=True and the ProfileConsolidator class.
+    """Patch the ProfileConsolidator class with a canned deduplicate result.
 
     Returns a context-manager-yielding helper used as ``with _patch_dedup(...):``.
     """
     mock_dedup = MagicMock()
     mock_dedup.deduplicate.return_value = (all_new, existing_ids, superseded)
     mock_dedup_cls = patch(_DEDUP_CLS)
-    flag = patch(_DEDUP_FLAG, return_value=True)
-    return mock_dedup, mock_dedup_cls, flag
+    return mock_dedup, mock_dedup_cls
 
 
 # ===========================================================================
@@ -145,12 +143,12 @@ def test_dedup_removal_soft_supersedes_and_reconstructs(tmp_path) -> None:
     )
 
     svc = _build_service(storage, org_id=org_id, user_id=user_id, request_id=request_id)
-    mock_dedup, mock_dedup_cls, flag = _patch_dedup(
+    mock_dedup, mock_dedup_cls = _patch_dedup(
         all_new=[p_new],
         existing_ids=[p_old.profile_id],
         superseded=[p_old],
     )
-    with mock_dedup_cls as cls, flag:
+    with mock_dedup_cls as cls:
         cls.return_value = mock_dedup
         svc._finalize_extracted_items([p_new])
 
@@ -207,12 +205,12 @@ def test_supersede_raises_does_not_hard_delete_or_write_legacy() -> None:
     svc = _build_service(
         mock_storage, org_id="org_B", user_id="u_B", request_id="run_B"
     )
-    mock_dedup, mock_dedup_cls, flag = _patch_dedup(
+    mock_dedup, mock_dedup_cls = _patch_dedup(
         all_new=[p_new],
         existing_ids=["old_B"],
         superseded=[p_old],
     )
-    with mock_dedup_cls as cls, flag:
+    with mock_dedup_cls as cls:
         cls.return_value = mock_dedup
         # Re-raises (symmetric with playbook) — the failure must not be silently
         # swallowed, or the extractor bookmark would advance over a window whose
@@ -238,12 +236,12 @@ def test_supersede_called_with_full_intent_and_no_legacy_write() -> None:
     svc = _build_service(
         mock_storage, org_id="org_B2", user_id="u_B2", request_id="run_B2"
     )
-    mock_dedup, mock_dedup_cls, flag = _patch_dedup(
+    mock_dedup, mock_dedup_cls = _patch_dedup(
         all_new=[p_new],
         existing_ids=["old_1", "old_2"],
         superseded=superseded,
     )
-    with mock_dedup_cls as cls, flag:
+    with mock_dedup_cls as cls:
         cls.return_value = mock_dedup
         svc._finalize_extracted_items([p_new])
 
@@ -272,12 +270,12 @@ def test_empty_request_id_skips_removal_and_fires_anomaly() -> None:
     p_new = _make_profile("u_C", "new_C")
 
     svc = _build_service(mock_storage, org_id="org_C", user_id="u_C", request_id="")
-    mock_dedup, mock_dedup_cls, flag = _patch_dedup(
+    mock_dedup, mock_dedup_cls = _patch_dedup(
         all_new=[p_new],
         existing_ids=["old_C"],
         superseded=[p_old],
     )
-    with mock_dedup_cls as cls, flag, patch(_CAPTURE_ANOMALY) as mock_anomaly:
+    with mock_dedup_cls as cls, patch(_CAPTURE_ANOMALY) as mock_anomaly:
         cls.return_value = mock_dedup
         svc._finalize_extracted_items([p_new])
 
@@ -307,12 +305,12 @@ def test_success_path_supersedes_and_never_hard_deletes() -> None:
     svc = _build_service(
         mock_storage, org_id="org_D", user_id="u_D", request_id="run_D"
     )
-    mock_dedup, mock_dedup_cls, flag = _patch_dedup(
+    mock_dedup, mock_dedup_cls = _patch_dedup(
         all_new=[p_new],
         existing_ids=["old_D"],
         superseded=[p_old],
     )
-    with mock_dedup_cls as cls, flag:
+    with mock_dedup_cls as cls:
         cls.return_value = mock_dedup
         svc._finalize_extracted_items([p_new])
 

--- a/tests/server/services/profile/test_profile_consolidator_contract.py
+++ b/tests/server/services/profile/test_profile_consolidator_contract.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 from pathlib import Path
 
 
@@ -31,7 +30,6 @@ def test_profile_consolidator_preserves_durable_names() -> None:
         ProfileConsolidator,
         ProfileDeduplicationOutput,
     )
-    from reflexio.server.site_var import feature_flags
     from reflexio.test_support.llm_model_registry import _build_registry
 
     registry = _build_registry()
@@ -39,4 +37,3 @@ def test_profile_consolidator_preserves_durable_names() -> None:
     assert ProfileConsolidator.DEDUPLICATION_PROMPT_ID == "profile_deduplication"
     assert registry["profile_deduplication"].model_class is ProfileDeduplicationOutput
     assert "deduplication_config" in UserPlaybookExtractorConfig.model_fields
-    assert '"deduplicator"' in inspect.getsource(feature_flags.is_deduplicator_enabled)

--- a/tests/server/services/storage/test_storage_contract_playbook.py
+++ b/tests/server/services/storage/test_storage_contract_playbook.py
@@ -434,6 +434,24 @@ class TestAgentPlaybookCRUD:
         result = storage.get_agent_playbooks(playbook_name="fb")
         assert len(result) == 2
 
+    def test_get_agent_playbooks_orders_tied_timestamps_deterministically(
+        self, storage
+    ):
+        playbooks = [
+            _make_agent_playbook(1, "fb", "v1"),
+            _make_agent_playbook(2, "fb", "v1"),
+            _make_agent_playbook(3, "fb", "v1"),
+        ]
+        for playbook in playbooks:
+            playbook.created_at = 1_700_000_000
+        storage.save_agent_playbooks(playbooks)
+
+        first_page = storage.get_agent_playbooks(limit=2, offset=0)
+        second_page = storage.get_agent_playbooks(limit=2, offset=2)
+
+        assert [p.agent_playbook_id for p in first_page] == [3, 2]
+        assert [p.agent_playbook_id for p in second_page] == [1]
+
     def test_get_agent_playbooks_filters_query_before_limit(self, storage):
         newer = _make_agent_playbook(1, "alpha", "v1")
         newer.content = "newer nonmatch"

--- a/tests/server/site_var/test_feature_flags.py
+++ b/tests/server/site_var/test_feature_flags.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 from reflexio.server.site_var.feature_flags import (
     get_all_feature_flags,
-    is_deduplicator_enabled,
     is_feature_enabled,
     is_lineage_dual_read_diff_enabled,
     is_resumable_extraction_agent_enabled,
@@ -22,9 +21,9 @@ MOCK_CONFIG = {
         "enabled": True,
         "enabled_org_ids": [],
     },
-    "deduplicator": {
+    "scoped_feature": {
         "enabled": False,
-        "enabled_org_ids": ["org-dedup"],
+        "enabled_org_ids": ["org-scoped"],
     },
     "resumable_extraction_agent": {
         "enabled": False,
@@ -50,7 +49,7 @@ class TestFeatureFlags(unittest.TestCase):
     )
     def test_org_specific_enabled(self, _mock):
         """A feature disabled globally but with org in enabled_org_ids should be enabled for that org."""
-        self.assertTrue(is_feature_enabled("org-dedup", "deduplicator"))
+        self.assertTrue(is_feature_enabled("org-scoped", "scoped_feature"))
 
     @patch(
         "reflexio.server.site_var.feature_flags._get_feature_flags_config",
@@ -58,7 +57,7 @@ class TestFeatureFlags(unittest.TestCase):
     )
     def test_org_not_in_enabled_list(self, _mock):
         """A feature disabled globally with org NOT in enabled_org_ids should be disabled."""
-        self.assertFalse(is_feature_enabled("org-999", "deduplicator"))
+        self.assertFalse(is_feature_enabled("org-999", "scoped_feature"))
 
     @patch(
         "reflexio.server.site_var.feature_flags._get_feature_flags_config",
@@ -89,7 +88,7 @@ class TestFeatureFlags(unittest.TestCase):
                 "analytics_v2": True,
                 "beta_feature": False,
                 "pre_retrieval": True,
-                "deduplicator": False,
+                "scoped_feature": False,
                 "resumable_extraction_agent": False,
             },
         )
@@ -107,7 +106,7 @@ class TestFeatureFlags(unittest.TestCase):
                 "analytics_v2": True,
                 "beta_feature": False,
                 "pre_retrieval": True,
-                "deduplicator": False,
+                "scoped_feature": False,
                 "resumable_extraction_agent": False,
             },
         )
@@ -128,31 +127,6 @@ class TestFeatureFlags(unittest.TestCase):
         """get_all_feature_flags with empty config should return empty dict."""
         result = get_all_feature_flags("org-123")
         self.assertEqual(result, {})
-
-    @patch(
-        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
-        return_value=MOCK_CONFIG,
-    )
-    def test_is_deduplicator_enabled_for_enabled_org(self, _mock):
-        """is_deduplicator_enabled should return True for orgs in enabled_org_ids."""
-        self.assertTrue(is_deduplicator_enabled("org-dedup"))
-
-    @patch(
-        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
-        return_value=MOCK_CONFIG,
-    )
-    def test_is_deduplicator_disabled_for_other_org(self, _mock):
-        """is_deduplicator_enabled should return False for orgs not in enabled_org_ids."""
-        self.assertFalse(is_deduplicator_enabled("org-123"))
-        self.assertFalse(is_deduplicator_enabled("org-999"))
-
-    @patch(
-        "reflexio.server.site_var.feature_flags._get_feature_flags_config",
-        return_value={},
-    )
-    def test_is_deduplicator_enabled_unknown_defaults_enabled(self, _mock):
-        """is_deduplicator_enabled with empty config should default to enabled."""
-        self.assertTrue(is_deduplicator_enabled("org-123"))
 
     @patch(
         "reflexio.server.site_var.feature_flags._get_feature_flags_config",


### PR DESCRIPTION
## Summary

- Make profile and playbook deduplication a durable default instead of an org feature-flag branch.
- Add stable, offset-based agent-playbook pagination for bounded enterprise maintenance jobs.
- Preserve generation, resume-worker, and lineage behavior while removing the legacy deduplicator flag.

## Changes

- Always invoke the profile and playbook consolidators when new learning rows are generated.
- Remove the `deduplicator` site-var helper and registry entry.
- Extend `get_agent_playbooks()` with an appended `offset` parameter and deterministic `created_at`, ID ordering.
- Update service code maps and regression tests for unconditional deduplication and pagination.

## Test Plan

- `uv run pytest -o 'addopts=' -q tests/server/services/storage/test_storage_contract_playbook.py tests/server/services/playbook/test_playbook_generation_service.py tests/server/services/profile/test_dedup_always_soft_integration.py tests/server/services/profile/test_profile_consolidator_contract.py tests/server/site_var/test_feature_flags.py tests/server/services/extraction/test_resume_worker.py`
- Ruff lint and formatting on all changed Python files.
- Pyright on all changed Python files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent playbook listings now support offset-based pagination for more reliable navigation through results.
  * Playbook and profile consolidation now runs automatically during generation.
* **Bug Fixes**
  * Improved deterministic ordering when paginating agent playbooks with matching timestamps.
  * Consolidated records are preserved with lineage rather than permanently deleted.
* **Documentation**
  * Updated feature flag and playbook consolidation documentation to reflect current behavior and available options.
* **Tests**
  * Expanded coverage for pagination, consolidation, lineage, and resumed extraction flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->