### PR TITLE
fix(api)!: reject publishes that carry no extractable content

### DIFF
--- a/reflexio/models/api_schema/common.py
+++ b/reflexio/models/api_schema/common.py
@@ -11,10 +11,34 @@ from pydantic import BaseModel, Field
 
 __all__ = [
     "NEVER_EXPIRES_TIMESTAMP",
-    "BlockingIssueKind",
     "BlockingIssue",
+    "BlockingIssueKind",
     "ToolUsed",
+    "sanitise_for_log",
 ]
+
+_MAX_LOG_VALUE_LEN = 64
+
+
+def sanitise_for_log(value: str, max_len: int = _MAX_LOG_VALUE_LEN) -> str:
+    """Make one caller-supplied string safe to put in a log line.
+
+    Strips control characters and bounds the length. A newline in a
+    caller-controlled value forges a line in a shared multi-tenant log stream,
+    and an unbounded value bloats the record. ``request_id`` is a
+    ``NonEmptyStr`` with no length cap and no character restrictions, so it
+    qualifies.
+
+    Args:
+        value (str): The caller-supplied string.
+        max_len (int): Maximum length before truncation.
+
+    Returns:
+        str: Printable, length-bounded text safe for a single log line.
+    """
+    cleaned = "".join(char if char.isprintable() else "?" for char in value)
+    return cleaned if len(cleaned) <= max_len else f"{cleaned[:max_len]}..."
+
 
 # OS-agnostic "never expires" timestamp (January 1, 2100 00:00:00 UTC)
 NEVER_EXPIRES_TIMESTAMP = 4102444800

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any, Literal, Self
+from typing import Any, Final, Literal, Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 from reflexio.defaults import DEFAULT_AGENT_VERSION
 
@@ -712,9 +718,87 @@ class InteractionData(BaseModel):
     def validate_image_url(cls, v: str) -> str:
         return _validate_image_url(v)
 
+    def carries_content(self) -> bool:
+        """
+        Whether this interaction carries anything worth storing.
+
+        The single source of truth for "is this interaction empty", shared by
+        ``PublishUserInteractionRequest``'s boundary validator and the
+        ``precondition_checks`` defense-in-depth guard so the two cannot drift.
+
+        Every content-bearing field counts, not just ``content``: a
+        tool-call-only agent turn, a shadow/expert-only row, and an image-only
+        turn all carry real information. Note ``user_action`` is compared
+        against ``UserActionType.NONE`` rather than tested for truthiness --
+        ``UserActionType`` is a ``StrEnum`` whose NONE member is the *truthy*
+        string ``"none"``, and a truthiness test there is what silently
+        disabled this check for the entire life of the guard.
+
+        Returns:
+            bool: True if any content-bearing field is populated.
+        """
+        if self.user_action != UserActionType.NONE:
+            return True
+        # Text fields are stripped: "   " is not content. Mirrors the
+        # ``session_id`` guard in ``precondition_checks``, which already
+        # rejects whitespace-only values.
+        return any(
+            value.strip() if isinstance(value, str) else value
+            for value in (getattr(self, name) for name in CONTENT_BEARING_FIELD_NAMES)
+        )
+
+    def shape_error(self) -> str | None:
+        """A contradiction in this interaction the caller must fix, or None.
+
+        These are genuine caller mistakes with no sensible recovery, so they
+        are fatal to the request. Emptiness is deliberately NOT one of them --
+        see ``PublishUserInteractionRequest.validate_interaction_shapes``.
+
+        Both rules used to live only in ``precondition_checks``, which on the
+        default ``wait_for_response=False`` path runs inside a background task
+        whose result is discarded, so neither was ever reportable. Keeping them
+        here lets the request model raise a 422 on both paths while
+        ``precondition_checks`` delegates, so the two cannot diverge.
+
+        Returns:
+            str | None: A caller-facing reason, or None when acceptable.
+        """
+        if self.user_action != UserActionType.NONE and not self.user_action_description:
+            return "user_action requires a user_action_description"
+        if self.interacted_image_url and self.image_encoding:
+            return "interacted_image_url and image_encoding cannot both be set"
+        return None
+
+
+# Every field ``carries_content`` consults, in one place. The prose in the
+# error message is DERIVED from this tuple rather than hand-written beside it,
+# so adding a field to the predicate cannot leave the caller-facing list stale.
+CONTENT_BEARING_FIELD_NAMES: Final = (
+    "content",
+    "shadow_content",
+    "expert_content",
+    "interacted_image_url",
+    "image_encoding",
+    "tools_used",
+    "citations",
+    "retrieved_learnings",
+)
+
+# How many original indices to name when reporting skipped empty rows.
+_MAX_SKIPPED_INDICES: Final = 10
+
+CONTENT_BEARING_FIELDS = (
+    f'{", ".join(CONTENT_BEARING_FIELD_NAMES)}, or a user_action other than "none"'
+)
+
 
 # publish user interaction request
 class PublishUserInteractionRequest(BaseModel):
+    # Set by ``validate_interaction_shapes`` against the caller's original
+    # list, before empty rows are filtered out; read by the route for logging.
+    _skipped_empty_indices: list[int] = PrivateAttr(default_factory=list)
+    _skipped_empty_count: int = PrivateAttr(default=0)
+
     request_id: NonEmptyStr | None = None
     user_id: NonEmptyStr
     interaction_data_list: list[InteractionData] = Field(min_length=1, max_length=1_000)
