### PR TITLE
fix(llm): wire provider_request_guard through both generation entry points

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -370,6 +370,7 @@ class TextGenerationMixin:
             max_retries=max_retries,
             fallback_models=fallback_models,
             structured_output_validator=structured_output_validator,
+            provider_request_guard=provider_request_guard,
             **kwargs,
         ).value
 
@@ -384,6 +385,7 @@ class TextGenerationMixin:
         max_retries: int | None = None,
         fallback_models: list[str] | None = None,
         structured_output_validator: StructuredOutputValidator | None = None,
+        provider_request_guard: ProviderRequestGuard | None = None,
         **kwargs: Any,
     ) -> CompletionResult[str | BaseModel | ToolCallingChatResponse]:
         """Generate a chat response paired with observed model provenance."""

--- a/tests/server/llm/test_provenance_forwarding.py
+++ b/tests/server/llm/test_provenance_forwarding.py
@@ -63,7 +63,9 @@ def test_plain_entry_point_forwards_every_declared_option(option):
     """
     inst = TextGenerationMixin.__new__(TextGenerationMixin)
     sentinel = object()
-    with patch.object(TextGenerationMixin, "generate_chat_response_with_provenance") as p:
+    with patch.object(
+        TextGenerationMixin, "generate_chat_response_with_provenance"
+    ) as p:
         p.return_value.value = "ok"
         PLAIN(inst, [{"role": "user", "content": "hi"}], **{option: sentinel})
     assert p.call_args.kwargs.get(option) is sentinel, (

--- a/tests/server/llm/test_provenance_forwarding.py
+++ b/tests/server/llm/test_provenance_forwarding.py
@@ -22,43 +22,53 @@ from unittest.mock import patch
 
 from reflexio.server.llm._litellm_text_generation import TextGenerationMixin
 
-# Forwarded options both entry points must accept. `generate_chat_response_with_provenance`
-# forwards each of these by name, so a missing parameter is a latent NameError.
-FORWARDED_OPTIONS = (
-    "tools",
-    "tool_choice",
-    "model_role",
-    "max_retries",
-    "fallback_models",
-    "structured_output_validator",
-    "provider_request_guard",
-)
+PLAIN = TextGenerationMixin.generate_chat_response
+PROVENANCE = TextGenerationMixin.generate_chat_response_with_provenance
+
+# Structural, not hand-maintained: the options are DERIVED from the signatures, so a
+# future option added to one entry point and forgotten in the other fails here without
+# anyone remembering to update this file. A hardcoded list would need the same manual
+# sync step that produced the original bug.
+_PLUMBING = {"self", "messages", "system_message", "kwargs"}
 
 
-def _params(func):
-    return set(inspect.signature(func).parameters)
+def _options(func):
+    return set(inspect.signature(func).parameters) - _PLUMBING
 
 
-def test_both_entry_points_declare_every_forwarded_option():
-    """Neither entry point may forward a name it does not declare."""
-    plain = _params(TextGenerationMixin.generate_chat_response)
-    provenance = _params(TextGenerationMixin.generate_chat_response_with_provenance)
-    for option in FORWARDED_OPTIONS:
-        assert option in plain, f"generate_chat_response is missing {option!r}"
-        assert option in provenance, (
-            f"generate_chat_response_with_provenance forwards {option!r} but does not "
-            f"declare it — this is a NameError at runtime, not a type error"
-        )
+def test_both_entry_points_declare_the_same_options():
+    """The two entry points must stay in lockstep.
+
+    `generate_chat_response` delegates to `generate_chat_response_with_provenance`
+    and forwards each option by name, so any asymmetry is either a NameError (declared
+    on neither side but forwarded) or a silently dropped argument.
+    """
+    plain, provenance = _options(PLAIN), _options(PROVENANCE)
+    assert plain == provenance, (
+        "signatures drifted — "
+        f"only in generate_chat_response: {sorted(plain - provenance)}; "
+        f"only in generate_chat_response_with_provenance: {sorted(provenance - plain)}"
+    )
 
 
 def test_forwarded_names_are_locals_not_globals():
-    """Every forwarded name must be a real parameter, not an accidental global lookup."""
-    code = TextGenerationMixin.generate_chat_response_with_provenance.__code__
-    for option in FORWARDED_OPTIONS:
+    """Every option must be a real local, not an accidental global lookup.
+
+    A name referenced in the forwarding block but absent from the signature compiles
+    fine and raises NameError only when that line executes.
+    """
+    code = PROVENANCE.__code__
+    for option in _options(PROVENANCE):
         assert option in code.co_varnames, (
             f"{option!r} is not a local in generate_chat_response_with_provenance; "
             f"referencing it would raise NameError"
         )
+
+
+def test_provider_request_guard_is_still_wired():
+    """Pin the specific regression the derived checks above generalise."""
+    assert "provider_request_guard" in _options(PLAIN)
+    assert "provider_request_guard" in _options(PROVENANCE)
 
 
 def test_provenance_call_without_a_guard_does_not_raise_nameerror():

--- a/tests/server/llm/test_provenance_forwarding.py
+++ b/tests/server/llm/test_provenance_forwarding.py
@@ -20,6 +20,8 @@ call test pins the specific regression.
 import inspect
 from unittest.mock import patch
 
+import pytest
+
 from reflexio.server.llm._litellm_text_generation import TextGenerationMixin
 
 PLAIN = TextGenerationMixin.generate_chat_response
@@ -51,18 +53,40 @@ def test_both_entry_points_declare_the_same_options():
     )
 
 
-def test_forwarded_names_are_locals_not_globals():
-    """Every option must be a real local, not an accidental global lookup.
+@pytest.mark.parametrize("option", sorted(_options(PLAIN)))
+def test_plain_entry_point_forwards_every_declared_option(option):
+    """Declaring an option is not enough — the delegation must actually pass it on.
 
-    A name referenced in the forwarding block but absent from the signature compiles
-    fine and raises NameError only when that line executes.
+    Signature parity alone would still pass if both entry points declared an option
+    and one dropped it in the call, which is exactly what `generate_chat_response`
+    did with `provider_request_guard`.
     """
