### PR TITLE
feat: add evaluation-only sampling override

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -520,6 +520,15 @@ class AgentSuccessConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
         le=1.0,
         description="Fraction of sessions to evaluate automatically.",
     )
+    evaluation_only_sampling_rate: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Fraction of evaluation-only sessions to evaluate automatically."
+            " None inherits sampling_rate."
+        ),
+    )
     retrieved_learning_sampling_rate: float | None = Field(
         default=None,
         ge=0.0,

--- a/reflexio/server/services/agent_success_evaluation/sampling.py
+++ b/reflexio/server/services/agent_success_evaluation/sampling.py
@@ -46,12 +46,19 @@ def samples_agent_success(
     org_id: str,
     user_id: str,
     session_id: str,
+    evaluation_only: bool = False,
 ) -> bool:
     """Whether this session is sampled for the session-success judge."""
     if agent_success_config is None:
         return False
+    rate = agent_success_config.sampling_rate
+    if (
+        evaluation_only
+        and agent_success_config.evaluation_only_sampling_rate is not None
+    ):
+        rate = agent_success_config.evaluation_only_sampling_rate
     return _samples(
-        float(agent_success_config.sampling_rate),
+        float(rate),
         stable_group_sampling_fraction(org_id, user_id, session_id),
     )
 

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -1071,7 +1071,9 @@ class GenerationService:
         """
         session_id = new_request.session_id
         run_agent_success, run_retrieved_learning = self._sampled_evaluation_families(
-            user_id=user_id, session_id=session_id
+            user_id=user_id,
+            session_id=session_id,
+            evaluation_only=new_request.evaluation_only,
         )
         if not (run_agent_success or run_retrieved_learning):
             logger.info(
@@ -1166,7 +1168,7 @@ class GenerationService:
         )
 
     def _sampled_evaluation_families(
-        self, *, user_id: str, session_id: str
+        self, *, user_id: str, session_id: str, evaluation_only: bool
     ) -> tuple[bool, bool]:
         """Which judge families this session is sampled for.
 
@@ -1186,7 +1188,9 @@ class GenerationService:
             "session_id": session_id,
         }
         return (
-            samples_agent_success(agent_success_config, **scope),
+            samples_agent_success(
+                agent_success_config, evaluation_only=evaluation_only, **scope
+            ),
             samples_retrieved_learning(agent_success_config, **scope),
         )
 

--- a/tests/models/test_config_f3_fields.py
+++ b/tests/models/test_config_f3_fields.py
@@ -32,6 +32,7 @@ def test_agent_success_evaluation_defaults_on_at_five_percent():
     assert c.agent_success_config is not None
     assert c.agent_success_config.sampling_rate == DEFAULT_AGENT_SUCCESS_SAMPLING_RATE
     assert c.agent_success_config.sampling_rate == 0.05
+    assert c.agent_success_config.evaluation_only_sampling_rate is None
     assert (
         c.agent_success_config.success_definition_prompt
         == DEFAULT_AGENT_SUCCESS_DEFINITION_PROMPT

--- a/tests/models/test_validators.py
+++ b/tests/models/test_validators.py
@@ -494,6 +494,24 @@ class TestNumericConstraints:
                 sampling_rate=1.5,
             )
 
+    @pytest.mark.parametrize("rate", [-0.1, 1.1])
+    def test_evaluation_only_sampling_rate_range(self, rate: float):
+        """evaluation_only_sampling_rate must be 0.0-1.0 when set."""
+        with pytest.raises(ValidationError):
+            AgentSuccessConfig(
+                success_definition_prompt="Check success",
+                evaluation_only_sampling_rate=rate,
+            )
+
+    @pytest.mark.parametrize("rate", [0.0, 1.0])
+    def test_evaluation_only_sampling_rate_accepts_bounds(self, rate: float):
+        config = AgentSuccessConfig(
+            success_definition_prompt="Check success",
+            evaluation_only_sampling_rate=rate,
+        )
+
+        assert config.evaluation_only_sampling_rate == rate
+
     def test_period_stats_non_negative(self):
         """PeriodStats counts must be >= 0."""
         with pytest.raises(ValidationError):

