### PR TITLE
test: keep local service-routing env vars out of OSS test runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,12 @@ from reflexio.cli.env_loader import load_reflexio_env  # noqa: E402
 
 load_reflexio_env()
 
+# The loader intentionally imports provider credentials from the developer
+# environment, but it can also reintroduce local service-routing variables from
+# an enterprise checkout. Keep those routing choices out of OSS tests.
+for _var in _OSS_TEST_POLLUTING_ENV_VARS:
+    os.environ.pop(_var, None)
+
 # Redirect `~/.reflexio` for the entire test session so tests that call
 # `reflexio.cli.paths.reflexio_home()` (e.g. via `LocalFileConfigStorage`'s
 # default `base_dir`) don't pick up the developer's existing
@@ -78,10 +84,14 @@ def pytest_unconfigure(config):
 
 @pytest.fixture(autouse=True)
 def _reset_runtime_services() -> Iterator[None]:
-    """Clear the process-global service registry before and after each test."""
+    """Clear process-global services and local routing before and after each test."""
+    for var in _OSS_TEST_POLLUTING_ENV_VARS:
+        os.environ.pop(var, None)
     reset_services()
     yield
     reset_services()
+    for var in _OSS_TEST_POLLUTING_ENV_VARS:
+        os.environ.pop(var, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
Keep enterprise-checkout service-routing env vars from leaking into OSS test runs. `load_reflexio_env()` intentionally imports provider credentials from the developer environment, but it can also reintroduce local routing variables (`DEPLOYMENT_MODE`, `REFLEXIO_STORAGE`, embedding/rerank endpoints) that flip OSS code paths mid-suite and cause full-suite-only failures.

## Changes
- `tests/conftest.py`: re-clear `_OSS_TEST_POLLUTING_ENV_VARS` immediately after `load_reflexio_env()` runs (the loader can reintroduce them after the session-start clear).
- `_reset_runtime_services` autouse fixture: pop the same vars before and after every test, so a test that sets one directly cannot leak it into later tests.

## Test Plan
- Existing OSS suite passes; CI sets none of these vars, so behavior there is unchanged.
- On a developer machine with an enterprise `.env`, tests that previously failed only in full-suite runs (routing vars leaking in) now run isolated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by consistently clearing routing and environment variables before and during test execution.
  * Updated test setup documentation to reflect the expanded cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->