-    code = PROVENANCE.__code__
-    for option in _options(PROVENANCE):
-        assert option in code.co_varnames, (
-            f"{option!r} is not a local in generate_chat_response_with_provenance; "
-            f"referencing it would raise NameError"
-        )
+    inst = TextGenerationMixin.__new__(TextGenerationMixin)
+    sentinel = object()
+    with patch.object(TextGenerationMixin, "generate_chat_response_with_provenance") as p:
+        p.return_value.value = "ok"
+        PLAIN(inst, [{"role": "user", "content": "hi"}], **{option: sentinel})
+    assert p.call_args.kwargs.get(option) is sentinel, (
+        f"generate_chat_response declares {option!r} but does not forward it — "
+        f"a caller's value is accepted and silently discarded"
+    )
+
+
+@pytest.mark.parametrize("option", sorted(_options(PROVENANCE)))
+def test_provenance_entry_point_forwards_every_declared_option(option):
+    """Each declared option must reach `_make_request`, exercising the real line.
+
+    This runs the forwarding block itself, so a name referenced there but missing
+    from the signature raises NameError here rather than in production.
+    """
+    inst = TextGenerationMixin.__new__(TextGenerationMixin)
+    sentinel = object()
+    with patch.object(TextGenerationMixin, "_make_request", return_value="ok") as m:
+        PROVENANCE(inst, [{"role": "user", "content": "hi"}], **{option: sentinel})
+    assert m.call_args.kwargs.get(option) is sentinel, (
+        f"generate_chat_response_with_provenance declares {option!r} but never "
+        f"forwards it into _make_request"
+    )
 
 
 def test_provider_request_guard_is_still_wired():

