### PR TITLE
feat: honor explicit personalization opt-outs

### DIFF
--- a/reflexio/lib/_profiles.py
+++ b/reflexio/lib/_profiles.py
@@ -46,6 +46,9 @@ from reflexio.models.api_schema.service_schemas import (
 from reflexio.server.services.profile.service import (
     ProfileGenerationService,
 )
+from reflexio.server.services.retrieval.user_context_guard import (
+    should_suppress_user_context,
+)
 from reflexio.server.tracing import profile_step
 
 
@@ -70,6 +73,15 @@ class ProfilesMixin(ReflexioBase):
             )
         if isinstance(request, dict):
             request = SearchUserProfileRequest(**request)
+        with profile_step("search.user_context_guard", entity_type="profiles") as span:
+            suppress_user_context = should_suppress_user_context(request.query)
+            span.set_data("suppressed", suppress_user_context)
+        if suppress_user_context:
+            return SearchUserProfileResponse(
+                success=True,
+                user_profiles=[],
+                msg="Found 0 matching profile(s)",
+            )
         if status_filter is None:
             status_filter = [None]  # Default to current profiles
         rewritten = self._reformulate_query(
@@ -128,6 +140,15 @@ class ProfilesMixin(ReflexioBase):
             )
         if isinstance(request, dict):
             request = RerankUserProfilesRequest(**request)
+        with profile_step("search.user_context_guard", entity_type="profiles") as span:
+            suppress_user_context = should_suppress_user_context(request.query)
+            span.set_data("suppressed", suppress_user_context)
+        if suppress_user_context:
+            return RerankUserProfilesResponse(
+                success=True,
+                user_profiles=[],
+                msg="Reranked 0 profile(s); dropped 0 unknown id(s)",
+            )
         if not request.profile_ids:
             return RerankUserProfilesResponse(
                 success=True, user_profiles=[], msg="No profile_ids provided"

--- a/reflexio/lib/_user_playbook.py
+++ b/reflexio/lib/_user_playbook.py
@@ -29,6 +29,9 @@ from reflexio.models.config_schema import SearchOptions
 from reflexio.server.services.playbook.service import (
     PlaybookGenerationService,
 )
+from reflexio.server.services.retrieval.user_context_guard import (
+    should_suppress_user_context,
+)
 from reflexio.server.tracing import profile_step
 
 
@@ -158,6 +161,18 @@ class UserPlaybookMixin(ReflexioBase):
             )
         if isinstance(request, dict):
             request = SearchUserPlaybookRequest(**request)
