### PR TITLE
test: drain background callbacks in e2e

### DIFF
--- a/reflexio/server/callback_executor.py
+++ b/reflexio/server/callback_executor.py
@@ -56,6 +56,7 @@ class BoundedCallbackExecutor:
         self._queue: deque[tuple[str, Callable[[], None]]] = deque()
         self._queue_size = queue_size
         self._cond = threading.Condition()
+        self._active = 0
         self._drop_times: deque[float] = deque()
         self._last_drop_anomaly = 0.0
         for i in range(workers):
@@ -78,9 +79,24 @@ class BoundedCallbackExecutor:
                 dropped_name, _ = self._queue.popleft()
                 drop_facts = self._record_drop_locked(dropped_name)
             self._queue.append((name, fn))
-            self._cond.notify()
+            self._cond.notify_all()
         if drop_facts is not None:
             self._emit_drop(drop_facts)
+
+    def drain(self, *, timeout_seconds: float = 5.0) -> bool:
+        """Wait until queued and in-flight callbacks finish.
+
+        This is primarily used by tests and graceful harnesses that must not let
+        daemon callback logs outlive their capture/lifecycle boundary.
+        """
+        deadline = time.monotonic() + timeout_seconds
+        with self._cond:
+            while self._queue or self._active:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._cond.wait(timeout=remaining)
+            return True
 
     def _record_drop_locked(self, dropped_name: str) -> _DropFacts:
         """Collect the facts of one drop while ``self._cond`` is held.
@@ -133,6 +149,7 @@ class BoundedCallbackExecutor:
                 while not self._queue:
                     self._cond.wait()
                 name, fn = self._queue.popleft()
+                self._active += 1
             try:
                 fn()
             except BaseException:  # noqa: BLE001 — daemon worker threads must
@@ -143,6 +160,11 @@ class BoundedCallbackExecutor:
                 logger.exception(
                     "event=callback_executor_callback_failed name=%s", name
                 )
+            finally:
+                with self._cond:
+                    self._active -= 1
+                    if not self._queue and self._active == 0:
+                        self._cond.notify_all()
 
 
 _executor: BoundedCallbackExecutor | None = None
@@ -162,3 +184,10 @@ def submit_callback(name: str, fn: Callable[[], None]) -> None:
             if _executor is None:
                 _executor = BoundedCallbackExecutor()
     _executor.submit(name, fn)
+
+
+def drain_callbacks(*, timeout_seconds: float = 5.0) -> bool:
+    """Wait for the process-global callback executor to become idle."""
+    if _executor is None:
+        return True
+    return _executor.drain(timeout_seconds=timeout_seconds)

--- a/reflexio/server/services/tagging/tagging_scheduler.py
+++ b/reflexio/server/services/tagging/tagging_scheduler.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from functools import partial
 
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.callback_executor import submit_callback
+from reflexio.server.callback_executor import drain_callbacks, submit_callback
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.services.tagging.service import TaggingService
 
@@ -72,6 +72,20 @@ class TaggingScheduler:
             self._scheduled[key] = (fire_time, callback)
             heapq.heappush(self._heap, (fire_time, key))
         self._wake_event.set()
+
+    def drain(self, *, timeout_seconds: float = 5.0) -> bool:
+        """Wait for scheduled tagging callbacks and executor work to settle."""
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            with self._mutex:
+                scheduled = bool(self._scheduled)
+            if not scheduled:
+                remaining = max(0.0, deadline - time.monotonic())
+                return drain_callbacks(timeout_seconds=remaining)
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            time.sleep(min(0.01, remaining))
 
     def _scheduler_loop(self) -> None:
         while True:
@@ -146,3 +160,10 @@ def schedule_tagging(
         )
 
     TaggingScheduler.get_instance().schedule(key, callback)
+
+
+def drain_tagging(*, timeout_seconds: float = 5.0) -> bool:
+    """Wait for the singleton tagging scheduler and callback executor to settle."""
+    if TaggingScheduler._instance is None:
+        return drain_callbacks(timeout_seconds=timeout_seconds)
+    return TaggingScheduler._instance.drain(timeout_seconds=timeout_seconds)

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -24,6 +24,7 @@ from reflexio.models.config_schema import (
     ToolUseConfig,
 )
 from reflexio.server.services.configurator.configurator import DefaultConfigurator
+from reflexio.server.services.tagging.tagging_scheduler import drain_tagging
 
 _TEST_DATA_DIR = Path(__file__).resolve().parent.parent / "test_data"
 _SCENARIO_DIR = _TEST_DATA_DIR / "scenarios" / "e2e"
@@ -50,6 +51,14 @@ def _zero_group_evaluation_delay():
         0,
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _drain_background_tagging_callbacks():
+    yield
+    assert drain_tagging(timeout_seconds=10.0), (
+        "background tagging callbacks did not drain before test teardown"
+    )
 
 
 @pytest.fixture

--- a/tests/server/services/tagging/test_tagging_scheduler.py
+++ b/tests/server/services/tagging/test_tagging_scheduler.py
@@ -26,6 +26,17 @@ def test_scheduler_fires_scheduled_callback(monkeypatch: Any) -> None:
     assert fired.wait(timeout=5)
 
 
+def test_scheduler_drain_waits_for_scheduled_callback(monkeypatch: Any) -> None:
+    # Keep the debounce tiny so the test does not wait on the real delay.
+    monkeypatch.setattr(tagging_scheduler, "_EFFECTIVE_DELAY_SECONDS", 0.01)
+    fired = threading.Event()
+    scheduler = TaggingScheduler.get_instance()
+    scheduler.schedule(("org", "drain-user", "v1"), fired.set)
+
+    assert scheduler.drain(timeout_seconds=2.0)
+    assert fired.is_set()
+
+
 def test_schedule_tagging_skips_when_no_user(monkeypatch: Any) -> None:
     scheduled: list[tuple[Any, Any]] = []
     monkeypatch.setattr(

--- a/tests/server/test_callback_executor.py
+++ b/tests/server/test_callback_executor.py
@@ -21,6 +21,38 @@ def test_callbacks_run() -> None:
     assert ran.wait(timeout=2.0)
 
 
+def test_drain_waits_for_active_and_queued_callbacks() -> None:
+    ex = BoundedCallbackExecutor(workers=1, queue_size=8)
+    started = threading.Event()
+    release = threading.Event()
+    ran: list[str] = []
+
+    def blocker() -> None:
+        started.set()
+        release.wait(timeout=5)
+        ran.append("blocker")
+
+    ex.submit("blocker", blocker)
+    assert started.wait(timeout=2.0), "blocker never started running"
+    ex.submit("after", lambda: ran.append("after"))
+
+    drained = threading.Event()
+
+    def drain() -> None:
+        if ex.drain(timeout_seconds=2.0):
+            drained.set()
+
+    waiter = threading.Thread(target=drain)
+    waiter.start()
+    time.sleep(0.05)
+    assert not drained.is_set(), "drain returned before active work completed"
+
+    release.set()
+    waiter.join(timeout=2.0)
+    assert drained.is_set(), f"drain timed out before callbacks finished: {ran}"
+    assert ran == ["blocker", "after"]
+
+
 def test_queue_bound_drops_oldest(monkeypatch) -> None:
     monkeypatch.setattr(
         ce_mod,


### PR DESCRIPTION
## Summary
- Add a bounded drain API for the process-global callback executor so tests and graceful harnesses can wait for queued and active background callbacks.
- Add a tagging scheduler drain wrapper that waits for scheduled tagging work and then drains the shared callback executor.
- Use the drain in E2E teardown so background tagging logs cannot outlive pytest's capture stream and emit closed-file logging tracebacks after a passing test.

## Changes
- Track active callbacks in `BoundedCallbackExecutor` and expose `drain_callbacks(...)` for the module singleton.
- Expose `TaggingScheduler.drain(...)` and `drain_tagging(...)`.
- Add E2E autouse cleanup that fails in-test if background tagging does not settle before teardown.
- Add unit tests for executor and tagging scheduler drain behavior.

## Test Plan
- `uv run --no-sync pytest open_source/reflexio/tests/server/test_callback_executor.py open_source/reflexio/tests/server/services/tagging/test_tagging_scheduler.py -q -o addopts=`
- `uv run --no-sync ruff check open_source/reflexio/reflexio/server/callback_executor.py open_source/reflexio/reflexio/server/services/tagging/tagging_scheduler.py open_source/reflexio/tests/e2e_tests/conftest.py open_source/reflexio/tests/server/test_callback_executor.py open_source/reflexio/tests/server/services/tagging/test_tagging_scheduler.py`
- `uv run --no-sync pyright open_source/reflexio/reflexio/server/callback_executor.py open_source/reflexio/reflexio/server/services/tagging/tagging_scheduler.py open_source/reflexio/tests/e2e_tests/conftest.py open_source/reflexio/tests/server/test_callback_executor.py open_source/reflexio/tests/server/services/tagging/test_tagging_scheduler.py`
- `uv run --no-sync pytest open_source/reflexio/tests/e2e_tests/test_interaction_workflows.py -m e2e -o addopts=`

## Finding Classification
- Layer: OSS code/test lifecycle.
- Root cause: background tagging callbacks could still be logging after pytest closed its capture stream.
- Fix: drain scheduled tagging and shared callback work during E2E teardown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added drain support for background callbacks, waiting until both queued and in-flight work has completed (with timeout and success/failure result).
  * Added drain support for the tagging scheduler, plus a global helper to drain tagging work even when initialization is partial.

* **Bug Fixes**
  * Improved background callback completion tracking to correctly account for active execution, including error cases.

* **Tests**
  * Added concurrency and scheduler drain tests, and an end-to-end teardown fixture that drains tagging callbacks before each test completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->