### PR TITLE
fix(storage): record a merge only when one happened, and stop losing the lock on handover

### DIFF
--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -288,14 +288,18 @@ class SQLiteLineageMixin:
         eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
         eligible_vals = list(_GC_ELIGIBLE_STATUSES)
         with self._lock:
-            # Only the sources this call actually tombstoned. ``source_ids`` on a
+            # Only the sources this call actually tombstoned, in sorted order.
+            # ``source_ids`` on a
             # lineage event means "records merged into entity_id"
             # (``LineageEvent.source_ids``), so listing a source that was ALREADY
             # tombstoned would claim a merge this operation did not perform — and
             # an already-MERGED source may have been merged into a DIFFERENT
             # survivor entirely.
             merged_source_ids: list[str] = []
-            for sid in source_ids:
+            # Sorted so concurrent merges over overlapping sources take their row
+            # locks in a consistent sequence — the Postgres RPC sorts identically,
+            # so both backends also emit source_ids in the same order.
+            for sid in sorted(source_ids):
                 if sid == survivor_id:
                     # Never tombstone the survivor itself, even if it is
                     # accidentally listed among the source ids.

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -258,9 +258,17 @@ class SQLiteLineageMixin:
         """Soft-delete each source into the survivor in one atomic transaction.
 
         Sets ``status=MERGED`` and ``merged_into=survivor_id`` on each source
-        whose status is not already a tombstone. Appends a single ``merge``
-        lineage event keyed on ``survivor_id``. Idempotent — re-running on
-        already-tombstoned sources is a no-op.
+        whose status is not already a tombstone.
+
+        Appends **at most one** ``merge`` lineage event keyed on ``survivor_id``,
+        and only when at least one source was actually tombstoned. The event
+        records the sources this call changed, not the sources it was asked to
+        change — a partial merge (say 2 of 5 sources still eligible) records
+        exactly those 2, because the other 3 were merged by some earlier
+        operation and possibly into a different survivor.
+
+        Idempotent in both the rows and the event: re-running on
+        already-tombstoned sources changes nothing and records nothing.
 
         Args:
             entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,
@@ -280,6 +288,13 @@ class SQLiteLineageMixin:
         eligible_ph = ",".join("?" * len(_GC_ELIGIBLE_STATUSES))
         eligible_vals = list(_GC_ELIGIBLE_STATUSES)
         with self._lock:
+            # Only the sources this call actually tombstoned. ``source_ids`` on a
+            # lineage event means "records merged into entity_id"
+            # (``LineageEvent.source_ids``), so listing a source that was ALREADY
+            # tombstoned would claim a merge this operation did not perform — and
+            # an already-MERGED source may have been merged into a DIFFERENT
+            # survivor entirely.
+            merged_source_ids: list[str] = []
             for sid in source_ids:
                 if sid == survivor_id:
                     # Never tombstone the survivor itself, even if it is
@@ -288,7 +303,7 @@ class SQLiteLineageMixin:
                 # Skip sources that already carry any eligible/tombstone status
                 # (MERGED, SUPERSEDED, or ARCHIVED) — avoids re-tombstoning an
                 # already-archived source and resetting its retired_at clock.
-                self.conn.execute(
+                cur = self.conn.execute(
                     f"UPDATE {table} SET status=?, merged_into=?, retired_at=? "  # noqa: S608
                     f"WHERE {pk}=? AND {pk}!=? "
                     f"AND (status IS NULL OR status NOT IN ({eligible_ph}))",
@@ -301,6 +316,16 @@ class SQLiteLineageMixin:
                         *eligible_vals,
                     ),
                 )
+                if cur.rowcount > 0:
+                    merged_source_ids.append(sid)
+            if not merged_source_ids:
+                # Nothing committed, so there is nothing to record. Emitting here
+                # would write a ``merge`` event asserting a state change that
+                # never happened; the sibling ``supersede_record`` already guards
+                # the same way on its single-statement ``rowcount``.
+                if self._own_transaction():
+                    self.conn.commit()
+                return
             _append_event_stmt(
                 self.conn,
                 org_id=self.org_id,
@@ -308,7 +333,7 @@ class SQLiteLineageMixin:
                 entity_id=survivor_id,
                 op="merge",
                 prov="wasDerivedFrom",
-                source_ids=source_ids,
+                source_ids=merged_source_ids,
                 actor=context.actor,
                 request_id=context.request_id,
                 reason=context.reason,

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -307,12 +307,27 @@ class OperationMixin:
 
             current_state = _json_loads(row["operation_state"]) or {}
 
-            # Check if lock is stale
-            updated_at_str = row["updated_at"]
-            is_stale = False
-            if updated_at_str:
-                updated_epoch = _iso_to_epoch(updated_at_str)
-                is_stale = (now - updated_epoch) > stale_lock_seconds
+            # Staleness is measured from when the HOLDER took the lock, not from
+            # the last write to the row. The queue-append branch at the bottom of
+            # this method rewrites the row — and therefore ``updated_at`` — on
+            # every REJECTED acquire, so keying off the row clock let each new
+            # contender refresh a dead holder's lock: above one request per
+            # ``stale_lock_seconds`` it could never expire and the service
+            # livelocked. The Postgres RPC has always measured from ``started_at``
+            # (``tenant.try_acquire_in_progress_lock``); this matches it, boundary
+            # included.
+            #
+            # ``updated_at`` stays as the fallback for rows written before
+            # ``started_at`` was stamped — unlike Postgres's ``COALESCE(…, 0)``,
+            # which would treat every such legacy row as instantly stale.
+            started_at = current_state.get("started_at")
+            if started_at is not None:
+                is_stale = (now - int(started_at)) >= stale_lock_seconds
+            else:
+                updated_at_str = row["updated_at"]
+                is_stale = bool(updated_at_str) and (
+                    (now - _iso_to_epoch(updated_at_str)) > stale_lock_seconds
+                )
 
             # ``in_progress`` is the canonical held-flag: it is what the Postgres
             # RPC ``tenant.try_acquire_in_progress_lock`` writes and reads, and
@@ -323,9 +338,11 @@ class OperationMixin:
             # ``status`` key at all, so this check read a live lock as free and
             # the next caller took it *and* reset the pending queue.
             #
-            # The ``status`` arm is a migration shim for rows written by an older
-            # build; nothing writes that key any more, and it can be dropped once
-            # no such rows can remain.
+            # The ``status`` arm is a migration shim for lock rows written by an
+            # older build. Nothing writes ``status`` on a ``::lock`` row any more —
+            # note ``operation_state_utils`` does still write a ``status`` key, but
+            # only on the separate ``::progress`` key space, which this method
+            # never reads. The arm can be dropped once no legacy lock rows remain.
             held = bool(current_state.get("in_progress")) or (
                 current_state.get("status") == "in_progress"
             )

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -292,7 +292,8 @@ class OperationMixin:
             if row is None:
                 # No state exists — acquire lock
                 state = {
-                    "status": "in_progress",
+                    "in_progress": True,
+                    "started_at": int(now),
                     "current_request_id": request_id,
                     "pending_request_id": None,
                     "pending_request_queue": [],
@@ -313,11 +314,27 @@ class OperationMixin:
                 updated_epoch = _iso_to_epoch(updated_at_str)
                 is_stale = (now - updated_epoch) > stale_lock_seconds
 
-            if current_state.get("status") != "in_progress" or is_stale:
+            # ``in_progress`` is the canonical held-flag: it is what the Postgres
+            # RPC ``tenant.try_acquire_in_progress_lock`` writes and reads, and
+            # what every writer in ``operation_state_utils`` emits — including
+            # ``release_lock_pop_queue``, which hands the lock to the next queued
+            # holder. Because ``upsert_operation_state`` REPLACES the whole blob
+            # rather than merging it, a handover left a row carrying no
+            # ``status`` key at all, so this check read a live lock as free and
+            # the next caller took it *and* reset the pending queue.
+            #
+            # The ``status`` arm is a migration shim for rows written by an older
+            # build; nothing writes that key any more, and it can be dropped once
+            # no such rows can remain.
+            held = bool(current_state.get("in_progress")) or (
+                current_state.get("status") == "in_progress"
+            )
+            if not held or is_stale:
                 # Acquire lock — reset queue (any pre-existing entries are
                 # stale-lock detritus from a crashed run; we want a clean slate).
                 state = {
-                    "status": "in_progress",
+                    "in_progress": True,
+                    "started_at": int(now),
                     "current_request_id": request_id,
                     "pending_request_id": None,
                     "pending_request_queue": [],

--- a/reflexio/server/services/storage/sqlite_storage/_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/_operations.py
@@ -325,8 +325,12 @@ class OperationMixin:
                 is_stale = (now - int(started_at)) >= stale_lock_seconds
             else:
                 updated_at_str = row["updated_at"]
+                # Same ``>=`` boundary as the canonical path above: the two
+                # branches are the same concept measured from different clocks, so
+                # a lock exactly ``stale_lock_seconds`` old must be reclaimable
+                # under both. (The pre-existing code here used ``>``.)
                 is_stale = bool(updated_at_str) and (
-                    (now - _iso_to_epoch(updated_at_str)) > stale_lock_seconds
+                    (now - _iso_to_epoch(updated_at_str)) >= stale_lock_seconds
                 )
 
             # ``in_progress`` is the canonical held-flag: it is what the Postgres

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -87,8 +87,14 @@ class LineageEventMixin:
         Idempotent in both the rows and the event — re-running on
         already-tombstoned sources changes nothing and records nothing.
 
-        This is the cross-backend contract; every implementation must match it,
-        and the shared storage contract tests assert it.
+        This is the cross-backend contract every implementation must match.
+
+        Note what does and does not enforce it: the shared storage contract tests
+        assert it only for the backends in the ``storage`` fixture, which is
+        SQLite today. The Postgres/Supabase implementation is held to the same
+        contract by ``tenant.lineage_merge_records`` (see the tenant migration
+        stream), not by those tests — so a backend can satisfy the fixture and
+        still drift here. Changing this contract means changing both.
 
         Args:
             entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,

--- a/reflexio/server/services/storage/storage_base/_lineage.py
+++ b/reflexio/server/services/storage/storage_base/_lineage.py
@@ -74,9 +74,21 @@ class LineageEventMixin:
         """Soft-delete each source into the survivor in one atomic transaction.
 
         Sets ``status=MERGED`` and ``merged_into=survivor_id`` on each source
