### PR TITLE
chore: remove invitation_only feature flag (open registration)

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -183,7 +183,7 @@ Key components:
 | `site_var_manager.py` | SiteVarManager (singleton) - loads JSON/TXT configs |
 | `feature_flags.py` | Per-org feature gating (`is_feature_enabled()`, `get_all_feature_flags()`) |
 
-**Feature Flags**: Config in `site_var_sources/feature_flags.json`. Each flag has global `enabled` toggle and per-org `enabled_org_ids` allowlist. Unknown flags default to enabled (fail-open). Currently gates: `invitation_only` (global flag, gates registration to require invitation codes), `deduplicator` (gates playbook deduplication).
+**Feature Flags**: Config in `site_var_sources/feature_flags.json`. Each flag has global `enabled` toggle and per-org `enabled_org_ids` allowlist. Unknown flags default to enabled (fail-open). Currently gates: `deduplicator` (gates playbook deduplication).
 
 Access: `SiteVarManager().get_site_var(key)` for raw values, `feature_flags.is_feature_enabled(org_id, name)` for flag checks
 

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -183,7 +183,7 @@ Key components:
 | `site_var_manager.py` | SiteVarManager (singleton) - loads JSON/TXT configs |
 | `feature_flags.py` | Per-org feature gating (`is_feature_enabled()`, `get_all_feature_flags()`) |
 
-**Feature Flags**: Config in `site_var_sources/feature_flags.json`. Each flag has global `enabled` toggle and per-org `enabled_org_ids` allowlist. Unknown flags default to enabled (fail-open). Currently gates: `deduplicator` (gates playbook deduplication).
+**Feature Flags**: Config in `site_var_sources/feature_flags.json`. Each flag has global `enabled` toggle and per-org `enabled_org_ids` allowlist. Unknown flags default to enabled (fail-open). Current flags: `resumable_extraction_agent`, `lineage_dual_read_diff`.
 
 Access: `SiteVarManager().get_site_var(key)` for raw values, `feature_flags.is_feature_enabled(org_id, name)` for flag checks
 

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -187,23 +187,6 @@ Key components:
 
 Access: `SiteVarManager().get_site_var(key)` for raw values, `feature_flags.is_feature_enabled(org_id, name)` for flag checks
 
