### PR TITLE
fix(logs): redact Customer Content from error/warning logs

### DIFF
--- a/reflexio/server/llm/_litellm_structured_output.py
+++ b/reflexio/server/llm/_litellm_structured_output.py
@@ -248,6 +248,13 @@ class StructuredOutputMixin:
 
                     repaired = repair_json(json_str, return_objects=True)
                     return _validate_structured_payload(response_format, repaired)
+                except StructuredOutputParseError:
+                    # Already a sanitized, content-free diagnostic raised
+                    # deliberately above (e.g. the truncation check). Its message
+                    # carries no Customer Content and IS used to steer the repair
+                    # turn, so propagate it unchanged rather than re-wrapping it
+                    # (which would drop the specific reason).
+                    raise
                 except Exception as e:
                     model = self.config.model
                     # Do NOT embed the raw model output in the exception message:
@@ -256,8 +263,16 @@ class StructuredOutputMixin:
                     # Content there. Log only the length; the raw text stays on
                     # `raw_content` for in-process repair (not serialized to logs).
                     content_len = len(content) if isinstance(content, str) else -1
+                    # Use the inner exception's TYPE, not str(e): a json/pydantic
+                    # error's message often echoes the offending input (Customer
+                    # Content). This exception's str() is logged downstream at
+                    # ERROR (error=%s) and wrapped into LiteLLMClientError, both
+                    # of which ride to Sentry/CloudWatch — so the message must
+                    # stay content-free. The raw text remains on raw_content for
+                    # in-process repair (never serialized to logs).
                     raise StructuredOutputParseError(
-                        f"Structured output parse failed for model={model!r}: {e}. "
-                        f"Content length: {content_len} chars (content omitted from logs).",
+                        f"Structured output parse failed for model={model!r}: "
+                        f"{type(e).__name__}. Content length: {content_len} chars "
+                        f"(content omitted from logs).",
                         raw_content=content if isinstance(content, str) else None,
                     ) from e

--- a/reflexio/server/llm/_litellm_structured_output.py
+++ b/reflexio/server/llm/_litellm_structured_output.py
@@ -250,13 +250,14 @@ class StructuredOutputMixin:
                     return _validate_structured_payload(response_format, repaired)
                 except Exception as e:
                     model = self.config.model
-                    snippet = (
-                        content[:200]
-                        if isinstance(content, str)
-                        else repr(content)[:200]
-                    )
+                    # Do NOT embed the raw model output in the exception message:
+                    # this exception is logged at ERROR and rides to Sentry/CloudWatch
+                    # via the logging bridge, so a content snippet would leak Customer
+                    # Content there. Log only the length; the raw text stays on
+                    # `raw_content` for in-process repair (not serialized to logs).
+                    content_len = len(content) if isinstance(content, str) else -1
                     raise StructuredOutputParseError(
                         f"Structured output parse failed for model={model!r}: {e}. "
-                        f"Content snippet: {snippet!r}",
+                        f"Content length: {content_len} chars (content omitted from logs).",
                         raw_content=content if isinstance(content, str) else None,
                     ) from e

--- a/reflexio/server/services/pre_retrieval/_document_expander.py
+++ b/reflexio/server/services/pre_retrieval/_document_expander.py
@@ -153,7 +153,12 @@ class DocumentExpander:
                             expansions[key.strip()] = synonyms
                 return expansions
         except json.JSONDecodeError:
-            logger.warning("Failed to parse expansion JSON: %s", text[:200])
+            # Log length only — `text` is raw model output and must not reach
+            # logs/Sentry/CloudWatch as Customer Content.
+            logger.warning(
+                "Failed to parse expansion JSON (length %d; content omitted)",
+                len(text or ""),
+            )
 
         return {}
 

--- a/reflexio/server/services/pre_retrieval/_document_expander.py
+++ b/reflexio/server/services/pre_retrieval/_document_expander.py
@@ -153,11 +153,13 @@ class DocumentExpander:
                             expansions[key.strip()] = synonyms
                 return expansions
         except json.JSONDecodeError:
