### PR TITLE
fix(client): tolerate operation timestamp skew

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2085,7 +2085,14 @@ class ReflexioClient:
                 continue
             status_response = GetOperationStatusResponse(**response)
             op = status_response.operation_status
-            if op and min_started_at is not None and op.started_at < min_started_at:
+            # The API stores operation timestamps at second precision. Accept a
+            # one-second skew so a just-submitted operation that starts near the
+            # client timestamp boundary is not treated as stale forever.
+            if (
+                op
+                and min_started_at is not None
+                and op.started_at < min_started_at - 1
+            ):
                 op = None
             if op and op.status in (
                 OperationStatus.COMPLETED,

--- a/tests/client/test_operation_status_polling.py
+++ b/tests/client/test_operation_status_polling.py
@@ -1,0 +1,38 @@
+"""Unit tests for ReflexioClient operation-status polling."""
+
+from reflexio.client import ReflexioClient
+from reflexio.models.api_schema.domain.enums import OperationStatus
+
+
+def test_poll_operation_status_accepts_one_second_started_at_skew():
+    client = ReflexioClient.__new__(ReflexioClient)
+
+    def fake_make_request(method: str, path: str, **kwargs):
+        assert method == "GET"
+        assert path == "/api/get_operation_status"
+        assert kwargs["params"] == {"service_name": "profile_generation"}
+        return {
+            "success": True,
+            "operation_status": {
+                "service_name": "profile_generation",
+                "status": "completed",
+                "started_at": 99,
+                "completed_at": 100,
+                "total_users": 1,
+                "processed_users": 1,
+                "failed_users": 0,
+                "progress_percentage": 100,
+            },
+        }
+
+    client._make_request = fake_make_request
+
+    response = client._poll_operation_status(
+        "profile_generation",
+        poll_interval=0,
+        max_wait=0.1,
+        min_started_at=100,
+    )
+
+    assert response.operation_status is not None
+    assert response.operation_status.status == OperationStatus.COMPLETED


### PR DESCRIPTION
## Summary
- Allow `ReflexioClient` operation-status polling to accept a one-second `started_at` skew when filtering stale operation rows.
- Add a focused regression test for the completed-operation case that previously could be ignored until timeout.

## Finding
Layer: OSS client code. Root cause: `_poll_operation_status(..., min_started_at=...)` compared second-precision server timestamps with the client submit timestamp too strictly. A just-submitted operation could report `started_at = submitted_at - 1`, be treated as stale, and cause `wait_for_response=True` rerun calls to poll until the 600s timeout despite the operation being completed.

## Test Plan
- Review Code PR Readiness: clean focused pass
- `uv run --no-sync ruff check open_source/reflexio/reflexio/client/client.py open_source/reflexio/tests/client/test_operation_status_polling.py`
- `uv run --no-sync pytest open_source/reflexio/tests/client/test_operation_status_polling.py -q -o addopts=`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved operation status polling to tolerate minor timestamp differences, preventing valid operations from being incorrectly treated as stale.
  - Polling now correctly recognizes completed operations when timestamps differ by up to one second.

- **Tests**
  - Added coverage for operation status polling with a one-second timestamp skew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->