### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -74,8 +74,8 @@ and `openclaw-smart repair`.
   `force_extraction=True` so the session's learnings are available before
   the next openClaw run.
 
-The full design lives in
-[`docs/superpowers/specs/2026-05-19-openclaw-smart-design.md`](../../../../docs/superpowers/specs/2026-05-19-openclaw-smart-design.md).
+The original design note lives in the internal enterprise repository; keep this
+README as the public install and architecture map for the shipped integration.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Removes a broken local link from the OpenClaw integration README and clarifies that the internal design note is not part of the public integration map.
- Keeps the README navigation-focused per the parent repository's `how_to_write_readme.md` policy.

## Repositories/submodules reviewed
- Parent: `ReflexioAI/reflexio-enterprise`
- Submodules: `ReflexioAI/reflexio`, `ReflexioAI/claude-smart`

## README files updated
- `reflexio/integrations/openclaw/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/integrations/openclaw/README.md`

## Notes/Risks
- README-only change; no code changes.
- The user-facing `open_source/reflexio/README.md` was not restructured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenClaw architecture documentation to clarify where detailed design information is maintained.
  * Confirmed that the README continues to provide public installation and architecture guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->