### PR TITLE
fix(client): serialize request bodies in JSON mode

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -375,7 +375,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/publish_interaction",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
             params=params,
         )
         return PublishUserInteractionResponse(**response)
@@ -395,7 +395,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "POST",
             "/api/publish_interaction",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
             params=params,
         )
         return PublishUserInteractionResponse(**response)
@@ -590,7 +590,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/search_interactions",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return SearchInteractionsViewResponse(**response)
 
@@ -651,7 +651,7 @@ class ReflexioClient:
             search_mode=search_mode,
         )
         response = self._make_request(
-            "POST", "/api/search_profiles", json=req.model_dump()
+            "POST", "/api/search_profiles", json=req.model_dump(mode="json")
         )
         return SearchProfilesViewResponse(**response)
 
@@ -734,7 +734,7 @@ class ReflexioClient:
             top_k=top_k,
         )
         response = self._make_request(
-            "POST", "/api/rerank_user_profiles", json=req.model_dump()
+            "POST", "/api/rerank_user_profiles", json=req.model_dump(mode="json")
         )
         return SearchProfilesViewResponse(**response)
 
@@ -812,7 +812,7 @@ class ReflexioClient:
             search_mode=search_mode,
         )
         response = self._make_request(
-            "POST", "/api/search_user_playbooks", json=req.model_dump()
+            "POST", "/api/search_user_playbooks", json=req.model_dump(mode="json")
         )
         return SearchUserPlaybooksViewResponse(**response)
 
@@ -870,7 +870,7 @@ class ReflexioClient:
             search_mode=search_mode,
         )
         response = self._make_request(
-            "POST", "/api/search_agent_playbooks", json=req.model_dump()
+            "POST", "/api/search_agent_playbooks", json=req.model_dump(mode="json")
         )
         return SearchAgentPlaybooksViewResponse(**response)
 
@@ -881,7 +881,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE",
             "/api/delete_profile",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteUserProfileResponse(**response)
 
@@ -892,7 +892,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "DELETE",
             "/api/delete_profile",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteUserProfileResponse(**response)
 
@@ -939,7 +939,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE",
             "/api/delete_interaction",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteUserInteractionResponse(**response)
 
@@ -950,7 +950,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "DELETE",
             "/api/delete_interaction",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteUserInteractionResponse(**response)
 
@@ -990,7 +990,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE",
             "/api/delete_request",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteRequestResponse(**response)
 
@@ -1001,7 +1001,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "DELETE",
             "/api/delete_request",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteRequestResponse(**response)
 
@@ -1037,7 +1037,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE",
             "/api/delete_session",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteSessionResponse(**response)
 
@@ -1048,7 +1048,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "DELETE",
             "/api/delete_session",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteSessionResponse(**response)
 
@@ -1145,7 +1145,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE",
             "/api/delete_agent_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteAgentPlaybookResponse(**response)
 
@@ -1156,7 +1156,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "DELETE",
             "/api/delete_agent_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteAgentPlaybookResponse(**response)
 
