### PR TITLE
fix: apply model-specific embedding retrieval policy

### DIFF
--- a/reflexio/benchmarks/retrieval_latency/embed_cache.py
+++ b/reflexio/benchmarks/retrieval_latency/embed_cache.py
@@ -35,6 +35,7 @@ from typing import Any, Literal
 
 from reflexio.models.config_schema import EMBEDDING_DIMENSIONS
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.server.services.embedding_text import embedding_input
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +46,6 @@ DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
 DEFAULT_EMBEDDING_DIMS = EMBEDDING_DIMENSIONS
 
 _CACHE_DIR = Path.home() / ".cache" / "reflexio-benchmarks"
-_DOCUMENT_PREFIX = "search_document: "
-_QUERY_PREFIX = "search_query: "
-
-
 EmbeddingPurpose = Literal["document", "query"]
 
 EmbeddingFn = Callable[[str, EmbeddingPurpose], list[float]]
@@ -132,20 +129,24 @@ class QueryEmbedCache:
         subsequent runs skip the network entirely.
 
         Args:
-            queries (Iterable[str]): Raw query strings (no prefix). The
-                ``search_query:`` prefix is applied internally.
+            queries (Iterable[str]): Raw query strings. Model-specific input
+                formatting is applied internally.
 
         Raises:
             RuntimeError: If the embedder cannot be reached and the cache is
                 not already populated for every query.
         """
         missing: list[str] = []
-        missing_prefixed: list[str] = []
+        missing_inputs: list[str] = []
         for q in queries:
-            prefixed = _QUERY_PREFIX + q
-            if _hash_key(prefixed) not in self._data:
+            formatted = embedding_input(
+                q,
+                model_name=self.model,
+                purpose="query",
+            )
+            if _hash_key(formatted) not in self._data:
                 missing.append(q)
-                missing_prefixed.append(prefixed)
+                missing_inputs.append(formatted)
         if not missing:
             return
 
@@ -156,9 +157,7 @@ class QueryEmbedCache:
         )
         client = LiteLLMClient(LiteLLMConfig(model=self.model))
         try:
-            vectors = client.get_embeddings(
-                missing_prefixed, self.model, self.dimensions
-            )
+            vectors = client.get_embeddings(missing_inputs, self.model, self.dimensions)
         except Exception as err:  # noqa: BLE001
             raise RuntimeError(
                 f"Failed to populate query embed cache for model {self.model}: "
@@ -166,13 +165,13 @@ class QueryEmbedCache:
                 "and re-run."
             ) from err
 
-        for prefixed, vec in zip(missing_prefixed, vectors, strict=True):
+        for formatted, vec in zip(missing_inputs, vectors, strict=True):
             if len(vec) != self.dimensions:
                 raise RuntimeError(
                     f"Embed cache got vector of length {len(vec)}, expected "
                     f"{self.dimensions} for model {self.model}"
                 )
-            self._data[_hash_key(prefixed)] = list(vec)
+            self._data[_hash_key(formatted)] = list(vec)
 
         self._path.parent.mkdir(parents=True, exist_ok=True)
         self._path.write_text(json.dumps(self._data))
@@ -191,8 +190,12 @@ class QueryEmbedCache:
         Raises:
             KeyError: If the text is not in the cache.
         """
-        prefix = _DOCUMENT_PREFIX if purpose == "document" else _QUERY_PREFIX
-        key = _hash_key(prefix + text)
+        formatted = embedding_input(
+            text,
+            model_name=self.model,
+            purpose=purpose,
+        )
+        key = _hash_key(formatted)
         try:
             return self._data[key]
         except KeyError as err:

--- a/reflexio/cli/commands/shortcuts.py
+++ b/reflexio/cli/commands/shortcuts.py
@@ -188,7 +188,10 @@ def register_shortcuts(app: typer.Typer) -> None:
         ctx: typer.Context,
         query: Annotated[str, typer.Argument(help="Search query text")],
         top_k: Annotated[int, typer.Option("--top-k", help="Max results per type")] = 5,
-        threshold: Annotated[float, typer.Option(help="Similarity threshold")] = 0.4,
+        threshold: Annotated[
+            float | None,
+            typer.Option(help="Similarity threshold (defaults by embedding model)"),
+        ] = None,
         user_id: Annotated[
             str | None, typer.Option("--user-id", help="Filter by user ID")
         ] = None,

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -534,6 +534,7 @@ class ReflexioClient:
         end_time: datetime | None = None,
         top_k: int | None = None,
         most_recent_k: int | None = None,