--- a/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py
+++ b/tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Callable, Iterator
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -73,7 +74,9 @@ def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
         agent_success_config=AgentSuccessConfig(
             evaluation_name="overall_success",
             success_definition_prompt="agent completes the requested task",
-            sampling_rate=1.0,
+            sampling_rate=0.0,
+            evaluation_only_sampling_rate=1.0,
+            retrieved_learning_sampling_rate=0.0,
         ),
     )
     instance = Reflexio(
@@ -88,6 +91,7 @@ def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
     agent_version = "agent_eval_only_delay"
     observed_request_model_counts: list[int] = []
     original_run = AgentSuccessEvaluationService.run
+    retrieved_learning_run = MagicMock()
 
     def recording_run(
         self: AgentSuccessEvaluationService,
@@ -99,6 +103,9 @@ def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
         return original_run(self, request)
 
     monkeypatch.setattr(AgentSuccessEvaluationService, "run", recording_run)
+    monkeypatch.setattr(
+        runner, "_run_retrieved_learning_evaluation", retrieved_learning_run
+    )
 
     with patched_litellm():
         first = instance.publish_interaction(
@@ -132,6 +139,18 @@ def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
         )
         assert second.success is True
 
+        ordinary_session_id = "session_ordinary"
+        ordinary = instance.publish_interaction(
+            {
+                "user_id": user_id,
+                "interaction_data_list": _interaction_pair("ordinary issue"),
+                "source": "integration",
+                "agent_version": agent_version,
+                "session_id": ordinary_session_id,
+            }
+        )
+        assert ordinary.success is True
+
         # This passes the first publish's original fire time but is still before
         # the second publish's rescheduled fire time.
         time.sleep(0.65)
@@ -150,8 +169,15 @@ def test_evaluation_only_publish_waits_and_batches_followup_session_requests(
             assert results[0].session_id == session_id
 
         _wait_until(assert_evaluated_once)
+        time.sleep(0.4)
+
+        results = storage.get_agent_success_evaluation_results(
+            agent_version=agent_version, limit=10
+        )
+        assert [result.session_id for result in results] == [session_id]
 
     stored_requests = storage.get_requests_by_session(user_id, session_id)
     assert len(stored_requests) == 2
     assert all(request.evaluation_only is True for request in stored_requests)
     assert observed_request_model_counts == [2]
+    retrieved_learning_run.assert_not_called()

--- a/tests/server/services/agent_success_evaluation/test_sampling.py
+++ b/tests/server/services/agent_success_evaluation/test_sampling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TypedDict
+
 from reflexio.models.config_schema import AgentSuccessConfig
 from reflexio.server.services.agent_success_evaluation.sampling import (
     samples_agent_success,
@@ -9,13 +11,29 @@ from reflexio.server.services.agent_success_evaluation.sampling import (
     stable_group_sampling_fraction,
 )
 
-SCOPE = {"org_id": "org-1", "user_id": "user-1", "session_id": "sess-1"}
+
+class SamplingScope(TypedDict):
+    org_id: str
+    user_id: str
+    session_id: str
 
 
-def _config(sampling_rate: float, retrieved: float | None = None) -> AgentSuccessConfig:
+SCOPE: SamplingScope = {
+    "org_id": "org-1",
+    "user_id": "user-1",
+    "session_id": "sess-1",
+}
+
+
+def _config(
+    sampling_rate: float,
+    retrieved: float | None = None,
+    evaluation_only: float | None = None,
+) -> AgentSuccessConfig:
     return AgentSuccessConfig(
         success_definition_prompt="Did the agent succeed?",
         sampling_rate=sampling_rate,
+        evaluation_only_sampling_rate=evaluation_only,
         retrieved_learning_sampling_rate=retrieved,
     )
 
@@ -33,6 +51,52 @@ def test_the_field_default_is_none_when_never_supplied() -> None:
     config = AgentSuccessConfig(success_definition_prompt="Did the agent succeed?")
 
     assert config.retrieved_learning_sampling_rate is None
+
+
+def test_evaluation_only_sampling_rate_default_is_none() -> None:
+    config = AgentSuccessConfig(success_definition_prompt="Did the agent succeed?")
+
+    assert config.evaluation_only_sampling_rate is None
+
+
+def test_evaluation_only_without_override_inherits_current_success_rate() -> None:
+    for rate in (0.0, 0.05, 1.0):
+        config = AgentSuccessConfig(
+            success_definition_prompt="Did the agent succeed?",
+            sampling_rate=rate,
+        )
+
+        assert samples_agent_success(
+            config, evaluation_only=True, **SCOPE
+        ) == samples_agent_success(config, **SCOPE)
+
+
+def test_evaluation_only_override_changes_only_evaluation_only_sampling() -> None:
+    config = _config(0.0, retrieved=0.0, evaluation_only=1.0)
+
+    assert samples_agent_success(config, **SCOPE) is False
+    assert samples_agent_success(config, evaluation_only=True, **SCOPE) is True
+    assert samples_retrieved_learning(config, **SCOPE) is False
+
+
+def test_denser_evaluation_only_override_preserves_nested_session_samples() -> None:
+    config = _config(0.1, evaluation_only=0.9)
+    ordinary_sampled = 0
+    both_sampled = 0
+
+    for n in range(500):
+        scope: SamplingScope = {
+            "org_id": "org-1",
+            "user_id": "u",
+            "session_id": f"s-{n}",
+        }
+        if samples_agent_success(config, **scope):
+            ordinary_sampled += 1
+            if samples_agent_success(config, evaluation_only=True, **scope):
+                both_sampled += 1
+
+    assert ordinary_sampled > 0
+    assert both_sampled == ordinary_sampled
 
 
 def test_an_org_that_never_opted_in_keeps_its_previous_behavior() -> None:
@@ -91,7 +155,11 @@ def test_a_denser_retrieved_rate_is_a_superset_of_the_agent_success_sample() -> 
     sampled_success = 0
     both = 0
     for n in range(500):
-        scope = {"org_id": "org-1", "user_id": "u", "session_id": f"s-{n}"}
+        scope: SamplingScope = {
+            "org_id": "org-1",
+            "user_id": "u",
+            "session_id": f"s-{n}",
+        }
         if samples_agent_success(config, **scope):
             sampled_success += 1
             if samples_retrieved_learning(config, **scope):

--- a/tests/server/services/test_generation_service_scheduling.py
+++ b/tests/server/services/test_generation_service_scheduling.py
@@ -99,7 +99,7 @@ def test_schedules_with_correct_key_when_session_id_present(
     assert callable(callback)
 
 
-def test_evaluation_only_does_not_bypass_sampling_rate(
+def test_evaluation_only_without_override_inherits_sampling_rate(
     service: GenerationService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A 0% sample rate skips scheduling even for evaluation-only requests."""
@@ -292,20 +292,28 @@ def test_learning_stall_path_calls_post_publish_helper(
 
 
 def _set_rates(
-    service: GenerationService, *, success: float, retrieved: float | None
+    service: GenerationService,
+    *,
+    success: float,
+    retrieved: float | None,
+    evaluation_only: float | None = None,
 ) -> None:
     cast(Any, service.configurator.get_config).return_value = Config(
         storage_config=StorageConfigSQLite(),
         agent_success_config=AgentSuccessConfig(
             success_definition_prompt="Evaluate whether the agent succeeded.",
             sampling_rate=success,
+            evaluation_only_sampling_rate=evaluation_only,
             retrieved_learning_sampling_rate=retrieved,
         ),
     )
 
 
 def _schedule_and_capture(
-    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+    service: GenerationService,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    evaluation_only: bool = False,
 ) -> MagicMock:
     """Schedule, then run the queued callback with run_group_evaluation stubbed."""
     scheduler = MagicMock()
@@ -319,7 +327,7 @@ def _schedule_and_capture(
     )
 
     service._schedule_group_evaluation_if_needed(
-        new_request=MagicMock(session_id="sess_split"),
+        new_request=MagicMock(session_id="sess_split", evaluation_only=evaluation_only),
         user_id="user_test",
         agent_version="v_test",
         source=None,
@@ -358,6 +366,29 @@ def test_success_only_sampling_skips_the_retrieved_learning_judge(
     kwargs = runner.call_args.kwargs
     assert kwargs["run_agent_success"] is True
     assert kwargs["run_retrieved_learning"] is False
+
+
+def test_evaluation_only_override_runs_only_success_judge(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_rates(service, success=0.0, retrieved=0.0, evaluation_only=1.0)
+
+    runner = _schedule_and_capture(service, monkeypatch, evaluation_only=True)
+
+    runner.assert_called_once()
+    kwargs = runner.call_args.kwargs
+    assert kwargs["run_agent_success"] is True
+    assert kwargs["run_retrieved_learning"] is False
+
+
+def test_evaluation_only_override_does_not_change_regular_sampling(
+    service: GenerationService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _set_rates(service, success=0.0, retrieved=0.0, evaluation_only=1.0)
+
+    runner = _schedule_and_capture(service, monkeypatch, evaluation_only=False)
+
+    runner.assert_not_called()
 
 
 def test_neither_family_sampled_does_not_schedule_at_all(


### PR DESCRIPTION
## Summary
- Let organizations set separate session-success coverage for evaluation-only traffic without changing ordinary publish sampling.
- Add an optional `evaluation_only_sampling_rate`; `null` dynamically inherits the configured `sampling_rate`.
- Keep deterministic session hashing and retrieved-learning sampling behavior unchanged.

## Changes
- Add and validate the public `AgentSuccessConfig.evaluation_only_sampling_rate` field.
- Pass the publish request's `evaluation_only` flag into the scheduler's success-sampling decision.
- Cover inherited and explicit rates, ordinary-session isolation, nested deterministic samples, retrieved-learning independence, and scheduler behavior.

## Test Plan
- `uv run ruff check` and `uv run ruff format` on changed Python files
- `uv run pyright` on changed Python files
- `uv run pytest -q --no-cov tests/models/test_config_f3_fields.py tests/models/test_validators.py tests/server/services/agent_success_evaluation/test_sampling.py tests/server/services/test_generation_service_scheduling.py tests/server/services/agent_success_evaluation/test_evaluation_only_scheduler_integration.py` (149 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional sampling-rate setting specifically for evaluation-only sessions.
  * Evaluation-only sessions can now use an independent sampling rate while regular sessions retain existing behavior.
  * Evaluation-only evaluations schedule only the applicable evaluation process when configured.

* **Bug Fixes**
  * Prevented retrieved-learning evaluations from running during evaluation-only publishing.

* **Tests**
  * Added coverage for sampling-rate inheritance, overrides, validation boundaries, and evaluation-only scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->