-        whose status is not already a tombstone (MERGED or SUPERSEDED). Appends
-        a single ``merge`` lineage event keyed on ``survivor_id``. Idempotent —
-        re-running on already-tombstoned sources is a no-op.
+        whose status is not already a tombstone (MERGED, SUPERSEDED, ARCHIVED,
+        or EXPIRED).
+
+        Appends **at most one** ``merge`` lineage event keyed on ``survivor_id``,
+        and only when at least one source was actually tombstoned. The event's
+        ``source_ids`` records the sources this call changed, not the sources it
+        was asked to change: a partial merge (say 2 of 5 still eligible) records
+        exactly those 2, because the other 3 were tombstoned by an earlier
+        operation and possibly into a different survivor.
+
+        Idempotent in both the rows and the event — re-running on
+        already-tombstoned sources changes nothing and records nothing.
+
+        This is the cross-backend contract; every implementation must match it,
+        and the shared storage contract tests assert it.
 
         Args:
             entity_type (str): One of ``"user_playbook"``, ``"agent_playbook"``,

--- a/tests/server/services/storage/test_lineage_contract.py
+++ b/tests/server/services/storage/test_lineage_contract.py
@@ -134,6 +134,52 @@ def test_merge_multi_source_skips_already_tombstoned(storage) -> None:
     merge_events = [e for e in events if e.op == "merge"]
     assert len(merge_events) == 1
 
