### PR TITLE
feat: add tag filters to unified search

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2508,6 +2508,7 @@ class ReflexioClient:
         agent_version: str | None = None,
         playbook_name: str | None = None,
         user_id: str | None = None,
+        tags: list[str] | None = None,
         entity_types: list[str] | None = None,
         agent_playbook_status_filter: list[PlaybookStatus | str] | None = None,
         enable_reformulation: bool | None = None,
@@ -2532,6 +2533,7 @@ class ReflexioClient:
             agent_version (Optional[str]): Filter by agent version (agent_playbooks, user_playbooks)
             playbook_name (Optional[str]): Filter by playbook name (agent_playbooks, user_playbooks)
             user_id (Optional[str]): Filter by user ID (profiles, user_playbooks)
+            tags (Optional[list[str]]): Match entities having any requested tag.
             entity_types (Optional[list[str]]): Entity types to search. Valid values:
                 "profiles", "user_playbooks", "agent_playbooks".
             agent_playbook_status_filter (Optional[list[Union[PlaybookStatus, str]]]):
@@ -2562,6 +2564,7 @@ class ReflexioClient:
             agent_version=agent_version,
             playbook_name=playbook_name,
             user_id=user_id,
+            tags=tags,
             entity_types=entity_types,
             agent_playbook_status_filter=agent_playbook_status_filter,
             enable_reformulation=enable_reformulation,

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -749,6 +749,7 @@ class UnifiedSearchRequest(BaseModel):
         agent_version (str, optional): Filter by agent version (agent_playbooks, user_playbooks)
         playbook_name (str, optional): Filter by playbook name (agent_playbooks, user_playbooks)
         user_id (str, optional): Filter by user ID (profiles, user_playbooks)
+        tags (list[str], optional): Match entities having any requested tag.
         entity_types (list[str], optional): Entity types to search. When omitted,
             searches profiles, user_playbooks, and agent_playbooks.
         agent_playbook_status_filter (list[PlaybookStatus], optional): Approval
@@ -765,6 +766,7 @@ class UnifiedSearchRequest(BaseModel):
     agent_version: str | None = None
     playbook_name: str | None = None
     user_id: str | None = None
+    tags: list[str] | None = None
     entity_types: list[UnifiedSearchEntityType] | None = None
     agent_playbook_status_filter: list[PlaybookStatus] | None = None
     conversation_history: list[ConversationTurn] | None = None

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -496,6 +496,7 @@ def _run_phase_b(
                     search_mode,
                     start_time,
                     end_time,
+                    tags=request.tags,
                 )
                 if "profiles" in entity_types
                 else None
@@ -514,6 +515,7 @@ def _run_phase_b(
                     options,
                     start_time,
                     end_time,
+                    tags=request.tags,
                 )
                 if "agent_playbooks" in entity_types
                 else None
