### PR TITLE
fix: prevent profile-dedup data loss and wire the repair ladder

### DIFF
--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -6,6 +6,7 @@ and against existing profiles in the database using hybrid search and LLM.
 import logging
 import os
 import uuid
+from collections import Counter
 from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -14,7 +15,11 @@ from reflexio.models.api_schema.retriever_schema import SearchUserProfileRequest
 from reflexio.models.api_schema.service_schemas import Status, UserProfile
 from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.litellm_client import (
+    LiteLLMClient,
+    LiteLLMClientError,
+    StructuredOutputRepairError,
+)
 from reflexio.server.services.deduplication_utils import (
     BaseDeduplicator,
     format_dedup_timestamp,
@@ -25,6 +30,7 @@ from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileTimeToLive,
     calculate_expiration_timestamp,
 )
+from reflexio.server.tracing import capture_anomaly
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +169,131 @@ class ProfileDeduplicationOutput(StrictStructuredOutput):
         extra="allow",
         json_schema_extra={"additionalProperties": False},
     )
+
+
+def _dedup_failure_kind(exc: BaseException) -> str:
+    """
+    Classify a deduplication failure for anomaly tagging.
+
+    Args:
+        exc (BaseException): The exception that aborted the dedup call.
+
+    Returns:
+        str: A coarse, low-cardinality failure class suitable as a Sentry tag.
+    """
+    if isinstance(exc, StructuredOutputRepairError):
+        return f"repair_{exc.failure_kind}"
+    if "timeout" in type(exc).__name__.lower() or "timed out" in str(exc).lower():
+        return "timeout"
+    if isinstance(exc, LiteLLMClientError):
+        return "llm_client_error"
+    return type(exc).__name__
+
+
+def _check_item_id(
+    item_id: str,
+    *,
+    field: str,
+    expected_prefix: str | None,
+    new_profile_count: int,
+    existing_profile_count: int,
+) -> str | None:
+    """
+    Validate a single NEW-/EXISTING- item id emitted by the dedup LLM.
+
+    Args:
+        item_id (str): The raw id as returned by the model.
+        field (str): Schema field the id came from, used in the error message.
+        expected_prefix (str | None): Required prefix, or None to allow either.
+        new_profile_count (int): Number of NEW profiles in the prompt.
+        existing_profile_count (int): Number of EXISTING profiles in the prompt.
+
+    Returns:
+        str | None: An error message, or None when the id is usable.
+    """
+    parsed = parse_item_id(item_id)
+    if parsed is None:
+        return f"{field}: '{item_id}' is not a valid NEW-<n> or EXISTING-<n> id."
+    prefix, idx = parsed
+    if expected_prefix is not None and prefix != expected_prefix:
+        return f"{field}: '{item_id}' must be an {expected_prefix}-<n> id."
+    limit = new_profile_count if prefix == "NEW" else existing_profile_count
+    if not (0 <= idx < limit):
+        return (
+            f"{field}: '{item_id}' is out of range — only {limit} "
+            f"{prefix} profiles were provided."
+        )
+    return None
+
+
+def validate_profile_dedup_output(
+    output: ProfileDeduplicationOutput,
+    *,
+    new_profile_count: int,
+    existing_profile_count: int,
+) -> list[str]:
+    """
+    Check dedup output for unusable ids and NEW-coverage violations.
+
+    Enforces the invariant the prompt itself states: every NEW profile appears
+    exactly once across duplicate_groups, unique_ids, and deletions. Errors are
+    fed back to the model through the structured-output repair ladder, so they
+    are phrased for the model rather than for a log reader.
+
+    Args:
+        output (ProfileDeduplicationOutput): Parsed LLM output to check.
+        new_profile_count (int): Number of NEW profiles in the prompt.
+        existing_profile_count (int): Number of EXISTING profiles in the prompt.
+
+    Returns:
+        list[str]: Human-readable errors; empty when the output is usable.
+    """
+    errors: list[str] = []
+    new_id_uses: Counter[int] = Counter()
+
+    def _check(item_id: str, field: str, expected_prefix: str | None) -> None:
+        error = _check_item_id(
+            item_id,
+            field=field,
+            expected_prefix=expected_prefix,
+            new_profile_count=new_profile_count,
+            existing_profile_count=existing_profile_count,
+        )
+        if error is not None:
+            errors.append(error)
+            return
+        parsed = parse_item_id(item_id)
+        if parsed is not None and parsed[0] == "NEW":
+            new_id_uses[parsed[1]] += 1
+
+    for group in output.duplicate_groups:
+        if not group.item_ids:
+            errors.append("duplicate_groups: a group has an empty item_ids list.")
+        for item_id in group.item_ids:
+            _check(item_id, "duplicate_groups.item_ids", None)
+
+    for unique_id in output.unique_ids:
+        _check(unique_id, "unique_ids", "NEW")
+
+    for deletion in output.deletions:
+        _check(deletion.new_id, "deletions.new_id", "NEW")
+        for existing_id in deletion.existing_ids:
+            _check(existing_id, "deletions.existing_ids", "EXISTING")
+
+    missing = [i for i in range(new_profile_count) if new_id_uses[i] == 0]
+    if missing:
+        errors.append(
+            "Every NEW profile must be referenced exactly once. Missing: "
+            + ", ".join(f"NEW-{i}" for i in missing)
+            + "."
+        )
+    duplicated = sorted(idx for idx, count in new_id_uses.items() if count > 1)
+    if duplicated:
+        errors.append(
+            "Every NEW profile must be referenced exactly once. Referenced more "
+            "than once: " + ", ".join(f"NEW-{i}" for i in duplicated) + "."
+        )
+    return errors
 
 
 class ProfileConsolidator(BaseDeduplicator):
