### PR TITLE
feat(playbook): schedule bounded incremental aggregation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,10 @@ REFLEXIO_SCHEDULER_ORG_WORKERS=
 # request serving, so the default is set at roughly a 2-minute run.
 # (optional; default 20000; non-numeric or <=0 falls back to default)
 REFLEXIO_MAX_CLUSTERING_PLAYBOOKS=20000
+# Idle timestamp written after an agent version is fully drained. New work still
+# advances the version to due-now; unchanged residual-only retries use their
+# separate exponential cooldown. (optional; default 3600 seconds)
+REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS=3600
 
 # Optional internal cross-encoder reranker service. Leave unset to score with
 # the in-process reranker. Set to a base URL without the /v1 suffix.

--- a/reflexio/lib/_generation.py
+++ b/reflexio/lib/_generation.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from typing import Any
 
@@ -16,6 +17,8 @@ from reflexio.models.api_schema.service_schemas import (
     RerunProfileGenerationRequest,
     RerunProfileGenerationResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class GenerationMixin(ReflexioBase):
@@ -44,6 +47,10 @@ class GenerationMixin(ReflexioBase):
             AGGREGATION_PROMPT_PROCESSOR,
         )
         from reflexio.server.services.playbook.aggregation_scheduler import (
+            AGGREGATION_BACKLOG_RETRY_SECONDS,
+            AGGREGATION_LEASE_SECONDS,
+            AGGREGATION_RETRY_SECONDS,
+            AggregationLeaseHeartbeat,
             aggregation_min_interval_seconds,
         )
         from reflexio.server.services.playbook.components.aggregator import (
@@ -73,14 +80,16 @@ class GenerationMixin(ReflexioBase):
             storage.schedule_playbook_aggregation(agent_version)
             claim = storage.claim_due_playbook_aggregation(
                 owner=f"admin-rerun:{uuid.uuid4().hex}",
-                lease_seconds=1800,
+                lease_seconds=AGGREGATION_LEASE_SECONDS,
                 agent_version=agent_version,
             )
             if claim is None:
                 raise RuntimeError(
                     "another playbook aggregation is already running for this organization"
                 )
+        heartbeat = None
         if claim is not None:
+            heartbeat = AggregationLeaseHeartbeat(storage, claim)
             aggregator_kwargs["aggregation_claim"] = claim
         playbook_aggregator = PlaybookAggregator(
             llm_client=self.llm_client,
@@ -89,22 +98,34 @@ class GenerationMixin(ReflexioBase):
             **aggregator_kwargs,
         )
         try:
+            if heartbeat is not None:
+                heartbeat.start()
             result = playbook_aggregator.run(aggregator_request)
+            if heartbeat is not None:
+                heartbeat.stop()
+                heartbeat.require_live()
         except Exception:
-            if claim is not None:
-                storage.finish_playbook_aggregation_claim(
-                    claim,
-                    success=False,
-                    retry_after_seconds=60,
-                    backlog_retry_after_seconds=1,
-                    min_interval_seconds=min_interval_seconds,
-                )
+            if heartbeat is not None:
+                heartbeat.stop()
+                try:
+                    storage.finish_playbook_aggregation_claim(
+                        heartbeat.claim,
+                        success=False,
+                        retry_after_seconds=AGGREGATION_RETRY_SECONDS,
+                        backlog_retry_after_seconds=(AGGREGATION_BACKLOG_RETRY_SECONDS),
+                        min_interval_seconds=min_interval_seconds,
+                    )
+                except Exception:
+                    logger.exception(
+                        "failed to release playbook aggregation claim after admin "
+                        "rerun failure"
+                    )
             raise
-        if claim is not None and not storage.finish_playbook_aggregation_claim(
-            claim,
+        if heartbeat is not None and not storage.finish_playbook_aggregation_claim(
+            heartbeat.claim,
             success=True,
-            retry_after_seconds=60,
-            backlog_retry_after_seconds=1,
+            retry_after_seconds=AGGREGATION_RETRY_SECONDS,
+            backlog_retry_after_seconds=AGGREGATION_BACKLOG_RETRY_SECONDS,
             min_interval_seconds=min_interval_seconds,
         ):
             raise RuntimeError("playbook aggregation rerun lost its database fence")

--- a/reflexio/lib/_generation.py
+++ b/reflexio/lib/_generation.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from reflexio.lib._base import (
@@ -42,6 +43,9 @@ class GenerationMixin(ReflexioBase):
         from reflexio.server.services.playbook.aggregation_prompt_processing import (
             AGGREGATION_PROMPT_PROCESSOR,
         )
+        from reflexio.server.services.playbook.aggregation_scheduler import (
+            aggregation_min_interval_seconds,
+        )
         from reflexio.server.services.playbook.components.aggregator import (
             PlaybookAggregator,
         )
@@ -50,23 +54,61 @@ class GenerationMixin(ReflexioBase):
         )
 
         aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
+        min_interval_seconds = aggregation_min_interval_seconds()
         aggregator_kwargs = {}
         if aggregation_prompt_processor is not None:
             aggregator_kwargs["aggregation_prompt_processor"] = (
                 aggregation_prompt_processor
             )
 
+        aggregator_request = PlaybookAggregatorRequest(
+            agent_version=agent_version,
+            rerun=True,
+        )
+        storage = self.request_context.storage
+        if storage is None:
+            raise ValueError(STORAGE_NOT_CONFIGURED_MSG)
+        claim = None
+        if getattr(storage, "supports_incremental_playbook_aggregation", False) is True:
+            storage.schedule_playbook_aggregation(agent_version)
+            claim = storage.claim_due_playbook_aggregation(
+                owner=f"admin-rerun:{uuid.uuid4().hex}",
+                lease_seconds=1800,
+                agent_version=agent_version,
+            )
+            if claim is None:
+                raise RuntimeError(
+                    "another playbook aggregation is already running for this organization"
+                )
+        if claim is not None:
+            aggregator_kwargs["aggregation_claim"] = claim
         playbook_aggregator = PlaybookAggregator(
             llm_client=self.llm_client,
             request_context=self.request_context,
             agent_version=agent_version,
             **aggregator_kwargs,
         )
-        aggregator_request = PlaybookAggregatorRequest(
-            agent_version=agent_version,
-            rerun=True,
-        )
-        return playbook_aggregator.run(aggregator_request)
+        try:
+            result = playbook_aggregator.run(aggregator_request)
+        except Exception:
+            if claim is not None:
+                storage.finish_playbook_aggregation_claim(
+                    claim,
+                    success=False,
+                    retry_after_seconds=60,
+                    backlog_retry_after_seconds=1,
+                    min_interval_seconds=min_interval_seconds,
+                )
+            raise
+        if claim is not None and not storage.finish_playbook_aggregation_claim(
+            claim,
+            success=True,
+            retry_after_seconds=60,
+            backlog_retry_after_seconds=1,
+            min_interval_seconds=min_interval_seconds,
+        ):
+            raise RuntimeError("playbook aggregation rerun lost its database fence")
+        return result
 
     def _run_generation_service(
         self,

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -522,7 +522,7 @@ Pre-computed embeddings passed to storage methods via `query_embedding` paramete
 | File | Purpose |
 |------|---------|
 | `storage_base/` | BaseStorage interface split by domain. Legacy facades (`_profiles.py`, `_playbook.py`, `_agent_run.py`, etc.) preserve imports while subpackages (`profiles/`, `playbook/`, `agent_run/`, `governance/`) hold focused abstract store contracts. |
-| `sqlite_storage/` | SQLite-backed implementation split across matching facades and subpackages (`profiles/`, `playbook/`, `agent_run/`, `governance/`, `base/`), including governance-aware retention/barrier handling and lineage/tombstone support. |
+| `sqlite_storage/` | SQLite-backed implementation split across matching facades and subpackages (`profiles/`, `playbook/`, `agent_run/`, `governance/`, `base/`), including governance-aware retention/barrier handling, lineage/tombstone support, and durable incremental playbook-aggregation state. |
 | `governance_validation.py` | Shared validation helpers for subject references and governance contracts before storage writes. |
 | `retention.py`, `retention_mixin.py` | Data retention and cleanup helpers |
 | `constants.py`, `error.py` | Storage constants and shared errors |

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -208,7 +208,7 @@ Access: `SiteVarManager().get_site_var(key)` for raw values, `feature_flags.is_f
 **Encapsulated Components**:
 - **Publish pipeline**: `generation_service.py` coordinates interaction persistence, profile generation, playbook generation, and deferred evaluation scheduling.
 - **Profile memory**: `profile/` extracts, deduplicates, and applies user profile updates.
-- **Playbook memory**: `playbook/` extracts user playbooks, consolidates them against existing rows, aggregates them into agent playbooks, and tracks aggregation change logs.
+- **Playbook memory**: `playbook/` extracts and consolidates user playbooks, durably schedules bounded same-version aggregation, and reconstructs aggregation change logs from lineage.
 - **Evaluation**: `agent_success_evaluation/service.py`, `agent_success_evaluation/runner.py`, `agent_success_evaluation/scheduler.py`, `agent_success_evaluation/components/evaluator.py`, `shadow_comparison/`, and `evaluation_overview/` handle session grading, per-turn shadow verdicts, regeneration jobs, and dashboard-facing rollups.
 - **Durable learning queue**: `durable_learning/scheduler.py` and `durable_learning/worker.py` drain `learning_jobs` after deferred publishes and report coverage through `GET /api/learning_status`.
 - **Async clarification**: `extraction/` manages resumable agent runs, pending tool calls, and prior-answer search.
@@ -342,35 +342,30 @@ Users can regenerate and manage profile versions using a four-state system:
 Key files:
 - `service.py`: Service orchestrator
 - `components/extractor.py`: Extractor that extracts user playbooks
-- `components/aggregator.py`: Aggregates similar user playbooks (with cluster-level change detection to skip unchanged clusters)
+- `aggregation_trigger.py` / `aggregation_scheduler.py`: Durably signal, claim, lease, and retry bounded per-version aggregation work
+- `components/aggregator.py`: Matches same-version centroids, clusters unmatched residuals, and generates agent playbooks
 - `components/consolidator.py`: Reconciles newly extracted playbooks against existing DB playbooks using LLM
 - `review_service.py`: Re-reviews current user playbooks selected by created-at bounds and commits each completed decision newest-first
 
 **Flow**:
 - Interactions → PlaybookExtractor (extraction-only) → PlaybookConsolidator (consolidates new vs existing DB playbooks) → UserPlaybook (with optional `blocking_issue`) → Storage
-- UserPlaybook (manual trigger) → PlaybookAggregator → cluster fingerprint comparison → LLM only for changed clusters → AgentPlaybook (with optional `blocking_issue`) → Storage
+- UserPlaybook write → durable due-now signal → PlaybookAggregationScheduler → same-version centroid match → bounded residual clustering → AgentPlaybook → Storage
+- `POST /api/run_playbook_aggregation` → fenced, capped administrative full rerun
 
 **Tool Analysis**: PlaybookExtractor reads `tool_can_use` from root `Config` and passes it to prompts for tool usage analysis and blocking issue detection.
 
 **Rerun Behavior**: Groups interactions by `user_id` for per-user playbook extraction (fetches all users, then processes each user's interactions together)
 
-**Playbook Aggregation with Cluster Change Detection** (`components/aggregator.py`):
+**Durable Playbook Aggregation** (`aggregation_scheduler.py`, `components/aggregator.py`):
 
-Aggregation clusters user playbooks by embedding similarity, then calls LLM per cluster to produce aggregated agent playbooks. Cluster-level change detection avoids redundant LLM calls on subsequent runs:
-
-1. Cluster all user playbooks (agglomerative for <50, HDBSCAN for >=50)
-2. Compute fingerprint per cluster (SHA-256 of sorted `raw_feedback_id`s, 16 hex chars)
-3. Compare against stored fingerprints from previous run (via `OperationStateManager.get_cluster_fingerprints`)
-4. Only call LLM for changed/new clusters; carry forward existing agent playbooks for unchanged clusters
-5. Archive old agent playbooks only for changed/disappeared clusters (via `archive_feedbacks_by_ids`)
-6. Store new fingerprints with feedback_id mapping (via `OperationStateManager.update_cluster_fingerprints`)
-
-| Scenario | Behavior |
-|---|---|
-| First run (no stored fingerprints) | All clusters treated as changed, full LLM run |
-| `rerun=True` | Bypasses fingerprint comparison, full archive/regenerate |
-| No changes | Logs skip message, updates bookmark, returns early |
-| Error during save | Restores only selectively archived playbooks |
+Automatic aggregation never rescans the full corpus. Each fenced unit admits
+undisposed CURRENT rows, attaches compatible rows to existing centroids for the
+same `agent_version`, and clusters only unmatched residuals. A drained version
+uses the configured one-hour idle minimum; new writes pull it due immediately,
+and unfinished backlog continues promptly. `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS`
+is the scheduled unit budget and the administrative rerun safety cap, not a
+maximum supported corpus size. See the [playbook service map](services/playbook/README.md)
+for storage contracts and failure dispositions.
 
 **Change Log Tracking**: The legacy `playbook_aggregation_change_logs` table is retired (Track B, 2026-06-24) — the aggregator no longer writes it. The change-log view served by `GET /api/playbook_aggregation_change_logs` is reconstructed on demand from `lineage_event` rows via `reconstruct_playbook_aggregation_change_log` (`lib/_agent_playbook.py`): each run's `op=aggregate` events form the "added" side and its `status_change→superseded` events form the "removed" side, grouped by `request_id`. Per-row `updated` pairing is not reconstructed (`updated_agent_playbooks=[]`, a tolerated parity delta).
 

--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -349,7 +349,7 @@ def _resolve_app_profile(
     return resolve_profile(mount_data_plane=mount_data_plane, require_auth=require_auth)
 
 
-def create_app(
+def create_app(  # noqa: C901
     get_org_id: Callable[..., str] | None = None,
     additional_routers: list[APIRouter] | None = None,
     middleware_config: dict | None = None,
@@ -465,6 +465,7 @@ def create_app(
         scheduler = None
         gc_scheduler = None
         durable_learning_scheduler = None
+        aggregation_scheduler = None
         started_caps: list = []
         # D8 config guards + D5 warm-before-ready. Both are dormant unless the
         # deployment has flipped to the in-process local embedder
@@ -514,6 +515,30 @@ def create_app(
                 bootstrap_org_id=bootstrap_org_id,
                 org_ids_provider=durable_org_ids_provider,
             )
+            # Enterprise owns cross-org aggregation through its capability.
+            # OSS still needs a startup-owned scheduler so pending SQLite work
+            # drains after a restart even when no new publish arrives.
+            if capabilities is None:
+                from reflexio.server.services.playbook.aggregation_scheduler import (
+                    ensure_local_playbook_aggregation_scheduler,
+                )
+
+                try:
+                    aggregation_context = RequestContext(org_id=bootstrap_org_id)
+                    aggregation_scheduler = ensure_local_playbook_aggregation_scheduler(
+                        aggregation_context
+                    )
+                except Exception:  # noqa: BLE001
+                    # A composition root may intentionally install an enterprise
+                    # configurator while exercising the OSS app shape without
+                    # enterprise deployment settings. The post-persist trigger
+                    # still starts the same scheduler lazily once a real context
+                    # exists.
+                    logger.warning(
+                        "playbook aggregation scheduler startup deferred: "
+                        "bootstrap context is unavailable",
+                        exc_info=True,
+                    )
         try:
             if capabilities is not None:
                 ctx = (
@@ -535,7 +560,12 @@ def create_app(
                         cap,
                         exc_info=True,
                     )
-            for sched in (scheduler, gc_scheduler, durable_learning_scheduler):
+            for sched in (
+                scheduler,
+                gc_scheduler,
+                durable_learning_scheduler,
+                aggregation_scheduler,
+            ):
                 if sched is not None:
                     sched.stop()
             from reflexio.server.services.publish_learning_worker import (

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -34,7 +34,7 @@ strings before deleting old import paths in the same PR.
 | Directory | Entry class | Key files |
 |-----------|-------------|-----------|
 | `profile/` | `ProfileGenerationService` | `service.py`, `components/extractor.py`, `components/consolidator.py` |
-| `playbook/` | `PlaybookGenerationService` | `components/extractor.py`, `components/consolidator.py`, `components/aggregator.py` (cluster-fingerprint change detection) — has its own [README](playbook/README.md) |
+| `playbook/` | `PlaybookGenerationService` | `aggregation_trigger.py` durably signals work; `aggregation_scheduler.py` claims fenced bounded units; `components/aggregator.py` performs same-version centroid matching and residual clustering — see [README](playbook/README.md) |
 | `agent_success_evaluation/` | `AgentSuccessEvaluationService` | `service.py` (session-level service), `runner.py` (`run_group_evaluation`), `scheduler.py` (`GroupEvaluationScheduler`, 10-min defer), `regen_jobs.py`, `components/evaluator.py` |
 
 ## Durable and Async Extraction
@@ -63,7 +63,7 @@ strings before deleting old import paths in the same PR.
 
 | Path | Purpose |
 |------|---------|
-| `storage/` | `storage_base/` and `sqlite_storage/` keep legacy domain facades while focused subpackages own `profiles/`, `playbook/`, `agent_run/`, `governance/`, durable `learning_jobs`, and SQLite `base/` helpers; plus `governance_validation.py` and `retention*.py`. Access via `request_context.storage` only. |
+| `storage/` | `storage_base/` and `sqlite_storage/` keep legacy domain facades while focused subpackages own `profiles/`, `playbook/`, `agent_run/`, `governance/`, durable `learning_jobs`, and SQLite `base/` helpers. `storage_base/playbook/_aggregation.py` defines fenced aggregation state; SQLite implements it in the matching playbook package. Access via `request_context.storage` only. |
 | `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
 
 ## Key Rules
@@ -73,5 +73,6 @@ strings before deleting old import paths in the same PR.
 - **ALWAYS use `LiteLLMClient`** for completions/embeddings and `request_context.prompt_manager.render_prompt(...)` for prompts — no hardcoded prompts, no direct OpenAI/Claude clients.
 - **All `_operation_state` writes go through `OperationStateManager`** — don't touch the table directly (it backs locks, bookmarks, progress, and cancellation).
 - **All durable queue claims go through `LearningJobStoreABC`** — do not update `learning_jobs` directly; completion is fenced by `claim_token` and must roll back the surrounding `commit_scope` when superseded.
+- **Aggregation state is per agent version** — scheduled intake, centroid matching, cluster membership, invalidation, and agent-playbook generation must never cross versions; keep LLM and clustering work outside `commit_scope()`.
 - **`tool_can_use` lives at root `Config`** — shared by playbook extraction and success evaluation, not per-service.
 - **Preserve governance subject refs/barriers** — route validation through `services/governance/` and `storage/governance_validation.py`; do not bypass retention or subject-write checks in storage implementations.

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -10,6 +10,7 @@ Description: Evidence-grounded playbook extraction, candidate review, aggregatio
 - **Candidate Reviewer**: `components/reviewer.py` - Accepts, narrowly revises, or rejects validated normal-extraction candidates before consolidation
 - **Persisted Review Service**: `review_service.py` - Re-reviews a bounded created-at selection and optionally commits each completed decision newest-first
 - **Playbook Aggregator**: `components/aggregator.py` - Clusters similar user playbooks and generates aggregated insights
+- **Aggregation Scheduler**: `aggregation_scheduler.py` - Claims durable per-version work and runs bounded incremental aggregation
 - **Playbook Consolidator**: `components/consolidator.py` - Reconciles reviewed candidates against existing storage with evidence-aware accounting and overlap guards
 
 ## Supporting Files
@@ -20,6 +21,8 @@ Description: Evidence-grounded playbook extraction, candidate review, aggregatio
 | `playbook_service_utils.py` | Request dataclasses, Pydantic output schemas, message construction utilities |
 | `playbook_evidence.py` | Strict evidence validation, call-local reference checks, and persisted provenance helpers |
 | `review_service.py` | Time-window selection, persisted evidence reconstruction, reporting, and newest-first per-playbook apply |
+| `aggregation_trigger.py` | Converts post-generation activity into an idempotent durable scheduling signal |
+| `aggregation_scheduler.py` | Polling, fleet claim/lease handling, retries, and structured aggregation progress telemetry |
 | `aggregation_prompt_processing.py` | Optional aggregation-boundary interfaces and helpers for prompt preprocessing, contextual prompt guidance, and output post-processing |
 
 ## Architecture
@@ -32,7 +35,9 @@ Interactions
     -> PlaybookCandidateReviewer (normal strict-evidence candidates only)
       -> PlaybookConsolidator (consolidates reviewed vs existing DB playbooks)
         -> UserPlaybook (validated evidence + persisted provenance) -> Storage
-        -> PlaybookAggregator (manual trigger)
+        -> Durable aggregation signal
+          -> PlaybookAggregationScheduler (hourly cadence, bounded work)
+            -> PlaybookAggregator (incremental clustering)
           -> AgentPlaybook (aggregated insights) -> Storage
 ```
 
@@ -93,7 +98,12 @@ earlier decisions.
 
 ### Playbook Aggregation (`components/aggregator.py`)
 
-Triggered manually via `/api/run_playbook_aggregation`. Clusters user playbooks and generates consolidated insights.
+Normal generation durably schedules bounded incremental aggregation through
+`aggregation_trigger.py`; `aggregation_scheduler.py` claims due work across
+processes. New playbooks first match compatible centroids for the same agent
+version, while unmatched residuals form new clusters in bounded batches. The
+manual `/api/run_playbook_aggregation` route remains a capped administrative
+full rerun.
 
 **Key Methods**:
 - `get_clusters(user_playbooks, config)` - HDBSCAN/Agglomerative clustering on embeddings

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -38,7 +38,7 @@ Interactions
         -> Durable aggregation signal
           -> PlaybookAggregationScheduler (hourly cadence, bounded work)
             -> PlaybookAggregator (incremental clustering)
-          -> AgentPlaybook (aggregated insights) -> Storage
+              -> AgentPlaybook (aggregated insights) -> Storage
 ```
 
 ### Playbook Extraction (`components/extractor.py`)

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -9,8 +9,8 @@ Description: Evidence-grounded playbook extraction, candidate review, aggregatio
 - **Playbook Extractor**: `components/extractor.py` - Extracts user playbooks from interactions via LLM
 - **Candidate Reviewer**: `components/reviewer.py` - Accepts, narrowly revises, or rejects validated normal-extraction candidates before consolidation
 - **Persisted Review Service**: `review_service.py` - Re-reviews a bounded created-at selection and optionally commits each completed decision newest-first
-- **Playbook Aggregator**: `components/aggregator.py` - Clusters similar user playbooks and generates aggregated insights
-- **Aggregation Scheduler**: `aggregation_scheduler.py` - Claims durable per-version work and runs bounded incremental aggregation
+- **Playbook Aggregator**: `components/aggregator.py` - Matches same-version cluster centroids, clusters residuals, and generates agent playbooks
+- **Aggregation Scheduler**: `aggregation_scheduler.py` - Claims fenced per-version work and runs one bounded aggregation unit
 - **Playbook Consolidator**: `components/consolidator.py` - Reconciles reviewed candidates against existing storage with evidence-aware accounting and overlap guards
 
 ## Supporting Files
@@ -35,8 +35,8 @@ Interactions
     -> PlaybookCandidateReviewer (normal strict-evidence candidates only)
       -> PlaybookConsolidator (consolidates reviewed vs existing DB playbooks)
         -> UserPlaybook (validated evidence + persisted provenance) -> Storage
-        -> Durable aggregation signal
-          -> PlaybookAggregationScheduler (hourly cadence, bounded work)
+        -> Durable aggregation signal (pulls new work due now)
+          -> PlaybookAggregationScheduler (bounded work; hourly idle minimum)
             -> PlaybookAggregator (incremental clustering)
               -> AgentPlaybook (aggregated insights) -> Storage
 ```
@@ -100,14 +100,31 @@ earlier decisions.
 
 Normal generation durably schedules bounded incremental aggregation through
 `aggregation_trigger.py`; `aggregation_scheduler.py` claims due work across
-processes. New playbooks first match compatible centroids for the same agent
-version, while unmatched residuals form new clusters in bounded batches. The
-manual `/api/run_playbook_aggregation` route remains a capped administrative
-full rerun.
+processes. A successful drained run waits at least
+`REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS` (default 3600) before an idle retry;
+a new durable signal pulls the version due immediately, and a remaining backlog
+continues in bounded follow-up units. The manual
+`/api/run_playbook_aggregation` route remains a fenced administrative full rerun.
 
-**Key Methods**:
-- `get_clusters(user_playbooks, config)` - HDBSCAN/Agglomerative clustering on embeddings
-- `aggregate()` - Full aggregation pipeline with LLM-based consolidation
+Incremental work is isolated by `agent_version`:
+
+1. Admit CURRENT, nonempty rows that have no durable disposition.
+2. Match embedded residuals against active centroids for that version only.
+3. Attach matches without regenerating their agent playbook.
+4. Cluster only unmatched residuals: agglomerative below 50 rows, HDBSCAN at 50 or more.
+5. Commit generated agent playbooks, lineage, cluster membership, centroid updates, and supersessions atomically.
+
+`REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` (default 20,000) is the shared row budget
+for one scheduled unit, including intake and invalidations. It is also the
+fail-before-mutation total-input cap for an administrative full rerun; it no
+longer prevents an organization with a larger corpus from making incremental
+progress. Retryable LLM outcomes stay residual, semantic-null outcomes become
+terminal no-ops, and missing embeddings remain pending for a later unit.
+
+The portable state contract is
+`storage/storage_base/playbook/_aggregation.py`; SQLite implements it in
+`storage/sqlite_storage/playbook/_aggregation.py`. Claims are lease-fenced, and
+all multi-write effects must remain inside `storage.commit_scope()`.
 
 **Optional prompt processing**: deployments can register an
 `AggregationPromptProcessor` via the `AGGREGATION_PROMPT_PROCESSOR` ServiceKey
@@ -118,7 +135,12 @@ post-processes generated outputs before storage or model-response logging.
 
 **Change Log**: The legacy `playbook_aggregation_change_logs` table is retired (Track B, 2026-06-24) — the aggregator no longer writes it. The change-log view is reconstructed on demand from `lineage_event` via `reconstruct_playbook_aggregation_change_log` (`lib/_agent_playbook.py`): each run emits `op=aggregate` events (the "added" side) and `status_change→superseded` events from the supersede calls (the "removed" side), grouped by the run's `request_id`. Per-row `updated` pairing is not reconstructed (`updated_agent_playbooks=[]`, a tolerated parity delta).
 
-**Clustering**: Embeds user playbooks -> HDBSCAN clustering -> falls back to Agglomerative if too few clusters
+**Requirements / Problems to Avoid**:
+
+- Never cluster, centroid-match, or attach rows across agent versions.
+- Never rediscover the full corpus on the scheduled path; use durable dispositions and bounded anti-join intake.
+- Never hold `commit_scope()` while embedding, clustering, or calling the LLM.
+- Do not clear pending state on partial failure, limiter deferral, or a lost lease.
 
 ### Playbook Consolidation (`components/consolidator.py`)
 

--- a/reflexio/server/services/playbook/aggregation_scheduler.py
+++ b/reflexio/server/services/playbook/aggregation_scheduler.py
@@ -1,0 +1,292 @@
+"""Durable, fleet-fenced incremental playbook aggregation scheduler."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.env_utils import env_str
+from reflexio.server.extensions import get_service
+from reflexio.server.operation_limiter import run_with_operation_limit
+from reflexio.server.scheduling import LeaderGate, ThreadedScheduler
+from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
+)
+from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
+from reflexio.server.services.playbook.playbook_service_utils import (
+    PlaybookAggregatorRequest,
+)
+from reflexio.server.services.storage.storage_base.playbook import (
+    PlaybookAggregationClaim,
+)
+
+logger = logging.getLogger("reflexio.server.services.playbook.aggregation_scheduler")
+
+_POLL_SECONDS = 10.0
+_LEASE_SECONDS = 300
+_RETRY_SECONDS = 60
+_BACKLOG_RETRY_SECONDS = 1
+_REPAIR_INTERVAL_SECONDS = 300.0
+
+
+def aggregation_min_interval_seconds() -> int:
+    raw = env_str("REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS", "3600")
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logger.warning(
+            "event=playbook_aggregation_invalid_interval value=%r default=3600", raw
+        )
+        return 3600
+
+
+class _LeaseHeartbeat:
+    def __init__(self, storage: Any, claim: PlaybookAggregationClaim) -> None:
+        self.storage = storage
+        self.claim = claim
+        self._stop = threading.Event()
+        self._lost = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._run,
+            name="reflexio-playbook-aggregation-heartbeat",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        while not self._stop.wait(_LEASE_SECONDS / 3):
+            renewed = self.storage.renew_playbook_aggregation_claim(
+                self.claim, lease_seconds=_LEASE_SECONDS
+            )
+            if renewed is None:
+                self._lost.set()
+                return
+            self.claim = renewed
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def require_live(self) -> None:
+        if self._lost.is_set():
+            raise RuntimeError("playbook aggregation lease was lost")
+
+
+class PlaybookAggregationScheduler(ThreadedScheduler):
+    """Poll durable per-version state and run one bounded unit per organization."""
+
+    def __init__(
+        self,
+        *,
+        context_provider: Callable[[], Iterable[RequestContext]],
+        poll_interval_seconds: float = _POLL_SECONDS,
+        leader_gate: LeaderGate | None = None,
+        worker_id: str | None = None,
+    ) -> None:
+        super().__init__(
+            thread_name="reflexio-playbook-aggregation-scheduler",
+            leader_gate=leader_gate,
+        )
+        self._context_provider = context_provider
+        self._poll_interval_seconds = poll_interval_seconds
+        self._worker_id = worker_id or uuid.uuid4().hex
+        self._last_repair_at: dict[str, float] = {}
+
+    def _run_context(self, context: RequestContext) -> None:
+        storage = context.storage
+        playbook_config = getattr(
+            context.configurator.get_config(), "user_playbook_extractor_config", None
+        )
+        if playbook_config is None or playbook_config.aggregation_config is None:
+            return
+        if storage is None or not getattr(
+            storage, "supports_incremental_playbook_aggregation", False
+        ):
+            return
+        repair_now = time.monotonic()
+        last_repair_at = self._last_repair_at.get(context.org_id)
+        if (
+            last_repair_at is None
+            or repair_now - last_repair_at >= _REPAIR_INTERVAL_SECONDS
+        ):
+            repaired = storage.repair_playbook_aggregation_pending_state()
+            self._last_repair_at[context.org_id] = repair_now
+            for agent_version in repaired:
+                logger.info(
+                    "event=playbook_aggregation_progress state=scheduled org_id=%s "
+                    "agent_version=%s reason=discovery_repair pending=true",
+                    context.org_id,
+                    agent_version,
+                )
+        claim = storage.claim_due_playbook_aggregation(
+            owner=f"aggregation:{self._worker_id}:{context.org_id}",
+            lease_seconds=_LEASE_SECONDS,
+        )
+        if claim is None:
+            return
+        started = time.perf_counter()
+        logger.info(
+            "event=playbook_aggregation_progress state=claimed org_id=%s "
+            "agent_version=%s fence=%s pending=true",
+            context.org_id,
+            claim.agent_version,
+            claim.fence,
+        )
+        heartbeat = _LeaseHeartbeat(storage, claim)
+        heartbeat.start()
+        success = False
+        result: dict[str, Any] = {}
+        after = None
+        try:
+            budget = _aggregation_budget()
+            invalidations = storage.get_playbook_aggregation_invalidations(
+                claim.agent_version, limit=max(1, budget // 4)
+            )
+            if invalidations and not storage.apply_playbook_aggregation_invalidations(
+                claim, [item.invalidation_id for item in invalidations]
+            ):
+                raise RuntimeError("playbook aggregation invalidation fence was lost")
+            from reflexio.lib.generation_client import (
+                create_generation_litellm_client,
+            )
+
+            kwargs: dict[str, Any] = {}
+            processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
+            if processor is not None:
+                kwargs["aggregation_prompt_processor"] = processor
+            aggregator = PlaybookAggregator(
+                llm_client=create_generation_litellm_client(context),
+                request_context=context,
+                agent_version=claim.agent_version,
+                aggregation_claim=claim,
+                work_budget=max(0, budget - len(invalidations)),
+                **kwargs,
+            )
+            logger.info(
+                "event=playbook_aggregation_progress state=started org_id=%s "
+                "agent_version=%s fence=%s",
+                context.org_id,
+                claim.agent_version,
+                claim.fence,
+            )
+            result = run_with_operation_limit(
+                org_id=context.org_id,
+                operation="aggregation",
+                fn=lambda: aggregator.run(
+                    PlaybookAggregatorRequest(agent_version=claim.agent_version)
+                ),
+            )
+            heartbeat.require_live()
+            success = True
+            after = storage.get_playbook_aggregation_backlog(claim.agent_version)
+        except TimeoutError:
+            logger.warning(
+                "event=playbook_aggregation_progress state=deferred org_id=%s "
+                "agent_version=%s reason=limiter_saturated",
+                context.org_id,
+                claim.agent_version,
+            )
+        except Exception:
+            logger.exception(
+                "event=playbook_aggregation_progress state=retryable_failed "
+                "org_id=%s agent_version=%s fence=%s",
+                context.org_id,
+                claim.agent_version,
+                claim.fence,
+            )
+        finally:
+            heartbeat.stop()
+            active_claim = heartbeat.claim
+            finished = storage.finish_playbook_aggregation_claim(
+                active_claim,
+                success=success,
+                retry_after_seconds=_RETRY_SECONDS,
+                backlog_retry_after_seconds=_BACKLOG_RETRY_SECONDS,
+                min_interval_seconds=aggregation_min_interval_seconds(),
+                backlog=after if success else None,
+            )
+            if not finished:
+                logger.warning(
+                    "event=playbook_aggregation_progress state=lease_lost org_id=%s "
+                    "agent_version=%s fence=%s",
+                    context.org_id,
+                    claim.agent_version,
+                    claim.fence,
+                )
+            elif success and after is not None:
+                logger.info(
+                    "event=playbook_aggregation_progress state=succeeded org_id=%s "
+                    "agent_version=%s fence=%s pending=%s undisposed=%s residual=%s "
+                    "invalidations=%s oldest_residual_age_seconds=%s "
+                    "dirty_repairs=%s duration_ms=%s creations=%s supersessions=%s "
+                    "retryable_failures=%s",
+                    context.org_id,
+                    claim.agent_version,
+                    claim.fence,
+                    str(after.pending).lower(),
+                    after.undisposed,
+                    after.residual,
+                    after.invalidations,
+                    after.oldest_residual_age_seconds,
+                    after.dirty_repairs,
+                    int((time.perf_counter() - started) * 1000),
+                    result.get("playbooks_generated", 0),
+                    result.get("supersessions", 0),
+                    result.get("retryable_failures", 0),
+                )
+
+    def _run_once(self) -> float:
+        try:
+            for context in self._context_provider():
+                if self._stop_event.is_set():
+                    break
+                self._run_context(context)
+        except Exception:
+            logger.exception("event=playbook_aggregation_scheduler_tick_failed")
+        return self._poll_interval_seconds
+
+    def _on_started(self) -> None:
+        logger.info("event=playbook_aggregation_scheduler_started")
+
+    def _on_stopped(self) -> None:
+        logger.info("event=playbook_aggregation_scheduler_stopped")
+
+
+def _aggregation_budget() -> int:
+    from reflexio.server.services.playbook.components.aggregator_clustering import (
+        max_clustering_playbooks,
+    )
+
+    return max_clustering_playbooks()
+
+
+_LOCAL_SCHEDULERS: dict[str, PlaybookAggregationScheduler] = {}
+_LOCAL_SCHEDULERS_LOCK = threading.Lock()
+
+
+def ensure_local_playbook_aggregation_scheduler(
+    request_context: RequestContext,
+) -> PlaybookAggregationScheduler | None:
+    """Lazily provide the time-driven scheduler in OSS local mode."""
+    if os.getenv("DEPLOYMENT_MODE", "").strip() in {"platform", "self_host"}:
+        return None
+    with _LOCAL_SCHEDULERS_LOCK:
+        scheduler = _LOCAL_SCHEDULERS.get(request_context.org_id)
+        if scheduler is None:
+            scheduler = PlaybookAggregationScheduler(
+                context_provider=lambda: [request_context]
+            )
+            _LOCAL_SCHEDULERS[request_context.org_id] = scheduler
+        if not scheduler.is_running():
+            scheduler.start()
+        return scheduler

--- a/reflexio/server/services/playbook/aggregation_scheduler.py
+++ b/reflexio/server/services/playbook/aggregation_scheduler.py
@@ -29,9 +29,9 @@ from reflexio.server.services.storage.storage_base.playbook import (
 logger = logging.getLogger("reflexio.server.services.playbook.aggregation_scheduler")
 
 _POLL_SECONDS = 10.0
-_LEASE_SECONDS = 300
-_RETRY_SECONDS = 60
-_BACKLOG_RETRY_SECONDS = 1
+AGGREGATION_LEASE_SECONDS = 300
+AGGREGATION_RETRY_SECONDS = 60
+AGGREGATION_BACKLOG_RETRY_SECONDS = 1
 _REPAIR_INTERVAL_SECONDS = 300.0
 
 
@@ -46,7 +46,7 @@ def aggregation_min_interval_seconds() -> int:
         return 3600
 
 
-class _LeaseHeartbeat:
+class AggregationLeaseHeartbeat:
     def __init__(self, storage: Any, claim: PlaybookAggregationClaim) -> None:
         self.storage = storage
         self.claim = claim
@@ -63,10 +63,20 @@ class _LeaseHeartbeat:
         self._thread.start()
 
     def _run(self) -> None:
-        while not self._stop.wait(_LEASE_SECONDS / 3):
-            renewed = self.storage.renew_playbook_aggregation_claim(
-                self.claim, lease_seconds=_LEASE_SECONDS
-            )
+        while not self._stop.wait(AGGREGATION_LEASE_SECONDS / 3):
+            try:
+                renewed = self.storage.renew_playbook_aggregation_claim(
+                    self.claim, lease_seconds=AGGREGATION_LEASE_SECONDS
+                )
+            except Exception:
+                logger.exception(
+                    "event=playbook_aggregation_progress state=lease_lost "
+                    "agent_version=%s fence=%s reason=renewal_failed",
+                    self.claim.agent_version,
+                    self.claim.fence,
+                )
+                self._lost.set()
+                return
             if renewed is None:
                 self._lost.set()
                 return
@@ -109,9 +119,19 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
         )
         if playbook_config is None or playbook_config.aggregation_config is None:
             return
-        if storage is None or not getattr(
-            storage, "supports_incremental_playbook_aggregation", False
-        ):
+        if storage is None:
+            return
+        if not getattr(storage, "supports_incremental_playbook_aggregation", False):
+            blocked_reason = getattr(
+                storage, "playbook_aggregation_blocked_reason", None
+            )
+            if blocked_reason:
+                logger.warning(
+                    "event=playbook_aggregation_progress state=blocked org_id=%s "
+                    "reason=%s",
+                    context.org_id,
+                    blocked_reason,
+                )
             return
         repair_now = time.monotonic()
         last_repair_at = self._last_repair_at.get(context.org_id)
@@ -130,7 +150,7 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
                 )
         claim = storage.claim_due_playbook_aggregation(
             owner=f"aggregation:{self._worker_id}:{context.org_id}",
-            lease_seconds=_LEASE_SECONDS,
+            lease_seconds=AGGREGATION_LEASE_SECONDS,
         )
         if claim is None:
             return
@@ -142,7 +162,7 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
             claim.agent_version,
             claim.fence,
         )
-        heartbeat = _LeaseHeartbeat(storage, claim)
+        heartbeat = AggregationLeaseHeartbeat(storage, claim)
         heartbeat.start()
         success = False
         result: dict[str, Any] = {}
@@ -210,8 +230,8 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
             finished = storage.finish_playbook_aggregation_claim(
                 active_claim,
                 success=success,
-                retry_after_seconds=_RETRY_SECONDS,
-                backlog_retry_after_seconds=_BACKLOG_RETRY_SECONDS,
+                retry_after_seconds=AGGREGATION_RETRY_SECONDS,
+                backlog_retry_after_seconds=AGGREGATION_BACKLOG_RETRY_SECONDS,
                 min_interval_seconds=aggregation_min_interval_seconds(),
                 backlog=after if success else None,
             )
@@ -259,6 +279,15 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
         logger.info("event=playbook_aggregation_scheduler_started")
 
     def _on_stopped(self) -> None:
+        if not self.is_running():
+            with _LOCAL_SCHEDULERS_LOCK:
+                stale_org_ids = [
+                    org_id
+                    for org_id, scheduler in _LOCAL_SCHEDULERS.items()
+                    if scheduler is self
+                ]
+                for org_id in stale_org_ids:
+                    _LOCAL_SCHEDULERS.pop(org_id, None)
         logger.info("event=playbook_aggregation_scheduler_stopped")
 
 
@@ -282,11 +311,10 @@ def ensure_local_playbook_aggregation_scheduler(
         return None
     with _LOCAL_SCHEDULERS_LOCK:
         scheduler = _LOCAL_SCHEDULERS.get(request_context.org_id)
-        if scheduler is None:
+        if scheduler is None or not scheduler.is_running():
             scheduler = PlaybookAggregationScheduler(
                 context_provider=lambda: [request_context]
             )
             _LOCAL_SCHEDULERS[request_context.org_id] = scheduler
-        if not scheduler.is_running():
             scheduler.start()
         return scheduler

--- a/reflexio/server/services/playbook/aggregation_trigger.py
+++ b/reflexio/server/services/playbook/aggregation_trigger.py
@@ -8,6 +8,9 @@ from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.services.playbook.aggregation_scheduler import (
     ensure_local_playbook_aggregation_scheduler,
 )
+from reflexio.server.services.playbook.aggregation_scheduler import (
+    logger as aggregation_progress_logger,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +81,7 @@ def maybe_trigger_user_playbook_aggregation(
             raise RuntimeError("playbook aggregation requires configured storage")
         storage.schedule_playbook_aggregation(agent_version)
         ensure_local_playbook_aggregation_scheduler(request_context)
-        logging.getLogger(
-            "reflexio.server.services.playbook.aggregation_scheduler"
-        ).info(
+        aggregation_progress_logger.info(
             "event=playbook_aggregation_progress state=scheduled org_id=%s "
             "agent_version=%s reason=%s pending=true",
             request_context.org_id,

--- a/reflexio/server/services/playbook/aggregation_trigger.py
+++ b/reflexio/server/services/playbook/aggregation_trigger.py
@@ -1,29 +1,19 @@
 from __future__ import annotations
 
 import logging
-import threading
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.extensions import get_service
-from reflexio.server.operation_limiter import run_with_operation_limit
-from reflexio.server.services.playbook.aggregation_prompt_processing import (
-    AGGREGATION_PROMPT_PROCESSOR,
-)
-from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
-from reflexio.server.services.playbook.playbook_service_utils import (
-    PlaybookAggregatorRequest,
+from reflexio.server.services.playbook.aggregation_scheduler import (
+    ensure_local_playbook_aggregation_scheduler,
 )
 
 logger = logging.getLogger(__name__)
 
 AggregationTriggerStatus = Literal[
-    "queued",
-    "triggered",
+    "scheduled",
     "skipped_no_config",
-    "skipped_saturated",
     "failed",
 ]
 
@@ -63,59 +53,10 @@ def has_user_playbook_aggregation_config(request_context: RequestContext) -> boo
     return bool(playbook_config and playbook_config.aggregation_config)
 
 
-def _run_aggregation_task(
-    *,
-    request_context: RequestContext,
-    aggregator: PlaybookAggregator,
-    request: PlaybookAggregatorRequest,
-    reason: str,
-) -> AggregationTriggerResult:
-    agent_version = request.agent_version
-    try:
-        run_with_operation_limit(
-            org_id=request_context.org_id,
-            operation="aggregation",
-            fn=lambda: aggregator.run(request),
-        )
-    except TimeoutError:
-        logger.info(
-            "Skipping background aggregation for agent_version=%s reason=%s: aggregation limiter is saturated",
-            agent_version,
-            reason,
-        )
-        return AggregationTriggerResult(
-            status="skipped_saturated",
-            reason=reason,
-            agent_version=agent_version,
-            error_type="TimeoutError",
-        )
-    except Exception as exc:  # noqa: BLE001
-        return _failed_result(
-            exc=exc,
-            reason=reason,
-            agent_version=agent_version,
-            message="User playbook aggregation failed after successor commit",
-        )
-    return AggregationTriggerResult(
-        status="triggered",
-        reason=reason,
-        agent_version=agent_version,
-    )
-
-
-def _start_aggregation_thread(task: Callable[[], AggregationTriggerResult]) -> None:
-    thread = threading.Thread(
-        target=task,
-        name="reflexio-user-playbook-aggregation",
-        daemon=True,
-    )
-    thread.start()
-
-
 def maybe_trigger_user_playbook_aggregation(
     *,
     request_context: RequestContext,
-    llm_client: Any,
+    llm_client: Any,  # noqa: ARG001 - retained for the public trigger contract
     agent_version: str,
     reason: str,
 ) -> AggregationTriggerResult:
@@ -132,36 +73,20 @@ def maybe_trigger_user_playbook_aggregation(
             agent_version,
             reason,
         )
-        aggregator_kwargs: dict[str, Any] = {}
-        aggregation_prompt_processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
-        if aggregation_prompt_processor is not None:
-            aggregator_kwargs["aggregation_prompt_processor"] = (
-                aggregation_prompt_processor
-            )
-
-        aggregator = PlaybookAggregator(
-            llm_client=llm_client,
-            request_context=request_context,
-            agent_version=agent_version,
-            **aggregator_kwargs,
+        storage = request_context.storage
+        if storage is None:
+            raise RuntimeError("playbook aggregation requires configured storage")
+        storage.schedule_playbook_aggregation(agent_version)
+        ensure_local_playbook_aggregation_scheduler(request_context)
+        logging.getLogger(
+            "reflexio.server.services.playbook.aggregation_scheduler"
+        ).info(
+            "event=playbook_aggregation_progress state=scheduled org_id=%s "
+            "agent_version=%s reason=%s pending=true",
+            request_context.org_id,
+            agent_version,
+            reason,
         )
-        request = PlaybookAggregatorRequest(agent_version=agent_version)
-        try:
-            _start_aggregation_thread(
-                lambda: _run_aggregation_task(
-                    request_context=request_context,
-                    aggregator=aggregator,
-                    request=request,
-                    reason=reason,
-                )
-            )
-        except Exception as exc:  # noqa: BLE001
-            return _failed_result(
-                exc=exc,
-                reason=reason,
-                agent_version=agent_version,
-                message="User playbook aggregation dispatch failed after successor commit",
-            )
     except Exception as exc:  # noqa: BLE001
         return _failed_result(
             exc=exc,
@@ -171,7 +96,7 @@ def maybe_trigger_user_playbook_aggregation(
         )
 
     return AggregationTriggerResult(
-        status="queued",
+        status="scheduled",
         reason=reason,
         agent_version=agent_version,
     )

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -485,7 +485,7 @@ class PlaybookAggregator:
         ]
         saved_playbooks: list[AgentPlaybook] = []
         replacement_agent_ids_by_outcome = {
-            id(outcome): self.storage.get_playbook_aggregation_replacement_agent_ids(  # type: ignore[attr-defined]
+            index: self.storage.get_playbook_aggregation_replacement_agent_ids(  # type: ignore[attr-defined]
                 self.agent_version,
                 [
                     int(item.user_playbook_id)
@@ -493,7 +493,7 @@ class PlaybookAggregator:
                     if item.user_playbook_id is not None
                 ],
             )
-            for outcome in outcomes
+            for index, outcome in enumerate(outcomes)
             if outcome.status == "generated"
         }
         replaced_agent_ids: set[int] = set()
@@ -521,7 +521,7 @@ class PlaybookAggregator:
                     if item.user_playbook_id is not None and item.embedding
                 ],
             )
-            for outcome in outcomes:
+            for outcome_index, outcome in enumerate(outcomes):
                 members = outcome.source_cluster
                 member_ids = [
                     int(item.user_playbook_id)
@@ -577,7 +577,9 @@ class PlaybookAggregator:
                         [outcome.playbook], lineage_contexts=lineage_contexts
                     )[0]
                 saved_playbooks.append(saved)
-                replaced_agent_ids.update(replacement_agent_ids_by_outcome[id(outcome)])
+                replaced_agent_ids.update(
+                    replacement_agent_ids_by_outcome[outcome_index]
+                )
                 embeddings = [item.embedding for item in members if item.embedding]
                 cluster_id = self._stable_aggregation_cluster_id(
                     self._compute_cluster_fingerprint(members)
@@ -961,9 +963,10 @@ class PlaybookAggregator:
                 pipeline="playbook",
                 playbook_name=playbook_name,
                 agent_version=self.agent_version,
-                outcome="should_skip",
+                outcome="failed",
                 count_value=total_user_playbooks,
                 metadata={
+                    "failure_reason": "full_rerun_safety_cap_exceeded",
                     "user_playbooks": total_user_playbooks,
                     "max_clustering_playbooks": max_playbooks,
                 },

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -628,17 +628,6 @@ class PlaybookAggregator:
             duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
             metadata=stats,
         )
-        self._record_learnings_generated(
-            learning_ids=[
-                str(item.agent_playbook_id)
-                for item in saved_playbooks
-                if item.agent_playbook_id is not None
-            ],
-            playbook_name=SINGLETON_USER_PLAYBOOK_NAME,
-            request_id=run_id,
-            metadata=stats,
-            total_count=len(saved_playbooks),
-        )
         return stats
 
     def _stable_aggregation_cluster_id(self, fingerprint: str) -> str:

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 import time
 import uuid
 from collections.abc import Callable, Sequence
 from contextlib import AbstractContextManager
-from typing import TYPE_CHECKING, Any, Protocol
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 if TYPE_CHECKING:
     import numpy as np
@@ -26,7 +28,10 @@ from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.error_reporting import capture_anomaly, error_tags
 from reflexio.server.llm._litellm_types import ModelProvenance
 from reflexio.server.llm.litellm_client import LiteLLMClient
-from reflexio.server.services.embedding_text import resolve_clustering_similarity
+from reflexio.server.services.embedding_text import (
+    embedding_text,
+    resolve_clustering_similarity,
+)
 from reflexio.server.services.operation_state_utils import OperationStateManager
 from reflexio.server.services.playbook.aggregation_prompt_processing import (
     AggregationPromptProcessingContext,
@@ -53,6 +58,9 @@ from reflexio.server.services.playbook.playbook_service_utils import (
 )
 from reflexio.server.services.service_utils import log_model_response
 from reflexio.server.services.storage.storage_base import AGGREGATE_REASON_PREFIX
+from reflexio.server.services.storage.storage_base.playbook import (
+    PlaybookAggregationClaim,
+)
 from reflexio.server.usage_metrics import record_usage_event
 
 logger = logging.getLogger(__name__)
@@ -62,6 +70,49 @@ logger = logging.getLogger(__name__)
 # PostgREST enforces `max_rows = 1000` (see supabase/*/config.toml).
 _AGGREGATION_PLAYBOOK_PAGE_SIZE = 500
 _SIGNED_BIGINT_MAX = (1 << 63) - 1
+_MAX_EXISTING_PLAYBOOKS_PER_PROMPT = 20
+
+
+def _select_relevant_existing_playbooks(
+    cluster: list[UserPlaybook], existing: list[AgentPlaybook]
+) -> list[AgentPlaybook]:
+    """Bound repeated context with one linear embedding/lexical-ranked pass."""
+    if len(existing) <= _MAX_EXISTING_PLAYBOOKS_PER_PROMPT:
+        return existing
+    embeddings = [item.embedding for item in cluster if item.embedding]
+    dimension = len(embeddings[0]) if embeddings else 0
+    embeddings = [value for value in embeddings if len(value) == dimension]
+    centroid = (
+        [sum(values) / len(embeddings) for values in zip(*embeddings, strict=True)]
+        if embeddings
+        else []
+    )
+    centroid_norm = math.sqrt(sum(value * value for value in centroid))
+    cluster_tokens = {
+        token
+        for item in cluster
+        for token in f"{item.trigger or ''} {item.content or ''}".lower().split()
+    }
+
+    def score(item: AgentPlaybook) -> tuple[float, int]:
+        if centroid_norm and len(item.embedding) == dimension:
+            item_norm = math.sqrt(sum(value * value for value in item.embedding))
+            if item_norm:
+                similarity = sum(
+                    left * right
+                    for left, right in zip(centroid, item.embedding, strict=True)
+                ) / (centroid_norm * item_norm)
+                return similarity, item.agent_playbook_id
+        item_tokens = f"{item.trigger or ''} {item.content}".lower().split()
+        token_set = set(item_tokens)
+        overlap = len(cluster_tokens & token_set) / max(
+            1, min(len(cluster_tokens), len(token_set))
+        )
+        return overlap, item.agent_playbook_id
+
+    ranked = [(score(item), item) for item in existing]
+    ranked.sort(key=lambda pair: (-pair[0][0], pair[0][1]))
+    return [item for _rank, item in ranked[:_MAX_EXISTING_PLAYBOOKS_PER_PROMPT]]
 
 
 def _read_all_pages[T](
@@ -102,6 +153,19 @@ class AggregationEffectCoordinator(Protocol):
     def complete(self, result: dict[str, Any]) -> None: ...
 
 
+AggregationGenerationStatus = Literal["generated", "semantic_null", "retryable_failure"]
+
+
+@dataclass(frozen=True)
+class AggregationGenerationOutcome:
+    """Unambiguous result for exactly one selected source cluster."""
+
+    status: AggregationGenerationStatus
+    source_cluster: list[UserPlaybook]
+    playbook: AgentPlaybook | None = None
+    provenance: ModelProvenance | None = None
+
+
 class PlaybookAggregator:
     def __init__(
         self,
@@ -110,6 +174,8 @@ class PlaybookAggregator:
         agent_version: str,
         aggregation_prompt_processor: AggregationPromptProcessor | None = None,
         effect_coordinator: AggregationEffectCoordinator | None = None,
+        aggregation_claim: PlaybookAggregationClaim | None = None,
+        work_budget: int | None = None,
     ) -> None:
         self.client = llm_client
         storage = request_context.storage
@@ -121,6 +187,8 @@ class PlaybookAggregator:
         self.agent_version = agent_version
         self.aggregation_prompt_processor = aggregation_prompt_processor
         self.effect_coordinator = effect_coordinator
+        self.aggregation_claim = aggregation_claim
+        self.work_budget = work_budget
         # Cohesive pre/post-processing component (the enterprise redaction
         # Protocol seam). Constructed from the SAME injected instance stored
         # above — do NOT re-resolve the AGGREGATION_PROMPT_PROCESSOR ServiceKey.
@@ -316,6 +384,381 @@ class PlaybookAggregator:
     # public methods
     # ===============================
 
+    def _run_incremental(
+        self,
+        *,
+        config: PlaybookAggregatorConfig,
+        run_id: str,
+        aggregation_start: float,
+    ) -> dict[str, Any]:
+        """Process one durable, bounded residual batch without touching old clusters."""
+        budget = (
+            aggregator_clustering.max_clustering_playbooks()
+            if self.work_budget is None
+            else max(0, self.work_budget)
+        )
+        bootstrap_work, bootstrap_complete = self._adopt_legacy_aggregation_state(
+            budget=budget
+        )
+        budget = max(0, budget - bootstrap_work)
+        if not bootstrap_complete:
+            return {
+                "clusters_found": 0,
+                "user_playbooks_processed": bootstrap_work,
+                "playbooks_generated": 0,
+                "staged": 0,
+                "attachments": 0,
+                "skipped": "legacy cluster adoption pending",
+            }
+        # Intake and residual processing share the same row budget. Reserve
+        # half for anti-join admission when there is undisposed work; unused
+        # capacity is naturally borrowed by residual processing.
+        intake_limit = (budget + 1) // 2
+        staged_ids = self.storage.stage_playbook_aggregation_intake(  # type: ignore[attr-defined]
+            self.agent_version, limit=intake_limit
+        )
+        residual_limit = max(0, budget - len(staged_ids))
+        residual_ids = self.storage.get_playbook_aggregation_residual_ids(  # type: ignore[attr-defined]
+            self.agent_version, limit=residual_limit
+        )
+        user_playbooks = self.storage.get_user_playbooks_by_ids_any_user(  # type: ignore[call-arg]
+            residual_ids,
+            status_filter=[None],
+            include_embedding=True,
+        )
+        user_playbooks = [
+            item for item in user_playbooks if item.content and item.content.strip()
+        ]
+        trigger_count = max(2, config.reaggregation_trigger_count)
+
+        # Bound the dedup prompt as well. Existing agent playbooks are context,
+        # not work discovery, and must never turn this path into an org scan.
+        existing_playbooks = self.storage.get_agent_playbooks(  # type: ignore[attr-defined]
+            limit=min(500, budget),
+            agent_version=self.agent_version,
+            status_filter=[None],
+            playbook_status_filter=[PlaybookStatus.APPROVED, PlaybookStatus.PENDING],
+        )
+        similarity_threshold = resolve_clustering_similarity(
+            config.clustering_similarity,
+            model_name=self.storage.embedding_model_name,
+        )
+        attachments: list[tuple[UserPlaybook, str]] = []
+        stage_b_playbooks: list[UserPlaybook] = []
+        missing_embedding_ids: list[int] = []
+        candidates: list[tuple[int, list[float]]] = []
+        for item in user_playbooks:
+            if item.user_playbook_id is None:
+                continue
+            item_id = int(item.user_playbook_id)
+            if not item.embedding:
+                missing_embedding_ids.append(item_id)
+                continue
+            candidates.append((item_id, item.embedding))
+        matches = self.storage.find_nearest_playbook_aggregation_clusters(  # type: ignore[attr-defined]
+            self.agent_version,
+            candidates,
+            embedding_model=self.storage.embedding_model_name,
+            limit=budget,
+        )
+        for item in user_playbooks:
+            if item.user_playbook_id is None or not item.embedding:
+                continue
+            match = matches.get(int(item.user_playbook_id))
+            if match is not None and match.similarity >= similarity_threshold:
+                attachments.append((item, match.cluster_id))
+            else:
+                stage_b_playbooks.append(item)
+
+        clusters = (
+            self.get_clusters(stage_b_playbooks, config)
+            if len(stage_b_playbooks) >= trigger_count
+            else {}
+        )
+        outcomes = self._generate_playbook_outcomes_with_source_clusters(
+            clusters,
+            existing_playbooks,
+            direction_overlap_threshold=config.direction_overlap_threshold,
+        )
+        retryable_outcomes = [
+            item for item in outcomes if item.status == "retryable_failure"
+        ]
+        saved_playbooks: list[AgentPlaybook] = []
+        replacement_agent_ids_by_outcome = {
+            id(outcome): self.storage.get_playbook_aggregation_replacement_agent_ids(  # type: ignore[attr-defined]
+                self.agent_version,
+                [
+                    int(item.user_playbook_id)
+                    for item in outcome.source_cluster
+                    if item.user_playbook_id is not None
+                ],
+            )
+            for outcome in outcomes
+            if outcome.status == "generated"
+        }
+        replaced_agent_ids: set[int] = set()
+        generated_playbooks = [
+            item.playbook
+            for item in outcomes
+            if item.status == "generated" and item.playbook is not None
+        ]
+        prepare = getattr(type(self.storage), "prepare_agent_playbooks_for_save", None)
+        if callable(prepare):
+            prepare(self.storage, generated_playbooks)
+        with self.storage.commit_scope():  # type: ignore[attr-defined]
+            self._require_live_aggregation_claim()
+            self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                self.agent_version,
+                missing_embedding_ids,
+                disposition="residual",
+                reason="embedding_pending",
+            )
+            self.storage.attach_playbook_aggregation_items(  # type: ignore[attr-defined]
+                agent_version=self.agent_version,
+                attachments=[
+                    (int(item.user_playbook_id), cluster_id, item.embedding)
+                    for item, cluster_id in attachments
+                    if item.user_playbook_id is not None and item.embedding
+                ],
+            )
+            for outcome in outcomes:
+                members = outcome.source_cluster
+                member_ids = [
+                    int(item.user_playbook_id)
+                    for item in members
+                    if item.user_playbook_id is not None
+                ]
+                if outcome.status == "retryable_failure":
+                    self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                        self.agent_version,
+                        member_ids,
+                        disposition="residual",
+                        reason="llm_retryable_failure",
+                    )
+                    continue
+                if outcome.status == "semantic_null":
+                    self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                        self.agent_version,
+                        member_ids,
+                        disposition="terminal_noop",
+                        reason="semantic_null",
+                    )
+                    continue
+                if outcome.playbook is None:
+                    raise RuntimeError("generated outcome is missing its playbook")
+                lineage_contexts = [
+                    LineageContext(
+                        op_kind="aggregate",
+                        actor="aggregator",
+                        request_id=run_id,
+                        source_ids=[str(value) for value in member_ids],
+                        reason=f"{AGGREGATE_REASON_PREFIX}incremental",
+                        model_name=(
+                            outcome.provenance.model_name
+                            if outcome.provenance
+                            else None
+                        ),
+                        provider=(
+                            outcome.provenance.provider if outcome.provenance else None
+                        ),
+                    )
+                ]
+                prepared_save = getattr(
+                    type(self.storage), "save_prepared_agent_playbooks", None
+                )
+                if callable(prepared_save):
+                    saved = prepared_save(  # pyright: ignore[reportIndexIssue]
+                        self.storage,
+                        [outcome.playbook],
+                        lineage_contexts=lineage_contexts,
+                    )[0]
+                else:
+                    saved = self.storage.save_agent_playbooks(  # type: ignore[attr-defined]
+                        [outcome.playbook], lineage_contexts=lineage_contexts
+                    )[0]
+                saved_playbooks.append(saved)
+                replaced_agent_ids.update(replacement_agent_ids_by_outcome[id(outcome)])
+                embeddings = [item.embedding for item in members if item.embedding]
+                cluster_id = self._stable_aggregation_cluster_id(
+                    self._compute_cluster_fingerprint(members)
+                )
+                self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
+                    cluster_id=cluster_id,
+                    agent_version=self.agent_version,
+                    agent_playbook_id=saved.agent_playbook_id,
+                    embeddings=embeddings,
+                    embedding_model=self.storage.embedding_model_name,
+                )
+                self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                    self.agent_version,
+                    member_ids,
+                    disposition="cluster_member",
+                    cluster_id=cluster_id,
+                    reason="generated",
+                )
+            supersessions = self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+                sorted(replaced_agent_ids), request_id=run_id
+            )
+            self.storage.delete_orphaned_playbook_aggregation_clusters(  # type: ignore[attr-defined]
+                self.agent_version
+            )
+            self._require_live_aggregation_claim()
+
+        stats = {
+            "clusters_found": len(clusters),
+            "user_playbooks_processed": len(user_playbooks),
+            "playbooks_generated": len(saved_playbooks),
+            "staged": len(staged_ids),
+            "attachments": len(attachments),
+            "supersessions": supersessions,
+            "retryable_failures": len(retryable_outcomes),
+        }
+        self._enqueue_playbook_optimization(saved_playbooks)
+        record_usage_event(
+            org_id=self.request_context.org_id,
+            event_name="aggregation_succeeded",
+            event_category="aggregation",
+            pipeline="playbook",
+            playbook_name=SINGLETON_USER_PLAYBOOK_NAME,
+            agent_version=self.agent_version,
+            outcome="partial_failure" if retryable_outcomes else "success",
+            count_value=len(saved_playbooks),
+            duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
+            metadata=stats,
+        )
+        self._record_learnings_generated(
+            learning_ids=[
+                str(item.agent_playbook_id)
+                for item in saved_playbooks
+                if item.agent_playbook_id is not None
+            ],
+            playbook_name=SINGLETON_USER_PLAYBOOK_NAME,
+            request_id=run_id,
+            metadata=stats,
+            total_count=len(saved_playbooks),
+        )
+        return stats
+
+    def _stable_aggregation_cluster_id(self, fingerprint: str) -> str:
+        return str(
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                f"{self.request_context.org_id}:{self.agent_version}:{fingerprint}",
+            )
+        )
+
+    def _adopt_legacy_aggregation_state(self, *, budget: int) -> tuple[int, bool]:
+        """Rebuild legacy fingerprint centroids in bounded, resumable pages."""
+        status = self.storage.get_playbook_aggregation_bootstrap_status(  # type: ignore[attr-defined]
+            self.agent_version
+        )
+        if status == "complete":
+            return 0, True
+        mgr = self._create_state_manager()
+        fingerprints = mgr.get_cluster_fingerprints(
+            name=SINGLETON_USER_PLAYBOOK_NAME, version=self.agent_version
+        )
+        if not isinstance(fingerprints, dict):
+            fingerprints = {}
+        consumed = 0
+        for fingerprint in sorted(fingerprints):
+            data = fingerprints[fingerprint]
+            if not isinstance(data, dict) or data.get("agent_playbook_id") is None:
+                # A legacy None is ambiguous (semantic null vs. failed output),
+                # so its members remain undisposed and are retried normally.
+                continue
+            try:
+                agent_playbook_id = int(data["agent_playbook_id"])
+                member_ids = sorted(
+                    {
+                        int(value)
+                        for value in data.get("user_playbook_ids", [])
+                        if int(value) > 0
+                    }
+                )
+            except (TypeError, ValueError):
+                continue
+            cluster_id = self._stable_aggregation_cluster_id(fingerprint)
+            progress = self.storage.get_playbook_aggregation_cluster_rebuild_cursor(  # type: ignore[attr-defined]
+                cluster_id
+            )
+            if progress is not None and progress[1] == "active":
+                continue
+            cursor = progress[0] if progress is not None else 0
+            pending_ids = [value for value in member_ids if value > cursor]
+            remaining = budget - consumed
+            if pending_ids and remaining <= 0:
+                return consumed, False
+            page_ids = pending_ids[:remaining]
+            consumed += len(page_ids)
+            rows = self.storage.get_user_playbooks_by_ids_any_user(  # type: ignore[call-arg]
+                page_ids,
+                status_filter=[None],
+                include_embedding=False,
+            )
+            rows_by_id = {
+                int(item.user_playbook_id): item
+                for item in rows
+                if item.user_playbook_id is not None
+            }
+            member_embeddings: list[tuple[int, list[float]]] = []
+            rebuild_cursor = cursor
+            blocked = False
+            embed = getattr(self.storage, "_get_embedding", None)
+            if not callable(embed) and page_ids:
+                raise RuntimeError("aggregation storage cannot re-embed legacy members")
+            embed_fn = cast(Callable[[str], list[float]], embed)
+            for user_playbook_id in page_ids:
+                item = rows_by_id.get(user_playbook_id)
+                if item is None or not item.content or not item.content.strip():
+                    rebuild_cursor = user_playbook_id
+                    continue
+                try:
+                    value = embed_fn(embedding_text(item))
+                except Exception:  # noqa: BLE001 - retry this exact member next run
+                    blocked = True
+                    break
+                if not value:
+                    blocked = True
+                    break
+                member_embeddings.append((user_playbook_id, cast(list[float], value)))
+                rebuild_cursor = user_playbook_id
+            complete = not blocked and rebuild_cursor >= max(member_ids, default=0)
+            if rebuild_cursor > cursor or not member_ids:
+                with self.storage.commit_scope():  # type: ignore[attr-defined]
+                    self._require_live_aggregation_claim()
+                    self.storage.adopt_legacy_playbook_aggregation_cluster_page(  # type: ignore[attr-defined]
+                        cluster_id=cluster_id,
+                        agent_version=self.agent_version,
+                        agent_playbook_id=agent_playbook_id,
+                        member_embeddings=member_embeddings,
+                        embedding_model=self.storage.embedding_model_name,
+                        embedding_dimension=int(
+                            self.storage.embedding_dimensions  # type: ignore[attr-defined]
+                        ),
+                        rebuild_cursor=rebuild_cursor,
+                        complete=complete,
+                    )
+                    self._require_live_aggregation_claim()
+            if blocked or not complete:
+                return consumed, False
+
+        with self.storage.commit_scope():  # type: ignore[attr-defined]
+            self._require_live_aggregation_claim()
+            self.storage.set_playbook_aggregation_bootstrap_status(  # type: ignore[attr-defined]
+                self.agent_version, "complete"
+            )
+            self._require_live_aggregation_claim()
+        return consumed, True
+
+    def _require_live_aggregation_claim(self) -> None:
+        if self.aggregation_claim is None:
+            return
+        if not self.storage.validate_playbook_aggregation_claim(  # type: ignore[attr-defined]
+            self.aggregation_claim
+        ):
+            raise RuntimeError("playbook aggregation effect lost its database fence")
+
     def run(self, playbook_aggregator_request: PlaybookAggregatorRequest) -> dict:  # noqa: C901
         """Run playbook aggregation.
 
@@ -382,6 +825,19 @@ class PlaybookAggregator:
                 **_empty_stats,
                 "skipped": skip_reason,
             }
+
+        if (
+            not playbook_aggregator_request.rerun
+            and getattr(
+                self.storage, "supports_incremental_playbook_aggregation", False
+            )
+            is True
+        ):
+            return self._run_incremental(
+                config=playbook_aggregator_config,
+                run_id=_run_id,
+                aggregation_start=aggregation_start,
+            )
 
         # Check if we should run aggregation based on new playbooks count
         # For rerun, use all user playbooks (last_processed_id=0) to determine if aggregation is needed
@@ -452,6 +908,7 @@ class PlaybookAggregator:
             lambda limit, max_id: self.storage.get_agent_playbooks(  # type: ignore[reportOptionalMemberAccess]
                 limit=limit,
                 max_agent_playbook_id=max_id,
+                agent_version=self.agent_version,
                 status_filter=[None],  # Current playbooks only
                 playbook_status_filter=[
                     PlaybookStatus.APPROVED,
@@ -471,11 +928,22 @@ class PlaybookAggregator:
         # reached -- the cap has to be enforced ahead of the load, not just
         # inside get_clusters().
         max_playbooks = aggregator_clustering.max_clustering_playbooks()
-        total_user_playbooks = self.storage.count_user_playbooks(  # pyright: ignore[reportOptionalMemberAccess]
-            min_user_playbook_id=0,
-            agent_version=self.agent_version,
-            status_filter=[None],
-        )
+        rerun_invalidation_ids: list[int] = []
+        if playbook_aggregator_request.rerun and self.aggregation_claim is not None:
+            rerun_snapshot = self.storage.capture_playbook_aggregation_rerun_snapshot(  # type: ignore[attr-defined]
+                self.agent_version,
+                limit=max_playbooks + 1,
+            )
+            user_playbooks = list(rerun_snapshot.user_playbooks)
+            user_high_watermark = rerun_snapshot.user_high_watermark
+            rerun_invalidation_ids = list(rerun_snapshot.invalidation_ids)
+            total_user_playbooks = len(user_playbooks)
+        else:
+            total_user_playbooks = self.storage.count_user_playbooks(  # pyright: ignore[reportOptionalMemberAccess]
+                min_user_playbook_id=0,
+                agent_version=self.agent_version,
+                status_filter=[None],
+            )
         if total_user_playbooks > max_playbooks:
             logger.error(
                 "Skipping user playbook aggregation for '%s' (agent_version=%s): "
@@ -500,25 +968,26 @@ class PlaybookAggregator:
                     "max_clustering_playbooks": max_playbooks,
                 },
             )
-            return {
-                **_empty_stats,
-                "skipped": (
-                    f"too many user playbooks to cluster "
-                    f"({total_user_playbooks} > {max_playbooks})"
-                ),
-            }
+            raise RuntimeError(
+                "full aggregation rerun exceeds the safety cap "
+                f"({total_user_playbooks} > {max_playbooks})"
+            )
 
-        # get all user playbooks and generate clusters
-        user_playbooks, user_high_watermark = _read_all_pages(
-            lambda limit, max_id: self.storage.get_user_playbooks(  # type: ignore[reportOptionalMemberAccess]
-                limit=limit,
-                max_user_playbook_id=max_id,
-                agent_version=self.agent_version,
-                status_filter=[None],  # Current playbooks only
-                include_embedding=True,
-            ),
-            lambda playbook: playbook.user_playbook_id,
-        )
+        # Non-fenced legacy runs retain ordinary pagination. Fenced reruns use
+        # the pre-compute repeatable-read snapshot materialized above.
+        if not (
+            playbook_aggregator_request.rerun and self.aggregation_claim is not None
+        ):
+            user_playbooks, user_high_watermark = _read_all_pages(
+                lambda limit, max_id: self.storage.get_user_playbooks(  # type: ignore[reportOptionalMemberAccess]
+                    limit=limit,
+                    max_user_playbook_id=max_id,
+                    agent_version=self.agent_version,
+                    status_filter=[None],  # Current playbooks only
+                    include_embedding=True,
+                ),
+                lambda playbook: playbook.user_playbook_id,
+            )
         full_archive_playbook_names = sorted(
             {
                 playbook.playbook_name
@@ -637,6 +1106,28 @@ class PlaybookAggregator:
                 pending_scope = self.effect_coordinator.apply_scope()
                 pending_scope.__enter__()
                 effect_scope = pending_scope
+            elif self.aggregation_claim is not None:
+                prepare = getattr(
+                    type(self.storage), "prepare_agent_playbooks_for_save", None
+                )
+                if callable(prepare):
+                    prepare(self.storage, new_playbooks)
+                pending_scope = self.storage.commit_scope()  # type: ignore[attr-defined]
+                pending_scope.__enter__()
+                effect_scope = pending_scope
+                self._require_live_aggregation_claim()
+            if (
+                playbook_aggregator_request.rerun
+                and self.aggregation_claim is not None
+                and new_playbooks
+            ):
+                self.storage.reset_playbook_aggregation_version(  # type: ignore[attr-defined]
+                    self.agent_version
+                )
+                self.storage.stage_playbook_aggregation_snapshot(  # type: ignore[attr-defined]
+                    self.agent_version,
+                    [item.user_playbook_id for item in user_playbooks],
+                )
 
             previous_fingerprints_for_changed_clusters = {}
             changed_fps_by_previous_fp = {}
@@ -726,22 +1217,30 @@ class PlaybookAggregator:
                     if fb.user_playbook_id
                 ]
                 if self.effect_coordinator is None:
-                    saved_fb = self.storage.save_agent_playbooks(  # type: ignore[reportOptionalMemberAccess]
-                        [playbook],
-                        lineage_contexts=[
-                            LineageContext(
-                                op_kind="aggregate",
-                                actor="aggregator",
-                                request_id=_run_id,
-                                source_ids=member_ids,
-                                reason=f"{AGGREGATE_REASON_PREFIX}{run_mode}",
-                                model_name=(
-                                    provenance.model_name if provenance else None
-                                ),
-                                provider=provenance.provider if provenance else None,
-                            )
-                        ],
-                    )[0]
+                    lineage_contexts = [
+                        LineageContext(
+                            op_kind="aggregate",
+                            actor="aggregator",
+                            request_id=_run_id,
+                            source_ids=member_ids,
+                            reason=f"{AGGREGATE_REASON_PREFIX}{run_mode}",
+                            model_name=provenance.model_name if provenance else None,
+                            provider=provenance.provider if provenance else None,
+                        )
+                    ]
+                    prepared_save = getattr(
+                        type(self.storage), "save_prepared_agent_playbooks", None
+                    )
+                    if self.aggregation_claim is not None and callable(prepared_save):
+                        saved_fb = prepared_save(  # pyright: ignore[reportIndexIssue]
+                            self.storage,
+                            [playbook],
+                            lineage_contexts=lineage_contexts,
+                        )[0]
+                    else:
+                        saved_fb = self.storage.save_agent_playbooks(  # type: ignore[reportOptionalMemberAccess]
+                            [playbook], lineage_contexts=lineage_contexts
+                        )[0]
                 else:
                     saved_fb = self.effect_coordinator.save_agent_playbook(
                         playbook,
@@ -759,6 +1258,31 @@ class PlaybookAggregator:
                         "agent_playbook_id": saved_fb.agent_playbook_id,
                         "user_playbook_ids": raw_ids,
                     }
+                    if (
+                        playbook_aggregator_request.rerun
+                        and self.aggregation_claim is not None
+                    ):
+                        cluster_embeddings = [
+                            item.embedding
+                            for item in cluster_playbooks
+                            if item.embedding
+                        ]
+                        if cluster_embeddings:
+                            cluster_id = self._stable_aggregation_cluster_id(fp_key)
+                            self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
+                                cluster_id=cluster_id,
+                                agent_version=self.agent_version,
+                                agent_playbook_id=saved_fb.agent_playbook_id,
+                                embeddings=cluster_embeddings,
+                                embedding_model=self.storage.embedding_model_name,
+                            )
+                            self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                                self.agent_version,
+                                raw_ids,
+                                disposition="cluster_member",
+                                cluster_id=cluster_id,
+                                reason="full_rerun",
+                            )
                     for prev_fp in previous_fingerprints_for_changed_clusters.get(
                         fp_key, {}
                     ):
@@ -891,7 +1415,10 @@ class PlaybookAggregator:
                         org_id=self.request_context.org_id,
                         request_id=_run_id,
                     )
-                    if self.effect_coordinator is not None:
+                    if (
+                        self.effect_coordinator is not None
+                        or self.aggregation_claim is not None
+                    ):
                         raise
 
             stats = {
@@ -899,10 +1426,29 @@ class PlaybookAggregator:
                 "user_playbooks_processed": len(user_playbooks),
                 "playbooks_generated": len(saved_playbook_list),
             }
+            if (
+                playbook_aggregator_request.rerun
+                and self.aggregation_claim is not None
+                and new_playbooks
+                and not self.storage.mark_playbook_aggregation_invalidations_processed(  # type: ignore[attr-defined]
+                    self.aggregation_claim,
+                    rerun_invalidation_ids,
+                )
+            ):
+                raise RuntimeError(
+                    "playbook aggregation rerun lost its invalidation fence"
+                )
             if self.effect_coordinator is not None:
                 self.effect_coordinator.complete(stats)
                 if effect_scope is None:
                     raise RuntimeError("aggregation effect scope was not entered")
+                completed_scope = effect_scope
+                effect_scope = None
+                completed_scope.__exit__(None, None, None)
+            elif self.aggregation_claim is not None:
+                self._require_live_aggregation_claim()
+                if effect_scope is None:
+                    raise RuntimeError("aggregation claim scope was not entered")
                 completed_scope = effect_scope
                 effect_scope = None
                 completed_scope.__exit__(None, None, None)
@@ -938,7 +1484,7 @@ class PlaybookAggregator:
                 duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
                 error_kind=type(e).__name__,
             )
-            if self.effect_coordinator is None:
+            if self.effect_coordinator is None and self.aggregation_claim is None:
                 logger.error(
                     "Error during playbook aggregation for '%s': %s. Restoring archived playbooks.",
                     playbook_name,
@@ -1105,16 +1651,34 @@ class PlaybookAggregator:
         existing_approved_playbooks: list[AgentPlaybook],
         direction_overlap_threshold: float = 0.6,
     ) -> list[tuple[AgentPlaybook, list[UserPlaybook], ModelProvenance | None]]:
-        """Generate playbooks with their exact source cluster and provenance."""
-        new_playbooks: list[
-            tuple[AgentPlaybook, list[UserPlaybook], ModelProvenance | None]
-        ] = []
-        approved_playbooks_str = (
-            "\n".join([f"- {fb.content}" for fb in existing_approved_playbooks])
-            if existing_approved_playbooks
-            else "None"
-        )
+        """Compatibility view containing only generated outcomes."""
+        return [
+            (outcome.playbook, outcome.source_cluster, outcome.provenance)
+            for outcome in self._generate_playbook_outcomes_with_source_clusters(
+                clusters,
+                existing_approved_playbooks,
+                direction_overlap_threshold,
+            )
+            if outcome.status == "generated" and outcome.playbook is not None
+        ]
+
+    def _generate_playbook_outcomes_with_source_clusters(
+        self,
+        clusters: dict[int, list[UserPlaybook]],
+        existing_approved_playbooks: list[AgentPlaybook],
+        direction_overlap_threshold: float = 0.6,
+    ) -> list[AggregationGenerationOutcome]:
+        """Return one tagged outcome for every selected source cluster."""
+        outcomes: list[AggregationGenerationOutcome] = []
         for cluster_playbooks in clusters.values():
+            relevant_existing = _select_relevant_existing_playbooks(
+                cluster_playbooks, existing_approved_playbooks
+            )
+            approved_playbooks_str = (
+                "\n".join(f"- {item.content}" for item in relevant_existing)
+                if relevant_existing
+                else "None"
+            )
             shared_state: dict[str, object] = {}
             processing_context = AggregationPromptProcessingContext(
                 data={
@@ -1132,16 +1696,21 @@ class PlaybookAggregator:
                     for playbook in cluster_playbooks
                 ]
 
-            generated = self._generate_playbook_from_cluster(
+            generated = self._generate_playbook_from_cluster_outcome(
                 prompt_cluster_playbooks,
                 approved_playbooks_str,
                 direction_overlap_threshold=direction_overlap_threshold,
                 processing_context=processing_context,
             )
-            if generated is not None:
-                playbook, provenance = generated
-                new_playbooks.append((playbook, cluster_playbooks, provenance))
-        return new_playbooks
+            outcomes.append(
+                AggregationGenerationOutcome(
+                    status=generated.status,
+                    source_cluster=cluster_playbooks,
+                    playbook=generated.playbook,
+                    provenance=generated.provenance,
+                )
+            )
+        return outcomes
 
     def _enqueue_playbook_optimization(
         self, saved_playbooks: Sequence[AgentPlaybook | None]
@@ -1189,6 +1758,24 @@ class PlaybookAggregator:
         direction_overlap_threshold: float = 0.6,
         processing_context: AggregationPromptProcessingContext | None = None,
     ) -> tuple[AgentPlaybook, ModelProvenance | None] | None:
+        """Compatibility view of the tagged generation result."""
+        outcome = self._generate_playbook_from_cluster_outcome(
+            cluster_playbooks,
+            existing_approved_playbooks_str,
+            direction_overlap_threshold,
+            processing_context,
+        )
+        if outcome.status != "generated" or outcome.playbook is None:
+            return None
+        return outcome.playbook, outcome.provenance
+
+    def _generate_playbook_from_cluster_outcome(
+        self,
+        cluster_playbooks: list[UserPlaybook],
+        existing_approved_playbooks_str: str,
+        direction_overlap_threshold: float = 0.6,
+        processing_context: AggregationPromptProcessingContext | None = None,
+    ) -> AggregationGenerationOutcome:
         """
         Generate a playbook from a cluster using structured JSON output.
 
@@ -1201,7 +1788,7 @@ class PlaybookAggregator:
             Generated playbook and its provenance, or None if no new playbook is needed
         """
         if not cluster_playbooks:
-            return None
+            return AggregationGenerationOutcome("retryable_failure", [])
 
         if os.getenv("MOCK_LLM_RESPONSE", "").lower() == "true":
             # Extract structured fields directly from cluster
@@ -1213,7 +1800,9 @@ class PlaybookAggregator:
             first_content = cluster_playbooks[0].content
             if not first_content:
                 logger.info("No valid content in cluster, skipping")
-                return None
+                return AggregationGenerationOutcome(
+                    "retryable_failure", cluster_playbooks
+                )
 
             # Build content directly as a freeform summary
             content_text = f"When {trigger}, {first_content}."
@@ -1229,12 +1818,17 @@ class PlaybookAggregator:
                 processing_context,
             )
             self._postproc._record_postprocessing_artifacts(artifact_count)
-            playbook = self._process_aggregation_response(response, cluster_playbooks)
-            if playbook is None:
-                return None
-            return (
-                playbook.model_copy(update={"playbook_metadata": "mock_generated"}),
-                None,
+            processed = self._process_aggregation_response_outcome(
+                response, cluster_playbooks
+            )
+            if processed.status != "generated" or processed.playbook is None:
+                return processed
+            return AggregationGenerationOutcome(
+                "generated",
+                cluster_playbooks,
+                processed.playbook.model_copy(
+                    update={"playbook_metadata": "mock_generated"}
+                ),
             )
 
         # Format raw playbooks for prompt using structured format
@@ -1291,12 +1885,19 @@ class PlaybookAggregator:
                     "LLM response was not parsed as PlaybookAggregationOutput (got %s), returning None.",
                     type(response).__name__,
                 )
-                return None
+                return AggregationGenerationOutcome(
+                    "retryable_failure", cluster_playbooks
+                )
 
-            playbook = self._process_aggregation_response(response, cluster_playbooks)
-            if playbook is None:
-                return None
-            return playbook, model_provenance
+            processed = self._process_aggregation_response_outcome(
+                response, cluster_playbooks
+            )
+            return AggregationGenerationOutcome(
+                processed.status,
+                cluster_playbooks,
+                processed.playbook,
+                model_provenance if processed.status == "generated" else None,
+            )
         except Exception as exc:
             processed_error, artifact_count = (
                 self._postproc._postprocess_aggregation_output(
@@ -1309,11 +1910,21 @@ class PlaybookAggregator:
                 "AgentPlaybook aggregation failed due to %s, returning None.",
                 processed_error,
             )
-            return None
+            return AggregationGenerationOutcome("retryable_failure", cluster_playbooks)
 
     def _process_aggregation_response(
         self, response: PlaybookAggregationOutput, cluster_playbooks: list[UserPlaybook]
     ) -> AgentPlaybook | None:
+        """Compatibility view of the tagged response classification."""
+        return self._process_aggregation_response_outcome(
+            response, cluster_playbooks
+        ).playbook
+
+    def _process_aggregation_response_outcome(
+        self,
+        response: PlaybookAggregationOutput,
+        cluster_playbooks: list[UserPlaybook],
+    ) -> AggregationGenerationOutcome:
         """
         Process structured response from LLM into AgentPlaybook.
 
@@ -1328,32 +1939,36 @@ class PlaybookAggregator:
             AgentPlaybook or None if no playbook should be generated
         """
         if not response:
-            return None
+            return AggregationGenerationOutcome("retryable_failure", cluster_playbooks)
 
         structured = response.playbook
         if structured is None:
             logger.info("LLM returned null playbook (duplicate of existing)")
-            return None
+            return AggregationGenerationOutcome("semantic_null", cluster_playbooks)
 
         # content is always the LLM's freeform summary;
         # fall back to formatted structured fields for backward compatibility
         playbook_content = ensure_playbook_content(structured.content, structured)
         if not playbook_content.strip():
             logger.info("Aggregated playbook has no valid content, skipping")
-            return None
+            return AggregationGenerationOutcome("retryable_failure", cluster_playbooks)
         logger.info(
             "Aggregated playbook content (freeform): %.200s",
             playbook_content,
         )
 
-        return AgentPlaybook(
-            playbook_name=cluster_playbooks[0].playbook_name,
-            agent_version=cluster_playbooks[0].agent_version,
-            content=playbook_content,
-            trigger=structured.trigger,
-            rationale=structured.rationale,
-            playbook_status=PlaybookStatus.PENDING,
-            playbook_metadata="",
+        return AggregationGenerationOutcome(
+            "generated",
+            cluster_playbooks,
+            AgentPlaybook(
+                playbook_name=cluster_playbooks[0].playbook_name,
+                agent_version=cluster_playbooks[0].agent_version,
+                content=playbook_content,
+                trigger=structured.trigger,
+                rationale=structured.rationale,
+                playbook_status=PlaybookStatus.PENDING,
+                playbook_metadata="",
+            ),
         )
 
     def _get_playbook_aggregator_config(self) -> PlaybookAggregatorConfig | None:

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -669,6 +669,10 @@ class PlaybookAggregator:
                 )
             except (TypeError, ValueError):
                 continue
+            if not member_ids:
+                # Empty legacy fingerprints have no centroid to adopt and must not
+                # become active clusters that nearest-centroid lookup cannot find.
+                continue
             cluster_id = self._stable_aggregation_cluster_id(fingerprint)
             progress = self.storage.get_playbook_aggregation_cluster_rebuild_cursor(  # type: ignore[attr-defined]
                 cluster_id

--- a/reflexio/server/services/playbook/components/aggregator_clustering.py
+++ b/reflexio/server/services/playbook/components/aggregator_clustering.py
@@ -17,7 +17,8 @@ logger = logging.getLogger(__name__)
 # Above this, use HDBSCAN (scales better, handles noise)
 CLUSTERING_ALGORITHM_THRESHOLD = 50
 
-# Upper bound on how many user playbooks a single aggregation run will cluster.
+# Shared upper bound on rows/embeddings consumed by one incremental run. Full
+# administrative reruns use the same value as a fail-before-mutation safety cap.
 #
 # This is a CPU bound, not a memory bound. HDBSCAN runs on raw unit-normalized
 # vectors (see cluster_with_hdbscan), so peak RSS stays flat -- ~320 MB at
@@ -27,8 +28,8 @@ CLUSTERING_ALGORITHM_THRESHOLD = 50
 #     n= 2_000 ->   1.3 s      n=10_000 ->  32 s
 #     n= 5_000 ->   8.0 s      n=20_000 -> 126 s
 #
-# Aggregation runs on a background daemon thread that shares one vCPU with
-# request serving, so the default is set where a run costs ~2 minutes.
+# The scheduler is durable and fleet-fenced, but still shares CPU with request
+# serving, so the default is set where one worst-case Stage B batch costs ~2 min.
 MAX_CLUSTERING_PLAYBOOKS_DEFAULT = 20_000
 MAX_CLUSTERING_PLAYBOOKS_ENV = "REFLEXIO_MAX_CLUSTERING_PLAYBOOKS"
 

--- a/reflexio/server/services/playbook/components/aggregator_prompt_formatting.py
+++ b/reflexio/server/services/playbook/components/aggregator_prompt_formatting.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from reflexio.models.api_schema.service_schemas import UserPlaybook
 
+MAX_EXACT_DIRECTION_GROUPING_ITEMS = 256
+
 
 def get_direction_key(fb: UserPlaybook) -> str:
     """
@@ -118,6 +120,11 @@ def format_structured_cluster_input(
     Returns:
         str: Formatted input for the aggregation prompt
     """
+    # Exact greedy grouping compares members pairwise. Preserve that useful hint
+    # for normal prompt-sized clusters, but keep formatting work linear once a
+    # cluster is large enough for the quadratic pass to matter.
+    if len(cluster_playbooks) > MAX_EXACT_DIRECTION_GROUPING_ITEMS:
+        return format_flat(cluster_playbooks)
     groups = group_playbooks_by_direction(
         cluster_playbooks, threshold=direction_overlap_threshold
     )

--- a/reflexio/server/services/profile/profile_generation_service_utils.py
+++ b/reflexio/server/services/profile/profile_generation_service_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
@@ -168,7 +168,7 @@ def calculate_expiration_timestamp(
     if profile_time_to_live == ProfileTimeToLive.INFINITY:
         return NEVER_EXPIRES_TIMESTAMP
 
-    last_modified_datetime = datetime.fromtimestamp(last_modified_timestamp)
+    last_modified_datetime = datetime.fromtimestamp(last_modified_timestamp, tz=UTC)
     if profile_time_to_live == ProfileTimeToLive.ONE_DAY:
         expiration_timestamp = last_modified_datetime + timedelta(days=1)
     elif profile_time_to_live == ProfileTimeToLive.ONE_WEEK:

--- a/reflexio/server/services/storage/sqlite_storage/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/__init__.py
@@ -43,6 +43,7 @@ from .playbook import (
     AgentEvaluationResultStoreMixin,
     AgentPlaybookStoreMixin,
     OptimizationJobStoreMixin,
+    PlaybookAggregationStoreMixin,
     PlaybookSourceLinkageMixin,
     UserPlaybookStoreMixin,
 )
@@ -59,6 +60,7 @@ class SQLiteStorage(
     ProfileSearchMixin,
     RequestMixin,
     SessionOutcomeStoreMixin,
+    PlaybookAggregationStoreMixin,
     AgentPlaybookStoreMixin,
     UserPlaybookStoreMixin,
     PlaybookSourceLinkageMixin,

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -810,6 +810,10 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
     # ------------------------------------------------------------------
 
     def migrate(self) -> bool:
+        # Import lazily: the aggregation mixin shares this base and importing its
+        # package while ``_base`` is still initializing would create a cycle.
+        from .playbook._aggregation import init_playbook_aggregation_tables
+
         self._migrate_feedback_schema()
         self._migrate_interactions_schema()
         # Backfill columns that _DDL indexes depend on BEFORE running _DDL.
@@ -843,6 +847,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             cur = self.conn.cursor()
             cur.executescript(_DDL)
             init_governance_tables(self.conn)
+            init_playbook_aggregation_tables(self.conn)
             self.conn.commit()
         self._migrate_session_outcomes_schema()
         if self._has_sqlite_vec:
@@ -910,6 +915,9 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 embedding float[{dim}]
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS agent_playbooks_vec USING vec0(
+                embedding float[{dim}]
+            );
+            CREATE VIRTUAL TABLE IF NOT EXISTS playbook_aggregation_clusters_vec USING vec0(
                 embedding float[{dim}]
             );
         """

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -918,7 +918,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                 embedding float[{dim}]
             );
             CREATE VIRTUAL TABLE IF NOT EXISTS playbook_aggregation_clusters_vec USING vec0(
-                embedding float[{dim}]
+                embedding float[{dim}] distance_metric=cosine
             );
         """
         with self._lock:

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -68,7 +68,7 @@ def _append_event_stmt(
 
     Returns the cursor so callers can inspect ``rowcount``/``lastrowid``.
     """
-    return conn.execute(
+    cursor = conn.execute(
         "INSERT OR IGNORE INTO lineage_event "
         "(org_id, entity_type, entity_id, op, prov_relation, source_ids, "
         "actor, request_id, reason, created_at, "
@@ -93,6 +93,39 @@ def _append_event_stmt(
             provider,
         ),
     )
+    if (
+        cursor.rowcount > 0
+        and entity_type == "user_playbook"
+        and op in {"create", "merge", "revise", "status_change", "purge"}
+    ):
+        candidate_ids = [
+            int(value) for value in [entity_id, *source_ids] if str(value).isdigit()
+        ]
+        if not candidate_ids:
+            return cursor
+        placeholders = ",".join("?" for _ in candidate_ids)
+        version_row = conn.execute(
+            "SELECT agent_version FROM user_playbooks "
+            f"WHERE user_playbook_id IN ({placeholders}) "
+            "AND trim(agent_version) <> '' LIMIT 1",
+            candidate_ids,
+        ).fetchone()
+        if version_row is not None:
+            agent_version = str(version_row[0])
+            conn.execute(
+                "INSERT INTO playbook_aggregation_invalidation "
+                "(agent_version, operation, entity_id, source_ids) VALUES (?, ?, ?, ?)",
+                (agent_version, op, int(entity_id), json.dumps(source_ids)),
+            )
+            conn.execute(
+                "INSERT INTO playbook_aggregation_state "
+                "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
+                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
+                "excluded.next_attempt_at)",
+                (agent_version,),
+            )
+    return cursor
 
 
 # Per-entity purge SQL: blank every PII/content column.

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -101,26 +101,37 @@ def _append_event_stmt(
         if not str(entity_id).isdigit():
             return cursor
         parsed_entity_id = int(entity_id)
-        candidate_ids = [
-            int(value)
-            for value in [parsed_entity_id, *source_ids]
-            if str(value).isdigit()
-        ]
+        candidate_ids = sorted(
+            {
+                int(value)
+                for value in [parsed_entity_id, *source_ids]
+                if str(value).isdigit()
+            }
+        )
         if not candidate_ids:
             return cursor
         placeholders = ",".join("?" for _ in candidate_ids)
-        version_row = conn.execute(
-            "SELECT agent_version FROM user_playbooks "
+        version_rows = conn.execute(
+            "SELECT user_playbook_id, agent_version FROM user_playbooks "
             f"WHERE user_playbook_id IN ({placeholders}) "
-            "AND trim(agent_version) <> '' LIMIT 1",
+            "AND trim(agent_version) <> '' "
+            "ORDER BY agent_version, user_playbook_id",
             candidate_ids,
-        ).fetchone()
-        if version_row is not None:
-            agent_version = str(version_row[0])
+        ).fetchall()
+        candidate_version_by_id = {
+            int(row[0]): str(row[1]).strip() for row in version_rows
+        }
+        source_id_values = [int(value) for value in source_ids if str(value).isdigit()]
+        for agent_version in sorted(set(candidate_version_by_id.values())):
+            version_source_ids = [
+                value
+                for value in source_id_values
+                if candidate_version_by_id.get(value) == agent_version
+            ]
             conn.execute(
                 "INSERT INTO playbook_aggregation_invalidation "
                 "(agent_version, operation, entity_id, source_ids) VALUES (?, ?, ?, ?)",
-                (agent_version, op, parsed_entity_id, json.dumps(source_ids)),
+                (agent_version, op, parsed_entity_id, json.dumps(version_source_ids)),
             )
             conn.execute(
                 "INSERT INTO playbook_aggregation_state "

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -98,8 +98,13 @@ def _append_event_stmt(
         and entity_type == "user_playbook"
         and op in {"create", "merge", "revise", "status_change", "purge"}
     ):
+        if not str(entity_id).isdigit():
+            return cursor
+        parsed_entity_id = int(entity_id)
         candidate_ids = [
-            int(value) for value in [entity_id, *source_ids] if str(value).isdigit()
+            int(value)
+            for value in [parsed_entity_id, *source_ids]
+            if str(value).isdigit()
         ]
         if not candidate_ids:
             return cursor
@@ -115,7 +120,7 @@ def _append_event_stmt(
             conn.execute(
                 "INSERT INTO playbook_aggregation_invalidation "
                 "(agent_version, operation, entity_id, source_ids) VALUES (?, ?, ?, ?)",
-                (agent_version, op, int(entity_id), json.dumps(source_ids)),
+                (agent_version, op, parsed_entity_id, json.dumps(source_ids)),
             )
             conn.execute(
                 "INSERT INTO playbook_aggregation_state "

--- a/reflexio/server/services/storage/sqlite_storage/playbook/__init__.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/__init__.py
@@ -1,10 +1,12 @@
 from ._agent import AgentPlaybookStoreMixin
+from ._aggregation import PlaybookAggregationStoreMixin
 from ._eval_results import AgentEvaluationResultStoreMixin
 from ._optimization import OptimizationJobStoreMixin
 from ._source_linkage import PlaybookSourceLinkageMixin
 from ._user import UserPlaybookStoreMixin
 
 __all__ = [
+    "PlaybookAggregationStoreMixin",
     "AgentEvaluationResultStoreMixin",
     "AgentPlaybookStoreMixin",
     "OptimizationJobStoreMixin",

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
@@ -90,8 +90,7 @@ CREATE TABLE IF NOT EXISTS playbook_aggregation_invalidation (
     created_at INTEGER NOT NULL DEFAULT (unixepoch()),
     processed_at INTEGER
 );
-DROP INDEX IF EXISTS idx_playbook_aggregation_invalidation_pending;
-CREATE INDEX idx_playbook_aggregation_invalidation_pending
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_invalidation_pending
     ON playbook_aggregation_invalidation(agent_version, invalidation_id)
     WHERE processed_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_invalidation_retention
@@ -992,17 +991,19 @@ class PlaybookAggregationStoreMixin:
                 row = self.conn.execute(
                     "SELECT c.cluster_id, v.distance FROM ("
                     "SELECT rowid, distance FROM playbook_aggregation_clusters_vec "
-                    "WHERE embedding MATCH ? ORDER BY distance LIMIT ?) v "
+                    "WHERE embedding MATCH ? AND rowid IN ("
+                    "SELECT index_rowid FROM playbook_aggregation_cluster "
+                    "WHERE agent_version=? AND embedding_model=? "
+                    "AND embedding_dimension=? AND state='active') "
+                    "ORDER BY distance LIMIT ?) v "
                     "JOIN playbook_aggregation_cluster c ON c.index_rowid=v.rowid "
-                    "WHERE c.agent_version=? AND c.embedding_model=? "
-                    "AND c.embedding_dimension=? AND c.state='active' "
                     "ORDER BY v.distance, c.cluster_id LIMIT 1",
                     (
                         json.dumps(embedding),
-                        candidate_limit,
                         agent_version,
                         embedding_model,
                         len(embedding),
+                        candidate_limit,
                     ),
                 ).fetchone()
                 if row is not None:

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
@@ -120,13 +120,27 @@ def init_playbook_aggregation_tables(conn: sqlite3.Connection) -> None:
 
 
 class PlaybookAggregationStoreMixin:
-    supports_incremental_playbook_aggregation = True
-
     conn: sqlite3.Connection
     _lock: threading.RLock
     _own_transaction: Any
     commit_scope: Any
     _has_sqlite_vec: bool
+
+    @property
+    def supports_incremental_playbook_aggregation(self) -> bool:
+        return self._has_sqlite_vec and getattr(
+            self, "_incremental_aggregation_enabled", True
+        )
+
+    @supports_incremental_playbook_aggregation.setter
+    def supports_incremental_playbook_aggregation(self, enabled: bool) -> None:
+        self._incremental_aggregation_enabled = bool(enabled)
+
+    @property
+    def playbook_aggregation_blocked_reason(self) -> str | None:
+        if self._has_sqlite_vec:
+            return None
+        return "blocked_missing_vector_index"
 
     def schedule_playbook_aggregation(self, agent_version: str) -> None:
         if not agent_version.strip():
@@ -355,6 +369,8 @@ class PlaybookAggregationStoreMixin:
                 ),
             )
             if cur.rowcount != 1:
+                if self._own_transaction():
+                    self.conn.rollback()
                 return False
             self.conn.execute(
                 "UPDATE playbook_aggregation_lease SET claim_owner=NULL, "
@@ -759,41 +775,28 @@ class PlaybookAggregationStoreMixin:
                     (agent_version,),
                 ).fetchone()[0]
             )
-            retry_rows = self.conn.execute(
-                "SELECT attempt_count, last_attempt_at "
+            residual_retry_after = self.conn.execute(
+                "SELECT COALESCE(MAX(0, MIN(CASE "
+                "WHEN attempt_count <= 0 OR last_attempt_at IS NULL THEN 0 "
+                "ELSE last_attempt_at + MIN(?, ? * (1 << MIN(MAX("
+                "attempt_count - 1, 0), 6))) - unixepoch() END)), 0) "
                 "FROM playbook_aggregation_item WHERE agent_version=? "
                 "AND disposition='residual'",
-                (agent_version,),
-            ).fetchall()
-            now = int(self.conn.execute("SELECT unixepoch()").fetchone()[0])
-            residual_retry_after = (
-                min(
-                    (
-                        max(
-                            0,
-                            int(last_attempt_at)
-                            + min(
-                                AGGREGATION_RETRY_MAX_SECONDS,
-                                AGGREGATION_RETRY_BASE_SECONDS
-                                * (1 << min(max(int(attempt_count) - 1, 0), 6)),
-                            )
-                            - now,
-                        )
-                        if int(attempt_count) > 0 and last_attempt_at is not None
-                        else 0
-                    )
-                    for attempt_count, last_attempt_at in retry_rows
-                )
-                if retry_rows
-                else 0
-            )
+                (
+                    AGGREGATION_RETRY_MAX_SECONDS,
+                    AGGREGATION_RETRY_BASE_SECONDS,
+                    agent_version,
+                ),
+            ).fetchone()[0]
         return PlaybookAggregationBacklog(
-            undisposed,
-            residual,
-            invalidations,
-            int(oldest_residual_age) if oldest_residual_age is not None else None,
-            dirty_repairs,
-            residual_retry_after,
+            undisposed=undisposed,
+            residual=residual,
+            invalidations=invalidations,
+            oldest_residual_age_seconds=(
+                int(oldest_residual_age) if oldest_residual_age is not None else None
+            ),
+            dirty_repairs=dirty_repairs,
+            residual_retry_after_seconds=int(residual_retry_after),
         )
 
     def append_playbook_aggregation_invalidation(

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
@@ -1,0 +1,1183 @@
+"""SQLite durable incremental playbook-aggregation state."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from typing import Any
+
+from reflexio.server.services.storage.storage_base.playbook import (
+    AGGREGATION_INVALIDATION_RETENTION_SECONDS,
+    AGGREGATION_RETRY_BASE_SECONDS,
+    AGGREGATION_RETRY_MAX_SECONDS,
+    AggregationDisposition,
+    PlaybookAggregationBacklog,
+    PlaybookAggregationClaim,
+    PlaybookAggregationClusterMatch,
+    PlaybookAggregationInvalidation,
+    PlaybookAggregationRerunSnapshot,
+)
+
+AGGREGATION_DDL = """
+CREATE TABLE IF NOT EXISTS playbook_aggregation_state (
+    agent_version TEXT PRIMARY KEY,
+    last_success_at INTEGER,
+    pending INTEGER NOT NULL DEFAULT 1 CHECK (pending IN (0, 1)),
+    next_attempt_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    state_version INTEGER NOT NULL DEFAULT 0,
+    retry_cursor INTEGER NOT NULL DEFAULT 0,
+    bootstrap_status TEXT NOT NULL DEFAULT 'pending'
+);
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_state_due
+    ON playbook_aggregation_state(pending, next_attempt_at, agent_version);
+
+CREATE TABLE IF NOT EXISTS playbook_aggregation_lease (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    claim_owner TEXT,
+    claim_fence INTEGER NOT NULL,
+    claim_expires_at INTEGER,
+    agent_version TEXT
+);
+
+CREATE TABLE IF NOT EXISTS playbook_aggregation_cluster (
+    cluster_id TEXT PRIMARY KEY,
+    index_rowid INTEGER UNIQUE,
+    agent_version TEXT NOT NULL,
+    agent_playbook_id INTEGER,
+    centroid TEXT,
+    vector_sum TEXT,
+    member_count INTEGER NOT NULL DEFAULT 0,
+    embedding_model TEXT,
+    embedding_dimension INTEGER,
+    normalization TEXT NOT NULL DEFAULT 'l2',
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'rebuilding')),
+    dirty INTEGER NOT NULL DEFAULT 0 CHECK (dirty IN (0, 1)),
+    rebuild_cursor INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_cluster_version
+    ON playbook_aggregation_cluster(agent_version, state, cluster_id);
+
+CREATE TABLE IF NOT EXISTS playbook_aggregation_item (
+    agent_version TEXT NOT NULL,
+    user_playbook_id INTEGER NOT NULL,
+    disposition TEXT NOT NULL CHECK (
+        disposition IN ('residual', 'cluster_member', 'terminal_noop')
+    ),
+    cluster_id TEXT,
+    reason TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_attempt_at INTEGER,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    PRIMARY KEY (agent_version, user_playbook_id)
+);
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_item_residual
+    ON playbook_aggregation_item(
+        agent_version, disposition, attempt_count, last_attempt_at, user_playbook_id
+    );
+
+CREATE INDEX IF NOT EXISTS idx_user_playbooks_aggregation_intake
+    ON user_playbooks(agent_version, user_playbook_id)
+    WHERE status IS NULL AND trim(content) <> '' AND trim(agent_version) <> '';
+
+CREATE TABLE IF NOT EXISTS playbook_aggregation_invalidation (
+    invalidation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_version TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    entity_id INTEGER NOT NULL,
+    source_ids TEXT NOT NULL DEFAULT '[]',
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    processed_at INTEGER
+);
+DROP INDEX IF EXISTS idx_playbook_aggregation_invalidation_pending;
+CREATE INDEX idx_playbook_aggregation_invalidation_pending
+    ON playbook_aggregation_invalidation(agent_version, invalidation_id)
+    WHERE processed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_invalidation_retention
+    ON playbook_aggregation_invalidation(processed_at)
+    WHERE processed_at IS NOT NULL;
+
+CREATE TRIGGER IF NOT EXISTS capture_playbook_aggregation_hard_delete
+BEFORE DELETE ON user_playbooks
+WHEN OLD.status IS NULL AND trim(OLD.agent_version) <> ''
+BEGIN
+    INSERT INTO playbook_aggregation_invalidation(
+        agent_version, operation, entity_id, source_ids
+    ) VALUES (OLD.agent_version, 'hard_delete', OLD.user_playbook_id, '[]');
+    INSERT INTO playbook_aggregation_state(
+        agent_version, pending, next_attempt_at
+    ) VALUES (OLD.agent_version, 1, unixepoch())
+    ON CONFLICT(agent_version) DO UPDATE SET pending=1,
+        next_attempt_at=min(playbook_aggregation_state.next_attempt_at,
+                            excluded.next_attempt_at);
+END;
+"""
+
+
+def init_playbook_aggregation_tables(conn: sqlite3.Connection) -> None:
+    conn.executescript(AGGREGATION_DDL)
+
+
+class PlaybookAggregationStoreMixin:
+    supports_incremental_playbook_aggregation = True
+
+    conn: sqlite3.Connection
+    _lock: threading.RLock
+    _own_transaction: Any
+    commit_scope: Any
+    _has_sqlite_vec: bool
+
+    def schedule_playbook_aggregation(self, agent_version: str) -> None:
+        if not agent_version.strip():
+            raise ValueError("agent_version must be non-empty")
+        with self._lock:
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_state "
+                "(agent_version, pending, next_attempt_at) "
+                "VALUES (?, 1, unixepoch()) "
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
+                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
+                "excluded.next_attempt_at)",
+                (agent_version,),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def repair_playbook_aggregation_pending_state(
+        self, *, limit: int = 100
+    ) -> list[str]:
+        if limit <= 0:
+            return []
+        with self._lock:
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_invalidation "
+                "WHERE processed_at IS NOT NULL AND processed_at < unixepoch()-?",
+                (AGGREGATION_INVALIDATION_RETENTION_SECONDS,),
+            )
+            rows = self.conn.execute(
+                "WITH work(agent_version) AS ("
+                "SELECT p.agent_version FROM user_playbooks p WHERE p.status IS NULL "
+                "AND trim(p.content) <> '' AND trim(p.agent_version) <> '' "
+                "AND NOT EXISTS (SELECT 1 FROM playbook_aggregation_item i WHERE "
+                "i.agent_version=p.agent_version AND "
+                "i.user_playbook_id=p.user_playbook_id) UNION "
+                "SELECT agent_version FROM playbook_aggregation_item "
+                "WHERE disposition='residual' UNION "
+                "SELECT agent_version FROM playbook_aggregation_invalidation "
+                "WHERE processed_at IS NULL UNION "
+                "SELECT agent_version FROM playbook_aggregation_cluster "
+                "WHERE dirty=1 OR state='rebuilding') "
+                "SELECT DISTINCT w.agent_version FROM work w LEFT JOIN "
+                "playbook_aggregation_state s ON s.agent_version=w.agent_version "
+                "WHERE COALESCE(s.pending, 0)=0 ORDER BY w.agent_version LIMIT ?",
+                (limit,),
+            ).fetchall()
+            versions = [str(row[0]) for row in rows]
+            self.conn.executemany(
+                "INSERT INTO playbook_aggregation_state "
+                "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
+                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
+                "excluded.next_attempt_at)",
+                [(version,) for version in versions],
+            )
+            if self._own_transaction():
+                self.conn.commit()
+            return versions
+
+    def claim_due_playbook_aggregation(
+        self,
+        *,
+        owner: str,
+        lease_seconds: int,
+        agent_version: str | None = None,
+    ) -> PlaybookAggregationClaim | None:
+        if not owner.strip() or lease_seconds <= 0:
+            raise ValueError("claim owner and lease_seconds must be valid")
+        with self._lock:
+            own = self._own_transaction()
+            if own:
+                self.conn.execute("BEGIN IMMEDIATE")
+            try:
+                now = int(self.conn.execute("SELECT unixepoch()").fetchone()[0])
+                lease = self.conn.execute(
+                    "SELECT claim_expires_at FROM playbook_aggregation_lease "
+                    "WHERE singleton=1"
+                ).fetchone()
+                if lease is not None and lease[0] is not None and int(lease[0]) > now:
+                    if own:
+                        self.conn.commit()
+                    return None
+                if agent_version is None:
+                    row = self.conn.execute(
+                        "SELECT agent_version, state_version "
+                        "FROM playbook_aggregation_state "
+                        "WHERE pending=1 AND next_attempt_at <= ? "
+                        "ORDER BY next_attempt_at, agent_version LIMIT 1",
+                        (now,),
+                    ).fetchone()
+                else:
+                    row = self.conn.execute(
+                        "SELECT agent_version, state_version "
+                        "FROM playbook_aggregation_state WHERE agent_version=?",
+                        (agent_version,),
+                    ).fetchone()
+                if row is None:
+                    if own:
+                        self.conn.commit()
+                    return None
+                old_fence = self.conn.execute(
+                    "SELECT claim_fence FROM playbook_aggregation_lease "
+                    "WHERE singleton=1"
+                ).fetchone()
+                fence = (int(old_fence[0]) if old_fence else 0) + 1
+                expires_at = now + lease_seconds
+                self.conn.execute(
+                    "INSERT INTO playbook_aggregation_lease "
+                    "(singleton, claim_owner, claim_fence, claim_expires_at, agent_version) "
+                    "VALUES (1, ?, ?, ?, ?) "
+                    "ON CONFLICT(singleton) DO UPDATE SET "
+                    "claim_owner=excluded.claim_owner, claim_fence=excluded.claim_fence, "
+                    "claim_expires_at=excluded.claim_expires_at, "
+                    "agent_version=excluded.agent_version",
+                    (owner, fence, expires_at, str(row[0])),
+                )
+                if own:
+                    self.conn.commit()
+                return PlaybookAggregationClaim(
+                    agent_version=str(row[0]),
+                    owner=owner,
+                    fence=fence,
+                    state_version=int(row[1]),
+                    expires_at=expires_at,
+                )
+            except Exception:
+                if own:
+                    self.conn.rollback()
+                raise
+
+    def renew_playbook_aggregation_claim(
+        self, claim: PlaybookAggregationClaim, *, lease_seconds: int
+    ) -> PlaybookAggregationClaim | None:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        with self._lock:
+            now = int(self.conn.execute("SELECT unixepoch()").fetchone()[0])
+            expires_at = now + lease_seconds
+            cur = self.conn.execute(
+                "UPDATE playbook_aggregation_lease SET claim_expires_at=? "
+                "WHERE singleton=1 AND claim_owner=? AND claim_fence=? "
+                "AND agent_version=? AND claim_expires_at > ?",
+                (
+                    expires_at,
+                    claim.owner,
+                    claim.fence,
+                    claim.agent_version,
+                    now,
+                ),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+            if cur.rowcount != 1:
+                return None
+            return PlaybookAggregationClaim(
+                claim.agent_version,
+                claim.owner,
+                claim.fence,
+                claim.state_version,
+                expires_at,
+            )
+
+    def _aggregation_claim_is_live(self, claim: PlaybookAggregationClaim) -> bool:
+        return (
+            self.conn.execute(
+                "SELECT 1 FROM playbook_aggregation_lease "
+                "WHERE singleton=1 AND claim_owner=? AND claim_fence=? "
+                "AND agent_version=? AND claim_expires_at > unixepoch()",
+                (claim.owner, claim.fence, claim.agent_version),
+            ).fetchone()
+            is not None
+        )
+
+    def validate_playbook_aggregation_claim(
+        self, claim: PlaybookAggregationClaim
+    ) -> bool:
+        with self._lock:
+            if not self._aggregation_claim_is_live(claim):
+                return False
+            row = self.conn.execute(
+                "SELECT state_version FROM playbook_aggregation_state "
+                "WHERE agent_version=?",
+                (claim.agent_version,),
+            ).fetchone()
+            return row is not None and int(row[0]) == claim.state_version
+
+    def finish_playbook_aggregation_claim(
+        self,
+        claim: PlaybookAggregationClaim,
+        *,
+        success: bool,
+        retry_after_seconds: int,
+        backlog_retry_after_seconds: int,
+        min_interval_seconds: int,
+        backlog: PlaybookAggregationBacklog | None = None,
+    ) -> bool:
+        with self._lock:
+            if not self._aggregation_claim_is_live(claim):
+                return False
+            if not success:
+                delay = retry_after_seconds
+                pending = True
+            else:
+                backlog = backlog or self.get_playbook_aggregation_backlog(
+                    claim.agent_version
+                )
+                pending = backlog.pending
+                if pending:
+                    delay = max(
+                        backlog_retry_after_seconds,
+                        backlog.continuation_delay_seconds,
+                    )
+                else:
+                    delay = min_interval_seconds
+            cur = self.conn.execute(
+                "UPDATE playbook_aggregation_state SET "
+                "last_success_at=CASE WHEN ? THEN unixepoch() ELSE last_success_at END, "
+                "pending=?, next_attempt_at=unixepoch()+?, state_version=state_version+1 "
+                "WHERE agent_version=? AND state_version=?",
+                (
+                    int(success),
+                    int(pending),
+                    max(0, delay),
+                    claim.agent_version,
+                    claim.state_version,
+                ),
+            )
+            if cur.rowcount != 1:
+                return False
+            self.conn.execute(
+                "UPDATE playbook_aggregation_lease SET claim_owner=NULL, "
+                "claim_expires_at=NULL, agent_version=NULL WHERE singleton=1 "
+                "AND claim_owner=? AND claim_fence=?",
+                (claim.owner, claim.fence),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+            return True
+
+    def stage_playbook_aggregation_intake(
+        self, agent_version: str, *, limit: int
+    ) -> list[int]:
+        if limit <= 0:
+            return []
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT p.user_playbook_id FROM user_playbooks p "
+                "WHERE p.agent_version=? AND p.status IS NULL "
+                "AND trim(p.content) <> '' AND NOT EXISTS ("
+                " SELECT 1 FROM playbook_aggregation_item i "
+                " WHERE i.agent_version=? "
+                " AND i.user_playbook_id=p.user_playbook_id) "
+                "ORDER BY p.user_playbook_id LIMIT ?",
+                (agent_version, agent_version, limit),
+            ).fetchall()
+            ids = [int(row[0]) for row in rows]
+            self.conn.executemany(
+                "INSERT OR IGNORE INTO playbook_aggregation_item "
+                "(agent_version, user_playbook_id, disposition, reason) "
+                "VALUES (?, ?, 'residual', 'new')",
+                [(agent_version, item_id) for item_id in ids],
+            )
+            if self._own_transaction():
+                self.conn.commit()
+            return ids
+
+    def get_playbook_aggregation_bootstrap_status(self, agent_version: str) -> str:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT bootstrap_status FROM playbook_aggregation_state "
+                "WHERE agent_version=?",
+                (agent_version,),
+            ).fetchone()
+        return str(row[0]) if row is not None else "pending"
+
+    def set_playbook_aggregation_bootstrap_status(
+        self, agent_version: str, status: str
+    ) -> None:
+        if status not in {"pending", "complete"}:
+            raise ValueError("invalid aggregation bootstrap status")
+        with self._lock:
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_state "
+                "(agent_version, bootstrap_status, pending, next_attempt_at) "
+                "VALUES (?, ?, 1, unixepoch()) ON CONFLICT(agent_version) "
+                "DO UPDATE SET bootstrap_status=excluded.bootstrap_status",
+                (agent_version, status),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def get_playbook_aggregation_cluster_rebuild_cursor(
+        self, cluster_id: str
+    ) -> tuple[int, str] | None:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT rebuild_cursor, state FROM playbook_aggregation_cluster "
+                "WHERE cluster_id=?",
+                (cluster_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return int(row[0]), str(row[1])
+
+    def adopt_legacy_playbook_aggregation_cluster_page(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        agent_playbook_id: int,
+        member_embeddings: list[tuple[int, list[float]]],
+        embedding_model: str,
+        embedding_dimension: int,
+        rebuild_cursor: int,
+        complete: bool,
+    ) -> None:
+        if any(len(value) != embedding_dimension for _, value in member_embeddings):
+            raise ValueError("legacy cluster embedding dimension changed")
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT index_rowid, vector_sum, member_count, state, "
+                "embedding_model, embedding_dimension "
+                "FROM playbook_aggregation_cluster WHERE cluster_id=?",
+                (cluster_id,),
+            ).fetchone()
+            if row is None:
+                next_rowid = int(
+                    self.conn.execute(
+                        "SELECT COALESCE(max(index_rowid), 0)+1 "
+                        "FROM playbook_aggregation_cluster"
+                    ).fetchone()[0]
+                )
+                self.conn.execute(
+                    "INSERT INTO playbook_aggregation_cluster "
+                    "(cluster_id, index_rowid, agent_version, agent_playbook_id, "
+                    "member_count, embedding_model, embedding_dimension, state) "
+                    "VALUES (?, ?, ?, ?, 0, ?, ?, 'rebuilding')",
+                    (
+                        cluster_id,
+                        next_rowid,
+                        agent_version,
+                        agent_playbook_id,
+                        embedding_model,
+                        embedding_dimension,
+                    ),
+                )
+                index_rowid = next_rowid
+                vector_sum = [0.0] * embedding_dimension
+                member_count = 0
+            else:
+                if str(row[3]) == "active":
+                    return
+                if row[4] != embedding_model or int(row[5]) != embedding_dimension:
+                    raise RuntimeError("legacy cluster embedding provenance changed")
+                index_rowid = int(row[0])
+                vector_sum = (
+                    [float(value) for value in json.loads(row[1])]
+                    if row[1]
+                    else [0.0] * embedding_dimension
+                )
+                member_count = int(row[2])
+            for user_playbook_id, embedding in member_embeddings:
+                inserted = self.conn.execute(
+                    "INSERT OR IGNORE INTO playbook_aggregation_item "
+                    "(agent_version, user_playbook_id, disposition, cluster_id, reason) "
+                    "VALUES (?, ?, 'cluster_member', ?, 'legacy_adopted')",
+                    (agent_version, user_playbook_id, cluster_id),
+                )
+                if inserted.rowcount == 1:
+                    vector_sum = [
+                        left + right
+                        for left, right in zip(vector_sum, embedding, strict=True)
+                    ]
+                    member_count += 1
+            centroid = (
+                [value / member_count for value in vector_sum] if member_count else None
+            )
+            self.conn.execute(
+                "UPDATE playbook_aggregation_cluster SET vector_sum=?, centroid=?, "
+                "member_count=?, rebuild_cursor=?, state=? WHERE cluster_id=?",
+                (
+                    json.dumps(vector_sum) if member_count else None,
+                    json.dumps(centroid) if centroid is not None else None,
+                    member_count,
+                    rebuild_cursor,
+                    "active" if complete else "rebuilding",
+                    cluster_id,
+                ),
+            )
+            if complete and centroid is not None:
+                self.conn.execute(
+                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                    (index_rowid,),
+                )
+                self.conn.execute(
+                    "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
+                    "VALUES (?, ?)",
+                    (index_rowid, json.dumps(centroid)),
+                )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def reset_playbook_aggregation_version(self, agent_version: str) -> None:
+        if self._own_transaction():
+            with self.commit_scope():
+                self.reset_playbook_aggregation_version(agent_version)
+            return
+        with self._lock:
+            index_rows = self.conn.execute(
+                "SELECT index_rowid FROM playbook_aggregation_cluster "
+                "WHERE agent_version=? AND index_rowid IS NOT NULL",
+                (agent_version,),
+            ).fetchall()
+            for row in index_rows:
+                self.conn.execute(
+                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                    (int(row[0]),),
+                )
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_item WHERE agent_version=?",
+                (agent_version,),
+            )
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_cluster WHERE agent_version=?",
+                (agent_version,),
+            )
+            self.set_playbook_aggregation_bootstrap_status(agent_version, "complete")
+
+    def capture_playbook_aggregation_rerun_snapshot(
+        self, agent_version: str, *, limit: int
+    ) -> PlaybookAggregationRerunSnapshot:
+        if limit <= 0:
+            return PlaybookAggregationRerunSnapshot((), (), None, None)
+        with self._lock:
+            own = self._own_transaction()
+            if own:
+                self.conn.execute("BEGIN")
+            try:
+                playbooks = self.get_user_playbooks(  # type: ignore[attr-defined]
+                    limit=limit,
+                    agent_version=agent_version,
+                    status_filter=[None],
+                    include_embedding=True,
+                    max_user_playbook_id=2**63 - 1,
+                )
+                invalidation_rows = self.conn.execute(
+                    "SELECT invalidation_id FROM playbook_aggregation_invalidation "
+                    "WHERE agent_version=? AND processed_at IS NULL "
+                    "ORDER BY invalidation_id LIMIT ?",
+                    (agent_version, limit),
+                ).fetchall()
+                if own:
+                    self.conn.commit()
+            except Exception:
+                if own:
+                    self.conn.rollback()
+                raise
+        invalidation_ids = tuple(int(row[0]) for row in invalidation_rows)
+        return PlaybookAggregationRerunSnapshot(
+            user_playbooks=tuple(playbooks),
+            invalidation_ids=invalidation_ids,
+            user_high_watermark=(
+                max(item.user_playbook_id for item in playbooks) if playbooks else None
+            ),
+            invalidation_high_watermark=(
+                max(invalidation_ids) if invalidation_ids else None
+            ),
+        )
+
+    def stage_playbook_aggregation_snapshot(
+        self, agent_version: str, user_playbook_ids: list[int]
+    ) -> None:
+        if not user_playbook_ids:
+            return
+        with self._lock:
+            self.conn.executemany(
+                "INSERT OR IGNORE INTO playbook_aggregation_item "
+                "(agent_version, user_playbook_id, disposition, reason) "
+                "VALUES (?, ?, 'residual', 'full_rerun_snapshot')",
+                [(agent_version, item_id) for item_id in user_playbook_ids],
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def mark_playbook_aggregation_invalidations_processed(
+        self,
+        claim: PlaybookAggregationClaim,
+        invalidation_ids: list[int],
+    ) -> bool:
+        if not invalidation_ids:
+            return True
+        if self._own_transaction():
+            with self.commit_scope():
+                return self.mark_playbook_aggregation_invalidations_processed(
+                    claim, invalidation_ids
+                )
+        with self._lock:
+            if not self._aggregation_claim_is_live(claim):
+                return False
+            placeholders = ",".join("?" for _ in invalidation_ids)
+            self.conn.execute(
+                "UPDATE playbook_aggregation_invalidation SET processed_at=unixepoch() "
+                f"WHERE agent_version=? AND invalidation_id IN ({placeholders}) "
+                "AND processed_at IS NULL",
+                (claim.agent_version, *invalidation_ids),
+            )
+            return True
+
+    def get_playbook_aggregation_residual_ids(
+        self, agent_version: str, *, limit: int
+    ) -> list[int]:
+        if limit <= 0:
+            return []
+        with self._lock:
+            fresh_quota = (limit + 1) // 2
+            retry_quota = limit - fresh_quota
+            fresh_rows = self.conn.execute(
+                "SELECT user_playbook_id FROM playbook_aggregation_item "
+                "WHERE agent_version=? AND disposition='residual' AND attempt_count=0 "
+                "ORDER BY user_playbook_id LIMIT ?",
+                (agent_version, fresh_quota),
+            ).fetchall()
+            retry_rows = self.conn.execute(
+                "SELECT user_playbook_id FROM playbook_aggregation_item "
+                "WHERE agent_version=? AND disposition='residual' AND attempt_count>0 "
+                "AND last_attempt_at+min(?, ?*(1 << min(max(attempt_count-1, 0), 6))) "
+                "<= unixepoch() "
+                "ORDER BY last_attempt_at, user_playbook_id LIMIT ?",
+                (
+                    agent_version,
+                    AGGREGATION_RETRY_MAX_SECONDS,
+                    AGGREGATION_RETRY_BASE_SECONDS,
+                    retry_quota,
+                ),
+            ).fetchall()
+            ids = [int(row[0]) for row in [*fresh_rows, *retry_rows]]
+            if len(ids) < limit:
+                placeholders = ",".join("?" for _ in ids)
+                exclusion = (
+                    f"AND user_playbook_id NOT IN ({placeholders})" if ids else ""
+                )
+                fill = self.conn.execute(
+                    "SELECT user_playbook_id FROM playbook_aggregation_item "
+                    "WHERE agent_version=? AND disposition='residual' "
+                    "AND (attempt_count=0 OR last_attempt_at IS NULL OR "
+                    "last_attempt_at+min(?, ?*(1 << min(max(attempt_count-1, 0), 6))) "
+                    "<= unixepoch()) "
+                    f"{exclusion} ORDER BY COALESCE(last_attempt_at, 0), "
+                    "user_playbook_id LIMIT ?",
+                    (
+                        agent_version,
+                        AGGREGATION_RETRY_MAX_SECONDS,
+                        AGGREGATION_RETRY_BASE_SECONDS,
+                        *ids,
+                        limit - len(ids),
+                    ),
+                ).fetchall()
+                ids.extend(int(row[0]) for row in fill)
+            self.conn.executemany(
+                "UPDATE playbook_aggregation_item SET attempt_count=attempt_count+1, "
+                "last_attempt_at=unixepoch(), updated_at=unixepoch() "
+                "WHERE agent_version=? AND user_playbook_id=?",
+                [(agent_version, item_id) for item_id in ids],
+            )
+            if self._own_transaction():
+                self.conn.commit()
+            return ids
+
+    def set_playbook_aggregation_disposition(
+        self,
+        agent_version: str,
+        user_playbook_ids: list[int],
+        *,
+        disposition: AggregationDisposition,
+        cluster_id: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        if not user_playbook_ids:
+            return
+        with self._lock:
+            self.conn.executemany(
+                "UPDATE playbook_aggregation_item SET disposition=?, cluster_id=?, "
+                "reason=?, updated_at=unixepoch() "
+                "WHERE agent_version=? AND user_playbook_id=?",
+                [
+                    (disposition, cluster_id, reason, agent_version, item_id)
+                    for item_id in user_playbook_ids
+                ],
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def get_playbook_aggregation_backlog(
+        self, agent_version: str
+    ) -> PlaybookAggregationBacklog:
+        with self._lock:
+            undisposed = int(
+                self.conn.execute(
+                    "SELECT count(*) FROM user_playbooks p WHERE p.agent_version=? "
+                    "AND p.status IS NULL AND trim(p.content) <> '' AND NOT EXISTS ("
+                    "SELECT 1 FROM playbook_aggregation_item i "
+                    "WHERE i.agent_version=? "
+                    "AND i.user_playbook_id=p.user_playbook_id)",
+                    (agent_version, agent_version),
+                ).fetchone()[0]
+            )
+            residual = int(
+                self.conn.execute(
+                    "SELECT count(*) FROM playbook_aggregation_item "
+                    "WHERE agent_version=? AND disposition='residual'",
+                    (agent_version,),
+                ).fetchone()[0]
+            )
+            invalidations = int(
+                self.conn.execute(
+                    "SELECT count(*) FROM playbook_aggregation_invalidation "
+                    "WHERE agent_version=? AND processed_at IS NULL",
+                    (agent_version,),
+                ).fetchone()[0]
+            )
+            oldest_residual_age = self.conn.execute(
+                "SELECT unixepoch()-min(created_at) FROM playbook_aggregation_item "
+                "WHERE agent_version=? AND disposition='residual'",
+                (agent_version,),
+            ).fetchone()[0]
+            dirty_repairs = int(
+                self.conn.execute(
+                    "SELECT count(*) FROM playbook_aggregation_cluster "
+                    "WHERE agent_version=? AND (dirty=1 OR state='rebuilding')",
+                    (agent_version,),
+                ).fetchone()[0]
+            )
+            retry_rows = self.conn.execute(
+                "SELECT attempt_count, last_attempt_at "
+                "FROM playbook_aggregation_item WHERE agent_version=? "
+                "AND disposition='residual'",
+                (agent_version,),
+            ).fetchall()
+            now = int(self.conn.execute("SELECT unixepoch()").fetchone()[0])
+            residual_retry_after = (
+                min(
+                    (
+                        max(
+                            0,
+                            int(last_attempt_at)
+                            + min(
+                                AGGREGATION_RETRY_MAX_SECONDS,
+                                AGGREGATION_RETRY_BASE_SECONDS
+                                * (1 << min(max(int(attempt_count) - 1, 0), 6)),
+                            )
+                            - now,
+                        )
+                        if int(attempt_count) > 0 and last_attempt_at is not None
+                        else 0
+                    )
+                    for attempt_count, last_attempt_at in retry_rows
+                )
+                if retry_rows
+                else 0
+            )
+        return PlaybookAggregationBacklog(
+            undisposed,
+            residual,
+            invalidations,
+            int(oldest_residual_age) if oldest_residual_age is not None else None,
+            dirty_repairs,
+            residual_retry_after,
+        )
+
+    def append_playbook_aggregation_invalidation(
+        self,
+        *,
+        agent_version: str,
+        operation: str,
+        entity_id: int,
+        source_ids: list[int] | None = None,
+    ) -> None:
+        with self._lock:
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_invalidation "
+                "(agent_version, operation, entity_id, source_ids) VALUES (?, ?, ?, ?)",
+                (agent_version, operation, entity_id, json.dumps(source_ids or [])),
+            )
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_state "
+                "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
+                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
+                "excluded.next_attempt_at)",
+                (agent_version,),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def get_playbook_aggregation_invalidations(
+        self, agent_version: str, *, limit: int
+    ) -> list[PlaybookAggregationInvalidation]:
+        if limit <= 0:
+            return []
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT invalidation_id, operation, entity_id, source_ids "
+                "FROM playbook_aggregation_invalidation "
+                "WHERE agent_version=? AND processed_at IS NULL "
+                "ORDER BY invalidation_id LIMIT ?",
+                (agent_version, limit),
+            ).fetchall()
+        return [
+            PlaybookAggregationInvalidation(
+                invalidation_id=int(row[0]),
+                agent_version=agent_version,
+                operation=str(row[1]),
+                entity_id=int(row[2]),
+                source_ids=tuple(int(value) for value in json.loads(row[3] or "[]")),
+            )
+            for row in rows
+        ]
+
+    def apply_playbook_aggregation_invalidations(
+        self,
+        claim: PlaybookAggregationClaim,
+        invalidation_ids: list[int],
+    ) -> bool:
+        if not invalidation_ids:
+            return True
+        if self._own_transaction():
+            with self.commit_scope():
+                return self.apply_playbook_aggregation_invalidations(
+                    claim, invalidation_ids
+                )
+        with self._lock:
+            if not self._aggregation_claim_is_live(claim):
+                return False
+            placeholders = ",".join("?" for _ in invalidation_ids)
+            rows = self.conn.execute(
+                "SELECT entity_id, source_ids FROM playbook_aggregation_invalidation "
+                f"WHERE invalidation_id IN ({placeholders}) AND agent_version=? "
+                "AND processed_at IS NULL",
+                (*invalidation_ids, claim.agent_version),
+            ).fetchall()
+            affected = {
+                int(value)
+                for row in rows
+                for value in [int(row[0]), *json.loads(row[1] or "[]")]
+            }
+            if affected:
+                item_placeholders = ",".join("?" for _ in affected)
+                cluster_rows = self.conn.execute(
+                    "SELECT DISTINCT cluster_id FROM playbook_aggregation_item "
+                    f"WHERE agent_version=? AND user_playbook_id IN ({item_placeholders}) "
+                    "AND cluster_id IS NOT NULL",
+                    (claim.agent_version, *sorted(affected)),
+                ).fetchall()
+                cluster_ids = [str(row[0]) for row in cluster_rows]
+                if cluster_ids:
+                    cluster_placeholders = ",".join("?" for _ in cluster_ids)
+                    index_rows = self.conn.execute(
+                        "SELECT index_rowid FROM playbook_aggregation_cluster "
+                        f"WHERE cluster_id IN ({cluster_placeholders})",
+                        cluster_ids,
+                    ).fetchall()
+                    self.conn.execute(
+                        "UPDATE playbook_aggregation_item SET disposition='residual', "
+                        "reason='cluster_invalidated', attempt_count=0, "
+                        "last_attempt_at=NULL, "
+                        "updated_at=unixepoch() WHERE agent_version=? "
+                        f"AND cluster_id IN ({cluster_placeholders})",
+                        (claim.agent_version, *cluster_ids),
+                    )
+                    for index_row in index_rows:
+                        self.conn.execute(
+                            "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                            (int(index_row[0]),),
+                        )
+                    self.conn.execute(
+                        "UPDATE playbook_aggregation_cluster SET state='rebuilding', "
+                        "dirty=1, centroid=NULL, vector_sum=NULL, member_count=0, "
+                        "rebuild_cursor=0 "
+                        f"WHERE cluster_id IN ({cluster_placeholders})",
+                        cluster_ids,
+                    )
+                self.conn.execute(
+                    "DELETE FROM playbook_aggregation_item "
+                    f"WHERE agent_version=? AND user_playbook_id IN ({item_placeholders})",
+                    (claim.agent_version, *sorted(affected)),
+                )
+            self.conn.execute(
+                "UPDATE playbook_aggregation_invalidation SET processed_at=unixepoch() "
+                f"WHERE invalidation_id IN ({placeholders}) AND agent_version=? "
+                "AND processed_at IS NULL",
+                (*invalidation_ids, claim.agent_version),
+            )
+            return True
+
+    def get_playbook_aggregation_replacement_agent_ids(
+        self, agent_version: str, user_playbook_ids: list[int]
+    ) -> list[int]:
+        if not user_playbook_ids:
+            return []
+        placeholders = ",".join("?" for _ in user_playbook_ids)
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT DISTINCT c.agent_playbook_id FROM playbook_aggregation_item i "
+                "JOIN playbook_aggregation_cluster c ON c.cluster_id=i.cluster_id "
+                f"WHERE i.agent_version=? AND i.user_playbook_id IN ({placeholders}) "
+                "AND c.state='rebuilding' AND c.agent_playbook_id IS NOT NULL "
+                "ORDER BY c.agent_playbook_id",
+                (agent_version, *user_playbook_ids),
+            ).fetchall()
+        return [int(row[0]) for row in rows]
+
+    def delete_orphaned_playbook_aggregation_clusters(self, agent_version: str) -> None:
+        with self._lock:
+            rows = self.conn.execute(
+                "SELECT index_rowid FROM playbook_aggregation_cluster c "
+                "WHERE c.agent_version=? AND c.state='rebuilding' "
+                "AND NOT EXISTS (SELECT 1 FROM playbook_aggregation_item i "
+                "WHERE i.cluster_id=c.cluster_id)",
+                (agent_version,),
+            ).fetchall()
+            self.conn.executemany(
+                "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                [(int(row[0]),) for row in rows],
+            )
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_cluster WHERE agent_version=? "
+                "AND state='rebuilding' AND NOT EXISTS ("
+                "SELECT 1 FROM playbook_aggregation_item i "
+                "WHERE i.cluster_id=playbook_aggregation_cluster.cluster_id)",
+                (agent_version,),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def find_nearest_playbook_aggregation_clusters(
+        self,
+        agent_version: str,
+        candidates: list[tuple[int, list[float]]],
+        *,
+        embedding_model: str,
+        limit: int,
+    ) -> dict[int, PlaybookAggregationClusterMatch]:
+        if not self._has_sqlite_vec:
+            raise RuntimeError(
+                "blocked_missing_vector_index: install sqlite-vec to enable "
+                "incremental playbook aggregation"
+            )
+        if limit <= 0 or not candidates:
+            return {}
+        candidate_ids = [item_id for item_id, _embedding in candidates]
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("aggregation candidate IDs must be unique")
+        # sqlite-vec rejects KNN queries whose k exceeds 4096.  The caller's
+        # limit is a run-level safety budget, so clamp only this ANN candidate
+        # query instead of shrinking the aggregation batch itself.
+        candidate_limit = min(limit, 4096)
+        matches: dict[int, PlaybookAggregationClusterMatch] = {}
+        with self._lock:
+            for item_id, embedding in candidates:
+                row = self.conn.execute(
+                    "SELECT c.cluster_id, v.distance FROM ("
+                    "SELECT rowid, distance FROM playbook_aggregation_clusters_vec "
+                    "WHERE embedding MATCH ? ORDER BY distance LIMIT ?) v "
+                    "JOIN playbook_aggregation_cluster c ON c.index_rowid=v.rowid "
+                    "WHERE c.agent_version=? AND c.embedding_model=? "
+                    "AND c.embedding_dimension=? AND c.state='active' "
+                    "ORDER BY v.distance, c.cluster_id LIMIT 1",
+                    (
+                        json.dumps(embedding),
+                        candidate_limit,
+                        agent_version,
+                        embedding_model,
+                        len(embedding),
+                    ),
+                ).fetchone()
+                if row is not None:
+                    matches[item_id] = PlaybookAggregationClusterMatch(
+                        str(row[0]), 1.0 - float(row[1])
+                    )
+        return matches
+
+    def create_playbook_aggregation_cluster(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        agent_playbook_id: int | None,
+        embeddings: list[list[float]],
+        embedding_model: str,
+    ) -> None:
+        if not embeddings:
+            raise ValueError("cluster embeddings must be non-empty")
+        dimension = len(embeddings[0])
+        if any(len(value) != dimension for value in embeddings):
+            raise ValueError("cluster embeddings must share one dimension")
+        vector_sum = [sum(values) for values in zip(*embeddings, strict=True)]
+        centroid = [value / len(embeddings) for value in vector_sum]
+        with self._lock:
+            existing = self.conn.execute(
+                "SELECT index_rowid FROM playbook_aggregation_cluster "
+                "WHERE cluster_id=?",
+                (cluster_id,),
+            ).fetchone()
+            if existing is None:
+                next_rowid = int(
+                    self.conn.execute(
+                        "SELECT COALESCE(max(index_rowid), 0)+1 "
+                        "FROM playbook_aggregation_cluster"
+                    ).fetchone()[0]
+                )
+                self.conn.execute(
+                    "INSERT INTO playbook_aggregation_cluster "
+                    "(cluster_id, index_rowid, agent_version, agent_playbook_id, "
+                    "centroid, vector_sum, member_count, embedding_model, "
+                    "embedding_dimension) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        cluster_id,
+                        next_rowid,
+                        agent_version,
+                        agent_playbook_id,
+                        json.dumps(centroid),
+                        json.dumps(vector_sum),
+                        len(embeddings),
+                        embedding_model,
+                        dimension,
+                    ),
+                )
+            else:
+                next_rowid = int(existing[0])
+                self.conn.execute(
+                    "UPDATE playbook_aggregation_cluster SET agent_version=?, "
+                    "agent_playbook_id=?, centroid=?, vector_sum=?, member_count=?, "
+                    "embedding_model=?, embedding_dimension=?, normalization='l2', "
+                    "state='active', dirty=0, rebuild_cursor=0 WHERE cluster_id=?",
+                    (
+                        agent_version,
+                        agent_playbook_id,
+                        json.dumps(centroid),
+                        json.dumps(vector_sum),
+                        len(embeddings),
+                        embedding_model,
+                        dimension,
+                        cluster_id,
+                    ),
+                )
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                (next_rowid,),
+            )
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
+                "VALUES (?, ?)",
+                (next_rowid, json.dumps(centroid)),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def attach_playbook_aggregation_items(
+        self,
+        *,
+        agent_version: str,
+        attachments: list[tuple[int, str, list[float]]],
+    ) -> None:
+        if not attachments:
+            return
+        item_ids = [item_id for item_id, _cluster_id, _embedding in attachments]
+        if len(item_ids) != len(set(item_ids)):
+            raise ValueError("aggregation attachment IDs must be unique")
+        grouped: dict[str, list[tuple[int, list[float]]]] = {}
+        for item_id, cluster_id, embedding in attachments:
+            grouped.setdefault(cluster_id, []).append((item_id, embedding))
+        with self._lock:
+            own_transaction = self._own_transaction()
+            try:
+                cluster_rows: dict[str, sqlite3.Row] = {}
+                cluster_ids = list(grouped)
+                for offset in range(0, len(cluster_ids), 500):
+                    page = cluster_ids[offset : offset + 500]
+                    placeholders = ",".join("?" for _value in page)
+                    rows = self.conn.execute(
+                        "SELECT cluster_id, index_rowid, vector_sum, member_count, "
+                        "embedding_dimension FROM playbook_aggregation_cluster "
+                        f"WHERE agent_version=? AND state='active' AND cluster_id IN ({placeholders})",
+                        (agent_version, *page),
+                    ).fetchall()
+                    cluster_rows.update({str(row[0]): row for row in rows})
+                if set(cluster_rows) != set(grouped):
+                    raise RuntimeError(
+                        "aggregation cluster is not active for agent version"
+                    )
+
+                cluster_updates: list[tuple[str, str, int, str]] = []
+                vector_updates: list[tuple[int, str]] = []
+                for cluster_id, members in grouped.items():
+                    row = cluster_rows[cluster_id]
+                    vector_sum = [float(value) for value in json.loads(row[2])]
+                    dimension = int(row[4])
+                    if len(vector_sum) != dimension or any(
+                        len(embedding) != dimension for _item_id, embedding in members
+                    ):
+                        raise ValueError("aggregation embedding dimension changed")
+                    batch_sum = [
+                        sum(embedding[index] for _item_id, embedding in members)
+                        for index in range(dimension)
+                    ]
+                    updated_sum = [
+                        left + right
+                        for left, right in zip(vector_sum, batch_sum, strict=True)
+                    ]
+                    count = int(row[3]) + len(members)
+                    centroid = [value / count for value in updated_sum]
+                    cluster_updates.append(
+                        (
+                            json.dumps(updated_sum),
+                            json.dumps(centroid),
+                            count,
+                            cluster_id,
+                        )
+                    )
+                    vector_updates.append((int(row[1]), json.dumps(centroid)))
+
+                before_changes = self.conn.total_changes
+                self.conn.executemany(
+                    "UPDATE playbook_aggregation_item SET disposition='cluster_member', "
+                    "cluster_id=?, reason='centroid_match', updated_at=unixepoch() "
+                    "WHERE agent_version=? AND user_playbook_id=? "
+                    "AND disposition='residual'",
+                    [
+                        (cluster_id, agent_version, item_id)
+                        for item_id, cluster_id, _embedding in attachments
+                    ],
+                )
+                if self.conn.total_changes - before_changes != len(attachments):
+                    raise RuntimeError("aggregation residual attachment lost its state")
+                self.conn.executemany(
+                    "UPDATE playbook_aggregation_cluster SET vector_sum=?, centroid=?, "
+                    "member_count=? WHERE cluster_id=? AND agent_version=?",
+                    [(*update, agent_version) for update in cluster_updates],
+                )
+                self.conn.executemany(
+                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                    [(rowid,) for rowid, _centroid in vector_updates],
+                )
+                self.conn.executemany(
+                    "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
+                    "VALUES (?, ?)",
+                    vector_updates,
+                )
+                if own_transaction:
+                    self.conn.commit()
+            except Exception:
+                if own_transaction:
+                    self.conn.rollback()
+                raise

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -1212,9 +1212,10 @@ class UserPlaybookStoreMixin:
         playbook_name: str | None = None,
     ) -> int:
         # Bulk delete-by-status emits no hard_delete lineage events (parity with
-        # the Supabase backend, which routes this through _hard_delete_and_log with
-        # emit_hard_delete=False). Accepts any status: the upgrade flow legitimately
-        # deletes old ARCHIVED playbooks via _delete_items_by_status(Status.ARCHIVED).
+        # the Supabase backend's emit_hard_delete=False path). SQLite's aggregation
+        # invalidation trigger still runs before each physical delete. Accepts any
+        # status: the upgrade flow legitimately deletes old ARCHIVED playbooks via
+        # _delete_items_by_status(Status.ARCHIVED).
         where = "status = ?"
         params: list[Any] = [status.value]
         if agent_version is not None:

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -178,6 +178,7 @@ class UserPlaybookStoreMixin:
     _assert_subject_writable_locked: Any
     _own_transaction: Any
     commit_scope: Any
+    append_playbook_aggregation_invalidation: Any
     _has_sqlite_vec: bool
 
     @SQLiteStorageBase.handle_exceptions
@@ -1276,9 +1277,10 @@ class UserPlaybookStoreMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def archive_user_playbook_by_id(self, user_id: str, user_playbook_id: int) -> bool:
-        with self._lock:
+        with self.commit_scope(), self._lock:
             row = self.conn.execute(
-                "SELECT user_id, governance_subject_ref FROM user_playbooks WHERE user_playbook_id = ? AND user_id = ?",
+                "SELECT user_id, governance_subject_ref, agent_version "
+                "FROM user_playbooks WHERE user_playbook_id = ? AND user_id = ?",
                 (user_playbook_id, user_id),
             ).fetchone()
             if row is None:
@@ -1291,9 +1293,14 @@ class UserPlaybookStoreMixin:
                 "WHERE user_playbook_id = ? AND user_id = ? AND status IS NULL",
                 (Status.ARCHIVED.value, _epoch_now(), user_playbook_id, user_id),
             )
-            if self._own_transaction():
-                self.conn.commit()
-        return cur.rowcount > 0
+            agent_version = str(row["agent_version"] or "").strip()
+            if cur.rowcount > 0 and agent_version:
+                self.append_playbook_aggregation_invalidation(
+                    agent_version=agent_version,
+                    operation="archive",
+                    entity_id=user_playbook_id,
+                )
+            return cur.rowcount > 0
 
     @SQLiteStorageBase.handle_exceptions
     def has_user_playbooks_with_status(
@@ -1475,6 +1482,8 @@ class UserPlaybookStoreMixin:
         self,
         user_playbook_ids: list[int],
         status_filter: list[Status | None] | None = None,
+        *,
+        include_embedding: bool = False,
     ) -> list[UserPlaybook]:
         if not user_playbook_ids:
             return []
@@ -1486,10 +1495,11 @@ class UserPlaybookStoreMixin:
             sql += f" AND {frag}"
             params.extend(sparams)
         rows = self._fetchall(sql, params)
-        by_id = {
-            _row_to_user_playbook(row).user_playbook_id: _row_to_user_playbook(row)
+        converted = [
+            _row_to_user_playbook(row, include_embedding=include_embedding)
             for row in rows
-        }
+        ]
+        by_id = {item.user_playbook_id: item for item in converted}
         return [by_id[upid] for upid in user_playbook_ids if upid in by_id]
 
     @SQLiteStorageBase.handle_exceptions

--- a/reflexio/server/services/storage/storage_base/__init__.py
+++ b/reflexio/server/services/storage/storage_base/__init__.py
@@ -48,6 +48,7 @@ from .playbook import (
     AgentEvaluationResultStoreMixin,
     AgentPlaybookStoreMixin,
     OptimizationJobStoreMixin,
+    PlaybookAggregationStoreMixin,
     PlaybookSourceLinkageMixin,
     UserPlaybookStoreMixin,
 )
@@ -63,6 +64,7 @@ class BaseStorage(
     ProfileSearchMixin,
     RequestMixin,
     SessionOutcomeStoreMixin,
+    PlaybookAggregationStoreMixin,
     AgentPlaybookStoreMixin,
     UserPlaybookStoreMixin,
     PlaybookSourceLinkageMixin,

--- a/reflexio/server/services/storage/storage_base/playbook/__init__.py
+++ b/reflexio/server/services/storage/storage_base/playbook/__init__.py
@@ -1,12 +1,34 @@
 from ._agent import AgentPlaybookStoreMixin
+from ._aggregation import (
+    AGGREGATION_INVALIDATION_RETENTION_SECONDS,
+    AGGREGATION_RETRY_BASE_SECONDS,
+    AGGREGATION_RETRY_MAX_SECONDS,
+    AggregationDisposition,
+    PlaybookAggregationBacklog,
+    PlaybookAggregationClaim,
+    PlaybookAggregationClusterMatch,
+    PlaybookAggregationInvalidation,
+    PlaybookAggregationRerunSnapshot,
+    PlaybookAggregationStoreMixin,
+)
 from ._eval_results import AgentEvaluationResultStoreMixin
 from ._optimization import OptimizationJobStoreMixin
 from ._source_linkage import PlaybookSourceLinkageMixin
 from ._user import UserPlaybookStoreMixin
 
 __all__ = [
+    "AGGREGATION_INVALIDATION_RETENTION_SECONDS",
+    "AGGREGATION_RETRY_BASE_SECONDS",
+    "AGGREGATION_RETRY_MAX_SECONDS",
+    "AggregationDisposition",
     "AgentEvaluationResultStoreMixin",
     "AgentPlaybookStoreMixin",
+    "PlaybookAggregationBacklog",
+    "PlaybookAggregationClaim",
+    "PlaybookAggregationClusterMatch",
+    "PlaybookAggregationInvalidation",
+    "PlaybookAggregationRerunSnapshot",
+    "PlaybookAggregationStoreMixin",
     "OptimizationJobStoreMixin",
     "PlaybookSourceLinkageMixin",
     "UserPlaybookStoreMixin",

--- a/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
@@ -1,0 +1,280 @@
+"""Durable state contracts for incremental user-playbook aggregation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from reflexio.models.api_schema.service_schemas import UserPlaybook
+
+AggregationDisposition = Literal["residual", "cluster_member", "terminal_noop"]
+
+AGGREGATION_RETRY_BASE_SECONDS = 60
+AGGREGATION_RETRY_MAX_SECONDS = 3_600
+AGGREGATION_INVALIDATION_RETENTION_SECONDS = 7 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class PlaybookAggregationClaim:
+    """One database-fenced, organization-wide aggregation claim."""
+
+    agent_version: str
+    owner: str
+    fence: int
+    state_version: int
+    expires_at: int
+
+
+@dataclass(frozen=True)
+class PlaybookAggregationBacklog:
+    """Bounded-work backlog counts used by scheduling and telemetry."""
+
+    undisposed: int
+    residual: int
+    invalidations: int
+    oldest_residual_age_seconds: int | None = None
+    dirty_repairs: int = 0
+    residual_retry_after_seconds: int = 0
+
+    @property
+    def pending(self) -> bool:
+        return bool(
+            self.undisposed or self.residual or self.invalidations or self.dirty_repairs
+        )
+
+    @property
+    def continuation_delay_seconds(self) -> int:
+        """Delay residual-only work until its durable retry cooldown expires."""
+        if self.undisposed or self.invalidations or self.dirty_repairs:
+            return 0
+        return max(0, self.residual_retry_after_seconds) if self.residual else 0
+
+
+@dataclass(frozen=True)
+class PlaybookAggregationInvalidation:
+    invalidation_id: int
+    agent_version: str
+    operation: str
+    entity_id: int
+    source_ids: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class PlaybookAggregationClusterMatch:
+    cluster_id: str
+    similarity: float
+
+
+@dataclass(frozen=True)
+class PlaybookAggregationRerunSnapshot:
+    """Inputs materialized from one pre-compute storage snapshot."""
+
+    user_playbooks: tuple[UserPlaybook, ...]
+    invalidation_ids: tuple[int, ...]
+    user_high_watermark: int | None
+    invalidation_high_watermark: int | None
+
+
+class PlaybookAggregationStoreMixin:
+    """Portable, deliberately narrow aggregation state API.
+
+    Tenant backends scope these records by schema; SQLite scopes them by the
+    storage database.  Callers must not use a sequence watermark for discovery.
+    """
+
+    def schedule_playbook_aggregation(self, agent_version: str) -> None:
+        """Durably mark a version pending without postponing existing work."""
+        raise NotImplementedError
+
+    def repair_playbook_aggregation_pending_state(
+        self, *, limit: int = 100
+    ) -> list[str]:
+        """Create pending state for eligible anti-join work after a lost signal."""
+        raise NotImplementedError
+
+    def claim_due_playbook_aggregation(
+        self,
+        *,
+        owner: str,
+        lease_seconds: int,
+        agent_version: str | None = None,
+    ) -> PlaybookAggregationClaim | None:
+        """Claim the oldest due (or requested admin) version using database time."""
+        raise NotImplementedError
+
+    def renew_playbook_aggregation_claim(
+        self, claim: PlaybookAggregationClaim, *, lease_seconds: int
+    ) -> PlaybookAggregationClaim | None:
+        """Renew a live claim or return None after ownership is lost."""
+        raise NotImplementedError
+
+    def validate_playbook_aggregation_claim(
+        self, claim: PlaybookAggregationClaim
+    ) -> bool:
+        """Lock and validate the lease fence plus expected state version."""
+        raise NotImplementedError
+
+    def finish_playbook_aggregation_claim(
+        self,
+        claim: PlaybookAggregationClaim,
+        *,
+        success: bool,
+        retry_after_seconds: int,
+        backlog_retry_after_seconds: int,
+        min_interval_seconds: int,
+        backlog: PlaybookAggregationBacklog | None = None,
+    ) -> bool:
+        """Fenced completion with separate failure, drain, and idle delays."""
+        raise NotImplementedError
+
+    def stage_playbook_aggregation_intake(
+        self, agent_version: str, *, limit: int
+    ) -> list[int]:
+        """Anti-join eligible CURRENT rows and durably stage them as residual."""
+        raise NotImplementedError
+
+    def get_playbook_aggregation_bootstrap_status(self, agent_version: str) -> str:
+        """Return ``pending`` or ``complete`` for legacy-state adoption."""
+        raise NotImplementedError
+
+    def set_playbook_aggregation_bootstrap_status(
+        self, agent_version: str, status: Literal["pending", "complete"]
+    ) -> None:
+        """Persist legacy-state adoption progress for one version."""
+        raise NotImplementedError
+
+    def get_playbook_aggregation_cluster_rebuild_cursor(
+        self, cluster_id: str
+    ) -> tuple[int, str] | None:
+        """Return a legacy cluster's member cursor and state, if it exists."""
+        raise NotImplementedError
+
+    def adopt_legacy_playbook_aggregation_cluster_page(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        agent_playbook_id: int,
+        member_embeddings: list[tuple[int, list[float]]],
+        embedding_model: str,
+        embedding_dimension: int,
+        rebuild_cursor: int,
+        complete: bool,
+    ) -> None:
+        """Append one bounded, re-embedded page to a legacy cluster rebuild."""
+        raise NotImplementedError
+
+    def reset_playbook_aggregation_version(self, agent_version: str) -> None:
+        """Clear typed cluster/item state before a fenced full rerun rebuild."""
+        raise NotImplementedError
+
+    def capture_playbook_aggregation_rerun_snapshot(
+        self, agent_version: str, *, limit: int
+    ) -> PlaybookAggregationRerunSnapshot:
+        """Materialize rerun rows and exact invalidations in one read snapshot."""
+        raise NotImplementedError
+
+    def stage_playbook_aggregation_snapshot(
+        self, agent_version: str, user_playbook_ids: list[int]
+    ) -> None:
+        """Stage exactly the captured rerun IDs, including later-deleted rows."""
+        raise NotImplementedError
+
+    def mark_playbook_aggregation_invalidations_processed(
+        self,
+        claim: PlaybookAggregationClaim,
+        invalidation_ids: list[int],
+    ) -> bool:
+        """Fenced completion for exact invalidations reflected by a rerun."""
+        raise NotImplementedError
+
+    def get_playbook_aggregation_residual_ids(
+        self, agent_version: str, *, limit: int
+    ) -> list[int]:
+        """Return a fair bounded residual page and record attempts."""
+        raise NotImplementedError
+
+    def set_playbook_aggregation_disposition(
+        self,
+        agent_version: str,
+        user_playbook_ids: list[int],
+        *,
+        disposition: AggregationDisposition,
+        cluster_id: str | None = None,
+        reason: str | None = None,
+    ) -> None:
+        """Move staged items to one durable disposition."""
+        raise NotImplementedError
+
+    def get_playbook_aggregation_backlog(
+        self, agent_version: str
+    ) -> PlaybookAggregationBacklog:
+        """Return scheduler/telemetry backlog counts."""
+        raise NotImplementedError
+
+    def append_playbook_aggregation_invalidation(
+        self,
+        *,
+        agent_version: str,
+        operation: str,
+        entity_id: int,
+        source_ids: list[int] | None = None,
+    ) -> None:
+        """Append a routed lifecycle invalidation in the caller's transaction."""
+        raise NotImplementedError
+
+    def get_playbook_aggregation_invalidations(
+        self, agent_version: str, *, limit: int
+    ) -> list[PlaybookAggregationInvalidation]:
+        """Read an ordered bounded invalidation page."""
+        raise NotImplementedError
+
+    def apply_playbook_aggregation_invalidations(
+        self,
+        claim: PlaybookAggregationClaim,
+        invalidation_ids: list[int],
+    ) -> bool:
+        """Fenced, idempotent removal plus invalidation completion."""
+        raise NotImplementedError
+
+    def get_playbook_aggregation_replacement_agent_ids(
+        self, agent_version: str, user_playbook_ids: list[int]
+    ) -> list[int]:
+        """Return prior agents for rebuilding clusters touched by these members."""
+        raise NotImplementedError
+
+    def delete_orphaned_playbook_aggregation_clusters(self, agent_version: str) -> None:
+        """Delete rebuilding clusters after no item retains their provenance."""
+        raise NotImplementedError
+
+    def find_nearest_playbook_aggregation_clusters(
+        self,
+        agent_version: str,
+        candidates: list[tuple[int, list[float]]],
+        *,
+        embedding_model: str,
+        limit: int,
+    ) -> dict[int, PlaybookAggregationClusterMatch]:
+        """Return nearest centroids for a version-isolated candidate batch."""
+        raise NotImplementedError
+
+    def create_playbook_aggregation_cluster(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        agent_playbook_id: int | None,
+        embeddings: list[list[float]],
+        embedding_model: str,
+    ) -> None:
+        """Persist a stable cluster and assign its staged members separately."""
+        raise NotImplementedError
+
+    def attach_playbook_aggregation_items(
+        self,
+        *,
+        agent_version: str,
+        attachments: list[tuple[int, str, list[float]]],
+    ) -> None:
+        """Atomically attach residuals and update each affected centroid once."""
+        raise NotImplementedError

--- a/reflexio/server/services/storage/storage_base/playbook/_user.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_user.py
@@ -331,6 +331,8 @@ class UserPlaybookStoreMixin:
         self,
         user_playbook_ids: list[int],
         status_filter: list[Status | None] | None = None,
+        *,
+        include_embedding: bool = False,
     ) -> list[UserPlaybook]:
         """Fetch user playbooks by ids without requiring a single owner id."""
         raise NotImplementedError

--- a/tests/lib/test_generation_unit.py
+++ b/tests/lib/test_generation_unit.py
@@ -5,7 +5,7 @@ rerun_profile_generation, manual_profile_generation, rerun_playbook_generation,
 manual_playbook_generation, and storage-not-configured error handling.
 """
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -121,6 +121,47 @@ class TestRunPlaybookAggregation:
 
         with pytest.raises(ValueError, match=STORAGE_NOT_CONFIGURED_MSG):
             mixin.run_playbook_aggregation(agent_version="v1", playbook_name="fb")
+
+    @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
+    def test_admin_rerun_uses_configured_min_interval(
+        self, mock_agg_cls, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS", "123")
+        mixin = _make_mixin()
+        storage = cast(Any, mixin.request_context.storage)
+        storage.supports_incremental_playbook_aggregation = True
+        storage.claim_due_playbook_aggregation.return_value = MagicMock()
+        storage.finish_playbook_aggregation_claim.return_value = True
+
+        mixin.run_playbook_aggregation(agent_version="v1")
+
+        assert storage.finish_playbook_aggregation_claim.call_args.kwargs == {
+            "success": True,
+            "retry_after_seconds": 60,
+            "backlog_retry_after_seconds": 1,
+            "min_interval_seconds": 123,
+        }
+
+    @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
+    def test_failed_admin_rerun_uses_configured_min_interval(
+        self, mock_agg_cls, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS", "123")
+        mixin = _make_mixin()
+        storage = cast(Any, mixin.request_context.storage)
+        storage.supports_incremental_playbook_aggregation = True
+        storage.claim_due_playbook_aggregation.return_value = MagicMock()
+        mock_agg_cls.return_value.run.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            mixin.run_playbook_aggregation(agent_version="v1")
+
+        assert storage.finish_playbook_aggregation_claim.call_args.kwargs == {
+            "success": False,
+            "retry_after_seconds": 60,
+            "backlog_retry_after_seconds": 1,
+            "min_interval_seconds": 123,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/lib/test_generation_unit.py
+++ b/tests/lib/test_generation_unit.py
@@ -163,6 +163,47 @@ class TestRunPlaybookAggregation:
             "min_interval_seconds": 123,
         }
 
+    @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
+    @patch(
+        "reflexio.server.services.playbook.aggregation_scheduler.AggregationLeaseHeartbeat"
+    )
+    def test_admin_rerun_finishes_with_heartbeat_renewed_claim(
+        self, heartbeat_cls, mock_agg_cls
+    ) -> None:
+        mixin = _make_mixin()
+        storage = cast(Any, mixin.request_context.storage)
+        storage.supports_incremental_playbook_aggregation = True
+        original_claim = MagicMock(name="original_claim")
+        renewed_claim = MagicMock(name="renewed_claim")
+        storage.claim_due_playbook_aggregation.return_value = original_claim
+        storage.finish_playbook_aggregation_claim.return_value = True
+        heartbeat_cls.return_value.claim = renewed_claim
+
+        mixin.run_playbook_aggregation(agent_version="v1")
+
+        heartbeat_cls.return_value.start.assert_called_once_with()
+        heartbeat_cls.return_value.stop.assert_called_once_with()
+        heartbeat_cls.return_value.require_live.assert_called_once_with()
+        assert storage.finish_playbook_aggregation_claim.call_args.args == (
+            renewed_claim,
+        )
+
+    @patch("reflexio.server.services.playbook.components.aggregator.PlaybookAggregator")
+    def test_admin_rerun_preserves_original_error_when_claim_cleanup_fails(
+        self, mock_agg_cls
+    ) -> None:
+        mixin = _make_mixin()
+        storage = cast(Any, mixin.request_context.storage)
+        storage.supports_incremental_playbook_aggregation = True
+        storage.claim_due_playbook_aggregation.return_value = MagicMock()
+        storage.finish_playbook_aggregation_claim.side_effect = RuntimeError(
+            "cleanup failed"
+        )
+        mock_agg_cls.return_value.run.side_effect = ValueError("aggregation failed")
+
+        with pytest.raises(ValueError, match="aggregation failed"):
+            mixin.run_playbook_aggregation(agent_version="v1")
+
 
 # ---------------------------------------------------------------------------
 # _run_generation_service

--- a/tests/server/services/durable_learning/test_compute_persist_split.py
+++ b/tests/server/services/durable_learning/test_compute_persist_split.py
@@ -296,6 +296,14 @@ def test_worker_scope_wraps_only_persist(monkeypatch):
             return _Tracker()
 
         monkeypatch.setattr(storage, "commit_scope", wrapped_scope)
+        # This test owns the durable-learning phase boundary, not the local
+        # aggregation daemon. Keep the durable scheduling signal while avoiding
+        # a second thread opening commit_scope after emit and racing the tracker.
+        monkeypatch.setattr(
+            "reflexio.server.services.playbook.aggregation_trigger."
+            "ensure_local_playbook_aggregation_scheduler",
+            lambda _context: None,
+        )
 
         def wrap(name, fn):
             def _inner(self, *a, **k):

--- a/tests/server/services/playbook/test_aggregation_lineage_integration.py
+++ b/tests/server/services/playbook/test_aggregation_lineage_integration.py
@@ -607,6 +607,9 @@ def test_e2e_reconstruct_incremental_run_mode(
     )
 
     # Run 2 — incremental (rerun=False, prev fingerprints now present).
+    # This test exercises reconstruction of the legacy fingerprint path. The
+    # durable incremental engine has its own typed-state integration coverage.
+    storage.supports_incremental_playbook_aggregation = False
     with (
         patch.object(
             PlaybookAggregator, "get_clusters", return_value={0: cluster_run2}

--- a/tests/server/services/playbook/test_aggregation_scheduler.py
+++ b/tests/server/services/playbook/test_aggregation_scheduler.py
@@ -5,7 +5,10 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 from reflexio.server.services.playbook import aggregation_scheduler
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base.playbook import (
     PlaybookAggregationBacklog,
     PlaybookAggregationClaim,
@@ -119,7 +122,6 @@ def test_scheduler_throttles_idle_repair_scans(monkeypatch) -> None:
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
     storage.repair_playbook_aggregation_pending_state.return_value = []
     storage.claim_due_playbook_aggregation.return_value = None
-    monkeypatch.setattr(aggregation_scheduler.time, "monotonic", lambda: 10.0)
     scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
         context_provider=lambda: [], worker_id="worker"
     )
@@ -127,6 +129,74 @@ def test_scheduler_throttles_idle_repair_scans(monkeypatch) -> None:
 
     scheduler._run_context(context)
     scheduler._run_context(context)
+    scheduler._last_repair_at["org-1"] -= (
+        aggregation_scheduler._REPAIR_INTERVAL_SECONDS + 1
+    )
+    scheduler._run_context(context)
 
-    storage.repair_playbook_aggregation_pending_state.assert_called_once_with()
-    assert storage.claim_due_playbook_aggregation.call_count == 2
+    assert storage.repair_playbook_aggregation_pending_state.call_count == 2
+    assert storage.claim_due_playbook_aggregation.call_count == 3
+
+
+def test_lease_heartbeat_marks_renewal_exception_as_lost() -> None:
+    claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
+    storage = MagicMock()
+    storage.renew_playbook_aggregation_claim.side_effect = RuntimeError("db down")
+    heartbeat = aggregation_scheduler.AggregationLeaseHeartbeat(storage, claim)
+    heartbeat._stop.wait = MagicMock(return_value=False)
+
+    heartbeat._run()
+
+    with pytest.raises(RuntimeError, match="lease was lost"):
+        heartbeat.require_live()
+
+
+def test_stopped_local_scheduler_drops_captured_context(monkeypatch) -> None:
+    monkeypatch.delenv("DEPLOYMENT_MODE", raising=False)
+    aggregation_scheduler._LOCAL_SCHEDULERS.clear()
+    monkeypatch.setattr(
+        aggregation_scheduler.PlaybookAggregationScheduler,
+        "start",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        aggregation_scheduler.PlaybookAggregationScheduler,
+        "is_running",
+        MagicMock(return_value=False),
+    )
+    first_context = _context(MagicMock())
+    first = aggregation_scheduler.ensure_local_playbook_aggregation_scheduler(
+        first_context
+    )
+    assert first is not None
+
+    first._on_stopped()
+    second_context = _context(MagicMock())
+    second = aggregation_scheduler.ensure_local_playbook_aggregation_scheduler(
+        second_context
+    )
+
+    assert second is not None
+    assert second is not first
+    assert list(second._context_provider()) == [second_context]
+
+
+def test_scheduler_keeps_sqlite_work_pending_when_vector_index_is_unavailable(
+    tmp_path, monkeypatch, caplog
+) -> None:
+    monkeypatch.setattr(SQLiteStorage, "_try_load_sqlite_vec", lambda _self: False)
+    storage = SQLiteStorage(org_id="org-1", db_path=str(tmp_path / "missing-vec.db"))
+    storage.schedule_playbook_aggregation("v1")
+    caplog.set_level(logging.WARNING, logger=aggregation_scheduler.logger.name)
+
+    scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
+        context_provider=lambda: [], worker_id="worker"
+    )
+    scheduler._run_context(_context(storage))
+
+    state = storage.conn.execute(
+        "SELECT pending FROM playbook_aggregation_state WHERE agent_version='v1'"
+    ).fetchone()
+    assert state is not None and int(state[0]) == 1
+    assert storage.supports_incremental_playbook_aggregation is False
+    assert "blocked_missing_vector_index" in caplog.text

--- a/tests/server/services/playbook/test_aggregation_scheduler.py
+++ b/tests/server/services/playbook/test_aggregation_scheduler.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+from reflexio.server.services.playbook import aggregation_scheduler
+from reflexio.server.services.storage.storage_base.playbook import (
+    PlaybookAggregationBacklog,
+    PlaybookAggregationClaim,
+)
+
+
+def _context(storage: MagicMock) -> Any:
+    aggregation_config = SimpleNamespace()
+    config = SimpleNamespace(
+        user_playbook_extractor_config=SimpleNamespace(
+            aggregation_config=aggregation_config
+        )
+    )
+    return SimpleNamespace(
+        org_id="org-1",
+        storage=storage,
+        configurator=SimpleNamespace(get_config=lambda: config),
+    )
+
+
+def test_scheduler_passes_claim_and_remaining_shared_budget(
+    monkeypatch, caplog
+) -> None:
+    claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
+    storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.repair_playbook_aggregation_pending_state.return_value = []
+    storage.claim_due_playbook_aggregation.return_value = claim
+    after = PlaybookAggregationBacklog(4, 1, 0, residual_retry_after_seconds=60)
+    storage.get_playbook_aggregation_backlog.return_value = after
+    storage.get_playbook_aggregation_invalidations.return_value = [
+        SimpleNamespace(invalidation_id=1),
+        SimpleNamespace(invalidation_id=2),
+    ]
+    storage.apply_playbook_aggregation_invalidations.return_value = True
+    storage.finish_playbook_aggregation_claim.return_value = True
+    captured: dict[str, object] = {}
+
+    class Aggregator:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run(self, _request: object) -> dict[str, int]:
+            return {"playbooks_generated": 1}
+
+    monkeypatch.setattr(aggregation_scheduler, "PlaybookAggregator", Aggregator)
+    monkeypatch.setattr(aggregation_scheduler, "_aggregation_budget", lambda: 8)
+    monkeypatch.setattr(
+        "reflexio.lib.generation_client.create_generation_litellm_client",
+        lambda _context: MagicMock(),
+    )
+    monkeypatch.setattr(
+        aggregation_scheduler,
+        "run_with_operation_limit",
+        lambda *, fn, **_kwargs: fn(),
+    )
+    caplog.set_level(logging.INFO, logger=aggregation_scheduler.logger.name)
+
+    scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
+        context_provider=lambda: [], worker_id="worker"
+    )
+    scheduler._run_context(_context(storage))
+
+    assert captured["aggregation_claim"] == claim
+    assert captured["work_budget"] == 6
+    storage.finish_playbook_aggregation_claim.assert_called_once()
+    assert storage.finish_playbook_aggregation_claim.call_args.kwargs["success"] is True
+    assert (
+        storage.finish_playbook_aggregation_claim.call_args.kwargs[
+            "backlog_retry_after_seconds"
+        ]
+        == 1
+    )
+    assert (
+        storage.finish_playbook_aggregation_claim.call_args.kwargs["backlog"] == after
+    )
+    storage.get_playbook_aggregation_backlog.assert_called_once_with("v1")
+    assert "state=succeeded" in caplog.text
+
+
+def test_scheduler_keeps_pending_on_limiter_deferral(monkeypatch) -> None:
+    claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
+    storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.repair_playbook_aggregation_pending_state.return_value = []
+    storage.claim_due_playbook_aggregation.return_value = claim
+    storage.get_playbook_aggregation_backlog.return_value = PlaybookAggregationBacklog(
+        1, 0, 0
+    )
+    storage.get_playbook_aggregation_invalidations.return_value = []
+    storage.finish_playbook_aggregation_claim.return_value = True
+    monkeypatch.setattr(
+        "reflexio.lib.generation_client.create_generation_litellm_client",
+        lambda _context: MagicMock(),
+    )
+    monkeypatch.setattr(
+        aggregation_scheduler,
+        "run_with_operation_limit",
+        lambda **_kwargs: (_ for _ in ()).throw(TimeoutError),
+    )
+
+    scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
+        context_provider=lambda: [], worker_id="worker"
+    )
+    scheduler._run_context(_context(storage))
+
+    assert (
+        storage.finish_playbook_aggregation_claim.call_args.kwargs["success"] is False
+    )
+
+
+def test_scheduler_throttles_idle_repair_scans(monkeypatch) -> None:
+    storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.repair_playbook_aggregation_pending_state.return_value = []
+    storage.claim_due_playbook_aggregation.return_value = None
+    monkeypatch.setattr(aggregation_scheduler.time, "monotonic", lambda: 10.0)
+    scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
+        context_provider=lambda: [], worker_id="worker"
+    )
+    context = _context(storage)
+
+    scheduler._run_context(context)
+    scheduler._run_context(context)
+
+    storage.repair_playbook_aggregation_pending_state.assert_called_once_with()
+    assert storage.claim_due_playbook_aggregation.call_count == 2

--- a/tests/server/services/playbook/test_aggregation_soft_delete_integration.py
+++ b/tests/server/services/playbook/test_aggregation_soft_delete_integration.py
@@ -335,6 +335,11 @@ def _run_aggregator_with_supersede(
 ) -> tuple[SQLiteStorage, RequestContext]:
     """Run one aggregation with one new and one old archived playbook."""
     storage = _make_storage(temp_dir, worker_id, suffix=suffix)
+    if not full_archive:
+        # These cases characterize the legacy fingerprint replacement path.
+        # Durable incremental aggregation only attaches or creates clusters and
+        # intentionally performs no supersession.
+        storage.supports_incremental_playbook_aggregation = False
     ctx = _make_request_context(storage, temp_dir, worker_id, suffix=suffix)
 
     # Seed old archived agent playbook (will be removed on SUCCESS path)

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1034,6 +1034,7 @@ class TestRun:
         agg.storage.get_agent_playbooks.assert_called_once_with(
             limit=page_size,
             max_agent_playbook_id=aggregator_module._SIGNED_BIGINT_MAX,
+            agent_version="v1",
             status_filter=[None],
             playbook_status_filter=[
                 PlaybookStatus.APPROVED,
@@ -1757,6 +1758,10 @@ class TestProcessAggregationResponse:
         response = PlaybookAggregationOutput(playbook=None)
         assert agg._process_aggregation_response(response, [_raw()]) is None
 
+        outcome = agg._process_aggregation_response_outcome(response, [_raw()])
+        assert outcome.status == "semantic_null"
+        assert outcome.playbook is None
+
     def test_valid_response_returns_playbook(self):
         from reflexio.server.services.playbook.playbook_service_utils import (
             PlaybookAggregationOutput,
@@ -1827,6 +1832,32 @@ class TestProcessAggregationResponse:
         )
 
         assert agg._process_aggregation_response(response, [_raw()]) is None
+        assert (
+            agg._process_aggregation_response_outcome(response, [_raw()]).status
+            == "retryable_failure"
+        )
+
+    def test_batch_preserves_one_tagged_outcome_per_cluster(self):
+        agg = _make_aggregator()
+        agg._generate_playbook_from_cluster_outcome = MagicMock(  # type: ignore[method-assign]
+            side_effect=[
+                aggregator_module.AggregationGenerationOutcome(
+                    "semantic_null", [_raw(1)]
+                ),
+                aggregator_module.AggregationGenerationOutcome(
+                    "retryable_failure", [_raw(2)]
+                ),
+            ]
+        )
+
+        outcomes = agg._generate_playbook_outcomes_with_source_clusters(
+            {0: [_raw(1)], 1: [_raw(2)]}, []
+        )
+
+        assert [item.status for item in outcomes] == [
+            "semantic_null",
+            "retryable_failure",
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -1890,6 +1921,39 @@ def test_aggregator_groups_by_content_similarity_not_polarity():
         f"high-overlap content must group together (no polarity gate), got {groups}"
     )
     assert len(groups[0]) == 2
+
+
+def test_large_prompt_cluster_skips_quadratic_direction_grouping(monkeypatch):
+    raws = [_make_pb(f"rule {index}", rid=index) for index in range(257)]
+    monkeypatch.setattr(
+        aggregator_module.aggregator_prompt_formatting,
+        "group_playbooks_by_direction",
+        MagicMock(side_effect=AssertionError("quadratic grouping should be bounded")),
+    )
+
+    rendered = (
+        aggregator_module.aggregator_prompt_formatting.format_structured_cluster_input(
+            raws
+        )
+    )
+
+    assert "TRIGGER conditions: (none specified)" in rendered
+
+
+def test_existing_prompt_context_is_embedding_ranked_and_bounded():
+    cluster = [_raw(1).model_copy(update={"embedding": [1.0, 0.0]})]
+    irrelevant = [
+        _agent_playbook(index).model_copy(update={"embedding": [0.0, 1.0]})
+        for index in range(1, 22)
+    ]
+    relevant = _agent_playbook(99).model_copy(update={"embedding": [1.0, 0.0]})
+
+    selected = aggregator_module._select_relevant_existing_playbooks(
+        cluster, [*irrelevant, relevant]
+    )
+
+    assert len(selected) == 20
+    assert selected[0].agent_playbook_id == 99
 
 
 def test_aggregation_preserves_distinct_do_and_avoid_rules():

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -569,6 +569,34 @@ def test_artifact_postprocessing_warning_does_not_write_usage_event(caplog):
     mock_record_usage_event.assert_not_called()
 
 
+def test_oversized_full_rerun_records_failed_gate(monkeypatch) -> None:
+    monkeypatch.setenv("REFLEXIO_MAX_CLUSTERING_PLAYBOOKS", "1")
+    agg = _make_aggregator()
+    agg.configurator.get_config.return_value.user_playbook_extractor_config = (
+        PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        )
+    )
+    agg.storage.count_user_playbooks.return_value = 2
+    agg.storage.get_agent_playbooks.return_value = []
+
+    with (
+        patch(
+            "reflexio.server.services.playbook.components.aggregator.record_usage_event"
+        ) as record_usage,
+        pytest.raises(RuntimeError, match="exceeds the safety cap"),
+    ):
+        agg.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+    assert record_usage.call_args.kwargs["outcome"] == "failed"
+    assert (
+        record_usage.call_args.kwargs["metadata"]["failure_reason"]
+        == "full_rerun_safety_cap_exceeded"
+    )
+
+
 def test_artifact_postprocessing_runs_before_exception_logging(caplog):
     agg = _make_aggregator(aggregation_prompt_processor=_MappingAwareProcessor())
     agg.request_context.prompt_manager.render_prompt.return_value = "prompt"
@@ -1839,6 +1867,8 @@ class TestProcessAggregationResponse:
 
     def test_batch_preserves_one_tagged_outcome_per_cluster(self):
         agg = _make_aggregator()
+        cluster_a = [_raw(1)]
+        cluster_b = [_raw(2)]
         agg._generate_playbook_from_cluster_outcome = MagicMock(  # type: ignore[method-assign]
             side_effect=[
                 aggregator_module.AggregationGenerationOutcome(
@@ -1851,13 +1881,16 @@ class TestProcessAggregationResponse:
         )
 
         outcomes = agg._generate_playbook_outcomes_with_source_clusters(
-            {0: [_raw(1)], 1: [_raw(2)]}, []
+            {0: cluster_a, 1: cluster_b}, []
         )
 
         assert [item.status for item in outcomes] == [
             "semantic_null",
             "retryable_failure",
         ]
+        assert [item.source_cluster for item in outcomes] == [cluster_a, cluster_b]
+        assert outcomes[0].source_cluster[0] is cluster_a[0]
+        assert outcomes[1].source_cluster[0] is cluster_b[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -1,6 +1,5 @@
 import datetime
 import tempfile
-from contextlib import nullcontext
 from datetime import UTC
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
@@ -22,13 +21,8 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.api_endpoints.request_context import RequestContext
-from reflexio.server.extensions import register_service
 from reflexio.server.llm._litellm_types import ModelProvenance
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
-from reflexio.server.services.playbook.aggregation_prompt_processing import (
-    AGGREGATION_PROMPT_PROCESSOR,
-    PassthroughPromptProcessor,
-)
 from reflexio.server.services.playbook.playbook_service_utils import (
     PlaybookGenerationRequest,
 )
@@ -89,141 +83,32 @@ def test_inline_aggregation_default_path_does_not_inject_processor():
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
     service = _service_for_inline_aggregation(configurator)
-    created_kwargs: list[dict[str, Any]] = []
-
-    class FakeAggregator:
-        def __init__(self, **kwargs: Any) -> None:
-            created_kwargs.append(kwargs)
-
-        def run(self, _request: Any) -> dict[str, int]:
-            return {"playbooks_generated": 0}
-
-    with (
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
-            FakeAggregator,
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
-            side_effect=lambda **kwargs: kwargs["fn"](),
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
-            side_effect=lambda task: task(),
-        ),
+    with patch(
+        "reflexio.server.services.playbook.aggregation_trigger."
+        "ensure_local_playbook_aggregation_scheduler"
     ):
         service._trigger_playbook_aggregation()
 
-    assert len(created_kwargs) == 1
-    assert "aggregation_prompt_processor" not in created_kwargs[0]
+    _storage(service).schedule_playbook_aggregation.assert_called_once_with("v1")
 
 
-def test_inline_aggregation_injects_registered_processor():
-    processor = PassthroughPromptProcessor()
-    register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
-
-    configurator = MagicMock()
-    configurator.get_config.return_value = _aggregation_enabled_config()
-    service = _service_for_inline_aggregation(configurator)
-    created_kwargs: list[dict[str, Any]] = []
-
-    class FakeAggregator:
-        def __init__(self, **kwargs: Any) -> None:
-            created_kwargs.append(kwargs)
-
-        def run(self, _request: Any) -> dict[str, int]:
-            return {"playbooks_generated": 0}
-
-    with (
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
-            FakeAggregator,
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
-            side_effect=lambda **kwargs: kwargs["fn"](),
-        ),
-    ):
-        service._trigger_playbook_aggregation()
-
-    assert len(created_kwargs) == 1
-    assert created_kwargs[0]["aggregation_prompt_processor"] is processor
-
-
-def test_inline_aggregation_does_not_thread_processor_prompt_text_separately():
-    processor: Any = PassthroughPromptProcessor()
-    processor.prompt_extra_instructions = "Extra aggregation instruction."
-    register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
-
-    configurator = MagicMock()
-    configurator.get_config.return_value = _aggregation_enabled_config()
-    service = _service_for_inline_aggregation(configurator)
-    created_kwargs: list[dict[str, Any]] = []
-
-    class FakeAggregator:
-        def __init__(self, **kwargs: Any) -> None:
-            created_kwargs.append(kwargs)
-
-        def run(self, _request: Any) -> dict[str, int]:
-            return {"playbooks_generated": 0}
-
-    with (
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
-            FakeAggregator,
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
-            side_effect=lambda **kwargs: kwargs["fn"](),
-        ),
-    ):
-        service._trigger_playbook_aggregation()
-
-    assert len(created_kwargs) == 1
-    assert created_kwargs[0]["aggregation_prompt_processor"] is processor
-    assert "aggregation_prompt_extra_instructions" not in created_kwargs[0]
-
-
-def test_maybe_trigger_user_playbook_aggregation_uses_limiter_and_processor():
+def test_maybe_trigger_user_playbook_aggregation_durably_schedules():
     from reflexio.server.services.playbook.aggregation_trigger import (
         maybe_trigger_user_playbook_aggregation,
     )
-
-    processor = PassthroughPromptProcessor()
-    register_service(AGGREGATION_PROMPT_PROCESSOR, processor, override=True)
 
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
     ctx = MagicMock()
     ctx.configurator = configurator
     ctx.org_id = "test-org"
+    ctx.storage = MagicMock()
     llm_client = MagicMock()
-    created_kwargs: list[dict[str, Any]] = []
-    requests: list[Any] = []
-    task_results: list[Any] = []
 
-    class FakeAggregator:
-        def __init__(self, **kwargs: Any) -> None:
-            created_kwargs.append(kwargs)
-
-        def run(self, request: Any) -> dict[str, int]:
-            requests.append(request)
-            return {"playbooks_generated": 0}
-
-    with (
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
-            FakeAggregator,
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
-            side_effect=lambda **kwargs: kwargs["fn"](),
-        ) as limiter,
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
-            side_effect=lambda task: task_results.append(task()),
-        ),
-    ):
+    with patch(
+        "reflexio.server.services.playbook.aggregation_trigger."
+        "ensure_local_playbook_aggregation_scheduler"
+    ) as ensure_scheduler:
         result = maybe_trigger_user_playbook_aggregation(
             request_context=ctx,
             llm_client=llm_client,
@@ -231,17 +116,11 @@ def test_maybe_trigger_user_playbook_aggregation_uses_limiter_and_processor():
             reason="unit_test",
         )
 
-    assert result.status == "queued"
+    assert result.status == "scheduled"
     assert result.reason == "unit_test"
     assert result.agent_version == "v1"
-    assert task_results[0].status == "triggered"
-    assert limiter.call_args.kwargs["org_id"] == "test-org"
-    assert limiter.call_args.kwargs["operation"] == "aggregation"
-    assert created_kwargs[0]["llm_client"] is llm_client
-    assert created_kwargs[0]["request_context"] is ctx
-    assert created_kwargs[0]["agent_version"] == "v1"
-    assert created_kwargs[0]["aggregation_prompt_processor"] is processor
-    assert requests[0].agent_version == "v1"
+    ctx.storage.schedule_playbook_aggregation.assert_called_once_with("v1")
+    ensure_scheduler.assert_called_once_with(ctx)
 
 
 def test_maybe_trigger_user_playbook_aggregation_reports_no_config():
@@ -268,7 +147,7 @@ def test_maybe_trigger_user_playbook_aggregation_reports_no_config():
     assert result.agent_version == "v1"
 
 
-def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising():
+def test_maybe_trigger_user_playbook_aggregation_reports_schedule_failure():
     from reflexio.server.services.playbook.aggregation_trigger import (
         maybe_trigger_user_playbook_aggregation,
     )
@@ -276,130 +155,17 @@ def test_maybe_trigger_user_playbook_aggregation_reports_failure_without_raising
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
     ctx = MagicMock(configurator=configurator, org_id="test-org")
-    task_results: list[Any] = []
+    ctx.storage.schedule_playbook_aggregation.side_effect = RuntimeError("boom")
 
-    class FailingAggregator:
-        def __init__(self, **_kwargs: Any) -> None:
-            pass
-
-        def run(self, _request: Any) -> dict[str, int]:
-            raise RuntimeError("boom")
-
-    with (
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
-            FailingAggregator,
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
-            side_effect=lambda **kwargs: kwargs["fn"](),
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
-            side_effect=lambda task: task_results.append(task()),
-        ),
-    ):
-        result = maybe_trigger_user_playbook_aggregation(
-            request_context=ctx,
-            llm_client=MagicMock(),
-            agent_version="v1",
-            reason="post_commit",
-        )
-
-    assert result.status == "queued"
-    assert task_results[0].status == "failed"
-    assert task_results[0].error_type == "RuntimeError"
-
-
-def test_maybe_trigger_user_playbook_aggregation_reports_timeout_saturation():
-    from reflexio.server.services.playbook.aggregation_trigger import (
-        maybe_trigger_user_playbook_aggregation,
+    result = maybe_trigger_user_playbook_aggregation(
+        request_context=ctx,
+        llm_client=MagicMock(),
+        agent_version="v1",
+        reason="post_commit",
     )
-
-    configurator = MagicMock()
-    configurator.get_config.return_value = _aggregation_enabled_config()
-    ctx = MagicMock(configurator=configurator, org_id="test-org")
-    task_results: list[Any] = []
-
-    with (
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit",
-            side_effect=TimeoutError("aggregation limiter saturated"),
-        ),
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger._start_aggregation_thread",
-            side_effect=lambda task: task_results.append(task()),
-        ),
-    ):
-        result = maybe_trigger_user_playbook_aggregation(
-            request_context=ctx,
-            llm_client=MagicMock(),
-            agent_version="v1",
-            reason="post_commit",
-        )
-
-    assert result.status == "queued"
-    assert task_results[0].status == "skipped_saturated"
-    assert task_results[0].error_type == "TimeoutError"
-
-
-@pytest.mark.parametrize(
-    ("patch_target", "error_type"),
-    [
-        (None, "RuntimeError"),
-        (
-            "reflexio.server.services.playbook.aggregation_trigger.get_service",
-            "LookupError",
-        ),
-        (
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregator",
-            "ValueError",
-        ),
-        (
-            "reflexio.server.services.playbook.aggregation_trigger.PlaybookAggregatorRequest",
-            "TypeError",
-        ),
-    ],
-)
-def test_maybe_trigger_user_playbook_aggregation_reports_setup_failure_without_raising(
-    patch_target: str | None, error_type: str
-):
-    from reflexio.server.services.playbook.aggregation_trigger import (
-        maybe_trigger_user_playbook_aggregation,
-    )
-
-    configurator = MagicMock()
-    configurator.get_config.return_value = _aggregation_enabled_config()
-    ctx = MagicMock(configurator=configurator, org_id="test-org")
-
-    expected_error = {
-        "RuntimeError": RuntimeError("config failed"),
-        "LookupError": LookupError("processor failed"),
-        "ValueError": ValueError("aggregator failed"),
-        "TypeError": TypeError("request failed"),
-    }[error_type]
-    if patch_target is None:
-        configurator.get_config.side_effect = expected_error
-        failure_context = nullcontext()
-    else:
-        failure_context = patch(patch_target, side_effect=expected_error)
-
-    with (
-        failure_context,
-        patch(
-            "reflexio.server.services.playbook.aggregation_trigger.run_with_operation_limit"
-        ) as limiter,
-    ):
-        result = maybe_trigger_user_playbook_aggregation(
-            request_context=ctx,
-            llm_client=MagicMock(),
-            agent_version="v1",
-            reason="post_commit",
-        )
 
     assert result.status == "failed"
-    assert result.error_type == error_type
-    limiter.assert_not_called()
+    assert result.error_type == "RuntimeError"
 
 
 @pytest.fixture

--- a/tests/server/services/playbook/test_playbook_generation_service.py
+++ b/tests/server/services/playbook/test_playbook_generation_service.py
@@ -79,7 +79,7 @@ def _service_for_inline_aggregation(configurator: Any) -> PlaybookGenerationServ
     return service
 
 
-def test_inline_aggregation_default_path_does_not_inject_processor():
+def test_inline_aggregation_default_path_schedules_durably():
     configurator = MagicMock()
     configurator.get_config.return_value = _aggregation_enabled_config()
     service = _service_for_inline_aggregation(configurator)

--- a/tests/server/services/playbook_optimizer/test_gepa_user_playbook_publication.py
+++ b/tests/server/services/playbook_optimizer/test_gepa_user_playbook_publication.py
@@ -266,7 +266,7 @@ def _canonical_authority(authority: dict[str, Any]) -> str:
 
 def _azure_client(
     *,
-    endpoint: str = "https://azure-one.example.test/",
+    endpoint: str = "https://example.com:4443/",
     api_version: str = "2024-02-15-preview",
     api_key: str = "azure-secret-one",
     model: str = "azure/judge-deployment",
@@ -662,7 +662,7 @@ def test_gepa_user_authority_changes_for_generation_settings(
     ("name", "client"),
     [
         ("provider", LiteLLMClient(LiteLLMConfig(model="gpt-4o-mini"))),
-        ("endpoint", _azure_client(endpoint="https://azure-two.example.test/")),
+        ("endpoint", _azure_client(endpoint="https://example.com:4444/")),
         ("api_version", _azure_client(api_version="2025-01-01-preview")),
     ],
 )
@@ -677,7 +677,7 @@ def test_gepa_user_authority_changes_for_independent_provider_identity(
 
 
 def test_gepa_user_authority_freezes_non_secret_provider_identity(tmp_path):
-    endpoint = "https://azure-one.example.test/"
+    endpoint = "https://example.com:4443/"
     authority = _judge_authority(tmp_path, llm_client=_azure_client(endpoint=endpoint))
     plan = authority["evaluator_identity"]["pairwise_judge_request_plan"]
     rung = plan["judge_generation_settings"]["rungs"][0]

--- a/tests/server/services/playbook_optimizer/test_judge_frozen_plan.py
+++ b/tests/server/services/playbook_optimizer/test_judge_frozen_plan.py
@@ -113,7 +113,7 @@ def test_pairwise_judge_rejects_frozen_plan_drift_before_provider_execution(
 def test_pairwise_judge_provider_params_match_frozen_sanitized_plan(monkeypatch):
     monkeypatch.setenv("REFLEXIO_LLM_SEED", "47")
     monkeypatch.setenv("REFLEXIO_LLM_HARD_TIMEOUT_GRACE_SECONDS", "7")
-    endpoint = "https://azure-one.example.test/"
+    endpoint = "https://example.com:4443/"
     secret = "azure-secret"
     client = LiteLLMClient(
         LiteLLMConfig(

--- a/tests/server/services/profile/test_profile_generation_service_utils.py
+++ b/tests/server/services/profile/test_profile_generation_service_utils.py
@@ -273,13 +273,15 @@ def test_calculate_expiration_timestamp_ignores_local_dst(
         pytest.skip("timezone switching is unavailable")
     before_pacific_dst_end = int(datetime(2026, 8, 3, 12, tzinfo=UTC).timestamp())
 
-    with monkeypatch.context() as context:
-        context.setenv("TZ", "America/Los_Angeles")
+    try:
+        with monkeypatch.context() as context:
+            context.setenv("TZ", "America/Los_Angeles")
+            tzset()
+            expiration = calculate_expiration_timestamp(
+                before_pacific_dst_end, ProfileTimeToLive.ONE_QUARTER
+            )
+    finally:
         tzset()
-        expiration = calculate_expiration_timestamp(
-            before_pacific_dst_end, ProfileTimeToLive.ONE_QUARTER
-        )
-    tzset()
 
     assert expiration == before_pacific_dst_end + 90 * 24 * 3600
 

--- a/tests/server/services/profile/test_profile_generation_service_utils.py
+++ b/tests/server/services/profile/test_profile_generation_service_utils.py
@@ -1,6 +1,7 @@
 """Tests for profile generation service utility functions."""
 
 import tempfile
+import time
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
@@ -262,6 +263,25 @@ def test_calculate_expiration_timestamp_finite_ttls(ttl, expected_delta_seconds)
     now = int(datetime.now(UTC).timestamp())
     expiration = calculate_expiration_timestamp(now, ttl)
     assert expiration == now + expected_delta_seconds
+
+
+def test_calculate_expiration_timestamp_ignores_local_dst(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tzset = getattr(time, "tzset", None)
+    if tzset is None:
+        pytest.skip("timezone switching is unavailable")
+    before_pacific_dst_end = int(datetime(2026, 8, 3, 12, tzinfo=UTC).timestamp())
+
+    with monkeypatch.context() as context:
+        context.setenv("TZ", "America/Los_Angeles")
+        tzset()
+        expiration = calculate_expiration_timestamp(
+            before_pacific_dst_end, ProfileTimeToLive.ONE_QUARTER
+        )
+    tzset()
+
+    assert expiration == before_pacific_dst_end + 90 * 24 * 3600
 
 
 if __name__ == "__main__":

--- a/tests/server/services/storage/test_playbook_aggregation_state_integration.py
+++ b/tests/server/services/storage/test_playbook_aggregation_state_integration.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import reflexio
+from reflexio.models.api_schema.domain.entities import LineageContext
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     PlaybookStatus,
@@ -29,6 +30,9 @@ from reflexio.server.services.playbook.playbook_service_utils import (
     PlaybookAggregatorRequest,
 )
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.sqlite_storage.playbook._aggregation import (
+    init_playbook_aggregation_tables,
+)
 from reflexio.server.services.storage.storage_base.playbook import (
     PlaybookAggregationBacklog,
 )
@@ -334,6 +338,56 @@ def test_archive_rolls_back_when_invalidation_fails(
     assert status is None
 
 
+def test_merge_invalidates_every_source_agent_version(tmp_path) -> None:
+    store = _store(tmp_path)
+    for item_id, version in ((1, "v2"), (2, "v1"), (3, "v2")):
+        _insert_current(store, item_id, version=version)
+
+    store.merge_records(
+        entity_type="user_playbook",
+        survivor_id="1",
+        source_ids=["2", "3"],
+        context=LineageContext(
+            op_kind="merge", actor="test", request_id="mixed-version-merge"
+        ),
+    )
+
+    invalidations = store.conn.execute(
+        "SELECT agent_version, entity_id, source_ids "
+        "FROM playbook_aggregation_invalidation ORDER BY agent_version"
+    ).fetchall()
+    assert [tuple(row) for row in invalidations] == [
+        ("v1", 1, "[2]"),
+        ("v2", 1, "[3]"),
+    ]
+    armed_versions = store.conn.execute(
+        "SELECT agent_version FROM playbook_aggregation_state "
+        "WHERE pending=1 ORDER BY agent_version"
+    ).fetchall()
+    assert [str(row[0]) for row in armed_versions] == ["v1", "v2"]
+
+
+def test_aggregation_schema_init_does_not_rebuild_pending_index(tmp_path) -> None:
+    store = _store(tmp_path)
+    statements: list[str] = []
+    store.conn.set_trace_callback(statements.append)
+    try:
+        init_playbook_aggregation_tables(store.conn)
+    finally:
+        store.conn.set_trace_callback(None)
+
+    assert not any(
+        "DROP INDEX" in statement
+        and "idx_playbook_aggregation_invalidation_pending" in statement
+        for statement in statements
+    )
+    index_sql = store.conn.execute(
+        "SELECT sql FROM sqlite_master "
+        "WHERE type='index' AND name='idx_playbook_aggregation_invalidation_pending'"
+    ).fetchone()[0]
+    assert "WHERE processed_at IS NULL" in index_sql
+
+
 def test_semantic_dispositions_are_unique_per_version_and_item(tmp_path) -> None:
     store = _store(tmp_path)
     _insert_current(store, 1)
@@ -527,7 +581,7 @@ def test_centroid_batches_are_strictly_isolated_by_agent_version(vec_store) -> N
         "v2",
         [(3, embedding)],
         embedding_model=store.embedding_model_name,
-        limit=10,
+        limit=1,
     )
     assert matches[3].cluster_id == "cluster-v2"
     with pytest.raises(RuntimeError, match="not active for agent version"):

--- a/tests/server/services/storage/test_playbook_aggregation_state_integration.py
+++ b/tests/server/services/storage/test_playbook_aggregation_state_integration.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import ast
+import json
+import sqlite3
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -35,6 +38,14 @@ def _store(tmp_path) -> SQLiteStorage:
     return SQLiteStorage(org_id="aggregation-org", db_path=str(tmp_path / "state.db"))
 
 
+@pytest.fixture
+def vec_store(tmp_path) -> SQLiteStorage:
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    return store
+
+
 def test_lineage_silent_bulk_delete_callers_only_remove_ineligible_rows() -> None:
     package_root = Path(reflexio.__file__).parent
     call_sites: list[tuple[str, str]] = []
@@ -60,7 +71,10 @@ def test_lineage_silent_bulk_delete_callers_only_remove_ineligible_rows() -> Non
         def visit_Call(self, node: ast.Call) -> None:
             if isinstance(node.func, ast.Attribute):
                 if node.func.attr == "delete_all_user_playbooks_by_status":
-                    call_sites.append((self.relative_path, self.function_stack[-1]))
+                    function_name = (
+                        self.function_stack[-1] if self.function_stack else "<module>"
+                    )
+                    call_sites.append((self.relative_path, function_name))
                 elif node.func.attr == "_delete_items_by_status" and node.args:
                     argument = node.args[0]
                     if isinstance(argument, ast.Attribute):
@@ -75,7 +89,7 @@ def test_lineage_silent_bulk_delete_callers_only_remove_ineligible_rows() -> Non
         ("server/services/playbook/service.py", "_delete_items_by_status"),
         ("server/services/playbook/service.py", "_pre_process_rerun"),
     ]
-    assert cleanup_statuses == ["ARCHIVED"]
+    assert sorted(cleanup_statuses) == ["ARCHIVED"]
 
 
 def _insert_current(
@@ -123,6 +137,11 @@ def test_org_claim_is_fenced_and_fence_is_monotonic(tmp_path) -> None:
     store = _store(tmp_path)
     store.schedule_playbook_aggregation("v2")
     store.schedule_playbook_aggregation("v1")
+    store.conn.execute(
+        "UPDATE playbook_aggregation_state SET next_attempt_at="
+        "(SELECT min(next_attempt_at) FROM playbook_aggregation_state)"
+    )
+    store.conn.commit()
 
     first = store.claim_due_playbook_aggregation(owner="worker-a", lease_seconds=30)
     assert first is not None
@@ -149,6 +168,42 @@ def test_org_claim_is_fenced_and_fence_is_monotonic(tmp_path) -> None:
         backlog_retry_after_seconds=1,
         min_interval_seconds=60,
     )
+
+
+def test_failed_finish_cas_rolls_back_owned_sqlite_transaction(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(tmp_path)
+    store.schedule_playbook_aggregation("v1")
+    claim = store.claim_due_playbook_aggregation(owner="worker", lease_seconds=30)
+    assert claim is not None
+    external = sqlite3.connect(str(tmp_path / "state.db"), timeout=0.1)
+    original_is_live = store._aggregation_claim_is_live
+
+    def race_state_version(candidate) -> bool:
+        is_live = original_is_live(candidate)
+        external.execute(
+            "UPDATE playbook_aggregation_state SET state_version=state_version+1 "
+            "WHERE agent_version='v1'"
+        )
+        external.commit()
+        return is_live
+
+    monkeypatch.setattr(store, "_aggregation_claim_is_live", race_state_version)
+
+    assert not store.finish_playbook_aggregation_claim(
+        claim,
+        success=False,
+        retry_after_seconds=60,
+        backlog_retry_after_seconds=1,
+        min_interval_seconds=3600,
+    )
+    assert store.conn.in_transaction is False
+    external.execute(
+        "UPDATE playbook_aggregation_state SET pending=1 WHERE agent_version='v1'"
+    )
+    external.commit()
+    external.close()
 
 
 def test_successful_bounded_run_with_backlog_is_due_again_immediately(tmp_path) -> None:
@@ -185,7 +240,7 @@ def test_new_signal_advances_an_idle_version_to_due_now(tmp_path) -> None:
         retry_after_seconds=60,
         backlog_retry_after_seconds=1,
         min_interval_seconds=3600,
-        backlog=PlaybookAggregationBacklog(0, 0, 0),
+        backlog=PlaybookAggregationBacklog(undisposed=0, residual=0, invalidations=0),
     )
 
     store.schedule_playbook_aggregation("v1")
@@ -197,17 +252,11 @@ def test_new_signal_advances_an_idle_version_to_due_now(tmp_path) -> None:
 
 
 def test_stale_claim_cannot_commit_incremental_effect(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from unittest.mock import MagicMock
-
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+    store = vec_store
     embedding = [0.0] * store.embedding_dimensions
     embedding[0] = 1.0
-    import json
-
     encoded = json.dumps(embedding)
     _insert_current(store, 1, embedding=encoded, trigger="same trigger")
     _insert_current(store, 2, embedding=encoded, trigger="same trigger")
@@ -339,6 +388,26 @@ def test_residual_retry_is_deferred_until_identical_work_cools_down(tmp_path) ->
     assert backlog.continuation_delay_seconds == backlog.residual_retry_after_seconds
 
 
+def test_residual_retry_cooldown_is_aggregated_in_sql(tmp_path) -> None:
+    store = _store(tmp_path)
+    for item_id in range(1, 101):
+        _insert_current(store, item_id)
+    store.stage_playbook_aggregation_intake("v1", limit=100)
+    store.conn.execute(
+        "UPDATE playbook_aggregation_item SET attempt_count=2, "
+        "last_attempt_at=unixepoch() WHERE agent_version='v1'"
+    )
+    store.conn.commit()
+    statements: list[str] = []
+    store.conn.set_trace_callback(statements.append)
+
+    backlog = store.get_playbook_aggregation_backlog("v1")
+
+    store.conn.set_trace_callback(None)
+    assert 61 <= backlog.residual_retry_after_seconds <= 120
+    assert any("COALESCE(MAX(0, MIN(CASE" in statement for statement in statements)
+
+
 def test_discovery_repairs_lost_post_commit_signal(tmp_path) -> None:
     store = _store(tmp_path)
     _insert_current(store, 42, version="lost-signal")
@@ -377,10 +446,8 @@ def test_dirty_cluster_keeps_aggregation_pending() -> None:
     assert backlog.pending is True
 
 
-def test_sqlite_vec_centroid_lookup_and_attachment(tmp_path) -> None:
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+def test_sqlite_vec_centroid_lookup_and_attachment(vec_store) -> None:
+    store = vec_store
     for item_id in (1, 2, 3):
         _insert_current(store, item_id)
     store.stage_playbook_aggregation_intake("v1", limit=10)
@@ -397,10 +464,15 @@ def test_sqlite_vec_centroid_lookup_and_attachment(tmp_path) -> None:
     store.set_playbook_aggregation_disposition(
         "v1", [1, 2], disposition="cluster_member", cluster_id=cluster_id
     )
+    vec_schema = store.conn.execute(
+        "SELECT sql FROM sqlite_master WHERE name='playbook_aggregation_clusters_vec'"
+    ).fetchone()[0]
+    assert "distance_metric=cosine" in vec_schema
+    scaled_embedding = [value * 10 for value in embedding]
 
     matches = store.find_nearest_playbook_aggregation_clusters(
         "v1",
-        [(3, embedding)],
+        [(3, scaled_embedding)],
         embedding_model=store.embedding_model_name,
         limit=10,
     )
@@ -410,7 +482,7 @@ def test_sqlite_vec_centroid_lookup_and_attachment(tmp_path) -> None:
     assert match.similarity > 0.99
     store.attach_playbook_aggregation_items(
         agent_version="v1",
-        attachments=[(3, cluster_id, embedding)],
+        attachments=[(3, cluster_id, scaled_embedding)],
     )
     assert (
         store.conn.execute(
@@ -421,10 +493,8 @@ def test_sqlite_vec_centroid_lookup_and_attachment(tmp_path) -> None:
     )
 
 
-def test_centroid_batches_are_strictly_isolated_by_agent_version(tmp_path) -> None:
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+def test_centroid_batches_are_strictly_isolated_by_agent_version(vec_store) -> None:
+    store = vec_store
     embedding = [0.0] * store.embedding_dimensions
     embedding[0] = 1.0
     other_embedding = [0.0] * store.embedding_dimensions
@@ -473,11 +543,9 @@ def test_centroid_batches_are_strictly_isolated_by_agent_version(tmp_path) -> No
 
 
 def test_invalidation_dissolves_cluster_and_requeues_unaffected_members(
-    tmp_path,
+    vec_store,
 ) -> None:
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+    store = vec_store
     for item_id in (1, 2):
         _insert_current(store, item_id)
     store.stage_playbook_aggregation_intake("v1", limit=10)
@@ -575,6 +643,42 @@ def test_archive_with_blank_agent_version_does_not_arm_aggregation(tmp_path) -> 
         ).fetchone()[0]
         == 0
     )
+
+
+def test_nonnumeric_lineage_entity_does_not_abort_on_numeric_source(tmp_path) -> None:
+    from reflexio.server.services.storage.sqlite_storage._lineage import (
+        _append_event_stmt,
+    )
+
+    store = _store(tmp_path)
+    _insert_current(store, 1)
+
+    _append_event_stmt(
+        store.conn,
+        org_id=store.org_id,
+        entity_type="user_playbook",
+        entity_id="external-id",
+        op="revise",
+        prov="wasRevisionOf",
+        source_ids=["1"],
+        actor="test",
+        request_id="nonnumeric-entity",
+        reason="regression",
+    )
+    store.conn.commit()
+
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM lineage_event WHERE entity_id='external-id'"
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_invalidation"
+        ).fetchone()[0]
+        == 0
+    )
     assert (
         store.conn.execute(
             "SELECT count(*) FROM playbook_aggregation_state"
@@ -584,17 +688,11 @@ def test_archive_with_blank_agent_version_does_not_arm_aggregation(tmp_path) -> 
 
 
 def test_incremental_run_creates_once_then_attaches_without_replacement(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from unittest.mock import MagicMock
-
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+    store = vec_store
     embedding = [0.0] * store.embedding_dimensions
     embedding[0] = 1.0
-    import json
-
     encoded = json.dumps(embedding)
     _insert_current(store, 1, embedding=encoded, trigger="same trigger")
     _insert_current(store, 2, embedding=encoded, trigger="same trigger")
@@ -676,17 +774,11 @@ def test_incremental_run_creates_once_then_attaches_without_replacement(
 
 
 def test_incremental_run_commits_healthy_clusters_when_one_llm_outcome_fails(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from unittest.mock import MagicMock
-
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+    store = vec_store
     embedding = [0.0] * store.embedding_dimensions
     embedding[0] = 1.0
-    import json
-
     encoded = json.dumps(embedding)
     for item_id in range(1, 5):
         _insert_current(store, item_id, embedding=encoded, trigger=f"trigger-{item_id}")
@@ -760,13 +852,9 @@ def test_incremental_run_commits_healthy_clusters_when_one_llm_outcome_fails(
 
 
 def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from unittest.mock import MagicMock
-
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+    store = vec_store
     embedding = [0.0] * store.embedding_dimensions
     embedding[0] = 1.0
     monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
@@ -830,17 +918,11 @@ def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
 
 
 def test_fenced_full_rerun_rebuilds_typed_cluster_state(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from unittest.mock import MagicMock
-
-    store = _store(tmp_path)
-    if not store._has_sqlite_vec:
-        pytest.skip("sqlite-vec is unavailable")
+    store = vec_store
     embedding = [0.0] * store.embedding_dimensions
     embedding[0] = 1.0
-    import json
-
     encoded = json.dumps(embedding)
     _insert_current(store, 1, embedding=encoded, trigger="same trigger")
     _insert_current(store, 2, embedding=encoded, trigger="same trigger")
@@ -900,6 +982,7 @@ def test_rerun_snapshot_finishes_only_materialized_work(tmp_path) -> None:
     store.append_playbook_aggregation_invalidation(
         agent_version="v1", operation="create", entity_id=2
     )
+    # Intentionally exercise the BEFORE DELETE aggregation-invalidation trigger.
     store.conn.execute("DELETE FROM user_playbooks WHERE user_playbook_id=1")
     store.conn.commit()
 

--- a/tests/server/services/storage/test_playbook_aggregation_state_integration.py
+++ b/tests/server/services/storage/test_playbook_aggregation_state_integration.py
@@ -1,0 +1,928 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import reflexio
+from reflexio.models.api_schema.service_schemas import (
+    AgentPlaybook,
+    PlaybookStatus,
+    Status,
+)
+from reflexio.models.config_schema import (
+    Config,
+    PlaybookAggregatorConfig,
+    PlaybookConfig,
+    StorageConfigSQLite,
+)
+from reflexio.server.services.operation_state_utils import OperationStateManager
+from reflexio.server.services.playbook.components.aggregator import (
+    AggregationGenerationOutcome,
+    PlaybookAggregator,
+)
+from reflexio.server.services.playbook.playbook_service_utils import (
+    PlaybookAggregatorRequest,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+from reflexio.server.services.storage.storage_base.playbook import (
+    PlaybookAggregationBacklog,
+)
+
+
+def _store(tmp_path) -> SQLiteStorage:
+    return SQLiteStorage(org_id="aggregation-org", db_path=str(tmp_path / "state.db"))
+
+
+def test_lineage_silent_bulk_delete_callers_only_remove_ineligible_rows() -> None:
+    package_root = Path(reflexio.__file__).parent
+    call_sites: list[tuple[str, str]] = []
+    cleanup_statuses: list[str] = []
+
+    class CallVisitor(ast.NodeVisitor):
+        def __init__(self, relative_path: str) -> None:
+            self.relative_path = relative_path
+            self.function_stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.function_stack.append(node.name)
+            self.generic_visit(node)
+            self.function_stack.pop()
+
+        def visit_AsyncFunctionDef(  # noqa: N802
+            self, node: ast.AsyncFunctionDef
+        ) -> None:
+            self.function_stack.append(node.name)
+            self.generic_visit(node)
+            self.function_stack.pop()
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if isinstance(node.func, ast.Attribute):
+                if node.func.attr == "delete_all_user_playbooks_by_status":
+                    call_sites.append((self.relative_path, self.function_stack[-1]))
+                elif node.func.attr == "_delete_items_by_status" and node.args:
+                    argument = node.args[0]
+                    if isinstance(argument, ast.Attribute):
+                        cleanup_statuses.append(argument.attr)
+            self.generic_visit(node)
+
+    for path in package_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        CallVisitor(str(path.relative_to(package_root))).visit(tree)
+
+    assert sorted(call_sites) == [
+        ("server/services/playbook/service.py", "_delete_items_by_status"),
+        ("server/services/playbook/service.py", "_pre_process_rerun"),
+    ]
+    assert cleanup_statuses == ["ARCHIVED"]
+
+
+def _insert_current(
+    store: SQLiteStorage,
+    item_id: int,
+    *,
+    version: str = "v1",
+    embedding: str | None = None,
+    trigger: str | None = None,
+) -> None:
+    store.conn.execute(
+        "INSERT INTO user_playbooks "
+        "(user_playbook_id, user_id, playbook_name, created_at, request_id, "
+        "agent_version, content, embedding, trigger) VALUES (?, ?, 'playbook', "
+        "'2026-07-31T00:00:00+00:00', ?, ?, ?, ?, ?)",
+        (
+            item_id,
+            f"user-{item_id}",
+            f"req-{item_id}",
+            version,
+            f"rule-{item_id}",
+            embedding,
+            trigger,
+        ),
+    )
+    store.conn.commit()
+
+
+def test_bounded_antijoin_discovers_late_lower_id(tmp_path) -> None:
+    store = _store(tmp_path)
+    for item_id in range(10, 17):
+        _insert_current(store, item_id)
+
+    assert store.stage_playbook_aggregation_intake("v1", limit=3) == [10, 11, 12]
+    assert store.stage_playbook_aggregation_intake("v1", limit=3) == [13, 14, 15]
+
+    # Simulates a lower sequence value whose allocating transaction committed late.
+    _insert_current(store, 2)
+    assert store.stage_playbook_aggregation_intake("v1", limit=3) == [2, 16]
+    assert store.stage_playbook_aggregation_intake("v1", limit=3) == []
+    assert store.get_playbook_aggregation_backlog("v1").undisposed == 0
+
+
+def test_org_claim_is_fenced_and_fence_is_monotonic(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.schedule_playbook_aggregation("v2")
+    store.schedule_playbook_aggregation("v1")
+
+    first = store.claim_due_playbook_aggregation(owner="worker-a", lease_seconds=30)
+    assert first is not None
+    assert first.agent_version == "v1"
+    assert (
+        store.claim_due_playbook_aggregation(owner="worker-b", lease_seconds=30) is None
+    )
+    assert store.finish_playbook_aggregation_claim(
+        first,
+        success=True,
+        retry_after_seconds=5,
+        backlog_retry_after_seconds=1,
+        min_interval_seconds=60,
+    )
+
+    second = store.claim_due_playbook_aggregation(owner="worker-b", lease_seconds=30)
+    assert second is not None
+    assert second.agent_version == "v2"
+    assert second.fence > first.fence
+    assert not store.finish_playbook_aggregation_claim(
+        first,
+        success=True,
+        retry_after_seconds=5,
+        backlog_retry_after_seconds=1,
+        min_interval_seconds=60,
+    )
+
+
+def test_successful_bounded_run_with_backlog_is_due_again_immediately(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 1)
+    store.schedule_playbook_aggregation("v1")
+    claim = store.claim_due_playbook_aggregation(owner="worker-a", lease_seconds=30)
+    assert claim is not None
+    assert store.stage_playbook_aggregation_intake("v1", limit=1) == [1]
+
+    assert store.finish_playbook_aggregation_claim(
+        claim,
+        success=True,
+        retry_after_seconds=60,
+        backlog_retry_after_seconds=0,
+        min_interval_seconds=3600,
+    )
+
+    continuation = store.claim_due_playbook_aggregation(
+        owner="worker-b", lease_seconds=30
+    )
+    assert continuation is not None
+    assert continuation.agent_version == "v1"
+
+
+def test_new_signal_advances_an_idle_version_to_due_now(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.schedule_playbook_aggregation("v1")
+    claim = store.claim_due_playbook_aggregation(owner="worker-a", lease_seconds=30)
+    assert claim is not None
+    assert store.finish_playbook_aggregation_claim(
+        claim,
+        success=True,
+        retry_after_seconds=60,
+        backlog_retry_after_seconds=1,
+        min_interval_seconds=3600,
+        backlog=PlaybookAggregationBacklog(0, 0, 0),
+    )
+
+    store.schedule_playbook_aggregation("v1")
+
+    assert (
+        store.claim_due_playbook_aggregation(owner="worker-b", lease_seconds=30)
+        is not None
+    )
+
+
+def test_stale_claim_cannot_commit_incremental_effect(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    import json
+
+    encoded = json.dumps(embedding)
+    _insert_current(store, 1, embedding=encoded, trigger="same trigger")
+    _insert_current(store, 2, embedding=encoded, trigger="same trigger")
+    store.schedule_playbook_aggregation("v1")
+    stale = store.claim_due_playbook_aggregation(owner="stale", lease_seconds=30)
+    assert stale is not None
+    store.conn.execute(
+        "UPDATE playbook_aggregation_lease SET claim_expires_at=0 WHERE singleton=1"
+    )
+    store.conn.commit()
+    replacement = store.claim_due_playbook_aggregation(
+        owner="replacement", lease_seconds=30
+    )
+    assert replacement is not None
+    assert replacement.fence > stale.fence
+
+    monkeypatch.setenv("MOCK_LLM_RESPONSE", "true")
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+        aggregation_claim=stale,
+    )
+
+    with pytest.raises(RuntimeError, match="lost its database fence"):
+        aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 0
+
+
+def test_archive_status_and_invalidation_commit_together(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 7)
+
+    assert store.archive_user_playbook_by_id("user-7", 7)
+    status = store.conn.execute(
+        "SELECT status FROM user_playbooks WHERE user_playbook_id=7"
+    ).fetchone()[0]
+    event = store.conn.execute(
+        "SELECT operation, entity_id FROM playbook_aggregation_invalidation"
+    ).fetchone()
+    assert status == "archived"
+    assert tuple(event) == ("archive", 7)
+
+
+def test_archive_rolls_back_when_invalidation_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 8)
+
+    def fail_invalidation(**_kwargs: object) -> None:
+        raise RuntimeError("injected invalidation failure")
+
+    monkeypatch.setattr(
+        store, "append_playbook_aggregation_invalidation", fail_invalidation
+    )
+    with pytest.raises(Exception, match="injected invalidation failure"):
+        store.archive_user_playbook_by_id("user-8", 8)
+
+    status = store.conn.execute(
+        "SELECT status FROM user_playbooks WHERE user_playbook_id=8"
+    ).fetchone()[0]
+    assert status is None
+
+
+def test_semantic_dispositions_are_unique_per_version_and_item(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 1)
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    store.set_playbook_aggregation_disposition(
+        "v1", [1], disposition="terminal_noop", reason="semantic_null"
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1", [1], disposition="residual", reason="retry"
+    )
+
+    rows = store.conn.execute(
+        "SELECT disposition FROM playbook_aggregation_item "
+        "WHERE agent_version='v1' AND user_playbook_id=1"
+    ).fetchall()
+    assert [row[0] for row in rows] == ["residual"]
+
+
+def test_residual_selection_reserves_fresh_and_retry_capacity(tmp_path) -> None:
+    store = _store(tmp_path)
+    for item_id in range(1, 5):
+        _insert_current(store, item_id)
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    assert set(store.get_playbook_aggregation_residual_ids("v1", limit=4)) == {
+        1,
+        2,
+        3,
+        4,
+    }
+
+    for item_id in range(5, 9):
+        _insert_current(store, item_id)
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    store.conn.execute(
+        "UPDATE playbook_aggregation_item SET last_attempt_at=unixepoch()-61 "
+        "WHERE agent_version='v1' AND user_playbook_id <= 4"
+    )
+    selected = set(store.get_playbook_aggregation_residual_ids("v1", limit=4))
+    assert len(selected & {1, 2, 3, 4}) == 2
+    assert len(selected & {5, 6, 7, 8}) == 2
+
+
+def test_residual_retry_is_deferred_until_identical_work_cools_down(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 1)
+    store.stage_playbook_aggregation_intake("v1", limit=1)
+
+    assert store.get_playbook_aggregation_residual_ids("v1", limit=1) == [1]
+    assert store.get_playbook_aggregation_residual_ids("v1", limit=1) == []
+    backlog = store.get_playbook_aggregation_backlog("v1")
+    assert 1 <= backlog.residual_retry_after_seconds <= 60
+    assert backlog.continuation_delay_seconds == backlog.residual_retry_after_seconds
+
+
+def test_discovery_repairs_lost_post_commit_signal(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 42, version="lost-signal")
+
+    assert store.repair_playbook_aggregation_pending_state() == ["lost-signal"]
+    claim = store.claim_due_playbook_aggregation(owner="repair", lease_seconds=30)
+    assert claim is not None
+    assert claim.agent_version == "lost-signal"
+
+
+def test_repair_prunes_only_expired_processed_invalidations(tmp_path) -> None:
+    store = _store(tmp_path)
+    store.conn.executemany(
+        "INSERT INTO playbook_aggregation_invalidation "
+        "(agent_version, operation, entity_id, processed_at) "
+        "VALUES ('v1', 'revise', ?, unixepoch()-?)",
+        [(1, 8 * 24 * 60 * 60), (2, 24 * 60 * 60)],
+    )
+
+    store.repair_playbook_aggregation_pending_state()
+
+    rows = store.conn.execute(
+        "SELECT entity_id FROM playbook_aggregation_invalidation ORDER BY entity_id"
+    ).fetchall()
+    assert [int(row[0]) for row in rows] == [2]
+
+
+def test_dirty_cluster_keeps_aggregation_pending() -> None:
+    backlog = PlaybookAggregationBacklog(
+        undisposed=0,
+        residual=0,
+        invalidations=0,
+        dirty_repairs=1,
+    )
+
+    assert backlog.pending is True
+
+
+def test_sqlite_vec_centroid_lookup_and_attachment(tmp_path) -> None:
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    for item_id in (1, 2, 3):
+        _insert_current(store, item_id)
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    cluster_id = "cluster-a"
+    store.create_playbook_aggregation_cluster(
+        cluster_id=cluster_id,
+        agent_version="v1",
+        agent_playbook_id=None,
+        embeddings=[embedding, embedding],
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1", [1, 2], disposition="cluster_member", cluster_id=cluster_id
+    )
+
+    matches = store.find_nearest_playbook_aggregation_clusters(
+        "v1",
+        [(3, embedding)],
+        embedding_model=store.embedding_model_name,
+        limit=10,
+    )
+    match = matches[3]
+    assert match is not None
+    assert match.cluster_id == cluster_id
+    assert match.similarity > 0.99
+    store.attach_playbook_aggregation_items(
+        agent_version="v1",
+        attachments=[(3, cluster_id, embedding)],
+    )
+    assert (
+        store.conn.execute(
+            "SELECT member_count FROM playbook_aggregation_cluster WHERE cluster_id=?",
+            (cluster_id,),
+        ).fetchone()[0]
+        == 3
+    )
+
+
+def test_centroid_batches_are_strictly_isolated_by_agent_version(tmp_path) -> None:
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    other_embedding = [0.0] * store.embedding_dimensions
+    other_embedding[1] = 1.0
+    for item_id, version in ((1, "v1"), (2, "v2"), (3, "v2")):
+        _insert_current(store, item_id, version=version)
+        store.stage_playbook_aggregation_intake(version, limit=10)
+    store.create_playbook_aggregation_cluster(
+        cluster_id="cluster-v1",
+        agent_version="v1",
+        agent_playbook_id=None,
+        embeddings=[embedding],
+        embedding_model=store.embedding_model_name,
+    )
+    store.create_playbook_aggregation_cluster(
+        cluster_id="cluster-v2",
+        agent_version="v2",
+        agent_playbook_id=None,
+        embeddings=[other_embedding],
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1", [1], disposition="cluster_member", cluster_id="cluster-v1"
+    )
+    store.set_playbook_aggregation_disposition(
+        "v2", [2], disposition="cluster_member", cluster_id="cluster-v2"
+    )
+
+    matches = store.find_nearest_playbook_aggregation_clusters(
+        "v2",
+        [(3, embedding)],
+        embedding_model=store.embedding_model_name,
+        limit=10,
+    )
+    assert matches[3].cluster_id == "cluster-v2"
+    with pytest.raises(RuntimeError, match="not active for agent version"):
+        store.attach_playbook_aggregation_items(
+            agent_version="v2",
+            attachments=[(3, "cluster-v1", embedding)],
+        )
+    disposition = store.conn.execute(
+        "SELECT disposition, cluster_id FROM playbook_aggregation_item "
+        "WHERE agent_version='v2' AND user_playbook_id=3"
+    ).fetchone()
+    assert tuple(disposition) == ("residual", None)
+
+
+def test_invalidation_dissolves_cluster_and_requeues_unaffected_members(
+    tmp_path,
+) -> None:
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    for item_id in (1, 2):
+        _insert_current(store, item_id)
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    store.create_playbook_aggregation_cluster(
+        cluster_id="cluster-to-dissolve",
+        agent_version="v1",
+        agent_playbook_id=None,
+        embeddings=[embedding, embedding],
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1",
+        [1, 2],
+        disposition="cluster_member",
+        cluster_id="cluster-to-dissolve",
+    )
+    store.append_playbook_aggregation_invalidation(
+        agent_version="v1", operation="status_change", entity_id=1
+    )
+    claim = store.claim_due_playbook_aggregation(owner="worker", lease_seconds=30)
+    assert claim is not None
+    invalidations = store.get_playbook_aggregation_invalidations("v1", limit=10)
+
+    assert store.apply_playbook_aggregation_invalidations(
+        claim, [item.invalidation_id for item in invalidations]
+    )
+    cluster = store.conn.execute(
+        "SELECT state, dirty, member_count FROM playbook_aggregation_cluster"
+    ).fetchone()
+    assert tuple(cluster) == ("rebuilding", 1, 0)
+    rows = store.conn.execute(
+        "SELECT user_playbook_id, disposition, cluster_id "
+        "FROM playbook_aggregation_item ORDER BY user_playbook_id"
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [(2, "residual", "cluster-to-dissolve")]
+    assert store.get_playbook_aggregation_backlog("v1").invalidations == 0
+
+    # Rebuilding the same deterministic membership must reactivate the retained
+    # cluster row rather than failing its cluster_id uniqueness constraint.
+    store.create_playbook_aggregation_cluster(
+        cluster_id="cluster-to-dissolve",
+        agent_version="v1",
+        agent_playbook_id=None,
+        embeddings=[embedding],
+        embedding_model=store.embedding_model_name,
+    )
+    rebuilt = store.conn.execute(
+        "SELECT state, dirty, member_count FROM playbook_aggregation_cluster"
+    ).fetchone()
+    assert tuple(rebuilt) == ("active", 0, 1)
+
+
+def test_hard_delete_trigger_preserves_membership_until_reconciliation(
+    tmp_path,
+) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 1)
+    store.stage_playbook_aggregation_intake("v1", limit=1)
+
+    store.delete_user_playbook(1)
+
+    assert (
+        store.conn.execute(
+            "SELECT disposition FROM playbook_aggregation_item WHERE user_playbook_id=1"
+        ).fetchone()[0]
+        == "residual"
+    )
+    invalidations = store.get_playbook_aggregation_invalidations("v1", limit=10)
+    assert [(item.operation, item.entity_id) for item in invalidations] == [
+        ("hard_delete", 1)
+    ]
+    claim = store.claim_due_playbook_aggregation(owner="worker", lease_seconds=30)
+    assert claim is not None
+    assert store.apply_playbook_aggregation_invalidations(
+        claim, [item.invalidation_id for item in invalidations]
+    )
+    assert (
+        store.conn.execute("SELECT count(*) FROM playbook_aggregation_item").fetchone()[
+            0
+        ]
+        == 0
+    )
+
+
+def test_archive_with_blank_agent_version_does_not_arm_aggregation(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 1, version="   ")
+
+    assert store.archive_user_playbook_by_id("user-1", 1)
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_invalidation"
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_state"
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_incremental_run_creates_once_then_attaches_without_replacement(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    import json
+
+    encoded = json.dumps(embedding)
+    _insert_current(store, 1, embedding=encoded, trigger="same trigger")
+    _insert_current(store, 2, embedding=encoded, trigger="same trigger")
+    monkeypatch.setenv("MOCK_LLM_RESPONSE", "true")
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    context = MagicMock(
+        org_id="aggregation-org", storage=store, configurator=configurator
+    )
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=context,
+        agent_version="v1",
+    )
+
+    first = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+    assert first["playbooks_generated"] == 1
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
+
+    _insert_current(store, 3, embedding=encoded, trigger="same trigger")
+    second = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+    assert second["playbooks_generated"] == 0
+    assert second["attachments"] == 1
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
+    assert (
+        store.conn.execute(
+            "SELECT member_count FROM playbook_aggregation_cluster"
+        ).fetchone()[0]
+        == 3
+    )
+
+    old_agent_id = int(
+        store.conn.execute(
+            "SELECT agent_playbook_id FROM agent_playbooks WHERE status IS NULL"
+        ).fetchone()[0]
+    )
+    store.append_playbook_aggregation_invalidation(
+        agent_version="v1", operation="revise", entity_id=1
+    )
+    claim = store.claim_due_playbook_aggregation(owner="replacement", lease_seconds=30)
+    assert claim is not None
+    invalidations = store.get_playbook_aggregation_invalidations("v1", limit=10)
+    assert store.apply_playbook_aggregation_invalidations(
+        claim, [item.invalidation_id for item in invalidations]
+    )
+
+    replacement = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=context,
+        agent_version="v1",
+        aggregation_claim=claim,
+        work_budget=10,
+    ).run(PlaybookAggregatorRequest(agent_version="v1"))
+    assert replacement["playbooks_generated"] == 1
+    assert replacement["supersessions"] == 1
+    rows = store.conn.execute(
+        "SELECT agent_playbook_id, status FROM agent_playbooks "
+        "ORDER BY agent_playbook_id"
+    ).fetchall()
+    assert rows[0][0] == old_agent_id
+    assert rows[0][1] == Status.SUPERSEDED.value
+    assert rows[1][1] is None
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_cluster"
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def test_incremental_run_commits_healthy_clusters_when_one_llm_outcome_fails(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    import json
+
+    encoded = json.dumps(embedding)
+    for item_id in range(1, 5):
+        _insert_current(store, item_id, embedding=encoded, trigger=f"trigger-{item_id}")
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    context = MagicMock(
+        org_id="aggregation-org", storage=store, configurator=configurator
+    )
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=context,
+        agent_version="v1",
+    )
+    monkeypatch.setattr(
+        aggregator,
+        "get_clusters",
+        lambda playbooks, _config: {0: playbooks[:2], 1: playbooks[2:]},
+    )
+
+    def generate_outcomes(
+        clusters, _existing, *, direction_overlap_threshold
+    ) -> list[AggregationGenerationOutcome]:
+        del direction_overlap_threshold
+        healthy, failed = clusters.values()
+        return [
+            AggregationGenerationOutcome(
+                "generated",
+                healthy,
+                AgentPlaybook(
+                    playbook_name="playbook",
+                    agent_version="v1",
+                    content="Healthy aggregate",
+                    trigger="healthy trigger",
+                    playbook_status=PlaybookStatus.PENDING,
+                ),
+            ),
+            AggregationGenerationOutcome("retryable_failure", failed),
+        ]
+
+    monkeypatch.setattr(
+        aggregator,
+        "_generate_playbook_outcomes_with_source_clusters",
+        generate_outcomes,
+    )
+
+    result = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+
+    assert result["playbooks_generated"] == 1
+    assert result["retryable_failures"] == 1
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
+    rows = store.conn.execute(
+        "SELECT user_playbook_id, disposition, reason "
+        "FROM playbook_aggregation_item ORDER BY user_playbook_id"
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        (1, "cluster_member", "generated"),
+        (2, "cluster_member", "generated"),
+        (3, "residual", "llm_retryable_failure"),
+        (4, "residual", "llm_retryable_failure"),
+    ]
+
+
+def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    _insert_current(store, 1, trigger="same trigger")
+    _insert_current(store, 2, trigger="same trigger")
+    existing = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Existing aggregate",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    OperationStateManager(
+        store, "aggregation-org", "playbook_aggregator"
+    ).update_cluster_fingerprints(
+        name="playbook",
+        version="v1",
+        fingerprints={
+            "legacy-fingerprint": {
+                "agent_playbook_id": existing.agent_playbook_id,
+                "user_playbook_ids": [1, 2],
+            }
+        },
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+    )
+
+    result = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+
+    assert result["playbooks_generated"] == 0
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
+    cluster = store.conn.execute(
+        "SELECT agent_playbook_id, member_count, state, embedding_model "
+        "FROM playbook_aggregation_cluster"
+    ).fetchone()
+    assert tuple(cluster) == (
+        existing.agent_playbook_id,
+        2,
+        "active",
+        store.embedding_model_name,
+    )
+    assert store.get_playbook_aggregation_bootstrap_status("v1") == "complete"
+
+
+def test_fenced_full_rerun_rebuilds_typed_cluster_state(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from unittest.mock import MagicMock
+
+    store = _store(tmp_path)
+    if not store._has_sqlite_vec:
+        pytest.skip("sqlite-vec is unavailable")
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    import json
+
+    encoded = json.dumps(embedding)
+    _insert_current(store, 1, embedding=encoded, trigger="same trigger")
+    _insert_current(store, 2, embedding=encoded, trigger="same trigger")
+    monkeypatch.setenv("MOCK_LLM_RESPONSE", "true")
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    store.schedule_playbook_aggregation("v1")
+    claim = store.claim_due_playbook_aggregation(owner="admin", lease_seconds=30)
+    assert claim is not None
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+        aggregation_claim=claim,
+    )
+
+    result = aggregator.run(PlaybookAggregatorRequest(agent_version="v1", rerun=True))
+
+    assert result["playbooks_generated"] == 1
+    cluster = store.conn.execute(
+        "SELECT member_count, state FROM playbook_aggregation_cluster"
+    ).fetchone()
+    assert tuple(cluster) == (2, "active")
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_item "
+            "WHERE disposition='cluster_member'"
+        ).fetchone()[0]
+        == 2
+    )
+    assert store.get_playbook_aggregation_bootstrap_status("v1") == "complete"
+
+
+def test_rerun_snapshot_finishes_only_materialized_work(tmp_path) -> None:
+    store = _store(tmp_path)
+    _insert_current(store, 1)
+    store.append_playbook_aggregation_invalidation(
+        agent_version="v1", operation="create", entity_id=1
+    )
+    store.schedule_playbook_aggregation("v1")
+    claim = store.claim_due_playbook_aggregation(owner="admin", lease_seconds=30)
+    assert claim is not None
+
+    snapshot = store.capture_playbook_aggregation_rerun_snapshot("v1", limit=10)
+    _insert_current(store, 2)
+    store.append_playbook_aggregation_invalidation(
+        agent_version="v1", operation="create", entity_id=2
+    )
+    store.conn.execute("DELETE FROM user_playbooks WHERE user_playbook_id=1")
+    store.conn.commit()
+
+    with store.commit_scope():
+        store.reset_playbook_aggregation_version("v1")
+        store.stage_playbook_aggregation_snapshot(
+            "v1", [item.user_playbook_id for item in snapshot.user_playbooks]
+        )
+        assert store.mark_playbook_aggregation_invalidations_processed(
+            claim, list(snapshot.invalidation_ids)
+        )
+
+    assert [
+        int(row[0])
+        for row in store.conn.execute(
+            "SELECT user_playbook_id FROM playbook_aggregation_item"
+        ).fetchall()
+    ] == [1]
+    assert [
+        (str(row[0]), int(row[1]))
+        for row in store.conn.execute(
+            "SELECT operation, entity_id FROM playbook_aggregation_invalidation "
+            "WHERE processed_at IS NULL ORDER BY invalidation_id"
+        ).fetchall()
+    ] == [("create", 2), ("hard_delete", 1)]
+    assert store.get_playbook_aggregation_backlog("v1").undisposed == 1

--- a/tests/server/services/storage/test_playbook_aggregation_state_integration.py
+++ b/tests/server/services/storage/test_playbook_aggregation_state_integration.py
@@ -971,6 +971,58 @@ def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
     assert store.get_playbook_aggregation_bootstrap_status("v1") == "complete"
 
 
+def test_empty_legacy_fingerprint_is_not_activated(vec_store, tmp_path) -> None:
+    store = vec_store
+    existing = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Legacy aggregate without sources",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    OperationStateManager(
+        store, "aggregation-org", "playbook_aggregator"
+    ).update_cluster_fingerprints(
+        name="playbook",
+        version="v1",
+        fingerprints={
+            "empty-legacy-fingerprint": {
+                "agent_playbook_id": existing.agent_playbook_id,
+                "user_playbook_ids": [],
+            }
+        },
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+    )
+
+    assert aggregator._adopt_legacy_aggregation_state(budget=10) == (0, True)
+    assert store.get_playbook_aggregation_bootstrap_status("v1") == "complete"
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_cluster"
+        ).fetchone()[0]
+        == 0
+    )
+
+
 def test_fenced_full_rerun_rebuilds_typed_cluster_state(
     vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Replace per-generation, full-corpus playbook aggregation with a durable signal and bounded scheduled work.
- Make newly armed work eligible immediately; apply the configured one-hour minimum only after a version drains successfully.
- Keep automatic runs efficient beyond `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` by processing a bounded row budget rather than treating it as a corpus ceiling.
- Match new playbooks only to compatible centroids for the same agent version, then cluster unmatched residuals without rereading or reclustering the full corpus.

## Changes

### Scheduling and execution

- Convert the post-generation trigger into an idempotent durable scheduling write.
- Add per-organization claims, database-time leases, fencing, retry handling, and backlog-aware continuation.
- Continue promptly while backlog remains; after a drained success, wait at least `REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS` (default: one hour).
- Keep the administrative full-rerun path capped and make it honor the same configured minimum interval.

### Incremental aggregation

- Add bounded intake, same-version nearest-centroid attachment, residual clustering, stable cluster identity, and centroid maintenance.
- Use agglomerative clustering for residual batches below 50 rows and HDBSCAN for larger batches.
- Treat `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` (default: 20,000) as the maximum rows admitted to one scheduled unit of work, including intake and invalidation repair; it is also the fail-before-mutation cap for an administrative full rerun.
- Distinguish generated, semantic-null, retryable-failure, and missing-embedding outcomes so healthy effects commit while only unfinished members remain pending.
- Reuse shared prompt context per batch and avoid repeated full-corpus reads or quadratic prompt grouping.

### Durable storage

- Add backend-neutral contracts for claims, backlog discovery, clusters, item dispositions, lifecycle invalidations, and atomic effects.
- Implement the contracts for SQLite, including vector-index dirty repair and pre-delete invalidation capture.
- Capture archive, revise, merge, status, purge, and delete changes without allowing stale cluster membership to survive.
- Group SQLite merge invalidations by source agent version so mixed-version merges arm every affected version.
- Filter SQLite ANN candidates for model, dimension, version, and active state before applying the nearest-neighbor limit.
- Preserve the pending-invalidation partial index across repeated SQLite storage initialization instead of dropping and recreating it.\n- Skip empty legacy fingerprints so they cannot become active clusters without a centroid or vector-index row.

### Documentation and compatibility

- Rewrite the playbook and server READMEs as code maps for the scheduler, storage contracts, cadence, budget semantics, version isolation, failure dispositions, and extension points.
- Isolate the durable-learning transaction regression test from the local scheduler thread so the test measures the transaction boundary deterministically.
- Rebase on current OSS main through receipt-finalization PR #408 while preserving the invariant from #407 that aggregation does not create a second learning charge.
- Calculate finite profile TTLs in UTC so crossing a local daylight-saving transition does not add or subtract an hour.

## Flow

```mermaid
flowchart LR
    A["User playbook committed"] --> B["Durable state due now"]
    B --> C["Scheduler claim"]
    C --> D["Bounded intake for one agent version"]
    D --> E{"Compatible centroid match?"}
    E -->|Yes| F["Attach and update centroid"]
    E -->|No| G["Durable residual"]
    G --> H["Bounded residual clustering"]
    H --> I["Generate agent playbook"]
    F --> J["Atomic fenced commit"]
    I --> J
    J --> K{"Backlog remains?"}
    K -->|Yes| C
    K -->|No| L["One-hour minimum before next drained run"]
```

## Test Plan

- `uv run ruff check` and `uv run ruff format --check` passed across the complete OSS source and test tree (879 files).
- Pyright on all changed Python paths: 0 errors.
- CodeRabbit regression coverage: 40 focused storage/profile tests passed, including mixed-version merge invalidation, repeated initialization, ANN limit/version isolation, empty legacy-cluster adoption, and guaranteed timezone restoration.
- Exact OSS CI unit command: 4,401 passed, 9 skipped, 6 subtests passed.
- OSS E2E suite: 47 passed, 51 skipped.
- A production-like companion self-host/native-Postgres run completed all 17 launch phases against an isolated database and real MiniMax LLM calls: 16 phases passed. Aggregation scheduling, profile/playbook generation, aggregation, search, cleanup, and evaluation all passed. The resumable-extraction phase completed its suspend/resume lifecycle but its evidence reviewer rejected the generated candidate, so no durable playbook was saved; this was reproduced twice on the companion checkout's currently pinned pre-evidence revision and is not counted as a pass.
- The live run did not exercise the four SQLite-only CodeRabbit fixes; those are covered by the focused SQLite regression suite above.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable, incremental playbook aggregation with scheduling, retries, progress tracking, and safe coordination.
  * Playbook updates now trigger bounded, resumable, version-scoped aggregation with invalidation handling and full-rerun support.
  * Added configurable minimum aggregation intervals and automatic local scheduling where supported.
  * Improved clustering with bounded processing, embedding-based matching, stable results, and safer large-cluster handling.

* **Documentation**
  * Updated storage and aggregation documentation for durable scheduling and incremental processing.

* **Bug Fixes**
  * Improved timestamp handling for profile expiration across timezone and daylight-saving changes.

* **Tests**
  * Expanded coverage for scheduling, retries, invalidations, clustering, reruns, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
