### PR TITLE
feat(observability): record WHICH gate skipped extraction, not just that it skipped

### DIFF
--- a/reflexio/server/services/base_generation/_should_run.py
+++ b/reflexio/server/services/base_generation/_should_run.py
@@ -59,6 +59,10 @@ class ShouldRunPrecheckMixin(Generic[TExtractorConfig, TGenerationServiceConfig]
     # The Precheck→Billing (INV-3) seam: written by
     # ``_collect_scoped_interactions_for_precheck``, read by ``_extraction_input_text``.
     _last_precheck_sessions: list[Any] | None
+    # The specific reason this gate skipped, when it is more precise than the
+    # caller's generic ``should_skip``. Read via ``getattr`` by the caller, since
+    # a subclass may override the gate entirely and never set it.
+    _last_gate_skip_outcome: str | None
 
     if TYPE_CHECKING:
         # Abstract on the base ABC (stays there per SINK-2); declared here type-only
@@ -88,6 +92,10 @@ class ShouldRunPrecheckMixin(Generic[TExtractorConfig, TGenerationServiceConfig]
         Returns:
             bool: True if extraction should proceed, False to skip
         """
+        # Cleared on every entry: a value left over from an earlier call would
+        # mislabel this decision.
+        self._last_gate_skip_outcome = None
+
         # Skip for non-auto runs (rerun/manual flows always run)
         if not getattr(self.service_config, "auto_run", True):
             return True
@@ -139,6 +147,19 @@ class ShouldRunPrecheckMixin(Generic[TExtractorConfig, TGenerationServiceConfig]
                 reject_reason,
                 getattr(self.service_config, "user_id", None) or "unknown",
             )
+            # Report WHICH heuristic rejected, not just that we skipped: the
+            # caller's bare ``should_skip`` cannot distinguish "the cheap
+            # pre-filter rejected on short/slash-command turns" from "the LLM
+            # gate voted no", and the cheap path never reaches the LLM so there
+            # is no token spend to infer it from either.
+            #
+            # Handed to the caller rather than emitted here, deliberately. The
+            # caller records an outcome for this return unconditionally, so
+            # emitting our own would produce TWO events for one decision -- and
+            # the second would read as an LLM verdict that never happened,
+            # double-counting the skip in exactly the metric this exists to
+            # make trustworthy.
+            self._last_gate_skip_outcome = f"skip_cheap_{reject_reason}"
             return False
 
         # Build prompt via subclass hook

--- a/reflexio/server/services/base_generation_service.py
+++ b/reflexio/server/services/base_generation_service.py
@@ -760,6 +760,40 @@ class BaseGenerationService(
             user_id=advance.user_id,
         )
 
+    def _record_skip(
+        self, reason: str, *, metadata: dict[str, Any] | None = None
+    ) -> None:
+        """Record that generation was skipped BEFORE the pre-extraction gate ran.
+
+        Emitted on the early-return paths of :meth:`_prepare_generation_run`. Those
+        paths previously logged at ``info``/``warning`` and wrote nothing durable, so
+        "a gate skipped this" was indistinguishable from "extraction ran and found
+        nothing" and from "extraction was never invoked" — all three looked identical
+        from the outside (publish returns success, no ``_agent_runs`` row, no usage
+        event). Diagnosing one such case took several hours and four wrong theories.
+
+        Uses the same ``generation_gate_evaluated`` event name as the gate itself so a
+        single query returns every decision, with ``outcome`` naming which gate fired:
+        ``skip_no_extractor_config`` / ``skip_source_not_enabled`` /
+        ``skip_stride_not_met`` from here, and ``should_run`` / ``should_skip`` from
+        the pre-extraction gate.
+
+        Args:
+            reason (str): Short slug for the gate that skipped, without the ``skip_``
+                prefix (added here so every outcome sorts together).
+            metadata (dict[str, Any] | None): Extra context for the event, e.g. the
+                request source that failed the source filter.
+        """
+        self._record_generation_event(
+            event_name="generation_gate_evaluated",
+            outcome=f"skip_{reason}",
+            count_value=1,
+            metadata={
+                "service": self._get_service_name(),
+                **(metadata or {}),
+            },
+        )
+
     def _prepare_generation_run(
         self, request: TRequest
     ) -> PreparedGenerationRun[TExtractorConfig] | None:
@@ -788,6 +822,7 @@ class BaseGenerationService(
         extractor_config = self._load_extractor_config()
         if extractor_config is None:
             logger.warning("No %s extractor config found", self._get_service_name())
+            self._record_skip("no_extractor_config")
             return None
 
         extractor_config = self._filter_extractor_config_by_service_config(
@@ -802,6 +837,7 @@ class BaseGenerationService(
                 self._get_service_name(),
                 source_display,
             )
+            self._record_skip("source_not_enabled", metadata={"source": source_display})
             return None
 
         extractor_config = self._filter_config_by_stride(extractor_config)
@@ -810,6 +846,7 @@ class BaseGenerationService(
                 "Extractor config did not pass stride_size check for %s",
                 self._get_service_name(),
             )
+            self._record_skip("stride_not_met")
             return None
 
         identifier = getattr(self.service_config, "user_id", None) or getattr(
@@ -818,9 +855,17 @@ class BaseGenerationService(
         extractor_name = get_extractor_name(extractor_config)
 
         should_run = self._should_run_before_extraction(extractor_config)
+        # Exactly ONE event per gate decision. The gate reports a more specific
+        # skip reason when it has one (e.g. the cheap pre-filter, which never
+        # reaches the LLM); recording our generic ``should_skip`` alongside it
+        # would double-count and imply an LLM verdict that never happened.
+        # ``getattr`` because a subclass may override the gate and not set it.
+        specific_outcome = getattr(self, "_last_gate_skip_outcome", None)
         self._record_generation_event(
             event_name="generation_gate_evaluated",
-            outcome="should_run" if should_run else "should_skip",
+            outcome=(
+                "should_run" if should_run else (specific_outcome or "should_skip")
+            ),
             count_value=1,
             metadata={
                 "identifier": identifier,

--- a/tests/server/services/test_generation_billing_emission.py
+++ b/tests/server/services/test_generation_billing_emission.py
@@ -3,7 +3,7 @@
 Verifies that:
 - A real extraction emits ``extraction_tokens`` and ``learnings_generated`` events.
 - A should_run-skipped request emits NO billing learning events (but the ops gate
-  event still fires with ``outcome=should_skip``).
+  event still fires, carrying the specific skip reason).
 - AgentSuccessEvaluationService (EMITS_LEARNING_BILLING=False) never emits ②
   Learning events — the gate blocks it regardless of outcome.
 
@@ -174,7 +174,8 @@ def test_real_extraction_emits_tokens_and_learnings(tmp_path):
 def test_should_run_skip_emits_no_learning_billing(tmp_path, monkeypatch):
     """A should_run-gated skip emits NO extraction_tokens / learnings_generated.
 
-    The ops gate event still fires with outcome=should_skip. We:
+    The ops gate event still fires, carrying the specific skip reason
+    (``skip_cheap_<reason>`` here, not the generic ``should_skip``). We:
     - Clear MOCK_LLM_RESPONSE so the pre-extraction gate is not bypassed.
     - Set stride_size=1 and seed a short interaction so the stride check passes
       but the cheap pre-filter rejects the batch (all_user_turns_too_short).
@@ -254,10 +255,20 @@ def test_should_run_skip_emits_no_learning_billing(tmp_path, monkeypatch):
     ]
     assert billing_learning == [], f"unexpected billing events: {billing_learning}"
 
-    # The existing ops event still fires with the skip outcome.
+    # EXACTLY ONE gate event per decision, carrying the specific reason.
+    #
+    # The cheap pre-filter used to record `skip_cheap_<reason>` itself while the
+    # caller also recorded a generic `should_skip`, so one decision produced two
+    # events -- and the second read as an LLM verdict on a path that never
+    # reaches the LLM, double-counting the skip in the very metric this exists
+    # to make trustworthy. Assert the count, not just the presence.
     gate_events = [e for e in events if e.event_name == "generation_gate_evaluated"]
-    assert any(e.outcome == "should_skip" for e in gate_events), (
-        f"expected should_skip gate event, got: {gate_events}"
+    assert len(gate_events) == 1, f"expected exactly one gate event, got: {gate_events}"
+    # The exact reason, not a prefix: this fixture's turns are all under the
+    # minimum length, and a prefix check would pass for any cheap-filter reason
+    # -- including one the fixture never exercises.
+    assert gate_events[0].outcome == "skip_cheap_all_user_turns_too_short", (
+        f"expected the specific cheap-filter reason, got: {gate_events[0].outcome}"
     )
 
 


### PR DESCRIPTION
## Why

Extraction can decline to run at **five** points before any LLM call. Four wrote nothing durable — they logged at `info`/`warning` and returned. The fifth (the LLM `should_run` gate) recorded a bare `should_skip` with no reason.

So these three states were **indistinguishable from outside**:

- a gate skipped this batch
- extraction ran and genuinely found nothing
- extraction was never invoked at all

All three look identical: `publish` returns `success: True`, no `_agent_runs` row, no `extraction_tokens` usage event, nothing queryable.

**This was found the expensive way.** A new production org published 15 explicit preference statements ("I'm vegetarian and allergic to peanuts", "always add type hints") and produced zero profiles. Diagnosis took several hours and **four wrong theories** — stride threshold, then source filtering, then per-org config, then a structured-output parse failure — because every wrong theory was consistent with every observable signal. The deciding evidence turned out to be an *absence*: `extraction_tokens` present for a healthy org, absent for this one.

## What this does

Records a `generation_gate_evaluated` usage event at **every** skip path, reusing the event name the LLM gate already emits, so one query returns every decision with `outcome` naming the gate:

| `outcome` | meaning |
|---|---|
| `skip_no_extractor_config` | no extractor config loaded |
| `skip_source_not_enabled` | source not in `request_sources_enabled` (metadata carries the source) |
| `skip_stride_not_met` | `stride_size` bookmark check failed |
| `skip_cheap_<reason>` | cheap pre-filter rejected before the LLM — `all_user_turns_too_short` / `all_slash_commands` / `extractor_prompt_echo` |
| `should_skip` / `should_run` | the LLM pre-extraction gate (unchanged) |

The `skip_cheap_*` case matters most: that path **never reaches the LLM**, so there is no token spend to infer it from, and its reason previously existed only in an `info` log.

## Behaviour

Unchanged. **No gate decision is altered — only recorded.**

## Verification

- 322 existing service tests pass (`pytest tests/server/services -k "should_run or generation or gate"`)
- `ruff check` + `ruff format` clean; `pyright` 0 errors

## Deliberately out of scope (tracked separately)

- **`_agent_runs` cannot express failure.** A structured-output repair that exhausts its budget still finalizes with `status: finalized` and `committed_output: {"profiles": null}` — identical to a genuine empty extraction. Needs a `failure_kind` column, i.e. a tenant-schema migration plus enterprise coordination.
- **`llm_structured_repair_exhausted`** is a WARNING never joined to the run that suffered it, and its repair retries the **same** model that just produced unparseable output. Observed 9 exhaustions in 24h on `ProfileDeduplicationOutput` / `PlaybookConsolidationOutput`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity of skipped generation runs with more specific, reason-based `generation_gate_evaluated` outcomes (e.g., `skip_cheap_<reason>`, missing/disabled extractor, stride-size mismatch).
  * Ensured only one gate decision event is emitted per pre-extraction evaluation to prevent double-counting.
  * Prevented stale “skip” outcomes from being reused across calls.
* **Tests**
  * Tightened skip-path assertions to require exactly one `generation_gate_evaluated` event with the specific cheap pre-filter reason (`skip_cheap_all_user_turns_too_short`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->