@@ -404,6 +535,32 @@ class ProfileConsolidator(BaseDeduplicator):
 
         output_schema_class = self._get_output_schema_class()
 
+        # Retain the first attempt that parsed, so an exhausted repair ladder
+        # degrades to it instead of throwing away all dedup work.
+        first_parsed_output: ProfileDeduplicationOutput | None = None
+
+        def _validate_output(output: BaseModel) -> list[str]:
+            nonlocal first_parsed_output
+            if not isinstance(output, ProfileDeduplicationOutput):
+                return [f"Unexpected output type: {type(output).__name__}."]
+            if first_parsed_output is None:
+                first_parsed_output = output
+            errors = validate_profile_dedup_output(
+                output,
+                new_profile_count=len(new_profiles),
+                existing_profile_count=len(existing_profiles),
+            )
+            if not errors:
+                return []
+            return [
+                *errors,
+                "Return a corrected JSON object with the same schema. Use only "
+                "NEW-<n> ids in range 0..<new_profile_count-1> and EXISTING-<n> "
+                "ids in range 0..<existing_profile_count-1>, and reference every "
+                "NEW profile exactly once across duplicate_groups, unique_ids, "
+                "and deletions.",
+            ]
+
         try:
             from reflexio.server.services.service_utils import (
                 log_llm_messages,
@@ -418,6 +575,7 @@ class ProfileConsolidator(BaseDeduplicator):
                 messages=[{"role": "user", "content": prompt}],
                 model=self.model_name,
                 response_format=output_schema_class,
+                structured_output_validator=_validate_output,
             )
 
             log_model_response(logger, "Deduplication response", response)
@@ -426,6 +584,12 @@ class ProfileConsolidator(BaseDeduplicator):
                 logger.warning(
                     "Unexpected response type from deduplication LLM: %s",
                     type(response),
+                )
+                capture_anomaly(
+                    "profile.dedup.bad_response_type",
+                    org_id=self.request_context.org_id,
+                    user_id=user_id,
+                    response_type=type(response).__name__,
                 )
                 return _strip_deletion_markers(new_profiles), [], []
 