+    # ...and it records only the source this call actually merged. The
+    # already-MERGED source belongs to some earlier merge into 999, so naming it
+    # here would assert a merge that never happened.
+    assert merge_events[0].source_ids == [str(current_source.user_playbook_id)]
+
+
+def test_merge_records_nothing_when_every_source_is_already_tombstoned(
+    storage,
+) -> None:
+    """A merge that changes no row must not record that it merged anything.
+
+    The row guard makes this a no-op, but the event was previously appended
+    unconditionally — so a retry under a NEW request_id wrote a ``merge`` event
+    asserting a state change that never occurred. A new request_id is essential
+    to the test: ``_append_event_stmt`` de-duplicates on
+    ``(org_id, entity_type, entity_id, op, request_id)``, so replaying the SAME
+    id would be suppressed by that key and hide the defect.
+    """
+    survivor = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-noop-survivor",
+        content="survivor",
+    )
+    already_merged = UserPlaybook(
+        user_id="u",
+        agent_version="v",
+        request_id="r-noop-old",
+        content="already merged",
+        status=Status.MERGED,
+        merged_into=999,
+    )
+    storage.save_user_playbooks([survivor, already_merged])
+
+    storage.merge_records(
+        entity_type="user_playbook",
+        survivor_id=str(survivor.user_playbook_id),
+        source_ids=[str(already_merged.user_playbook_id)],
+        context=LineageContext(
+            op_kind="merge", actor="test", request_id="r-noop-attempt-1"
+        ),
+    )
+
+    events = storage.get_lineage_events(entity_id=str(survivor.user_playbook_id))
+    assert [e for e in events if e.op == "merge"] == []
+
 
 # ---------------------------------------------------------------------------
 # B1 contract cases: update / hard_delete / archive / idempotency