@@ -1193,7 +1193,7 @@ class ReflexioClient:
         response = self._make_request(
             "DELETE",
             "/api/delete_user_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteUserPlaybookResponse(**response)
 
@@ -1204,7 +1204,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "DELETE",
             "/api/delete_user_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return DeleteUserPlaybookResponse(**response)
 
@@ -1274,7 +1274,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_interactions",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return GetInteractionsViewResponse(**response)
 
@@ -1362,7 +1362,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_profiles",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         result = GetProfilesViewResponse(**response)
 
@@ -1474,7 +1474,7 @@ class ReflexioClient:
         return self._make_request(
             "POST",
             "/api/set_config",
-            json=config.model_dump(),  # type: ignore[reportAttributeAccessIssue]
+            json=config.model_dump(mode="json"),  # type: ignore[reportAttributeAccessIssue]
         )
 
     def update_config(self, partial: dict) -> dict:
@@ -1602,7 +1602,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_user_playbooks",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return GetUserPlaybooksViewResponse(**response)
 
@@ -1631,7 +1631,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/add_user_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return AddUserPlaybookResponse(**response)
 
@@ -1662,7 +1662,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/add_agent_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return AddAgentPlaybookResponse(**response)
 
@@ -1722,7 +1722,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/add_user_profile",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return AddUserProfileResponse(**response)
 
@@ -1760,7 +1760,7 @@ class ReflexioClient:
         response = self._make_request(
             "PUT",
             "/api/update_user_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return UpdateUserPlaybookResponse(**response)
 
@@ -1802,7 +1802,7 @@ class ReflexioClient:
         response = self._make_request(
             "PUT",
             "/api/update_agent_playbook",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         self._cache.invalidate("get_agent_playbooks")
         return UpdateAgentPlaybookResponse(**response)
@@ -1836,7 +1836,7 @@ class ReflexioClient:
         response = self._make_request(
             "PUT",
             "/api/update_agent_playbook_status",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         self._cache.invalidate("get_agent_playbooks")
         return UpdatePlaybookStatusResponse(**response)
@@ -1913,7 +1913,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_agent_playbooks",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         result = GetAgentPlaybooksViewResponse(**response)
 
@@ -1976,7 +1976,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_requests",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return GetRequestsViewResponse(**response)
 
@@ -2012,7 +2012,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_agent_success_evaluation_results",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return GetEvaluationResultsViewResponse(**response)
 
@@ -2043,7 +2043,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/get_retrieved_learning_evaluation_results",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return GetRetrievedLearningEvaluationResultsResponse(**response)
 
@@ -2078,7 +2078,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/evaluations/regenerate",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return RegenerateStartResponse(**response)
 
@@ -2130,7 +2130,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/evaluations/grade_on_demand",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return GradeOnDemandResponse(**response)
 
@@ -2202,7 +2202,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/rerun_profile_generation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         initial = RerunProfileGenerationResponse(**response)
         if not initial.success:
@@ -2240,7 +2240,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "POST",
             "/api/rerun_profile_generation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return RerunProfileGenerationResponse(**response)
 
@@ -2310,7 +2310,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/upgrade_all_profiles",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return UpgradeProfilesResponse(**response)
 
@@ -2336,7 +2336,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/upgrade_all_user_playbooks",
-            json=req.model_dump(),
+            json=req.model_dump(mode="json"),
         )
         return UpgradeUserPlaybooksResponse(**response)
 
@@ -2347,7 +2347,7 @@ class ReflexioClient:
         await self._make_async_request(
             "POST",
             "/api/manual_profile_generation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
 
     def manual_profile_generation(
@@ -2395,7 +2395,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/rerun_playbook_generation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         initial = RerunPlaybookGenerationResponse(**response)
         if not initial.success:
@@ -2433,7 +2433,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "POST",
             "/api/rerun_playbook_generation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return RerunPlaybookGenerationResponse(**response)
 
@@ -2485,7 +2485,7 @@ class ReflexioClient:
         await self._make_async_request(
             "POST",
             "/api/manual_playbook_generation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
 
     def manual_playbook_generation(
@@ -2529,7 +2529,7 @@ class ReflexioClient:
         response = self._make_request(
             "POST",
             "/api/run_playbook_aggregation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return RunPlaybookAggregationResponse(**response)
 
@@ -2540,7 +2540,7 @@ class ReflexioClient:
         response = await self._make_async_request(
             "POST",
             "/api/run_playbook_aggregation",
-            json=request.model_dump(),
+            json=request.model_dump(mode="json"),
         )
         return RunPlaybookAggregationResponse(**response)
 
@@ -2656,7 +2656,7 @@ class ReflexioClient:
             session_id=session_id,
             interaction_id=interaction_id,
         )
-        response = self._make_request("POST", "/api/search", json=req.model_dump())
+        response = self._make_request("POST", "/api/search", json=req.model_dump(mode="json"))
         return UnifiedSearchViewResponse(**response)
 
     # =========================================================================
@@ -2674,7 +2674,7 @@ class ReflexioClient:
         """
         req = DeleteRequestsByIdsRequest(request_ids=request_ids)
         response = self._make_request(
-            "DELETE", "/api/delete_requests_by_ids", json=req.model_dump()
+            "DELETE", "/api/delete_requests_by_ids", json=req.model_dump(mode="json")
         )
         return BulkDeleteResponse(**response)
 
@@ -2689,7 +2689,7 @@ class ReflexioClient:
         """
         req = DeleteProfilesByIdsRequest(profile_ids=profile_ids)
         response = self._make_request(
-            "DELETE", "/api/delete_profiles_by_ids", json=req.model_dump()
+            "DELETE", "/api/delete_profiles_by_ids", json=req.model_dump(mode="json")
         )
         self._cache.invalidate("get_profiles")
         return BulkDeleteResponse(**response)
@@ -2707,7 +2707,7 @@ class ReflexioClient:
         """
         req = DeleteAgentPlaybooksByIdsRequest(agent_playbook_ids=agent_playbook_ids)
         response = self._make_request(
-            "DELETE", "/api/delete_agent_playbooks_by_ids", json=req.model_dump()
+            "DELETE", "/api/delete_agent_playbooks_by_ids", json=req.model_dump(mode="json")
         )
         self._cache.invalidate("get_agent_playbooks")
         return BulkDeleteResponse(**response)
@@ -2725,7 +2725,7 @@ class ReflexioClient:
         """
         req = DeleteUserPlaybooksByIdsRequest(user_playbook_ids=user_playbook_ids)
         response = self._make_request(
-            "DELETE", "/api/delete_user_playbooks_by_ids", json=req.model_dump()
+            "DELETE", "/api/delete_user_playbooks_by_ids", json=req.model_dump(mode="json")
         )
         return BulkDeleteResponse(**response)
 
@@ -3007,7 +3007,7 @@ class ReflexioClient:
         """
         req = ClearUserDataRequest(user_id=user_id)
         response = self._make_request(
-            "POST", "/api/clear_user_data", json=req.model_dump()
+            "POST", "/api/clear_user_data", json=req.model_dump(mode="json")
         )
         # Nuclear — clear everything that could reference this user.
         self._cache.clear()

--- a/tests/client/test_evaluation_client.py
+++ b/tests/client/test_evaluation_client.py
@@ -192,11 +192,16 @@ def test_get_retrieved_learning_evaluation_results_posts_filters(
     args, kwargs = mock_session.request.call_args
     assert args[0] == "POST"
     assert args[1].endswith("/api/get_retrieved_learning_evaluation_results")
+    # Times go out as ISO strings, not datetime objects: `requests` runs
+    # json.dumps on this body, which cannot serialize a datetime. This
+    # assertion previously expected the raw objects, which is why the
+    # unserializable payload went unnoticed -- see
+    # tests/client/test_request_serialization.py.
     assert kwargs["json"] == {
         "user_id": "user-1",
         "session_id": "session-1",
-        "start_time": datetime(2026, 1, 1, tzinfo=UTC),
-        "end_time": datetime(2026, 1, 2, tzinfo=UTC),
+        "start_time": "2026-01-01T00:00:00Z",
+        "end_time": "2026-01-02T00:00:00Z",
         "limit": 25,
     }
 

--- a/tests/client/test_request_serialization.py
+++ b/tests/client/test_request_serialization.py
@@ -1,0 +1,150 @@
+"""Every request body the client sends must survive ``json.dumps``.
+
+Request models carry ``datetime`` fields (``start_time`` / ``end_time`` on all
+the time-filtered reads). A plain ``model_dump()`` leaves those as ``datetime``
+objects, and ``requests`` then raises ``TypeError: Object of type datetime is
+not JSON serializable`` *before the request ever leaves the process* — so every
+time-filtered read was unusable, on both the kwargs and request-object paths.
+
+A mock-based call-assertion cannot catch this: the mock never serializes. These
+tests assert the payload itself is JSON-safe, plus a source-level guard so a new
+call site cannot reintroduce the bug.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from reflexio.client import ReflexioClient
+from reflexio.client import client as client_module
+
+_CLIENT_SOURCE = Path(client_module.__file__)
+
+START = datetime(2026, 6, 1, tzinfo=UTC)
+END = datetime(2026, 7, 1, tzinfo=UTC)
+
+
+def _json_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.content = b"{}"
+    response.headers = {"Content-Type": "application/json"}
+    return response
+
+
+# Every read that accepts a datetime filter: method, minimal valid response, and
+# any required arguments beyond the time filters.
+_TIME_FILTERED_READS = [
+    (
+        "get_agent_success_evaluation_results",
+        {"success": True, "agent_success_evaluation_results": []},
+        {},
+    ),
+    ("get_retrieved_learning_evaluation_results", {"success": True, "results": []}, {}),
+    ("get_requests", {"success": True, "sessions": []}, {}),
+    ("get_interactions", {"success": True, "interactions": []}, {"user_id": "u1"}),
+    ("get_profiles", {"success": True, "user_profiles": []}, {"user_id": "u1"}),
+    ("get_user_playbooks", {"success": True, "user_playbooks": []}, {}),
+    ("get_agent_playbooks", {"success": True, "agent_playbooks": []}, {}),
+]
+
+
+@pytest.mark.parametrize(("method_name", "payload", "extra"), _TIME_FILTERED_READS)
+@patch("reflexio.client.client.requests.Session")
+def test_datetime_filters_serialize_to_json(
+    mock_session_class, method_name: str, payload: dict, extra: dict
+) -> None:
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    mock_session.request.return_value = _json_response(payload)
+    client = ReflexioClient(api_key="test_key", url_endpoint="http://localhost:8000")
+
+    getattr(client, method_name)(start_time=START, end_time=END, **extra)
+
+    _, kwargs = mock_session.request.call_args
+    body = kwargs.get("json")
+    assert body is not None, f"{method_name} sent no JSON body"
+
+    # The real failure mode: requests calls json.dumps on this and blows up.
+    json.dumps(body)
+
+    # Compare instants, not spelling — pydantic renders UTC as "...Z" while
+    # datetime.isoformat() renders "+00:00"; both are valid ISO 8601.
+    assert isinstance(body["start_time"], str)
+    assert datetime.fromisoformat(body["start_time"]) == START
+    assert datetime.fromisoformat(body["end_time"]) == END
+
+
+@patch("reflexio.client.client.requests.Session")
+def test_request_object_path_serializes_too(mock_session_class) -> None:
+    """The request-object path must not diverge from the kwargs path.
+
+    Some parameters (``offset`` on ``get_requests``) are only reachable by
+    passing a request object, so it is a real call path, not a legacy alias.
+    """
+    from reflexio.models.api_schema.retriever_schema import GetRequestsRequest
+
+    mock_session = MagicMock()
+    mock_session_class.return_value = mock_session
+    mock_session.request.return_value = _json_response(
+        {"success": True, "sessions": []}
+    )
+    client = ReflexioClient(api_key="test_key", url_endpoint="http://localhost:8000")
+
+    client.get_requests(
+        GetRequestsRequest(source="s", start_time=START, end_time=END, offset=40)
+    )
+
+    _, kwargs = mock_session.request.call_args
+    json.dumps(kwargs["json"])
+    assert kwargs["json"]["offset"] == 40
+
+
+def _json_kwarg_dumps(tree: ast.AST) -> list[tuple[int, ast.Call]]:
+    """Every ``model_dump(...)`` passed as a ``json=`` keyword, with its line."""
+    found: list[tuple[int, ast.Call]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        for keyword in node.keywords:
+            value = keyword.value
+            if (
+                keyword.arg == "json"
+                and isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Attribute)
+                and value.func.attr == "model_dump"
+            ):
+                found.append((value.lineno, value))
+    return found
+
+
+def test_no_request_body_uses_python_mode_model_dump() -> None:
+    """Source guard: catches any NEW call site reintroducing the bug.
+
+    Scoped to ``model_dump`` results handed to ``json=`` — a bare
+    ``model_dump()`` elsewhere (in-process use) is unaffected and stays legal.
+    """
+    tree = ast.parse(_CLIENT_SOURCE.read_text(encoding="utf-8"))
+    dumps = _json_kwarg_dumps(tree)
+    assert dumps, "found no json=<model>.model_dump(...) call sites — guard is blind"
+
+    offenders = [
+        lineno
+        for lineno, call in dumps
+        if not any(
+            kw.arg == "mode"
+            and isinstance(kw.value, ast.Constant)
+            and kw.value.value == "json"
+            for kw in call.keywords
+        )
+    ]
+    assert not offenders, (
+        f"{_CLIENT_SOURCE.name} lines {offenders} pass model_dump() to json= "
+        'without mode="json"; datetime fields will not serialize'
+    )


### PR DESCRIPTION
## Problem

Every request model carrying a `datetime` field was unusable over the client.
`model_dump()` leaves `start_time` / `end_time` as `datetime` objects, and
`requests` then raises before the request ever leaves the process:

```
TypeError: Object of type datetime is not JSON serializable
```

Reproducing against a live backend, on the plain kwargs path:

```python
c.get_agent_success_evaluation_results(start_time=A, end_time=B)   # TypeError
c.get_retrieved_learning_evaluation_results(start_time=A, end_time=B)  # TypeError
c.get_requests(source="x", start_time=A, end_time=B)               # TypeError
```

11 request models carry the field, so this covered every time-filtered read —
`get_requests`, `get_interactions`, `get_profiles`, `get_user_playbooks`,
`get_agent_playbooks`, the four `search_*` methods, and both evaluation reads —
on the kwargs path and the request-object path alike.

## Fix

All 51 `json=<model>.model_dump()` call sites become
`model_dump(mode="json")`. Datetimes render as ISO strings; every other field
type serializes identically, so the wire format is otherwise unchanged.

`params=` call sites were checked and are plain `str`/`int` dicts — no models,
nothing to change there.

## Test change worth a look

`test_get_retrieved_learning_evaluation_results_posts_filters` asserted the
**buggy** payload — raw `datetime` objects in the JSON body. That expectation
is why the unserializable body went unnoticed, so it is corrected rather than
worked around. The body it described could never have been sent.

## New tests

`tests/client/test_request_serialization.py`:

- Each time-filtered read is invoked and its body passed through `json.dumps`.
  This is the assertion a mock-based call check structurally cannot make, since
  the mock never serializes — which is how the bug survived existing coverage.
- An AST guard that fails on any new `json=` call site omitting `mode="json"`,
  so the class cannot return one method at a time.

All 9 fail without the fix and pass with it (verified by reverting the source
change and re-running).

## Verification

- `tests/client/`: 68 passed
- Full unit tier: 4005 passed, 2 failed
- Both failures (`test_extraction_eval.py::test_live_extraction_provider_returns_canned_items`,
  `test_llm_mock_schema_compliance.py::...[playbook_extraction-playbook_extraction]`)
  reproduce on a clean tree — pre-existing, unrelated to serialization
- ruff + pyright clean on all touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request serialization so date and time filters are sent in JSON-compatible ISO 8601 format.
  * Improved compatibility for API operations involving searches, retrievals, evaluations, deletions, and other requests that include date/time values.

* **Tests**
  * Added coverage to verify request payloads are valid JSON and preserve date/time values accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->