### PR TITLE
feat: persist experiment output token metrics

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -245,6 +245,7 @@ class Interaction(BaseModel):
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
     role: str = "User"
     content: str = ""
+    token_count: int | None = Field(default=None, ge=0)
     user_action: UserActionType = UserActionType.NONE
     user_action_description: str = ""
     interacted_image_url: str = ""

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -774,6 +774,8 @@ class RetrievalExperimentArmMetrics(BaseModel):
     average_corrections: float | None = None
     average_turns_to_resolution: float | None = None
     escalation_rate: float | None = None
+    average_output_tokens: float | None = None
+    output_token_session_count: int = 0
 
 
 class RetrievalExperimentResultsResponse(BaseModel):

--- a/reflexio/server/routes/experiments.py
+++ b/reflexio/server/routes/experiments.py
@@ -190,8 +190,14 @@ def get_retrieval_experiment_results(
         if storage is not None
         else []
     )
+    output_token_counts = (
+        storage.get_retrieval_experiment_output_token_counts(experiment_id)
+        if storage is not None
+        else {}
+    )
     return build_retrieval_experiment_results(
         experiment=experiment,
         assignments=assignments,
         evaluation_results=evaluation_results,
+        output_token_counts=output_token_counts,
     )

--- a/reflexio/server/services/retrieval_experiment.py
+++ b/reflexio/server/services/retrieval_experiment.py
@@ -97,6 +97,7 @@ def build_retrieval_experiment_results(
     experiment: RetrievalExperimentRecord,
     assignments: dict[tuple[str, str], RetrievalExperimentArm],
     evaluation_results: list[AgentSuccessEvaluationResult],
+    output_token_counts: dict[tuple[str, str], int] | None = None,
 ) -> RetrievalExperimentResultsResponse:
     """Join request attribution to session evaluations and aggregate both arms."""
     attributed: dict[RetrievalExperimentArm, list[AgentSuccessEvaluationResult]] = {
@@ -111,8 +112,13 @@ def build_retrieval_experiment_results(
             continue
         attributed[arm].append(result)
 
-    treatment = _arm_metrics("treatment", assignments, attributed["treatment"])
-    holdout = _arm_metrics("holdout", assignments, attributed["holdout"])
+    measured_output_tokens = output_token_counts or {}
+    treatment = _arm_metrics(
+        "treatment", assignments, attributed["treatment"], measured_output_tokens
+    )
+    holdout = _arm_metrics(
+        "holdout", assignments, attributed["holdout"], measured_output_tokens
+    )
     lift: float | None = None
     relative_lift: float | None = None
     confidence_interval: tuple[float, float] | None = None
@@ -149,6 +155,7 @@ def _arm_metrics(
     arm: RetrievalExperimentArm,
     assignments: dict[tuple[str, str], RetrievalExperimentArm],
     results: list[AgentSuccessEvaluationResult],
+    output_token_counts: dict[tuple[str, str], int],
 ) -> RetrievalExperimentArmMetrics:
     assigned_pairs = [
         pair for pair, assigned_arm in assignments.items() if assigned_arm == arm
@@ -163,6 +170,11 @@ def _arm_metrics(
         if result.user_turns_to_resolution is not None
     )
     escalation_rate = _mean(float(result.is_escalated) for result in results)
+    measured_output_token_counts = [
+        float(output_token_counts[pair])
+        for pair in assigned_pairs
+        if pair in output_token_counts
+    ]
     return RetrievalExperimentArmMetrics(
         arm=arm,
         assigned_user_count=len({user_id for user_id, _ in assigned_pairs}),
@@ -173,6 +185,8 @@ def _arm_metrics(
         average_corrections=corrections,
         average_turns_to_resolution=turns,
         escalation_rate=escalation_rate,
+        average_output_tokens=_mean(measured_output_token_counts),
+        output_token_session_count=len(measured_output_token_counts),
     )
 
 

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -479,6 +479,7 @@ def _row_to_interaction(row: sqlite3.Row) -> Interaction:
         request_id=d["request_id"],
         created_at=_iso_to_epoch(d["created_at"]),
         role=d.get("role") or "User",
+        token_count=d.get("token_count"),
         user_action=UserActionType(d["user_action"]),
         user_action_description=d["user_action_description"],
         interacted_image_url=d["interacted_image_url"],
@@ -898,6 +899,14 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             with self._lock:
                 self.conn.execute(
                     "ALTER TABLE interactions ADD COLUMN retrieved_learnings TEXT"
+                )
+                self.conn.commit()
+
+        if "token_count" not in columns:
+            logger.info("Adding token_count column to interactions table.")
+            with self._lock:
+                self.conn.execute(
+                    "ALTER TABLE interactions ADD COLUMN token_count INTEGER"
                 )
                 self.conn.commit()
 
@@ -2367,6 +2376,7 @@ CREATE TABLE IF NOT EXISTS interactions (
     request_id TEXT NOT NULL,
     created_at TEXT NOT NULL,
     role TEXT NOT NULL DEFAULT 'User',
+    token_count INTEGER,
     user_action TEXT NOT NULL DEFAULT 'none',
     user_action_description TEXT NOT NULL DEFAULT '',
     interacted_image_url TEXT NOT NULL DEFAULT '',

--- a/reflexio/server/services/storage/sqlite_storage/_requests.py
+++ b/reflexio/server/services/storage/sqlite_storage/_requests.py
@@ -317,6 +317,50 @@ class RequestMixin:
         }
 
     @SQLiteStorageBase.handle_exceptions
+    def get_retrieval_experiment_output_token_counts(
+        self, experiment_id: str
+    ) -> dict[tuple[str, str], int]:
+        rows = self._fetchall(
+            """SELECT r.user_id,
+                      r.session_id,
+                      COALESCE(SUM(
+                          CASE
+                              WHEN LOWER(TRIM(
+                                  i.role,
+                                  char(9) || char(10) || char(11) ||
+                                  char(12) || char(13) || ' '
+                              )) <> 'user'
+                              THEN i.token_count
+                              ELSE 0
+                          END
+                      ), 0) AS output_token_count,
+                      SUM(
+                          CASE
+                              WHEN LOWER(TRIM(
+                                  i.role,
+                                  char(9) || char(10) || char(11) ||
+                                  char(12) || char(13) || ' '
+                              )) <> 'user'
+                                   AND i.token_count IS NULL
+                              THEN 1
+                              ELSE 0
+                          END
+                      ) AS missing_token_count
+               FROM requests r
+               LEFT JOIN interactions i ON i.request_id = r.request_id
+               WHERE r.retrieval_experiment_id = ?
+               GROUP BY r.user_id, r.session_id""",
+            (experiment_id,),
+        )
+        return {
+            (str(row["user_id"]), str(row["session_id"])): int(
+                row["output_token_count"]
+            )
+            for row in rows
+            if int(row["missing_token_count"] or 0) == 0
+        }
+
+    @SQLiteStorageBase.handle_exceptions
     def get_session_ids_in_window(
         self, from_ts: int, to_ts: int
     ) -> list[SessionDescriptor]:

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_interaction_store.py
@@ -13,6 +13,7 @@ from reflexio.models.api_schema.service_schemas import (
     DeleteUserInteractionRequest,
     Interaction,
 )
+from reflexio.server.billing_signals import count_input_tokens
 from reflexio.server.llm.providers.embedding_service_provider import (
     EmbeddingUnavailableError,
 )
@@ -97,6 +98,7 @@ class InteractionStoreMixin:
 
     def _insert_interaction(self, interaction: Interaction) -> int:
         created_at_iso = _epoch_to_iso(interaction.created_at)
+        interaction.token_count = count_input_tokens(interaction.content)
         subject_ref = self._subject_ref_for_user_id(interaction.user_id)
         with self._lock:
             own_txn = self._own_transaction()
@@ -108,11 +110,11 @@ class InteractionStoreMixin:
                     self.conn.execute(
                         """INSERT OR REPLACE INTO interactions
                            (interaction_id, user_id, content, request_id, created_at,
-                            role, user_action, user_action_description,
+                            role, token_count, user_action, user_action_description,
                             interacted_image_url, image_encoding, shadow_content,
                             expert_content, tools_used, citations, retrieved_learnings,
                             embedding, governance_subject_ref)
-                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                         (
                             interaction.interaction_id,
                             interaction.user_id,
@@ -120,6 +122,7 @@ class InteractionStoreMixin:
                             interaction.request_id,
                             created_at_iso,
                             interaction.role,
+                            interaction.token_count,
                             interaction.user_action.value,
                             interaction.user_action_description,
                             interaction.interacted_image_url,
@@ -147,17 +150,18 @@ class InteractionStoreMixin:
                     cur = self.conn.execute(
                         """INSERT INTO interactions
                            (user_id, content, request_id, created_at,
-                            role, user_action, user_action_description,
+                            role, token_count, user_action, user_action_description,
                             interacted_image_url, image_encoding, shadow_content,
                             expert_content, tools_used, citations, retrieved_learnings,
                             embedding, governance_subject_ref)
-                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                         (
                             interaction.user_id,
                             interaction.content,
                             interaction.request_id,
                             created_at_iso,
                             interaction.role,
+                            interaction.token_count,
                             interaction.user_action.value,
                             interaction.user_action_description,
                             interaction.interacted_image_url,

--- a/reflexio/server/services/storage/storage_base/_requests.py
+++ b/reflexio/server/services/storage/storage_base/_requests.py
@@ -144,6 +144,17 @@ class RequestMixin:
         raise NotImplementedError
 
     @abstractmethod
+    def get_retrieval_experiment_output_token_counts(
+        self, experiment_id: str
+    ) -> dict[tuple[str, str], int]:
+        """Return stored output-token totals for fully measured tagged sessions.
+
+        A session is omitted when any non-user interaction has a NULL token count.
+        Sessions with no non-user interactions are included with a zero total.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
     def get_session_ids_in_window(
         self, from_ts: int, to_ts: int
     ) -> list[SessionDescriptor]:

--- a/tests/server/services/storage/test_sqlite_storage_bc_extras.py
+++ b/tests/server/services/storage/test_sqlite_storage_bc_extras.py
@@ -93,6 +93,42 @@ def _add_request_with_interactions(
     return request_id
 
 
+def test_experiment_output_tokens_exclude_sessions_with_legacy_null_counts(
+    storage: SQLiteStorage,
+) -> None:
+    request = Request(
+        request_id="req_token_coverage",
+        user_id="user_token_coverage",
+        session_id="session_token_coverage",
+        agent_version="v1",
+        source="test",
+        created_at=_now(),
+        retrieval_experiment_id="exp-token-coverage",
+        retrieval_experiment_arm="treatment",
+    )
+    storage.add_request(request)
+    interaction = Interaction(
+        user_id=request.user_id,
+        request_id=request.request_id,
+        role="assistant",
+        content="measured output",
+    )
+    storage.add_user_interactions_bulk(request.user_id, [interaction])
+    assert storage.get_retrieval_experiment_output_token_counts(
+        "exp-token-coverage"
+    ) == {(request.user_id, request.session_id): interaction.token_count}
+
+    storage.conn.execute(
+        "UPDATE interactions SET token_count = NULL WHERE request_id = ?",
+        (request.request_id,),
+    )
+    storage.conn.commit()
+
+    assert (
+        storage.get_retrieval_experiment_output_token_counts("exp-token-coverage") == {}
+    )
+
+
 # ---------------------------------------------------------------------------
 # count_sessions_with_shadow_content
 # ---------------------------------------------------------------------------

--- a/tests/server/services/storage/test_storage_contract_profiles.py
+++ b/tests/server/services/storage/test_storage_contract_profiles.py
@@ -15,6 +15,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserActionType,
     UserProfile,
 )
+from reflexio.server.billing_signals import count_input_tokens
 from reflexio.server.services.storage.error import StorageError
 from reflexio.server.services.storage.storage_base import BaseStorage
 
@@ -361,6 +362,7 @@ class TestInteractionCRUD:
         result = storage.get_user_interaction("u1")
         assert len(result) == 1
         assert result[0].content == "clicked item"
+        assert result[0].token_count == count_input_tokens("clicked item")
 
     def test_add_interactions_bulk(self, storage: BaseStorage) -> None:
         interactions = [
@@ -370,6 +372,9 @@ class TestInteractionCRUD:
 
         result = storage.get_user_interaction("u1")
         assert len(result) == 3
+        assert {item.token_count for item in result} == {
+            count_input_tokens(f"action {i}") for i in range(1, 4)
+        }
 
     def test_get_all_interactions(self, storage: BaseStorage) -> None:
         storage.add_user_interaction("u1", _make_interaction("u1", 1, "a1", "req1"))

--- a/tests/server/services/storage/test_storage_contract_requests.py
+++ b/tests/server/services/storage/test_storage_contract_requests.py
@@ -143,3 +143,62 @@ class TestSessionQueries:
         assert stored is not None
         assert stored.retrieval_experiment_id == "exp-1"
         assert stored.retrieval_experiment_arm == "holdout"
+
+    def test_retrieval_experiment_output_tokens_use_stored_non_user_counts(
+        self, storage: BaseStorage
+    ) -> None:
+        treatment = _make_request("r1", "u1", session_id="s1")
+        treatment.retrieval_experiment_id = "exp-1"
+        treatment.retrieval_experiment_arm = "treatment"
+        treatment_continued = _make_request("r4", "u1", session_id="s1")
+        treatment_continued.retrieval_experiment_id = "exp-1"
+        treatment_continued.retrieval_experiment_arm = "treatment"
+        holdout = _make_request("r2", "u2", session_id="s2")
+        holdout.retrieval_experiment_id = "exp-1"
+        holdout.retrieval_experiment_arm = "holdout"
+        other = _make_request("r3", "u3", session_id="s3")
+        other.retrieval_experiment_id = "exp-2"
+        other.retrieval_experiment_arm = "treatment"
+        for request in (treatment, treatment_continued, holdout, other):
+            storage.add_request(request)
+
+        interactions = [
+            Interaction(
+                user_id="u1",
+                request_id="r1",
+                role="\t UsEr \r\n",
+                content="ignored",
+            ),
+            Interaction(
+                user_id="u1", request_id="r1", role="Assistant", content="hello 世界"
+            ),
+            Interaction(
+                user_id="u1", request_id="r1", role="tool", content="tool output"
+            ),
+            Interaction(
+                user_id="u1", request_id="r4", role="system", content="continued output"
+            ),
+            Interaction(
+                user_id="u2", request_id="r2", role="USER", content="only input"
+            ),
+            Interaction(
+                user_id="u3",
+                request_id="r3",
+                role="assistant",
+                content="other experiment",
+            ),
+        ]
+        for interaction in interactions:
+            storage.add_user_interaction(interaction.user_id, interaction)
+
+        counts = storage.get_retrieval_experiment_output_token_counts("exp-1")
+
+        assert counts == {
+            ("u1", "s1"): sum(
+                interaction.token_count or 0
+                for interaction in interactions
+                if interaction.request_id in {"r1", "r4"}
+                and interaction.role.strip().lower() != "user"
+            ),
+            ("u2", "s2"): 0,
+        }

--- a/tests/server/services/test_retrieval_experiment.py
+++ b/tests/server/services/test_retrieval_experiment.py
@@ -131,6 +131,13 @@ def test_results_join_session_outcomes_and_report_clustered_interval() -> None:
         ),
         assignments=assignments,
         evaluation_results=outcomes,
+        output_token_counts={
+            ("t1", "s1"): 90,
+            ("t2", "s3"): 30,
+            ("h1", "s4"): 120,
+            ("h1", "s5"): 0,
+            ("h2", "s6"): 60,
+        },
     )
 
     assert response.treatment.evaluated_session_count == 3
@@ -140,3 +147,7 @@ def test_results_join_session_outcomes_and_report_clustered_interval() -> None:
     assert response.confidence_interval_95_percentage_points is not None
     assert response.evaluated_session_coverage == 6 / 7
     assert response.unattributed_evaluated_session_count == 1
+    assert response.treatment.average_output_tokens == 60
+    assert response.treatment.output_token_session_count == 2
+    assert response.holdout.average_output_tokens == 60
+    assert response.holdout.output_token_session_count == 3


### PR DESCRIPTION
## Summary

- Persist canonical `cl100k_base` content-token counts when interactions are written.
- Compare average non-user output tokens across fully measured treatment and holdout sessions.
- Make legacy coverage explicit by excluding sessions with missing non-user token counts.

## Changes

- Add nullable `Interaction.token_count` storage support and SQLite schema upgrade handling.
- Recompute token counts at single, bulk, and upsert write chokepoints instead of trusting model input.
- Aggregate stored output-token totals by attributed user and session without tokenizing in the results endpoint.
- Extend retrieval experiment arm metrics with the average and measured-session count.
- Cover Unicode and empty content, normalized roles, zero-output sessions, legacy `NULL` rows, multi-request sessions, and upserts.

## Test Plan

- `uv run ruff check` on all changed Python files
- `uv run pyright` on all changed runtime files
- `uv run pytest -o 'addopts=' tests/server/services/storage/test_sqlite_storage_bc_extras.py tests/server/services/storage/test_storage_contract_profiles.py tests/server/services/storage/test_storage_contract_requests.py tests/server/services/test_retrieval_experiment.py` — 70 passed
- Focused SQLite role-whitespace regression test — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Retrieval experiment results now include average output tokens and the number of sessions with measured output tokens for each experiment arm.
  - Interaction records now capture token counts automatically.
  - Existing databases are updated to support stored token counts without requiring manual migration.

- **Bug Fixes**
  - Sessions with incomplete token data are excluded from output-token averages, while sessions with no generated output are counted as zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->