### PR TITLE
test: make the unit tiers pass without provider credentials

### DIFF
--- a/reflexio/cli/utils.py
+++ b/reflexio/cli/utils.py
@@ -7,6 +7,7 @@ import dataclasses
 import hashlib
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -57,6 +58,11 @@ def find_pids_on_port(port: int) -> list[int]:
     Returns:
         list[int]: Sorted, de-duplicated PIDs holding a socket bound to the port
     """
+    return _pids_from_lsof(port) or _pids_from_ss(port)
+
+
+def _pids_from_lsof(port: int) -> list[int]:
+    """Find port holders via ``lsof`` (the only option on macOS)."""
     try:
         result = subprocess.run(
             ["lsof", "-nP", "-Fpn", f"-iTCP:{port}"],
@@ -79,6 +85,41 @@ def find_pids_on_port(port: int) -> list[int]:
             name = line[1:]
             if "->" not in name and name.endswith(suffix):
                 pids.add(current_pid)
+    return sorted(pids)
+
+
+def _pids_from_ss(port: int) -> list[int]:
+    """Find port holders via ``ss`` — the Linux half of the CLOSED-socket case.
+
+    On Linux ``lsof -iTCP:<port>`` reports nothing for a socket that is bound
+    but never ``listen()``ed, even though the kernel still rejects a competing
+    bind with EADDRINUSE. ``ss`` shows it as ``UNCONN``, so without this the
+    orphaned-worker case ``find_pids_on_port`` exists to diagnose is invisible
+    on exactly the platform the servers run on. Absent on macOS, where ``lsof``
+    already covers it.
+    """
+    try:
+        result = subprocess.run(
+            ["ss", "-tanpH", "sport", "=", f":{port}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return []
+    if result.returncode != 0:
+        return []
+
+    pids: set[int] = set()
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        # State Recv-Q Send-Q Local:Port Peer:Port users:((...)). A concrete
+        # peer means the row is a connection that merely happens to use this
+        # port as its source, not a holder of it — same exclusion as the
+        # ``->`` check on the lsof path.
+        if len(fields) < 5 or not fields[4].endswith(":*"):
+            continue
+        pids.update(int(pid) for pid in re.findall(r"pid=(\d+)", line))
     return sorted(pids)
 
 

--- a/reflexio/test_support/llm_credentials.py
+++ b/reflexio/test_support/llm_credentials.py
@@ -1,0 +1,45 @@
+"""Provider-credential floor for the OS and enterprise test suites.
+
+Service constructors resolve their default model eagerly — e.g.
+``AgentSuccessEvaluator.__init__`` and ``SQLiteStorage.__init__`` both call
+``model_defaults.resolve_model_name``, which raises ``RuntimeError: No LLM
+provider available`` when the environment carries no provider key. Unit and
+integration tests never make a real call (``litellm.completion`` is patched
+globally) but they still run through those constructors, so on a machine with
+no credentials the suites collapse at fixture setup rather than testing
+anything.
+
+A developer machine hides this: ``./.env``, ``~/.reflexio/.env``, and litellm's
+import-time dotenv walk-up all feed real keys into ``os.environ``. CI has none,
+which is why the same suite can be green locally and ~1,250 errors deep in CI.
+"""
+
+from __future__ import annotations
+
+import os
+
+from reflexio.server.llm.model_defaults import (
+    GENERATION_CAPABLE_PROVIDERS,
+    detect_available_providers,
+)
+
+# Matches the string already used by the `storage` fixture in
+# tests/server/llm/conftest.py and by the repo's heavy-skill preflight docs.
+_PLACEHOLDER_KEY = "sk-placeholder-mock"
+
+
+def ensure_provider_credential() -> None:
+    """Pin a placeholder provider key when the environment offers none.
+
+    Only fills a vacuum — a real key, or an opted-in local CLI provider, is
+    left untouched, so the ``requires_credentials`` tier still runs against
+    whatever the developer has configured.
+
+    Gating on :func:`detect_available_providers` rather than a hand-copied list
+    of env var names keeps this from drifting, and correctly treats an
+    embedding-only provider (``local``) as "no generation provider" — that case
+    resolves embeddings fine but still raises for every other model role.
+    """
+    if any(p in GENERATION_CAPABLE_PROVIDERS for p in detect_available_providers()):
+        return
+    os.environ["OPENAI_API_KEY"] = _PLACEHOLDER_KEY

--- a/reflexio/test_support/llm_credentials.py
+++ b/reflexio/test_support/llm_credentials.py
@@ -32,8 +32,10 @@ def ensure_provider_credential() -> None:
     """Pin a placeholder provider key when the environment offers none.
 
     Only fills a vacuum — a real key, or an opted-in local CLI provider, is