@@ -439,7 +603,38 @@ class ProfileConsolidator(BaseDeduplicator):
                 "Failed to identify duplicates (%s); keeping profiles un-deduped",
                 str(e),
             )
-            return _strip_deletion_markers(new_profiles), [], []
+            if first_parsed_output is None:
+                # Nothing usable came back at all. Tag the failure so the rate of
+                # un-deduped writes is measurable — this path silently persists
+                # duplicates and drops any pending forget request.
+                capture_anomaly(
+                    "profile.dedup.failed",
+                    org_id=self.request_context.org_id,
+                    user_id=user_id,
+                    failure_kind=_dedup_failure_kind(e),
+                    new_profile_count=len(new_profiles),
+                    existing_profile_count=len(existing_profiles),
+                )
+                return _strip_deletion_markers(new_profiles), [], []
+            # The ladder exhausted, but an earlier attempt parsed. Prefer it over
+            # discarding the dedup entirely. It may still carry the semantic
+            # errors the validator rejected it for (out-of-range ids, NEW
+            # profiles referenced zero or twice), which is safe only because
+            # _build_deduplicated_results defends against exactly those: it
+            # drops out-of-range indices, skips a group it cannot resolve
+            # without marking anything, and re-adds any unreferenced NEW
+            # profile via the safety fallback.
+            logger.warning(
+                "Falling back to the first parsed deduplication attempt after "
+                "repair exhausted"
+            )
+            capture_anomaly(
+                "profile.dedup.degraded_to_first_attempt",
+                org_id=self.request_context.org_id,
+                user_id=user_id,
+                failure_kind=_dedup_failure_kind(e),
+            )
+            dedup_output = first_parsed_output
 
         if not dedup_output.duplicate_groups and not dedup_output.deletions:
             logger.info("No duplicate or deletion actions for request %s", request_id)
@@ -539,7 +734,46 @@ class ProfileConsolidator(BaseDeduplicator):
                 )
                 continue
 
-            # Mark NEW indices as handled only after the overlap check passes.
+            # Resolve the merge template BEFORE marking anything. A group either
+            # writes a merged replacement profile or touches nothing at all:
+            # marking first and bailing on a missing template supersedes the
+            # EXISTING rows with no replacement written, and strands the NEW
+            # facts too (handled_new_indices suppresses the safety fallback
+            # below), so both sides of the group are lost.
+            group_new_profiles = [
+                new_profiles[i] for i in group_new_indices if 0 <= i < len(new_profiles)
+            ]
+            group_existing_profiles = [
+                existing_profiles[i]
+                for i in group_existing_indices
+                if 0 <= i < len(existing_profiles)
+            ]
+
+            # Prefer a NEW member so a merge carrying freshly extracted facts
+            # inherits their metadata. An EXISTING-only group is legal per the
+            # prompt ("a duplicate group can contain ANY mix of NEW and
+            # EXISTING items"), and collapsing it is how duplicates that
+            # accumulated in the DB during past dedup failures get cleaned up.
+            template_profile: UserProfile | None = next(
+                iter(group_new_profiles or group_existing_profiles), None
+            )
+
+            if template_profile is None:
+                # Every id in the group was unparseable or out of range.
+                logger.warning(
+                    "Skipping duplicate group %s: no in-range NEW or EXISTING "
+                    "member to use as a merge template",
+                    group.item_ids,
+                )
+                capture_anomaly(
+                    "profile.dedup.group_unresolvable",
+                    org_id=self.request_context.org_id,
+                    user_id=user_id,
+                )
+                continue
+
+            # Past this point the group is committed to producing a merged
+            # profile, so it is safe to consume its members.
             for idx in group_new_indices:
                 handled_new_indices.add(idx)
 
@@ -553,25 +787,13 @@ class ProfileConsolidator(BaseDeduplicator):
                     superseded_profiles,
                 )
 
