### PR TITLE
test: stabilize profile workflow e2e fixtures

### DIFF
--- a/reflexio/server/llm/_litellm_structured_output.py
+++ b/reflexio/server/llm/_litellm_structured_output.py
@@ -20,7 +20,7 @@ so this module moves BEFORE ``_litellm_text_generation``.
 
 import json
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, get_origin
+from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 import litellm
 from pydantic import BaseModel
@@ -48,9 +48,20 @@ def _single_list_field_name(response_format: type[BaseModel]) -> str | None:
         return None
 
     field_name, field = next(iter(fields.items()))
-    if field.annotation is list or get_origin(field.annotation) is list:
+    if _is_list_annotation(field.annotation):
         return field_name
     return None
+
+
+def _is_list_annotation(annotation: Any) -> bool:
+    """Return whether an annotation accepts a list value."""
+    if annotation is list or get_origin(annotation) is list:
+        return True
+    return any(
+        _is_list_annotation(arg)
+        for arg in get_args(annotation)
+        if arg is not type(None)
+    )
 
 
 def _validate_structured_payload(

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -27,6 +27,12 @@ from reflexio.server.services.configurator.configurator import DefaultConfigurat
 
 _TEST_DATA_DIR = Path(__file__).resolve().parent.parent / "test_data"
 _SCENARIO_DIR = _TEST_DATA_DIR / "scenarios" / "e2e"
+_CUSTOMER_SUPPORT_WINDOW_SIZE = 20
+_CUSTOMER_SUPPORT_PROFILE_DEFINITION = """
+name, occupation, location, membership tier, order context, communication preferences,
+formatting preferences, timeline preferences, and other durable customer-support
+personalization facts from the conversation
+"""
 
 
 @pytest.fixture(autouse=True)
@@ -76,6 +82,8 @@ def reflexio_instance(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
+        skip_should_run_check=True,
+        window_size=_CUSTOMER_SUPPORT_WINDOW_SIZE,
         # Single configured profile extractor (the list-valued field is retired and
         # the Config constructor would ignore it, dropping tagging_definition_prompt).
         profile_extractor_config=ProfileExtractorConfig(
@@ -83,9 +91,7 @@ def reflexio_instance(
             context_prompt="""
 Conversation between sales agent and user, extract any information from the interaction if contains any information listed under definition
 """,
-            extraction_definition_prompt="""
-name, age, intent of the conversations
-""",
+            extraction_definition_prompt=_CUSTOMER_SUPPORT_PROFILE_DEFINITION,
             tagging_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,
@@ -126,15 +132,15 @@ def reflexio_instance_profile_only(
     config = Config(
         storage_config=sqlite_storage_config,
         agent_context_prompt="this is a sales agent",
+        skip_should_run_check=True,
+        window_size=_CUSTOMER_SUPPORT_WINDOW_SIZE,
         user_playbook_extractor_config=None,
         profile_extractor_config=ProfileExtractorConfig(
             extractor_name="test_profile_extractor",
             context_prompt="""
 Conversation between sales agent and user, extract any information from the interaction if contains any information listed under definition
 """,
-            extraction_definition_prompt="""
-name, age, intent of the conversations
-""",
+            extraction_definition_prompt=_CUSTOMER_SUPPORT_PROFILE_DEFINITION,
             tagging_definition_prompt="""
 choice of ['basic_info', 'conversation_intent']
 """,

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -78,6 +78,10 @@ class SingleListResponse(BaseModel):
     items: list[SampleResponse] = Field(default_factory=list)
 
 
+class OptionalListResponse(BaseModel):
+    items: list[SampleResponse] | None = None
+
+
 class MultiFieldListResponse(BaseModel):
     items: list[SampleResponse] = Field(default_factory=list)
     source: str
@@ -1074,11 +1078,20 @@ class TestMaybeParseStructuredOutput:
         assert len(result.items) == 1
         assert result.items[0].answer == "ok"
 
-    def test_top_level_list_wrapped_for_bare_list_schema(self, client):
+    def test_top_level_list_wrapped_for_optional_list_schema(self, client):
         content = json.dumps([{"answer": "ok", "score": 5}])
         result = client._maybe_parse_structured_output(
-            content, BareListResponse, True
+            content, OptionalListResponse, True
         )
+
+        assert isinstance(result, OptionalListResponse)
+        assert result.items is not None
+        assert len(result.items) == 1
+        assert result.items[0].answer == "ok"
+
+    def test_top_level_list_wrapped_for_bare_list_schema(self, client):
+        content = json.dumps([{"answer": "ok", "score": 5}])
+        result = client._maybe_parse_structured_output(content, BareListResponse, True)
 
         assert isinstance(result, BareListResponse)
         assert result.items == [{"answer": "ok", "score": 5}]
@@ -1086,9 +1099,7 @@ class TestMaybeParseStructuredOutput:
     def test_top_level_list_not_wrapped_for_multi_field_schema(self, client):
         content = json.dumps([{"answer": "ok", "score": 5}])
         with pytest.raises(StructuredOutputParseError):
-            client._maybe_parse_structured_output(
-                content, MultiFieldListResponse, True
-            )
+            client._maybe_parse_structured_output(content, MultiFieldListResponse, True)
 
     def test_json_in_markdown_code_block(self, client):
         content = '```json\n{"answer": "ok", "score": 5}\n```'


### PR DESCRIPTION
## Summary
- Stabilizes the direct-library profile workflow E2E tests by removing live should-run classifier variance from fixtures that are testing profile storage/search/rerun mechanics.
- Keeps the customer-support scenario faithful by widening the extraction window and aligning the profile definition with the scenario's durable customer facts.
- Hardens structured-output parsing so single-field optional list schemas, such as profile extraction output, accept provider responses that arrive as a top-level list.

## Changes
- Added optional-list detection to the structured-output single-list wrapper path.
- Added unit coverage for top-level lists against `list[...] | None` wrapper schemas.
- Updated E2E profile fixtures to bypass the should-run gate and include the full customer-support scenario window.

## Test Plan
- `uv run --no-sync ruff check open_source/reflexio/reflexio/server/llm/_litellm_structured_output.py open_source/reflexio/tests/e2e_tests/conftest.py open_source/reflexio/tests/server/llm/test_litellm_client_unit.py`
- `uv run --no-sync pyright open_source/reflexio/reflexio/server/llm/_litellm_structured_output.py open_source/reflexio/tests/e2e_tests/conftest.py open_source/reflexio/tests/server/llm/test_litellm_client_unit.py`
- `uv run --no-sync pytest open_source/reflexio/tests/server/llm/test_litellm_client_unit.py -q -o addopts=`
- `uv run --no-sync pytest open_source/reflexio/tests/e2e_tests/test_profile_workflows.py -m e2e -o addopts=`
- `uv run --no-sync pytest open_source/reflexio/tests/e2e_tests/test_interaction_workflows.py -m e2e -o addopts=`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured response handling for list data wrapped in optional or union-based schemas.
  * Top-level list responses are now correctly parsed into compatible response models.
  * Preserved validation for schemas with multiple fields that cannot safely wrap list responses.

* **Tests**
  * Added coverage for optional list fields and customer-support profile extraction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->