### PR TITLE
fix(test): pin consolidator fallback test to the config model

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2095,11 +2095,7 @@ class ReflexioClient:
             # The API stores operation timestamps at second precision. Accept a
             # one-second skew so a just-submitted operation that starts near the
             # client timestamp boundary is not treated as stale forever.
-            if (
-                op
-                and min_started_at is not None
-                and op.started_at < min_started_at - 1
-            ):
+            if op and min_started_at is not None and op.started_at < min_started_at - 1:
                 op = None
             if op and op.status in (
                 OperationStatus.COMPLETED,

--- a/tests/server/services/playbook/test_playbook_consolidator_integration.py
+++ b/tests/server/services/playbook/test_playbook_consolidator_integration.py
@@ -944,16 +944,16 @@ def _build_real_client_consolidator(
 
     Returns:
         PlaybookConsolidator: Consolidator whose ``client`` is a real
-            ``LiteLLMClient``; ``model_name`` is fixed to ``"gpt-test"`` via
-            the same ``SiteVarManager`` patch used by the file's shared
-            fixture so the apply path is comparable.
+            ``LiteLLMClient`` and whose request model matches the supplied
+            config so structured-output fallback compatibility is exercised
+            against the intended primary model.
     """
     client = LiteLLMClient(config)
     with patch(
         "reflexio.server.services.deduplication_utils.SiteVarManager"
     ) as mock_svm:
         mock_svm.return_value.get_site_var.return_value = {
-            "default_generation_model_name": "gpt-test"
+            "default_generation_model_name": config.model
         }
         return PlaybookConsolidator(request_context=request_context, llm_client=client)
 


### PR DESCRIPTION
## Why

`main` is red. `test_consolidator_calls_litellm_with_fallback_configured` has been
failing since #372 landed:

```
E   ValueError: Structured-output fallback models must use the same transport
    strategy as 'gpt-test' (pydantic_passthrough); incompatible fallbacks: ['gpt-5.4-mini']
```

## Root cause

`_build_real_client_consolidator` patched the generation site var to a fake
`"gpt-test"`, so the `LiteLLMConfig(model=...)` each test passed never reached the
request — `PlaybookConsolidator` reads its request model from the site var
(`deduplication_utils.py:191`), not from the client config, and passes it as
`model=self.model_name` (`components/consolidator.py:743`).

#372 added `_validate_structured_fallback_strategies`, which resolves a transport
strategy per model and rejects a ladder whose fallbacks disagree with the primary.
Measured strategies:

| model | provider | strategy |
|---|---|---|
| `gpt-test` | *(unresolvable)* | `pydantic_passthrough` |
| `gpt-5.4-mini` | openai | `native_json_schema` |
| `minimax/MiniMax-M3` | minimax | `native_json_schema` |

The fake model made the pairing artificially incompatible. The guard itself is
correct — the test was asserting against a model it never intended to use.

## Fix

Pin the patched site var to `config.model`. The fallback-configured case now
exercises a realistic production pairing (MiniMax primary + OpenAI fallback, both
`native_json_schema`). The second test (`claude-code/...`, no fallbacks) never
reaches the guard and is unaffected.

Also included: a `style:` commit applying `ruff format` to `client/client.py`,
the only file in the package `ruff format --check` flagged. No behavior change.

## Verification

- `pytest tests/server/services/playbook/test_playbook_consolidator_integration.py` — 14 passed (1 failed before)
- `ruff format --check reflexio tests` — 821 files already formatted
- `ruff check` + `pyright` clean on both touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of outdated operation status updates, helping prevent stale results from being processed.

* **Tests**
  * Updated integration coverage to validate structured-output fallback behavior using the configured primary model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->