@@ -736,6 +820,72 @@ class PublishUserInteractionRequest(BaseModel):
         if self.evaluation_only and not self.session_id:
             raise ValueError("evaluation_only publishes require session_id")
         return self
+
+    @model_validator(mode="after")
+    def validate_interaction_shapes(self) -> Self:
+        """Reject contradictory interactions; drop empty ones.
+
+        Runs during request parsing, so it applies on *both* the synchronous
+        and the ``wait_for_response=False`` background-task path -- unlike
+        ``precondition_checks``, whose ``success=False`` is discarded inside
+        the background task after the caller was told 200 "queued".
+
+        An individual empty interaction is **skipped, not fatal**. Making it
+        fatal was implemented and reverted: both first-party plugins append an
+        empty ``Assistant`` placeholder unconditionally, so one empty row
+        rejected the whole batch -- including the real user turn beside it --
+        and their adapters swallow the error without advancing the publish
+        watermark, retrying the same doomed batch forever. A batch where
+        *every* interaction is empty is still fatal, and that is exactly the
+        incident this validation exists for (50 of 50 rows empty).
+
+        Raises:
+            ValueError: for a contradictory interaction, or an all-empty batch.
+        """
+        for index, interaction in enumerate(self.interaction_data_list):
+            if reason := interaction.shape_error():
+                raise ValueError(f"interaction_data_list[{index}] {reason}")
+
+        # Indices are computed against the ORIGINAL list, before filtering, so
+        # what gets reported matches the payload the caller actually sent.
+        skipped = [
+            index
+            for index, interaction in enumerate(self.interaction_data_list)
+            if not interaction.carries_content()
+        ]
+        if len(skipped) == len(self.interaction_data_list):
+            raise ValueError(
+                "every interaction is empty: at least one must set"
+                f' "content" (or any of: {CONTENT_BEARING_FIELDS})'
+            )
+        self._skipped_empty_indices = skipped[:_MAX_SKIPPED_INDICES]
+        self._skipped_empty_count = len(skipped)
+        self.interaction_data_list = [
+            interaction
+            for interaction in self.interaction_data_list
+            if interaction.carries_content()
+        ]
+        return self
+
+    def skipped_empty_summary(self) -> str | None:
+        """A log-safe description of empty interactions that were dropped.
+
+        Returns None when nothing was skipped. Indices refer to the payload as
+        the caller sent it, not the filtered list. Bounded, because the count is
+        caller-controlled.
+
+        Returns:
+            str | None: Summary for the server log, or None.
+        """
+        if not self._skipped_empty_count:
+            return None
+        shown = ", ".join(str(index) for index in self._skipped_empty_indices)
+        more = self._skipped_empty_count - len(self._skipped_empty_indices)
+        return (
+            f"skipped {self._skipped_empty_count} empty interaction(s) that"
+            f" carried no content, at index(es) {shown}"
+            f"{f', +{more} more' if more else ''}"
+        )
 
     @model_validator(mode="after")
     def validate_retrieved_learnings_total(self) -> Self:

--- a/reflexio/server/api_endpoints/precondition_checks.py
+++ b/reflexio/server/api_endpoints/precondition_checks.py
@@ -1,7 +1,6 @@
 from reflexio.models.api_schema.service_schemas import (
     DeleteUserProfileRequest,
     PublishUserInteractionRequest,
-    UserActionType,
 )
 
 