@@ -524,6 +526,7 @@ def _run_phase_b(
                     user_id=request.user_id,
                     agent_version=request.agent_version,
                     playbook_name=request.playbook_name,
+                    tags=request.tags,
                     status_filter=None,
                     threshold=threshold,
                     top_k=top_k,
@@ -630,6 +633,7 @@ def _run_phase_b_single_rpc(
         user_id=request.user_id,
         agent_version=request.agent_version,
         playbook_name=request.playbook_name,
+        tags=request.tags,
         agent_playbook_statuses=statuses,
         search_mode=search_mode,
         include_profiles="profiles" in entity_types and bool(request.user_id),
@@ -896,6 +900,7 @@ def _search_agent_playbooks_via_storage(
     options: SearchOptions,
     start_time: datetime | None = None,
     end_time: datetime | None = None,
+    tags: list[str] | None = None,
 ) -> list[AgentPlaybook]:
     """Search agent playbooks, restricted to one or more approval statuses.
 
@@ -904,7 +909,8 @@ def _search_agent_playbooks_via_storage(
     genuinely want REJECTED playbooks must opt in by passing the full list.
     ``start_time``/``end_time`` bound ``created_at`` (query-derived time
     windows from reformulation temporal signals; unset when the query names
-    no window).
+    no window). ``tags`` matches playbooks having any requested tag (OR
+    semantics); None or an empty list disables tag filtering.
     """
     with profile_step(
         "search.branch.agent_playbooks",
@@ -920,6 +926,7 @@ def _search_agent_playbooks_via_storage(
             query=query,
             agent_version=agent_version,
             playbook_name=playbook_name,
+            tags=tags,
             status_filter=[None],
             playbook_status_filter=statuses,
             threshold=threshold,
@@ -951,6 +958,7 @@ def _search_profiles_via_storage(
     search_mode: SearchMode,
     start_time: datetime | None = None,
     end_time: datetime | None = None,
+    tags: list[str] | None = None,
 ) -> list[UserProfile]:
     """Search profiles via storage.search_user_profile, returning [] on error or missing user_id.
 
@@ -960,6 +968,7 @@ def _search_profiles_via_storage(
         top_k (int): Maximum results
         threshold (float): Minimum match threshold
         user_id (Optional[str]): User ID filter (required for profile search)
+        tags (Optional[list[str]]): Match profiles having any requested tag
         embedding (Optional[list[float]]): Pre-computed query embedding, or None for text-only search
         search_mode (SearchMode): Search mode (hybrid/vector/fts)
         start_time (Optional[datetime]): Lower bound on last_modified_timestamp
@@ -985,6 +994,7 @@ def _search_profiles_via_storage(
                     query=query,
                     top_k=top_k,
                     threshold=threshold,
+                    tags=tags,
                     search_mode=search_mode,
                     start_time=start_time,
                     end_time=end_time,

--- a/tests/client/test_search.py
+++ b/tests/client/test_search.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from reflexio import ReflexioClient
+
+
+def test_unified_search_serializes_tag_filter(monkeypatch) -> None:
+    client = ReflexioClient(api_key="test-key", url_endpoint="http://localhost:8000")
+    captured: dict[str, Any] = {}
+
+    def fake_make_request(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        captured.update(method=method, path=path, **kwargs)
+        return {
+            "success": True,
+            "profiles": [],
+            "agent_playbooks": [],
+            "user_playbooks": [],
+        }
+
+    monkeypatch.setattr(client, "_make_request", fake_make_request)
+
+    client.search(query="billing", tags=["billing", "support"])
+
+    assert captured["method"] == "POST"
+    assert captured["path"] == "/api/search"
+    assert captured["json"]["tags"] == ["billing", "support"]

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -26,6 +26,7 @@ from reflexio.server.services.pre_retrieval import ReformulationResult
 from reflexio.server.services.retrieval.recency import RecencyConfig, ScoredItem
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.services.unified_search_service import (
+    _run_phase_b,
     _search_agent_playbooks_via_storage,
     run_unified_search,
 )
@@ -493,6 +494,35 @@ def _leg_search_modes(storage):
         "agent_playbooks": storage.search_agent_playbooks.call_args.args[0].search_mode,
         "user_playbooks": storage.search_user_playbooks.call_args.args[0].search_mode,
     }
+
+
+def test_phase_b_passes_tag_filter_to_every_fanout_leg() -> None:
+    storage = _fanout_storage()
+
+    _run_phase_b(
+        request=UnifiedSearchRequest(
+            query="billing", user_id="user-1", tags=["billing", "support"]
+        ),
+        org_id="test-org",
+        storage=storage,
+        embedding=[0.1] * 1536,
+        query="billing",
+        top_k=5,
+        threshold=0.3,
+    )
+
+    assert storage.search_user_profile.call_args.args[0].tags == [
+        "billing",
+        "support",
+    ]
+    assert storage.search_agent_playbooks.call_args.args[0].tags == [
+        "billing",
+        "support",
+    ]
+    assert storage.search_user_playbooks.call_args.args[0].tags == [
+        "billing",
+        "support",
+    ]
 
 
 class TestEmbeddingFailureDegradesToFTS(unittest.TestCase):

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -33,10 +33,19 @@ class _CombinedStorage:
         self.result = result
         self.raise_on_combined = raise_on_combined
         self.combined_calls: list[dict[str, Any]] = []
+        self.scored_calls: list[dict[str, Any]] = []
         self.fanout_calls: list[str] = []
 
     def unified_hybrid_search(self, **kwargs: Any):
         self.combined_calls.append(kwargs)
+        if self.raise_on_combined:
+            raise RuntimeError("function public.unified_hybrid_search does not exist")
+        return self.result
+
+    # Selected instead of ``unified_hybrid_search`` when recency is on, since
+    # recency needs the per-row ``combined_score`` sidecars.
+    def unified_hybrid_search_scored(self, **kwargs: Any):
+        self.scored_calls.append(kwargs)
         if self.raise_on_combined:
             raise RuntimeError("function public.unified_hybrid_search does not exist")
         return self.result
@@ -76,15 +85,22 @@ class _MissingCombinedMethodStorage:
         return []
 
 
-def _run_phase_b(storage: _CombinedStorage, *, user_id: str | None = "u"):
+def _run_phase_b(
+    storage: _CombinedStorage,
+    *,
+    user_id: str | None = "u",
+    tags: list[str] | None = None,
+    recency_on: bool = False,
+):
     return uss._run_phase_b(
-        request=UnifiedSearchRequest(query="q", user_id=user_id, top_k=5),
+        request=UnifiedSearchRequest(query="q", user_id=user_id, tags=tags, top_k=5),
         org_id="o",
         storage=cast(BaseStorage, storage),
         embedding=[0.1, 0.2],
         query="q",
         top_k=5,
         threshold=0.3,
+        recency_on=recency_on,
     )
 
 
@@ -124,6 +140,26 @@ def test_single_rpc_skips_profiles_without_user_id(monkeypatch):
     _run_phase_b(storage, user_id=None)
 
     assert storage.combined_calls[0]["include_profiles"] is False
+
+
+def test_single_rpc_passes_tag_filter(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _CombinedStorage()
+
+    _run_phase_b(storage, tags=["billing", "support"])
+
+    assert storage.combined_calls[0]["tags"] == ["billing", "support"]
+
+
+def test_single_rpc_passes_tag_filter_on_scored_path(monkeypatch):
+    """Recency routes to ``unified_hybrid_search_scored``; tags must survive."""
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _CombinedStorage()
+
+    _run_phase_b(storage, tags=["billing", "support"], recency_on=True)
+
+    assert storage.combined_calls == []
+    assert storage.scored_calls[0]["tags"] == ["billing", "support"]
 
 
 def test_single_rpc_failure_falls_back_to_fanout(monkeypatch):


### PR DESCRIPTION
## Summary
- Add optional tag filtering to Unified Search so callers can retrieve entities matching any requested tag.
- Preserve the existing profile/playbook OR semantics by forwarding the same tag list into every selected storage search arm.
- Cover both fan-out and combined-RPC paths, including the scored path used for recency-aware search.

## Changes
- Add `tags` to `UnifiedSearchRequest` and `ReflexioClient.search`.
- Pass tags to profile, user-playbook, and agent-playbook searches.
- Add client serialization and service propagation regression tests.

## Test Plan
- `ruff check` on all changed Python files
- `pyright` on all changed Python files
- `pytest tests/client/test_search.py tests/server/services/test_unified_search_service.py tests/server/services/test_unified_search_single_rpc.py -q -o "addopts="` (28 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tag-based filtering to unified search.
  * Search requests can now include one or more tags to match relevant results across entity types.
  * Tag filters are supported across standard and optimized search flows.

* **Bug Fixes**
  * Ensured tag filters are consistently applied to all unified search result types and search modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->