--- a/tests/server/llm/test_provenance_forwarding.py
+++ b/tests/server/llm/test_provenance_forwarding.py
@@ -1,0 +1,108 @@
+"""Guard the forwarding contract between the two text-generation entry points.
+
+``generate_chat_response`` and ``generate_chat_response_with_provenance`` share a
+copy-pasted block that forwards optional keyword arguments into ``_make_request``.
+When a new option is added to one and the forwarding line is pasted into the other
+without also adding the parameter, the result is a ``NameError`` that only fires at
+runtime, on the exact call path that uses it.
+
+That happened in production: ``provider_request_guard`` was added to
+``generate_chat_response`` and its forwarding block pasted into
+``generate_chat_response_with_provenance``, whose signature never gained the
+parameter. Every tool-loop call raised
+``NameError: name 'provider_request_guard' is not defined``, which surfaced as
+"Playbook extraction failed without structured output".
+
+The signature-parity test below fails on any future instance of that class; the
+call test pins the specific regression.
+"""
+
+import inspect
+from unittest.mock import patch
+
+from reflexio.server.llm._litellm_text_generation import TextGenerationMixin
+
+# Forwarded options both entry points must accept. `generate_chat_response_with_provenance`
+# forwards each of these by name, so a missing parameter is a latent NameError.
+FORWARDED_OPTIONS = (
+    "tools",
+    "tool_choice",
+    "model_role",
+    "max_retries",
+    "fallback_models",
+    "structured_output_validator",
+    "provider_request_guard",
+)
+
+
+def _params(func):
+    return set(inspect.signature(func).parameters)
+
+
+def test_both_entry_points_declare_every_forwarded_option():
+    """Neither entry point may forward a name it does not declare."""
+    plain = _params(TextGenerationMixin.generate_chat_response)
+    provenance = _params(TextGenerationMixin.generate_chat_response_with_provenance)
+    for option in FORWARDED_OPTIONS:
+        assert option in plain, f"generate_chat_response is missing {option!r}"
+        assert option in provenance, (
+            f"generate_chat_response_with_provenance forwards {option!r} but does not "
+            f"declare it — this is a NameError at runtime, not a type error"
+        )
+
+
+def test_forwarded_names_are_locals_not_globals():
+    """Every forwarded name must be a real parameter, not an accidental global lookup."""
+    code = TextGenerationMixin.generate_chat_response_with_provenance.__code__
+    for option in FORWARDED_OPTIONS:
+        assert option in code.co_varnames, (
+            f"{option!r} is not a local in generate_chat_response_with_provenance; "
+            f"referencing it would raise NameError"
+        )
+
+
+def test_provenance_call_without_a_guard_does_not_raise_nameerror():
+    """The exact production call path: no guard supplied, tool loop invokes it."""
+    inst = TextGenerationMixin.__new__(TextGenerationMixin)
+    with patch.object(TextGenerationMixin, "_make_request", return_value="ok"):
+        result = TextGenerationMixin.generate_chat_response_with_provenance(
+            inst, [{"role": "user", "content": "hi"}]
+        )
+    assert result == "ok"
+
+
+def test_provenance_call_forwards_the_guard_when_supplied():
+    inst = TextGenerationMixin.__new__(TextGenerationMixin)
+
+    def guard(_params):
+        return None
+
+    with patch.object(
+        TextGenerationMixin, "_make_request", return_value="ok"
+    ) as make_request:
+        TextGenerationMixin.generate_chat_response_with_provenance(
+            inst, [{"role": "user", "content": "hi"}], provider_request_guard=guard
+        )
+    assert make_request.call_args.kwargs["provider_request_guard"] is guard
+
+
+def test_plain_entry_point_does_not_silently_drop_the_guard():
+    """``generate_chat_response`` accepted the guard and never passed it on.
+
+    The parameter was declared but omitted from the delegation, so a caller's guard
+    was accepted and silently ignored — no error, no guard, just a request that was
+    never inspected.
+    """
+    inst = TextGenerationMixin.__new__(TextGenerationMixin)
+
+    def guard(_params):
+        return None
+
+    with patch.object(
+        TextGenerationMixin, "generate_chat_response_with_provenance"
+    ) as provenance:
+        provenance.return_value.value = "ok"
+        TextGenerationMixin.generate_chat_response(
+            inst, [{"role": "user", "content": "hi"}], provider_request_guard=guard
+        )
+    assert provenance.call_args.kwargs["provider_request_guard"] is guard


### PR DESCRIPTION
## Problem

`provider_request_guard` was added by #385 and wired backwards on **both** sides:

| Entry point | Defect |
|---|---|
| `generate_chat_response_with_provenance` | Forwards the name (line 427) **without declaring it** → `NameError` on every call |
| `generate_chat_response` | **Declares** the parameter but omits it from its delegation → the caller's guard is silently dropped |

The NameError is **live in production right now**. `run_tool_loop` calls the provenance
entry point, so the tool loop dies mid-flight, playbook extraction returns no structured
output, and it surfaces as:

```
ExtractorExecutionError: Extractor failed for playbook_generation ...
  Playbook extraction failed without structured output: error (type=RuntimeError)
```

Sentry: `PYTHON-FASTAPI-PW` (the NameError, root cause), with `PYTHON-FASTAPI-PV` and
`PYTHON-FASTAPI-NQ` as the downstream extraction failures.

**Ruff already caught this on `main`** — `F821 Undefined name 'provider_request_guard'`
twice (lines 427, 428) plus `ARG002` for the unused declaration at line 322. The bug was
statically detectable before it shipped; nothing gated on the result.

## Fix

Two lines: declare the parameter on the provenance entry point, and pass it through in
the plain entry point's delegation.

## Verification

Reproduced the exact production error against `origin/main`, then confirmed it resolved
(run with the repo first on `PYTHONPATH` — importing the installed editable copy instead
silently tests the wrong file):

| Tree | `generate_chat_response_with_provenance(...)` |
|---|---|
| `origin/main` | `NameError: name 'provider_request_guard' is not defined` |
| this branch | returns normally |

- New guard test: **all 5 cases fail on unpatched `main`**, pass here.
- `tests/server/llm`: **654 passed**, 61 skipped.
- Ruff on this file: **3 errors → 0**. Pyright: 0 errors.

The test targets the **class**, not just these two sites: it asserts both entry points
declare every forwarded option, and that each forwarded name is a local rather than an
accidental global lookup. A future option pasted into one signature and not the other
fails here instead of in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the configured provider request safeguards throughout chat response generation, including provenance-enabled flows.
  - Ensured the safeguard can be passed through without being dropped between the standard and provenance entry points.

- **Tests**
  - Added a new test suite to verify signature parity and correct forwarding behavior for the provider request safeguard, including when it’s omitted or supplied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->