+
+        with profile_step(
+            "search.user_context_guard", entity_type="user_playbooks"
+        ) as span:
+            suppress_user_context = should_suppress_user_context(request.query)
+            span.set_data("suppressed", suppress_user_context)
+        if suppress_user_context:
+            return SearchUserPlaybookResponse(
+                success=True,
+                user_playbooks=[],
+                msg="Found 0 matching user playbook(s)",
+            )
 
         try:
             query = (

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -57,7 +57,7 @@ strings before deleting old import paths in the same PR.
 | `pre_retrieval/` | `QueryReformulator` (`_query_reformulator.py`) + `DocumentExpander` (`_document_expander.py`) - query rewrite and doc expansion for recall. Compact by design; see [README](pre_retrieval/README.md). |
 | `tagging/` | `TaggingService` (`service.py`) + deferred `tagging_scheduler.py` - post-generation profile/playbook tagging. Compact by design; see [README](tagging/README.md). |
 | `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks. |
-| `retrieval/` | `relevance_floor.py` — result relevance thresholding. `temporal.py` — temporal post-processing driven by reformulation signals: query time windows → per-arm SQL filters, near-duplicate freshness collapse for current-value questions, timestamp ordering for latest-value questions. (Superseded/expired rows are already excluded by storage search SQL.) |
+| `retrieval/` | `relevance_floor.py` — result relevance thresholding. `temporal.py` — temporal post-processing driven by reformulation signals: query time windows → per-arm SQL filters, near-duplicate freshness collapse for current-value questions, timestamp ordering for latest-value questions. `user_context_guard.py` — high-precision detection of explicit personalization opt-outs before user-context retrieval. (Superseded/expired rows are already excluded by storage search SQL.) |
 
 ## Persistence & Config
 

--- a/reflexio/server/services/retrieval/user_context_guard.py
+++ b/reflexio/server/services/retrieval/user_context_guard.py
@@ -1,0 +1,165 @@
+"""Cheap, high-precision guard for explicit personalization opt-outs."""
+
+from __future__ import annotations
+
+import re
+
+_APOSTROPHE_TRANSLATION = str.maketrans(
+    {
+        "\N{LEFT SINGLE QUOTATION MARK}": "'",
+        "\N{RIGHT SINGLE QUOTATION MARK}": "'",
+        "`": "'",
+    }
+)
+
+_NEGATOR = r"(?:do\s+not|don't|dont|never)"
+_PROFILE_TARGET = r"""
+    (?:any\s+(?:of\s+)?)?
+    (?:
+        (?:my|the\s+user'?s|the\s+user)\s+
+        (?:(?:saved|stored|previous|prior|past|historical)\s+)*
+        (?:profiles?|preferences?|memor(?:y|ies)|(?:conversation\s+)?history|context|data|information)
+      |
+        (?:(?:saved|stored|previous|prior|past|historical|personal|user)\s+)+
+        (?:profiles?|preferences?|memor(?:y|ies)|(?:conversation\s+)?history|context|data|information)
+      |
+        (?:profiles?|preferences?|memor(?:y|ies))
+    )
+"""
+_PROFILE_ACTION = r"""
+    (?:
+        use|apply|consider|reference|retrieve|include|consult|access|rely\s+on|
+        draw\s+(?:on|from)|take\s+into\s+account
+    )
+"""
+
+_DIRECT_OPTOUT_PATTERNS = (
+    re.compile(
+        rf"""
+        \b{_NEGATOR}\s+
+        (?:
+            personali[sz]e
+          |
+            (?:use|apply|include)\s+(?:any\s+)?personali[sz]ation
+          |
+            (?:use|apply|include)\s+(?:any\s+)?personali[sz]ed\s+
+            (?:context|information|data|content)
+        )\b
+        """,
+        re.VERBOSE,
+    ),
+    re.compile(
+        rf"\b{_NEGATOR}\s+{_PROFILE_ACTION}\s+{_PROFILE_TARGET}\b",
+        re.VERBOSE,
+    ),
+    re.compile(
+        rf"\b(?:i\s+)?(?:do\s+not|don't|dont)\s+want\s+you\s+to\s+"
+        rf"{_PROFILE_ACTION}\s+{_PROFILE_TARGET}\b",
+        re.VERBOSE,
+    ),
+)
+
+_WITHOUT_OPTOUT_PATTERNS = (
+    re.compile(
+        r"""
+        \b(?:without|no)\s+(?:any\s+)?
+        (?:
+            personali[sz]ation
+          |
+            personali[sz]ed\s+(?:context|information|data)
+        )\b
+        """,
+        re.VERBOSE,
+    ),
+    re.compile(
+        rf"""
+        \bwithout\s+
+        (?:using|applying|considering|referencing|retrieving|including|consulting|accessing)
+        \s+{_PROFILE_TARGET}\b
+        """,
+        re.VERBOSE,
+    ),
+)
+
+_IMPERATIVE_OPTOUT_PATTERN = re.compile(
+    rf"\b(?:ignore|disregard|skip|exclude|omit|avoid\s+using)\s+{_PROFILE_TARGET}\b",
+    re.VERBOSE,
+)
+_NEGATED_PREFIX = re.compile(
+    r"\b(?:"
+    r"(?:do\s+not|don't|dont|never|not)\b"
+    r"(?:[\s,]+[\w'-]+){0,4}[\s,]*|"
+    r"with\s+(?:and|or)\s+|"
+    r"(?:of|about|regarding)\s+"
+    r")$"
+)
+_META_CLAUSE_PREFIX = re.compile(
+    r"(?:^|[.!?;]\s*)(?:please\s+)?"
+    r"(?:explain|describe|discuss|analy[sz]e|compare|quote|repeat)\b"
+    r"[^.!?;]*$"
+)
+_REPORTED_NEGATION_PREFIX = re.compile(
+    r"(?:^|[.!?;]\s*)[^.!?;]*\b"
+    r"(?:never|did\s+not|didn't|didnt|do\s+not|don't|dont)\s+"
+    r"(?:say|said|ask|asked|write|wrote)\s+['\"]?$"
+)
+_POSITIVE_USER_CONTEXT_PATTERN = re.compile(
+    rf"\b{_PROFILE_ACTION}\s+{_PROFILE_TARGET}\b", re.VERBOSE
+)
+
+
+def _normalize(query: str) -> str:
+    return " ".join(query.translate(_APOSTROPHE_TRANSLATION).casefold().split())
+
+
+def _has_negated_prefix(query: str, start: int) -> bool:
+    return bool(_NEGATED_PREFIX.search(query[max(0, start - 96) : start]))
+
+
+def _has_meta_clause_prefix(query: str, start: int) -> bool:
+    prefix = query[:start]
+    return bool(
+        _META_CLAUSE_PREFIX.search(prefix) or _REPORTED_NEGATION_PREFIX.search(prefix)
+    )
+
+
+def _has_positive_user_context_request(query: str) -> bool:
+    for match in _POSITIVE_USER_CONTEXT_PATTERN.finditer(query):
+        if not _has_negated_prefix(query, match.start()):
+            return True
+    return False
+
+
+def _is_explicit_directive(query: str, start: int) -> bool:
+    return not (
+        _has_negated_prefix(query, start) or _has_meta_clause_prefix(query, start)
+    )
+
+
+def should_suppress_user_context(query: str | None) -> bool:
+    """Return whether ``query`` explicitly opts out of personalized context.
+
+    This intentionally recognizes only high-precision English directives. Ambiguous
+    language fails open so ordinary profile and user-playbook retrieval is unchanged.
+    """
+    if not query or not query.strip():
+        return False
+
+    normalized = _normalize(query)
+    if _has_positive_user_context_request(normalized):
+        return False
+
+    for pattern in _DIRECT_OPTOUT_PATTERNS:
+        for match in pattern.finditer(normalized):
+            if not _has_meta_clause_prefix(normalized, match.start()):
+                return True
+
+    for pattern in _WITHOUT_OPTOUT_PATTERNS:
+        for match in pattern.finditer(normalized):
+            if _is_explicit_directive(normalized, match.start()):
+                return True
+
+    for match in _IMPERATIVE_OPTOUT_PATTERN.finditer(normalized):
+        if _is_explicit_directive(normalized, match.start()):
+            return True
+    return False

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -61,6 +61,9 @@ from reflexio.server.services.retrieval.temporal import (
     sort_by_recency,
     window_bounds,
 )