-            # Get template from first NEW profile in group (for metadata)
-            template_profile: UserProfile | None = None
-            if group_new_indices:
-                first_new_idx = group_new_indices[0]
-                if 0 <= first_new_idx < len(new_profiles):
-                    template_profile = new_profiles[first_new_idx]
-
-            if template_profile is None:
-                logger.warning("Could not find template profile for group, skipping")
-                continue
-
-            # Merge custom_features from all NEW profiles in group
-            group_new_profiles = [
-                new_profiles[i] for i in group_new_indices if 0 <= i < len(new_profiles)
-            ]
-            merged_custom_features = self._merge_custom_features(group_new_profiles)
-
-            # Merge extractor_names from all NEW profiles in group
-            merged_extractor_names = self._merge_extractor_names(group_new_profiles)
+            # Merge metadata from the NEW members, falling back to the EXISTING
+            # members for an EXISTING-only group so custom_features and
+            # extractor_names are carried into the merged profile rather than
+            # dropped. Mixed groups keep their previous NEW-only behavior.
+            metadata_sources = group_new_profiles or group_existing_profiles
+            merged_custom_features = self._merge_custom_features(metadata_sources)
+            merged_extractor_names = self._merge_extractor_names(metadata_sources)
 
             # Determine TTL
             try:

--- a/tests/server/services/profile/test_profile_consolidator.py
+++ b/tests/server/services/profile/test_profile_consolidator.py
@@ -27,14 +27,20 @@ from reflexio.models.api_schema.service_schemas import (
     ProfileTimeToLive,
     UserProfile,
 )
-from reflexio.server.llm.litellm_client import LiteLLMClient
+from reflexio.server.llm.litellm_client import (
+    LiteLLMClient,
+    LiteLLMClientError,
+    StructuredOutputRepairError,
+)
 from reflexio.server.services.deduplication_utils import parse_item_id
 from reflexio.server.services.profile.components.consolidator import (
     ProfileConsolidator,
     ProfileDeduplicationOutput,
     ProfileDeletionDirective,
     ProfileDuplicateGroup,
+    _dedup_failure_kind,
     _format_profile_timestamp,
+    validate_profile_dedup_output,
 )
 
 # ===============================
@@ -1458,6 +1464,414 @@ class TestRetrieveExistingProfilesStatusFilter:
         assert len(existing) == 1
         assert existing[0].profile_id == "p-existing-1"
         assert existing[0].status == Status.PENDING