--- a/tests/server/services/storage/test_storage_contract_operations.py
+++ b/tests/server/services/storage/test_storage_contract_operations.py
@@ -1,5 +1,7 @@
 """Contract tests for OperationMixin — run against every local storage backend."""
 
+import time
+
 import pytest
 
 pytestmark = pytest.mark.integration
@@ -169,12 +171,14 @@ class TestPendingRequestQueue:
             "acquired"
         ]
 
-        # Exactly what release_lock_pop_queue writes when it promotes req_2.
+        # Exactly what release_lock_pop_queue writes when it promotes req_2 —
+        # including a CURRENT started_at. A fixed past timestamp here would make
+        # the new holder instantly stale and the assertion below meaningless.
         storage.upsert_operation_state(
             "svc_handover",
             {
                 "in_progress": True,
-                "started_at": 1_700_000_000,
+                "started_at": int(time.time()),
                 "current_request_id": "req_2",
                 "pending_request_id": None,
                 "pending_request_queue": [],
@@ -188,6 +192,51 @@ class TestPendingRequestQueue:
         )
         state = self._state(storage, "svc_handover")
         assert state.get("current_request_id") == "req_2"
+
+    def test_a_legacy_status_keyed_lock_is_still_honoured(self, storage):
+        """Rows written before the canonical flag must not read as free.
+
+        An older build wrote the held-flag as ``status: "in_progress"``. On first
+        run after upgrade those rows are still live locks; without the shim every
+        one of them would be read as free and stolen. Nothing writes this shape
+        any more, so this test is what keeps the shim honest until it is removed.
+        """
+        storage.upsert_operation_state(
+            "svc_legacy",
+            {
+                "status": "in_progress",
+                "current_request_id": "req_old",
+                "pending_request_queue": [],
+            },
+        )
+
+        result = storage.try_acquire_in_progress_lock("svc_legacy", "req_new")
+        assert result["acquired"] is False
+        assert self._state(storage, "svc_legacy").get("current_request_id") == "req_old"
+
+    def test_a_rejected_acquire_does_not_extend_the_holders_lock(self, storage):
+        """Contention must not refresh the staleness clock.
+
+        The queue-append branch rewrites the row on every rejected acquire. When
+        staleness was measured from the row's ``updated_at``, each new contender
+        pushed the deadline out, so a crashed holder's lock could never expire
+        under sustained load. Measuring from the holder's ``started_at`` fixes it.
+        """
+        storage.try_acquire_in_progress_lock("svc_stale", "req_holder")
+
+        # Backdate the holder well past any plausible staleness window, leaving
+        # the row's own updated_at fresh — exactly the post-contention shape.
+        state = self._state(storage, "svc_stale")
+        state["started_at"] = int(time.time()) - 10_000
+        storage.upsert_operation_state("svc_stale", state)
+
+        result = storage.try_acquire_in_progress_lock(
+            "svc_stale", "req_new", stale_lock_seconds=300
+        )
+        assert result["acquired"] is True, (
+            "a lock whose holder started 10000s ago was not reclaimed — staleness "
+            "is being measured from the row clock, which contention refreshes"
+        )
 
     def test_acquire_records_started_at_for_the_shared_reader(self, storage):
         """``acquire_simple_lock`` reads ``started_at``, defaulting to 0.

--- a/tests/server/services/storage/test_storage_contract_operations.py
+++ b/tests/server/services/storage/test_storage_contract_operations.py
@@ -150,3 +150,54 @@ class TestPendingRequestQueue:
 
         state = self._state(storage, "svc_lock_5")
         assert state.get("pending_request_queue", []) == []
+
+    def test_lock_stays_held_across_a_handover(self, storage):
+        """A handover must not look like a release to the next acquirer.
+
+        ``release_lock_pop_queue`` hands the lock to the next queued holder by
+        upserting a state blob with ``in_progress: True``. ``upsert_operation_state``
+        REPLACES the blob rather than merging it, so any acquirer that keys off a
+        different flag than the handover writes will read a live lock as free —
+        and ``try_acquire`` also RESETS ``pending_request_queue`` when it acquires,
+        so the queued work is silently dropped along with the lock.
+
+        Three requests are the minimum to reach it: two to build a queue, and a
+        third to arrive after the handover.
+        """
+        assert storage.try_acquire_in_progress_lock("svc_handover", "req_1")["acquired"]
+        assert not storage.try_acquire_in_progress_lock("svc_handover", "req_2")[
+            "acquired"
+        ]
+
+        # Exactly what release_lock_pop_queue writes when it promotes req_2.
+        storage.upsert_operation_state(
+            "svc_handover",
+            {
+                "in_progress": True,
+                "started_at": 1_700_000_000,
+                "current_request_id": "req_2",
+                "pending_request_id": None,
+                "pending_request_queue": [],
+            },
+        )
+
+        result = storage.try_acquire_in_progress_lock("svc_handover", "req_3")
+        assert result["acquired"] is False, (
+            "req_3 took a lock still held by req_2 — the acquirer and the "
+            "handover disagree about which key means 'held'"
+        )
+        state = self._state(storage, "svc_handover")
+        assert state.get("current_request_id") == "req_2"
+
+    def test_acquire_records_started_at_for_the_shared_reader(self, storage):
+        """``acquire_simple_lock`` reads ``started_at``, defaulting to 0.
+
+        A held lock written without it computes ``now - 0`` and is therefore
+        always stale, so the shared reader would steal a lock this backend
+        considers held. The two must agree on the payload, not just the flag.
+        """
+        storage.try_acquire_in_progress_lock("svc_started_at", "req_1")
+        state = self._state(storage, "svc_started_at")
+        assert state.get("in_progress") is True
+        assert isinstance(state.get("started_at"), int)
+        assert state["started_at"] > 0


### PR DESCRIPTION
## What

Two independent SQLite-backend defects, plus review follow-ups. Each is an instance of the same shape: **two pieces of code that must agree about one fact, with nothing forcing them to.** None of them raises when they drift — they just disagree.

## 1. `merge_records` recorded merges that never happened

The per-source `UPDATE` is guarded (an already-tombstoned source is skipped), but its result was discarded and the `merge` lineage event was appended **unconditionally**. A merge whose sources were all already tombstoned wrote an event asserting a state change that did not occur. The sibling `supersede_record`, in the same file, has always checked `rowcount` first.

The event payload changes too: `LineageEvent.source_ids` means *"records merged into entity_id"*, so naming an already-tombstoned source claims a merge this call did not perform — and that source may have been merged into a **different survivor**. A partial merge of 2-of-5 now records exactly those 2.

**Why it was invisible:** `_append_event_stmt` de-duplicates on `(org_id, entity_type, entity_id, op, request_id)`, so replaying with the *same* request_id was suppressed by that key. Only a **new** request_id surfaces it.

## 2. A lock handover looked like a release

`try_acquire_in_progress_lock` wrote and read `status: "in_progress"`, while every writer in `operation_state_utils` — and the Postgres RPC — uses a boolean `in_progress`. Since `upsert_operation_state` **replaces** the whole blob, a handover via `release_lock_pop_queue` left a row with no `status` key: the next acquirer read a live lock as free, took it, **and reset `pending_request_queue`**, dropping the queued work.

Acquire now writes the canonical `in_progress` plus `started_at`, with the `status` read retained as a migration shim (without it, every currently-held lock would read as free on first run after upgrade).

## 3. Review follow-ups

**Lock staleness was measured from the row, not the holder.** The queue-append branch rewrites the row on every *rejected* acquire, so each new contender refreshed a dead holder's clock — above one request per `stale_lock_seconds` (default 300) a crashed holder's lock could **never expire** and the service livelocked. Postgres has always measured from `started_at` and self-heals. SQLite now reads it too, which also makes that newly-written field load-bearing rather than write-only. `updated_at` stays as the fallback for pre-stamp rows — deliberately *not* Postgres's `COALESCE(…, 0)`, which would treat every legacy row as instantly stale.

**Two comment corrections.** "Nothing writes that key any more" was wrong — `operation_state_utils` still writes `status`, on the separate `::progress` key space this method never reads. And the abstract `merge_records` docstring in `storage_base` still described the old unconditional-emit behaviour and listed the tombstone set as two members when it has four; that docstring is the cross-backend contract an implementer reads.

## Correction to this PR's original justification

The first version of this body argued that `tenant.lineage_merge_records` has the same defect, so shipping SQLite-only left the backends *"uniformly wrong rather than divergent."* Review **refuted** that. The premise was right; the conclusion was not — the two would have disagreed on the **ordinary partial-merge path**, in an append-only audit log, while `supabase_storage/_lineage.py` documents its semantics as mirroring SQLite exactly, and while the new assertions here live in the **shared storage contract tests**.

The Postgres companion therefore lands with this: **ReflexioAI/reflexio-enterprise#875**. Merge that alongside.

## Verification

- Every new/strengthened assertion was confirmed to **fail** against the code it guards — including the staleness test against the row-clock version.
- Fixed a brittle fixture found by that: the handover test hardcoded `started_at=1_700_000_000`, which the staleness change correctly reclaimed as three years stale.
- Full OSS storage suite: **1054 passed**. ruff, ruff format, pyright clean.

**Known gap:** the shared contract fixture is `params=["sqlite"]`, so behavioural parity between backends is asserted by neither suite. The Postgres equivalents need live Supabase credentials. Tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merge events now include only sources successfully tombstoned, preventing inaccurate lineage records.
  * Repeated merges of already-tombstoned records now correctly perform no action.
  * Improved lock handover and staleness handling, including compatibility with legacy lock states.
  * Rejected lock attempts no longer extend the current holder’s lock window.

* **Tests**
  * Added coverage for partial merges, idempotency, lock handovers, legacy states, and timestamp-based expiry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->