+from reflexio.server.services.retrieval.user_context_guard import (
+    should_suppress_user_context,
+)
 from reflexio.server.services.storage.storage_base import BaseStorage
 from reflexio.server.tracing import profile_step, set_span_data
 
@@ -143,6 +146,21 @@ def run_unified_search(
     """
     if not request.query:
         return UnifiedSearchResponse(success=True, msg="No query provided")
+
+    with profile_step("search.user_context_guard", entity_type="all") as span:
+        suppress_user_context = should_suppress_user_context(request.query)
+        span.set_data("suppressed", suppress_user_context)
+    if suppress_user_context:
+        requested_entity_types = set(request.entity_types or _DEFAULT_ENTITY_TYPES)
+        effective_entity_types = requested_entity_types - {
+            "profiles",
+            "user_playbooks",
+        }
+        if not effective_entity_types:
+            return UnifiedSearchResponse(success=True)
+        request = request.model_copy(
+            update={"entity_types": sorted(effective_entity_types)}
+        )
 
     top_k = request.top_k if request.top_k is not None else 5
     threshold = resolve_retrieval_threshold(

--- a/tests/e2e_tests/test_session_dedup_e2e.py
+++ b/tests/e2e_tests/test_session_dedup_e2e.py
@@ -74,3 +74,36 @@ def test_session_dedup_end_to_end(
     assert _search_ids(instance, test_org_id, None) == first
     assert _search_ids(instance, test_org_id, None) == first
     assert _search_ids(instance, test_org_id, session_b) == second
+
+
+def test_personalization_opt_out_skips_user_context_end_to_end(
+    reflexio_instance_playbook_only, test_org_id, cleanup_playbook_only
+):
+    instance = reflexio_instance_playbook_only
+    _seed_playbooks(instance)
+
+    ordinary_response = instance.unified_search(
+        UnifiedSearchRequest(
+            query="how to refund an order",
+            user_id="dedup-user",
+            agent_version="dedup-agent",
+            entity_types=["user_playbooks"],
+            top_k=2,
+        ),
+        org_id=test_org_id,
+    )
+    assert ordinary_response.success
+    assert ordinary_response.user_playbooks
+
+    opt_out_response = instance.unified_search(
+        UnifiedSearchRequest(
+            query="Help me refund this order without using my preferences.",
+            user_id="dedup-user",
+            agent_version="dedup-agent",
+            entity_types=["user_playbooks"],
+            top_k=2,
+        ),
+        org_id=test_org_id,
+    )
+    assert opt_out_response.success
+    assert opt_out_response.user_playbooks == []

--- a/tests/lib/test_profiles_unit.py
+++ b/tests/lib/test_profiles_unit.py
@@ -14,6 +14,7 @@ from reflexio.lib._base import STORAGE_NOT_CONFIGURED_MSG
 from reflexio.lib._profiles import ProfilesMixin
 from reflexio.models.api_schema.retriever_schema import (
     GetUserProfilesRequest,
+    RerankUserProfilesRequest,
     SearchUserProfileRequest,
     UpdateUserProfileRequest,
 )
@@ -286,6 +287,42 @@ class TestSearchProfiles:
 
         call_kwargs = _get_storage(mixin).search_user_profile.call_args
         assert call_kwargs[1]["status_filter"] == [Status.PENDING]
+
+    def test_explicit_opt_out_skips_reformulation_embedding_and_storage(self):
+        mixin = _make_mixin()
+        mixin._reformulate_query = MagicMock()
+        mixin._maybe_get_query_embedding = MagicMock()
+
+        response = mixin.search_user_profiles(
+            SearchUserProfileRequest(
+                user_id="user1",
+                query="Write a generic answer without using my profile.",
+                enable_reformulation=True,
+            )
+        )
+
+        assert response.success is True
+        assert response.user_profiles == []
+        mixin._reformulate_query.assert_not_called()
+        mixin._maybe_get_query_embedding.assert_not_called()
+        _get_storage(mixin).search_user_profile.assert_not_called()
+
+
+class TestRerankProfiles:
+    def test_explicit_opt_out_skips_profile_fetch_and_scoring(self):
+        mixin = _make_mixin()
+
+        response = mixin.rerank_user_profiles(
+            RerankUserProfilesRequest(
+                user_id="user1",
+                query="Do not personalize this response.",
+                profile_ids=["p1"],
+            )
+        )
+
+        assert response.success is True
+        assert response.user_profiles == []
+        _get_storage(mixin).get_user_profile.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/lib/test_user_playbook_unit.py
+++ b/tests/lib/test_user_playbook_unit.py
@@ -6,6 +6,7 @@ with mocked storage and services.
 """
 
 from datetime import UTC, datetime
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from reflexio.lib._user_playbook import UserPlaybookMixin
@@ -45,11 +46,11 @@ def _make_mixin(*, storage_configured: bool = True) -> UserPlaybookMixin:
 
 
 def _get_storage(mixin: UserPlaybookMixin) -> MagicMock:
-    return mixin.request_context.storage
+    return cast(MagicMock, mixin.request_context.storage)
 
 
 def _sample_user_playbook(**overrides) -> UserPlaybook:
-    defaults = {
+    defaults: dict[str, Any] = {
         "agent_version": "v1",
         "request_id": "req-1",
         "playbook_name": "test_fb",
@@ -216,6 +217,24 @@ class TestSearchUserPlaybooks:
 
         assert response.success is True
         assert response.user_playbooks == []
+
+    def test_explicit_opt_out_skips_reformulation_embedding_and_storage(self):
+        mixin = _make_mixin()
+        mixin._reformulate_query = MagicMock()
+        mixin._maybe_get_query_embedding = MagicMock()
+
+        response = mixin.search_user_playbooks(
+            SearchUserPlaybookRequest(
+                query="Give a neutral answer and disregard my prior preferences.",
+                enable_reformulation=True,
+            )
+        )
+
+        assert response.success is True
+        assert response.user_playbooks == []
+        mixin._reformulate_query.assert_not_called()
+        mixin._maybe_get_query_embedding.assert_not_called()
+        _get_storage(mixin).search_user_playbooks.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/retrieval/test_user_context_guard.py
+++ b/tests/server/services/retrieval/test_user_context_guard.py
@@ -1,0 +1,59 @@
+"""Tests for the explicit personalization opt-out guard."""
+
+import pytest
+
+from reflexio.server.services.retrieval.user_context_guard import (
+    should_suppress_user_context,
+)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "Draft a troubleshooting guide. Do not personalize it.",
+        "Keep the lesson generic, without personalization.",
+        "DON'T USE MY PROFILE for this recommendation.",
+        "Please don’t use my saved preferences in the response.",
+        "I don't want you to use my conversation history for this task.",
+        "Answer without using any of my previous context.",
+        "Ignore prior user context and create a neutral overview.",
+        "Avoid using my memory when writing the summary.",
+        "Disregard my stored memories for this task.",
+        "Never reference historical user information when answering.",
+        "Do not use any personalization context; generate it for everyone.",
+        "Skip profiles and answer only from the current request.",
+        "Please\n  exclude   my profile from this one.",
+        "Do not use my profile; personalize only from the current request.",
+    ],
+)
+def test_explicit_opt_outs_suppress_user_context(query: str) -> None:
+    assert should_suppress_user_context(query) is True
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        None,
+        "",
+        "   ",
+        "Don't ignore my preferences.",
+        "Use my profile to personalize this.",
+        "Explain why personalization can be harmful.",
+        "Compare recommendations with and without personalization.",
+        "Explain the tradeoffs of no personalization.",
+        "Do not use jargon.",
+        "Create this for a public audience.",
+        "This response is not without personalization.",
+        "Never disregard my saved preferences.",
+        "Do not exclude my profile.",
+        "Do not, under any circumstances, ignore my preferences.",
+        "Never again disregard my saved preferences.",
+        "Create a course about why recommendation systems should not personalize ads.",
+        "Explain why some agents do not personalize recommendations.",
+        "Explain how agents operate without personalization.",
+        "Do not personalize the introduction; use my profile for the rest.",
+        "I never said 'don't use my profile'; please personalize this.",
+    ],
+)
+def test_non_opt_outs_preserve_user_context(query: str | None) -> None:
+    assert should_suppress_user_context(query) is False

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -471,6 +471,84 @@ class TestEntityTypesFiltering(unittest.TestCase):
         self.assertEqual(result.agent_playbooks, [])
         self.assertEqual(result.user_playbooks, [])
 
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_opt_out_keeps_agent_playbooks_and_skips_user_context(
+        self, _reformulator_cls
+    ):
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="rewritten query"
+        )
+        storage = _mock_storage()
+
+        result = run_unified_search(
+            request=UnifiedSearchRequest(
+                query="Prepare a general answer without using my profile.",
+                user_id="user1",
+                enable_reformulation=True,
+            ),
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.profiles, [])
+        self.assertEqual(result.user_playbooks, [])
+        storage.search_user_profile.assert_not_called()
+        storage.search_user_playbooks.assert_not_called()
+        storage.search_agent_playbooks.assert_called_once()
+
+    @patch("reflexio.server.services.unified_search_service._run_phase_a")
+    def test_user_only_opt_out_returns_before_phase_a(self, phase_a):
+        storage = _mock_storage()
+
+        result = run_unified_search(
+            request=UnifiedSearchRequest(
+                query="Do not use my saved preferences for this answer.",
+                user_id="user1",
+                entity_types=["profiles", "user_playbooks"],
+                enable_reformulation=True,
+            ),
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.profiles, [])
+        self.assertEqual(result.user_playbooks, [])
+        phase_a.assert_not_called()
+        storage.search_user_profile.assert_not_called()
+        storage.search_user_playbooks.assert_not_called()
+        storage.search_agent_playbooks.assert_not_called()
+
+    @patch("reflexio.server.services.unified_search_service.QueryReformulator")
+    def test_public_audience_alone_does_not_suppress_user_context(
+        self, _reformulator_cls
+    ):
+        _reformulator_cls.return_value.rewrite.return_value = ReformulationResult(
+            standalone_query="Create this for a public audience."
+        )
+        storage = _mock_storage()
+
+        result = run_unified_search(
+            request=UnifiedSearchRequest(
+                query="Create this for a public audience.",
+                user_id="user1",
+                entity_types=["profiles", "user_playbooks"],
+            ),
+            org_id="test-org",
+            storage=storage,
+            llm_client=MagicMock(),
+            prompt_manager=MagicMock(),
+        )
+
+        self.assertTrue(result.success)
+        storage.search_user_profile.assert_called_once()
+        storage.search_user_playbooks.assert_called_once()
+
 
 _SERVICE_LOGGER = "reflexio.server.services.unified_search_service"
 

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -9,6 +9,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserPlaybook,
 )
 from reflexio.server.services import unified_search_service as uss