+
+
+# ===============================
+# Test: Supersede-without-replacement invariant
+# ===============================
+
+
+def _make_existing(content: str, profile_id: str) -> UserProfile:
+    """Build an EXISTING-side profile for group-resolution tests."""
+    return UserProfile(
+        profile_id=profile_id,
+        user_id="test_user",
+        content=content,
+        last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+        generated_from_request_id="req_existing",
+        profile_time_to_live=ProfileTimeToLive.ONE_MONTH,
+        source="extractor_a",
+    )
+
+
+class TestSupersedeAlwaysHasReplacement:
+    """
+    Contract tests for the core dedup invariant: a duplicate group either
+    writes a merged replacement profile or marks nothing for deletion.
+
+    Regression guard for the bug where a group's EXISTING members were queued
+    for supersede (and its NEW members marked handled) *before* the merge
+    template was resolved, so an unresolvable group deleted stored profiles
+    with no replacement written and stranded the NEW facts too.
+    """
+
+    @pytest.fixture
+    def existing_profiles(self):
+        return [
+            _make_existing("User uses dark theme in the IDE", "p-existing-0"),
+            _make_existing("User codes in Python daily", "p-existing-1"),
+        ]
+
+    @staticmethod
+    def _consolidator(mock_request_context, mock_llm_client):
+        return ProfileConsolidator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+
+    @pytest.mark.parametrize(
+        ("item_ids", "expect_supersede"),
+        [
+            # EXISTING-only group: legal per the prompt ("ANY mix of NEW and
+            # EXISTING"). Collapses into a merged replacement.
+            (["EXISTING-0", "EXISTING-1"], True),
+            # Out-of-range NEW falls back to the EXISTING member as template.
+            (["NEW-7", "EXISTING-0"], True),
+            # Nothing resolvable: must not supersede anything.
+            (["NEW-7", "EXISTING-9"], False),
+            (["garbage", "also-bad"], False),
+            # Mixed group: unchanged behavior.
+            (["NEW-0", "EXISTING-0"], True),
+        ],
+    )
+    def test_group_never_supersedes_without_writing_a_replacement(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        sample_profiles,
+        existing_profiles,
+        item_ids,
+        expect_supersede,
+    ):
+        dedup_output = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=item_ids,
+                    merged_content="MERGED",
+                    merged_time_to_live="one_month",
+                )
+            ],
+        )
+
+        result_profiles, delete_ids, superseded = self._consolidator(
+            mock_request_context, mock_llm_client
+        )._build_deduplicated_results(
+            new_profiles=sample_profiles,
+            existing_profiles=existing_profiles,
+            dedup_output=dedup_output,
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        merged = [p for p in result_profiles if p.content == "MERGED"]
+
+        # The invariant: superseding anything requires a written replacement.
+        if delete_ids:
+            assert merged, (
+                f"group {item_ids} superseded {delete_ids} without writing a "
+                "replacement profile"
+            )
+        assert len(delete_ids) == len(superseded)
+        assert bool(delete_ids) is expect_supersede
+
+        # No NEW profile may be silently dropped, whatever happened to the group.
+        assert len(result_profiles) >= len(sample_profiles) - len(item_ids)
+        for idx, profile in enumerate(sample_profiles):
+            consumed_by_group = f"NEW-{idx}" in item_ids
+            if not consumed_by_group:
+                assert profile in result_profiles, (
+                    f"NEW-{idx} was not part of group {item_ids} but went missing"
+                )
+
+    def test_existing_only_group_carries_metadata_into_the_merge(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        existing_profiles,
+    ):
+        """An EXISTING-only merge must not drop custom_features/extractor_names."""
+        existing_profiles[0].custom_features = {"theme": "dark"}
+        existing_profiles[0].extractor_names = ["extractor_a"]
+        existing_profiles[1].extractor_names = ["extractor_b"]
+
+        dedup_output = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=["EXISTING-0", "EXISTING-1"],
+                    merged_content="MERGED",
+                    merged_time_to_live="one_year",
+                )
+            ],
+        )
+
+        result_profiles, delete_ids, _ = self._consolidator(
+            mock_request_context, mock_llm_client
+        )._build_deduplicated_results(
+            new_profiles=[],
+            existing_profiles=existing_profiles,
+            dedup_output=dedup_output,
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        assert len(result_profiles) == 1
+        merged = result_profiles[0]
+        assert merged.content == "MERGED"
+        assert merged.custom_features == {"theme": "dark"}
+        assert merged.extractor_names == ["extractor_a", "extractor_b"]
+        assert merged.profile_time_to_live == ProfileTimeToLive.ONE_YEAR
+        # Both originals superseded, one replacement written.
+        assert set(delete_ids) == {"p-existing-0", "p-existing-1"}
+
+    def test_deletion_directives_still_supersede_without_replacement(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        existing_profiles,
+    ):
+        """
+        The invariant is scoped to duplicate_groups. A deletion directive is
+        an intentional erase-with-no-replacement and must stay that way.
+        """
+        directive = UserProfile(
+            profile_id=str(uuid.uuid4()),
+            user_id="test_user",
+            content="Requested removal of dark theme preference",
+            last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+            generated_from_request_id="req_1",
+            profile_time_to_live=ProfileTimeToLive.ONE_MONTH,
+            source="extractor_a",
+        )
+        dedup_output = ProfileDeduplicationOutput(
+            deletions=[
+                ProfileDeletionDirective(
+                    new_id="NEW-0",
+                    existing_ids=["EXISTING-0"],
+                    reasoning="meta-request to forget",
+                )
+            ],
+        )
+
+        result_profiles, delete_ids, superseded = self._consolidator(
+            mock_request_context, mock_llm_client
+        )._build_deduplicated_results(
+            new_profiles=[directive],
+            existing_profiles=existing_profiles,
+            dedup_output=dedup_output,
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        assert delete_ids == ["p-existing-0"]
+        assert len(superseded) == 1
+        assert result_profiles == []
+
+
+# ===============================
+# Test: Dedup output validator (repair-ladder feedback)
+# ===============================
+
+
+class TestValidateProfileDedupOutput:
+    """
+    Tests for the semantic validator fed to the structured-output repair
+    ladder. These cover the failure class the ladder can actually correct:
+    output that parses but references unusable ids.
+    """
+
+    @staticmethod
+    def _validate(output, new_count=3, existing_count=2):
+        return validate_profile_dedup_output(
+            output,
+            new_profile_count=new_count,
+            existing_profile_count=existing_count,
+        )
+
+    def test_well_formed_output_passes(self):
+        output = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=["NEW-0", "EXISTING-1"],
+                    merged_content="merged",
+                    merged_time_to_live="one_month",
+                )
+            ],
+            unique_ids=["NEW-1", "NEW-2"],
+        )
+        assert self._validate(output) == []
+
+    def test_out_of_range_ids_are_reported(self):
+        output = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=["NEW-7", "EXISTING-9"],
+                    merged_content="merged",
+                    merged_time_to_live="one_month",
+                )
+            ],
+            unique_ids=["NEW-0", "NEW-1", "NEW-2"],
+        )
+        errors = self._validate(output)
+        assert any("NEW-7" in e and "out of range" in e for e in errors)
+        assert any("EXISTING-9" in e and "out of range" in e for e in errors)
+
+    def test_unparseable_id_is_reported(self):
+        output = ProfileDeduplicationOutput(unique_ids=["NEW-0", "NEW-1", "banana"])
+        errors = self._validate(output)
+        assert any("banana" in e for e in errors)
+
+    def test_missing_new_coverage_is_reported(self):
+        """The prompt's own invariant: every NEW profile referenced exactly once."""
+        output = ProfileDeduplicationOutput(unique_ids=["NEW-0"])
+        errors = self._validate(output)
+        assert any("NEW-1" in e and "Missing" in e for e in errors)
+        assert any("NEW-2" in e and "Missing" in e for e in errors)
+
+    def test_duplicate_new_coverage_is_reported(self):
+        output = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=["NEW-0", "NEW-1"],
+                    merged_content="merged",
+                    merged_time_to_live="one_month",
+                )
+            ],
+            unique_ids=["NEW-0", "NEW-2"],
+        )
+        errors = self._validate(output)
+        assert any("more than once" in e and "NEW-0" in e for e in errors)
+
+    def test_deletion_directive_ids_are_range_checked(self):
+        output = ProfileDeduplicationOutput(
+            unique_ids=["NEW-1", "NEW-2"],
+            deletions=[
+                ProfileDeletionDirective(
+                    new_id="NEW-0",
+                    existing_ids=["EXISTING-4"],
+                    reasoning="forget",
+                )
+            ],
+        )
+        errors = self._validate(output)
+        assert any("EXISTING-4" in e and "out of range" in e for e in errors)
+
+    def test_wrong_prefix_is_reported(self):
+        """unique_ids must be NEW ids — an EXISTING id there is a real error."""
+        output = ProfileDeduplicationOutput(
+            unique_ids=["NEW-0", "NEW-1", "NEW-2", "EXISTING-0"]
+        )
+        errors = self._validate(output)
+        assert any("EXISTING-0" in e and "must be an NEW-<n> id" in e for e in errors)
+
+
+# ===============================
+# Test: Failure instrumentation and repair-ladder wiring
+# ===============================
+
+
+class TestDedupFailureHandling:
+    """Tests for the observability and degradation behavior of deduplicate()."""
+
+    @pytest.fixture
+    def consolidator(
+        self, mock_request_context, mock_llm_client, mock_site_var_manager
+    ):
+        mock_request_context.org_id = "org-test"
+        return ProfileConsolidator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )
+
+    def test_validator_is_passed_to_the_client(self, consolidator, sample_profiles):
+        """The dedup call must opt into the corrective repair ladder."""
+        consolidator.client.generate_chat_response.return_value = (
+            ProfileDeduplicationOutput(unique_ids=["NEW-0", "NEW-1", "NEW-2"])
+        )
+        consolidator.deduplicate(sample_profiles, "test_user", "req-1")
+
+        kwargs = consolidator.client.generate_chat_response.call_args.kwargs
+        assert callable(kwargs["structured_output_validator"])
+
+    def test_total_failure_is_reported_and_degrades_to_undeduped(
+        self, consolidator, sample_profiles
+    ):
+        consolidator.client.generate_chat_response.side_effect = LiteLLMClientError(
+            "Connection timed out after 120.0 seconds"
+        )
+
+        with patch(
+            "reflexio.server.services.profile.components.consolidator.capture_anomaly"
+        ) as mock_capture:
+            profiles, delete_ids, superseded = consolidator.deduplicate(
+                sample_profiles, "test_user", "req-1"
+            )
+
+        assert len(profiles) == len(sample_profiles)
+        assert delete_ids == []
+        assert superseded == []
+        mock_capture.assert_called_once()
+        assert mock_capture.call_args.args[0] == "profile.dedup.failed"
+        assert mock_capture.call_args.kwargs["failure_kind"] == "timeout"
+        assert mock_capture.call_args.kwargs["new_profile_count"] == 3
+
+    def test_exhausted_ladder_degrades_to_first_parsed_attempt(
+        self, consolidator, sample_profiles
+    ):
+        """
+        When the ladder exhausts but an attempt parsed, that attempt is used
+        rather than throwing away all dedup work.
+        """
+        partial = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=["NEW-0", "NEW-1"],
+                    merged_content="MERGED",
+                    merged_time_to_live="one_month",
+                )
+            ],
+            # NEW-2 deliberately uncovered — the semantic error the validator
+            # rejected this attempt for.
+        )
+
+        def _call(**kwargs):
+            kwargs["structured_output_validator"](partial)
+            raise StructuredOutputRepairError(
+                "Structured output repair exhausted",
+                failure_kind="semantic",
+                model="minimax/MiniMax-M3",
+            )
+
+        consolidator.client.generate_chat_response.side_effect = _call
+
+        with patch(
+            "reflexio.server.services.profile.components.consolidator.capture_anomaly"
+        ) as mock_capture:
+            profiles, _, _ = consolidator.deduplicate(
+                sample_profiles, "test_user", "req-1"
+            )
+
+        # The merge was applied, and the uncovered NEW-2 still survived via the
+        # safety fallback — nothing was lost.
+        contents = {p.content for p in profiles}
+        assert "MERGED" in contents
+        assert sample_profiles[2].content in contents
+        assert (
+            mock_capture.call_args.args[0] == "profile.dedup.degraded_to_first_attempt"
+        )
+        assert mock_capture.call_args.kwargs["failure_kind"] == "repair_semantic"
+
+
+class TestDedupFailureKind:
+    """Tests for the anomaly failure-class tag."""
+
+    def test_repair_error_carries_its_failure_kind(self):
+        exc = StructuredOutputRepairError(
+            "exhausted", failure_kind="parse", model="minimax/MiniMax-M3"
+        )
+        assert _dedup_failure_kind(exc) == "repair_parse"
+
+    def test_timeout_is_detected_from_the_message(self):
+        exc = LiteLLMClientError("Connection timed out after 120.0 seconds")
+        assert _dedup_failure_kind(exc) == "timeout"
+
+    def test_other_client_errors_are_grouped(self):
+        assert _dedup_failure_kind(LiteLLMClientError("boom")) == "llm_client_error"
+
+    def test_unexpected_errors_use_their_type_name(self):
+        assert _dedup_failure_kind(ValueError("boom")) == "ValueError"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes a silent data-loss path in the profile deduplication consolidator and adds
the observability and corrective-retry machinery it was missing. All three issues
were surfaced by `minimax/MiniMax-M3` structured-output failures on the profile
dedup call in production.

