### PR TITLE
fix(llm): accept list payloads for single-list schemas

### DIFF
--- a/reflexio/server/llm/_litellm_structured_output.py
+++ b/reflexio/server/llm/_litellm_structured_output.py
@@ -20,7 +20,7 @@ so this module moves BEFORE ``_litellm_text_generation``.
 
 import json
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, get_origin
 
 import litellm
 from pydantic import BaseModel
@@ -39,6 +39,29 @@ from reflexio.server.llm.llm_utils import (
 
 if TYPE_CHECKING:
     from reflexio.server.llm._litellm_types import LiteLLMConfig
+
+
+def _single_list_field_name(response_format: type[BaseModel]) -> str | None:
+    """Return the wrapper field for schemas shaped as ``{"items": [...]}``."""
+    fields = getattr(response_format, "model_fields", {})
+    if len(fields) != 1:
+        return None
+
+    field_name, field = next(iter(fields.items()))
+    if field.annotation is list or get_origin(field.annotation) is list:
+        return field_name
+    return None
+
+
+def _validate_structured_payload(
+    response_format: type[BaseModel],
+    parsed: Any,
+) -> BaseModel:
+    if isinstance(parsed, list) and (
+        field_name := _single_list_field_name(response_format)
+    ):
+        return response_format.model_validate({field_name: parsed})
+    return response_format.model_validate(parsed)
 
 
 class StructuredOutputMixin:
@@ -159,14 +182,14 @@ class StructuredOutputMixin:
             parsed = json.loads(json_str)
 
             # response_format must be a Pydantic model (validated at entry points)
-            return response_format.model_validate(parsed)
+            return _validate_structured_payload(response_format, parsed)
         except Exception:
             # LLMs sometimes produce Python-style output (single quotes, True/False,
             # trailing commas). Try to sanitize before giving up.
             try:
                 sanitized = _sanitize_json_string(json_str)
                 parsed = json.loads(sanitized)
-                return response_format.model_validate(parsed)
+                return _validate_structured_payload(response_format, parsed)
             except Exception:
                 # Last resort: json-repair can recover complete responses with
                 # small syntax glitches, such as missing commas. Do not repair
@@ -182,7 +205,7 @@ class StructuredOutputMixin:
                         )
 
                     repaired = repair_json(json_str, return_objects=True)
-                    return response_format.model_validate(repaired)
+                    return _validate_structured_payload(response_format, repaired)
                 except Exception as e:
                     model = self.config.model
                     snippet = (

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -74,6 +74,19 @@ class MathResult(BaseModel):
     explanation: str
 
 
+class SingleListResponse(BaseModel):
+    items: list[SampleResponse] = Field(default_factory=list)
+
+
+class MultiFieldListResponse(BaseModel):
+    items: list[SampleResponse] = Field(default_factory=list)
+    source: str
+
+
+class BareListResponse(BaseModel):
+    items: list = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1050,6 +1063,32 @@ class TestMaybeParseStructuredOutput:
         result = client._maybe_parse_structured_output(json_str, SampleResponse, True)
         assert isinstance(result, SampleResponse)
         assert result.answer == "ok"
+
+    def test_top_level_list_wrapped_for_single_list_schema(self, client):
+        content = json.dumps([{"answer": "ok", "score": 5}])
+        result = client._maybe_parse_structured_output(
+            content, SingleListResponse, True
+        )
+
+        assert isinstance(result, SingleListResponse)
+        assert len(result.items) == 1
+        assert result.items[0].answer == "ok"
+
+    def test_top_level_list_wrapped_for_bare_list_schema(self, client):
+        content = json.dumps([{"answer": "ok", "score": 5}])
+        result = client._maybe_parse_structured_output(
+            content, BareListResponse, True
+        )
+
+        assert isinstance(result, BareListResponse)
+        assert result.items == [{"answer": "ok", "score": 5}]
+
+    def test_top_level_list_not_wrapped_for_multi_field_schema(self, client):
+        content = json.dumps([{"answer": "ok", "score": 5}])
+        with pytest.raises(StructuredOutputParseError):
+            client._maybe_parse_structured_output(
+                content, MultiFieldListResponse, True
+            )
 
     def test_json_in_markdown_code_block(self, client):
         content = '```json\n{"answer": "ok", "score": 5}\n```'


### PR DESCRIPTION
## Summary
- Accept top-level JSON arrays for structured-output schemas that are only a single list wrapper field
- Keep multi-field schemas strict so malformed outputs still surface as parse failures
- Add unit coverage for both accepted and rejected top-level list payloads

## Finding
`test-backend-pipeline` surfaced a playbook extraction parse failure from MiniMax where the model returned a semantically valid list of playbook entries while the schema expected the canonical object wrapper (`{"playbooks": [...]}`). Layer: codebase under test. Root cause: the structured-output parser was too brittle for single-list wrapper schemas, causing one extraction batch to fail and leaving too few user playbooks for aggregation.

## Fix
Normalize only the safe case: when the target Pydantic response model has exactly one `list[...]` field and the parsed JSON root is a list, validate `{"<field>": parsed_list}`. All other schemas keep the existing strict validation behavior.

## Verification
- Review Code PR Readiness: clean
- `uv run --no-sync ruff check open_source/reflexio/reflexio/server/llm/_litellm_structured_output.py open_source/reflexio/tests/server/llm/test_litellm_client_unit.py`
- `uv run --no-sync pytest open_source/reflexio/tests/server/llm/test_litellm_client_unit.py -q -o 'addopts='` (`220 passed`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-output parsing when responses are returned as top-level JSON arrays.
  * Automatically wraps array payloads to match schemas shaped as a single list field.
  * Maintains correct failures when the schema expects additional fields beyond a single list wrapper.
* **Tests**
  * Added/expanded unit coverage for single-list, bare-list, and multi-field list schema handling for structured parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->