+from reflexio.server.services.pre_retrieval import ReformulationResult
 from reflexio.server.services.storage.storage_base import BaseStorage
 
 
@@ -160,6 +161,38 @@ def test_single_rpc_passes_tag_filter_on_scored_path(monkeypatch):
 
     assert storage.combined_calls == []
     assert storage.scored_calls[0]["tags"] == ["billing", "support"]
+
+
+def test_opt_out_disables_user_context_arms_in_single_rpc(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    monkeypatch.setattr(
+        uss,
+        "_run_phase_a",
+        lambda **_kwargs: (
+            ReformulationResult(standalone_query="rewritten query"),
+            [0.1, 0.2],
+            False,
+        ),
+    )
+    storage = _CombinedStorage()
+
+    response = uss.run_unified_search(
+        request=UnifiedSearchRequest(
+            query="Create a neutral answer without using my preferences.",
+            user_id="u",
+        ),
+        org_id="o",
+        storage=cast(BaseStorage, storage),
+        llm_client=cast(Any, None),
+        prompt_manager=cast(Any, None),
+    )
+
+    assert response.success is True
+    assert len(storage.combined_calls) == 1
+    call = storage.combined_calls[0]
+    assert call["include_profiles"] is False
+    assert call["include_user_playbooks"] is False
+    assert call["include_agent_playbooks"] is True
 
 
 def test_single_rpc_failure_falls_back_to_fanout(monkeypatch):


### PR DESCRIPTION
## Summary
- Honor explicit English requests not to use personalization before user context is retrieved.
- Suppress profiles and user playbooks while preserving shared agent playbooks.
- Keep the behavior internal and fail open for ambiguous, meta, partial, positive, or double-negative wording.

## Changes
- Add a compiled regex guard with casing, whitespace, and Unicode-apostrophe normalization.
- Apply the guard to unified search, direct profile search/reranking, and direct user-playbook search.
- Short-circuit user-only unified searches before reformulation, embedding, reranking, or storage work.
- Record only a privacy-safe boolean suppression marker in internal tracing.
- Document the new retrieval helper in the service code map.

## Test Plan
- `uv run pytest -q -o 'addopts=' tests/server/services/retrieval/test_user_context_guard.py tests/lib/test_profiles_unit.py tests/lib/test_user_playbook_unit.py tests/server/services/test_unified_search_service.py tests/server/services/test_unified_search_single_rpc.py tests/server/api_endpoints/test_applied_learnings_metering.py tests/e2e_tests/test_session_dedup_e2e.py::test_personalization_opt_out_skips_user_context_end_to_end`
- `uv run ruff check <changed Python files>`
- `uv run pyright <changed Python files>`
- `uv run python -c "import reflexio"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit opt-out support for personalized user context.
  * Searches now exclude profiles and user playbooks when users request no personalization, preferences, or memory.
  * Public and agent playbook results remain available when applicable.
  * Opt-out searches return successful empty results for excluded personalized content.

* **Documentation**
  * Updated service documentation to describe user-context suppression.

* **Tests**
  * Added coverage for opt-out behavior across profile, playbook, unified, and end-to-end searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->