-    left untouched, so the ``requires_credentials`` tier still runs against
-    whatever the developer has configured.
+    left untouched. The placeholder that lands here is a real value to every
+    env-var reader, including :func:`detect_available_providers`, so tests
+    gating a live provider call must ask :func:`real_provider_key` rather than
+    ``os.getenv``.
 
     Gating on :func:`detect_available_providers` rather than a hand-copied list
     of env var names keeps this from drifting, and correctly treats an
@@ -43,3 +45,25 @@ def ensure_provider_credential() -> None:
     if any(p in GENERATION_CAPABLE_PROVIDERS for p in detect_available_providers()):
         return
     os.environ["OPENAI_API_KEY"] = _PLACEHOLDER_KEY
+
+
+def real_provider_key(name: str) -> str | None:
+    """Return ``name``'s value, or None when it is only the placeholder.
+
+    A drop-in replacement for ``os.getenv(name)`` at any site that gates a
+    **live** provider call. :func:`detect_available_providers` deliberately
+    *does* count the placeholder — that is the entire mechanism, since model
+    resolution reads the same env vars it does — so a raw ``os.getenv`` cannot
+    tell a real key from the one the floor just pinned, and a
+    ``requires_credentials`` test that skipped cleanly on a bare machine would
+    instead run against a credential that authenticates with nothing.
+
+    Args:
+        name (str): Provider env var name, e.g. ``"OPENAI_API_KEY"``.
+
+    Returns:
+        str | None: The configured credential, or None when unset, blank, or
+            the placeholder.
+    """
+    value = os.environ.get(name, "")
+    return None if value in ("", _PLACEHOLDER_KEY) else value

--- a/tests/cli/test_setup_cmd.py
+++ b/tests/cli/test_setup_cmd.py
@@ -747,6 +747,13 @@ class TestEnsureUserEnvForSetup:
     (e.g. a worktree root or unrelated project).
     """
 
+    @pytest.fixture(autouse=True)
+    def _no_env_file_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``user_env_file()`` honors ``REFLEXIO_ENV_FILE`` ahead of the
+        module constants these tests patch, so a developer (or a CI job) that
+        exports it would redirect the write out from under the assertions."""
+        monkeypatch.delenv("REFLEXIO_ENV_FILE", raising=False)
+
     def test_setup_init_writes_to_user_home_not_cwd(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,17 @@ from reflexio.server.extensions import reset_services  # noqa: E402
 
 _test_server.LOCAL_STORAGE_PATH = os.environ["LOCAL_STORAGE_PATH"]
 
+from reflexio.test_support.llm_credentials import (  # noqa: E402
+    ensure_provider_credential,
+)
 from reflexio.test_support.llm_mock import cleanup_llm_mock, configure_llm_mock
+
+# Service constructors resolve a default model eagerly, so a machine with no
+# provider key errors out at fixture setup instead of running the suite. Runs
+# after `load_reflexio_env()` and after the `reflexio.server` import (which
+# pulls in litellm, whose import-time dotenv walk-up can also supply keys), so
+# every credential source has had its chance before we decide to fill the gap.
+ensure_provider_credential()
 
 
 def pytest_configure(config):

--- a/tests/server/llm/test_litellm_client.py
+++ b/tests/server/llm/test_litellm_client.py
@@ -29,6 +29,7 @@ from reflexio.server.llm.litellm_client import (
     _sanitize_json_string,
     create_litellm_client,
 )
+from reflexio.test_support.llm_credentials import real_provider_key
 from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
 # Skip all tests if neither API key is set
@@ -36,7 +37,8 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.requires_credentials,
     pytest.mark.skipif(
-        not os.getenv("OPENAI_API_KEY") and not os.getenv("ANTHROPIC_API_KEY"),
+        not real_provider_key("OPENAI_API_KEY")
+        and not real_provider_key("ANTHROPIC_API_KEY"),
         reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY environment variable is set",
     ),
 ]