+        threshold: float | None = None,
         search_mode: SearchMode | None = None,
     ) -> SearchInteractionsViewResponse:
         """Search for user interactions.
@@ -547,6 +548,8 @@ class ReflexioClient:
             end_time (Optional[datetime]): Filter by end time
             top_k (Optional[int]): Maximum number of results to return
             most_recent_k (Optional[int]): Return most recent k interactions
+            threshold (Optional[float]): Similarity threshold. When omitted,
+                the embedding model's default is used.
 
         Returns:
             SearchInteractionsViewResponse: Response containing matching interactions
@@ -561,6 +564,7 @@ class ReflexioClient:
             end_time=end_time,
             top_k=top_k,
             most_recent_k=most_recent_k,
+            threshold=threshold,
             search_mode=search_mode,
         )
         response = self._make_request(
@@ -602,7 +606,8 @@ class ReflexioClient:
             custom_feature (Optional[str]): Filter by custom feature
             extractor_name (Optional[str]): Deprecated compatibility field. Accepted but ignored.
             tags (Optional[list[str]]): Match profiles having any of these tags.
-            threshold (Optional[float]): Similarity threshold (default: 0.7)
+            threshold (Optional[float]): Similarity threshold. When omitted,
+                the embedding model's default is used.
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
 
         Returns:
@@ -763,7 +768,8 @@ class ReflexioClient:
             status_filter (Optional[list[Optional[Status]]]): Filter by status (None for CURRENT, PENDING, ARCHIVED)
             tags (Optional[list[str]]): Match playbooks having any of these tags.
             top_k (Optional[int]): Maximum number of results to return (default: 10)
-            threshold (Optional[float]): Similarity threshold for vector search (default: 0.4)
+            threshold (Optional[float]): Similarity threshold for vector search.
+                When omitted, the embedding model's default is used.
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
 
         Returns:
@@ -820,7 +826,8 @@ class ReflexioClient:
             playbook_status_filter (Optional[PlaybookStatus]): Filter by playbook status (PENDING, APPROVED, REJECTED)
             tags (Optional[list[str]]): Match playbooks having any of these tags.
             top_k (Optional[int]): Maximum number of results to return (default: 10)
-            threshold (Optional[float]): Similarity threshold for vector search (default: 0.4)
+            threshold (Optional[float]): Similarity threshold for vector search.
+                When omitted, the embedding model's default is used.
             enable_reformulation (Optional[bool]): Enable LLM query reformulation (default: False)
 
         Returns:
@@ -2524,7 +2531,8 @@ class ReflexioClient:
             request (Optional[UnifiedSearchRequest]): The search request object (alternative to kwargs)
             query (str): Search query text
             top_k (Optional[int]): Maximum results per entity type (default: 5)
-            threshold (Optional[float]): Similarity threshold for vector search (default: 0.45)
+            threshold (Optional[float]): Similarity threshold for vector search.
+                When omitted, the embedding model's default is used.
             agent_version (Optional[str]): Filter by agent version (agent_playbooks, user_playbooks)
             playbook_name (Optional[str]): Filter by playbook name (agent_playbooks, user_playbooks)
             user_id (Optional[str]): Filter by user ID (profiles, user_playbooks)

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -41,6 +41,7 @@ class SearchInteractionRequest(BaseModel):
     end_time: datetime | None = None
     top_k: int | None = Field(default=None, gt=0)
     most_recent_k: int | None = Field(default=None, gt=0)
+    threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     search_mode: SearchMode = SearchMode.HYBRID
 
     @model_validator(mode="after")
@@ -68,7 +69,7 @@ class SearchUserProfileRequest(BaseModel):
         None  # Deprecated compatibility field; accepted but ignored.
     )
     tags: list[str] | None = None
-    threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
+    threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
 
@@ -318,7 +319,8 @@ class SearchUserPlaybookRequest(BaseModel):
         end_time (datetime, optional): End time for created_at filter
         status_filter (list[Optional[Status]], optional): Filter by status (None for CURRENT, PENDING, ARCHIVED)
         top_k (int, optional): Maximum number of results to return. Defaults to 10
-        threshold (float, optional): Similarity threshold for vector search. Defaults to 0.4
+        threshold (float, optional): Similarity threshold for vector search.
+            When omitted, the embedding model's default is used.
     """
 
     query: str | None = None
@@ -330,7 +332,7 @@ class SearchUserPlaybookRequest(BaseModel):
     status_filter: list[Status | None] | None = None
     tags: list[str] | None = None
     top_k: int | None = Field(default=10, gt=0)
-    threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
+    threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
     # Caller correlation IDs for billing attribution on the Application line.
@@ -376,7 +378,8 @@ class SearchAgentPlaybookRequest(BaseModel):
             a single storage query without per-status fan-out. Defaults to
             None (no status predicate).
         top_k (int, optional): Maximum number of results to return. Defaults to 10
-        threshold (float, optional): Similarity threshold for vector search. Defaults to 0.4
+        threshold (float, optional): Similarity threshold for vector search.
+            When omitted, the embedding model's default is used.
     """
 
     query: str | None = None
@@ -388,7 +391,7 @@ class SearchAgentPlaybookRequest(BaseModel):
     playbook_status_filter: PlaybookStatus | list[PlaybookStatus] | None = None
     tags: list[str] | None = None
     top_k: int | None = Field(default=10, gt=0)
-    threshold: float | None = Field(default=0.4, ge=0.0, le=1.0)
+    threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     enable_reformulation: bool | None = False
     search_mode: SearchMode = SearchMode.HYBRID
     # Caller correlation IDs for billing attribution on the Application line.
@@ -741,7 +744,8 @@ class UnifiedSearchRequest(BaseModel):
     Args:
         query (str): Search query text
         top_k (int, optional): Maximum results per entity type. Defaults to 5
-        threshold (float, optional): Similarity threshold for vector search. Defaults to 0.45
+        threshold (float, optional): Similarity threshold for vector search.
+            When omitted, the embedding model's default is used.
         agent_version (str, optional): Filter by agent version (agent_playbooks, user_playbooks)
         playbook_name (str, optional): Filter by playbook name (agent_playbooks, user_playbooks)
         user_id (str, optional): Filter by user ID (profiles, user_playbooks)
@@ -757,7 +761,7 @@ class UnifiedSearchRequest(BaseModel):
 
     query: NonEmptyStr
     top_k: int | None = Field(default=5, gt=0)
-    threshold: float | None = Field(default=0.45, ge=0.0, le=1.0)
+    threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     agent_version: str | None = None
     playbook_name: str | None = None
     user_id: str | None = None

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -369,11 +369,14 @@ class APIKeyConfig(BaseModel):
 class DeduplicationConfig(BaseModel):
     """Configuration for playbook deduplication search parameters.
 
-    Controls the hybrid search behavior when looking for existing playbooks
-    to deduplicate against.
+    Controls bounded candidate generation when looking for existing playbooks
+    to deduplicate against. The candidate threshold is intentionally independent
+    from the embedding model's user-facing retrieval default because an LLM
+    performs the final duplicate decision.
 
     Args:
