### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -132,7 +132,7 @@ client (Python SDK)
 - **`api_endpoints/`**: Request handling, `RequestContext` (bundles storage/config/prompts), auth
 - **`routes/`**: Domain route modules (`system.py`, `interactions.py`, `profiles.py`, `playbooks.py`, `search.py`, `provenance.py`, `evaluation.py`, `braintrust.py`, `config.py`) included into `api.py`'s `core_router`
 - **`db/`**: Auth & config storage only (SQLite) - NOT for profiles/interactions
-- **`llm/`**: Unified LiteLLM client, provider adapters, local rerank helpers, structured-output repair, and fail-open per-provider concurrency caps
+- **`llm/`**: Unified LiteLLM client, provider adapters, local/internal embedding service routing, cross-encoder rerank service support, structured-output repair, and fail-open per-provider concurrency caps
 - **`prompt/`**: Versioned prompt templates in `prompt_bank/`
 - **`services/`**: Core business logic
   - `generation_service.py` - Orchestrator (runs profile/playbook/success services)

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -118,7 +118,10 @@ Key files:
 - `litellm_client.py`: Stable import surface, client config/credential resolution, and `LiteLLMClient` facade
 - `_litellm_text_generation.py`, `_litellm_embedding.py`, `_litellm_structured_output.py`: Completion/tool-call, embedding, and structured-output mixins
 - `_litellm_json_extraction.py`, `_litellm_subprocess.py`, `_provider_concurrency.py`, `_litellm_types.py`: JSON parsing, hard-timeout subprocess snapshots/workers, per-provider fail-open concurrency caps, and shared public types/errors
-- `providers/`: Optional local/provider adapters (`claude-code/`, OpenClaw, local embedding, Nomic embedding); registration is opt-in via environment/config
+- `embedding_service.py`: OpenAI-compatible local/internal embedding daemon with `/v1/embeddings`, `/v1/rerank`, `/health`, micro-batching, and single-active-model warmup
+- `providers/embedding_service_provider.py`: Routing boundary for `REFLEXIO_EMBEDDING_PROVIDER` (`cloud`, `local_service`, `internal_service`, `inprocess`, `off`), service URL/timeouts, local daemon probing, and request splitting
+- `rerank/cross_encoder_reranker.py`: Cross-encoder rerank helper; uses in-process scoring by default or delegates to `REFLEXIO_RERANK_SERVICE_URL`
+- `providers/`: Optional local/provider adapters (`claude-code/`, OpenClaw, local embedding, Nomic embedding, embedding service); registration is opt-in via environment/config
 - `openai_client.py`: OpenAI implementation (legacy, do not use directly)
 - `claude_client.py`: Claude implementation (legacy, do not use directly)
 - `llm_utils.py`: Helper functions for Pydantic model conversion


### PR DESCRIPTION
## Summary
- Syncs OSS code-map READMEs with the current LLM embedding/rerank routing architecture.
- Documents the embedding daemon, embedding service provider boundary, and cross-encoder rerank service delegation in the server map.
- Follows `/root/reflexio-enterprise/how_to_write_readme.md` by keeping updates concise, navigation-focused, and limited to model-facing code-map READMEs.

## Repositories/submodules reviewed
- `ReflexioAI/reflexio-enterprise` parent repository
- `ReflexioAI/reflexio` submodule
- `ReflexioAI/claude-smart` submodule

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/README.md reflexio/server/README.md`

## Notes/Risks
- README-only change.
- `open_source/reflexio/README.md` was intentionally not modified because it is the user-facing public README excluded by the policy.
