### PR TITLE
feat: derive corrective turns from session judge

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -612,7 +612,14 @@ class AgentSuccessEvaluationResult(BaseModel):
     evaluation_name: str | None = None
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
     regular_vs_shadow: RegularVsShadow | None = None
-    number_of_correction_per_session: int = 0
+    number_of_correction_per_session: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Number of user turns in the session that corrected or redirected an "
+            "earlier agent response or action."
+        ),
+    )
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
     embedding: EmbeddingVector = []

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -22,10 +22,11 @@ BucketLiteral = Literal["day", "week"]
 class HeroBucket(BaseModel):
     """One point on the trend chart in the hero block.
 
-    ``avg_corrections`` is the mean of ``number_of_correction_per_session``
-    across this bucket's evaluation results. Surfaced so the frontend can
-    plot a "corrections over time" line beside the success-rate trend.
-    Lower is better.
+    ``avg_corrections`` is the mean judge-derived count of user turns that
+    corrected or redirected an earlier agent response, across every evaluation
+    result in this bucket (including zero-count sessions). Surfaced so the
+    frontend can plot a "corrections over time" line beside the success-rate
+    trend. Lower is better.
 
     ``escalation_rate`` is the fraction of sessions in this bucket whose
     eval result had ``is_escalated=True``. Range 0.0 – 1.0. Surfaced so

--- a/reflexio/models/api_schema/ui/entities.py
+++ b/reflexio/models/api_schema/ui/entities.py
@@ -124,7 +124,14 @@ class EvaluationResultView(BaseModel):
     evaluation_name: str | None = None
     created_at: int = Field(default_factory=lambda: int(datetime.now(UTC).timestamp()))
     regular_vs_shadow: RegularVsShadow | None = None
-    number_of_correction_per_session: int = 0
+    number_of_correction_per_session: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Number of user turns in the session that corrected or redirected an "
+            "earlier agent response or action."
+        ),
+    )
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
 

--- a/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.0.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.0.0.prompt.md
@@ -1,5 +1,5 @@
 ---
-active: true
+active: false
 description: "Evaluates agent success based on user interactions"
 variables:
   - agent_context_prompt

--- a/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.1.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.1.0.prompt.md
@@ -1,0 +1,97 @@
+---
+active: true
+description: "Evaluates session success, escalation, and corrective user turns"
+changelog: "v1.1.0: adds a required count of corrective user turns, distinguishes revisions from new intents, and keeps correction count independent from final task success."
+variables:
+  - agent_context_prompt
+  - success_definition_prompt
+  - tool_can_use
+  - metadata_definition_prompt
+  - interactions
+---
+
+[Instruction]
+Given the interactions above, evaluate if the agent has successfully completed the user's primary requested task by the end of the session, based on the success definition below.
+The agent may make mistakes or take wrong actions during the session. The user may provide corrections or ask the agent to try differently. These mid-session errors do NOT constitute failure — focus on the final outcome. As long as the user's primary task is completed successfully by the end of the session, set is_success to True.
+
+Step 1: Identify the user's primary task from the interactions. Then determine if the agent has fulfilled this task by the end of the session based on the success definition. If so, set is_success to True. Otherwise set is_success to False and continue to the next step.
+
+Step 2: If the agent did not complete the primary task by the end of the session, determine the failure type and failure reason.
+There are four types of failures:
+- 'missing_tool': Agent does not have the right tool or action that it can take to get sufficient information to answer the user's request.
+- 'wrong_tool': Tools or actions are available, but the agent did not use the right tool or perform the right action.
+- 'insufficient_info_from_tool': Agent performed the right action and tool use, but the tool or action did not provide enough or correct information to answer successfully.
+- 'wrong_answer': Agent had enough information but still did not answer successfully.
+
+Step 3: Determine if the user was escalated (handed off to a human agent or another agent). Set is_escalated to True if so, False otherwise. Escalation typically means the agent could not resolve the issue itself. Escalated sessions are likely unsuccessful, but unsuccessful sessions are not necessarily escalated.
+
+Step 4: Count corrective user turns across the entire session.
+
+A user turn is corrective only when ALL of these are true:
+1. It refers to an earlier agent response or action.
+2. It indicates explicitly or by strong implication that the earlier response or action was incorrect, incomplete, insufficient, or misaligned.
+3. It steers the agent toward revising that earlier response or action, such as by supplying corrected information, identifying missing content, changing a constraint, rejecting an approach, requesting a redo, or specifying how the response should change.
+
+Count each qualifying user turn once, even if it corrects multiple issues. Count separate later corrective turns separately, including repeated corrections of the same issue. A correction may refer to an agent turn earlier than the immediately preceding turn.
+
+Do NOT count:
+- the user's initial request;
+- a genuinely different question or a request for a separate new deliverable, even when it concerns the same general topic;
+- an ordinary follow-up question that seeks additional information without indicating the earlier response should change;
+- an answer to a clarification question asked by the agent;
+- a confirmation, acknowledgment, approval, or request to continue;
+- information supplied before the agent made the relevant mistake;
+- an agent self-correction that was not prompted by a corrective user turn.
+
+To distinguish a corrective turn from a new intent, ask whether the user is evaluating, modifying, rejecting, completing, or replacing an earlier agent response. Topic continuity alone is not evidence of a correction. If the new intent can be fulfilled without revising the earlier response, do not count it.
+
+Examples:
+- Agent gives the wrong limit; user says the limit is 50 and asks for the answer to be fixed: count 1 factual correction.
+- Agent omits rollback steps; user says they were missed and asks to add them: count 1 insufficient-response correction.
+- Agent uses a CLI approach; user rejects it and asks to use the API instead: count 1 redirected correction.
+- One user turn fixes several details in the same response: count that turn once.
+- The user corrects the response and later has to correct it again: count each corrective user turn separately.
+- User accepts an answer and asks a different question about the same topic: count 0 for the new question.
+- User asks for a separate implementation plan after receiving an explanation: count 0 for the new deliverable.
+- User supplies information in response to the agent's clarification question: count 0.
+
+Set number_of_correction_per_session to the resulting non-negative integer. This count is independent of is_success: a session may contain corrective turns and still be successful if the primary task is completed by the end.
+
+[Context]
+{agent_context_prompt}
+
+[Success definition]
+{success_definition_prompt}
+
+[Interactions]
+User and agent interactions:
+{interactions}
+
+[Tools]
+{tool_can_use}
+
+[Metadata Definition]
+{metadata_definition_prompt}
+
+[Output]
+Generate the output in valid JSON format using the following schema.
+
+# success case example
+```json
+{{
+    "is_success": true,
+    "is_escalated": false,
+    "number_of_correction_per_session": 2
+}}
+```
+
+# failure case example
+```json
+{{
+    "is_success": false,
+    "failure_type": "missing_tool" or "wrong_tool" or "insufficient_info_from_tool" or "wrong_answer",
+    "failure_reason": "explain the reason for failure and what the agent needs to do differently",
+    "is_escalated": true,
+    "number_of_correction_per_session": 1
+}}
+```

--- a/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.1.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.1.0.prompt.md
@@ -86,10 +86,12 @@ Generate the output in valid JSON format using the following schema.
 ```
 
 # failure case example
+`failure_type` must be one of `missing_tool`, `wrong_tool`, `insufficient_info_from_tool`, or `wrong_answer`; this example uses `missing_tool`.
+
 ```json
 {{
     "is_success": false,
-    "failure_type": "missing_tool" or "wrong_tool" or "insufficient_info_from_tool" or "wrong_answer",
+    "failure_type": "missing_tool",
     "failure_reason": "explain the reason for failure and what the agent needs to do differently",
     "is_escalated": true,
     "number_of_correction_per_session": 1

--- a/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.1.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.1.0.prompt.md
@@ -45,16 +45,6 @@ Do NOT count:
 
 To distinguish a corrective turn from a new intent, ask whether the user is evaluating, modifying, rejecting, completing, or replacing an earlier agent response. Topic continuity alone is not evidence of a correction. If the new intent can be fulfilled without revising the earlier response, do not count it.
 
-Examples:
-- Agent gives the wrong limit; user says the limit is 50 and asks for the answer to be fixed: count 1 factual correction.
-- Agent omits rollback steps; user says they were missed and asks to add them: count 1 insufficient-response correction.
-- Agent uses a CLI approach; user rejects it and asks to use the API instead: count 1 redirected correction.
-- One user turn fixes several details in the same response: count that turn once.
-- The user corrects the response and later has to correct it again: count each corrective user turn separately.
-- User accepts an answer and asks a different question about the same topic: count 0 for the new question.
-- User asks for a separate implementation plan after receiving an explanation: count 0 for the new deliverable.
-- User supplies information in response to the agent's clarification question: count 0.
-
 Set number_of_correction_per_session to the resulting non-negative integer. This count is independent of is_success: a session may contain corrective turns and still be successful if the primary task is completed by the end.
 
 [Context]

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_constants.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_constants.py
@@ -20,13 +20,14 @@ class AgentSuccessEvaluationOutput(StrictStructuredOutput):
     """
     Unified output schema for agent success evaluation.
 