-## Scripts
-
-**Directory**: `scripts/`
-
-| File | Purpose |
-|------|---------|
-| `manage_invitation_codes.py` | CLI to generate and list invitation codes |
-| `show_raw_feedback_with_interactions.py` | Debug script to display user playbook alongside interaction context |
-
-**Usage**:
-```shell
-python -m reflexio.server.scripts.manage_invitation_codes generate --count 5
-python -m reflexio.server.scripts.manage_invitation_codes generate --count 3 --expires-in-days 30
-python -m reflexio.server.scripts.manage_invitation_codes list
-python -m reflexio.server.scripts.manage_invitation_codes list --show-used
-```
-
 ## Services
 
 **Directory**: `services/`

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -10,7 +10,6 @@ Description: FastAPI backend server that processes user interactions to generate
 - [LLM Client](#llm-client)
 - [Prompts](#prompts)
 - [Site Variables](#site-variables)
-- [Scripts](#scripts)
 - [Services](#services)
   - [Orchestrator](#orchestrator)
   - [Base Infrastructure](#base-infrastructure)
@@ -97,7 +96,7 @@ Description: FastAPI backend server that processes user interactions to generate
 - **Operations/admin**: `GET /api/get_operation_status`, `POST /api/cancel_operation`, `POST /api/admin/cache/invalidate`, `DELETE /api/delete_interaction`, `DELETE /api/delete_request`, `DELETE /api/delete_session`, `DELETE /api/delete_requests_by_ids`, `DELETE /api/delete_all_interactions`, `POST /api/clear_user_data`
 - **Human clarification/stall state**: `GET /api/pending_tool_calls`, `GET /api/pending_tool_calls/{pending_tool_call_id}`, `POST /api/pending_tool_calls/{pending_tool_call_id}/resolve`, `PATCH /api/pending_tool_calls/{pending_tool_call_id}/answer`, `POST /api/pending_tool_calls/{pending_tool_call_id}/not_applicable`, `POST /api/pending_tool_calls/{pending_tool_call_id}/cancel`, `GET /api/stall_state`, `POST /api/stall_state/notified`
 
-**Authentication Pattern**: The open-source app uses `default_get_org_id` and `DEFAULT_ORG_ID` for local/no-auth starts. The enterprise extension wraps `create_app()` with authenticated org resolution, login/OAuth/account/share/waitlist routers, admin checks, Sentry tracing, and usage metrics.
+**Authentication Pattern**: The open-source app uses `default_get_org_id` and `DEFAULT_ORG_ID` for local/no-auth starts. The enterprise extension wraps `create_app()` with authenticated org resolution, login/OAuth/account/share routers, admin checks, Sentry tracing, and usage metrics.
 
 **Pattern**: Core route handlers call `Reflexio` through `get_reflexio(org_id)`; endpoint helper files should not instantiate `Reflexio` directly.
 

--- a/reflexio/server/scheduling.py
+++ b/reflexio/server/scheduling.py
@@ -2,7 +2,7 @@
 
 Reflexio runs a family of background daemons — extraction resume, lineage GC,
 and (in the enterprise layer) billing ship / lease / period-close / integrity /
-audit / offline-tuner / governance-retention / invitation-reclamation. Every one
+audit / offline-tuner / governance-retention. Every one
 of them hand-rolled the SAME thread mechanics: a :class:`threading.Event`
 stop-signal, a daemon :class:`threading.Thread` running a ``while not
 stop.is_set()`` loop, and a ``.join(timeout)`` graceful stop.

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -98,7 +98,7 @@ def set_leader_gate(gate: LeaderGate | None) -> None:
     _leader_gate_hook = gate
 
 
-# Global sweeps run once per tick (for GLOBAL tables like invitation_codes),
+# Global sweeps run once per tick (for GLOBAL, non-tenant-scoped tables),
 # gated on expiry_reclamation.enabled. Each fn takes `now` (unix epoch) and
 # returns a deleted-row count. Enterprise registers its sweeps here at startup;
 # empty (OSS default) keeps behavior byte-for-byte identical to before.

--- a/reflexio/server/site_var/README.md
+++ b/reflexio/server/site_var/README.md
@@ -42,7 +42,7 @@ get_all_feature_flags(org_id)               # All flags as dict[str, bool]
 
 **Resolution logic**: Enabled if `enabled=True` (global) OR `org_id` in `enabled_org_ids`. Unknown flags default to enabled (fail-open).
 
-**Current flags**: `invitation_only` (global, gates registration), `resumable_extraction_agent`, `lineage_dual_read_diff`.
+**Current flags**: `resumable_extraction_agent`, `lineage_dual_read_diff`.
 
 ## Usage
 

--- a/reflexio/server/site_var/feature_flags.py
+++ b/reflexio/server/site_var/feature_flags.py
@@ -76,20 +76,6 @@ def get_all_feature_flags(org_id: str) -> dict[str, bool]:
     return result
 
 
-def is_invitation_only_enabled() -> bool:
-    """
-    Check if invitation-only registration mode is enabled globally.
-
-    Returns:
-        bool: True if invitation-only mode is enabled
-    """
-    config = _get_feature_flags_config()
-    invitation_config = config.get("invitation_only")
-    if invitation_config is None:
-        return False
-    return invitation_config.get("enabled", False)
-
-
 def _is_fail_closed_flag_enabled(org_id: str, feature_key: str) -> bool:
     """
     Shared fail-closed helper: returns False if key absent or config malformed.

--- a/reflexio/server/site_var/site_var_sources/feature_flags.json
+++ b/reflexio/server/site_var/site_var_sources/feature_flags.json
@@ -1,7 +1,4 @@
 {
-    "invitation_only": {
-        "enabled": true
-    },
     "resumable_extraction_agent": {
         "enabled": true,
         "enabled_org_ids": []


### PR DESCRIPTION
## Summary

Removes the `invitation_only` feature flag (`is_invitation_only_enabled()` helper + the `invitation_only` entry in `feature_flags.json` + its README lines).

This is part of the Reflexio **open-registration** change: the enterprise app no longer gates OAuth registration on an invitation code, so the flag has no remaining reader. The sole reader was enterprise `oauth.py`, which stopped importing it in the enterprise open-registration PR.

## Context

Companion to the enterprise open-registration PR series (delete waitlist + invitation codes, open registration, arm OAuth). No behavior change in OSS — the flag had no OSS-side consumer.

## Tests

`pytest -k feature_flag` → 21 passed; `git grep invitation_only` → no matches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated feature checks for `resumable_extraction_agent` and `lineage_dual_read_diff`.
* **Bug Fixes**
  * Updated feature-flag validation for `lineage_dual_read_diff` to fail closed when configuration is missing or malformed.
  * Removed the legacy invitation-only feature gate in favor of the currently supported flags.
* **Documentation**
  * Updated server and site-variable READMEs (including the feature-flag list and background-daemon notes) to reflect the new/active gate set.
  * Refreshed feature-flag JSON to drop the `invitation_only` entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->