## Changes

**1. Eliminate delete-without-replacement (`_build_deduplicated_results`)**
A duplicate group's EXISTING members were queued for supersede, and its NEW
indices marked handled, *before* the merge template was resolved. When the
template turned out to be unresolvable, the `continue` left the existing rows
deleted with no replacement written and the new facts stranded (the safety
fallback can't recover them — they're already marked handled). The dedup prompt
explicitly permits a group of "ANY mix of NEW and EXISTING items", so an
EXISTING-only group is valid model output, not just hallucination — this fired
in prod.

Template resolution now happens **before** any marking: a group either writes a
merged replacement profile or touches nothing. When a group has no in-range NEW
member, the first in-range EXISTING member is used as the template, which
collapses duplicate rows that accumulated in the DB during past dedup failures.

**2. Instrument the dedup-failure fallbacks**
The three silent-degrade exits now emit `capture_anomaly` (level=warning) tagged
with a coarse `failure_kind` (`repair_*` / `timeout` / `llm_client_error`) and
the new/existing profile counts, so the rate of un-deduped writes — previously
warning-log-only — is measurable in Sentry.

**3. Wire the dedup call onto the existing structured-output repair ladder**
The dedup call now passes `structured_output_validator`, porting the pattern the
playbook consolidator already runs in production (including the
`first_parsed_output` degrade so an exhausted ladder falls back to the first
parsed attempt rather than discarding all dedup work). A malformed dedup response
now gets a corrective retry that echoes the validation errors, instead of the old
identical-params re-roll with a pinned seed. The new `validate_profile_dedup_output`
reports unusable `NEW-`/`EXISTING-` ids and NEW-coverage violations back to the
model.

