### PR TITLE
fix(api)!: report contentless and mis-keyed publish payloads

### DIFF
--- a/AI_AGENT_INTEGRATION.md
+++ b/AI_AGENT_INTEGRATION.md
@@ -241,7 +241,9 @@ Publish request fields:
 | `force_extraction` | No | `False` for normal background publishing. `True` for manual learn-now, tests, or final flushes where you intentionally want extraction to run immediately. | `false` |
 | `wait_for_response` | SDK/query option | `False` on interactive paths. `True` only when the caller is prepared to wait for extraction results. | `false` |
 
-Each interaction row should resemble Reflexio's `InteractionData` shape:
+Each interaction row must use Reflexio's `InteractionData` field names exactly.
+Unknown keys are dropped (and reported in the response's `warnings[]`), so a
+misspelling silently loses that value rather than being coerced:
 
 ```json
 {
@@ -497,8 +499,35 @@ Follow these rules for production agent integrations:
 - Keep hook latency bounded. Use short HTTP timeouts on interactive hooks.
 - Never let Reflexio exceptions fail the user's agent turn.
 - Buffer locally before network calls.
-- Advance publish watermarks only after success.
-- Retry failed publishes later.
+- Advance publish watermarks only after success — but **classify the failure
+  first**. Holding the watermark on a permanently-rejected batch wedges the
+  buffer: the same batch is re-sent forever and nothing is ever published.
+  Advancing on a transient failure loses data. Neither default is safe, so
+  branch on the status:
+
+  | Response | Meaning | Do |
+  |---|---|---|
+  | `5xx`, timeout, connection error | Transient | **Hold** the watermark; retry with backoff |
+  | `408`, `429` | Transient (slow down) | **Hold**; retry with backoff, honour `Retry-After` |
+  | `401`, `403` | Auth/config broken, not the payload | **Hold** and escalate — do not discard; the data is fine |
+  | `400`, `422` | The payload itself is invalid | **Advance** past it; retrying cannot succeed |
+
+  A `422` names the offending `interaction_data_list` index. Prefer
+  dead-lettering just that row and re-sending its valid siblings over
+  discarding the whole batch — the batch is rejected as a unit, so a blind
+  advance drops good interactions alongside the bad one.
+- Retry failed publishes later, using the same classification.
+- Build the wire payload with an **allowlist** of `InteractionData` fields, not
+  by passing your buffer record through minus a few keys. A denylist silently
+  ships your internal bookkeeping and rots every time you add a record key.
+- Every interaction must carry something — `content`, `shadow_content`,
+  `expert_content`, `interacted_image_url`, `image_encoding`, `tools_used`,
+  `citations`, `retrieved_learnings`, or a `user_action` other than `"none"`.
+  A wholly empty interaction is rejected with `422`; drop empty turns before
+  sending rather than letting one poison the batch.
+- Unknown fields are accepted but **dropped**, and named back to you in the
+  response's `warnings[]`. Check that list: a populated one means a field you
+  sent did not bind and that data was silently discarded.
 - Truncate large tool fields before publishing.
 - Do not run extraction synchronously on every turn.
 - Make retrieval query-aware; do not dump all memory into every prompt.

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -464,6 +464,22 @@ class ReflexioClient:
                 In ``wait_for_response=True`` mode the server waits for
                 extraction and the response includes ``request_id``,
                 storage routing, and real profile/playbook deltas.
+
+                ``warnings`` reports anything that was quietly altered:
+                unrecognised interaction fields that were dropped (a key you
+                sent did not bind and its value was discarded — check for a
+                typo), and interactions that carried nothing and were
+                skipped. Indices refer to the list as you passed it. The list
+                is bounded, so on a large batch treat it as a sample.
+
+        Raises:
+            ValueError: If ``session_id`` is missing or blank.
+            pydantic.ValidationError: Raised locally, before any HTTP call, if
+                an interaction carries nothing at all (no content, image,
+                tools, citations, learnings, or non-"none" user_action), if a
+                ``user_action`` has no ``user_action_description``, or if both
+                ``interacted_image_url`` and ``image_encoding`` are set. The
+                message names the offending ``interaction_data_list`` index.
         """
         if session_id is None or not session_id.strip():
             raise ValueError("session_id is required and cannot be empty")
@@ -490,6 +506,14 @@ class ReflexioClient:
         result = self._publish_interaction_sync(
             request, wait_for_response=wait_for_response
         )
+        # Merge the warnings detected locally. Building InteractionData above
+        # already stripped the caller's unknown keys, so ``request.model_dump()``
+        # sends a clean payload and the server never sees them -- it cannot echo
+        # what it was never told. Without this, unrecognised fields are reported
+        # over raw HTTP but are invisible through the SDK, which is the primary
+        # integration path and the one this method's docstring promises.
+        if local_warnings := request.payload_warnings():
+            result.warnings = [*result.warnings, *local_warnings]
         self._cache.invalidate("get_profiles")
         self._cache.invalidate("get_agent_playbooks")
         return result

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/reflexio_adapter.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/reflexio_adapter.py
@@ -17,6 +17,26 @@ from openclaw_smart import runtime
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _log_payload_warnings(result: object) -> None:
+    """Log anything the publish quietly altered. Never raises.
+
+    The publish has already succeeded by the time this runs, and the caller
+    advances its publish watermark on the adapter's return value -- so an
+    exception here would be misread as a publish failure and stall the buffer.
+    Total belt-and-braces on a diagnostic path is the right trade.
+    """
+    try:
+        warnings = getattr(result, "warnings", None) or []
+        if warnings:
+            _LOGGER.warning(
+                "publish_interaction altered the payload: %s",
+                "; ".join(str(warning) for warning in warnings),
+            )
+    except Exception:  # noqa: BLE001 - diagnostics must never break publishing
+        _LOGGER.debug("could not render publish warnings", exc_info=True)
+
+
 _ENV_URL = "REFLEXIO_URL"
 _DEFAULT_URL = "http://localhost:8071/"
 _SEARCH_MODE_HYBRID = "hybrid"  # reflexio.models.config_schema.SearchMode.HYBRID
@@ -80,7 +100,7 @@ class Adapter:
         if client is None:
             return False
         try:
-            client.publish_interaction(
+            result = client.publish_interaction(
                 user_id=project_id,
                 interactions=list(interactions),
                 agent_version=runtime.agent_version(),
@@ -89,10 +109,17 @@ class Adapter:
                 force_extraction=force_extraction,
                 skip_aggregation=skip_aggregation,
             )
-            return True
         except Exception as exc:  # noqa: BLE001
             _LOGGER.warning("publish_interaction failed: %s", exc)
             return False
+
+        # Diagnostics only, and deliberately OUTSIDE the try above: the publish
+        # has already succeeded, and the caller advances its watermark on our
+        # return value. Anything raised while merely reporting warnings would be
+        # caught as a publish failure, stalling the watermark and republishing
+        # the same batch on every later hook.
+        _log_payload_warnings(result)
+        return True
 
     def apply_extraction_defaults(self, *, window_size: int, stride_size: int) -> bool:
         """Push openclaw-smart's preferred extraction defaults to the reflexio server.

--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/state.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/state.py
@@ -36,6 +36,28 @@ _DEFAULT_STATE_DIR = Path.home() / ".openclaw-smart" / "sessions"
 
 _TOOL_DATA_FIELD_MAX_LEN = 256
 
+# Fields the server's ``InteractionData`` accepts. Declared literally rather
+# than imported so this module keeps no runtime dependency on ``reflexio``;
+# ``tests/test_state.py`` pins it against the real model so the two cannot
+# drift. Anything not in here is buffer-internal bookkeeping and must not
+# reach the wire.
+_INTERACTION_DATA_FIELDS = frozenset(
+    {
+        "created_at",
+        "role",
+        "content",
+        "shadow_content",
+        "expert_content",
+        "user_action",
+        "user_action_description",
+        "interacted_image_url",
+        "image_encoding",
+        "tools_used",
+        "citations",
+        "retrieved_learnings",
+    }
+)
+
 _VALID_CITATION_KINDS = frozenset(
     {"playbook", "profile", "user_playbook", "agent_playbook"}
 )
@@ -315,9 +337,13 @@ def unpublished_slice(
             pending_tools.append(tool_entry)
             continue
         if role in {"User", "Assistant"}:
-            turn = {
-                k: v for k, v in rec.items() if k not in {"role", "ts", "cited_items"}
-            }
+            # Allowlist, not denylist. This used to drop three known keys and
+            # pass everything else through, so buffer-internal bookkeeping
+            # (``user_id``, ``id``, ``kind``, ``title``, ...) rode along onto
+            # the wire. The server ignored it, but the denylist rots every time
+            # a hook adds a record key, and a stricter server turns that rot
+            # into a publish failure the adapter swallows silently.
+            turn = {k: v for k, v in rec.items() if k in _INTERACTION_DATA_FIELDS}
             turn["role"] = role
             if role == "Assistant":
                 citations = _to_wire_citations(rec.get("cited_items"))

--- a/reflexio/integrations/openclaw/plugin/tests/test_state.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_state.py
@@ -261,3 +261,45 @@ def test_to_wire_citations_preserves_explicit_playbook_source_kind() -> None:
         "user_playbook",
         "profile",
     ]
+
+
+class TestWirePayloadContract:
+    """The wire dict must contain only fields the server's model accepts.
+
+    ``unpublished_slice`` used to build the payload with a denylist (drop three
+    known keys, pass the rest through), so buffer bookkeeping such as
+    ``user_id`` rode along. The server ignored it -- until it didn't, at which
+    point the adapter swallowed the error and the publish watermark never
+    advanced, so the same batch retried forever and nothing was published.
+    """
+
+    def test_bookkeeping_keys_never_reach_the_wire(self):
+        _, turns = state.unpublished_slice(
+            [{"ts": 1, "role": "User", "content": "x", "user_id": "proj-a", "id": "r1"}]
+        )
+        assert turns, "expected one wire turn"
+        assert "user_id" not in turns[0]
+        assert "id" not in turns[0]
+        assert turns[0]["content"] == "x"
+
+    def test_allowlist_matches_the_server_model(self):
+        """Pin the literal field set against the real InteractionData."""
+        interaction_data = pytest.importorskip(
+            "reflexio.models.api_schema.domain.entities"
+        ).InteractionData
+        assert set(interaction_data.model_fields) == state._INTERACTION_DATA_FIELDS
+
+    def test_wire_turn_validates_against_the_server_model(self):
+        """Every dict the slicer emits must construct a real InteractionData."""
+        interaction_data = pytest.importorskip(
+            "reflexio.models.api_schema.domain.entities"
+        ).InteractionData
+        _, turns = state.unpublished_slice(
+            [
+                {"ts": 1, "role": "User", "content": "hi", "user_id": "p"},
+                {"ts": 2, "role": "Assistant", "content": "hello", "user_id": "p"},
+            ]
+        )
+        for turn in turns:
+            built = interaction_data(**turn)
+            assert built.unknown_field_names() == []

--- a/reflexio/models/api_schema/common.py
+++ b/reflexio/models/api_schema/common.py
@@ -6,15 +6,140 @@ that are genuinely shared belong here.
 """
 
 from enum import StrEnum
+from typing import Self
 
-from pydantic import BaseModel, Field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 __all__ = [
     "NEVER_EXPIRES_TIMESTAMP",
-    "BlockingIssueKind",
     "BlockingIssue",
+    "BlockingIssueKind",
+    "CapturesUnknownFields",
     "ToolUsed",
+    "cap_warning_list",
+    "sanitise_for_log",
+    "summarise_unknown_names",
 ]
+
+# Unknown-key names are caller-controlled: uncapped in length and count, and
+# free to contain newlines or control characters. They are echoed into both the
+# HTTP response and a log line, so they need bounding on THREE axes -- per-name
+# length, names-per-interaction, and total entries in the warning list -- plus
+# control-character stripping, or a caller can forge log lines in a shared
+# multi-tenant stream. The #377 redaction invariant covers values; names are
+# equally caller data.
+_MAX_REPORTED_NAMES = 5
+_MAX_NAME_LEN = 64
+_MAX_WARNING_ENTRIES = 20
+_MAX_STATUS_LEN = 100
+
+
+def sanitise_for_log(value: str, max_len: int = _MAX_NAME_LEN) -> str:
+    """Make one caller-supplied string safe to put in a log line.
+
+    Strips control characters and bounds the length. Any caller-controlled value
+    that reaches a log record needs this, not just unknown field names: a
+    newline forges a line in a shared multi-tenant stream, and an unbounded
+    value bloats the record. ``request_id`` is a ``NonEmptyStr`` with no length
+    cap and no character restrictions, so it qualifies.
+
+    Args:
+        value (str): The caller-supplied string.
+        max_len (int): Maximum length before truncation.
+
+    Returns:
+        str: Printable, length-bounded text safe for a single log line.
+    """
+    cleaned = "".join(char if char.isprintable() else "?" for char in value)
+    return cleaned if len(cleaned) <= max_len else f"{cleaned[:max_len]}..."
+
+
+def _sanitise_name(name: str) -> str:
+    """Strip control characters and bound the length of one caller-supplied key."""
+    return sanitise_for_log(name)
+
+
+def summarise_unknown_names(names: list[str]) -> str:
+    """Render unknown key names for a caller-facing warning, bounded and safe.
+
+    Args:
+        names (list[str]): The unrecognised key names, already sorted.
+
+    Returns:
+        str: Comma-separated sanitised names, each truncated, with a "+N more"
+            suffix when the list was longer than the cap.
+    """
+    shown = [_sanitise_name(name) for name in names[:_MAX_REPORTED_NAMES]]
+    remaining = len(names) - len(shown)
+    return ", ".join(shown) + (f", +{remaining} more" if remaining > 0 else "")
+
+
+def cap_warning_list(warnings: list[str]) -> list[str]:
+    """Bound the number of warning entries.
+
+    Per-name caps alone do not bound the total: ``interaction_data_list``
+    permits 1000 entries, so one warning each still adds up to a
+    multi-hundred-KB response body and a single enormous log record.
+
+    Args:
+        warnings (list[str]): Individually-bounded warning strings.
+
+    Returns:
+        list[str]: At most ``_MAX_WARNING_ENTRIES`` entries, with a trailing
+            summary when entries were dropped.
+    """
+    if len(warnings) <= _MAX_WARNING_ENTRIES:
+        # Copy: the caller appends the skip summary to what we return, and
+        # mutating its input list would be a surprise.
+        return list(warnings)
+    dropped = len(warnings) - _MAX_WARNING_ENTRIES
+    return [
+        *warnings[:_MAX_WARNING_ENTRIES],
+        f"...and {dropped} more interaction(s) with the same problem",
+    ]
+
+
+class CapturesUnknownFields(BaseModel):
+    """Records unrecognised keys instead of silently discarding them.
+
+    ``extra="allow"`` here is only a means of *seeing* what the caller sent;
+    the validator strips the extras straight back out so nothing unexpected
+    reaches storage or a re-serialised request. Only NAMES are retained --
+    values are caller payload, potentially Customer Content, and must never
+    reach a log or an error body (the redaction invariant from #377).
+
+    Deliberately NOT ``extra="forbid"``: rejecting unknown keys broke every
+    first-party plugin publish, because they build their wire payload with a
+    denylist and so carry request-level bookkeeping on each turn.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    _unknown_field_names: list[str] = PrivateAttr(default_factory=list)
+
+    @model_validator(mode="after")
+    def capture_and_strip_unknown_fields(self) -> Self:
+        """Record unknown key names, then drop them.
+
+        Returns:
+            Self: this model, with unknown keys recorded and removed.
+        """
+        if extra := self.__pydantic_extra__:
+            self._unknown_field_names = sorted(extra)
+            self.__pydantic_extra__ = {}
+        return self
+
+    def unknown_field_names(self) -> list[str]:
+        """Names of unrecognised keys the caller sent, if any."""
+        return self._unknown_field_names
+
 
 # OS-agnostic "never expires" timestamp (January 1, 2100 00:00:00 UTC)
 NEVER_EXPIRES_TIMESTAMP = 4102444800
@@ -34,8 +159,40 @@ class BlockingIssue(BaseModel):
     )
 
 
-class ToolUsed(BaseModel):
+class ToolUsed(CapturesUnknownFields):
     tool_name: str
     tool_data: dict = Field(
         default_factory=dict
     )  # tool metadata: input, output, latency, etc.
+    # Declared because both first-party plugins already send it on every tool
+    # entry ("success" / "error", derived from the tool response). It was being
+    # silently discarded -- real signal lost, and the single largest source of
+    # unknown-field warnings once nested capture started reporting it.
+    status: str = ""
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def coerce_status(cls, value: object) -> str:
+        """Accept whatever the caller sent; never reject the batch over it.
+
+        Declaring this field strictly (``str`` with ``max_length``) would turn
+        five previously-harmless cases -- an int, None, a bool, a dict, an
+        over-long string -- into a 422 that rejects the WHOLE publish. Before it
+        was declared they were silently ignored and the publish returned 200.
+
+        That regression matters more than it looks: the first-party plugin
+        adapters swallow the resulting error and never advance their publish
+        watermark, so the same batch retries forever and nothing is ever
+        published. It is the exact failure this schema's ``extra="allow"``
+        decision exists to avoid -- see ``CapturesUnknownFields``. Declaring a
+        field must not be a backdoor to the strictness that was rejected.
+
+        Args:
+            value (object): Whatever the caller put in ``status``.
+
+        Returns:
+            str: A bounded string; never raises.
+        """
+        if value is None:
+            return ""
+        return str(value)[:_MAX_STATUS_LEN]

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Literal, Self
+from typing import Any, Final, Literal, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 from reflexio.defaults import DEFAULT_AGENT_VERSION
 
@@ -11,7 +17,10 @@ from ..common import (
     NEVER_EXPIRES_TIMESTAMP,
     BlockingIssue,
     BlockingIssueKind,
+    CapturesUnknownFields,
     ToolUsed,
+    cap_warning_list,
+    summarise_unknown_names,
 )
 from ..validators import (
     EmbeddingVector,
@@ -136,7 +145,7 @@ __all__ = [
 type CitationKind = Literal["playbook", "profile", "user_playbook", "agent_playbook"]
 
 
-class Citation(BaseModel):
+class Citation(CapturesUnknownFields):
     """A playbook or profile item the agent cited as influential.
 
     Carried inline on an Assistant ``InteractionData`` row to mark
@@ -172,7 +181,7 @@ type RetrievedLearningKind = Literal["profile", "user_playbook", "agent_playbook
 type LearningImpact = Literal["positive", "negative", "neutral"]
 
 
-class RetrievedLearning(BaseModel):
+class RetrievedLearning(CapturesUnknownFields):
     """A learning the caller retrieved and injected into the agent context.
 
     Deliberately minimal — just the identity pair. It does NOT reuse
@@ -685,7 +694,26 @@ class ClearUserDataResponse(BaseModel):
 
 
 # user provided interaction data from the request
-class InteractionData(BaseModel):
+class InteractionData(CapturesUnknownFields):
+    # Every field below has a default, so under Pydantic's default
+    # ``extra="ignore"`` a mis-keyed field (``Content``, ``text``, an extra
+    # nesting level) silently produced a *valid* interaction carrying nothing,
+    # and the publish returned 200. That shipped 50 empty rows to a real org
+    # and generated no learnings, with no error on any layer.
+    #
+    # We capture unknown keys instead of forbidding them. ``extra="forbid"``
+    # was tried and rejected: the first-party plugins build their wire payload
+    # with a *denylist* (drop a few known keys, pass the rest through), so
+    # every turn carries request-level bookkeeping such as ``user_id``. Under
+    # ``forbid`` that raises, the plugin adapter swallows the exception, and
+    # its publish watermark never advances -- so the same batch retries
+    # forever and nothing is ever published. That is a strictly worse silent
+    # data loss than the one this validation exists to prevent, and it would
+    # hit already-installed plugins the moment the server deployed.
+    #
+    # So: accept the request, drop the unknown keys as before, but record
+    # their NAMES (never their values -- see the redaction invariant in #377)
+    # so the caller is told on the response and the server logs it.
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
     role: str = Field(default="User", max_length=1_000)
     content: str = Field(default="", max_length=1_000_000)
@@ -712,9 +740,112 @@ class InteractionData(BaseModel):
     def validate_image_url(cls, v: str) -> str:
         return _validate_image_url(v)
 
+    def reportable_unknown_fields(self) -> list[str]:
+        """Unknown key names worth telling the caller about, nested included.
+
+        Excludes ``_BENIGN_UNKNOWN_KEYS``: request-level identifiers that
+        callers routinely duplicate onto each interaction. They are still
+        stripped, but warning about them would emit one entry per interaction
+        on every publish from a correctly-behaving integration, training
+        operators to ignore the channel before it carries real signal.
+
+        Returns:
+            list[str]: Field paths, e.g. ``["Content", "tools_used[0].status"]``.
+        """
+        names = [n for n in self.unknown_field_names() if n not in _BENIGN_UNKNOWN_KEYS]
+        for attr in ("tools_used", "citations", "retrieved_learnings"):
+            for index, item in enumerate(getattr(self, attr)):
+                names.extend(
+                    f"{attr}[{index}].{nested}" for nested in item.unknown_field_names()
+                )
+        return names
+
+    def carries_content(self) -> bool:
+        """
+        Whether this interaction carries anything worth storing.
+
+        The single source of truth for "is this interaction empty", shared by
+        ``PublishUserInteractionRequest``'s boundary validator and the
+        ``precondition_checks`` defense-in-depth guard so the two cannot drift.
+
+        Every content-bearing field counts, not just ``content``: a
+        tool-call-only agent turn, a shadow/expert-only row, and an image-only
+        turn all carry real information. Note ``user_action`` is compared
+        against ``UserActionType.NONE`` rather than tested for truthiness --
+        ``UserActionType`` is a ``StrEnum`` whose NONE member is the *truthy*
+        string ``"none"``, and a truthiness test there is what silently
+        disabled this check for the entire life of the guard.
+
+        Returns:
+            bool: True if any content-bearing field is populated.
+        """
+        if self.user_action != UserActionType.NONE:
+            return True
+        # Text fields are stripped: "   " is not content. Mirrors the
+        # ``session_id`` guard in ``precondition_checks``, which already
+        # rejects whitespace-only values.
+        return any(
+            value.strip() if isinstance(value, str) else value
+            for value in (getattr(self, name) for name in CONTENT_BEARING_FIELD_NAMES)
+        )
+
+    def shape_error(self) -> str | None:
+        """A contradiction in this interaction the caller must fix, or None.
+
+        These are genuine caller mistakes with no sensible recovery, so they
+        are fatal to the request. Emptiness is deliberately NOT one of them --
+        see ``PublishUserInteractionRequest.validate_interaction_shapes``.
+
+        Both rules used to live only in ``precondition_checks``, which on the
+        default ``wait_for_response=False`` path runs inside a background task
+        whose result is discarded, so neither was ever reportable. Keeping them
+        here lets the request model raise a 422 on both paths while
+        ``precondition_checks`` delegates, so the two cannot diverge.
+
+        Returns:
+            str | None: A caller-facing reason, or None when acceptable.
+        """
+        if self.user_action != UserActionType.NONE and not self.user_action_description:
+            return "user_action requires a user_action_description"
+        if self.interacted_image_url and self.image_encoding:
+            return "interacted_image_url and image_encoding cannot both be set"
+        return None
+
+
+# Every field ``carries_content`` consults, in one place. The prose in the
+# error message is DERIVED from this tuple rather than hand-written beside it,
+# so adding a field to the predicate cannot leave the caller-facing list stale.
+CONTENT_BEARING_FIELD_NAMES: Final = (
+    "content",
+    "shadow_content",
+    "expert_content",
+    "interacted_image_url",
+    "image_encoding",
+    "tools_used",
+    "citations",
+    "retrieved_learnings",
+)
+
+# Request-level identifiers callers routinely duplicate onto each interaction.
+# Still stripped, but not warned about: claude-smart sends ``user_id`` on every
+# turn, so warning would emit one entry per interaction on every correct
+# publish and train operators to ignore the channel.
+_BENIGN_UNKNOWN_KEYS: Final = frozenset({"user_id", "session_id"})
+
+# How many original indices to name when reporting skipped empty rows.
+_MAX_SKIPPED_INDICES: Final = 10
+
+CONTENT_BEARING_FIELDS = (
+    f'{", ".join(CONTENT_BEARING_FIELD_NAMES)}, or a user_action other than "none"'
+)
+
 
 # publish user interaction request
 class PublishUserInteractionRequest(BaseModel):
+    # Set by ``validate_interaction_shapes`` against the caller's original
+    # list, before empty rows are filtered out; read by payload_warnings().
+    _payload_warnings: list[str] = PrivateAttr(default_factory=list)
+
     request_id: NonEmptyStr | None = None
     user_id: NonEmptyStr
     interaction_data_list: list[InteractionData] = Field(min_length=1, max_length=1_000)
@@ -736,6 +867,90 @@ class PublishUserInteractionRequest(BaseModel):
         if self.evaluation_only and not self.session_id:
             raise ValueError("evaluation_only publishes require session_id")
         return self
+
+    @model_validator(mode="after")
+    def validate_interaction_shapes(self) -> Self:
+        """Reject contradictory interactions; drop empty ones.
+
+        Runs during request parsing, so it applies on *both* the synchronous
+        and the ``wait_for_response=False`` background-task path -- unlike
+        ``precondition_checks``, whose ``success=False`` is discarded inside
+        the background task after the caller was told 200 "queued".
+
+        An individual empty interaction is **skipped, not fatal**. Making it
+        fatal was implemented and reverted: both first-party plugins append an
+        empty ``Assistant`` placeholder unconditionally, so one empty row
+        rejected the whole batch -- including the real user turn beside it --
+        and their adapters swallow the error without advancing the publish
+        watermark, retrying the same doomed batch forever. A batch where
+        *every* interaction is empty is still fatal, and that is exactly the
+        incident this validation exists for (50 of 50 rows empty).
+
+        Raises:
+            ValueError: for a contradictory interaction, or an all-empty batch.
+        """
+        for index, interaction in enumerate(self.interaction_data_list):
+            if reason := interaction.shape_error():
+                raise ValueError(f"interaction_data_list[{index}] {reason}")
+
+        # Build the warnings against the ORIGINAL list, BEFORE filtering.
+        # Computing them afterwards silently defeated the whole feature: a
+        # mis-keyed ``content`` produces an *empty* interaction, so the row
+        # carrying the typo is exactly the row that gets skipped -- its
+        # "unrecognised field Content" warning was dropped, leaving the caller
+        # with "skipped 1 empty interaction" and no idea which field was wrong.
+        # It also renumbered every surviving index, so a warning pointed at a
+        # different row than the caller sent.
+        warnings = [
+            f"interaction_data_list[{index}]: ignored unrecognised field(s)"
+            f" {summarise_unknown_names(names)}"
+            for index, interaction in enumerate(self.interaction_data_list)
+            if (names := interaction.reportable_unknown_fields())
+        ]
+
+        skipped = [
+            index
+            for index, interaction in enumerate(self.interaction_data_list)
+            if not interaction.carries_content()
+        ]
+        if len(skipped) == len(self.interaction_data_list):
+            raise ValueError(
+                "every interaction is empty: at least one must set"
+                f' "content" (or any of: {CONTENT_BEARING_FIELDS})'
+            )
+        # Cap the per-interaction warnings, THEN append the batch-level skip
+        # summary, so the cap can never drop it. Capping the combined list
+        # silently swallowed the summary whenever there were >= 20 unknown-field
+        # warnings -- and "25 interactions were dropped" is the single most
+        # important thing the caller needs to know about that batch.
+        self._payload_warnings = cap_warning_list(warnings)
+        if skipped:
+            shown = ", ".join(str(index) for index in skipped[:_MAX_SKIPPED_INDICES])
+            more = len(skipped) - min(len(skipped), _MAX_SKIPPED_INDICES)
+            self._payload_warnings.append(
+                f"skipped {len(skipped)} empty interaction(s) that carried no"
+                f" content, at index(es) {shown}{f', +{more} more' if more else ''}"
+            )
+        self.interaction_data_list = [
+            interaction
+            for interaction in self.interaction_data_list
+            if interaction.carries_content()
+        ]
+        return self
+
+    def payload_warnings(self) -> list[str]:
+        """Caller-facing warnings for anything quietly altered in the payload.
+
+        Covers unrecognised keys that were stripped and empty interactions that
+        were skipped. Indices refer to the payload **as the caller sent it**,
+        not the filtered list. Names only, sanitised and bounded -- values are
+        caller payload (the #377 redaction invariant) and names are equally
+        caller-controlled, so both volume and control characters are handled.
+
+        Returns:
+            list[str]: Bounded warnings, empty when nothing was altered.
+        """
+        return self._payload_warnings
 
     @model_validator(mode="after")
     def validate_retrieved_learnings_total(self) -> Self:

--- a/reflexio/server/api_endpoints/precondition_checks.py
+++ b/reflexio/server/api_endpoints/precondition_checks.py
@@ -1,7 +1,6 @@
 from reflexio.models.api_schema.service_schemas import (
     DeleteUserProfileRequest,
     PublishUserInteractionRequest,
-    UserActionType,
 )
 
 
@@ -27,29 +26,21 @@ def validate_publish_user_interaction_request(
     if not request.session_id or not request.session_id.strip():
         return False, "session_id is required and cannot be empty"
 
-    for interaction_data in request.interaction_data_list:
-        if (
-            interaction_data.user_action != UserActionType.NONE
-            and not interaction_data.user_action_description
-        ):
-            return False, "User action description is required for user action"
+    # Delegates to InteractionData.validation_error(), the single definition of
+    # the per-interaction rules, so this guard and PublishUserInteractionRequest's
+    # validator cannot diverge. The emptiness rule in particular used to be dead
+    # code here: it ended in `not interaction_data.user_action`, and UserActionType
+    # is a StrEnum whose NONE member is the truthy string "none", so the branch
+    # could never fire and a publish of entirely empty interactions was accepted.
+    for index, interaction_data in enumerate(request.interaction_data_list):
+        if reason := interaction_data.shape_error():
+            return False, f"interaction_data_list[{index}] {reason}"
 
-        if interaction_data.interacted_image_url and interaction_data.image_encoding:
-            return (
-                False,
-                "Image encoding and interacted image url cannot be provided together",
-            )
-
-        if (
-            not interaction_data.content
-            and not interaction_data.interacted_image_url
-            and not interaction_data.image_encoding
-            and not interaction_data.user_action
-        ):
-            return (
-                False,
-                "Text interaction, interacted image url, image encoding, and user action cannot be all empty",
-            )
+    # An individual empty interaction is skipped by the request model, not
+    # rejected (plugins emit empty placeholder turns). Only a wholly empty
+    # batch -- the original incident -- is fatal.
+    if not any(x.carries_content() for x in request.interaction_data_list):
+        return False, "every interaction is empty"
 
     return True, ""
 

--- a/reflexio/server/routes/interactions.py
+++ b/reflexio/server/routes/interactions.py
@@ -1,6 +1,7 @@
 """Interaction route handlers (extracted from api.py, Tier3 A2)."""
 
 import logging
+import sys
 import uuid
 from typing import TYPE_CHECKING
 
@@ -15,6 +16,7 @@ from fastapi import (
     Request,
 )
 
+from reflexio.models.api_schema.common import sanitise_for_log
 from reflexio.models.api_schema.retriever_schema import (
     GetInteractionsRequest,
     GetInteractionsViewResponse,
@@ -68,11 +70,23 @@ def publish_user_interaction(
     wait_for_response: bool = False,
     _gate: None = Depends(default_billing_gate("learnings_generated")),  # noqa: B008
 ) -> PublishUserInteractionResponse:
+    # Unrecognised keys are dropped rather than rejected (see InteractionData's
+    # model_config). Tell the caller on the response and record it server-side,
+    # so a mis-keyed field is visible instead of silently losing data. Names
+    # only -- values are caller payload.
+    payload_warnings = payload.payload_warnings()
+    if payload_warnings:
+        logger.warning(
+            "Publish for org %s altered the payload: %s",
+            org_id,
+            "; ".join(payload_warnings),
+        )
+
     if wait_for_response:
         # Sync callers wait for the real result, so preserve bounded backpressure
         # before any storage side effects. The inner service limiter is disabled
         # because this route already owns the publish slot.
-        return _run_limited_api(
+        sync_response = _run_limited_api(
             org_id,
             "publish",
             lambda: publisher_api.add_user_interaction(
@@ -81,6 +95,8 @@ def publish_user_interaction(
                 use_publish_limiter=False,
             ),
         )
+        sync_response.warnings = [*sync_response.warnings, *payload_warnings]
+        return sync_response
 
     # Resolve the request_id BEFORE backgrounding so we can return it to the
     # caller for polling. GenerationService uses a caller-supplied request_id
@@ -89,16 +105,53 @@ def publish_user_interaction(
     # id we hand back here.
     request_id = payload.request_id or str(uuid.uuid4())
     payload.request_id = request_id
+    # request_id is caller-supplied (NonEmptyStr: no length cap, no character
+    # restrictions) and is logged below at ERROR, which Sentry ingests as an
+    # event body. A newline in it would forge a line in a shared multi-tenant
+    # log stream -- the same hazard as the unknown field names.
+    safe_request_id = sanitise_for_log(request_id)
 
     def _publish_task() -> None:
         try:
-            publisher_api.add_user_interaction(
+            response = publisher_api.add_user_interaction(
                 org_id=org_id,
                 request=payload,
                 defer_learning=True,
             )
+            # The caller was already handed 200 "queued" below, so a
+            # ``success=False`` return here is otherwise invisible -- it is not
+            # an exception, so the handler underneath never sees it. Log it, or
+            # a rejected publish looks identical to an accepted one from both
+            # ends. Per-interaction shape problems are already caught as a 422
+            # by PublishUserInteractionRequest's validators; this covers
+            # whatever else add_user_interaction can refuse.
+            #
+            # Deliberately NOT logging ``response.message``: on the storage
+            # path it is ``str(e)`` from a catch-all (lib/_interactions.py), an
+            # unbounded exception string with no content-freeness guarantee,
+            # and Sentry ingests ERROR records as event bodies without
+            # scrubbing them. #377 established that such messages must be
+            # content-free by construction, so log a bounded shape instead.
+            if not response.success:
+                logger.error(
+                    "Background publish rejected for org %s (request_id=%s):"
+                    " %d-char reason withheld (may contain Customer Content)",
+                    org_id,
+                    safe_request_id,
+                    len(response.message or ""),
+                )
         except Exception:
-            logger.exception("Background publish failed for org %s", org_id)
+            # Same content-freeness problem as response.message above: an
+            # exception string (and its traceback locals) has no guarantee of
+            # being free of Customer Content, and Sentry ingests this as an
+            # event body. Log the type, not the message.
+            logger.error(
+                "Background publish failed for org %s (request_id=%s):"
+                " %s (detail withheld, may contain Customer Content)",
+                org_id,
+                safe_request_id,
+                type(sys.exc_info()[1]).__name__,
+            )
 
     # Run in background — caller gets immediate acknowledgement.
     # learning_status="deferred" tells the caller that extraction has not yet
@@ -110,6 +163,7 @@ def publish_user_interaction(
         message="Interaction queued for processing",
         request_id=request_id,
         learning_status="deferred",
+        warnings=payload_warnings,
     )
 
 

--- a/tests/cli/test_helpers.py
+++ b/tests/cli/test_helpers.py
@@ -84,6 +84,34 @@ class TestInteractionsFromPayload:
         result = _interactions_from_payload(payload)
         assert result[0].role == "User"
 
+    def test_misspelled_field_is_recorded_not_silently_dropped(self) -> None:
+        """A typo'd key in a user's JSON file must be traceable.
+
+        ``InteractionData`` defaults every field, so a mis-keyed ``content``
+        used to yield an interaction with ``content=''`` and the CLI cheerfully
+        published empty rows with nothing to debug. Unknown keys are still
+        dropped (forbidding them wedged the first-party plugins), but their
+        names are now recorded so a caller can be told.
+        """
+        payload = {
+            "interactions": [{"role": "user", "content": "hi", "Content": "typo"}]
+        }
+        interactions = _interactions_from_payload(payload)
+        assert interactions[0].unknown_field_names() == ["Content"]
+
+    def test_wholly_miskeyed_interaction_is_flagged_as_empty(self) -> None:
+        """A fully unbound interaction is detectably empty before publish.
+
+        ``_interactions_from_payload`` builds ``InteractionData`` directly, so
+        the request-level validator has not run yet; the client raises on it
+        later when it builds ``PublishUserInteractionRequest``. What matters
+        here is that the parsed object is not mistaken for valid content.
+        """
+        payload = {"interactions": [{"Content": "everything mis-keyed"}]}
+        interaction = _interactions_from_payload(payload)[0]
+        assert interaction.carries_content() is False
+        assert interaction.shape_error() is None  # not contradictory, just empty
+
     def test_tools_used_preserved(self) -> None:
         """Structured tools_used metadata survives the CLI adapter so the
         server renderer can emit `[used tool: ...]` markers for playbook

--- a/tests/client/test_publish_interaction.py
+++ b/tests/client/test_publish_interaction.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from reflexio.client import ReflexioClient
+from reflexio.models.api_schema.service_schemas import (
+    PublishUserInteractionRequest,
+)
 
 
 @patch("reflexio.client.client.requests.Session")
@@ -36,3 +39,65 @@ def test_publish_interaction_rejects_blank_session_id(mock_session_class):
         )
 
     mock_session.request.assert_not_called()
+
+
+@patch("reflexio.client.client.requests.Session")
+def test_publish_interaction_surfaces_locally_dropped_field_warnings(
+    mock_session_class,
+):
+    """SDK callers must see unrecognised-field warnings.
+
+    ``publish_interaction`` builds ``InteractionData`` before
+    ``request.model_dump()``, which strips unknown keys — so the payload the
+    server receives is already clean and it cannot echo what it never saw.
+    Without merging the locally-detected warnings, a mis-keyed field was
+    reported over raw HTTP but completely invisible through the client, which
+    is the primary integration path.
+    """
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    mock_session.request.return_value.status_code = 200
+    mock_session.request.return_value.json.return_value = {
+        "success": True,
+        "message": "Interaction queued for processing",
+    }
+    client = ReflexioClient(api_key="test_key")
+
+    result = client.publish_interaction(
+        user_id="user",
+        interactions=[{"content": "real turn", "Content": "typo"}],
+        session_id="s",
+    )
+
+    assert any("Content" in warning for warning in result.warnings), result.warnings
+    # Names only — the value is caller payload and must not be echoed.
+    assert not any("typo" in warning for warning in result.warnings), result.warnings
+
+
+@patch("reflexio.client.client.requests.Session")
+def test_wire_payload_carries_no_unknown_keys(mock_session_class):
+    """Pin the premise the client-side merge depends on.
+
+    The merge is only correct because unknown keys never reach the server, so
+    the server cannot report them too. If that ever changes — the strip in
+    ``CapturesUnknownFields`` removed, ``model_dump()`` made to include extras,
+    ``revalidate_instances`` set — every warning would silently double, and the
+    merge has no dedup. Assert the invariant directly rather than relying on it.
+    """
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    mock_session.request.return_value.status_code = 200
+    mock_session.request.return_value.json.return_value = {"success": True}
+    client = ReflexioClient(api_key="test_key")
+
+    client.publish_interaction(
+        user_id="user",
+        interactions=[{"content": "real", "Content": "typo"}],
+        session_id="s",
+    )
+
+    sent = mock_session.request.call_args.kwargs["json"]
+    assert "Content" not in str(sent)
+    # Re-parse exactly what the route would parse: it must find nothing to warn about.
+    reparsed = PublishUserInteractionRequest(**sent)
+    assert reparsed.payload_warnings() == []

--- a/tests/models/api_schema/test_plugin_wire_contract.py
+++ b/tests/models/api_schema/test_plugin_wire_contract.py
@@ -1,0 +1,62 @@
+"""The bundled openclaw plugin's wire allowlist must track InteractionData.
+
+The plugin builds its publish payload from a literal frozenset of field names
+rather than importing the model, so the module keeps no runtime dependency on
+``reflexio``. That literal can drift.
+
+This guard lives in ``tests/`` deliberately. The plugin has its own suite under
+``reflexio/integrations/openclaw/plugin/tests/``, but ``testpaths = ["tests"]``
+in pyproject.toml means the root pytest run never collects it and no CI workflow
+invokes it — so an equivalent assertion there would only ever run when someone
+remembered to call it by hand with ``PYTHONPATH`` set. A drift guard that does
+not execute is not a guard.
+
+The plugin's own suite keeps its round-trip test (it needs the real slicer);
+what must be pinned *here* is the field list, because that is what breaks
+silently when a field is added to or renamed on the model.
+"""
+
+import sys
+from pathlib import Path
+
+from reflexio.models.api_schema.domain.entities import InteractionData
+
+_THIS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _THIS_DIR.parents[2]  # tests/models/api_schema/ -> repo root
+_PLUGIN_SRC = _REPO_ROOT / "reflexio" / "integrations" / "openclaw" / "plugin" / "src"
+
+
+def _plugin_allowlist() -> set[str]:
+    """Import the bundled plugin's wire allowlist.
+
+    The path is inside this repo, so this resolves deterministically — no
+    ``importorskip``, because a skip here would silently disable the guard.
+    """
+    if str(_PLUGIN_SRC) not in sys.path:
+        sys.path.insert(0, str(_PLUGIN_SRC))
+    from openclaw_smart import state
+
+    return set(state._INTERACTION_DATA_FIELDS)
+
+
+def test_plugin_src_is_where_this_test_expects() -> None:
+    """Fail loudly if the plugin moves, rather than skipping the real check."""
+    assert (_PLUGIN_SRC / "openclaw_smart" / "state.py").is_file(), (
+        f"plugin source not found at {_PLUGIN_SRC}; update this guard"
+    )
+
+
+def test_plugin_allowlist_matches_interaction_data_fields() -> None:
+    """A field added to or renamed on the model must be mirrored in the plugin.
+
+    Without this, a new field is silently stripped from every plugin publish —
+    the same class of silent data loss the surrounding validation exists to
+    surface.
+    """
+    model_fields = set(InteractionData.model_fields)
+    allowlist = _plugin_allowlist()
+    assert allowlist == model_fields, (
+        f"plugin allowlist drifted from InteractionData:"
+        f" missing={sorted(model_fields - allowlist)}"
+        f" extra={sorted(allowlist - model_fields)}"
+    )

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -51,17 +51,18 @@ class TestPublishInteraction:
 
     @staticmethod
     def _publish_payload():
+        # Every key inside interaction_data_list must be a real InteractionData
+        # field. This fixture previously sent user_message/agent_message/
+        # interaction_type -- none of which exist on the model -- so it posted
+        # an interaction that bound to nothing and stored content=''. It still
+        # asserted 200, which is exactly the silent failure this suite now
+        # guards against.
         return {
             "user_id": "user-1",
             "session_id": "sess-1",
             "interaction_data_list": [
-                {
-                    "user_id": "user-1",
-                    "session_id": "sess-1",
-                    "interaction_type": "conversation",
-                    "user_message": "Hello",
-                    "agent_message": "Hi there!",
-                }
+                {"role": "User", "content": "Hello"},
+                {"role": "Agent", "content": "Hi there!"},
             ],
         }
 
@@ -105,6 +106,90 @@ class TestPublishInteraction:
         data = response.json()
         assert data["success"] is True
         assert "queued" in data["message"].lower()
+
+    def test_async_publish_rejects_contentless_interactions(
+        self, client, patched_reflexio
+    ):
+        """A contentless publish must 422 on the async path too.
+
+        This is the regression that matters most: the async path returns 200
+        "queued" before the publisher runs, and discards the publisher's result,
+        so a rejection there is invisible to the caller. Validating on the
+        request model is what makes this path fail loudly. Previously this
+        returned 200 and silently stored rows with content=''.
+        """
+        payload = self._publish_payload()
+        payload["interaction_data_list"] = [{"role": "User"}]
+        response = client.post("/api/publish_interaction", json=payload)
+        assert response.status_code == 422
+        assert "is empty" in response.text
+
+    def test_async_publish_warns_on_unknown_interaction_field(
+        self, client, patched_reflexio
+    ):
+        """A mis-keyed field is accepted but reported, never silently dropped.
+
+        Asserts structurally rather than on a substring of ``response.text``:
+        the whole request body is echoed inside a 422's ``input``, so a
+        substring check like ``"Content" in response.text`` passes even when
+        the unknown-field handling is removed entirely. That false-pass was
+        demonstrated by mutation-testing an earlier revision of this test.
+        """
+        payload = self._publish_payload()
+        payload["interaction_data_list"] = [
+            {"role": "User", "content": "hi", "Content": "typo"}
+        ]
+        response = client.post("/api/publish_interaction", json=payload)
+        assert response.status_code == 200
+        warnings = response.json()["warnings"]
+        assert any("Content" in w for w in warnings), warnings
+        # Names only -- never the value.
+        assert not any("typo" in w for w in warnings), warnings
+
+    def test_async_publish_accepts_plugin_wire_shape(self, client, patched_reflexio):
+        """Regression: a request-level key on an interaction must not break.
+
+        Both first-party plugins build their wire payload with a denylist, so
+        every turn carries ``user_id``. Forbidding unknown keys wedged them
+        into a silent retry loop that never published again.
+        """
+        payload = self._publish_payload()
+        payload["interaction_data_list"] = [
+            {"role": "User", "content": "how do I do X?", "user_id": "proj-a"}
+        ]
+        response = client.post("/api/publish_interaction", json=payload)
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_background_publish_rejection_is_logged(
+        self, client, patched_reflexio, caplog
+    ):
+        """A discarded background ``success=False`` must leave a trace.
+
+        The async path hands the caller 200 "queued" and throws the publisher's
+        return value away, so this log line is the only evidence a rejected
+        publish ever produces. The reason string is deliberately withheld -- it
+        can be an unbounded ``str(e)`` and Sentry ingests ERROR bodies unscrubbed.
+        """
+        import logging
+
+        with (
+            patch(
+                "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
+                return_value=PublishUserInteractionResponse(
+                    success=False, message="CUSTOMER-SECRET-XYZ"
+                ),
+            ),
+            caplog.at_level(
+                logging.ERROR, logger="reflexio.server.routes.interactions"
+            ),
+        ):
+            response = client.post(
+                "/api/publish_interaction", json=self._publish_payload()
+            )
+        assert response.status_code == 200
+        assert "Background publish rejected" in caplog.text
+        assert "CUSTOMER-SECRET-XYZ" not in caplog.text
 
     def test_async_publish_does_not_gate_durable_write_on_limiter(
         self, client, patched_reflexio

--- a/tests/server/api_endpoints/test_precondition_checks.py
+++ b/tests/server/api_endpoints/test_precondition_checks.py
@@ -1,3 +1,4 @@
+from reflexio.models.api_schema.common import ToolUsed
 from reflexio.models.api_schema.service_schemas import (
     DeleteUserProfileRequest,
     InteractionData,
@@ -13,17 +14,15 @@ from reflexio.server.api_endpoints.precondition_checks import (
 def _make_publish_request(
     interactions: list[InteractionData] | None = None,
 ) -> PublishUserInteractionRequest:
-    if interactions is not None:
-        return PublishUserInteractionRequest(
-            user_id="test-user",
-            session_id="test-session",
-            interaction_data_list=interactions,
-        )
-    # Bypass Pydantic min_length=1 validation to test the precondition check
+    # Always ``model_construct``: these tests exercise the precondition guard
+    # in isolation, and that guard exists specifically to cover callers that
+    # bypass Pydantic. Building a validated request here would instead trip
+    # ``PublishUserInteractionRequest``'s own validators (min_length=1, and the
+    # contentless-interaction rule), so the guard itself would never be reached.
     return PublishUserInteractionRequest.model_construct(
         user_id="test-user",
         session_id="test-session",
-        interaction_data_list=[],
+        interaction_data_list=interactions if interactions is not None else [],
     )
 
 
@@ -43,7 +42,7 @@ class TestValidatePublishUserInteractionRequest:
         request = _make_publish_request([interaction])
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
-        assert msg == "User action description is required for user action"
+        assert "user_action_description" in msg
 
     def test_empty_session_id(self):
         request = PublishUserInteractionRequest.model_construct(
@@ -64,14 +63,16 @@ class TestValidatePublishUserInteractionRequest:
         request = _make_publish_request([interaction])
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
-        assert (
-            msg == "Image encoding and interacted image url cannot be provided together"
-        )
+        assert "cannot both be set" in msg
 
-    def test_all_fields_empty_with_none_action_passes(self):
-        # UserActionType.NONE is "none" (truthy), so the "all empty" branch
-        # in the source is unreachable via normal model construction.
-        # With NONE, the validator considers user_action as present and passes.
+    def test_all_fields_empty_with_none_action_is_rejected(self):
+        # Regression: this branch MUST be reachable. It previously could not
+        # fire, because ``UserActionType`` is a ``StrEnum`` with NONE = "none"
+        # — a truthy string — so the old ``not interaction_data.user_action``
+        # test was always False and the whole "all empty" chain was dead code.
+        # A publish of 50 such interactions was accepted with 200 and stored 50
+        # rows with content='', which silently produced no learnings at all.
+        # The comparison must be ``!= UserActionType.NONE``, never truthiness.
         interaction = InteractionData(
             content="",
             interacted_image_url="",
@@ -80,8 +81,57 @@ class TestValidatePublishUserInteractionRequest:
         )
         request = _make_publish_request([interaction])
         valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is False
+        assert "is empty" in msg
+
+    def test_tools_used_only_is_accepted(self):
+        # A tool-call-only agent turn carries real information. Making the
+        # emptiness guard live against its original narrow field list (content
+        # / image_url / image_encoding / user_action) would have started
+        # rejecting these, so the predicate must consider tools_used too.
+        interaction = InteractionData(
+            content="",
+            tools_used=[ToolUsed(tool_name="search", tool_data={"query": "x"})],
+        )
+        request = _make_publish_request([interaction])
+        valid, msg = validate_publish_user_interaction_request(request)
         assert valid is True
         assert msg == ""
+
+    def test_shadow_content_only_is_accepted(self):
+        interaction = InteractionData(content="", shadow_content="shadow variant")
+        request = _make_publish_request([interaction])
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is True
+        assert msg == ""
+
+    def test_expert_content_only_is_accepted(self):
+        interaction = InteractionData(content="", expert_content="expert answer")
+        request = _make_publish_request([interaction])
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is True
+        assert msg == ""
+
+    def test_contentless_interaction_among_real_turns_is_allowed(self):
+        # An empty row beside real turns is skipped by the request model, not
+        # rejected -- plugins append empty placeholder turns unconditionally,
+        # and failing the batch wedged them into a permanent retry loop.
+        request = _make_publish_request(
+            [
+                InteractionData(content="real turn"),
+                InteractionData(),
+                InteractionData(content="another real turn"),
+            ]
+        )
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is True
+        assert msg == ""
+
+    def test_wholly_empty_batch_is_rejected(self):
+        request = _make_publish_request([InteractionData(), InteractionData()])
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is False
+        assert "every interaction is empty" in msg
 
     def test_valid_with_content(self):
         interaction = InteractionData(content="hello world")
@@ -127,7 +177,7 @@ class TestValidatePublishUserInteractionRequest:
         request = _make_publish_request([good, bad])
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
-        assert msg == "User action description is required for user action"
+        assert "user_action_description" in msg
 
 
 class TestValidateDeleteUserProfileRequest:

--- a/tests/server/api_endpoints/test_publish_validation.py
+++ b/tests/server/api_endpoints/test_publish_validation.py
@@ -1,0 +1,367 @@
+"""Boundary validation for publish payloads.
+
+Regression suite for a class of silent data loss: a publish whose interaction
+objects never bound was accepted with 200 and stored rows with ``content=''``,
+producing no learnings and no error anywhere. Three defects combined to hide it:
+
+1. Every ``InteractionData`` field has a default and unknown keys were ignored
+   with no trace, so a mis-keyed ``content`` yielded a valid empty interaction.
+2. The precondition guard meant to catch empty interactions was dead code
+   (truthiness test against a truthy ``StrEnum`` member).
+3. On the default async path the precondition result is discarded entirely.
+
+The per-interaction rules therefore live on the request model, which is the
+only layer that fires on both the sync and the background-task path. Unknown
+keys are *warned*, not rejected -- see ``InteractionData.model_config`` for why
+forbidding them was tried and reverted.
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from reflexio.models.api_schema.common import ToolUsed
+from reflexio.models.api_schema.domain.entities import (
+    CONTENT_BEARING_FIELD_NAMES,
+    Citation,
+    RetrievedLearning,
+)
+from reflexio.models.api_schema.domain.enums import UserActionType
+from reflexio.models.api_schema.service_schemas import (
+    InteractionData,
+    PublishUserInteractionRequest,
+)
+
+# One populated sample per content-bearing field. Keyed by field name so the
+# acceptance test below can be driven from CONTENT_BEARING_FIELD_NAMES itself:
+# adding a field to the predicate without covering it here fails collection,
+# which is how `citations` and `retrieved_learnings` previously went untested.
+_CONTENT_SAMPLES: dict[str, Any] = {
+    "content": "hello",
+    "shadow_content": "shadow variant",
+    "expert_content": "expert answer",
+    "interacted_image_url": "https://example.com/i.png",
+    "image_encoding": "base64data",
+    "tools_used": [ToolUsed(tool_name="search", tool_data={"q": "x"})],
+    "citations": [Citation(kind="profile", real_id="p-1")],
+    "retrieved_learnings": [RetrievedLearning(kind="profile", learning_id="p-1")],
+}
+
+
+def _publish(
+    interactions: list[InteractionData] | list[dict[str, Any]],
+) -> PublishUserInteractionRequest:
+    return PublishUserInteractionRequest.model_validate(
+        {
+            "user_id": "test-user",
+            "session_id": "test-session",
+            "interaction_data_list": interactions,
+        }
+    )
+
+
+class TestUnknownFieldsWarned:
+    """Unknown keys are dropped as before, but no longer silently.
+
+    Forbidding them was tried and reverted: the first-party plugins build their
+    wire payload with a denylist, so every turn carries request-level keys such
+    as ``user_id``. Rejecting those wedged the plugins into a silent retry loop.
+    """
+
+    def test_miskeyed_content_is_recorded_not_silently_dropped(self):
+        interaction = InteractionData.model_validate(
+            {"content": "real text", "Content": "an important user preference"}
+        )
+        assert interaction.unknown_field_names() == ["Content"]
+
+    def test_unknown_key_does_not_leak_into_model_dump(self):
+        # ``extra="allow"`` is only a means of seeing the key; it must not
+        # travel onward into storage or a re-serialised client request.
+        interaction = InteractionData.model_validate(
+            {"content": "real text", "Content": "x"}
+        )
+        assert "Content" not in interaction.model_dump()
+
+    def test_request_surfaces_warning_naming_the_field(self):
+        request = _publish([{"content": "real", "Content": "typo"}])
+        assert request.payload_warnings() == [
+            "interaction_data_list[0]: ignored unrecognised field(s) Content"
+        ]
+
+    def test_warning_names_the_key_but_never_its_value(self):
+        # The value is caller payload -- potentially Customer Content -- and
+        # must not reach a log or a response body (invariant from #377).
+        request = _publish([{"content": "real", "Content": "SECRET-VALUE-XYZ"}])
+        assert "SECRET-VALUE-XYZ" not in " ".join(request.payload_warnings())
+
+    def test_clean_payload_produces_no_warnings(self):
+        assert _publish([{"role": "User", "content": "hello"}]).payload_warnings() == []
+
+    def test_plugin_wire_shape_is_accepted(self):
+        # Regression for the P1 that reverted ``extra="forbid"``: both plugins
+        # build the wire dict with a denylist, so every turn carries a
+        # request-level ``user_id``. Rejecting it made the adapter swallow the
+        # error and never advance its watermark -- publishing stopped forever.
+        request = _publish(
+            [{"content": "how do I do X?", "user_id": "proj-a", "role": "User"}]
+        )
+        assert request.interaction_data_list[0].content == "how do I do X?"
+
+    def test_correctly_keyed_payload_still_binds(self):
+        # Send a NON-default role: asserting role == "User" could not tell a
+        # bound value from the schema default, which is the very tell-tale that
+        # exposed the original bug.
+        request = _publish([{"role": "Agent", "content": "hello"}])
+        assert request.interaction_data_list[0].content == "hello"
+        assert request.interaction_data_list[0].role == "Agent"
+
+
+class TestEmptyInteractions:
+    """Empty rows are skipped; only a wholly empty batch is fatal.
+
+    Making a single empty row fatal was implemented and reverted: both
+    first-party plugins append an empty ``Assistant`` placeholder
+    unconditionally, so one empty row rejected the batch containing the real
+    user turn, and their adapters swallow the error without advancing the
+    publish watermark -- retrying the same doomed batch forever.
+    """
+
+    def test_all_empty_batch_is_rejected(self):
+        # The actual production incident: 50 of 50 rows carried nothing.
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([{} for _ in range(50)])
+
+    def test_single_empty_interaction_is_rejected_because_it_is_the_whole_batch(self):
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([InteractionData()])
+
+    def test_whitespace_only_content_does_not_count(self):
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([{"content": "   \n\t "}])
+
+    def test_user_action_none_does_not_count_as_content(self):
+        # UserActionType.NONE is the truthy string "none"; treating it as
+        # content is the dead-guard bug this suite exists for.
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([{"user_action": "none"}])
+
+    def test_empty_row_beside_a_real_turn_is_skipped_not_fatal(self):
+        # Regression for the plugin wedge: the real turn must still publish.
+        request = _publish(
+            [{"role": "User", "content": "REAL"}, {"role": "Assistant", "content": ""}]
+        )
+        assert [i.content for i in request.interaction_data_list] == ["REAL"]
+        assert any("skipped 1 empty" in w for w in request.payload_warnings())
+
+    def test_skip_is_reported_with_a_count(self):
+        request = _publish([{"content": "a"}, {}, {}, {"content": "b"}])
+        assert len(request.interaction_data_list) == 2
+        assert any("skipped 2 empty" in w for w in request.payload_warnings())
+
+
+class TestSiblingRulesEnforcedAtBoundary:
+    """The other two per-interaction rules must 422 too.
+
+    They previously lived only in ``precondition_checks``, whose result is
+    discarded on the async path -- so they returned 200 "queued" and then
+    silently refused the write.
+    """
+
+    def test_user_action_without_description_is_rejected(self):
+        with pytest.raises(ValidationError, match="user_action_description"):
+            _publish([{"content": "hi", "user_action": "click"}])
+
+    def test_image_url_and_encoding_together_is_rejected(self):
+        with pytest.raises(ValidationError, match="cannot both be set"):
+            _publish(
+                [
+                    {
+                        "interacted_image_url": "https://example.com/i.png",
+                        "image_encoding": "base64data",
+                    }
+                ]
+            )
+
+
+class TestLegitimateTurnsStillAccepted:
+    """Guards against over-rejecting: these all carry real information."""
+
+    def test_content_bearing_field_set_is_pinned(self):
+        """Pin the SET, not just iterate it.
+
+        The parametrize below is driven by CONTENT_BEARING_FIELD_NAMES, so
+        deleting a field from that tuple silently deletes its own coverage --
+        a mutation dropping `citations` and `retrieved_learnings` killed zero
+        tests. This assertion is the independent anchor: narrowing the
+        predicate now fails here.
+        """
+        assert set(CONTENT_BEARING_FIELD_NAMES) == {
+            "content",
+            "shadow_content",
+            "expert_content",
+            "interacted_image_url",
+            "image_encoding",
+            "tools_used",
+            "citations",
+            "retrieved_learnings",
+        }
+
+    @pytest.mark.parametrize("field_name", CONTENT_BEARING_FIELD_NAMES)
+    def test_each_content_bearing_field_alone_is_accepted(self, field_name: str):
+        # Driven from the predicate's own field tuple, so a field can never be
+        # added to `carries_content()` without acceptance coverage.
+        assert field_name in _CONTENT_SAMPLES, (
+            f"{field_name} is content-bearing but has no sample here"
+        )
+        request = _publish([{field_name: _CONTENT_SAMPLES[field_name]}])
+        assert len(request.interaction_data_list) == 1
+
+    def test_user_action_with_description_is_accepted(self):
+        request = _publish(
+            [
+                {
+                    "user_action": UserActionType.CLICK,
+                    "user_action_description": "clicked submit",
+                }
+            ]
+        )
+        assert len(request.interaction_data_list) == 1
+
+    def test_real_conversation_is_accepted(self):
+        request = _publish(
+            [
+                {"role": "User", "content": "I prefer Postgres over MySQL."},
+                {"role": "Agent", "content": "Noted, I'll target Postgres."},
+            ]
+        )
+        assert len(request.interaction_data_list) == 2
+
+
+class TestWarningsAreComputedBeforeFiltering:
+    """Warnings must describe the payload the CALLER sent.
+
+    Regression: warnings were originally computed after empty rows were
+    filtered out, which silently defeated the feature in its primary case --
+    a mis-keyed ``content`` yields an *empty* interaction, so the row carrying
+    the typo was exactly the row removed, and its warning vanished. Surviving
+    indices were renumbered too, pointing at a different row than was sent.
+    """
+
+    def test_miskeyed_content_on_an_otherwise_empty_row_is_still_reported(self):
+        request = _publish([{"content": "real"}, {"Content": "IMPORTANT"}])
+        assert any("Content" in w for w in request.payload_warnings()), (
+            request.payload_warnings()
+        )
+
+    def test_reported_index_matches_what_the_caller_sent(self):
+        # The caller put "Oops" at index 1; index 0 is empty and gets skipped.
+        request = _publish([{}, {"content": "real", "Oops": "typo"}])
+        assert any(
+            "interaction_data_list[1]" in w and "Oops" in w
+            for w in request.payload_warnings()
+        ), request.payload_warnings()
+
+    def test_skip_warning_names_the_original_indices(self):
+        request = _publish([{"content": "a"}, {}, {"content": "b"}, {}])
+        skip = next(w for w in request.payload_warnings() if "skipped" in w)
+        assert "1, 3" in skip, skip
+
+
+class TestWarningsAreBoundedAndSafe:
+    """Unknown key names are caller data: bound them and strip control chars."""
+
+    def test_control_characters_cannot_forge_log_lines(self):
+        request = _publish([{"content": "x", "ev\nFAKE LOG LINE": "v"}])
+        joined = " ".join(request.payload_warnings())
+        assert "\n" not in joined
+        assert "?" in joined
+
+    def test_total_warning_volume_is_capped(self):
+        # Per-name caps alone do not bound the total: interaction_data_list
+        # permits 1000 entries, which totalled ~350 KB before this cap.
+        request = _publish(
+            [{"content": f"t{i}", ("k" * 300) + str(i): "v"} for i in range(1000)]
+        )
+        warnings = request.payload_warnings()
+        assert len(warnings) <= 21, len(warnings)
+        assert sum(len(w) for w in warnings) < 10_000
+        assert "more interaction(s)" in warnings[-1]
+
+    def test_long_key_names_are_truncated(self):
+        request = _publish([{"content": "x", "k" * 500: "v"}])
+        assert all(len(w) < 300 for w in request.payload_warnings())
+
+    def test_skip_summary_survives_the_entry_cap(self):
+        # The batch-level "N interactions were dropped" fact must never be the
+        # thing the cap discards -- it is more important than the 20th
+        # per-interaction field warning. Capping the combined list swallowed it
+        # whenever there were >= 20 unknown-field warnings.
+        request = _publish(
+            [{f"Bad{i}": "v"} for i in range(25)] + [{"content": "real"}]
+        )
+        warnings = request.payload_warnings()
+        assert any("skipped 25 empty" in w for w in warnings), warnings
+        assert len(warnings) <= 22, len(warnings)
+
+
+class TestToolStatusIsCaptured:
+    """``ToolUsed.status`` is real signal, not an unknown key.
+
+    Both first-party plugins derive "success"/"error" from the tool response and
+    send it on every tool entry. It was silently discarded, which made it both
+    lost data and the largest single source of unknown-field warnings once
+    nested capture began reporting it.
+    """
+
+    def test_status_binds_and_produces_no_warning(self):
+        request = _publish(
+            [{"content": "x", "tools_used": [{"tool_name": "Bash", "status": "error"}]}]
+        )
+        assert request.interaction_data_list[0].tools_used[0].status == "error"
+        assert request.payload_warnings() == []
+
+    def test_genuinely_unknown_nested_key_still_warns(self):
+        request = _publish(
+            [{"content": "x", "tools_used": [{"tool_name": "Bash", "stat": "typo"}]}]
+        )
+        assert any("tools_used[0].stat" in w for w in request.payload_warnings()), (
+            request.payload_warnings()
+        )
+
+
+class TestLogSafety:
+    """Caller-controlled values must not be able to forge log lines."""
+
+    def test_request_id_control_characters_are_neutralised(self):
+        from reflexio.models.api_schema.common import sanitise_for_log
+
+        forged = "ok\nERROR Background publish rejected for org 99: FAKE"
+        assert "\n" not in sanitise_for_log(forged)
+
+    def test_request_id_length_is_bounded(self):
+        from reflexio.models.api_schema.common import sanitise_for_log
+
+        # request_id is NonEmptyStr: no length cap on the model, so the log
+        # site must impose one.
+        assert len(sanitise_for_log("z" * 5000)) < 100
+
+    @pytest.mark.parametrize(
+        "bad_status",
+        [1, None, True, {"a": 1}, "a" * 101],
+        ids=["int", "none", "bool", "dict", "over-long"],
+    )
+    def test_out_of_contract_status_never_rejects_the_batch(self, bad_status):
+        """Declaring a field must not smuggle in the strictness we rejected.
+
+        A strictly-typed `status` turned five previously-harmless values into a
+        422 for the WHOLE publish. The plugin adapters swallow that and never
+        advance their watermark, so the same batch retries forever — the exact
+        failure `extra="allow"` exists to avoid.
+        """
+        request = _publish(
+            [{"content": "x", "tools_used": [{"tool_name": "B", "status": bad_status}]}]
+        )
+        stored = request.interaction_data_list[0].tools_used[0].status
+        assert isinstance(stored, str)
+        assert len(stored) <= 100


### PR DESCRIPTION
## The bug

A publish of 50 interactions returned **200 OK** and stored 50 rows with `content = ''`. No profiles were generated, and nothing on any layer reported a problem. Fleet-wide check: exactly one org affected; every other org with interactions had zero empty content and non-zero profiles. A validation gap, not a pipeline bug.

## Three defects combined to hide it

**1. Unknown keys vanished without trace.** Every `InteractionData` field has a default, so a mis-keyed field produced a *valid* interaction carrying nothing. The tell-tale in storage: `role` came back as the literal default `"User"` though `"user"` was sent. **When a field you set reads back as its default, nothing in that object bound.**

**2. The guard written for exactly this case was dead code.** `UserActionType` is a `StrEnum` whose `NONE` member is the truthy string `"none"`, so `not interaction_data.user_action` was always `False` and the four-way "all empty" chain could never fire:

```
bool(UserActionType.NONE) = True
validate_publish_user_interaction_request(50 empty) -> (True, '')
```

Ten lines above, the same function already used the correct `!= UserActionType.NONE`. It survived because **a test pinned it** — `test_all_fields_empty_with_none_action_passes` diagnosed the dead branch in its own comment, then asserted `valid is True`. Now inverted.

**3. On the async path the rejection is discarded.** `add_user_interaction` runs in a `BackgroundTask` whose return value was dropped, after the caller already got `200 "queued"`. A `success=False` isn't an exception, so it wasn't logged either.

## The fix

The per-interaction rules live in a `model_validator` on `PublishUserInteractionRequest` — it runs during request parsing, so it 422s on **both** the sync and background-task path.

`InteractionData.validation_error()` holds **all three** per-interaction rules in one place and `precondition_checks` delegates to it. That closes the class: the other two rules (`user_action` needs a description; `interacted_image_url` xor `image_encoding`) previously existed *only* on the discarded path, so they returned 200 and then silently refused the write.

`carries_content()` counts every content-bearing field — `tools_used`, shadow/expert content, `citations`, `retrieved_learnings` — because a narrower list would reject legitimate tool-call-only and shadow-mode turns. Text is stripped, so `"   "` is not content.

## `extra="forbid"` was implemented, then reverted — this is the important part

The first revision forbade unknown keys. Review reproduced that this **breaks 100% of publishes from both first-party plugins**, and does so in the worst possible way.

Both plugins build their wire payload with a **denylist** (drop three known keys, pass the rest through), so every turn carries request-level bookkeeping such as `user_id`:

```python
turn = {k: v for k, v in rec.items() if k not in {"role", "ts", "cited_items"}}
```

Under `forbid` that raises — and the failure is invisible and self-perpetuating:

```
InteractionData(**turn) → ValidationError: user_id
  → reflexio_adapter: except Exception → _LOGGER.warning → return False
  → publish.py: `if ok:` → watermark NEVER advances
  → next hook rebuilds the SAME poisoned dict → fails again, forever
```

claude-smart POSTs raw JSON, so already-installed plugins would break the moment the server deployed, before any upgrade. That converts *partial* data loss into *total, permanent* loss — strictly worse than the bug being fixed.

**So unknown keys are reported, not rejected**: captured, stripped so they cannot reach storage, and their **names** (never values, per the #377 redaction invariant) returned in `warnings[]` and logged once server-side. Nested payload models capture the same way, which surfaces `ToolUsed.status` — a field both plugins send on every tool call that was being dropped silently.

## The emptiness rule also had to soften — same wedge, different rule

Verification then reproduced that a per-interaction emptiness 422 wedges the plugins *identically*. Both append an empty `Assistant` placeholder unconditionally, so one empty row rejected the batch containing the real user turn:

```
wire: [{'role':'User','content':'REAL USER CONTENT'}, {'role':'Assistant','content':''}]
  -> 422 interaction_data_list[1] is empty
  -> whole batch refused, watermark never advances, retries forever
```

So an individual empty interaction is **skipped and reported**; a batch where *every* interaction is empty is still a 422 — which is exactly the incident (50 of 50). Verified: the real turn now publishes, with `warnings: ["skipped 1 empty interaction(s)…"]`.

## Bounded and de-noised

- Unknown key **names** are caller-controlled and were uncapped: 2000 long keys produced a **411 KB** warning echoed into both the response body and one log record. Now capped at 5 truncated names + a count — 411 KB → 411 bytes.
- Request-level keys callers duplicate per-interaction (`user_id`, `session_id`) are stripped but **not** warned about. A correct 50-turn claude-smart batch went from 50 warnings to **0**.
- Both background-task log lines now withhold their reason string, not just the one I first fixed.

```json
POST {"interaction_data_list": [{"content": "hello", "Content": "typo"}]}
200 {"success": true,
     "warnings": ["interaction_data_list[0]: ignored unrecognised field(s) Content"]}
```

The contentless 422 alone still catches the original incident — that payload was fully-defaulted empty objects.

## Also in this PR

- **openclaw plugin** builds its wire dict from an **allowlist** of `InteractionData` fields, with a contract test pinning the allowlist to the real model and asserting every emitted turn validates. The denylist rots every time a hook adds a record key.
- **Background rejection log withholds `response.message`** — on the storage path that is an unbounded `str(e)` from a catch-all, and Sentry ingests ERROR records as event bodies without scrubbing them.
- **`AI_AGENT_INTEGRATION.md`** no longer tells integrators to hold the watermark on *every* failure. That guidance is precisely what turns a 4xx into a permanent wedge; it now splits retryable from non-retryable and documents the allowlist rule.
- **`fix(api)!:` + `BREAKING CHANGE:`** footer. Verified against the installed parser that the previous `Breaking:` line yielded `bump: patch, breaking_descriptions: []` — it would have shipped a breaking change as 0.2.29 with no release-note signal. There is no CHANGELOG in this repo, so the footer is the only place it gets recorded.

## Tests

Written RED first (8 failures against the old source), including the inverted characterization test.

- `TestLegitimateTurnsStillAccepted` is **driven from `CONTENT_BEARING_FIELD_NAMES`**, so a field cannot be added to the predicate without acceptance coverage — `citations` and `retrieved_learnings` previously had none (a mutation dropping both killed zero tests).
- The route test for unknown fields now asserts **structurally**. Mutation testing proved the earlier substring version passed even with the feature reverted, because a 422 echoes the whole request body in `input`.
- New: async-path 422, plugin-wire-shape acceptance, and the background rejection log asserting the secret does **not** appear.
- A route-test fixture was itself an instance of this bug — posting `user_message`/`agent_message`/`interaction_type` and asserting 200. Fixed the data, not the assertion.

**4898 OSS + 4368 enterprise tests pass, 0 failures.** 146 openclaw plugin tests pass. ruff clean, **pyright 0 errors across all changed files including tests**.

### Coverage hole the verifier caught

The `citations`/`retrieved_learnings` acceptance test was **self-referential** — parametrized from the same tuple that drives the predicate, so deleting a field deleted its own coverage. A mutation dropping both killed zero tests. There is now an independent pinned-set assertion as the anchor.

---

Companion PRs: **ReflexioAI/claude-smart#144** (same denylist→allowlist fix for the other plugin) and enterprise **#849** (public docs + submodule repin).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown or misspelled interaction fields are now captured and reported to callers as `warnings` (field names only), including nested cases, with bounded and sanitized output.
  * Stricter publish-time validation now enforces per-interaction shape/sibling rules, provides index-level errors, and rejects empty contentless batches.
  * Background publish failures log clearer details; responses may include warnings when payload filtering occurs.
* **Tests**
  * Added/expanded coverage for warning generation (including async and indexing), empty/allowed content-only interactions, and plugin wire-contract drift protection.
* **Documentation**
  * Updated the publish contract and reliability guidance to align with warning-based handling and stricter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->