@@ -113,7 +115,7 @@ class ColorAnalysis(BaseModel):
 @pytest.fixture
 def openai_client() -> LiteLLMClient:
     """Create an OpenAI-based LiteLLM client."""
-    if not os.getenv("OPENAI_API_KEY"):
+    if not real_provider_key("OPENAI_API_KEY"):
         pytest.skip("OPENAI_API_KEY not set")
     # GPT-5 models use reasoning tokens internally, so we need more max_tokens
     return create_litellm_client(
@@ -127,7 +129,7 @@ def openai_client() -> LiteLLMClient:
 @pytest.fixture
 def claude_client() -> LiteLLMClient:
     """Create a Claude-based LiteLLM client."""
-    if not os.getenv("ANTHROPIC_API_KEY"):
+    if not real_provider_key("ANTHROPIC_API_KEY"):
         pytest.skip("ANTHROPIC_API_KEY not set")
     return create_litellm_client(
         model=_get_claude_test_model(),
@@ -488,7 +490,9 @@ class TestLiteLLMClientModelSwitching:
     @skip_low_priority
     def test_switch_from_openai_to_claude(self):
         """Test that we can create clients for different providers."""
-        if not os.getenv("OPENAI_API_KEY") or not os.getenv("ANTHROPIC_API_KEY"):
+        if not real_provider_key("OPENAI_API_KEY") or not real_provider_key(
+            "ANTHROPIC_API_KEY"
+        ):
             pytest.skip("Both OPENAI_API_KEY and ANTHROPIC_API_KEY required")
 
         # Create OpenAI client (GPT-5 needs more tokens due to reasoning)
@@ -762,7 +766,7 @@ class TestLiteLLMClientAPIKeyOverride:
     @skip_low_priority
     def test_generate_response_with_api_key_override_openai(self):
         """Test generating response using OpenAI API key from config override."""
-        openai_key = os.getenv("OPENAI_API_KEY")
+        openai_key = real_provider_key("OPENAI_API_KEY")
         if not openai_key:
             pytest.skip("OPENAI_API_KEY not set")
 
@@ -785,7 +789,7 @@ class TestLiteLLMClientAPIKeyOverride:
     @skip_low_priority
     def test_generate_response_with_api_key_override_anthropic(self):
         """Test generating response using Anthropic API key from config override."""
-        anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+        anthropic_key = real_provider_key("ANTHROPIC_API_KEY")
         if not anthropic_key:
             pytest.skip("ANTHROPIC_API_KEY not set")
 
@@ -808,7 +812,7 @@ class TestLiteLLMClientAPIKeyOverride:
     @skip_low_priority
     def test_embeddings_with_api_key_override(self):
         """Test embedding generation with API key override."""
-        openai_key = os.getenv("OPENAI_API_KEY")
+        openai_key = real_provider_key("OPENAI_API_KEY")
         if not openai_key:
             pytest.skip("OPENAI_API_KEY not set")
 
@@ -828,7 +832,7 @@ class TestLiteLLMClientAPIKeyOverride:
     @skip_low_priority
     def test_structured_output_with_api_key_override(self):
         """Test structured output with API key override."""
-        openai_key = os.getenv("OPENAI_API_KEY")
+        openai_key = real_provider_key("OPENAI_API_KEY")
         if not openai_key:
             pytest.skip("OPENAI_API_KEY not set")
 
@@ -876,7 +880,7 @@ class TestLiteLLMClientAPIKeyOverride:
     @skip_low_priority
     def test_chat_response_with_api_key_override(self):
         """Test multi-turn chat response with API key override."""
-        openai_key = os.getenv("OPENAI_API_KEY")
+        openai_key = real_provider_key("OPENAI_API_KEY")
         if not openai_key:
             pytest.skip("OPENAI_API_KEY not set")
 
@@ -903,7 +907,7 @@ class TestLiteLLMClientAPIKeyOverride:
     @skip_low_priority
     def test_image_analysis_with_api_key_override(self, test_image_bytes: bytes):
         """Test image analysis with API key override."""
-        openai_key = os.getenv("OPENAI_API_KEY")
+        openai_key = real_provider_key("OPENAI_API_KEY")
         if not openai_key:
             pytest.skip("OPENAI_API_KEY not set")
 

--- a/tests/server/llm/test_llm_credentials.py
+++ b/tests/server/llm/test_llm_credentials.py
@@ -10,6 +10,7 @@ from reflexio.server.llm.model_defaults import _ENV_TO_PROVIDER
 from reflexio.test_support.llm_credentials import (
     _PLACEHOLDER_KEY,
     ensure_provider_credential,
+    real_provider_key,
 )
 
 
@@ -41,3 +42,19 @@ def test_fills_when_only_an_embedding_provider_is_available(
     )
     ensure_provider_credential()
     assert os.environ["OPENAI_API_KEY"] == _PLACEHOLDER_KEY
+
+
+def test_placeholder_does_not_read_as_a_real_credential() -> None:
+    """The floor must not silently un-skip the ``requires_credentials`` tier."""
+    ensure_provider_credential()
+    # Detection still sees it — that is what keeps model resolution working.
+    assert os.environ["OPENAI_API_KEY"] == _PLACEHOLDER_KEY
+    assert real_provider_key("OPENAI_API_KEY") is None
+
+
+def test_real_provider_key_returns_a_configured_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
+    assert real_provider_key("OPENAI_API_KEY") == "sk-real"
+    assert real_provider_key("ANTHROPIC_API_KEY") is None

--- a/tests/server/llm/test_llm_credentials.py
+++ b/tests/server/llm/test_llm_credentials.py
@@ -1,0 +1,43 @@
+"""Tests for the test-suite provider-credential floor."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reflexio.server.llm.model_defaults import _ENV_TO_PROVIDER
+from reflexio.test_support.llm_credentials import (
+    _PLACEHOLDER_KEY,
+    ensure_provider_credential,
+)
+
+
+@pytest.fixture(autouse=True)
+def _bare_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip every provider key; the directory conftest strips the CLI opt-ins."""
+    for var in _ENV_TO_PROVIDER:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_fills_a_bare_environment() -> None:
+    ensure_provider_credential()
+    assert os.environ["OPENAI_API_KEY"] == _PLACEHOLDER_KEY
+
+
+def test_leaves_a_real_key_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-real")
+    ensure_provider_credential()
+    assert os.environ.get("OPENAI_API_KEY") is None
+
+
+def test_fills_when_only_an_embedding_provider_is_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``local`` resolves embeddings but no generation-role model."""
+    monkeypatch.setattr(
+        "reflexio.test_support.llm_credentials.detect_available_providers",
+        lambda: ["local"],
+    )
+    ensure_provider_credential()
+    assert os.environ["OPENAI_API_KEY"] == _PLACEHOLDER_KEY


### PR DESCRIPTION
## Problem

Service constructors resolve their default model **eagerly** via `model_defaults.resolve_model_name` — `AgentSuccessEvaluator.__init__`, `SQLiteStorage.__init__`, and many others — which raises `RuntimeError: No LLM provider available` when the environment carries no provider key.

Unit and integration tests never make a real call (`litellm.completion` is patched globally), but they still run through those constructors. So on a machine with no credentials the suite collapses at fixture setup rather than testing anything.

A developer machine hides this completely: `./.env`, `~/.reflexio/.env`, and litellm's import-time dotenv walk-up all feed real keys into `os.environ`. CI has none.

Measured on this suite with every provider var blanked:

| | failed | errors | passed |
|---|---|---|---|
| before | 190 | 341 | 3206 |
| after | 0 | 0 | **3742** |

3742 passed / 9 skipped is byte-identical to the count with the developer's real keys present — the floor is inert whenever the environment already offers a generation provider.

## Changes

- **`reflexio/test_support/llm_credentials.py`** (new) — `ensure_provider_credential()` pins `sk-placeholder-mock` only when `detect_available_providers()` surfaces no generation-capable provider. Gating on that function rather than a hand-copied list of env var names keeps it from drifting, and correctly treats an embedding-only `local` provider as "no generation provider" (it resolves embeddings fine but raises for every other model role).

  This generalises a workaround that already existed, scoped to a single fixture, in `tests/server/llm/conftest.py`:

  > `SQLiteStorage.__init__` resolves a generation model via provider auto-detection, which needs SOME provider key in the env. Guarantee one so the fixture works on machines without real API keys.

- **`tests/conftest.py`** — call it after `load_reflexio_env()` and the `reflexio.server` import, so every real credential source has had its chance before we fill the gap.

- **`tests/server/llm/test_llm_credentials.py`** (new) — covers all three branches: bare environment, real key present, embedding-only provider.

- **`tests/cli/test_setup_cmd.py`** — `TestEnsureUserEnvForSetup` patches the module-level `_USER_ENV_FILE`, but `user_env_file()` reads `REFLEXIO_ENV_FILE` ahead of it. Clear the var so an exported value can't silently redirect the write out from under the assertions. (Found while building the keyless sandbox.)

Real API keys and the `requires_credentials` tier are untouched.

## Test plan

Keyless sandbox — blanking the vars rather than unsetting them, because litellm's dotenv walk-up otherwise re-imports `./.env`:

```
KEYLESS="REFLEXIO_ENV_FILE=<empty file> OPENAI_API_KEY= ANTHROPIC_API_KEY= GEMINI_API_KEY=
  DEEPSEEK_API_KEY= OPENROUTER_API_KEY= MINIMAX_API_KEY= DASHSCOPE_API_KEY= XAI_API_KEY=
  MOONSHOT_API_KEY= ZAI_API_KEY= CLAUDE_SMART_USE_LOCAL_CLI= CLAUDE_SMART_USE_LOCAL_EMBEDDING="
```

`detect_available_providers()` returns `[]` under it. Then the exact CI command:

```
env $KEYLESS uv run pytest tests/ --ignore=tests/e2e_tests/ -m "not integration" \
  -o 'addopts=' -n auto --dist worksteal --timeout=120 -q
  before: 190 failed, 341 errors, 3206 passed
  after:  3742 passed, 9 skipped
```

Same command with the developer's normal environment: `3742 passed, 9 skipped` — unchanged.

`ruff check`, `ruff format --check`, `pyright` clean on all touched files.

## Note

`tests/e2e_tests/` deliberately bypasses the LLM mock and needs real credentials, so this does not help the CI-Full lane that runs them. That is a separate decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test and setup reliability when no language-model provider credentials are configured.
  * Prevented external environment settings from impacting setup command validation.
  * Enhanced CLI port-holder detection by supporting both `lsof` and `ss` for more accurate process discovery.
* **Tests**
  * Added coverage for credential-handling behavior across scenarios: no providers, generation-capable providers, and embedding-only providers.
  * Updated integration-test gating to avoid treating placeholder credentials as real.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->