### PR TITLE
fix: preserve stored config across schema changes

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -983,3 +983,18 @@ class Config(BaseModel):
     @batch_interval.setter
     def batch_interval(self, value: int) -> None:
         self.stride_size = value
+
+
+def validate_stored_config(data: dict[str, Any]) -> Config:
+    """Validate persisted config with schema-evolution read compatibility.
+
+    Persisted JSON can contain fields that were valid when it was written but
+    have since been deleted. Ignore only those unknown fields while retaining
+    normal validation for recognized values. Missing fields continue to use
+    their current schema defaults.
+
+    API writes intentionally construct ``Config`` directly and therefore keep
+    the model's strict ``extra="forbid"`` behavior.
+    """
+    normalized = normalize_legacy_config_shape(data)
+    return Config.model_validate(normalized, extra="ignore")

--- a/reflexio/server/services/configurator/local_file_config_storage.py
+++ b/reflexio/server/services/configurator/local_file_config_storage.py
@@ -12,7 +12,7 @@ from reflexio.models.config_schema import (
     PlaybookConfig,
     ProfileExtractorConfig,
     StorageConfigSQLite,
-    normalize_legacy_config_shape,
+    validate_stored_config,
 )
 from reflexio.server.services.configurator.config_storage import ConfigStorage
 
@@ -80,16 +80,9 @@ class LocalFileConfigStorage(ConfigStorage):
             with Path(self.config_file).open(encoding="utf-8") as f:
                 config_content = f.read()
                 data = json.loads(str(config_content))
-                removed_reflection_config = False
-                # Upgrade retired list-valued extractor fields (e.g.
-                # agent_success_configs) to their singular replacements before
-                # validation. Without this, Config would drop the unknown legacy
-                # keys and silently lose the user's customization.
-                if isinstance(data, dict):
-                    data = normalize_legacy_config_shape(data)
-                    data = dict(data)
-                    removed_reflection_config = "reflection_config" in data
-                    data.pop("reflection_config", None)
+                if not isinstance(data, dict):
+                    raise ValueError("Configuration JSON must decode to an object")
+                original_payload = data
                 # Detect legacy on-disk configs that used the removed "disk"
                 # storage backend and rewrite only the storage_config field
                 # to default SQLite. Other persisted fields (extractors,
@@ -109,15 +102,15 @@ class LocalFileConfigStorage(ConfigStorage):
                     )
                     data = dict(data)
                     data["storage_config"] = self._default_storage_config().model_dump()
-                config: Config = Config(**data)
-                if removed_reflection_config:
+                config = validate_stored_config(data)
+                if config.model_dump(mode="json") != original_payload:
                     try:
                         self._save_config_to_local_dir(config=config)
                     except OSError:
                         logger.exception(
-                            "Loaded config from %s after removing retired "
-                            "reflection_config, but could not rewrite the file; "
-                            "the cleanup will be retried on the next load.",
+                            "Loaded config from %s after normalizing its stored "
+                            "schema, but could not rewrite the file; cleanup will "
+                            "be retried on the next load.",
                             self.config_file,
                         )
                 return config

--- a/reflexio/server/services/configurator/local_file_config_storage.py
+++ b/reflexio/server/services/configurator/local_file_config_storage.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import json
 import logging
 import os
@@ -82,7 +83,7 @@ class LocalFileConfigStorage(ConfigStorage):
                 data = json.loads(str(config_content))
                 if not isinstance(data, dict):
                     raise ValueError("Configuration JSON must decode to an object")
-                original_payload = data
+                original_payload = copy.deepcopy(data)
                 # Detect legacy on-disk configs that used the removed "disk"
                 # storage backend and rewrite only the storage_config field
                 # to default SQLite. Other persisted fields (extractors,

--- a/tests/server/services/configurator/test_config_storage_contract.py
+++ b/tests/server/services/configurator/test_config_storage_contract.py
@@ -8,6 +8,7 @@ backends later.
 
 from __future__ import annotations
 
+import json
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -80,6 +81,44 @@ class TestConfigStorageContract:
         assert isinstance(loaded, Config)
         assert loaded.storage_config == default.storage_config
         assert loaded.window_size == default.window_size