## Test Plan

- New `TestSupersedeAlwaysHasReplacement` contract tests drive
  `_build_deduplicated_results` with EXISTING-only, out-of-range `NEW`/`EXISTING`,
  fully-unparseable, and mixed groups, asserting the core invariant for every case:
  **anything superseded has a written replacement**, and no NEW profile is dropped.
  The deletion-directive path (intentional erase-without-replacement) is covered
  as a regression.
- Validator unit tests cover out-of-range ids, unparseable ids, wrong-prefix ids,
  and missing/duplicate NEW coverage.
- Repair-ladder tests confirm the validator is passed through, that total failure
  degrades to un-deduped with a `profile.dedup.failed` anomaly, and that an
  exhausted ladder degrades to the first parsed attempt.
- A standalone repro confirms the fix: the invariant assertion **fails on the
  pre-fix code** (`DATA LOSS: group ['NEW-7','EXISTING-0'] superseded
  ['p-existing-0'] with no replacement`) and passes after.
- Verified end to end against a real `MiniMax-M3` dedup call (publish → extract →
  dedup): the profile survives dedup with no orphaned supersede, and the actual
  dedup prompt + response were traced through the LLM I/O log.
- Full profile + playbook consolidator suites pass (shared `parse_item_id` /
  `deduplication_utils`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger validation for profile deduplication results.
  * Added anomaly tracking for deduplication failures, unexpected responses, and degraded outcomes.
  * Preserved existing profile metadata when consolidating existing-only duplicates.
  * Prevented profiles from being marked for deletion unless a replacement profile is created.

* **Bug Fixes**
  * Improved handling of invalid or unresolvable duplicate groups.
  * Ensured failed deduplication safely falls back to an undeduplicated result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->