-            # Log length only — `text` is raw model output and must not reach
-            # logs/Sentry/CloudWatch as Customer Content.
+            # Log the raw output length only — the model output is Customer
+            # Content and must not reach logs/Sentry/CloudWatch. `text` is the
+            # normalized (stripped, fence-extracted) buffer, so report `output`
+            # to reflect the true response size.
             logger.warning(
                 "Failed to parse expansion JSON (length %d; content omitted)",
-                len(text or ""),
+                len(output),
             )
 
         return {}

--- a/reflexio/server/services/pre_retrieval/_query_reformulator.py
+++ b/reflexio/server/services/pre_retrieval/_query_reformulator.py
@@ -199,13 +199,19 @@ class QueryReformulator:
         log_model_response(logger, "Query reformulation model response", result)
 
         if not isinstance(result, ReformulationResult):
-            logger.warning("LLM returned non-structured reformulation: %r", result)
+            # Log the type only — `result` may contain the user's query text, which
+            # must not reach logs/Sentry/CloudWatch as Customer Content.
+            logger.warning(
+                "LLM returned non-structured reformulation (type %s)",
+                type(result).__name__,
+            )
             return ReformulationResult(standalone_query=query)
 
         extracted = self._extract_reformulated_query(result.standalone_query)
         if not extracted:
             logger.warning(
-                "LLM returned invalid reformulation: %s", result.standalone_query
+                "LLM returned invalid reformulation (length %d; content omitted)",
+                len(result.standalone_query or ""),
             )
             return ReformulationResult(standalone_query=query)
         return result.model_copy(update={"standalone_query": extracted})

--- a/reflexio/server/services/profile/components/extractor.py
+++ b/reflexio/server/services/profile/components/extractor.py
@@ -228,7 +228,12 @@ class ProfileExtractor:
                 f"Profile extraction failed for user {self.service_config.user_id}"
             ) from e
 
-        logger.info("Generated raw profiles: %s", raw_profiles)
+        # Log only the count — the raw profile dicts are extracted Customer
+        # Content, and INFO records become Sentry breadcrumbs (LoggingIntegration
+        # level=INFO), whose bodies before_send does not scrub.
+        logger.info(
+            "Generated raw profiles: count=%d", len(raw_profiles) if raw_profiles else 0
+        )
         source_interaction_ids = [
             interaction.interaction_id
             for request_model in request_interaction_data_models

--- a/reflexio/server/services/profile/components/extractor.py
+++ b/reflexio/server/services/profile/components/extractor.py
@@ -295,7 +295,11 @@ class ProfileExtractor:
                 not isinstance(profile_content, dict)
                 or "content" not in profile_content
             ):
-                logger.warning("Invalid profile content: %s", profile_content)
+                logger.warning(
+                    "Invalid profile content: expected a dict with a 'content' key, got %s "
+                    "(content omitted from logs)",
+                    type(profile_content).__name__,
+                )
                 continue
 
             # Get all custom features by excluding content and time_to_live


### PR DESCRIPTION
## What
Redacts Customer Content (LLM output snippets, profile text, user queries) from ERROR/WARNING log and breadcrumb sites so it does not reach error monitoring (Sentry) or CloudWatch.

## Why
Supports the reflexio.ai managed-platform Privacy Policy representation that Customer Content is not sent to analytics or error-monitoring providers. Before this change, a structured-output parse error logged a ~200-char LLM output snippet at ERROR, and profile text / user queries were attached as breadcrumbs — which made Sentry/CloudWatch a Customer-Data recipient.

## Changes
- `_litellm_structured_output.py`: drop the content snippet from the parse-error log message (retain `raw_content` as a structured attribute only)
- `extractor.py`, `_query_reformulator.py`, `_document_expander.py`: log length/type instead of the content text

## Scope
Log-message redaction only — no behavior change to extraction or generation. Paired with the reflexio-enterprise legal-docs PR, which relies on this for its "no Customer Content in logs" representation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Security**
  * Improved privacy by removing raw AI-generated content from structured parse error messages and JSON decoding warnings.
  * Prevented re-wrapping of earlier structured parse failures during the repair flow, preserving the original error.
  * Reduced log exposure across query reformulation, document expansion, and profile extraction by logging only type names and content lengths (or counts) instead of full values.
  * Parsing, repair, and fallback behaviors remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->