### PR TITLE
fix(llm): unwrap bare-list structured output; share one generation deadline

### DIFF
--- a/reflexio/server/llm/_litellm_structured_output.py
+++ b/reflexio/server/llm/_litellm_structured_output.py
@@ -25,7 +25,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, get_args, get_origin
 
 import litellm
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from reflexio.server.llm._litellm_json_extraction import (
     _extract_json_from_string,
@@ -103,6 +103,65 @@ def _single_list_item_model(response_format: type[BaseModel]) -> type[BaseModel]
     return None
 
 
+def _sole_matching_list_field(
+    response_format: type[BaseModel], items: list[Any]
+) -> str | None:
+    """Return the one list field a bare-list payload unambiguously belongs to.
+
+    Generalizes :func:`_single_list_field_name` to multi-field schemas. Providers
+    (MiniMax in particular) sometimes emit the *inner* array and drop the object
+    that wraps it — e.g. returning ``ProfileDeduplicationOutput``'s
+    ``duplicate_groups`` list on its own. That schema has three fields, so the
+    single-field rule does not fire and the payload is rejected outright.
+
+    The wrap is only applied when it is unambiguous: exactly one list field
+    accepts the items, and every other field is optional (so the reconstructed
+    object is complete). Zero or several candidates means the payload could
+    belong to more than one field, so this returns ``None`` and the caller falls
+    through to the normal bounded repair path rather than guessing.
+
+    Args:
+        response_format (type[BaseModel]): Target schema.
+        items (list[Any]): Bare list payload returned by the provider.
+
+    Returns:
+        str | None: The unique field name to wrap into, or ``None`` when the
+            placement is ambiguous or would leave a required field unset.
+    """
+    fields = getattr(response_format, "model_fields", {})
+    candidates = [
+        name
+        for name, field in fields.items()
+        if _is_list_annotation(field.annotation)
+        and _annotation_accepts(field.annotation, items)
+    ]
+    if len(candidates) != 1:
+        return None
+    if any(
+        field.is_required() for name, field in fields.items() if name != candidates[0]
+    ):
+        return None
+    return candidates[0]
+
+
+def _annotation_accepts(annotation: Any, value: Any) -> bool:
+    """Return whether *value* validates against *annotation*.
+
+    Args:
+        annotation (Any): Field annotation to test against.
+        value (Any): Candidate payload.
+
+    Returns:
+        bool: True when the value validates, False for any failure — an
+            unbuildable adapter counts as "does not accept", never a crash.
+    """
+    try:
+        TypeAdapter(annotation).validate_python(value)
+    except Exception:
+        return False
+    return True
+
+
 def _is_list_annotation(annotation: Any) -> bool:
     """Return whether an annotation accepts a list value."""
     if annotation is list or get_origin(annotation) is list:
@@ -126,6 +185,12 @@ def _validate_structured_payload(
     if isinstance(parsed, list) and (
         field_name := _single_list_field_name(response_format)
     ):
+        return response_format.model_validate({field_name: parsed})
+    if isinstance(parsed, list) and (
+        field_name := _sole_matching_list_field(response_format, parsed)
+    ):
+        # Multi-field schema whose inner array arrived without its wrapper.
+        # Only reached when the placement is unambiguous (see the helper).
         return response_format.model_validate({field_name: parsed})
     if (
         isinstance(parsed, dict)

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -6,8 +6,8 @@ import os
 import threading
 import time
 import uuid
-from collections.abc import Callable, Mapping
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from contextlib import nullcontext
 from dataclasses import dataclass, field
@@ -101,6 +101,72 @@ class _SharedDeadline:
                 which reads as a bug at the call site).
         """
         return max(0.0, self._deadline - time.monotonic())
+
+
+def _completed_within_shared_budget(
+    awaited: Sequence[tuple[Future[Any], str]],
+    *,
+    request_id: str,
+    warnings: list[str],
+    timeout_seconds: float = GENERATION_SERVICE_TIMEOUT_SECONDS,
+) -> Iterator[tuple[str, Any]]:
+    """Await futures in order under ONE shared budget, yielding what completed.
+
+    Both generation call sites awaited their futures with a copy of this loop.
+    Sharing it keeps the budget arithmetic and the timeout/failure reporting in
+    a single place, so neither site can silently drift back to handing every
+    future a fresh full timeout.
+
+    Args:
+        awaited (Sequence[tuple[Future[Any], str]]): Futures paired with the
+            service name used in logs and warnings, awaited in this order.
+        request_id (str): Correlation id for the log line.
+        warnings (list[str]): Mutated in place with one entry per failed or
+            timed-out service, mirroring the previous per-site behaviour.
+        timeout_seconds (float): Total wall-clock budget for ALL of *awaited*.
+
+    Yields:
+        tuple[str, Any]: ``(service_name, value)`` for each future that
+            completed inside the shared budget. Timed-out and failed services
+            are reported and skipped, never yielded.
+    """
+    budget = _SharedDeadline(timeout_seconds)
+    for future, service_name in awaited:
+        remaining = budget.remaining()
+        try:
+            value = future.result(timeout=remaining)
+        except FuturesTimeoutError:  # noqa: PERF203
+            # Report the budget actually enforced. The second service inherits
+            # only the leftover, so naming the full total here would misreport
+            # the wait that just expired.
+            msg = (
+                f"{service_name} timed out after {remaining:.1f}s "
+                f"of the shared {timeout_seconds:.0f}s budget"
+            )
+            with sentry_tags(
+                subsystem="generation",
+                service=service_name,
+                request_id=request_id,
+                error_type="timeout",
+            ):
+                logger.error("%s for request %s", msg, sanitise_for_log(request_id))
+            warnings.append(msg)
+            continue
+        except Exception as e:
+            msg = f"{service_name} failed: {e}"
+            with sentry_tags(
+                subsystem="generation",
+                service=service_name,
+                request_id=request_id,
+                error_type=type(e).__name__,
+            ):
+                logger.exception(
+                    "Generation service failed for request %s",
+                    sanitise_for_log(request_id),
+                )
+            warnings.append(msg)
+            continue
+        yield service_name, value
 
 
 # Retrieved-learning statuses that committed NOTHING and have no other retry
@@ -761,49 +827,20 @@ class GenerationService:
                 playbook_service.compute_generation,
                 playbook_request,
             )
-            budget = _SharedDeadline(GENERATION_SERVICE_TIMEOUT_SECONDS)
-            for future, service_name, service in (
-                (profile_future, "profile_generation", profile_service),
-                (playbook_future, "playbook_generation", playbook_service),
+            for service_name, plan in _completed_within_shared_budget(
+                (
+                    (profile_future, "profile_generation"),
+                    (playbook_future, "playbook_generation"),
+                ),
+                request_id=request_id,
+                warnings=warnings,
             ):
-                try:
-                    plan = future.result(timeout=budget.remaining())
-                except FuturesTimeoutError:  # noqa: PERF203
-                    msg = (
-                        f"{service_name} timed out after "
-                        f"{GENERATION_SERVICE_TIMEOUT_SECONDS}s"
-                    )
-                    with sentry_tags(
-                        subsystem="generation",
-                        service=service_name,
-                        request_id=request_id,
-                        error_type="timeout",
-                    ):
-                        logger.error(
-                            "%s for request %s", msg, sanitise_for_log(request_id)
-                        )
-                    warnings.append(msg)
-                    continue
-                except Exception as e:
-                    msg = f"{service_name} failed: {e}"
-                    with sentry_tags(
-                        subsystem="generation",
-                        service=service_name,
-                        request_id=request_id,
-                        error_type=type(e).__name__,
-                    ):
-                        logger.exception(
-                            "Generation service failed for request %s",
-                            sanitise_for_log(request_id),
-                        )
-                    warnings.append(msg)
-                    continue
                 if plan is None:
                     continue
                 if service_name == "profile_generation":
-                    profile_pair = (service, plan)
+                    profile_pair = (profile_service, plan)
                 else:
-                    playbook_pair = (service, plan)
+                    playbook_pair = (playbook_service, plan)
         finally:
             executor.shutdown(wait=False, cancel_futures=True)
 
@@ -1023,38 +1060,14 @@ class GenerationService:
                 ]
 
                 service_names = ["profile_generation", "playbook_generation"]
-                budget = _SharedDeadline(GENERATION_SERVICE_TIMEOUT_SECONDS)
-                for future, service_name in zip(futures, service_names, strict=True):
-                    try:
-                        future.result(timeout=budget.remaining())
-                    except FuturesTimeoutError:  # noqa: PERF203
-                        msg = (
-                            f"{service_name} timed out after "
-                            f"{GENERATION_SERVICE_TIMEOUT_SECONDS}s"
-                        )
-                        with sentry_tags(
-                            subsystem="generation",
-                            service=service_name,
-                            request_id=request_id,
-                            error_type="timeout",
-                        ):
-                            logger.error(
-                                "%s for request %s", msg, sanitise_for_log(request_id)
-                            )
-                        result.warnings.append(msg)
-                    except Exception as e:
-                        msg = f"{service_name} failed: {e}"
-                        with sentry_tags(
-                            subsystem="generation",
-                            service=service_name,
-                            request_id=request_id,
-                            error_type=type(e).__name__,
-                        ):
-                            logger.exception(
-                                "Generation service failed for request %s",
-                                sanitise_for_log(request_id),
-                            )
-                        result.warnings.append(msg)
+                # Drained for its warnings side-effect; this path keeps no
+                # per-service value (each service already persisted its own).
+                for _ in _completed_within_shared_budget(
+                    list(zip(futures, service_names, strict=True)),
+                    request_id=request_id,
+                    warnings=result.warnings,
+                ):
+                    pass
             finally:
                 executor.shutdown(wait=False, cancel_futures=True)
 

--- a/reflexio/server/services/generation_service.py
+++ b/reflexio/server/services/generation_service.py
@@ -74,6 +74,35 @@ CLEANUP_STALE_LOCK_SECONDS = 600
 GENERATION_SERVICE_TIMEOUT_SECONDS = 600
 _STALL_WARNING_PREFIX = "Reflexio learning is paused"
 
+
+class _SharedDeadline:
+    """One wall-clock budget shared by several sequentially awaited futures.
+
+    Profile and playbook generation run concurrently but are awaited one after
+    the other. Passing each ``future.result()`` the same constant timeout hands
+    the second service a FRESH full budget on top of whatever the first already
+    consumed — so a 600s setting really allowed up to 1200s, and the
+    "timed out after 600s" log line misreported the budget it had enforced.
+
+    Attributes:
+        _deadline (float): Monotonic timestamp after which nothing may wait.
+    """
+
+    def __init__(self, timeout_seconds: float) -> None:
+        self._deadline = time.monotonic() + timeout_seconds
+
+    def remaining(self) -> float:
+        """Return seconds left in the shared budget.
+
+        Returns:
+            float: Time until the deadline, clamped at ``0.0`` once spent so an
+                exhausted budget fails the wait immediately instead of wrapping
+                into a negative (which ``Future.result`` treats as "no wait" but
+                which reads as a bug at the call site).
+        """
+        return max(0.0, self._deadline - time.monotonic())
+
+
 # Retrieved-learning statuses that committed NOTHING and have no other retry
 # trigger. These are the only ones worth re-running.
 #
@@ -732,12 +761,13 @@ class GenerationService:
                 playbook_service.compute_generation,
                 playbook_request,
             )
+            budget = _SharedDeadline(GENERATION_SERVICE_TIMEOUT_SECONDS)
             for future, service_name, service in (
                 (profile_future, "profile_generation", profile_service),
                 (playbook_future, "playbook_generation", playbook_service),
             ):
                 try:
-                    plan = future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
+                    plan = future.result(timeout=budget.remaining())
                 except FuturesTimeoutError:  # noqa: PERF203
                     msg = (
                         f"{service_name} timed out after "
@@ -993,9 +1023,10 @@ class GenerationService:
                 ]
 
                 service_names = ["profile_generation", "playbook_generation"]
+                budget = _SharedDeadline(GENERATION_SERVICE_TIMEOUT_SECONDS)
                 for future, service_name in zip(futures, service_names, strict=True):
                     try:
-                        future.result(timeout=GENERATION_SERVICE_TIMEOUT_SECONDS)
+                        future.result(timeout=budget.remaining())
                     except FuturesTimeoutError:  # noqa: PERF203
                         msg = (
                             f"{service_name} timed out after "

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -94,6 +94,24 @@ class BareListResponse(BaseModel):
     items: list = Field(default_factory=list)
 
 
+class OptionalMultiListResponse(BaseModel):
+    """Multi-field schema whose fields are ALL optional lists.
+
+    Mirrors ``ProfileDeduplicationOutput``: providers sometimes emit one inner
+    array and drop the object wrapping it, and only one field can accept it.
+    """
+
+    groups: list[SampleResponse] = Field(default_factory=list)
+    unique_ids: list[str] = Field(default_factory=list)
+
+
+class AmbiguousMultiListResponse(BaseModel):
+    """Two optional fields accept the same item shape — placement is a guess."""
+
+    primary_ids: list[str] = Field(default_factory=list)
+    secondary_ids: list[str] = Field(default_factory=list)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -1351,9 +1369,47 @@ class TestMaybeParseStructuredOutput:
         assert result.items == [{"answer": "ok", "score": 5}]
 
     def test_top_level_list_not_wrapped_for_multi_field_schema(self, client):
+        """A required sibling field means the wrap cannot rebuild a whole object."""
         content = json.dumps([{"answer": "ok", "score": 5}])
         with pytest.raises(StructuredOutputParseError):
             client._maybe_parse_structured_output(content, MultiFieldListResponse, True)
+
+    def test_top_level_list_wrapped_for_multi_field_schema_when_unambiguous(
+        self, client
+    ):
+        """MiniMax drops the wrapper object and returns the inner array alone.
+
+        Only ``groups`` accepts these items and every sibling is optional, so
+        the placement is unambiguous — this is the ProfileDeduplicationOutput
+        failure that produced 12.5k Sentry events.
+        """
+        content = json.dumps([{"answer": "ok", "score": 5}])
+        result = client._maybe_parse_structured_output(
+            content, OptionalMultiListResponse, True
+        )
+
+        assert isinstance(result, OptionalMultiListResponse)
+        assert len(result.groups) == 1
+        assert result.groups[0].answer == "ok"
+        assert result.unique_ids == []
+
+    def test_top_level_list_routed_to_the_only_field_that_accepts_it(self, client):
+        """Item shape, not field order, decides which list field receives it."""
+        content = json.dumps(["NEW-2", "NEW-3"])
+        result = client._maybe_parse_structured_output(
+            content, OptionalMultiListResponse, True
+        )
+
+        assert result.unique_ids == ["NEW-2", "NEW-3"]
+        assert result.groups == []
+
+    def test_top_level_list_not_wrapped_when_two_fields_accept_it(self, client):
+        """Ambiguous placement must fail to the repair path, never be guessed."""
+        content = json.dumps(["a", "b"])
+        with pytest.raises(StructuredOutputParseError):
+            client._maybe_parse_structured_output(
+                content, AmbiguousMultiListResponse, True
+            )
 
     def test_json_in_markdown_code_block(self, client):
         content = '```json\n{"answer": "ok", "score": 5}\n```'

--- a/tests/server/services/test_generation_shared_deadline.py
+++ b/tests/server/services/test_generation_shared_deadline.py
@@ -5,6 +5,10 @@ Passing each ``future.result()`` the same constant handed the second service a
 fresh full budget on top of whatever the first had already consumed, so a 600s
 setting really allowed up to 1200s and the "timed out after 600s" log line
 misreported the budget it had enforced.
+
+These drive ``_completed_within_shared_budget`` — the loop BOTH production call
+sites use — and assert on the timeout actually handed to each ``result()``
+call, so they fail if either site reverts to a per-future constant.
 """
 
 from __future__ import annotations
@@ -12,10 +16,145 @@ from __future__ import annotations
 import time
 from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any
 
 import pytest
 
-from reflexio.server.services.generation_service import _SharedDeadline
+from reflexio.server.services.generation_service import (
+    _completed_within_shared_budget,
+    _SharedDeadline,
+)
+
+
+class _RecordingFuture:
+    """Future stand-in that records the timeout it was awaited with."""
+
+    def __init__(self, granted: list[float], outcome: Any = "value") -> None:
+        self._granted = granted
+        self._outcome = outcome
+
+    def result(self, timeout: float | None = None) -> Any:
+        self._granted.append(float(timeout if timeout is not None else -1.0))
+        if isinstance(self._outcome, BaseException):
+            raise self._outcome
+        return self._outcome
+
+
+def _drain(
+    awaited: list[tuple[Any, str]], warnings: list[str]
+) -> list[tuple[str, Any]]:
+    return list(
+        _completed_within_shared_budget(
+            awaited,  # type: ignore[arg-type]
+            request_id="req-1",
+            warnings=warnings,
+            timeout_seconds=600.0,
+        )
+    )
+
+
+def test_second_future_gets_only_the_leftover_budget(monkeypatch: pytest.MonkeyPatch):
+    """The regression: two sequential waits must not each get a full budget."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+    granted: list[float] = []
+
+    class _SlowFirst(_RecordingFuture):
+        def result(self, timeout: float | None = None) -> Any:
+            value = super().result(timeout)
+            clock["now"] += 590.0  # first service burns most of the budget
+            return value
+
+    warnings: list[str] = []
+    completed = _drain(
+        [
+            (_SlowFirst(granted), "profile_generation"),
+            (_RecordingFuture(granted), "playbook_generation"),
+        ],
+        warnings,
+    )
+
+    assert [name for name, _ in completed] == [
+        "profile_generation",
+        "playbook_generation",
+    ]
+    assert granted[0] == pytest.approx(600.0)
+    assert granted[1] == pytest.approx(10.0)
+    assert warnings == []
+
+
+def test_exhausted_budget_grants_the_second_future_zero(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An overspent budget must clamp to 0, not wrap into a negative."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+    granted: list[float] = []
+
+    class _Overrunning(_RecordingFuture):
+        def result(self, timeout: float | None = None) -> Any:
+            value = super().result(timeout)
+            clock["now"] += 900.0
+            return value
+
+    warnings: list[str] = []
+    _drain(
+        [
+            (_Overrunning(granted), "profile_generation"),
+            (_RecordingFuture(granted), "playbook_generation"),
+        ],
+        warnings,
+    )
+
+    assert granted[1] == 0.0
+
+
+def test_timeout_warning_reports_the_budget_actually_enforced(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Naming the full 600s total would misreport the wait that just expired."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+    granted: list[float] = []
+
+    class _SlowFirst(_RecordingFuture):
+        def result(self, timeout: float | None = None) -> Any:
+            super().result(timeout)
+            clock["now"] += 590.0
+            return "value"
+
+    warnings: list[str] = []
+    completed = _drain(
+        [
+            (_SlowFirst(granted), "profile_generation"),
+            (
+                _RecordingFuture(granted, FuturesTimeoutError()),
+                "playbook_generation",
+            ),
+        ],
+        warnings,
+    )
+
+    assert [name for name, _ in completed] == ["profile_generation"]
+    assert len(warnings) == 1
+    assert "playbook_generation timed out after 10.0s" in warnings[0]
+    assert "shared 600s budget" in warnings[0]
+
+
+def test_a_failing_service_is_reported_and_does_not_stop_the_other():
+    warnings: list[str] = []
+    granted: list[float] = []
+
+    completed = _drain(
+        [
+            (_RecordingFuture(granted, RuntimeError("boom")), "profile_generation"),
+            (_RecordingFuture(granted, "plan"), "playbook_generation"),
+        ],
+        warnings,
+    )
+
+    assert completed == [("playbook_generation", "plan")]
+    assert warnings == ["profile_generation failed: boom"]
 
 
 def test_remaining_shrinks_as_the_budget_is_spent(monkeypatch: pytest.MonkeyPatch):
@@ -27,47 +166,6 @@ def test_remaining_shrinks_as_the_budget_is_spent(monkeypatch: pytest.MonkeyPatc
 
     clock["now"] += 250.0
     assert budget.remaining() == pytest.approx(350.0)
-
-    clock["now"] += 100.0
-    assert budget.remaining() == pytest.approx(250.0)
-
-
-def test_remaining_clamps_at_zero_once_exhausted(monkeypatch: pytest.MonkeyPatch):
-    """An overspent budget must fail the next wait, not wrap to a negative."""
-    clock = {"now": 1000.0}
-    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
-
-    budget = _SharedDeadline(600.0)
-    clock["now"] += 900.0
-
-    assert budget.remaining() == 0.0
-
-
-def test_second_future_inherits_only_the_leftover_budget(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """The regression: two sequential waits must not each get a full budget."""
-    clock = {"now": 1000.0}
-    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
-
-    budget = _SharedDeadline(600.0)
-    granted: list[float] = []
-
-    # First service resolves immediately but burns 590s of wall clock.
-    first: Future = Future()
-    first.set_result("profile")
-    granted.append(budget.remaining())
-    first.result(timeout=granted[-1])
-    clock["now"] += 590.0
-
-    # Second service is still running; it may only have what is left.
-    second: Future = Future()
-    granted.append(budget.remaining())
-
-    assert granted[0] == pytest.approx(600.0)
-    assert granted[1] == pytest.approx(10.0)
-    with pytest.raises(FuturesTimeoutError):
-        second.result(timeout=0.01)
 
 
 def test_exhausted_budget_does_not_wait_for_a_pending_future():

--- a/tests/server/services/test_generation_shared_deadline.py
+++ b/tests/server/services/test_generation_shared_deadline.py
@@ -1,0 +1,82 @@
+"""The generation timeout is ONE budget shared by both awaited futures.
+
+Profile and playbook generation run concurrently but are awaited in sequence.
+Passing each ``future.result()`` the same constant handed the second service a
+fresh full budget on top of whatever the first had already consumed, so a 600s
+setting really allowed up to 1200s and the "timed out after 600s" log line
+misreported the budget it had enforced.
+"""
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+import pytest
+
+from reflexio.server.services.generation_service import _SharedDeadline
+
+
+def test_remaining_shrinks_as_the_budget_is_spent(monkeypatch: pytest.MonkeyPatch):
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+
+    budget = _SharedDeadline(600.0)
+    assert budget.remaining() == pytest.approx(600.0)
+
+    clock["now"] += 250.0
+    assert budget.remaining() == pytest.approx(350.0)
+
+    clock["now"] += 100.0
+    assert budget.remaining() == pytest.approx(250.0)
+
+
+def test_remaining_clamps_at_zero_once_exhausted(monkeypatch: pytest.MonkeyPatch):
+    """An overspent budget must fail the next wait, not wrap to a negative."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+
+    budget = _SharedDeadline(600.0)
+    clock["now"] += 900.0
+
+    assert budget.remaining() == 0.0
+
+
+def test_second_future_inherits_only_the_leftover_budget(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The regression: two sequential waits must not each get a full budget."""
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(time, "monotonic", lambda: clock["now"])
+
+    budget = _SharedDeadline(600.0)
+    granted: list[float] = []
+
+    # First service resolves immediately but burns 590s of wall clock.
+    first: Future = Future()
+    first.set_result("profile")
+    granted.append(budget.remaining())
+    first.result(timeout=granted[-1])
+    clock["now"] += 590.0
+
+    # Second service is still running; it may only have what is left.
+    second: Future = Future()
+    granted.append(budget.remaining())
+
+    assert granted[0] == pytest.approx(600.0)
+    assert granted[1] == pytest.approx(10.0)
+    with pytest.raises(FuturesTimeoutError):
+        second.result(timeout=0.01)
+
+
+def test_exhausted_budget_does_not_wait_for_a_pending_future():
+    """A spent budget fails fast instead of blocking for another full timeout."""
+    budget = _SharedDeadline(0.0)
+    pending: Future = Future()
+
+    started = time.monotonic()
+    with pytest.raises(FuturesTimeoutError):
+        pending.result(timeout=budget.remaining())
+
+    assert time.monotonic() - started < 1.0


### PR DESCRIPTION
Two production fixes found while investigating the Sentry backlog.

## 1. Bare-list structured output is rejected on multi-field schemas

Providers — MiniMax/MiniMax-M3 in particular — sometimes emit the **inner array** and drop the object wrapping it, returning `ProfileDeduplicationOutput`'s `duplicate_groups` list on its own.

The existing wrap in `_validate_structured_payload` only fires for *single-field* schemas, so a 3-field schema like that one was rejected outright. In Sentry: **12,539 events since 2026-06-07, still firing**, silently degrading profile dedup and agent-success evaluation.

Verified this is still live on `main` (not just a stale deployed image) by replaying the exact payload shape through `_validate_structured_payload`.

`_sole_matching_list_field` generalizes the wrap, but only where placement is **unambiguous**:

- exactly one list field accepts the items, **and**
- every other field is optional, so the reconstructed object is complete.

Zero or several candidates falls through to the existing bounded repair path rather than guessing which field the data belonged to. That guard is what keeps the existing multi-field rejection correct — `MultiFieldListResponse` has a required `source`, so it still refuses to wrap, and `test_top_level_list_not_wrapped_for_multi_field_schema` passes unchanged.

## 2. The generation timeout was not a shared budget

Profile and playbook generation run concurrently on a 2-worker pool but are awaited **in sequence**. Both call sites passed each `future.result()` the same constant `GENERATION_SERVICE_TIMEOUT_SECONDS`, so the second service received a *fresh full budget* on top of whatever the first had already consumed:

- a 600s setting really allowed up to **1200s**, asymmetrically (first service 600s, second up to 1200s)
- the `"timed out after 600s"` log line reported a budget that had not been enforced

Found while investigating `PYTHON-FASTAPI-1C` (513 occurrences since 2026-05-06, still firing, user-facing). This is **not** the cause of the slowness itself — it is why the enforced ceiling did not match the configured one.

`_SharedDeadline` states the invariant once and is unit-tested directly, rather than duplicating the arithmetic at both sites.

## Testing

- `4157 passed` across the OSS unit tier (`-m "not integration and not e2e"`, excluding `tests/eval` which needs `polars`, absent in this env)
- ruff + pyright clean on all changed files
- New: 4 shared-deadline tests, 3 bare-list tests (unambiguous wrap, shape-based routing, ambiguity rejection)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved structured-output parsing when a provider returns a top-level bare list for multi-field responses, including safer handling of unambiguous vs ambiguous list placement.
  * Fixed generation timing so concurrent learning/generation steps share a single wall-clock timeout budget, preventing the overall wait from exceeding the configured limit.

* **Tests**
  * Added unit tests covering unambiguous wrapping, ambiguous placement failures, and shared-timeout behavior (including overspent budgets and exception handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->