### PR TITLE
fix: stop aggregation OOM and restore lifespan schedulers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,14 @@ REFLEXIO_MISSING_VECTOR_BACKFILL_CAP=200
 # scheduler. SQLite storage is pinned to serial (1) regardless of this value.
 # (optional; default 8; non-numeric or <=0 falls back to default)
 REFLEXIO_SCHEDULER_ORG_WORKERS=
+# Max current user playbooks a single playbook-aggregation run will cluster.
+# Above this the run is skipped rather than sampled down, so results stay
+# reproducible. This bounds CPU, not memory: clustering runs on raw vectors, so
+# peak RSS stays ~flat, but runtime grows quadratically. Measured on 512-dim
+# embeddings: 5k -> 8s, 10k -> 32s, 20k -> 126s. Aggregation shares a vCPU with
+# request serving, so the default is set at roughly a 2-minute run.
+# (optional; default 20000; non-numeric or <=0 falls back to default)
+REFLEXIO_MAX_CLUSTERING_PLAYBOOKS=20000
 
 # Optional internal cross-encoder reranker service. Leave unset to score with
 # the in-process reranker. Set to a base URL without the /v1 suffix.

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -202,6 +202,27 @@ def _add_openapi_security(app: FastAPI) -> None:
     app.openapi = custom_openapi  # type: ignore[method-assign]
 
 
+# Injection seam: enterprise registers a resolver that returns a REAL org id at
+# composition time, exactly like gc_scheduler.set_org_id_provider. Needed because
+# the request-scoped `get_org_id` dependency takes FastAPI parameters and so can
+# never be called outside a request -- without this hook the lifespan falls
+# through to the `default_get_org_id()` sentinel ("self-host-org"), which matches
+# no organization row in ANY deployment mode. Every config read keyed on it then
+# raises, which silently skipped the lineage-GC and extraction-resume schedulers.
+_lifespan_org_id_resolver: Callable[[], str] | None = None
+
+
+def set_lifespan_org_id_resolver(resolver: Callable[[], str] | None) -> None:
+    """Register the resolver used to pick the bootstrap org for lifespan schedulers.
+
+    Args:
+        resolver (Callable[[], str] | None): Callable returning a real org id, or
+            ``None`` to clear the hook (used by tests to restore OSS defaults).
+    """
+    global _lifespan_org_id_resolver  # noqa: PLW0603
+    _lifespan_org_id_resolver = resolver
+
+
 def _resolve_lifespan_org_id(get_org_id: Callable[..., str] | None) -> str:
     """Resolve the bootstrap org ID for lifespan schedulers without a request context.
 
@@ -213,6 +234,15 @@ def _resolve_lifespan_org_id(get_org_id: Callable[..., str] | None) -> str:
         str: The resolved org ID string.
     """
     from reflexio.server.auth import default_get_org_id
+
+    if _lifespan_org_id_resolver is not None:
+        try:
+            resolved = str(_lifespan_org_id_resolver())
+            if resolved:
+                return resolved
+            logger.warning("Lifespan org_id resolver returned empty; using default org")
+        except Exception:
+            logger.exception("Lifespan org_id resolver failed; using default org")
 
     if get_org_id is None:
         return default_get_org_id()

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -237,9 +237,12 @@ def _resolve_lifespan_org_id(get_org_id: Callable[..., str] | None) -> str:
 
     if _lifespan_org_id_resolver is not None:
         try:
-            resolved = str(_lifespan_org_id_resolver())
+            # Check the RAW value before str(): str(None) is the truthy literal
+            # "None", which would sail through as a bootstrap org id matching no
+            # organization row -- reintroducing exactly the failure this hook fixes.
+            resolved = _lifespan_org_id_resolver()
             if resolved:
-                return resolved
+                return str(resolved)
             logger.warning("Lifespan org_id resolver returned empty; using default org")
         except Exception:
             logger.exception("Lifespan org_id resolver failed; using default org")

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -513,6 +513,14 @@ def maybe_start_lineage_gc(
         LineageGCScheduler: The started scheduler, or ``None`` if no start
         condition holds (see the startup criteria above).
     """
+    # Registered sweeps carry their own per-org gates, so they must start the
+    # scheduler whether or not the bootstrap org's config is readable. Evaluate
+    # that first: the config read below needs a real org, and a failure there
+    # must not silence sweeps that were explicitly registered. Production ran
+    # with 8 registered sweeps (metering force-seal/retention/derive, governance
+    # retention, missing-vector backfill) never firing because this read raised.
+    has_registered_sweeps = bool(_per_org_sweep_hooks) or bool(_global_sweep_hooks)
+
     try:
         ctx = request_context_factory(bootstrap_org_id)
         cfg = ctx.configurator.get_config()
@@ -547,25 +555,34 @@ def maybe_start_lineage_gc(
         governance_retention_enabled = getattr(
             gr, "audit_events_retention_enabled", False
         )
-        # Also start when any reclamation sweep has been registered — registered
-        # hooks carry their own per-org gates (in the enterprise closure), so the
-        # scheduler must run even if the bootstrap org's config has all flags off.
-        # This preserves the "start unconditionally, gate per-org" invariant of
-        # the deleted GovernanceRetentionScheduler.
-        if not (
+        config_enabled = bool(
             cfg.lineage_gc.enabled
             or expiry_reclamation_enabled
             or governance_retention_enabled
-            or bool(_per_org_sweep_hooks)
-            or bool(_global_sweep_hooks)
-        ):
-            return None
+        )
     except Exception as exc:
+        # Only a deployment with nothing registered has nothing to lose here.
+        if not has_registered_sweeps:
+            logger.warning(
+                "event=lineage_gc_scheduler_start_skipped error_type=%s error=%s",
+                type(exc).__name__,
+                exc,
+            )
+            return None
         logger.warning(
-            "event=lineage_gc_scheduler_start_skipped error_type=%s error=%s",
+            "event=lineage_gc_config_read_failed error_type=%s error=%s "
+            "starting anyway: registered sweeps gate themselves per-org",
             type(exc).__name__,
             exc,
         )
+        config_enabled = False
+
+    # Also start when any reclamation sweep has been registered — registered
+    # hooks carry their own per-org gates (in the enterprise closure), so the
+    # scheduler must run even if the bootstrap org's config has all flags off.
+    # This preserves the "start unconditionally, gate per-org" invariant of
+    # the deleted GovernanceRetentionScheduler.
+    if not (config_enabled or has_registered_sweeps):
         return None
 
     scheduler = LineageGCScheduler(

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -465,6 +465,49 @@ class PlaybookAggregator:
             len(existing_playbooks),
         )
 
+        # Preflight the corpus size with a COUNT before paging it in. The read
+        # below pulls every current user playbook WITH its embedding, so an
+        # oversized org costs ~1 GB of resident floats before clustering is even
+        # reached -- the cap has to be enforced ahead of the load, not just
+        # inside get_clusters().
+        max_playbooks = aggregator_clustering.max_clustering_playbooks()
+        total_user_playbooks = self.storage.count_user_playbooks(  # pyright: ignore[reportOptionalMemberAccess]
+            min_user_playbook_id=0,
+            agent_version=self.agent_version,
+            status_filter=[None],
+        )
+        if total_user_playbooks > max_playbooks:
+            logger.error(
+                "Skipping user playbook aggregation for '%s' (agent_version=%s): "
+                "%d current user playbooks exceeds the %s cap of %d",
+                playbook_name,
+                self.agent_version,
+                total_user_playbooks,
+                aggregator_clustering.MAX_CLUSTERING_PLAYBOOKS_ENV,
+                max_playbooks,
+            )
+            record_usage_event(
+                org_id=self.request_context.org_id,
+                event_name="aggregation_gate_evaluated",
+                event_category="aggregation",
+                pipeline="playbook",
+                playbook_name=playbook_name,
+                agent_version=self.agent_version,
+                outcome="should_skip",
+                count_value=total_user_playbooks,
+                metadata={
+                    "user_playbooks": total_user_playbooks,
+                    "max_clustering_playbooks": max_playbooks,
+                },
+            )
+            return {
+                **_empty_stats,
+                "skipped": (
+                    f"too many user playbooks to cluster "
+                    f"({total_user_playbooks} > {max_playbooks})"
+                ),
+            }
+
         # get all user playbooks and generate clusters
         user_playbooks, user_high_watermark = _read_all_pages(
             lambda limit, max_id: self.storage.get_user_playbooks(  # type: ignore[reportOptionalMemberAccess]
@@ -1024,7 +1067,6 @@ class PlaybookAggregator:
 
         # Extract embeddings from user playbooks
         import numpy as np
-        from sklearn.metrics.pairwise import cosine_distances
 
         embedded_playbooks = [
             playbook for playbook in user_playbooks if playbook.embedding
@@ -1036,7 +1078,9 @@ class PlaybookAggregator:
                 skipped_without_embedding,
             )
         user_playbooks = embedded_playbooks
-        embeddings = np.array([playbook.embedding for playbook in user_playbooks])
+        embeddings = np.asarray(
+            [playbook.embedding for playbook in user_playbooks], dtype=np.float64
+        )
 
         if len(embeddings) < min_cluster_size:
             logger.info(
@@ -1046,19 +1090,35 @@ class PlaybookAggregator:
             )
             return {}
 
-        # Compute cosine distance matrix for better text embedding clustering
-        distance_matrix = cosine_distances(embeddings)
+        max_playbooks = aggregator_clustering.max_clustering_playbooks()
+        if len(embeddings) > max_playbooks:
+            # Refuse rather than sampling down: a sampled subset would silently
+            # produce different agent playbooks run-to-run.
+            logger.error(
+                "Refusing to cluster %d user playbooks (cap %d). Raise %s to "
+                "allow it -- runtime grows quadratically, so expect roughly "
+                "(n/20000)^2 * 2 minutes of CPU.",
+                len(embeddings),
+                max_playbooks,
+                aggregator_clustering.MAX_CLUSTERING_PLAYBOOKS_ENV,
+            )
+            return {}
 
         # Choose algorithm based on dataset size
         # Convert similarity threshold to distance threshold (distance = 1 - similarity)
         distance_threshold = 1.0 - similarity_threshold
         if len(embeddings) < CLUSTERING_ALGORITHM_THRESHOLD:
+            # Small input only: the precomputed cosine matrix is O(n^2), which is
+            # negligible below the threshold and catastrophic above it.
+            from sklearn.metrics.pairwise import cosine_distances
+
             cluster_labels = self._cluster_with_agglomerative(
-                distance_matrix, min_cluster_size, distance_threshold
+                cosine_distances(embeddings), min_cluster_size, distance_threshold
             )
         else:
+            # HDBSCAN clusters the raw vectors directly -- no O(n^2) matrix.
             cluster_labels = self._cluster_with_hdbscan(
-                distance_matrix, min_cluster_size, distance_threshold
+                embeddings, min_cluster_size, distance_threshold
             )
 
         # Group playbooks by cluster
@@ -1097,12 +1157,12 @@ class PlaybookAggregator:
 
     def _cluster_with_hdbscan(
         self,
-        distance_matrix: np.ndarray,
+        embeddings: np.ndarray,
         min_cluster_size: int,
         distance_threshold: float,
     ) -> np.ndarray:
         return aggregator_clustering.cluster_with_hdbscan(
-            distance_matrix, min_cluster_size, distance_threshold
+            embeddings, min_cluster_size, distance_threshold
         )
 
     def _generate_playbooks_with_source_clusters(

--- a/reflexio/server/services/playbook/components/aggregator_clustering.py
+++ b/reflexio/server/services/playbook/components/aggregator_clustering.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     import numpy as np
 
 from reflexio.models.api_schema.service_schemas import UserPlaybook
+from reflexio.server.llm.llm_utils import positive_int_env
 
 logger = logging.getLogger(__name__)
 
@@ -15,6 +16,33 @@ logger = logging.getLogger(__name__)
 # Below this, use Agglomerative (works better with small datasets)
 # Above this, use HDBSCAN (scales better, handles noise)
 CLUSTERING_ALGORITHM_THRESHOLD = 50
+
+# Upper bound on how many user playbooks a single aggregation run will cluster.
+#
+# This is a CPU bound, not a memory bound. HDBSCAN runs on raw unit-normalized
+# vectors (see cluster_with_hdbscan), so peak RSS stays flat -- ~320 MB at
+# n=20_000 against 512-dim embeddings. Runtime is what grows, and it grows
+# quadratically; measured on a 512-dim corpus:
+#
+#     n= 2_000 ->   1.3 s      n=10_000 ->  32 s
+#     n= 5_000 ->   8.0 s      n=20_000 -> 126 s
+#
+# Aggregation runs on a background daemon thread that shares one vCPU with
+# request serving, so the default is set where a run costs ~2 minutes.
+MAX_CLUSTERING_PLAYBOOKS_DEFAULT = 20_000
+MAX_CLUSTERING_PLAYBOOKS_ENV = "REFLEXIO_MAX_CLUSTERING_PLAYBOOKS"
+
+
+def max_clustering_playbooks() -> int:
+    """
+    Resolve the per-run cap on user playbooks fed to clustering.
+
+    Returns:
+        int: The configured cap, or MAX_CLUSTERING_PLAYBOOKS_DEFAULT.
+    """
+    return positive_int_env(
+        MAX_CLUSTERING_PLAYBOOKS_ENV, MAX_CLUSTERING_PLAYBOOKS_DEFAULT, logger
+    )
 
 
 def compute_cluster_fingerprint(cluster_playbooks: list[UserPlaybook]) -> str:
@@ -153,18 +181,63 @@ def cluster_with_agglomerative(
     return clusterer.fit_predict(distance_matrix)
 
 
+def unit_normalize(embeddings: np.ndarray) -> np.ndarray:
+    """
+    Scale each row to unit L2 norm, leaving zero rows at the origin.
+
+    Args:
+        embeddings (np.ndarray): Raw embedding matrix, shape (n_samples, n_features)
+
+    Returns:
+        np.ndarray: Row-normalized copy of ``embeddings``
+    """
+    import numpy as np
+
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    # A zero row has no direction, so it cannot be normalized. Leave it at the
+    # origin rather than dividing by zero: it sits sqrt(2) away from every unit
+    # vector, which is beyond any reachable threshold, so it becomes noise.
+    norms[norms == 0.0] = 1.0
+    return embeddings / norms
+
+
+def cosine_threshold_to_euclidean(distance_threshold: float) -> float:
+    """
+    Convert a cosine distance threshold to its unit-sphere euclidean equivalent.
+
+    For unit vectors ``d_euclidean == sqrt(2 * d_cosine)`` exactly. The mapping
+    is monotonic, so it preserves the MST and therefore the cluster hierarchy --
+    only the epsilon cut-off needs converting.
+
+    Args:
+        distance_threshold (float): Cosine distance (1 - similarity)
+
+    Returns:
+        float: The equivalent euclidean distance between unit vectors
+    """
+    import numpy as np
+
+    return float(np.sqrt(2.0 * max(distance_threshold, 0.0)))
+
+
 def cluster_with_hdbscan(
-    distance_matrix: np.ndarray,
+    embeddings: np.ndarray,
     min_cluster_size: int,
     distance_threshold: float,
 ) -> np.ndarray:
     """
     Cluster using HDBSCAN - best for large datasets with potential noise.
 
+    Takes raw embeddings rather than a precomputed distance matrix. A
+    precomputed cosine matrix is O(n^2): at n=62_766 it asked for 29.4 GiB and
+    OOM-killed the container. Unit-normalizing and clustering under the
+    euclidean metric is mathematically equivalent (see
+    cosine_threshold_to_euclidean) and keeps peak memory linear in n.
+
     Args:
-        distance_matrix: Precomputed cosine distance matrix
-        min_cluster_size: Minimum number of points to form a cluster
-        distance_threshold: Maximum cosine distance for cluster merging (1 - similarity_threshold)
+        embeddings (np.ndarray): Raw embedding matrix, shape (n_samples, n_features)
+        min_cluster_size (int): Minimum number of points to form a cluster
+        distance_threshold (float): Maximum cosine distance for cluster merging (1 - similarity_threshold)
 
     Returns:
         np.ndarray: Cluster labels for each point (-1 indicates noise)
@@ -173,7 +246,7 @@ def cluster_with_hdbscan(
 
     logger.info(
         "Using HDBSCAN for %d playbooks (>= %d threshold), distance_threshold=%.2f",
-        len(distance_matrix),
+        len(embeddings),
         CLUSTERING_ALGORITHM_THRESHOLD,
         distance_threshold,
     )
@@ -181,9 +254,9 @@ def cluster_with_hdbscan(
     clusterer = hdbscan.HDBSCAN(
         min_cluster_size=min_cluster_size,
         min_samples=1,
-        metric="precomputed",
+        metric="euclidean",
         cluster_selection_epsilon=0.0,
-        cluster_selection_epsilon_max=distance_threshold,
+        cluster_selection_epsilon_max=cosine_threshold_to_euclidean(distance_threshold),
     )
 
-    return clusterer.fit_predict(distance_matrix)
+    return clusterer.fit_predict(unit_normalize(embeddings))

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -321,6 +321,33 @@ def test_maybe_start_lineage_gc_returns_none_on_factory_error():
     assert result is None
 
 
+def test_maybe_start_lineage_gc_starts_when_config_unreadable_but_sweeps_registered(
+    caplog,
+):
+    """A config-read failure must not silence explicitly registered sweeps.
+
+    Registered hooks carry their own per-org gates, so the documented
+    "start unconditionally, gate per-org" invariant still applies. Production
+    ran with 8 registered sweeps never firing because this read raised on a
+    bootstrap org id that matched no organization row.
+    """
+
+    def bad_factory(org_id: str):
+        raise RuntimeError("Organization self-host-org not found")
+
+    register_per_org_sweep(lambda _org_id, _budget: 0)
+    try:
+        with caplog.at_level(logging.WARNING):
+            sched = maybe_start_lineage_gc(bad_factory, bootstrap_org_id="org_1")
+        assert sched is not None
+        sched.stop(timeout_seconds=1.0)
+    finally:
+        clear_per_org_sweeps()
+
+    assert "lineage_gc_config_read_failed" in caplog.text
+    assert "lineage_gc_scheduler_start_skipped" not in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # list_org_ids — degraded-mode fallback is visible (not silent)
 # ---------------------------------------------------------------------------

--- a/tests/server/services/playbook/test_playbook_aggregator_clustering.py
+++ b/tests/server/services/playbook/test_playbook_aggregator_clustering.py
@@ -26,6 +26,7 @@ from reflexio.server.services.playbook.components.aggregator import (
 )
 from reflexio.server.services.playbook.components.aggregator_clustering import (
     cluster_with_hdbscan,
+    unit_normalize,
 )
 
 
@@ -271,13 +272,19 @@ class TestHDBSCANClustering:
             mock_agg.assert_not_called()
 
     def test_similarity_is_an_hdbscan_maximum_distance(self):
-        distance_matrix = np.zeros((2, 2), dtype=float)
+        """The cosine threshold is passed through as its euclidean equivalent.
+
+        HDBSCAN runs on raw unit-normalized vectors rather than a precomputed
+        cosine matrix (that matrix is O(n^2) and OOM-killed production), so the
+        epsilon cut-off must be converted with sqrt(2 * d_cosine).
+        """
+        embeddings = np.ones((2, 4), dtype=float)
         fitted = MagicMock()
         fitted.fit_predict.return_value = np.array([0, 0])
 
         with patch("hdbscan.HDBSCAN", return_value=fitted) as hdbscan_cls:
             labels = cluster_with_hdbscan(
-                distance_matrix,
+                embeddings,
                 min_cluster_size=2,
                 distance_threshold=0.15,
             )
@@ -286,10 +293,53 @@ class TestHDBSCANClustering:
         hdbscan_cls.assert_called_once_with(
             min_cluster_size=2,
             min_samples=1,
+            metric="euclidean",
+            cluster_selection_epsilon=0.0,
+            cluster_selection_epsilon_max=float(np.sqrt(2 * 0.15)),
+        )
+
+    @pytest.mark.parametrize("similarity", [0.30, 0.75, 0.85])
+    def test_raw_euclidean_matches_precomputed_cosine(self, similarity):
+        """The refactor must not change which playbooks cluster together.
+
+        Guards the load-bearing identity behind the rewrite: for unit vectors
+        d_euclidean == sqrt(2 * d_cosine), which is monotonic and therefore
+        preserves the MST and the whole cluster hierarchy. Covers every
+        similarity production actually resolves (0.30 MiniLM, 0.85 Nomic).
+        """
+        import hdbscan
+        from sklearn.metrics.pairwise import cosine_distances
+
+        rng = np.random.default_rng(20260731)
+        centroids = rng.normal(size=(12, 128))
+        embeddings = np.repeat(centroids, 20, axis=0) + rng.normal(
+            scale=0.35, size=(240, 128)
+        )
+        distance_threshold = 1.0 - similarity
+
+        # The pre-refactor implementation, reproduced verbatim.
+        legacy_labels = hdbscan.HDBSCAN(
+            min_cluster_size=2,
+            min_samples=1,
             metric="precomputed",
             cluster_selection_epsilon=0.0,
-            cluster_selection_epsilon_max=0.15,
+            cluster_selection_epsilon_max=distance_threshold,
+        ).fit_predict(cosine_distances(embeddings))
+
+        new_labels = cluster_with_hdbscan(
+            embeddings, min_cluster_size=2, distance_threshold=distance_threshold
         )
+
+        assert new_labels.tolist() == legacy_labels.tolist()
+
+    def test_zero_embeddings_do_not_produce_nan(self):
+        """A zero row has no direction; normalizing must not divide by zero."""
+        embeddings = np.zeros((3, 8), dtype=float)
+
+        normalized = unit_normalize(embeddings)
+
+        assert not np.isnan(normalized).any()
+        assert (normalized == 0.0).all()
 
 
 class TestClusteringThreshold:
@@ -326,6 +376,59 @@ class TestClusteringThreshold:
         ) as mock_hdb:
             mock_playbook_aggregator.get_clusters(user_playbooks, config)
             mock_hdb.assert_called_once()
+
+
+class TestClusteringInputCap:
+    """Tests for the per-run cap on clustering input size."""
+
+    def test_over_cap_refuses_without_building_a_matrix(
+        self, mock_playbook_aggregator, monkeypatch
+    ):
+        """Above the cap, refuse before allocating anything O(n^2).
+
+        The production OOM was a 29.4 GiB cosine_distances() call, so the
+        assertion that matters is that the matrix is never even requested --
+        not merely that the result is empty.
+        """
+        monkeypatch.setenv("REFLEXIO_MAX_CLUSTERING_PLAYBOOKS", "10")
+        config = PlaybookAggregatorConfig(min_cluster_size=2)
+        user_playbooks = create_user_playbooks_with_embeddings(
+            create_similar_embeddings(11)
+        )
+
+        with (
+            patch("sklearn.metrics.pairwise.cosine_distances") as cosine,
+            patch.object(PlaybookAggregator, "_cluster_with_hdbscan") as hdb,
+        ):
+            clusters = mock_playbook_aggregator.get_clusters(user_playbooks, config)
+
+        assert clusters == {}
+        cosine.assert_not_called()
+        hdb.assert_not_called()
+
+    def test_at_cap_still_clusters(self, mock_playbook_aggregator, monkeypatch):
+        """The cap is an inclusive upper bound, not an off-by-one refusal."""
+        monkeypatch.setenv("REFLEXIO_MAX_CLUSTERING_PLAYBOOKS", "10")
+        config = PlaybookAggregatorConfig(min_cluster_size=2)
+        user_playbooks = create_user_playbooks_with_embeddings(
+            create_similar_embeddings(10)
+        )
+
+        clusters = mock_playbook_aggregator.get_clusters(user_playbooks, config)
+
+        assert clusters != {}
+
+    def test_large_input_never_builds_a_distance_matrix(self, mock_playbook_aggregator):
+        """Above CLUSTERING_ALGORITHM_THRESHOLD, HDBSCAN takes raw vectors."""
+        config = PlaybookAggregatorConfig(min_cluster_size=2)
+        user_playbooks = create_user_playbooks_with_embeddings(
+            create_similar_embeddings(CLUSTERING_ALGORITHM_THRESHOLD + 1)
+        )
+
+        with patch("sklearn.metrics.pairwise.cosine_distances") as cosine:
+            mock_playbook_aggregator.get_clusters(user_playbooks, config)
+
+        cosine.assert_not_called()
 
 
 class TestEdgeCases:

--- a/tests/server/test_auth_default_org.py
+++ b/tests/server/test_auth_default_org.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from reflexio.server import api
 from reflexio.server.auth import DEFAULT_ORG_ID, default_get_org_id
 
 _ENV = "REFLEXIO_DEFAULT_ORG_ID"
@@ -34,3 +35,53 @@ def test_blank_value_falls_back_to_default(
     # at the empty string — it resolves to the default, like unset.
     monkeypatch.setenv(_ENV, blank)
     assert default_get_org_id() == DEFAULT_ORG_ID
+
+
+class TestLifespanOrgIdResolver:
+    """The bootstrap org for lifespan schedulers, which has no request to read.
+
+    ``DEFAULT_ORG_ID`` is a sentinel, not a real organization: in every
+    enterprise deployment mode a config read keyed on it raises "Organization
+    self-host-org not found". Multi-tenant apps therefore register a resolver
+    that returns a real org id.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_resolver(self):
+        api.set_lifespan_org_id_resolver(None)
+        yield
+        api.set_lifespan_org_id_resolver(None)
+
+    def test_falls_back_to_default_without_a_resolver(self) -> None:
+        assert api._resolve_lifespan_org_id(None) == DEFAULT_ORG_ID
+
+    def test_registered_resolver_wins(self) -> None:
+        api.set_lifespan_org_id_resolver(lambda: "org_42")
+        assert api._resolve_lifespan_org_id(None) == "org_42"
+
+    def test_resolver_wins_over_a_parameterized_dependency(self) -> None:
+        """The regression this hook exists for.
+
+        A request-scoped ``get_org_id`` is a FastAPI dependency taking
+        parameters, so it can never be called outside a request and the
+        lifespan silently fell through to the sentinel.
+        """
+
+        def enterprise_get_org_id(credentials=None) -> str:
+            raise AssertionError("must not be called outside a request")
+
+        api.set_lifespan_org_id_resolver(lambda: "org_7")
+        assert api._resolve_lifespan_org_id(enterprise_get_org_id) == "org_7"
+
+    @pytest.mark.parametrize(
+        "resolver",
+        [
+            pytest.param(
+                lambda: (_ for _ in ()).throw(RuntimeError("boom")), id="raises"
+            ),
+            pytest.param(lambda: "", id="empty"),
+        ],
+    )
+    def test_broken_resolver_degrades_to_default(self, resolver) -> None:
+        api.set_lifespan_org_id_resolver(resolver)
+        assert api._resolve_lifespan_org_id(None) == DEFAULT_ORG_ID

--- a/tests/server/test_auth_default_org.py
+++ b/tests/server/test_auth_default_org.py
@@ -80,6 +80,9 @@ class TestLifespanOrgIdResolver:
                 lambda: (_ for _ in ()).throw(RuntimeError("boom")), id="raises"
             ),
             pytest.param(lambda: "", id="empty"),
+            # str(None) is the truthy literal "None" -- a resolver violating the
+            # str contract must fall through, not hand back "None" as an org id.
+            pytest.param(lambda: None, id="none"),
         ],
     )
     def test_broken_resolver_degrades_to_default(self, resolver) -> None:


### PR DESCRIPTION
Two production defects found while investigating the `/ecs/reflexio` CloudWatch log group. Both are OSS-side; the companion enterprise PR follows once this merges.

## 1. Playbook aggregation OOM-killed the backend

```
aggregator.py:1050  distance_matrix = cosine_distances(embeddings)
numpy ArrayMemoryError: Unable to allocate 29.4 GiB for shape (62766, 62766), dtype float64
→ 18:05:36 WARN exited: fastapi (terminated by SIGKILL)
```

`get_clusters` built a dense cosine distance matrix *before* choosing an algorithm. Its only size guard was a lower bound (`len(embeddings) < min_cluster_size`). At 62,766 user playbooks the allocation was 29.4 GiB against a 4 GiB container, so the kernel killed uvicorn and took request serving down with it (~40s outage).

**Fix:** HDBSCAN now clusters raw unit-normalized vectors under the euclidean metric. For unit vectors `d_euclidean == sqrt(2 · d_cosine)` exactly, and the mapping is monotonic — so it preserves the MST and therefore the whole cluster hierarchy. Only the epsilon cut-off needs converting. The O(n²) matrix now survives only in the agglomerative branch, which runs solely below n=50 where it is negligible.

**This is behaviour-preserving, and that is tested, not asserted.** Labels are byte-identical to the old precomputed-cosine path at every similarity production actually resolves — 0.30 (MiniLM), 0.75, 0.85 (Nomic):

| similarity | identical labels | ARI |
|---|---|---|
| 0.30 | ✅ | 1.000000 |
| 0.75 | ✅ | 1.000000 |
| 0.85 | ✅ | 1.000000 |

`test_raw_euclidean_matches_precomputed_cosine` runs the pre-refactor implementation verbatim alongside the new one and requires exact label equality.

### The cap, and why it exists

Memory is now flat — ~320 MB at n=20,000, against 2.98 GiB for the matrix alone. **CPU becomes the binding constraint**, because runtime is still quadratic (measured, 512-dim):

| n | time | peak RSS | matrix would have been |
|---|---|---|---|
| 2,000 | 1.3 s | 167 MB | 0.03 GiB |
| 5,000 | 8.0 s | 210 MB | 0.19 GiB |
| 10,000 | 32 s | 279 MB | 0.75 GiB |
| 20,000 | 126 s | 324 MB | 2.98 GiB |

So `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` (default 20,000 ≈ a 2-minute run) bounds it. Aggregation runs on a background daemon thread sharing one vCPU with request serving, which is what sets the default.

Enforced in **two** places:
- A `count_user_playbooks()` COUNT preflight **before** paging the corpus in. The existing read pulls every current user playbook *with* its embedding — ~1 GB of resident floats at 62k, before clustering is even reached. A check only inside `get_clusters` would be too late.
- Inside `get_clusters` itself, for direct callers and tests.

Over the cap the run is **skipped, not sampled down** — a sampled subset would silently produce different agent playbooks run-to-run. This follows the existing `MAX_CANONICAL_CANDIDATES` refuse-loudly pattern in `retrieved_learning_evaluator.py`.

## 2. Lifespan schedulers never started — in every deployment mode

Every boot logged:

```
extraction_resume_scheduler_start_skipped  error_type=OfflineTunerConfigResetError
lineage_gc_scheduler_start_skipped         error_type=OfflineTunerConfigResetError
```

`_resolve_lifespan_org_id` falls back to `default_get_org_id()` whenever the injected getter takes parameters — which a request-scoped FastAPI dependency always does. That returns the `"self-host-org"` sentinel, which matches no organization row, so every config read keyed on it raised.

This is **not** self-host-specific: Supabase and SQLite config storage raise the identical "Organization … not found" for the same sentinel.

Consequence: both schedulers silently skipped, and with them **8 sweeps** registered on the lineage-GC host — metering force-seal, metering retention, metering derive, governance retention, and missing-vector backfill.

**Fix, two parts:**
- `set_lifespan_org_id_resolver()` injection seam, matching the existing `set_org_id_provider` pattern, so a multi-tenant app can supply a real org id. OSS default behaviour is unchanged.
- `maybe_start_lineage_gc` now evaluates its start predicate **before** the config read. Registered sweeps carry their own per-org gates, so a config-read failure must not silence them — that was already the function's own documented "start unconditionally, gate per-org" invariant, it just ran after the read that was failing. A deployment with nothing registered still returns `None` and still logs the original skip event.

## Verification

| Gate | Result |
|---|---|
| `ruff check` | All checks passed |
| `ruff format --check` | 896 files already formatted |
| `pyright` (changed files) | 0 errors, 0 warnings |
| `pytest -m "not integration and not e2e"` | **4212 passed**, 9 skipped |

Three failures are excluded above and were **proven pre-existing** by re-running them in a detached worktree at the base commit `c920ad1d`: `test_aggregate.py` and `test_gepa_user_playbook_publication.py` (collection errors) and `test_judge_frozen_plan.py::test_pairwise_judge_provider_params_match_frozen_sanitized_plan`. All three are the same environmental cause — a pydantic validator resolving `*.example.test` hostnames via DNS.

The new cap guards assert `cosine_distances` is **never called**, not merely that the result is empty — and the patch target was mutation-checked: a small (n<50) input does reach it through the same patch, so the guard genuinely fails on regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit of 20,000 playbooks per clustering run.
  * Added flexible organization resolution for application startup.
  * Lineage cleanup now starts when registered cleanup tasks are available, even if configuration cannot be loaded.

* **Bug Fixes**
  * Improved clustering stability and memory usage for large datasets.
  * Prevented invalid results from zero-length embeddings.
  * Preserved clustering behavior at the configured limit while safely skipping oversized datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->