@@ -27,29 +26,24 @@ def validate_publish_user_interaction_request(
     if not request.session_id or not request.session_id.strip():
         return False, "session_id is required and cannot be empty"
 
-    for interaction_data in request.interaction_data_list:
-        if (
-            interaction_data.user_action != UserActionType.NONE
-            and not interaction_data.user_action_description
-        ):
-            return False, "User action description is required for user action"
+    # Delegates to InteractionData.shape_error(), the single definition of
+    # the per-interaction rules, so this guard and PublishUserInteractionRequest's
+    # validator cannot diverge. The emptiness rule in particular used to be dead
+    # code here: it ended in `not interaction_data.user_action`, and UserActionType
+    # is a StrEnum whose NONE member is the truthy string "none", so the branch
+    # could never fire and a publish of entirely empty interactions was accepted.
+    for index, interaction_data in enumerate(request.interaction_data_list):
+        if reason := interaction_data.shape_error():
+            return False, f"interaction_data_list[{index}] {reason}"
 
-        if interaction_data.interacted_image_url and interaction_data.image_encoding:
-            return (
-                False,
-                "Image encoding and interacted image url cannot be provided together",
-            )
-
-        if (
-            not interaction_data.content
-            and not interaction_data.interacted_image_url
-            and not interaction_data.image_encoding
-            and not interaction_data.user_action
-        ):
-            return (
-                False,
-                "Text interaction, interacted image url, image encoding, and user action cannot be all empty",
-            )
+    # An individual empty interaction is skipped by the request model, not
+    # rejected (plugins emit empty placeholder turns). Only a wholly empty
+    # batch -- the original incident -- is fatal.
+    if not any(
+        interaction_data.carries_content()
+        for interaction_data in request.interaction_data_list
+    ):
+        return False, "every interaction is empty"
 
     return True, ""
 

--- a/reflexio/server/routes/interactions.py
+++ b/reflexio/server/routes/interactions.py
@@ -15,6 +15,7 @@ from fastapi import (
     Request,
 )
 
+from reflexio.models.api_schema.common import sanitise_for_log
 from reflexio.models.api_schema.retriever_schema import (
     GetInteractionsRequest,
     GetInteractionsViewResponse,
@@ -68,6 +69,15 @@ def publish_user_interaction(
     wait_for_response: bool = False,
     _gate: None = Depends(default_billing_gate("learnings_generated")),  # noqa: B008
 ) -> PublishUserInteractionResponse:
+    # An empty interaction is dropped rather than failing the batch (plugins
+    # emit empty placeholder turns). Record it server-side so the drop is not
+    # silent; a caller-facing warnings channel is a separate change.
+    # INFO, not WARNING: the surrounding design treats an empty placeholder turn
+    # as normal plugin behaviour, so warning on it would train operators to
+    # ignore the channel.
+    if skipped := payload.skipped_empty_summary():
+        logger.info("Publish for org %s %s", org_id, skipped)
+
     if wait_for_response:
         # Sync callers wait for the real result, so preserve bounded backpressure
         # before any storage side effects. The inner service limiter is disabled
@@ -89,16 +99,64 @@ def publish_user_interaction(
     # id we hand back here.
     request_id = payload.request_id or str(uuid.uuid4())
     payload.request_id = request_id
+    # request_id is caller-supplied (NonEmptyStr: no length cap, no character
+    # restrictions) and is logged below at ERROR, which Sentry ingests as an
+    # event body. A newline in it would forge a line in a shared multi-tenant
+    # log stream -- the same hazard as the unknown field names.
+    safe_request_id = sanitise_for_log(request_id)
 
     def _publish_task() -> None:
         try:
-            publisher_api.add_user_interaction(
+            response = publisher_api.add_user_interaction(
                 org_id=org_id,
                 request=payload,
                 defer_learning=True,
             )
-        except Exception:
-            logger.exception("Background publish failed for org %s", org_id)
+            # The caller was already handed 200 "queued" below, so a
+            # ``success=False`` return here is otherwise invisible -- it is not
+            # an exception, so the handler underneath never sees it. Log it, or
+            # a rejected publish looks identical to an accepted one from both
+            # ends. Per-interaction shape problems are already caught as a 422
+            # by PublishUserInteractionRequest's validators; this covers
+            # whatever else add_user_interaction can refuse.
+            #
+            # Deliberately NOT logging ``response.message``: on the storage
+            # path it is ``str(e)`` from a catch-all (lib/_interactions.py), an
+            # unbounded exception string with no content-freeness guarantee,
+            # and Sentry ingests ERROR records as event bodies without
+            # scrubbing them. #377 established that such messages must be
+            # content-free by construction, so log a bounded shape instead.
+            if not response.success:
+                logger.error(
+                    "Background publish rejected for org %s (request_id=%s):"
+                    " %d-char reason withheld (may contain Customer Content)",
+                    org_id,
+                    safe_request_id,
+                    len(response.message or ""),
+                )
+        except Exception as exc:  # noqa: BLE001 - a background task must never raise past add_task
+            # Same content-freeness problem as response.message above: an
+            # exception string (and its traceback locals) has no guarantee of
+            # being free of Customer Content, and Sentry ingests this as an
+            # event body. Log the type and the raising location -- file:line is
+            # content-free and is the only way to find a background failure --
+            # but never the message.
+            tb = exc.__traceback__
+            while tb is not None and tb.tb_next is not None:
+                tb = tb.tb_next
+            origin = (
+                f"{tb.tb_frame.f_code.co_filename}:{tb.tb_lineno}"
+                if tb is not None
+                else "unknown"
+            )
+            logger.error(
+                "Background publish failed for org %s (request_id=%s): %s at %s"
+                " (message withheld, may contain Customer Content)",
+                org_id,
+                safe_request_id,
+                type(exc).__name__,
+                origin,
+            )
 
     # Run in background — caller gets immediate acknowledgement.
     # learning_status="deferred" tells the caller that extraction has not yet

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from reflexio.defaults import resolve_agent_version
+from reflexio.models.api_schema.common import sanitise_for_log
 from reflexio.models.api_schema.service_schemas import (
     Interaction,
     PublishUserInteractionRequest,
@@ -265,7 +266,7 @@ class GenerationService:
             if not new_interactions:
                 logger.info(
                     "No interactions from the publish user interaction request: %s, get all interactions for the user: %s",
-                    request_id,
+                    sanitise_for_log(request_id),
                     user_id,
                 )
                 return result
@@ -658,7 +659,7 @@ class GenerationService:
                 "durable-learning same-user lock held; leaving job reclaimable "
                 "(user_id=%s request_id=%s)",
                 user_id,
-                request_id,
+                sanitise_for_log(request_id),
             )
             return DeferredLearningPlan(
                 request_id=request_id,
@@ -726,7 +727,9 @@ class GenerationService:
                         request_id=request_id,
                         error_type="timeout",
                     ):
-                        logger.error("%s for request %s", msg, request_id)
+                        logger.error(
+                            "%s for request %s", msg, sanitise_for_log(request_id)
+                        )
                     warnings.append(msg)
                     continue
                 except Exception as e:
@@ -739,7 +742,7 @@ class GenerationService:
                     ):
                         logger.exception(
                             "Generation service failed for request %s",
-                            request_id,
+                            sanitise_for_log(request_id),
                         )
                     warnings.append(msg)
                     continue
@@ -807,7 +810,7 @@ class GenerationService:
                     logger.exception(
                         "Failed to emit profile side effects for deferred "
                         "learning request %s",
-                        plan.request_id,
+                        sanitise_for_log(plan.request_id),
                     )
             if plan.playbook is not None:
                 playbook_service, playbook_plan = plan.playbook
@@ -817,7 +820,7 @@ class GenerationService:
                     logger.exception(
                         "Failed to emit playbook side effects for deferred "
                         "learning request %s",
-                        plan.request_id,
+                        sanitise_for_log(plan.request_id),
                     )
             try:
                 schedule_tagging(
@@ -830,7 +833,7 @@ class GenerationService:
             except Exception:
                 logger.exception(
                     "Failed to schedule tagging for deferred learning request %s",
-                    plan.request_id,
+                    sanitise_for_log(plan.request_id),
                 )
         finally:
             self._release_durable_learning_lock(
@@ -948,7 +951,7 @@ class GenerationService:
                     ):
                         logger.exception(
                             "Generation service failed for request %s",
-                            request_id,
+                            sanitise_for_log(request_id),
                         )
                     result.warnings.append(msg)
         else:
@@ -982,7 +985,9 @@ class GenerationService:
                             request_id=request_id,
                             error_type="timeout",
                         ):
-                            logger.error("%s for request %s", msg, request_id)
+                            logger.error(
+                                "%s for request %s", msg, sanitise_for_log(request_id)
+                            )
                         result.warnings.append(msg)
                     except Exception as e:
                         msg = f"{service_name} failed: {e}"
@@ -994,7 +999,7 @@ class GenerationService:
                         ):
                             logger.exception(
                                 "Generation service failed for request %s",
-                                request_id,
+                                sanitise_for_log(request_id),
                             )
                         result.warnings.append(msg)
             finally:
@@ -1011,7 +1016,7 @@ class GenerationService:
         except Exception:
             logger.exception(
                 "Failed to schedule tagging for publish request %s",
-                request_id,
+                sanitise_for_log(request_id),
             )
 
     def _schedule_post_publish_evaluations(

--- a/tests/server/api_endpoints/test_api_routes.py
+++ b/tests/server/api_endpoints/test_api_routes.py
@@ -51,17 +51,18 @@ class TestPublishInteraction:
 
     @staticmethod
     def _publish_payload():
+        # Every key inside interaction_data_list must be a real InteractionData
+        # field. This fixture previously sent user_message/agent_message/
+        # interaction_type -- none of which exist on the model -- so it posted
+        # an interaction that bound to nothing and stored content=''. It still
+        # asserted 200, which is exactly the silent failure this suite now
+        # guards against.
         return {
             "user_id": "user-1",
             "session_id": "sess-1",
             "interaction_data_list": [
-                {
-                    "user_id": "user-1",
-                    "session_id": "sess-1",
-                    "interaction_type": "conversation",
-                    "user_message": "Hello",
-                    "agent_message": "Hi there!",
-                }
+                {"role": "User", "content": "Hello"},
+                {"role": "Agent", "content": "Hi there!"},
             ],
         }
 
@@ -105,6 +106,68 @@ class TestPublishInteraction:
         data = response.json()
         assert data["success"] is True
         assert "queued" in data["message"].lower()
+
+    def test_async_publish_rejects_contentless_interactions(
+        self, client, patched_reflexio
+    ):
+        """A contentless publish must 422 on the async path too.
+
+        This is the regression that matters most: the async path returns 200
+        "queued" before the publisher runs, and discards the publisher's result,
+        so a rejection there is invisible to the caller. Validating on the
+        request model is what makes this path fail loudly. Previously this
+        returned 200 and silently stored rows with content=''.
+        """
+        payload = self._publish_payload()
+        payload["interaction_data_list"] = [{"role": "User"}]
+        response = client.post("/api/publish_interaction", json=payload)
+        assert response.status_code == 422
+        assert "is empty" in response.text
+
+    def test_async_publish_accepts_plugin_wire_shape(self, client, patched_reflexio):
+        """Regression: a request-level key on an interaction must not break.
+
+        Both first-party plugins build their wire payload with a denylist, so
+        every turn carries ``user_id``. Rejecting unknown keys wedged them into
+        a silent retry loop that never published again, so they stay ignored.
+        """
+        payload = self._publish_payload()
+        payload["interaction_data_list"] = [
+            {"role": "User", "content": "how do I do X?", "user_id": "proj-a"}
+        ]
+        response = client.post("/api/publish_interaction", json=payload)
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_background_publish_rejection_is_logged(
+        self, client, patched_reflexio, caplog
+    ):
+        """A discarded background ``success=False`` must leave a trace.
+
+        The async path hands the caller 200 "queued" and throws the publisher's
+        return value away, so this log line is the only evidence a rejected
+        publish ever produces. The reason string is deliberately withheld -- it
+        can be an unbounded ``str(e)`` and Sentry ingests ERROR bodies unscrubbed.
+        """
+        import logging
+
+        with (
+            patch(
+                "reflexio.server.api_endpoints.publisher_api.add_user_interaction",
+                return_value=PublishUserInteractionResponse(
+                    success=False, message="CUSTOMER-SECRET-XYZ"
+                ),
+            ),
+            caplog.at_level(
+                logging.ERROR, logger="reflexio.server.routes.interactions"
+            ),
+        ):
+            response = client.post(
+                "/api/publish_interaction", json=self._publish_payload()
+            )
+        assert response.status_code == 200
+        assert "Background publish rejected" in caplog.text
+        assert "CUSTOMER-SECRET-XYZ" not in caplog.text
 
     def test_async_publish_does_not_gate_durable_write_on_limiter(
         self, client, patched_reflexio

--- a/tests/server/api_endpoints/test_precondition_checks.py
+++ b/tests/server/api_endpoints/test_precondition_checks.py
@@ -1,3 +1,4 @@
+from reflexio.models.api_schema.common import ToolUsed
 from reflexio.models.api_schema.service_schemas import (
     DeleteUserProfileRequest,
     InteractionData,
@@ -13,17 +14,15 @@ from reflexio.server.api_endpoints.precondition_checks import (
 def _make_publish_request(
     interactions: list[InteractionData] | None = None,
 ) -> PublishUserInteractionRequest:
-    if interactions is not None:
-        return PublishUserInteractionRequest(
-            user_id="test-user",
-            session_id="test-session",
-            interaction_data_list=interactions,
-        )
-    # Bypass Pydantic min_length=1 validation to test the precondition check
+    # Always ``model_construct``: these tests exercise the precondition guard
+    # in isolation, and that guard exists specifically to cover callers that
+    # bypass Pydantic. Building a validated request here would instead trip
+    # ``PublishUserInteractionRequest``'s own validators (min_length=1, and the
+    # contentless-interaction rule), so the guard itself would never be reached.
     return PublishUserInteractionRequest.model_construct(
         user_id="test-user",
         session_id="test-session",
-        interaction_data_list=[],
+        interaction_data_list=interactions if interactions is not None else [],
     )
 
 
@@ -43,7 +42,7 @@ class TestValidatePublishUserInteractionRequest:
         request = _make_publish_request([interaction])
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
-        assert msg == "User action description is required for user action"
+        assert "user_action_description" in msg
 
     def test_empty_session_id(self):
         request = PublishUserInteractionRequest.model_construct(
@@ -64,14 +63,16 @@ class TestValidatePublishUserInteractionRequest:
         request = _make_publish_request([interaction])
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
-        assert (
-            msg == "Image encoding and interacted image url cannot be provided together"
-        )
+        assert "cannot both be set" in msg
 
-    def test_all_fields_empty_with_none_action_passes(self):
-        # UserActionType.NONE is "none" (truthy), so the "all empty" branch
-        # in the source is unreachable via normal model construction.
-        # With NONE, the validator considers user_action as present and passes.
+    def test_all_fields_empty_with_none_action_is_rejected(self):
+        # Regression: this branch MUST be reachable. It previously could not
+        # fire, because ``UserActionType`` is a ``StrEnum`` with NONE = "none"
+        # — a truthy string — so the old ``not interaction_data.user_action``
+        # test was always False and the whole "all empty" chain was dead code.
+        # A publish of 50 such interactions was accepted with 200 and stored 50
+        # rows with content='', which silently produced no learnings at all.
+        # The comparison must be ``!= UserActionType.NONE``, never truthiness.
         interaction = InteractionData(
             content="",
             interacted_image_url="",
@@ -80,8 +81,57 @@ class TestValidatePublishUserInteractionRequest:
         )
         request = _make_publish_request([interaction])
         valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is False
+        assert "is empty" in msg
+
+    def test_tools_used_only_is_accepted(self):
+        # A tool-call-only agent turn carries real information. Making the
+        # emptiness guard live against its original narrow field list (content
+        # / image_url / image_encoding / user_action) would have started
+        # rejecting these, so the predicate must consider tools_used too.
+        interaction = InteractionData(
+            content="",
+            tools_used=[ToolUsed(tool_name="search", tool_data={"query": "x"})],
+        )
+        request = _make_publish_request([interaction])
+        valid, msg = validate_publish_user_interaction_request(request)
         assert valid is True
         assert msg == ""
+
+    def test_shadow_content_only_is_accepted(self):
+        interaction = InteractionData(content="", shadow_content="shadow variant")
+        request = _make_publish_request([interaction])
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is True
+        assert msg == ""
+
+    def test_expert_content_only_is_accepted(self):
+        interaction = InteractionData(content="", expert_content="expert answer")
+        request = _make_publish_request([interaction])
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is True
+        assert msg == ""
+
+    def test_contentless_interaction_among_real_turns_is_allowed(self):
+        # An empty row beside real turns is skipped by the request model, not
+        # rejected -- plugins append empty placeholder turns unconditionally,
+        # and failing the batch wedged them into a permanent retry loop.
+        request = _make_publish_request(
+            [
+                InteractionData(content="real turn"),
+                InteractionData(),
+                InteractionData(content="another real turn"),
+            ]
+        )
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is True
+        assert msg == ""
+
+    def test_wholly_empty_batch_is_rejected(self):
+        request = _make_publish_request([InteractionData(), InteractionData()])
+        valid, msg = validate_publish_user_interaction_request(request)
+        assert valid is False
+        assert "every interaction is empty" in msg
 
     def test_valid_with_content(self):
         interaction = InteractionData(content="hello world")
@@ -127,7 +177,7 @@ class TestValidatePublishUserInteractionRequest:
         request = _make_publish_request([good, bad])
         valid, msg = validate_publish_user_interaction_request(request)
         assert valid is False
-        assert msg == "User action description is required for user action"
+        assert "user_action_description" in msg
 
 
 class TestValidateDeleteUserProfileRequest:

--- a/tests/server/api_endpoints/test_publish_validation.py
+++ b/tests/server/api_endpoints/test_publish_validation.py
@@ -1,0 +1,278 @@
+"""Boundary validation for publish payloads.
+
+Regression suite for a class of silent data loss: a publish whose interaction
+objects never bound was accepted with 200 and stored rows with ``content=''``,
+producing no learnings and no error anywhere. Three defects combined to hide it:
+
+1. Every ``InteractionData`` field has a default and unknown keys were ignored
+   with no trace, so a mis-keyed ``content`` yielded a valid empty interaction.
+2. The precondition guard meant to catch empty interactions was dead code
+   (truthiness test against a truthy ``StrEnum`` member).
+3. On the default async path the precondition result is discarded entirely.
+
+The per-interaction rules therefore live on the request model, which is the
+only layer that fires on both the sync and the background-task path.
+
+Unknown keys stay silently ignored here, deliberately. Rejecting them was
+implemented and reverted -- it broke every first-party plugin publish -- and
+*reporting* them to the caller is a separate change; this one fixes the
+incident.
+"""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from reflexio.models.api_schema.common import ToolUsed, sanitise_for_log
+from reflexio.models.api_schema.domain.entities import (
+    CONTENT_BEARING_FIELD_NAMES,
+    Citation,
+    RetrievedLearning,
+)
+from reflexio.models.api_schema.domain.enums import UserActionType
+from reflexio.models.api_schema.service_schemas import (
+    InteractionData,
+    PublishUserInteractionRequest,
+)
+
+# One populated sample per content-bearing field. Keyed by field name so the
+# acceptance test below can be driven from CONTENT_BEARING_FIELD_NAMES itself:
+# adding a field to the predicate without covering it here fails collection,
+# which is how `citations` and `retrieved_learnings` previously went untested.
+_CONTENT_SAMPLES: dict[str, Any] = {
+    "content": "hello",
+    "shadow_content": "shadow variant",
+    "expert_content": "expert answer",
+    "interacted_image_url": "https://example.com/i.png",
+    "image_encoding": "base64data",
+    "tools_used": [ToolUsed(tool_name="search", tool_data={"q": "x"})],
+    "citations": [Citation(kind="profile", real_id="p-1")],
+    "retrieved_learnings": [RetrievedLearning(kind="profile", learning_id="p-1")],
+}
+
+
+def _publish(
+    interactions: list[InteractionData] | list[dict[str, Any]],
+) -> PublishUserInteractionRequest:
+    return PublishUserInteractionRequest.model_validate(
+        {
+            "user_id": "test-user",
+            "session_id": "test-session",
+            "interaction_data_list": interactions,
+        }
+    )
+
+
+class TestEmptyInteractions:
+    """Empty rows are skipped; only a wholly empty batch is fatal.
+
+    Making a single empty row fatal was implemented and reverted: both
+    first-party plugins append an empty ``Assistant`` placeholder
+    unconditionally, so one empty row rejected the batch containing the real
+    user turn, and their adapters swallow the error without advancing the
+    publish watermark -- retrying the same doomed batch forever.
+    """
+
+    def test_all_empty_batch_is_rejected(self):
+        # The actual production incident: 50 of 50 rows carried nothing.
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([{} for _ in range(50)])
+
+    def test_single_empty_interaction_is_rejected_because_it_is_the_whole_batch(self):
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([InteractionData()])
+
+    def test_whitespace_only_content_does_not_count(self):
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([{"content": "   \n\t "}])
+
+    def test_user_action_none_does_not_count_as_content(self):
+        # UserActionType.NONE is the truthy string "none"; treating it as
+        # content is the dead-guard bug this suite exists for.
+        with pytest.raises(ValidationError, match="every interaction is empty"):
+            _publish([{"user_action": "none"}])
+
+    def test_empty_row_beside_a_real_turn_is_skipped_not_fatal(self):
+        # Regression for the plugin wedge: the real turn must still publish.
+        request = _publish(
+            [{"role": "User", "content": "REAL"}, {"role": "Assistant", "content": ""}]
+        )
+        assert [i.content for i in request.interaction_data_list] == ["REAL"]
+        assert "skipped 1 empty" in (request.skipped_empty_summary() or "")
+
+    def test_skip_is_summarised_with_original_indices(self):
+        request = _publish([{"content": "a"}, {}, {}, {"content": "b"}])
+        assert len(request.interaction_data_list) == 2
+        summary = request.skipped_empty_summary()
+        assert summary is not None
+        assert "skipped 2 empty" in summary
+        # Indices are the caller's, not the filtered list's.
+        assert "1, 2" in summary, summary
+
+
+class TestSiblingRulesEnforcedAtBoundary:
+    """The other two per-interaction rules must 422 too.
+
+    They previously lived only in ``precondition_checks``, whose result is
+    discarded on the async path -- so they returned 200 "queued" and then
+    silently refused the write.
+    """
+
+    def test_user_action_without_description_is_rejected(self):
+        with pytest.raises(ValidationError, match="user_action_description"):
+            _publish([{"content": "hi", "user_action": "click"}])
+
+    def test_image_url_and_encoding_together_is_rejected(self):
+        with pytest.raises(ValidationError, match="cannot both be set"):
+            _publish(
+                [
+                    {
+                        "interacted_image_url": "https://example.com/i.png",
+                        "image_encoding": "base64data",
+                    }
+                ]
+            )
+
+
+class TestLegitimateTurnsStillAccepted:
+    """Guards against over-rejecting: these all carry real information."""
+
+    def test_content_bearing_field_set_is_pinned(self):
+        """Pin the SET, not just iterate it.
+
+        The parametrize below is driven by CONTENT_BEARING_FIELD_NAMES, so
+        deleting a field from that tuple silently deletes its own coverage --
+        a mutation dropping `citations` and `retrieved_learnings` killed zero
+        tests. This assertion is the independent anchor: narrowing the
+        predicate now fails here.
+        """
+        assert set(CONTENT_BEARING_FIELD_NAMES) == {
+            "content",
+            "shadow_content",
+            "expert_content",
+            "interacted_image_url",
+            "image_encoding",
+            "tools_used",
+            "citations",
+            "retrieved_learnings",
+        }
+
+    @pytest.mark.parametrize("field_name", CONTENT_BEARING_FIELD_NAMES)
+    def test_each_content_bearing_field_alone_is_accepted(self, field_name: str):
+        # Driven from the predicate's own field tuple, so a field can never be
+        # added to `carries_content()` without acceptance coverage.
+        assert field_name in _CONTENT_SAMPLES, (
+            f"{field_name} is content-bearing but has no sample here"
+        )
+        request = _publish([{field_name: _CONTENT_SAMPLES[field_name]}])
+        assert len(request.interaction_data_list) == 1
+
+    def test_user_action_with_description_is_accepted(self):
+        request = _publish(
+            [
+                {
+                    "user_action": UserActionType.CLICK,
+                    "user_action_description": "clicked submit",
+                }
+            ]
+        )
+        assert len(request.interaction_data_list) == 1
+
+    def test_real_conversation_is_accepted(self):
+        request = _publish(
+            [
+                {"role": "User", "content": "I prefer Postgres over MySQL."},
+                {"role": "Agent", "content": "Noted, I'll target Postgres."},
+            ]
+        )
+        assert len(request.interaction_data_list) == 2
+
+
+class TestLogSafety:
+    """`sanitise_for_log` is a security control, so pin it.
+
+    Any caller-supplied value reaching a log record needs it: a newline forges a
+    line in a shared multi-tenant stream that Sentry ingests, and an unbounded
+    value bloats the record. `request_id` qualifies — it is a `NonEmptyStr` with
+    no length cap and no character restrictions.
+    """
+
+    def test_newline_cannot_forge_a_log_line(self):
+        forged = "ok\nERROR Background publish rejected for org 99: FAKE"
+        cleaned = sanitise_for_log(forged)
+        assert "\n" not in cleaned
+        assert "?" in cleaned
+
+    def test_other_control_characters_are_replaced(self):
+        assert "\r" not in sanitise_for_log("a\rb")
+        assert "\t" not in sanitise_for_log("a\tb")
+
+    def test_length_is_bounded(self):
+        # No cap on the model, so the log site must impose one.
+        assert len(sanitise_for_log("z" * 5000)) < 100
+
+    def test_ordinary_values_pass_through_unchanged(self):
+        for value in ("req-123", "a b c", "sess/42"):
+            assert sanitise_for_log(value) == value
+
+    def test_no_log_call_interpolates_a_raw_request_id(self):
+        """Fix by class: no logger call may pass a bare `request_id`.
+
+        Three sites log it -- two in generation_service, one in the publish
+        route -- and the first pass fixed only the route. Scans the argument
+        lines of every logger call for an unsanitised `request_id`.
+        """
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[3] / "reflexio"
+        offenders: list[str] = []
+        for path in root.rglob("*.py"):
+            if "test" in path.name:
+                continue
+            lines = path.read_text().splitlines()
+            in_call = False
+            for number, line in enumerate(lines, 1):
+                # error/warning/exception are the Sentry-ingested levels, and
+                # info still lands in the shared stream.
+                if any(
+                    f"logger.{level}(" in line
+                    for level in ("error", "warning", "exception", "info")
+                ):
+                    in_call = ")" not in line.split("logger.", 1)[1]
+                    continue
+                if not in_call:
+                    continue
+                # Match attribute access too: `plan.request_id,` is the same
+                # caller-supplied value, and three logger.exception calls were
+                # passing it raw while an exact-equality check passed clean.
+                stripped = line.strip()
+                if stripped == "request_id," or stripped.endswith(".request_id,"):
+                    offenders.append(f"{path.relative_to(root)}:{number}")
+                if ")" in line:
+                    in_call = False
+        # Two modules outside this change's blast radius carry the same
+        # pre-existing pattern (10 sites at the time of writing). They are
+        # allowlisted BY FILE rather than by line so the guard still fails for
+        # any NEW file, and so the debt stays visible and countable instead of
+        # being hidden by narrowing the scan. Sanitising them is a separate
+        # change: this PR is the minimal publish-validation fix, and widening it
+        # to unrelated modules is how a small fix turns into a large one.
+        known_pending = {
+            "server/services/publish_learning_worker.py",
+            "server/services/extraction/resumable_agent.py",
+        }
+        new_offenders = [
+            offender
+            for offender in offenders
+            if offender.rsplit(":", 1)[0] not in known_pending
+        ]
+        assert new_offenders == [], (
+            "these logger calls pass an unsanitised caller-supplied request_id;"
+            f" wrap with sanitise_for_log(): {new_offenders}"
+        )
+        # And the known set must not grow silently either.
+        assert len(offenders) <= 10, (
+            f"pre-existing unsanitised request_id sites grew to {len(offenders)}:"
+            f" {offenders}"
+        )


### PR DESCRIPTION
Fixes the incident: a publish of 50 interactions returned **200 OK** and stored 50 rows with `content = ''`. No profiles were ever generated, and nothing on any layer reported a problem.

This is the **minimal** fix, split out of #383 so the incident fix can land on its own. Everything about *reporting* dropped fields back to the caller stays in #383.

## Three defects combined to hide it

**1. The guard written for exactly this case was dead code.** `UserActionType` is a `StrEnum` whose `NONE` member is the truthy string `"none"`, so `not interaction_data.user_action` was always `False` and the four-way "all empty" chain could never fire:

```
bool(UserActionType.NONE) = True
validate_publish_user_interaction_request(50 empty) -> (True, '')
```

Ten lines above, the same function already used the correct `!= UserActionType.NONE`. It survived because **a test pinned it** — `test_all_fields_empty_with_none_action_passes` diagnosed the dead branch in its own comment, then asserted `valid is True`. That test is now inverted.

**2. Two sibling rules lived only on a discarded path.** `user_action` needs a description; `interacted_image_url` xor `image_encoding`. Both existed *only* in the precondition guard, so neither was ever reportable either.

**3. On the default async path the rejection is thrown away.** `add_user_interaction` runs inside a `BackgroundTask` whose return value was dropped, after the caller already got `200 "queued"`. A `success=False` isn't an exception, so it wasn't logged either.

## The fix

The rules live in a `model_validator` on `PublishUserInteractionRequest` — it runs during request parsing, so it applies on **both** the sync and background-task path. `InteractionData.shape_error()` holds the contradictions and `precondition_checks` delegates to it, so the two layers cannot diverge.

**An individual empty interaction is skipped, not fatal.** Failing the batch was implemented and reverted: both first-party plugins append an empty `Assistant` placeholder unconditionally, so one empty row rejected the batch containing the real user turn — and their adapters swallow the error without advancing the publish watermark, retrying the same doomed batch forever. Reproduced end to end. A batch where *every* interaction is empty is still a 422, which is precisely the incident (50 of 50). Skips are logged server-side with the caller's **original** indices.

`carries_content()` counts every content-bearing field — `tools_used`, shadow/expert content, `citations`, `retrieved_learnings` — because a narrower list rejects legitimate tool-call-only and shadow-mode turns. Text is stripped, so `"   "` is not content.

Both background log lines withhold their reason string (on the storage path it is an unbounded `str(e)` from a catch-all, and Sentry ingests ERROR records as event bodies unscrubbed), and `request_id` is sanitised before reaching them — it is a `NonEmptyStr` with no length cap and no character restrictions, so a newline could forge a line in a shared multi-tenant log stream.

## Deliberately out of scope

Unknown fields stay **silently ignored, exactly as on `main`**. Rejecting them (`extra="forbid"`) broke every first-party plugin publish into the same silent retry loop, and *reporting* them to the caller is a larger feature — capture/strip, nested models, volume caps, sanitisation, SDK propagation. That is #383, reviewed on its own merits.

## Tests

Written RED first. `TestEmptyInteractions` and `TestSiblingRulesEnforcedAtBoundary` pin the 422s on the async path — the one that previously returned 200 "queued" and then silently refused the write. `TestLegitimateTurnsStillAccepted` is driven from `CONTENT_BEARING_FIELD_NAMES` **plus an independent pinned-set assertion**, because a parametrize driven only by that tuple deletes its own coverage when a field is removed (proven by mutation).

A route-test fixture was itself an instance of this bug — posting `user_message`/`agent_message`/`interaction_type`, none of which are `InteractionData` fields, and asserting 200. Fixed the data, not the assertion.

`ruff` clean, `pyright` 0 errors, full OSS + enterprise suites green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved publish interaction validation: detects contradictory field combinations and reports the failing interaction index.
  - Empty placeholder interactions are now skipped; requests with fully empty interaction batches are rejected.
- **Bug Fixes**
  - Publish endpoint now correctly accepts plugin-style per-turn payloads (extra keys alongside role/content).
  - Async publish now rejects contentless interaction turns with HTTP 422.
  - Background publishing failures are logged with safer, non-sensitive messages.
- **Tests**
  - Added regressions for boundary validation, empty-interaction skipping/rejection, plugin wire shape, and request-id log sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->