-    For successful evaluations, only is_success=True is required.
-    For failed evaluations, all fields are required to provide failure details.
+    Every evaluation includes a corrective-user-turn count. Failed evaluations
+    additionally provide failure details.
 
     Attributes:
         is_success (bool): Indicates whether the agent successfully responded to the user
         failure_type (Optional[str]): Type of failure - 'missing_tool', 'wrong_tool', 'insufficient_info_from_tool', or 'wrong_answer'. Required when is_success=False
         failure_reason (Optional[str]): Explanation for the failure and what the agent needs to do differently. Required when is_success=False
+        number_of_correction_per_session (int): Number of user turns that corrected or redirected an earlier agent response.
     """
 
     is_success: bool = Field(
@@ -48,6 +49,14 @@ class AgentSuccessEvaluationOutput(StrictStructuredOutput):
     is_escalated: bool = Field(
         default=False,
         description="Whether the user was handed off to a human agent or another agent during the session.",
+    )
+    number_of_correction_per_session: int = Field(
+        ge=0,
+        strict=True,
+        description=(
+            "Number of user turns in the session that corrected or redirected an "
+            "earlier agent response or action."
+        ),
     )
     # OpenAI schema parsing requires explicitly forbidding additional properties
     model_config = ConfigDict(

--- a/reflexio/server/services/agent_success_evaluation/components/evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/components/evaluator.py
@@ -282,7 +282,9 @@ class AgentSuccessEvaluator:
             failure_type=evaluation_response.failure_type or "",
             failure_reason=evaluation_response.failure_reason or "",
             regular_vs_shadow=None,
-            number_of_correction_per_session=self._get_correction_count(),
+            number_of_correction_per_session=(
+                evaluation_response.number_of_correction_per_session
+            ),
             user_turns_to_resolution=(
                 self._count_user_turns(request_interaction_data_models)
                 if evaluation_response.is_success
@@ -334,25 +336,6 @@ class AgentSuccessEvaluator:
                 if interaction.role.lower() not in agent_roles:
                     count += 1
         return count
-
-    def _get_correction_count(self) -> int:
-        """
-        Count user playbooks linked to the current session.
-
-        Returns:
-            int: Number of user playbooks for the session, defaulting to 0 on error.
-        """
-        try:
-            count = self.request_context.storage.count_user_playbooks_by_session(  # type: ignore[reportOptionalMemberAccess]
-                self.service_config.session_id
-            )
-            return count if count is not None else 0
-        except Exception:
-            logger.warning(
-                "Failed to count user playbooks for session %s, defaulting to 0",
-                self.service_config.session_id,
-            )
-            return 0
 
     # F1 cleanup: ``_map_comparison_to_enum`` was retracted along with
     # ``_evaluate_with_shadow_comparison``. Per-turn shadow comparison has its

--- a/reflexio/server/services/agent_success_evaluation/runner.py
+++ b/reflexio/server/services/agent_success_evaluation/runner.py
@@ -112,12 +112,11 @@ def run_group_evaluation(
     2. Fetch all requests for the session
     3. Verify completion (latest request created_at >= delay ago; skipped when force_regenerate)
     4. Fetch interactions and build data models
-    5. Capture prior result_ids (when regenerating) so they
-       can be removed AFTER the new save lands
+    5. Capture prior result_ids (when regenerating) for post-save reconciliation
     6. Run evaluation service (which saves new rows)
-    7. On success, delete the captured prior rows by id — the new rows have
-       fresh auto-increment ids that do not overlap. A failure here leaves
-       the session in a consistent pre-regen state instead of zero rows.
+    7. On success, delete captured prior rows only when the backend inserted
+       fresh result_ids; preserve ids updated in place by an enterprise upsert.
+       A generation/save failure leaves the prior result untouched.
     8. Mark as evaluated in operation state
 
     Args:
@@ -252,19 +251,21 @@ def run_group_evaluation(
         )
         return GroupEvaluationOutcome("not_applicable", "skipped")
 
-    # 5. When regenerating, capture the prior result_ids
-    # so we can delete ONLY them AFTER the new rows have been saved. Doing
-    # the delete before the LLM call risks wiping the session's rows if the
-    # call fails (rate limit, network) and nothing replaces them. The new
-    # rows always get fresh auto-increment ids, so deleting the captured set
-    # afterwards cannot remove the new rows.
+    # 5. When regenerating, capture the prior result_ids so we can reconcile
+    # them AFTER the new rows have been saved. SQLite inserts a fresh row that
+    # needs the prior row cleaned up; enterprise storage upserts the prior row
+    # in place and therefore keeps its result_id. Doing any delete before the
+    # LLM call risks wiping the session's rows if the call fails (rate limit,
+    # network) and nothing replaces them.
     old_result_ids: list[int] = []
+    evaluation_name = ""
     if force_regenerate:
         config = request_context.configurator.get_config()
+        evaluation_name = get_extractor_name(config)
         old_result_ids = storage.get_agent_success_evaluation_result_ids(  # type: ignore[reportOptionalMemberAccess]
             user_id=user_id,
             session_id=session_id,
-            evaluation_name=get_extractor_name(config),
+            evaluation_name=evaluation_name,
             agent_version=agent_version,
         )
 
@@ -310,20 +311,36 @@ def run_group_evaluation(
         )
         return GroupEvaluationOutcome("failed", "skipped")
 
-    # 6. New rows saved successfully — now safe to remove the captured prior
-    # rows. New rows have fresh auto-increment result_ids that do not overlap
-    # with old_result_ids, so this cannot delete the regenerated verdict.
+    # 6. New rows saved successfully. Delete captured prior rows only when the
+    # writer created a distinct new result_id (SQLite). Enterprise storage uses
+    # an in-place upsert, so its post-save ids are unchanged; deleting those ids
+    # would delete the regenerated verdict itself.
     if old_result_ids:
-        deleted = storage.delete_agent_success_evaluation_results_by_ids(  # type: ignore[reportOptionalMemberAccess]
-            old_result_ids
+        saved_result_ids = storage.get_agent_success_evaluation_result_ids(  # type: ignore[reportOptionalMemberAccess]
+            user_id=user_id,
+            session_id=session_id,
+            evaluation_name=evaluation_name,
+            agent_version=agent_version,
         )
-        logger.info(
-            "Regenerate cleanup: deleted %d prior result row(s) for session=%s"
-            " (expected %d)",
-            deleted,
-            session_id,
-            len(old_result_ids),
-        )
+        inserted_result_ids = set(saved_result_ids).difference(old_result_ids)
+        if inserted_result_ids:
+            deleted = storage.delete_agent_success_evaluation_results_by_ids(  # type: ignore[reportOptionalMemberAccess]
+                old_result_ids
+            )
+            logger.info(
+                "Regenerate cleanup: deleted %d prior result row(s) for session=%s"
+                " (expected %d)",
+                deleted,
+                session_id,
+                len(old_result_ids),
+            )
+        else:
+            logger.info(
+                "Regenerate cleanup: storage updated %d prior result row(s) in place"
+                " for session=%s",
+                len(old_result_ids),
+                session_id,
+            )
 
     # 7. Mark as evaluated
     evaluated_at = int(datetime.now(UTC).timestamp())

--- a/reflexio/server/services/agent_success_evaluation/runner.py
+++ b/reflexio/server/services/agent_success_evaluation/runner.py
@@ -260,8 +260,8 @@ def run_group_evaluation(
     old_result_ids: list[int] = []
     evaluation_name = ""
     if force_regenerate:
-        config = request_context.configurator.get_config()
-        evaluation_name = get_extractor_name(config)
+        root_config = request_context.configurator.get_config()
+        evaluation_name = get_extractor_name(root_config.agent_success_config)
         old_result_ids = storage.get_agent_success_evaluation_result_ids(  # type: ignore[reportOptionalMemberAccess]
             user_id=user_id,
             session_id=session_id,
@@ -311,7 +311,7 @@ def run_group_evaluation(
         )
         return GroupEvaluationOutcome("failed", "skipped")
 
-    # 6. New rows saved successfully. Delete captured prior rows only when the
+    # 7. New rows saved successfully. Delete captured prior rows only when the
     # writer created a distinct new result_id (SQLite). Enterprise storage uses
     # an in-place upsert, so its post-save ids are unchanged; deleting those ids
     # would delete the regenerated verdict itself.

--- a/reflexio/test_support/llm_model_registry.py
+++ b/reflexio/test_support/llm_model_registry.py
@@ -117,6 +117,7 @@ def _build_registry() -> dict[str, ModelRegistryEntry]:
             minimal_valid={
                 "is_success": True,
                 "is_escalated": False,
+                "number_of_correction_per_session": 0,
             },
         ),
         "retrieved_learning_relevance": ModelRegistryEntry(

--- a/tests/fixtures/llm/agent_success_evaluation.json
+++ b/tests/fixtures/llm/agent_success_evaluation.json
@@ -2,7 +2,7 @@
   "choices": [
     {
       "message": {
-        "content": "{\"is_success\": true, \"is_escalated\": false}"
+        "content": "{\"is_success\": true, \"is_escalated\": false, \"number_of_correction_per_session\": 0}"
       },
       "finish_reason": "stop"
     }

--- a/tests/server/services/__snapshots__/test_llm_mock_schema_compliance/TestMockResponseSnapshots.test_recorded_fixture_content[agent_success_evaluation].json
+++ b/tests/server/services/__snapshots__/test_llm_mock_schema_compliance/TestMockResponseSnapshots.test_recorded_fixture_content[agent_success_evaluation].json
@@ -1,4 +1,5 @@
 {
   "is_escalated": false,
-  "is_success": true
+  "is_success": true,
+  "number_of_correction_per_session": 0
 }

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
@@ -13,6 +13,47 @@ from reflexio.server.services.agent_success_evaluation.agent_success_evaluation_
 )
 
 
+def _render_agent_success_prompt() -> str:
+    return PromptManager().render_prompt(
+        "agent_success_evaluation",
+        {
+            "agent_context_prompt": "Test agent",
+            "success_definition_prompt": "Complete the requested task",
+            "tool_can_use": "No tools",
+            "metadata_definition_prompt": "No metadata",
+            "interactions": "user: ```hello```",
+        },
+    )
+
+
+def test_agent_success_prompt_v1_1_0_is_active_and_renders() -> None:
+    prompt_manager = PromptManager()
+
+    assert prompt_manager.get_active_version("agent_success_evaluation") == "1.1.0"
+    assert "Step 4: Count corrective user turns" in _render_agent_success_prompt()
+
+
+@pytest.mark.parametrize(
+    ("case", "expected_fragment"),
+    [
+        ("no correction", "the user's initial request"),
+        ("factual correction", "wrong limit"),
+        ("incomplete-answer revision", "omits rollback steps"),
+        ("approach redirection", "rejects it and asks to use the API"),
+        ("several issues in one turn", "fixes several details"),
+        ("repeated corrections", "later has to correct it again"),
+        ("same-topic new question", "different question about the same topic"),
+        ("new deliverable", "separate implementation plan"),
+        ("clarification answer", "agent's clarification question"),
+    ],
+)
+def test_agent_success_prompt_documents_correction_rubric_cases(
+    case: str, expected_fragment: str
+) -> None:
+    del case
+    assert expected_fragment in _render_agent_success_prompt()
+
+
 def test_construct_agent_success_evaluation_messages_with_sessions():
     """Test that construct_agent_success_evaluation_messages_from_sessions formats interactions correctly in the rendered prompt."""
     # Create test interactions with both content and actions
@@ -130,6 +171,13 @@ def test_construct_agent_success_evaluation_messages_with_sessions():
                     "Evaluate if the agent successfully completed the task" in content
                 ), "Expected success definition in prompt"
                 assert "search, calculator" in content, "Expected tools in prompt"
+                assert (
+                    "Count corrective user turns across the entire session" in content
+                )
+                assert (
+                    "Topic continuity alone is not evidence of a correction" in content
+                )
+                assert '"number_of_correction_per_session"' in content
 
                 found_interactions = True
                 break

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
@@ -1,5 +1,7 @@
 """Tests for agent success evaluation utility functions."""
 
+import json
+import re
 from datetime import UTC, datetime
 
 import pytest
@@ -31,6 +33,17 @@ def test_agent_success_prompt_v1_1_0_is_active_and_renders() -> None:
 
     assert prompt_manager.get_active_version("agent_success_evaluation") == "1.1.0"
     assert "Step 4: Count corrective user turns" in _render_agent_success_prompt()
+
+
+def test_agent_success_prompt_examples_are_valid_json() -> None:
+    """Every rendered output example must honor the prompt's JSON contract."""
+    examples = re.findall(
+        r"```json\n(.*?)\n```", _render_agent_success_prompt(), flags=re.DOTALL
+    )
+
+    assert len(examples) == 2
+    for example in examples:
+        json.loads(example)
 
 
 @pytest.mark.parametrize(

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
@@ -11,6 +11,7 @@ import tempfile
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.models.api_schema.service_schemas import (
@@ -41,7 +42,8 @@ def mock_llm_client():
     client = MagicMock(spec=LiteLLMClient)
     # Return a successful AgentSuccessEvaluationOutput
     client.generate_chat_response.return_value = AgentSuccessEvaluationOutput(
-        is_success=True
+        is_success=True,
+        number_of_correction_per_session=0,
     )
     return client
 
@@ -403,63 +405,58 @@ class TestCountUserTurns:
         assert evaluator._count_user_turns(models) == 1
 
 
-class TestGetCorrectionCount:
-    """Tests for AgentSuccessEvaluator._get_correction_count."""
+class TestCorrectionCount:
+    """Tests for the judge-derived corrective-user-turn count."""
 
-    def test_returns_zero_on_storage_exception(self, mock_llm_client, temp_storage_dir):
-        """_get_correction_count returns 0 when storage raises."""
-        config = AgentSuccessConfig(
-            evaluation_name="test",
-            success_definition_prompt="test",
-        )
-        service_config = AgentSuccessGenerationServiceConfig(
-            session_id="test_session",
-            agent_version="v1",
-            user_id="user1",
-            request_interaction_data_models=[],
-            source="api",
-        )
-        request_context = RequestContext(
-            org_id="test_org", storage_base_dir=temp_storage_dir
-        )
-        request_context.storage = MagicMock()
-        request_context.storage.count_user_playbooks_by_session.side_effect = (
-            RuntimeError("db down")
-        )
+    def test_output_requires_correction_count(self):
+        with pytest.raises(ValidationError):
+            AgentSuccessEvaluationOutput.model_validate({"is_success": True})
 
+    def test_output_rejects_negative_correction_count(self):
+        with pytest.raises(ValidationError):
+            AgentSuccessEvaluationOutput(
+                is_success=True,
+                number_of_correction_per_session=-1,
+            )
+
+    @pytest.mark.parametrize("invalid_count", ["1", 1.5])
+    def test_output_rejects_non_integer_correction_count(self, invalid_count):
+        with pytest.raises(ValidationError):
+            AgentSuccessEvaluationOutput.model_validate(
+                {
+                    "is_success": True,
+                    "number_of_correction_per_session": invalid_count,
+                }
+            )
+
+    @pytest.mark.parametrize("is_success", [True, False])
+    def test_result_uses_judge_count_without_playbook_storage(
+        self,
+        is_success,
+        mock_llm_client,
+        request_context,
+        extractor_config,
+        service_config,
+        sample_request_interaction_models,
+    ):
         evaluator = AgentSuccessEvaluator(
             request_context=request_context,
             llm_client=mock_llm_client,
-            extractor_config=config,
+            extractor_config=extractor_config,
             service_config=service_config,
             agent_context="Test agent",
         )
-        assert evaluator._get_correction_count() == 0
+        response = AgentSuccessEvaluationOutput(
+            is_success=is_success,
+            failure_type=None if is_success else "wrong_answer",
+            failure_reason=None if is_success else "The final answer was incorrect.",
+            number_of_correction_per_session=3,
+        )
 
-    def test_returns_count_from_storage(self, mock_llm_client, temp_storage_dir):
-        """_get_correction_count returns the value from storage."""
-        config = AgentSuccessConfig(
-            evaluation_name="test",
-            success_definition_prompt="test",
+        result = evaluator._build_evaluation_result(
+            response,
+            sample_request_interaction_models,
         )
-        service_config = AgentSuccessGenerationServiceConfig(
-            session_id="test_session",
-            agent_version="v1",
-            user_id="user1",
-            request_interaction_data_models=[],
-            source="api",
-        )
-        request_context = RequestContext(
-            org_id="test_org", storage_base_dir=temp_storage_dir
-        )
-        request_context.storage = MagicMock()
-        request_context.storage.count_user_playbooks_by_session.return_value = 5
 
-        evaluator = AgentSuccessEvaluator(
-            request_context=request_context,
-            llm_client=mock_llm_client,
-            extractor_config=config,
-            service_config=service_config,
-            agent_context="Test agent",
-        )
-        assert evaluator._get_correction_count() == 5
+        assert result.number_of_correction_per_session == 3
+        request_context.storage.count_user_playbooks_by_session.assert_not_called()

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
@@ -5,8 +5,9 @@ These cover the regenerate flow's behavior at the runner layer:
   short-circuit and the completeness-delay gate so an operator can re-evaluate
   any session.
 - When regenerating, the runner captures the session's prior result_ids BEFORE
-  running the eval, then deletes those rows by id AFTER the new save lands. This
-  guarantees that an LLM/save failure never wipes the session's eval rows.
+  running the eval, then reconciles them AFTER the new save lands. Insert-style
+  storage deletes prior rows; upsert-style storage keeps the updated row id.
+  This guarantees that an LLM/save failure never wipes the session's eval rows.
 """
 
 from datetime import UTC, datetime
@@ -248,6 +249,7 @@ def test_force_regenerate_deletes_prior_results() -> None:
         )
     ]
     storage = _make_storage(with_evaluated_marker=True, prior_results=prior)
+    storage.get_agent_success_evaluation_result_ids.side_effect = [[42], [43, 42]]
     request_context = MagicMock()
     request_context.storage = storage
     llm_client = MagicMock()
@@ -279,12 +281,54 @@ def test_force_regenerate_deletes_prior_results() -> None:
             force_regenerate=True,
         )
 
-    # By-id delete called once with the captured prior result_ids — proving the
-    # runner passed the matching (user_a, session_a, overall_success, 1.0.0) identity to
-    # get_agent_success_evaluation_result_ids (the mock now filters on it).
+    # Insert-style storage returns a fresh id after save, so the runner removes
+    # only the captured prior id.
     storage.delete_agent_success_evaluation_results_by_ids.assert_called_once_with([42])
     # The old triple-scoped delete must NOT be called by the new flow.
     storage.delete_agent_success_evaluation_results_for_session.assert_not_called()
+
+
+def test_force_regenerate_preserves_result_updated_in_place() -> None:
+    """Upsert-style storage keeps the prior id, so cleanup must not delete it."""
+    prior = [
+        _make_prior_result(
+            result_id=42, session_id="session_a", evaluation_name="overall_success"
+        )
+    ]
+    storage = _make_storage(with_evaluated_marker=True, prior_results=prior)
+    storage.get_agent_success_evaluation_result_ids.side_effect = [[42], [42]]
+    request_context = MagicMock()
+    request_context.storage = storage
+
+    with (
+        patch(
+            "reflexio.server.services.agent_success_evaluation"
+            ".runner.AgentSuccessEvaluationService"
+        ) as service_cls,
+        patch(
+            "reflexio.server.services.agent_success_evaluation"
+            ".runner.get_extractor_name",
+            return_value="overall_success",
+        ),
+    ):
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=MagicMock(),
+            force_regenerate=True,
+        )
+
+    storage.delete_agent_success_evaluation_results_by_ids.assert_not_called()
+    assert storage.get_agent_success_evaluation_result_ids.call_count == 2
 
 
 def test_force_regenerate_with_no_prior_rows_does_not_delete() -> None:
@@ -480,6 +524,7 @@ def test_regenerate_happy_path_with_real_sqlite_storage(tmp_path) -> None:
                 [
                     AgentSuccessEvaluationResult(
                         result_id=0,
+                        user_id="user_a",
                         session_id="session_a",
                         agent_version="1.0.0",
                         evaluation_name="overall_success",
@@ -487,7 +532,7 @@ def test_regenerate_happy_path_with_real_sqlite_storage(tmp_path) -> None:
                         failure_type="new_value",
                         failure_reason="fresh verdict",
                         regular_vs_shadow=None,
-                        number_of_correction_per_session=0,
+                        number_of_correction_per_session=4,
                         user_turns_to_resolution=None,
                         is_escalated=False,
                         embedding=[],
@@ -535,6 +580,7 @@ def test_regenerate_happy_path_with_real_sqlite_storage(tmp_path) -> None:
         ]
         assert len(matching) == 1
         assert matching[0].failure_type == "new_value"
+        assert matching[0].number_of_correction_per_session == 4
 
 
 def test_regenerate_failure_preserves_old_rows_with_real_sqlite_storage(

--- a/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
+++ b/tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py
@@ -11,12 +11,17 @@ These cover the regenerate flow's behavior at the runner layer:
 """
 
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 from reflexio.models.api_schema.service_schemas import (
     AgentSuccessEvaluationResult,
     Interaction,
     Request,
+)
+from reflexio.models.config_schema import (
+    SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
+    AgentSuccessConfig,
 )
 from reflexio.server.services.agent_success_evaluation.runner import (
     run_group_evaluation,
@@ -329,6 +334,57 @@ def test_force_regenerate_preserves_result_updated_in_place() -> None:
 
     storage.delete_agent_success_evaluation_results_by_ids.assert_not_called()
     assert storage.get_agent_success_evaluation_result_ids.call_count == 2
+
+
+def test_force_regenerate_uses_agent_success_config_evaluation_name() -> None:
+    """Regeneration must look up rows under the evaluator's singleton name."""
+    prior = [
+        _make_prior_result(
+            result_id=42,
+            session_id="session_a",
+            evaluation_name=SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
+        )
+    ]
+    storage = _make_storage(with_evaluated_marker=True, prior_results=prior)
+    storage.get_agent_success_evaluation_result_ids.side_effect = [[42], [42]]
+    request_context = MagicMock()
+    request_context.storage = storage
+    request_context.configurator.get_config.return_value = SimpleNamespace(
+        agent_success_config=AgentSuccessConfig(
+            success_definition_prompt="Complete the user's task."
+        )
+    )
+
+    with patch(
+        "reflexio.server.services.agent_success_evaluation"
+        ".runner.AgentSuccessEvaluationService"
+    ) as service_cls:
+        service = MagicMock()
+        service.has_run_failures.return_value = False
+        service.last_run_saved_result_count = 1
+        service_cls.return_value = service
+
+        run_group_evaluation(
+            org_id="org_a",
+            user_id="user_a",
+            session_id="session_a",
+            agent_version="1.0.0",
+            source="api",
+            request_context=request_context,
+            llm_client=MagicMock(),
+            force_regenerate=True,
+        )
+
+    expected_lookup = call(
+        user_id="user_a",
+        session_id="session_a",
+        evaluation_name=SINGLETON_AGENT_SUCCESS_EVALUATION_NAME,
+        agent_version="1.0.0",
+    )
+    assert storage.get_agent_success_evaluation_result_ids.call_args_list == [
+        expected_lookup,
+        expected_lookup,
+    ]
 
 
 def test_force_regenerate_with_no_prior_rows_does_not_delete() -> None:

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -46,7 +46,7 @@ PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     "profile_should_generate_override": ("v1.0.0", "boolean_evaluation"),
     "profile_deduplication": ("v1.0.0", "profile_deduplication"),
     "tagging": ("v1.0.0", "tagging"),
-    "agent_success_evaluation": ("v1.0.0", "agent_success_evaluation"),
+    "agent_success_evaluation": ("v1.1.0", "agent_success_evaluation"),
     # Retrieved-learning judges — per-learning relevance/impact verdicts for
     # sessions publishing interactions with ``retrieved_learnings``.
     "retrieved_learning_relevance": ("v1.0.0", "retrieved_learning_relevance"),


### PR DESCRIPTION
## Summary
- Make corrective user turns an independent output of the session-level agent-success judge instead of deriving them from user-playbook rows.
- Keep corrective-turn counting independent from final task success and distinguish revisions from new questions or deliverables.
- Preserve the existing public result field and historical storage schema while making regeneration safe for both SQLite inserts and enterprise in-place upserts.

## Changes
### Evaluation contract
- Require a strict, non-negative `number_of_correction_per_session` in the structured judge response.
- Add and activate agent-success prompt v1.1.0 with the corrective-turn rubric; deactivate v1.0.0.
- Copy the judge value directly into `AgentSuccessEvaluationResult` and remove playbook-count lookup/fallback behavior.

### Persistence and regeneration
- Reconcile prior result IDs after a successful save: delete prior SQLite rows only when a fresh ID was inserted, while preserving enterprise rows updated in place.
- Keep failed or empty regeneration attempts from deleting prior results.

### Schemas and tests
- Document the existing result field as a judge-derived corrective-user-turn count.
- Update deterministic LLM fixtures, snapshots, and prompt-version guards.
- Add structured-output, prompt-rubric, evaluator, and regeneration coverage for required/non-negative counts and insert/upsert storage semantics.

## Test Plan
- `uv run ruff check` on all changed Python files
- `uv run pyright` on all changed Python files
- `uv run pytest -q --no-cov tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py tests/server/services/agent_success_evaluation/test_group_evaluation_runner_regen.py tests/server/services/test_prompt_model_mapping.py`
- Result after CodeRabbit follow-up: 89 passed, 2 skipped

## Follow-ups
- Addressed every actionable CodeRabbit review item in `cd549b5a`: valid JSON output examples, nested agent-success config lookup during regeneration, and corrected runner step numbering.
- Added regression coverage that parses both rendered JSON examples and verifies regeneration uses the evaluator's singleton identity.
- Merge order: merge this OSS PR before the companion enterprise gitlink update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an updated agent success evaluation that measures corrective user turns across the full session.
  - Added clearer failure classification and escalation assessment.
  - Added validation to ensure correction counts are non-negative integers.

- **Bug Fixes**
  - Regenerated evaluations now preserve results correctly across different storage behaviors.
  - Correction counts now reflect evaluation results rather than stored playbook counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