+
+    def test_load_ignores_retired_fields_without_resetting_user_values(
+        self, config_storage: ConfigStorage
+    ) -> None:
+        """Schema deletions drop only retired fields from stored config."""
+        config_path = Path(config_storage.config_file)  # type: ignore[attr-defined]
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            json.dumps(
+                {
+                    "storage_config": {"db_path": None},
+                    "agent_context_prompt": "preserve this",
+                    "window_size": 23,
+                    "stride_size": 8,
+                    "profile_extractor_config": {
+                        "extraction_definition_prompt": "preserve nested value",
+                        "retired_nested_field": True,
+                    },
+                    "retired_after_deployment": {"enabled": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        loaded = config_storage.load_config()
+
+        assert loaded.agent_context_prompt == "preserve this"
+        assert loaded.window_size == 23
+        assert loaded.profile_extractor_config is not None
+        assert (
+            loaded.profile_extractor_config.extraction_definition_prompt
+            == "preserve nested value"
+        )
+        assert loaded.enable_document_expansion is False
+        assert "retired_after_deployment" not in loaded.model_dump()
+        assert (
+            "retired_nested_field" not in loaded.profile_extractor_config.model_dump()
+        )
 
     def test_get_version_returns_none_or_tuple(
         self, config_storage: ConfigStorage

--- a/tests/server/services/configurator/test_config_storage_contract.py
+++ b/tests/server/services/configurator/test_config_storage_contract.py
@@ -83,10 +83,13 @@ class TestConfigStorageContract:
         assert loaded.window_size == default.window_size
 
     def test_load_ignores_retired_fields_without_resetting_user_values(
-        self, config_storage: ConfigStorage
+        self, tmp_path: Path
     ) -> None:
         """Schema deletions drop only retired fields from stored config."""
-        config_path = Path(config_storage.config_file)  # type: ignore[attr-defined]
+        local_storage = LocalFileConfigStorage(
+            org_id="legacy-config-org", base_dir=str(tmp_path)
+        )
+        config_path = Path(local_storage.config_file)
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(
             json.dumps(
@@ -105,7 +108,7 @@ class TestConfigStorageContract:
             encoding="utf-8",
         )
 
-        loaded = config_storage.load_config()
+        loaded = local_storage.load_config()
 
         assert loaded.agent_context_prompt == "preserve this"
         assert loaded.window_size == 23


### PR DESCRIPTION
## Summary

- Prevent persisted user configuration from resetting when the `Config` schema adds or removes fields.
- Keep API validation strict while giving stored data a dedicated schema-evolution compatibility boundary.
- Canonicalize compatible local config files so retired fields are removed and new fields receive only their declared defaults.

## Changes

### Stored config validation

- Add `validate_stored_config()` to normalize known legacy shapes and ignore fields retired from the current schema.
- Preserve validation errors for recognized fields with invalid values.
- Leave normal `Config` construction unchanged, retaining `extra="forbid"` for API writes.

### Local persistence

- Route local-file loads through the stored-config compatibility boundary.
- Rewrite successfully loaded non-canonical payloads atomically using the current schema.
- Keep an isolated deep-copy of the pre-normalization payload so downstream validation cannot invalidate the canonicalization diff.

### Tests

- Add config-storage contract coverage for top-level and nested retired fields.
- Verify recognized values survive and newly introduced fields receive their schema defaults.
- Keep disk-specific legacy-file setup on an explicit local-file backend rather than the parameterized storage contract fixture.

## Follow-ups

- Merged as `9b3ef6a`; downstream consumers can now pin the compatibility implementation from OSS `origin/main`.
- Review follow-ups isolated the pre-normalization snapshot and the disk-specific local-file test setup before merge.

## Test Plan

- `uv run ruff check` and `uv run ruff format` on changed files
- `uv run pyright` on changed files
- `uv run pytest -q tests/server/services/configurator/test_config_storage_contract.py tests/models/test_removed_reflection_config.py -o addopts=''` — 10 passed
- Full OSS unit/integration run — 4,713 passed, 73 skipped; 8 embedding-dependent failures because the configured local daemon at `127.0.0.1:8099` was unavailable
- Full OSS E2E run — 41 passed, 49 skipped; 2 search failures from the same unavailable embedding daemon


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of saved configurations across schema changes by validating persisted JSON with read-time schema evolution.
  * Unknown/retired fields are now ignored during load without resetting existing user-provided values.
  * Invalid config files that are not JSON objects now fail with a clear validation error.
  * Stored configs may be automatically rewritten when normalization changes the persisted content.
* **Tests**
  * Added contract coverage to confirm retired fields (including nested settings) don’t overwrite user values after load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->