-        search_threshold: Minimum similarity score for search results (0.0-1.0).
+        search_threshold: Minimum similarity score for deduplication candidates
+            (0.0-1.0), independent from user-facing retrieval defaults.
         search_top_k: Maximum number of existing playbooks to retrieve per new playbook.
         max_unified_content_chars: Soft cap on a unified playbook's content length.
     """
@@ -382,7 +385,11 @@ class DeduplicationConfig(BaseModel):
         default=0.4,
         ge=0.0,
         le=1.0,
-        description="Minimum similarity score for deduplication search results.",
+        description=(
+            "Minimum similarity score for deduplication candidates. This is a "
+            "dedup-specific override, independent from the embedding model's "
+            "user-facing retrieval default."
+        ),
     )
     search_top_k: int = Field(
         default=5,

--- a/reflexio/server/services/deduplication_utils.py
+++ b/reflexio/server/services/deduplication_utils.py
@@ -55,7 +55,7 @@ def resolve_dedup_query_embeddings(
             logger.info(
                 "%s dedup query embeddings: source=storage model=%s",
                 entity_label,
-                getattr(storage, "embedding_model_name", "unknown"),
+                storage.embedding_model_name,
             )
             embeddings = [
                 cast(
@@ -75,7 +75,11 @@ def resolve_dedup_query_embeddings(
             embeddings = list(
                 client.get_embeddings(
                     [
-                        embedding_input(query_text, purpose="query")
+                        embedding_input(
+                            query_text,
+                            model_name=embedding_model_name,
+                            purpose="query",
+                        )
                         for query_text in query_texts
                     ],
                     model=embedding_model_name,

--- a/reflexio/server/services/embedding_text.py
+++ b/reflexio/server/services/embedding_text.py
@@ -1,7 +1,8 @@
-"""Canonical text and prefixes used for vector embeddings."""
+"""Canonical text and model-specific policy used for vector embeddings."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Literal
 
 from reflexio.models.api_schema.service_schemas import (
@@ -14,6 +15,38 @@ from reflexio.models.api_schema.service_schemas import (
 
 SEARCH_DOCUMENT_PREFIX = "search_document: "
 SEARCH_QUERY_PREFIX = "search_query: "
+
+
+@dataclass(frozen=True)
+class EmbeddingModelPolicy:
+    """Input formatting and retrieval defaults owned by one embedding model."""
+
+    document_prefix: str
+    query_prefix: str
+    retrieval_threshold: float
+
+
+_DEFAULT_MODEL_POLICY = EmbeddingModelPolicy(
+    document_prefix="",
+    query_prefix="",
+    retrieval_threshold=0.45,
+)
+_NOMIC_MODEL_POLICY = EmbeddingModelPolicy(
+    document_prefix=SEARCH_DOCUMENT_PREFIX,
+    query_prefix=SEARCH_QUERY_PREFIX,
+    retrieval_threshold=0.70,
+)
+_EMBEDDING_MODEL_POLICIES = {
+    "local/minilm-l6-v2": EmbeddingModelPolicy(
+        document_prefix="",
+        query_prefix="",
+        retrieval_threshold=0.30,
+    ),
+    "local/nomic-embed-text-v1.5": _NOMIC_MODEL_POLICY,
+    # Backward-compatible provider alias. New configuration should use the
+    # canonical ``local/nomic-embed-text-v1.5`` identifier.
+    "local/nomic-embed-v1.5": _NOMIC_MODEL_POLICY,
+}
 
 EmbeddingTextEntity = (
     Interaction
@@ -45,18 +78,38 @@ def embedding_text(entity: EmbeddingTextEntity) -> str:
 
 
 def embedding_input(
-    text: str, *, purpose: Literal["document", "query"] = "document"
+    text: str,
+    *,
+    model_name: str,
+    purpose: Literal["document", "query"] = "document",
 ) -> str:
-    """Apply the asymmetric search prefix used before embedding calls.
+    """Apply input formatting owned by the selected embedding model.
 
     ``purpose`` must be ``"document"`` or ``"query"``; any other value raises so a
     misspelled call site fails fast instead of silently writing or searching the
-    wrong vector space.
+    wrong vector space. Unrecognized models receive the text unchanged.
     """
+    policy = _EMBEDDING_MODEL_POLICIES.get(
+        model_name.strip().casefold(), _DEFAULT_MODEL_POLICY
+    )
     if purpose == "document":
-        return SEARCH_DOCUMENT_PREFIX + text
+        return policy.document_prefix + text
     if purpose == "query":
-        return SEARCH_QUERY_PREFIX + text
+        return policy.query_prefix + text
     raise ValueError(
         f"Unknown embedding purpose {purpose!r}; expected 'document' or 'query'"
     )
+
+
+def resolve_retrieval_threshold(
+    requested_threshold: float | None,
+    *,
+    model_name: str,
+) -> float:
+    """Return an explicit threshold or the selected model's default."""
+    if requested_threshold is not None:
+        return requested_threshold
+    policy = _EMBEDDING_MODEL_POLICIES.get(
+        model_name.strip().casefold(), _DEFAULT_MODEL_POLICY
+    )
+    return policy.retrieval_threshold

--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -46,6 +46,12 @@ _format_profile_timestamp = format_dedup_timestamp
 # are never persisted as facts.
 _DELETION_MARKER_PREFIX = "Requested removal of"
 
+# Deduplication search is bounded candidate generation for a second-stage LLM,
+# not user-facing retrieval. Keep its threshold independent from the active
+# embedding model's retrieval default so Nomic's stricter default does not hide
+# plausible duplicates before the consolidator can inspect them.
+_DEDUP_CANDIDATE_SEARCH_THRESHOLD = 0.4
+
 
 def _strip_deletion_markers(
     profiles: list[UserProfile],
@@ -466,7 +472,7 @@ class ProfileConsolidator(BaseDeduplicator):
                         query=query_text,
                         user_id=user_id,
                         top_k=10,
-                        threshold=0.4,
+                        threshold=_DEDUP_CANDIDATE_SEARCH_THRESHOLD,
                     ),
                     status_filter=search_status_filter,
                     query_embedding=embeddings[i],

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -51,6 +51,7 @@ from reflexio.server.llm.model_defaults import (
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
 )
+from reflexio.server.services.embedding_text import embedding_input
 from reflexio.server.services.storage.error import (
     StorageError,
     require_non_empty_session_id,
@@ -182,6 +183,8 @@ def _vector_rank_rows(
     rows: Sequence[Any],
     query_embedding: list[float],
     match_count: int,
+    *,
+    threshold: float,
 ) -> list[Any]:
     """Rank rows by cosine similarity to the query embedding.
 
@@ -189,6 +192,7 @@ def _vector_rank_rows(
         rows: Candidate rows with stored embeddings.
         query_embedding: The query's embedding vector.
         match_count: Number of results to return.
+        threshold: Strict minimum cosine similarity for the vector arm.
 
     Returns:
         Top ``match_count`` rows sorted by cosine similarity descending.
@@ -212,13 +216,18 @@ def _vector_rank_rows(
     # per vector search call (~200 bytes).
     if scored:
         top = [round(s, 3) for _, s in scored[:10]]
+        passing = [(row, score) for row, score in scored if score > threshold]
         logger.info(
-            "vector_rank: candidates=%d match_count=%d top_scores=%s",
+            "vector_rank: candidates=%d passing=%d threshold=%.3f "
+            "match_count=%d top_scores=%s",
             len(scored),
+            len(passing),
+            threshold,
             match_count,
             top,
         )
-    return [row for row, _ in scored[:match_count]]
+        return [row for row, _ in passing[:match_count]]
+    return []
 
 
 def _true_rrf_merge(
@@ -1673,21 +1682,25 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     def _get_embedding(
         self, text: str, purpose: Literal["document", "query"] = "document"
     ) -> list[float]:
-        """Generate an embedding with a purpose-specific prefix.
+        """Generate an embedding with model-specific input formatting.
 
         Args:
             text: The text to embed.
             purpose: Either ``"document"`` (stored embeddings) or ``"query"``
-                (search-time embeddings).  The prefix improves asymmetric
-                retrieval quality for models that support it.
+                (search-time embeddings).
 
         Returns:
             The embedding vector as a list of floats.
         """
-        prefix = "search_document: " if purpose == "document" else "search_query: "
         try:
             return self.llm_client.get_embedding(
-                prefix + text, self.embedding_model_name, self.embedding_dimensions
+                embedding_input(
+                    text,
+                    model_name=self.embedding_model_name,
+                    purpose=purpose,
+                ),
+                self.embedding_model_name,
+                self.embedding_dimensions,
             )
         except EmbeddingUnavailableError as exc:
             logger.warning(

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -19,6 +19,7 @@ from reflexio.models.api_schema.service_schemas import (
     Status,
 )
 from reflexio.models.config_schema import SearchMode, SearchOptions
+from reflexio.server.services.embedding_text import resolve_retrieval_threshold
 from reflexio.server.services.storage.lifecycle_filters import (
     validate_include_inactive,
 )
@@ -81,6 +82,7 @@ class AgentPlaybookStoreMixin:
     _lock: Any
     conn: sqlite3.Connection
     org_id: str
+    embedding_model_name: str
     _execute: Any
     _fetchone: Any
     _fetchall: Any
@@ -902,6 +904,10 @@ class AgentPlaybookStoreMixin:
         mode = _effective_search_mode(
             request.search_mode, query_embedding, request.query
         )
+        threshold = resolve_retrieval_threshold(
+            request.threshold,
+            model_name=self.embedding_model_name,
+        )
         rrf_k = options.rrf_k if options else 60
         vector_weight = options.vector_weight if options else 1.0
         fts_weight = options.fts_weight if options else 1.0
@@ -955,7 +961,12 @@ class AgentPlaybookStoreMixin:
                       {base_where}
                       ORDER BY ap.created_at DESC"""
             rows = self._fetchall(sql, params)
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
             return [_row_to_agent_playbook(r) for r in rows]
 
         if query:
@@ -975,7 +986,12 @@ class AgentPlaybookStoreMixin:
                               ORDER BY ap.created_at DESC
                               LIMIT ?"""
                 vec_candidates = self._fetchall(vec_sql, [*params, vec_limit])
-                vec_rows = _vector_rank_rows(vec_candidates, query_embedding, overfetch)
+                vec_rows = _vector_rank_rows(
+                    vec_candidates,
+                    query_embedding,
+                    overfetch,
+                    threshold=threshold,
+                )
                 rows = _true_rrf_merge(
                     fts_rows,
                     vec_rows,
@@ -995,7 +1011,12 @@ class AgentPlaybookStoreMixin:
                       {base_where}
                       ORDER BY ap.created_at DESC"""
             rows = self._fetchall(sql, params)
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
             return [_row_to_agent_playbook(r) for r in rows]
 
         # No query text, no embedding -- recency fallback

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -10,6 +10,7 @@ from reflexio.models.api_schema.common import BlockingIssue
 from reflexio.models.api_schema.retriever_schema import SearchUserPlaybookRequest
 from reflexio.models.api_schema.service_schemas import Status, UserPlaybook
 from reflexio.models.config_schema import SearchMode, SearchOptions
+from reflexio.server.services.embedding_text import resolve_retrieval_threshold
 from reflexio.server.services.storage.lifecycle_filters import (
     validate_include_inactive,
 )
@@ -64,6 +65,7 @@ class UserPlaybookStoreMixin:
     _lock: Any
     conn: sqlite3.Connection
     org_id: str
+    embedding_model_name: str
     _fetchone: Any
     _fetchall: Any
     _get_embedding: Any
@@ -638,6 +640,10 @@ class UserPlaybookStoreMixin:
         mode = _effective_search_mode(
             request.search_mode, query_embedding, request.query
         )
+        threshold = resolve_retrieval_threshold(
+            request.threshold,
+            model_name=self.embedding_model_name,
+        )
         rrf_k = options.rrf_k if options else 60
         vector_weight = options.vector_weight if options else 1.0
         fts_weight = options.fts_weight if options else 1.0
@@ -684,7 +690,12 @@ class UserPlaybookStoreMixin:
                       {base_where}
                       ORDER BY up.created_at DESC"""
             rows = self._fetchall(sql, params)
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
             return [_row_to_user_playbook(r) for r in rows]
 
         if query:
@@ -704,7 +715,12 @@ class UserPlaybookStoreMixin:
                               ORDER BY up.created_at DESC
                               LIMIT ?"""
                 vec_candidates = self._fetchall(vec_sql, [*params, vec_limit])
-                vec_rows = _vector_rank_rows(vec_candidates, query_embedding, overfetch)
+                vec_rows = _vector_rank_rows(
+                    vec_candidates,
+                    query_embedding,
+                    overfetch,
+                    threshold=threshold,
+                )
                 rows = _true_rrf_merge(
                     fts_rows,
                     vec_rows,
@@ -724,7 +740,12 @@ class UserPlaybookStoreMixin:
                       {base_where}
                       ORDER BY up.created_at DESC"""
             rows = self._fetchall(sql, params)
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
             return [_row_to_user_playbook(r) for r in rows]
 
         # No query text, no embedding -- recency fallback

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -16,6 +16,7 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
 )
+from reflexio.server.services.embedding_text import embedding_input
 
 from .._base import (
     SQLiteStorageBase,
@@ -84,7 +85,7 @@ class InteractionStoreMixin:
     def add_user_interaction(self, user_id: str, interaction: Interaction) -> None:  # noqa: ARG002
         # NOTE: distinct from the bulk/backfill derivation
         # (_embed_text_for_interaction). This legacy single-insert path embeds via
-        # the purpose-prefixed _get_embedding ("search_document: ...") and its own
+        # the model-formatted _get_embedding path and its own
         # f-string, so it is intentionally NOT routed through the shared helper —
         # aligning it would silently change stored embedding values (e.g. null ->
         # literal "None"). The real bulk ingest + backfill share the helper.
@@ -221,7 +222,15 @@ class InteractionStoreMixin:
                 ]
                 try:
                     embeddings = self.llm_client.get_embeddings(
-                        texts, self.embedding_model_name, self.embedding_dimensions
+                        [
+                            embedding_input(
+                                text,
+                                model_name=self.embedding_model_name,
+                            )
+                            for text in texts
+                        ],
+                        self.embedding_model_name,
+                        self.embedding_dimensions,
                     )
                 except EmbeddingUnavailableError as exc:
                     logger.warning(
@@ -253,7 +262,15 @@ class InteractionStoreMixin:
         ]
         try:
             embeddings = self.llm_client.get_embeddings(
-                texts, self.embedding_model_name, self.embedding_dimensions
+                [
+                    embedding_input(
+                        text,
+                        model_name=self.embedding_model_name,
+                    )
+                    for text in texts
+                ],
+                self.embedding_model_name,
+                self.embedding_dimensions,
             )
         except EmbeddingUnavailableError as exc:
             logger.warning(
@@ -333,7 +350,15 @@ class InteractionStoreMixin:
         texts = [text for _, text in pairs]
         try:
             embeddings = self.llm_client.get_embeddings(
-                texts, self.embedding_model_name, self.embedding_dimensions
+                [
+                    embedding_input(
+                        text,
+                        model_name=self.embedding_model_name,
+                    )
+                    for text in texts
+                ],
+                self.embedding_model_name,
+                self.embedding_dimensions,
             )
         except EmbeddingUnavailableError as exc:
             logger.warning(

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_search.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_search.py
@@ -19,6 +19,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserProfile,
 )
 from reflexio.models.config_schema import SearchMode
+from reflexio.server.services.embedding_text import resolve_retrieval_threshold
 
 from .._base import (
     SQLiteStorageBase,
@@ -41,6 +42,7 @@ class ProfileSearchMixin:
 
     # Type hints for instance attributes/methods provided by SQLiteStorageBase via MRO
     _fetchall: Any
+    embedding_model_name: str
 
     # ------------------------------------------------------------------
     # Search — Interactions & Profiles
@@ -56,6 +58,10 @@ class ProfileSearchMixin:
         has_query = bool(req.query)
         match_count = req.most_recent_k or 10
         mode = _effective_search_mode(req.search_mode, query_embedding, req.query)
+        threshold = resolve_retrieval_threshold(
+            req.threshold,
+            model_name=self.embedding_model_name,
+        )
 
         conditions: list[str] = ["i.user_id = ?"]
         params: list[str | int | float] = [req.user_id]
@@ -85,7 +91,12 @@ class ProfileSearchMixin:
                       ORDER BY i.created_at DESC
                       LIMIT ?"""
             rows = self._fetchall(sql, (*params, vector_limit))
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
         elif has_query:
             # FTS search (with optional HYBRID re-ranking)
             fts_query = _sanitize_fts_query(req.query)  # type: ignore[arg-type]
@@ -106,7 +117,12 @@ class ProfileSearchMixin:
                               ORDER BY i.created_at DESC
                               LIMIT ?"""
                 vec_candidates = self._fetchall(vec_sql, (*params, vec_limit))
-                vec_rows = _vector_rank_rows(vec_candidates, query_embedding, overfetch)
+                vec_rows = _vector_rank_rows(
+                    vec_candidates,
+                    query_embedding,
+                    overfetch,
+                    threshold=threshold,
+                )
                 rows = _true_rrf_merge(
                     fts_rows,
                     vec_rows,
@@ -147,6 +163,10 @@ class ProfileSearchMixin:
         current_ts = _epoch_now()
         has_query = bool(req.query)
         mode = _effective_search_mode(req.search_mode, query_embedding, req.query)
+        threshold = resolve_retrieval_threshold(
+            req.threshold,
+            model_name=self.embedding_model_name,
+        )
         has_embedding = query_embedding is not None
         logger.info(
             "Profile search: requested_mode=%s, effective_mode=%s, has_query=%s, has_embedding=%s, user_id=%s",
@@ -197,7 +217,12 @@ class ProfileSearchMixin:
             logger.info(
                 "VECTOR search: %d candidates fetched, ranking by embedding", len(rows)
             )
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
         elif has_query:
             fts_query = _sanitize_fts_query(req.query)  # type: ignore[arg-type]
             sql = f"""SELECT p.* FROM profiles p
@@ -218,7 +243,12 @@ class ProfileSearchMixin:
                               ORDER BY p.last_modified_timestamp DESC
                               LIMIT ?"""
                 vec_candidates = self._fetchall(vec_sql, (*params, vec_limit))
-                vec_rows = _vector_rank_rows(vec_candidates, query_embedding, overfetch)
+                vec_rows = _vector_rank_rows(
+                    vec_candidates,
+                    query_embedding,
+                    overfetch,
+                    threshold=threshold,
+                )
                 rows = _true_rrf_merge(
                     fts_rows,
                     vec_rows,
@@ -241,7 +271,12 @@ class ProfileSearchMixin:
                 "HYBRID (no query text) search: %d candidates, ranking by embedding",
                 len(rows),
             )
-            rows = _vector_rank_rows(rows, query_embedding, match_count)
+            rows = _vector_rank_rows(
+                rows,
+                query_embedding,
+                match_count,
+                threshold=threshold,
+            )
         else:
             if req.generated_from_request_id:
                 conditions.append("p.generated_from_request_id = ?")

--- a/reflexio/server/services/storage/storage_base/_base.py
+++ b/reflexio/server/services/storage/storage_base/_base.py
@@ -40,6 +40,12 @@ class BaseStorageCore(ABC):  # noqa: B024
     # Capability flag — backends that implement `_get_embedding` set this to True.
     supports_embedding: ClassVar[bool] = False
 
+    # Concrete backends resolve and assign this during initialization. Unified
+    # search requires the exact model name to select its retrieval policy; a
+    # backend that omits it is incomplete and should fail rather than silently
+    # falling back to another model's threshold.
+    embedding_model_name: str
+
     # Capability flag — backends that can serve every unified-search arm in a
     # single database round trip expose a `unified_hybrid_search` method and
     # set this to True (see reflexio.server.services.unified_search_service).

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -42,6 +42,7 @@ from reflexio.models.config_schema import (
 )
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.prompt.prompt_manager import PromptManager
+from reflexio.server.services.embedding_text import resolve_retrieval_threshold
 from reflexio.server.services.pre_retrieval import QueryReformulator
 from reflexio.server.services.retrieval.recency import (
     RecencyConfig,
@@ -144,7 +145,10 @@ def run_unified_search(
         return UnifiedSearchResponse(success=True, msg="No query provided")
 
     top_k = request.top_k if request.top_k is not None else 5
-    threshold = request.threshold if request.threshold is not None else 0.45
+    threshold = resolve_retrieval_threshold(
+        request.threshold,
+        model_name=storage.embedding_model_name,
+    )
 
     floor_cfg = retrieval_floor or RetrievalFloorConfig()
     floor_on = floor_cfg.enabled
@@ -856,7 +860,7 @@ def _get_cached_query_embedding(
     query: str,
 ) -> list[float]:
     """Return a cached query embedding when available."""
-    model_name = str(getattr(storage, "embedding_model_name", "unknown"))
+    model_name = storage.embedding_model_name
     dimensions = int(getattr(storage, "embedding_dimensions", 0) or 0)
     normalized_query = " ".join(query.casefold().split())
     key = (model_name, dimensions, normalized_query, "query")

--- a/tests/server/services/playbook/test_playbook_consolidator.py
+++ b/tests/server/services/playbook/test_playbook_consolidator.py
@@ -282,7 +282,7 @@ class TestRetrieveExistingPlaybooks:
         mock_consolidator._retrieve_existing_playbooks([new_fb])
 
         mock_consolidator.client.get_embeddings.assert_called_once_with(
-            ["search_query: user asks about billing"],
+            ["user asks about billing"],
             model="local/test-embedding-model",
             dimensions=768,
         )

--- a/tests/server/services/profile/test_profile_consolidator.py
+++ b/tests/server/services/profile/test_profile_consolidator.py
@@ -1375,6 +1375,10 @@ class TestRetrieveExistingProfilesStatusFilter:
         assert mock_request_context.storage.search_user_profile.call_count == 1
         call_kwargs = mock_request_context.storage.search_user_profile.call_args.kwargs
         assert call_kwargs["status_filter"] == [None]
+        search_request = (
+            mock_request_context.storage.search_user_profile.call_args.args[0]
+        )
+        assert search_request.threshold == 0.4
 
     def test_rerun_mode_searches_pending_profiles_only(
         self, mock_request_context, mock_llm_client, mock_site_var_manager
@@ -1427,7 +1431,7 @@ class TestRetrieveExistingProfilesStatusFilter:
         )
 
         mock_llm_client.get_embeddings.assert_called_once_with(
-            ["search_query: User likes dark mode"],
+            ["User likes dark mode"],
             model="local/test-embedding-model",
             dimensions=768,
         )

--- a/tests/server/services/storage/test_sqlite_storage.py
+++ b/tests/server/services/storage/test_sqlite_storage.py
@@ -17,7 +17,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
     UserProfile,
 )
-from reflexio.models.config_schema import SearchMode, SearchOptions
+from reflexio.models.config_schema import LLMConfig, SearchMode, SearchOptions
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
 )
@@ -407,7 +407,12 @@ class TestVectorRankRowsLogging:
             "INFO",
             logger="reflexio.server.services.storage.sqlite_storage._base",
         ):
-            _vector_rank_rows(rows, [1.0, 0.0, 0.0], match_count=2)
+            _vector_rank_rows(
+                rows,
+                [1.0, 0.0, 0.0],
+                match_count=2,
+                threshold=0.0,
+            )
         msgs = [r.getMessage() for r in caplog.records]
         assert any("vector_rank:" in m for m in msgs)
         # The log line must include candidate count and the ranked scores.
@@ -422,8 +427,26 @@ class TestVectorRankRowsLogging:
             "INFO",
             logger="reflexio.server.services.storage.sqlite_storage._base",
         ):
-            _vector_rank_rows([], [1.0, 0.0, 0.0], match_count=5)
+            _vector_rank_rows(
+                [],
+                [1.0, 0.0, 0.0],
+                match_count=5,
+                threshold=0.0,
+            )
         assert not any("vector_rank:" in r.getMessage() for r in caplog.records)
+
+    def test_strictly_filters_scores_at_or_below_threshold(self) -> None:
+        above = self._row([1.0, 0.0])
+        equal = self._row([0.0, 1.0])
+
+        results = _vector_rank_rows(
+            [equal, above],
+            [1.0, 0.0],
+            match_count=2,
+            threshold=0.0,
+        )
+
+        assert results == [above]
 
     def test_top_scores_truncated_to_10(self, caplog) -> None:
         """Long candidate lists must not flood the log."""
@@ -432,7 +455,12 @@ class TestVectorRankRowsLogging:
             "INFO",
             logger="reflexio.server.services.storage.sqlite_storage._base",
         ):
-            _vector_rank_rows(rows, [1.0, 0.0] + [0.0] * 510, match_count=3)
+            _vector_rank_rows(
+                rows,
+                [1.0, 0.0] + [0.0] * 510,
+                match_count=3,
+                threshold=0.0,
+            )
         line = next(
             r.getMessage() for r in caplog.records if "vector_rank:" in r.getMessage()
         )
@@ -974,8 +1002,8 @@ def test_hybrid_surfaces_semantic_only_user_playbook(storage):
 # ---------------------------------------------------------------------------
 
 
-def test_embedding_prefix_applied():
-    """_get_embedding should prefix text with 'search_document:' or 'search_query:' based on purpose."""
+def test_embedding_input_formatting_is_model_specific():
+    """MiniLM stays raw while Nomic receives its asymmetric task prefixes."""
     captured_texts = []
 
     def mock_llm_get_embedding(text, model, dimensions):
@@ -992,16 +1020,24 @@ def test_embedding_prefix_applied():
         with patch.object(SQLiteStorage, "_try_load_sqlite_vec", return_value=False):
             s = SQLiteStorage(org_id="0", db_path=f"{temp_dir}/reflexio.db")
 
-        # Document purpose
+        # MiniLM owns no input prefix.
         s._get_embedding("hello world", purpose="document")
-        assert captured_texts[-1] == "search_document: hello world"
-
-        # Query purpose
+        assert captured_texts[-1] == "hello world"
         s._get_embedding("hello world", purpose="query")
-        assert captured_texts[-1] == "search_query: hello world"
+        assert captured_texts[-1] == "hello world"
 
-        # Default purpose is document
-        s._get_embedding("hello world")
+        with patch.object(SQLiteStorage, "_try_load_sqlite_vec", return_value=False):
+            nomic = SQLiteStorage(
+                org_id="0",
+                db_path=f"{temp_dir}/nomic.db",
+                llm_config=LLMConfig(
+                    embedding_model_name="local/nomic-embed-text-v1.5"
+                ),
+            )
+
+        nomic._get_embedding("hello world", purpose="query")
+        assert captured_texts[-1] == "search_query: hello world"
+        nomic._get_embedding("hello world")
         assert captured_texts[-1] == "search_document: hello world"
 
 

--- a/tests/server/services/test_embedding_text.py
+++ b/tests/server/services/test_embedding_text.py
@@ -4,7 +4,11 @@ from reflexio.models.api_schema.service_schemas import (
     AgentSuccessEvaluationResult,
     UserProfile,
 )
-from reflexio.server.services.embedding_text import embedding_input, embedding_text
+from reflexio.server.services.embedding_text import (
+    embedding_input,
+    embedding_text,
+    resolve_retrieval_threshold,
+)
 
 
 def test_user_profile_embedding_text_omits_empty_custom_features() -> None:
@@ -62,11 +66,53 @@ def test_agent_success_embedding_text_omits_missing_failure_fields() -> None:
     )
 
 
-def test_embedding_input_applies_asymmetric_prefixes() -> None:
-    assert embedding_input("hello") == "search_document: hello"
-    assert embedding_input("hello", purpose="query") == "search_query: hello"
+def test_embedding_input_applies_nomic_asymmetric_prefixes() -> None:
+    model = "local/nomic-embed-text-v1.5"
+    assert embedding_input("hello", model_name=model) == "search_document: hello"
+    assert (
+        embedding_input("hello", model_name=model, purpose="query")
+        == "search_query: hello"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["local/minilm-l6-v2", "text-embedding-3-small", "unknown-model"],
+)
+def test_embedding_input_leaves_non_nomic_models_unprefixed(model_name: str) -> None:
+    assert embedding_input("hello", model_name=model_name) == "hello"
+    assert embedding_input("hello", model_name=model_name, purpose="query") == "hello"
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("local/minilm-l6-v2", 0.30),
+        ("local/nomic-embed-text-v1.5", 0.70),
+        ("local/nomic-embed-v1.5", 0.70),
+        ("unknown-model", 0.45),
+    ],
+)
+def test_retrieval_threshold_defaults_by_model(
+    model_name: str, expected: float
+) -> None:
+    assert resolve_retrieval_threshold(None, model_name=model_name) == expected
+
+
+def test_explicit_retrieval_threshold_wins_including_zero() -> None:
+    assert (
+        resolve_retrieval_threshold(
+            0.0,
+            model_name="local/nomic-embed-text-v1.5",
+        )
+        == 0.0
+    )
 
 
 def test_embedding_input_rejects_unknown_purpose() -> None:
     with pytest.raises(ValueError, match="Unknown embedding purpose"):
-        embedding_input("hello", purpose="documnt")  # type: ignore[arg-type]
+        embedding_input(
+            "hello",
+            model_name="local/minilm-l6-v2",
+            purpose="documnt",  # type: ignore[arg-type]
+        )

--- a/tests/server/services/test_unified_search_floor.py
+++ b/tests/server/services/test_unified_search_floor.py
@@ -35,6 +35,7 @@ class _FakeStorage:
     # run_unified_search reads storage.supports_embedding before _run_phase_a runs,
     # so the stub must expose it even though the phases are monkeypatched.
     supports_embedding = False
+    embedding_model_name = "local/minilm-l6-v2"
 
 
 def test_floor_applied_per_arm(monkeypatch):

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -34,6 +34,7 @@ from reflexio.server.services.unified_search_service import (
 def _mock_storage(embedding=None):
     """Create a mock storage with configurable embedding."""
     storage = MagicMock()
+    storage.embedding_model_name = "local/minilm-l6-v2"
     storage._get_embedding.return_value = embedding or [0.1] * 1536
     # Storage search methods return empty lists by default
     storage.search_user_profile.return_value = []
@@ -44,6 +45,19 @@ def _mock_storage(embedding=None):
 
 class TestRunUnifiedSearch(unittest.TestCase):
     """Tests for the top-level run_unified_search function."""
+
+    def test_storage_must_declare_embedding_model_name(self):
+        storage = _mock_storage()
+        del storage.embedding_model_name
+
+        with self.assertRaisesRegex(AttributeError, "embedding_model_name"):
+            run_unified_search(
+                request=UnifiedSearchRequest(query="test query"),
+                org_id="test-org",
+                storage=storage,
+                llm_client=MagicMock(),
+                prompt_manager=MagicMock(),
+            )
 
     def test_empty_query_rejected_by_validation(self):
         """Empty query is now rejected at the Pydantic validation level."""
@@ -307,6 +321,7 @@ class TestRunUnifiedSearch(unittest.TestCase):
         class _PgLikeStorage:
             supports_embedding = False
             supports_unified_hybrid_search = False
+            embedding_model_name = "local/minilm-l6-v2"
 
             def unified_hybrid_search_scored(self, **_kwargs):
                 return ([], [], [])

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -21,6 +21,7 @@ def _agent_playbook(playbook_id: int, content: str) -> AgentPlaybook:
 class _CombinedStorage:
     """Fake storage advertising the combined Phase B capability."""
 
+    embedding_model_name = "local/minilm-l6-v2"
     supports_embedding = True
     supports_unified_hybrid_search = True
 
@@ -55,6 +56,7 @@ class _CombinedStorage:
 
 
 class _MissingCombinedMethodStorage:
+    embedding_model_name = "local/minilm-l6-v2"
     supports_embedding = True
     supports_unified_hybrid_search = True
 


### PR DESCRIPTION
## Summary
- Prevent unrelated queries from passing retrieval because of model-inappropriate input prefixes and a single global similarity floor.
- Centralize embedding text preparation and default threshold selection as an explicit per-model policy.
- Use raw text with a `0.30` default for MiniLM, Nomic search/document prefixes with a `0.70` default for `local/nomic-embed-text-v1.5`, and raw text with a `0.45` fallback for unknown models.
- Preserve explicit caller thresholds, including `0.0`, and keep profile deduplication's `0.40` candidate-generation threshold intentionally separate.

## Changes
- Added model-aware embedding prefix and retrieval-threshold resolution.
- Routed SQLite storage, unified search, playbook/profile retrieval, caching, and deduplication through the shared model policy.
- Made omitted API/client thresholds resolve from the active embedding model while retaining explicit overrides.
- Declared `embedding_model_name` on the storage contract so threshold selection cannot silently fall back to an unknown model.
- Added regression coverage for MiniLM/Nomic/unknown-model policy, strict score filtering, unified search, storage behavior, and deduplication semantics.

## Test Plan
- `uv run ruff check <changed Python files>`
- `uv run ruff format --check <changed Python files>`
- Focused embedding, storage, unified-search, playbook, and profile tests: 197 passed.
- Broader OSS unit/integration suite: 4,784 passed.
- Live MiniLM retrieval probe: unrelated `hello` score `-0.025` and image-query score `0.153`; both filtered by the `0.30` default.
- Repository-wide `uv run pyright` currently reports 223 existing test typing errors outside this change; focused type checking for the changed implementation previously passed with 0 errors.
- OSS E2E has 11 environment failures because the configured Claude OAuth credential is expired.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search thresholds now default automatically based on the selected embedding model when not specified.
  * Interaction search supports an optional similarity threshold.
  * Embedding text formatting now adapts to the active embedding model.

* **Bug Fixes**
  * Search results now consistently enforce strict similarity thresholds.
  * Improved embedding cache consistency across search and retrieval workflows.

* **Documentation**
  * Updated threshold descriptions to clarify retrieval and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->