### PR TITLE
fix(search): enforce one Phase B deadline

### DIFF
--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -614,6 +614,7 @@ def _run_phase_b(
             )
             return None, None, None
         except Exception as e:
+            _cancel_unfinished_futures(tracked_futures)
             logger.error("Unified search failed: %s", e)
             return None, None, None
 

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -17,6 +17,7 @@ from collections import OrderedDict
 from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, cast
 
@@ -86,6 +87,7 @@ _SEARCH_FANOUT_EXECUTOR = ThreadPoolExecutor(
     max_workers=_SEARCH_FANOUT_MAX_WORKERS,
     thread_name_prefix="reflexio-search",
 )
+_SEARCH_PHASE_B_TIMEOUT_SECONDS = 30.0
 _ENV_SINGLE_RPC = "REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC"
 # Working-pool floor for temporal reordering (freshness collapse / recency
 # sort): matches the RecencyConfig default pool so the fresh version of a
@@ -111,6 +113,16 @@ _embedding_cache_lock = threading.Lock()
 _embedding_cache: OrderedDict[tuple[str, int, str, str], tuple[float, list[float]]] = (
     OrderedDict()
 )
+
+
+@dataclass(frozen=True)
+class _TrackedSearchFuture:
+    """Executor submission metadata used for timing and cancellation."""
+
+    task: str
+    future: Future[Any]
+    submitted_at: float
+    deadline_monotonic: float
 
 
 def run_unified_search(
@@ -431,13 +443,16 @@ def _run_phase_b(
 
     entity_types = set(request.entity_types or _DEFAULT_ENTITY_TYPES)
     allowed_agent_statuses = request.agent_playbook_status_filter
-    try:
-        with profile_step(
-            "search.phase_b",
-            backend=_storage_backend_name(storage),
-            entity_types=sorted(entity_types),
-            top_k=top_k,
-        ) as span:
+    deadline_monotonic = time.monotonic() + _SEARCH_PHASE_B_TIMEOUT_SECONDS
+    tracked_futures: list[_TrackedSearchFuture] = []
+    with profile_step(
+        "search.phase_b",
+        backend=_storage_backend_name(storage),
+        entity_types=sorted(entity_types),
+        top_k=top_k,
+        deadline_seconds=_SEARCH_PHASE_B_TIMEOUT_SECONDS,
+    ) as span:
+        try:
             # Recency needs the per-row ``combined_score``, which only the scored
             # single-RPC method threads back. Backends that don't advertise
             # ``supports_unified_hybrid_search`` (e.g. native Postgres, which still
@@ -469,6 +484,8 @@ def _run_phase_b(
                     allowed_agent_statuses=allowed_agent_statuses,
                     recency_on=recency_on,
                     search_mode=search_mode,
+                    deadline_monotonic=deadline_monotonic,
+                    tracked_futures=tracked_futures,
                 )
                 if combined is not None:
                     profiles, agent_playbooks, user_playbooks = combined
@@ -486,6 +503,8 @@ def _run_phase_b(
             profiles_future = (
                 _submit_with_current_context(
                     _SEARCH_FANOUT_EXECUTOR,
+                    "profiles",
+                    deadline_monotonic,
                     _search_profiles_via_storage,
                     storage,
                     query,
@@ -504,6 +523,8 @@ def _run_phase_b(
             agent_playbooks_future = (
                 _submit_with_current_context(
                     _SEARCH_FANOUT_EXECUTOR,
+                    "agent_playbooks",
+                    deadline_monotonic,
                     _search_agent_playbooks_via_storage,
                     storage,
                     query,
@@ -536,6 +557,8 @@ def _run_phase_b(
                 )
                 user_playbooks_future = _submit_with_current_context(
                     _SEARCH_FANOUT_EXECUTOR,
+                    "user_playbooks",
+                    deadline_monotonic,
                     _search_user_playbooks_via_storage,
                     storage,
                     rf_request,
@@ -544,14 +567,23 @@ def _run_phase_b(
             else:
                 user_playbooks_future = None
 
-            profiles = profiles_future.result(timeout=30) if profiles_future else []
+            tracked_futures.extend(
+                future
+                for future in (
+                    profiles_future,
+                    agent_playbooks_future,
+                    user_playbooks_future,
+                )
+                if future is not None
+            )
+            profiles = _result_with_deadline(profiles_future) if profiles_future else []
             agent_playbooks = (
-                agent_playbooks_future.result(timeout=30)
+                _result_with_deadline(agent_playbooks_future)
                 if agent_playbooks_future
                 else []
             )
             user_playbooks = (
-                user_playbooks_future.result(timeout=30)
+                _result_with_deadline(user_playbooks_future)
                 if user_playbooks_future
                 else []
             )
@@ -563,12 +595,27 @@ def _run_phase_b(
                     "user_playbooks_count": len(user_playbooks),
                 },
             )
-    except FuturesTimeoutError:
-        logger.error("Unified search timed out")
-        return None, None, None
-    except Exception as e:
-        logger.error("Unified search failed: %s", e)
-        return None, None, None
+        except FuturesTimeoutError:
+            cancellation_counts = _cancel_unfinished_futures(tracked_futures)
+            set_span_data(
+                span,
+                {
+                    "timed_out": True,
+                    **cancellation_counts,
+                },
+            )
+            logger.error(
+                "event=unified_search_timeout deadline_seconds=%.1f "
+                "cancelled_queued=%d running=%d completed=%d",
+                _SEARCH_PHASE_B_TIMEOUT_SECONDS,
+                cancellation_counts["cancelled_queued_count"],
+                cancellation_counts["running_count"],
+                cancellation_counts["completed_count"],
+            )
+            return None, None, None
+        except Exception as e:
+            logger.error("Unified search failed: %s", e)
+            return None, None, None
 
     return profiles, agent_playbooks, user_playbooks
 
@@ -590,6 +637,8 @@ def _run_phase_b_single_rpc(
     allowed_agent_statuses: list[PlaybookStatus] | None,
     recency_on: bool = False,
     search_mode: SearchMode = SearchMode.HYBRID,
+    deadline_monotonic: float,
+    tracked_futures: list[_TrackedSearchFuture],
 ) -> tuple[list[Any], list[Any], list[Any]] | None:
     """Run all Phase B arms through one combined storage round trip.
 
@@ -601,8 +650,8 @@ def _run_phase_b_single_rpc(
     Returns:
         The three result lists, or None when the combined call fails so the
         caller can fall back to the per-arm fan-out (e.g. the SQL function
-        is not yet migrated on this deployment). Timeouts propagate like the
-        fan-out path so a hung database is not retried.
+        is not yet migrated on this deployment). The RPC and any fallback
+        share the Phase B deadline; deadline exhaustion propagates to the caller.
     """
     statuses = (
         list(allowed_agent_statuses)
@@ -625,6 +674,8 @@ def _run_phase_b_single_rpc(
 
     future = _submit_with_current_context(
         _SEARCH_FANOUT_EXECUTOR,
+        "unified",
+        deadline_monotonic,
         unified_hybrid_search,
         query=query,
         query_embedding=embedding,
@@ -639,12 +690,16 @@ def _run_phase_b_single_rpc(
         include_profiles="profiles" in entity_types and bool(request.user_id),
         include_agent_playbooks="agent_playbooks" in entity_types,
         include_user_playbooks="user_playbooks" in entity_types,
+        _retry_deadline_monotonic=deadline_monotonic,
     )
+    tracked_futures.append(future)
     try:
-        profiles, agent_playbooks, user_playbooks = future.result(timeout=30)
+        profiles, agent_playbooks, user_playbooks = _result_with_deadline(future)
     except FuturesTimeoutError:
         raise
     except Exception:
+        if _remaining_deadline_seconds(deadline_monotonic) <= 0:
+            raise FuturesTimeoutError from None
         logger.warning(
             "Unified single-RPC search failed; falling back to per-arm fan-out",
             exc_info=True,
@@ -1027,12 +1082,102 @@ def _search_user_playbooks_via_storage(
 
 def _submit_with_current_context(
     executor: ThreadPoolExecutor,
+    task: str,
+    deadline_monotonic: float,
     fn: Callable[..., object],
     *args: object,
     **kwargs: object,
-) -> Future[Any]:
+) -> _TrackedSearchFuture:
+    submitted_at = time.monotonic()
     context = contextvars.copy_context()
-    return executor.submit(context.run, fn, *args, **kwargs)
+
+    def run() -> object:
+        started_at = time.monotonic()
+        queue_wait_ms = (started_at - submitted_at) * 1000
+        deadline_remaining_ms = max(0.0, deadline_monotonic - started_at) * 1000
+        with profile_step(
+            "search.executor.task",
+            task=task,
+            queue_wait_ms=queue_wait_ms,
+            deadline_remaining_ms_at_start=deadline_remaining_ms,
+        ) as span:
+            execution_started_at = time.monotonic()
+            outcome = "success"
+            try:
+                if deadline_remaining_ms <= 0:
+                    outcome = "deadline_expired"
+                    raise FuturesTimeoutError(
+                        f"Search task {task} started after its deadline"
+                    )
+                return fn(*args, **kwargs)
+            except FuturesTimeoutError:
+                if outcome != "deadline_expired":
+                    outcome = "timeout"
+                raise
+            except BaseException:
+                outcome = "failure"
+                raise
+            finally:
+                set_span_data(
+                    span,
+                    {
+                        "execution_ms": (time.monotonic() - execution_started_at)
+                        * 1000,
+                        "outcome": outcome,
+                    },
+                )
+
+    future = executor.submit(context.run, run)
+    return _TrackedSearchFuture(
+        task=task,
+        future=future,
+        submitted_at=submitted_at,
+        deadline_monotonic=deadline_monotonic,
+    )
+
+
+def _remaining_deadline_seconds(deadline_monotonic: float) -> float:
+    return max(0.0, deadline_monotonic - time.monotonic())
+
+
+def _result_with_deadline(tracked_future: _TrackedSearchFuture) -> Any:
+    return tracked_future.future.result(
+        timeout=_remaining_deadline_seconds(tracked_future.deadline_monotonic)
+    )
+
+
+def _cancel_unfinished_futures(
+    tracked_futures: list[_TrackedSearchFuture],
+) -> dict[str, int]:
+    counts = {
+        "cancelled_queued_count": 0,
+        "running_count": 0,
+        "completed_count": 0,
+    }
+    for tracked in tracked_futures:
+        future = tracked.future
+        if future.done():
+            counts["completed_count"] += 1
+            continue
+        if future.cancel():
+            counts["cancelled_queued_count"] += 1
+            queue_wait_ms = (time.monotonic() - tracked.submitted_at) * 1000
+            with profile_step(
+                "search.executor.task",
+                task=tracked.task,
+                queue_wait_ms=queue_wait_ms,
+                deadline_remaining_ms_at_start=None,
+            ) as span:
+                set_span_data(
+                    span,
+                    {"execution_ms": 0.0, "outcome": "cancelled_queued"},
+                )
+            continue
+        if future.done():
+            counts["completed_count"] += 1
+        else:
+            counts["running_count"] += 1
+    return counts
 
 
 def _storage_backend_name(storage: BaseStorage) -> str:

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -1,6 +1,13 @@
 """Phase B single-RPC routing: combined storage call, fallback, kill switch."""
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from contextlib import contextmanager
 from typing import Any, cast
+
+import pytest
 
 from reflexio.models.api_schema.retriever_schema import UnifiedSearchRequest
 from reflexio.models.api_schema.service_schemas import (
@@ -10,6 +17,28 @@ from reflexio.models.api_schema.service_schemas import (
 )
 from reflexio.server.services import unified_search_service as uss
 from reflexio.server.services.storage.storage_base import BaseStorage
+from reflexio.server.tracing import configure_tracer
+
+
+class _RecordingSpan:
+    def __init__(self, record: dict[str, Any]) -> None:
+        self.record = record
+
+    def set_data(self, key: str, value: Any) -> None:
+        self.record[key] = value
+
+
+class _RecordingTracer:
+    def __init__(self, records: list[dict[str, Any]]) -> None:
+        self.records = records
+
+    @contextmanager
+    def span(self, name: str, **data: Any):
+        record = {"name": name, **data}
+        try:
+            yield _RecordingSpan(record)
+        finally:
+            self.records.append(record)
 
 
 def _agent_playbook(playbook_id: int, content: str) -> AgentPlaybook:
@@ -177,6 +206,26 @@ def test_single_rpc_failure_falls_back_to_fanout(monkeypatch):
     assert (profiles, agent_playbooks, user_playbooks) == ([], [], [])
 
 
+def test_single_rpc_and_fallback_share_one_deadline(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _CombinedStorage(raise_on_combined=True)
+    observed_deadlines: list[float] = []
+    original_remaining = uss._remaining_deadline_seconds
+
+    def record_remaining(deadline_monotonic: float) -> float:
+        observed_deadlines.append(deadline_monotonic)
+        return original_remaining(deadline_monotonic)
+
+    monkeypatch.setattr(uss, "_remaining_deadline_seconds", record_remaining)
+
+    assert _run_phase_b(storage) == ([], [], [])
+    assert len(observed_deadlines) >= 4
+    assert len(set(observed_deadlines)) == 1
+    assert (
+        storage.combined_calls[0]["_retry_deadline_monotonic"] == observed_deadlines[0]
+    )
+
+
 def test_single_rpc_missing_callable_falls_back_to_fanout(monkeypatch):
     monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
     storage = _MissingCombinedMethodStorage()
@@ -211,3 +260,203 @@ def test_single_rpc_kill_switch_disables_combined_path(monkeypatch):
         "agent_playbooks",
         "user_playbooks",
     }
+
+
+def test_cancels_queued_future_but_reports_running_future():
+    executor = ThreadPoolExecutor(max_workers=1)
+    running_started = threading.Event()
+    release_running = threading.Event()
+    queued_called = threading.Event()
+
+    def blocking_task() -> list[Any]:
+        running_started.set()
+        assert release_running.wait(timeout=2)
+        return []
+
+    def queued_task() -> list[Any]:
+        queued_called.set()
+        return []
+
+    deadline = time.monotonic() + 5
+    running = uss._submit_with_current_context(
+        executor, "running", deadline, blocking_task
+    )
+    assert running_started.wait(timeout=1)
+    queued = uss._submit_with_current_context(executor, "queued", deadline, queued_task)
+
+    try:
+        counts = uss._cancel_unfinished_futures([running, queued])
+
+        assert counts == {
+            "cancelled_queued_count": 1,
+            "running_count": 1,
+            "completed_count": 0,
+        }
+        assert queued.future.cancelled()
+        assert not queued_called.is_set()
+    finally:
+        release_running.set()
+        running.future.result(timeout=1)
+        executor.shutdown(wait=True)
+
+
+def test_executor_span_separates_queue_wait_from_execution_time():
+    records: list[dict[str, Any]] = []
+    executor = ThreadPoolExecutor(max_workers=1)
+    running_started = threading.Event()
+    release_running = threading.Event()
+
+    def blocking_task() -> None:
+        running_started.set()
+        assert release_running.wait(timeout=2)
+
+    configure_tracer(_RecordingTracer(records))
+    deadline = time.monotonic() + 5
+    try:
+        running = uss._submit_with_current_context(
+            executor, "running", deadline, blocking_task
+        )
+        assert running_started.wait(timeout=1)
+        queued = uss._submit_with_current_context(
+            executor, "queued", deadline, lambda: "done"
+        )
+        time.sleep(0.01)
+        release_running.set()
+        assert queued.future.result(timeout=1) == "done"
+        running.future.result(timeout=1)
+    finally:
+        release_running.set()
+        executor.shutdown(wait=True)
+        configure_tracer(None)
+
+    queued_record = next(
+        record
+        for record in records
+        if record["name"] == "search.executor.task" and record["task"] == "queued"
+    )
+    assert queued_record["queue_wait_ms"] >= 10
+    assert queued_record["execution_ms"] >= 0
+    assert queued_record["deadline_remaining_ms_at_start"] > 0
+    assert queued_record["outcome"] == "success"
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_outcome"),
+    [(RuntimeError("failed"), "failure"), (FuturesTimeoutError(), "timeout")],
+)
+def test_executor_span_records_failure_outcomes(
+    exc: BaseException, expected_outcome: str
+):
+    records: list[dict[str, Any]] = []
+    executor = ThreadPoolExecutor(max_workers=1)
+
+    def fail() -> None:
+        raise exc
+
+    configure_tracer(_RecordingTracer(records))
+    try:
+        tracked = uss._submit_with_current_context(
+            executor, "failing", time.monotonic() + 5, fail
+        )
+        with pytest.raises(type(exc)):
+            tracked.future.result(timeout=1)
+    finally:
+        executor.shutdown(wait=True)
+        configure_tracer(None)
+
+    record = next(
+        record for record in records if record["name"] == "search.executor.task"
+    )
+    assert record["outcome"] == expected_outcome
+    assert record["execution_ms"] >= 0
+
+
+def test_executor_task_does_not_call_storage_after_deadline():
+    records: list[dict[str, Any]] = []
+    called = threading.Event()
+    executor = ThreadPoolExecutor(max_workers=1)
+    configure_tracer(_RecordingTracer(records))
+    try:
+        tracked = uss._submit_with_current_context(
+            executor,
+            "expired",
+            time.monotonic() - 1,
+            called.set,
+        )
+        with pytest.raises(FuturesTimeoutError):
+            tracked.future.result(timeout=1)
+    finally:
+        executor.shutdown(wait=True)
+        configure_tracer(None)
+
+    assert not called.is_set()
+    record = next(
+        record for record in records if record["name"] == "search.executor.task"
+    )
+    assert record["deadline_remaining_ms_at_start"] == 0
+    assert record["outcome"] == "deadline_expired"
+
+
+def test_cancelled_queued_task_records_cancellation_outcome():
+    records: list[dict[str, Any]] = []
+    executor = ThreadPoolExecutor(max_workers=1)
+    running_started = threading.Event()
+    release_running = threading.Event()
+
+    def blocking_task() -> None:
+        running_started.set()
+        assert release_running.wait(timeout=2)
+
+    configure_tracer(_RecordingTracer(records))
+    deadline = time.monotonic() + 5
+    try:
+        running = uss._submit_with_current_context(
+            executor, "running", deadline, blocking_task
+        )
+        assert running_started.wait(timeout=1)
+        queued = uss._submit_with_current_context(
+            executor, "queued", deadline, lambda: None
+        )
+
+        counts = uss._cancel_unfinished_futures([running, queued])
+
+        assert counts["cancelled_queued_count"] == 1
+    finally:
+        release_running.set()
+        executor.shutdown(wait=True)
+        configure_tracer(None)
+
+    record = next(
+        record
+        for record in records
+        if record["name"] == "search.executor.task" and record["task"] == "queued"
+    )
+    assert record["deadline_remaining_ms_at_start"] is None
+    assert record["execution_ms"] == 0
+    assert record["outcome"] == "cancelled_queued"
+
+
+def test_phase_b_timeout_records_parent_cancellation_counts(monkeypatch):
+    records: list[dict[str, Any]] = []
+
+    class TimeoutStorage(_CombinedStorage):
+        def search_agent_playbooks(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+            raise FuturesTimeoutError("storage timeout")
+
+    monkeypatch.setenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", "0")
+    configure_tracer(_RecordingTracer(records))
+    try:
+        assert _run_phase_b(TimeoutStorage()) == (None, None, None)
+    finally:
+        configure_tracer(None)
+
+    phase_record = next(
+        record for record in records if record["name"] == "search.phase_b"
+    )
+    assert phase_record["timed_out"] is True
+    assert (
+        phase_record["cancelled_queued_count"]
+        + phase_record["running_count"]
+        + phase_record["completed_count"]
+        == 3
+    )

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -320,7 +320,7 @@ def test_executor_span_separates_queue_wait_from_execution_time():
         queued = uss._submit_with_current_context(
             executor, "queued", deadline, lambda: "done"
         )
-        time.sleep(0.01)
+        time.sleep(0.05)
         release_running.set()
         assert queued.future.result(timeout=1) == "done"
         running.future.result(timeout=1)
@@ -460,3 +460,24 @@ def test_phase_b_timeout_records_parent_cancellation_counts(monkeypatch):
         + phase_record["completed_count"]
         == 3
     )
+
+
+def test_phase_b_failure_cleans_up_active_futures(monkeypatch):
+    cleaned: list[list[uss._TrackedSearchFuture]] = []
+
+    class FailingStorage(_CombinedStorage):
+        def search_agent_playbooks(self, *_args: Any, **_kwargs: Any) -> list[Any]:
+            raise RuntimeError("storage failed")
+
+    monkeypatch.setenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", "0")
+    monkeypatch.setattr(
+        uss, "_cancel_unfinished_futures", lambda futures: cleaned.append(futures)
+    )
+
+    assert _run_phase_b(FailingStorage()) == (None, None, None)
+    assert len(cleaned) == 1
+    assert {tracked.task for tracked in cleaned[0]} == {
+        "profiles",
+        "agent_playbooks",
+        "user_playbooks",
+    }


### PR DESCRIPTION
## Summary
- enforce one absolute 30-second Phase B retrieval deadline across the combined search RPC and legacy fanout fallback
- prevent executor tasks that start after the deadline from calling storage
- cancel queued futures on timeout while distinguishing them from already-running synchronous work
- clean up unfinished sibling futures on non-timeout fanout failures
- expose executor queue wait and execution latency as separate tracing fields

## Changes
- pass the Phase B monotonic deadline through the combined storage call and every future wait
- track executor submissions by task, submission time, and deadline
- emit `search.executor.task` spans with task timing and outcome fields
- record cancelled, running, and completed future counts on Phase B timeout
- invoke the same sibling-future cleanup on non-timeout fanout failures
- add deterministic regression coverage for shared deadlines, cancellation, and tracing outcomes

## Test Plan
- `uv run ruff check reflexio/server/services/unified_search_service.py tests/server/services/test_unified_search_single_rpc.py`
- `uv run pyright reflexio/server/services/unified_search_service.py tests/server/services/test_unified_search_single_rpc.py`
- `uv run pytest tests/server/services/test_unified_search_single_rpc.py -q -o 'addopts='`
- full OSS non-E2E tier before review: 5,102 passed, 73 skipped, 6 subtests passed
- relevant non-paid E2E search path: 3 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unified search reliability by enforcing a shared monotonic execution deadline across the Phase B fan-out workflow and the single-RPC fallback path.
  * Prevented tasks from starting after the deadline is exceeded, and ensured queued work is cancelled appropriately while running work is allowed to complete.
  * Enhanced handling of Phase B timeouts and failure cleanup to avoid incomplete or hanging results.

* **Monitoring**
  * Added more detailed search execution tracing, including queue time vs execution time, explicit outcome labeling (failure/timeout/deadline expired), and accurate cancellation/running/completed counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->