### PR TITLE
fix: make receipt finalization winner-aware

### DIFF
--- a/reflexio/server/services/deferred_learning_plan.py
+++ b/reflexio/server/services/deferred_learning_plan.py
@@ -27,6 +27,20 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class FinalizationResult:
+    """Internal outcome of resumable learning finalization.
+
+    ``won_receipt`` is true only for the caller whose learning writes and
+    immutable finalization receipt committed together. Receipt-reuse callers
+    still receive the winner's ordered ids but must not replay billing or other
+    winner-only side effects.
+    """
+
+    learning_ids: list[str]
+    won_receipt: bool
+
+
+@dataclass(frozen=True)
 class ExtractorBookmarkAdvance:
     """The extractor stride-bookmark advance, deferred out of the extractor (F1).
 

--- a/reflexio/server/services/deferred_learning_plan.py
+++ b/reflexio/server/services/deferred_learning_plan.py
@@ -40,6 +40,10 @@ class FinalizationResult:
     won_receipt: bool
 
 
+class _FinalizationReceiptAlreadyExistsError(Exception):
+    """Rollback signal for a finalization transaction that lost receipt ownership."""
+
+
 @dataclass(frozen=True)
 class ExtractorBookmarkAdvance:
     """The extractor stride-bookmark advance, deferred out of the extractor (F1).

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -19,6 +19,7 @@ from reflexio.server.error_reporting import error_tags
 from reflexio.server.llm._litellm_types import ModelProvenance
 from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 from reflexio.server.llm.model_defaults import ModelRole, resolve_model_name
+from reflexio.server.services.deferred_learning_plan import FinalizationResult
 from reflexio.server.services.extraction.agent_run_records import build_scope_hash
 from reflexio.server.services.extraction.pending_tool_call_dispatch import (
     PendingToolCallToolContext,
@@ -871,7 +872,7 @@ class ExtractionResumeWorker:
         items: list[Any],
         *,
         model_provenance: ModelProvenance | None = None,
-    ) -> None:
+    ) -> FinalizationResult:
         if run.binding.extractor_kind == "profile":
             service = ProfileGenerationService(
                 llm_client=self.client,
@@ -893,7 +894,7 @@ class ExtractionResumeWorker:
                 self._record_finalized_learnings(
                     run, result.learning_ids, entity_type="profile"
                 )
-            return
+            return result
         if run.binding.extractor_kind == "playbook":
             service = PlaybookGenerationService(
                 llm_client=self.client,
@@ -916,7 +917,7 @@ class ExtractionResumeWorker:
                 self._record_finalized_learnings(
                     run, result.learning_ids, entity_type="user_playbook"
                 )
-            return
+            return result
         raise ResumeWorkerError(
             f"Unsupported extractor kind {run.binding.extractor_kind!r}"
         )

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -318,8 +318,9 @@ class ExtractionResumeWorker:
 
         try:
             self.storage.update_agent_run_status(run.id, AgentRunStatus.FINALIZING)
-            self._finalize_items(run, items, model_provenance=model_provenance)
-            self._schedule_finalized_tagging(run)
+            result = self._finalize_items(run, items, model_provenance=model_provenance)
+            if result.won_receipt:
+                self._schedule_finalized_tagging(run)
             self.storage.consume_run_tool_dependencies(run.id)
             finalized_status = (
                 AgentRunStatus.FINALIZED_PENDING_TOOL
@@ -364,8 +365,9 @@ class ExtractionResumeWorker:
             items, pending_tool_call_ids, model_provenance = (
                 self._items_from_committed_output(run)
             )
-            self._finalize_items(run, items, model_provenance=model_provenance)
-            self._schedule_finalized_tagging(run)
+            result = self._finalize_items(run, items, model_provenance=model_provenance)
+            if result.won_receipt:
+                self._schedule_finalized_tagging(run)
             self.storage.consume_run_tool_dependencies(run.id)
             finalized_status = (
                 AgentRunStatus.FINALIZED_PENDING_TOOL

--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -884,12 +884,15 @@ class ExtractionResumeWorker:
                 auto_run=False,
                 force_extraction=True,
             )
-            learning_ids = service._finalize_extracted_items(
+            result = service._finalize_extracted_items_with_outcome(
                 items,
                 model_provenance=model_provenance,
                 finalization_run_id=run.id,
             )
-            self._record_finalized_learnings(run, learning_ids, entity_type="profile")
+            if result.won_receipt:
+                self._record_finalized_learnings(
+                    run, result.learning_ids, entity_type="profile"
+                )
             return
         if run.binding.extractor_kind == "playbook":
             service = PlaybookGenerationService(
@@ -904,14 +907,15 @@ class ExtractionResumeWorker:
                 auto_run=False,
                 force_extraction=True,
             )
-            learning_ids = service._finalize_extracted_items(
+            result = service._finalize_extracted_items_with_outcome(
                 items,
                 model_provenance=model_provenance,
                 finalization_run_id=run.id,
             )
-            self._record_finalized_learnings(
-                run, learning_ids, entity_type="user_playbook"
-            )
+            if result.won_receipt:
+                self._record_finalized_learnings(
+                    run, result.learning_ids, entity_type="user_playbook"
+                )
             return
         raise ResumeWorkerError(
             f"Unsupported extractor kind {run.binding.extractor_kind!r}"

--- a/reflexio/server/services/playbook/service.py
+++ b/reflexio/server/services/playbook/service.py
@@ -604,10 +604,16 @@ class PlaybookGenerationService(
         committed finalization attempt; derived scheduler work has no durable
         replay idempotency.
         """
-        self._enqueue_user_playbook_optimization(plan.new_playbooks)
+        try:
+            self._enqueue_user_playbook_optimization(plan.new_playbooks)
+        except Exception:
+            logger.exception("Failed to schedule user playbook optimization")
         if not plan.output_pending_status and not plan.skip_aggregation:
-            logger.info("Trigger playbook aggregation")
-            self._trigger_playbook_aggregation()
+            try:
+                logger.info("Trigger playbook aggregation")
+                self._trigger_playbook_aggregation()
+            except Exception:
+                logger.exception("Failed to schedule user playbook aggregation")
 
     def emit_generation_side_effects(self, plan: GenerationComputePlan) -> None:
         """Post-commit side-effects — base telemetry/billing + playbook schedulers.
@@ -631,13 +637,12 @@ class PlaybookGenerationService(
     ) -> list[str]:
         """Finalize extracted playbooks for synchronous resume/manual callers.
 
-        Kept for the synchronous resume/manual callers
-        (``ExtractionResumeWorker`` calls this directly). Routes them through the
-        same ``_resolve_write_plan`` (compute) + ``_persist_write_plan``
-        (persist) split the durable worker uses. Derived schedulers dispatch
-        best-effort after the finalization transaction commits. When an existing
-        finalization receipt is found, the method intentionally returns its
-        learning ids without replaying those schedulers.
+        Compatibility surface for synchronous callers that expect ordered
+        learning ids. Routes them through the same ``_resolve_write_plan``
+        (compute) + ``_persist_write_plan`` (persist) split the durable worker
+        uses. Derived schedulers dispatch best-effort after the finalization
+        transaction commits. When an existing finalization receipt is found,
+        the method returns its learning ids without replaying those schedulers.
         """
         return self._finalize_extracted_items_with_outcome(
             all_playbooks,

--- a/reflexio/server/services/playbook/service.py
+++ b/reflexio/server/services/playbook/service.py
@@ -30,7 +30,10 @@ from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     StatusChangeOperation,
 )
-from reflexio.server.services.deferred_learning_plan import PlaybookWritePlan
+from reflexio.server.services.deferred_learning_plan import (
+    FinalizationResult,
+    PlaybookWritePlan,
+)
 from reflexio.server.services.playbook.aggregation_trigger import (
     maybe_trigger_user_playbook_aggregation,
 )
@@ -636,6 +639,20 @@ class PlaybookGenerationService(
         finalization receipt is found, the method intentionally returns its
         learning ids without replaying those schedulers.
         """
+        return self._finalize_extracted_items_with_outcome(
+            all_playbooks,
+            model_provenance=model_provenance,
+            finalization_run_id=finalization_run_id,
+        ).learning_ids
+
+    def _finalize_extracted_items_with_outcome(
+        self,
+        all_playbooks: list[UserPlaybook],
+        *,
+        model_provenance: ModelProvenance | None = None,
+        finalization_run_id: str | None = None,
+    ) -> FinalizationResult:
+        """Finalize playbooks and expose the atomic receipt winner internally."""
         entity_type = "user_playbook"
         if finalization_run_id is not None:
             receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
@@ -645,7 +662,7 @@ class PlaybookGenerationService(
             if receipt is not None:
                 # Receipts make persistence/billing idempotent. Derived schedulers
                 # are best-effort at-most-once and lack durable replay idempotency.
-                return receipt
+                return FinalizationResult(receipt, won_receipt=False)
         if model_provenance is not None:
             self._last_model_provenance = model_provenance
         plan = self._resolve_write_plan([all_playbooks])
@@ -654,14 +671,17 @@ class PlaybookGenerationService(
             if plan is not None:
                 self._persist_write_plan(plan)
                 self._dispatch_playbook_schedulers(plan)
-            return (
-                [
-                    str(playbook.user_playbook_id)
-                    for playbook in plan.new_playbooks
-                    if playbook.user_playbook_id
-                ]
-                if plan is not None
-                else []
+            return FinalizationResult(
+                learning_ids=(
+                    [
+                        str(playbook.user_playbook_id)
+                        for playbook in plan.new_playbooks
+                        if playbook.user_playbook_id
+                    ]
+                    if plan is not None
+                    else []
+                ),
+                won_receipt=False,
             )
 
         with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
@@ -670,7 +690,7 @@ class PlaybookGenerationService(
                 entity_type=entity_type,
             )
             if receipt is not None:
-                return receipt
+                return FinalizationResult(receipt, won_receipt=False)
             if plan is not None:
                 self._persist_write_plan(plan)
                 learning_ids = [
@@ -685,7 +705,7 @@ class PlaybookGenerationService(
             )
         if plan is not None:
             self._dispatch_playbook_schedulers(plan)
-        return learning_ids
+        return FinalizationResult(learning_ids, won_receipt=True)
 
     def _apply_consolidation_lineage(
         self,

--- a/reflexio/server/services/playbook/service.py
+++ b/reflexio/server/services/playbook/service.py
@@ -33,6 +33,7 @@ from reflexio.server.services.base_generation_service import (
 from reflexio.server.services.deferred_learning_plan import (
     FinalizationResult,
     PlaybookWritePlan,
+    _FinalizationReceiptAlreadyExistsError,
 )
 from reflexio.server.services.playbook.aggregation_trigger import (
     maybe_trigger_user_playbook_aggregation,
@@ -689,25 +690,38 @@ class PlaybookGenerationService(
                 won_receipt=False,
             )
 
-        with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
+        try:
+            with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
+                receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
+                    run_id=finalization_run_id,
+                    entity_type=entity_type,
+                )
+                if receipt is not None:
+                    return FinalizationResult(receipt, won_receipt=False)
+                if plan is not None:
+                    self._persist_write_plan(plan)
+                    learning_ids = [
+                        str(playbook.user_playbook_id)
+                        for playbook in plan.new_playbooks
+                        if playbook.user_playbook_id
+                    ]
+                inserted = self.storage.save_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
+                    run_id=finalization_run_id,
+                    entity_type=entity_type,
+                    learning_ids=learning_ids,
+                )
+                if not inserted:
+                    raise _FinalizationReceiptAlreadyExistsError
+        except _FinalizationReceiptAlreadyExistsError:
             receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
                 run_id=finalization_run_id,
                 entity_type=entity_type,
             )
-            if receipt is not None:
-                return FinalizationResult(receipt, won_receipt=False)
-            if plan is not None:
-                self._persist_write_plan(plan)
-                learning_ids = [
-                    str(playbook.user_playbook_id)
-                    for playbook in plan.new_playbooks
-                    if playbook.user_playbook_id
-                ]
-            self.storage.save_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
-                run_id=finalization_run_id,
-                entity_type=entity_type,
-                learning_ids=learning_ids,
-            )
+            if receipt is None:
+                raise RuntimeError(
+                    "finalization receipt disappeared after insert conflict"
+                ) from None
+            return FinalizationResult(receipt, won_receipt=False)
         if plan is not None:
             self._dispatch_playbook_schedulers(plan)
         return FinalizationResult(learning_ids, won_receipt=True)

--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -344,11 +344,11 @@ class ProfileGenerationService(
     ) -> list[str]:
         """Permanent V3 wrapper: compute-then-persist together (no external fence).
 
-        Kept for the synchronous resume/manual callers
-        (``ExtractionResumeWorker`` calls this directly). Routes them through the
-        same ``_resolve_write_plan`` (compute) + ``_persist_write_plan``
-        (persist) split the durable worker uses — with no external
-        ``commit_scope`` — so the result is identical to the pre-split monolith.
+        Compatibility surface for synchronous callers that expect ordered
+        learning ids. Routes them through the same ``_resolve_write_plan``
+        (compute) + ``_persist_write_plan`` (persist) split the durable worker
+        uses, with no external ``commit_scope``, so the result is identical to
+        the pre-split monolith.
         """
         return self._finalize_extracted_items_with_outcome(
             all_new_profiles,

--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -30,7 +30,10 @@ from reflexio.server.services.base_generation_service import (
     BaseGenerationService,
     StatusChangeOperation,
 )
-from reflexio.server.services.deferred_learning_plan import ProfileWritePlan
+from reflexio.server.services.deferred_learning_plan import (
+    FinalizationResult,
+    ProfileWritePlan,
+)
 from reflexio.server.services.profile.components.extractor import ProfileExtractor
 from reflexio.server.services.profile.profile_generation_service_utils import (
     ProfileGenerationRequest,
@@ -347,6 +350,20 @@ class ProfileGenerationService(
         (persist) split the durable worker uses — with no external
         ``commit_scope`` — so the result is identical to the pre-split monolith.
         """
+        return self._finalize_extracted_items_with_outcome(
+            all_new_profiles,
+            model_provenance=model_provenance,
+            finalization_run_id=finalization_run_id,
+        ).learning_ids
+
+    def _finalize_extracted_items_with_outcome(
+        self,
+        all_new_profiles: list[UserProfile],
+        *,
+        model_provenance: ModelProvenance | None = None,
+        finalization_run_id: str | None = None,
+    ) -> FinalizationResult:
+        """Finalize profiles and expose the atomic receipt winner internally."""
         entity_type = "profile"
         if finalization_run_id is not None:
             receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
@@ -354,7 +371,7 @@ class ProfileGenerationService(
                 entity_type=entity_type,
             )
             if receipt is not None:
-                return receipt
+                return FinalizationResult(receipt, won_receipt=False)
         if model_provenance is not None:
             self._last_model_provenance = model_provenance
         plan = self._resolve_write_plan([all_new_profiles])
@@ -371,7 +388,7 @@ class ProfileGenerationService(
         if finalization_run_id is None:
             if plan is not None:
                 self._persist_write_plan(plan)
-            return learning_ids
+            return FinalizationResult(learning_ids, won_receipt=False)
 
         with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
             receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
@@ -379,7 +396,7 @@ class ProfileGenerationService(
                 entity_type=entity_type,
             )
             if receipt is not None:
-                return receipt
+                return FinalizationResult(receipt, won_receipt=False)
             if plan is not None:
                 self._persist_write_plan(plan)
             self.storage.save_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
@@ -387,7 +404,7 @@ class ProfileGenerationService(
                 entity_type=entity_type,
                 learning_ids=learning_ids,
             )
-        return learning_ids
+        return FinalizationResult(learning_ids, won_receipt=True)
 
     def check_and_update_profiles(self, profiles: list[UserProfile]) -> None:
         """check if the profiles are expired and update them if they are"""

--- a/reflexio/server/services/profile/service.py
+++ b/reflexio/server/services/profile/service.py
@@ -33,6 +33,7 @@ from reflexio.server.services.base_generation_service import (
 from reflexio.server.services.deferred_learning_plan import (
     FinalizationResult,
     ProfileWritePlan,
+    _FinalizationReceiptAlreadyExistsError,
 )
 from reflexio.server.services.profile.components.extractor import ProfileExtractor
 from reflexio.server.services.profile.profile_generation_service_utils import (
@@ -390,20 +391,33 @@ class ProfileGenerationService(
                 self._persist_write_plan(plan)
             return FinalizationResult(learning_ids, won_receipt=False)
 
-        with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
+        try:
+            with self.storage.commit_scope():  # type: ignore[reportOptionalMemberAccess]
+                receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
+                    run_id=finalization_run_id,
+                    entity_type=entity_type,
+                )
+                if receipt is not None:
+                    return FinalizationResult(receipt, won_receipt=False)
+                if plan is not None:
+                    self._persist_write_plan(plan)
+                inserted = self.storage.save_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
+                    run_id=finalization_run_id,
+                    entity_type=entity_type,
+                    learning_ids=learning_ids,
+                )
+                if not inserted:
+                    raise _FinalizationReceiptAlreadyExistsError
+        except _FinalizationReceiptAlreadyExistsError:
             receipt = self.storage.get_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
                 run_id=finalization_run_id,
                 entity_type=entity_type,
             )
-            if receipt is not None:
-                return FinalizationResult(receipt, won_receipt=False)
-            if plan is not None:
-                self._persist_write_plan(plan)
-            self.storage.save_agent_run_finalization_receipt(  # type: ignore[reportOptionalMemberAccess]
-                run_id=finalization_run_id,
-                entity_type=entity_type,
-                learning_ids=learning_ids,
-            )
+            if receipt is None:
+                raise RuntimeError(
+                    "finalization receipt disappeared after insert conflict"
+                ) from None
+            return FinalizationResult(receipt, won_receipt=False)
         return FinalizationResult(learning_ids, won_receipt=True)
 
     def check_and_update_profiles(self, profiles: list[UserProfile]) -> None:

--- a/reflexio/server/services/storage/sqlite_storage/agent_run/_agent_run_store.py
+++ b/reflexio/server/services/storage/sqlite_storage/agent_run/_agent_run_store.py
@@ -254,7 +254,7 @@ class SQLiteAgentRunStoreMixin:
         run_id: str,
         entity_type: str,
         learning_ids: list[str],
-    ) -> None:
+    ) -> bool:
         expected_by_extractor = {
             "profile": "profile",
             "playbook": "user_playbook",
@@ -275,13 +275,16 @@ class SQLiteAgentRunStoreMixin:
                 raise ValueError(
                     "agent-run finalization receipt entity type is invalid"
                 )
-            self.conn.execute(
-                """
+            inserted = (
+                self.conn.execute(
+                    """
                 INSERT OR IGNORE INTO _agent_run_finalization_receipts
                     (run_id, entity_type, learning_ids)
                 VALUES (?, ?, ?)
                 """,
-                (run_id, entity_type, encoded_ids),
+                    (run_id, entity_type, encoded_ids),
+                ).rowcount
+                == 1
             )
             stored = self.conn.execute(
                 """
@@ -291,14 +294,14 @@ class SQLiteAgentRunStoreMixin:
                 """,
                 (run_id,),
             ).fetchone()
-            if (
-                stored is None
-                or stored["entity_type"] != entity_type
-                or json.loads(stored["learning_ids"]) != learning_ids
-            ):
+            if stored is None or stored["entity_type"] != entity_type:
                 raise ValueError("agent-run finalization receipt is immutable")
+            stored_ids = json.loads(stored["learning_ids"])
+            if not _valid_finalized_learning_ids(stored_ids):
+                raise ValueError("agent-run finalization receipt is corrupt")
             if self._own_transaction():
                 self.conn.commit()
+            return inserted
 
     @SQLiteStorageBase.handle_exceptions
     def get_latest_finalized_agent_run_for_request(

--- a/reflexio/server/services/storage/storage_base/agent_run/_agent_run_store.py
+++ b/reflexio/server/services/storage/storage_base/agent_run/_agent_run_store.py
@@ -39,8 +39,8 @@ class AgentRunStoreABC:
         run_id: str,
         entity_type: str,
         learning_ids: list[str],
-    ) -> None:
-        """Persist an immutable run-to-learning binding with the learning writes."""
+    ) -> bool:
+        """Persist an immutable run-to-learning binding and report insert ownership."""
         raise NotImplementedError(f"{type(self).__name__} does not support agent runs")
 
     def get_latest_finalized_agent_run_for_request(

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -33,7 +33,14 @@ from reflexio.server.services.playbook.components.consolidator import (
     PlaybookConsolidationOutput,
     UnifyDecision,
 )
-from reflexio.server.services.playbook.service import PlaybookGenerationService
+from reflexio.server.services.playbook.service import (
+    PlaybookGenerationService,
+    PlaybookGenerationServiceConfig,
+)
+from reflexio.server.services.profile.service import (
+    ProfileGenerationService,
+    ProfileGenerationServiceConfig,
+)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base import (
     AgentBinding,
@@ -81,6 +88,115 @@ def request_context(storage):
         f"{prompt_id}: {variables}"
     )
     return ctx
+
+
+def _finalization_context(storage: SQLiteStorage) -> RequestContext:
+    context = RequestContext.__new__(RequestContext)
+    context.org_id = "org_1"
+    context.storage = storage
+    context.storage_base_dir = None
+    context.configurator = MagicMock()
+    context.configurator.get_config.return_value = Config(
+        storage_config=StorageConfigSQLite(),
+        profile_extractor_config=ProfileExtractorConfig(
+            extraction_definition_prompt="Extract durable user facts.",
+        ),
+        user_playbook_extractor_config=PlaybookConfig(
+            extraction_definition_prompt="Extract durable operating rules.",
+        ),
+        pending_tool_call_config=PendingToolCallConfig(enabled=True),
+    )
+    context.prompt_manager = MagicMock()
+    context.prompt_manager.get_active_version.return_value = None
+    return context
+
+
+def _finalizing_run(
+    *, run_id: str, extractor_kind: str, request_id: str
+) -> AgentRunRecord:
+    return AgentRunRecord(
+        id=run_id,
+        binding=AgentBinding(
+            org_id="org_1",
+            extractor_kind=extractor_kind,
+            user_id="user_1",
+            request_id=request_id,
+            agent_version="v1",
+            source="api",
+        ),
+        status=AgentRunStatus.FINALIZING,
+        generation_request_snapshot={"request_id": request_id},
+    )
+
+
+def _gate_initial_receipt_reads(
+    storages: tuple[SQLiteStorage, SQLiteStorage],
+) -> None:
+    barrier = threading.Barrier(len(storages))
+
+    def install_gate(storage: SQLiteStorage) -> None:
+        original = storage.get_agent_run_finalization_receipt
+        first_read = True
+
+        def gated_read(*, run_id: str, entity_type: str) -> list[str] | None:
+            nonlocal first_read
+            receipt = original(run_id=run_id, entity_type=entity_type)
+            if first_read:
+                first_read = False
+                barrier.wait(timeout=5)
+            return receipt
+
+        storage.get_agent_run_finalization_receipt = MagicMock(  # type: ignore[method-assign]
+            side_effect=gated_read
+        )
+
+    for storage in storages:
+        install_gate(storage)
+
+
+def _profile_service(
+    context: RequestContext, *, request_id: str
+) -> ProfileGenerationService:
+    service = ProfileGenerationService(llm_client=MagicMock(), request_context=context)
+    service.service_config = ProfileGenerationServiceConfig(
+        user_id="user_1",
+        request_id=request_id,
+        source="api",
+        auto_run=False,
+        force_extraction=True,
+    )
+    return service
+
+
+def _playbook_service(
+    context: RequestContext, *, request_id: str
+) -> PlaybookGenerationService:
+    service = PlaybookGenerationService(llm_client=MagicMock(), request_context=context)
+    service.service_config = PlaybookGenerationServiceConfig(
+        request_id=request_id,
+        agent_version="v1",
+        user_id="user_1",
+        source="api",
+        auto_run=False,
+        force_extraction=True,
+    )
+    return service
+
+
+def _playbook_candidates(*, request_id: str, prefix: str) -> list[UserPlaybook]:
+    return [
+        UserPlaybook(
+            user_id="user_1",
+            agent_version="v1",
+            request_id=request_id,
+            content=f"Use deployment procedure {prefix}-{index}.",
+            trigger=f"when deployment condition {prefix}-{index} occurs",
+            rationale=f"Procedure {prefix}-{index} is required.",
+            source="api",
+            source_interaction_ids=[1, 2],
+        )
+        for index in range(2)
+    ]
 
 
 @pytest.mark.parametrize(
@@ -661,93 +777,158 @@ def test_retry_after_billing_reuses_ids_without_replaying_playbook_schedulers(
     assert playbook_keys == [f"learn:user_playbook:{playbook_survivor_ids[0]}"]
 
 
-def test_two_stale_sqlite_workers_bill_only_the_receipt_winner(tmp_path):
+@pytest.mark.parametrize("failing_scheduler", ["optimizer", "aggregation"])
+def test_playbook_scheduler_failure_preserves_billing_and_isolated_retry(
+    storage,
+    failing_scheduler,
+):
+    run = _finalizing_run(
+        run_id=f"run_scheduler_failure_{failing_scheduler}",
+        extractor_kind="playbook",
+        request_id=f"request_scheduler_failure_{failing_scheduler}",
+    )
+    storage.create_agent_run(run)
+    worker = ExtractionResumeWorker(
+        request_context=_finalization_context(storage),
+        llm_client=MagicMock(),
+    )
+    candidates = _playbook_candidates(
+        request_id=run.binding.request_id,
+        prefix=failing_scheduler,
+    )
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with (
+            patch.object(
+                PlaybookGenerationService,
+                "_configured_playbook_config",
+                return_value=None,
+            ),
+            patch(
+                "reflexio.server.services.playbook.components.consolidator."
+                "PlaybookConsolidator.deduplicate",
+                side_effect=lambda results, *_args, **_kwargs: (
+                    [playbook for result in results for playbook in result],
+                    [],
+                    [],
+                ),
+            ) as deduplicate,
+            patch.object(
+                PlaybookGenerationService,
+                "_enqueue_user_playbook_optimization",
+                side_effect=(
+                    RuntimeError("optimizer unavailable")
+                    if failing_scheduler == "optimizer"
+                    else None
+                ),
+            ) as optimize,
+            patch.object(
+                PlaybookGenerationService,
+                "_trigger_playbook_aggregation",
+                side_effect=(
+                    RuntimeError("aggregation unavailable")
+                    if failing_scheduler == "aggregation"
+                    else None
+                ),
+            ) as aggregate,
+        ):
+            winner = worker._finalize_items(run, candidates)
+            retry = worker._finalize_items(run, candidates)
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert winner.won_receipt is True
+    assert retry == FinalizationResult(winner.learning_ids, won_receipt=False)
+    assert deduplicate.call_count == 1
+    optimize.assert_called_once()
+    aggregate.assert_called_once()
+    billing_ids = [
+        event.entity_id
+        for event in events
+        if event.event_name == "learnings_generated"
+        and event.entity_type == "user_playbook"
+    ]
+    assert billing_ids == winner.learning_ids
+
+
+def test_empty_profile_receipt_wins_once_without_billing_or_recompute(storage):
+    run = _finalizing_run(
+        run_id="run_empty_profile",
+        extractor_kind="profile",
+        request_id="request_empty_profile",
+    )
+    storage.create_agent_run(run)
+    context = _finalization_context(storage)
+    worker = ExtractionResumeWorker(request_context=context, llm_client=MagicMock())
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with patch.object(
+            ProfileGenerationService,
+            "_resolve_write_plan",
+            return_value=None,
+        ) as resolve:
+            winner = worker._finalize_items(run, [])
+            retry = worker._finalize_items(run, [])
+            wrapper_ids = _profile_service(
+                context, request_id=run.binding.request_id
+            )._finalize_extracted_items([], finalization_run_id=run.id)
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert winner == FinalizationResult([], won_receipt=True)
+    assert retry == FinalizationResult([], won_receipt=False)
+    assert type(wrapper_ids) is list
+    assert wrapper_ids == []
+    resolve.assert_called_once()
+    assert (
+        storage.get_agent_run_finalization_receipt(run_id=run.id, entity_type="profile")
+        == []
+    )
+    assert [
+        event for event in events if event.event_name == "learnings_generated"
+    ] == []
+
+
+def test_two_stale_profile_workers_preserve_order_and_bill_only_winner(tmp_path):
     db_path = str(tmp_path / "stale-finalizers.db")
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
         storage_a = SQLiteStorage(org_id="org_1", db_path=db_path)
         storage_b = SQLiteStorage(org_id="org_1", db_path=db_path)
-    storage_a.create_agent_run(
-        AgentRunRecord(
-            id="run_race",
-            binding=AgentBinding(
-                org_id="org_1",
-                extractor_kind="profile",
-                user_id="user_1",
-                request_id="request_race",
-                agent_version="v1",
-                source="api",
-            ),
-            status=AgentRunStatus.FINALIZING,
-            generation_request_snapshot={"request_id": "request_race"},
-        )
+    run = _finalizing_run(
+        run_id="run_profile_race",
+        extractor_kind="profile",
+        request_id="request_profile_race",
     )
-    barrier = threading.Barrier(2)
-
-    def _context(storage_instance: SQLiteStorage) -> RequestContext:
-        context = RequestContext.__new__(RequestContext)
-        context.org_id = "org_1"
-        context.storage = storage_instance
-        context.configurator = MagicMock()
-        context.configurator.get_config.return_value = Config(
-            storage_config=StorageConfigSQLite(),
-            profile_extractor_config=ProfileExtractorConfig(
-                extraction_definition_prompt="Extract durable user facts.",
-            ),
-        )
-        return context
-
-    def _gate_first_receipt_read(storage_instance: SQLiteStorage) -> None:
-        original = storage_instance.get_agent_run_finalization_receipt
-        first_read = True
-
-        def gated_read(*, run_id: str, entity_type: str) -> list[str] | None:
-            nonlocal first_read
-            receipt = original(run_id=run_id, entity_type=entity_type)
-            if first_read:
-                first_read = False
-                barrier.wait(timeout=5)
-            return receipt
-
-        storage_instance.get_agent_run_finalization_receipt = MagicMock(  # type: ignore[method-assign]
-            side_effect=gated_read
-        )
-
-    _gate_first_receipt_read(storage_a)
-    _gate_first_receipt_read(storage_b)
+    storage_a.create_agent_run(run)
+    _gate_initial_receipt_reads((storage_a, storage_b))
+    contexts = [_finalization_context(storage) for storage in (storage_a, storage_b)]
     resume_workers = [
-        ExtractionResumeWorker(
-            request_context=_context(storage), llm_client=MagicMock()
-        )
-        for storage in (storage_a, storage_b)
+        ExtractionResumeWorker(request_context=context, llm_client=MagicMock())
+        for context in contexts
     ]
-    run = AgentRunRecord(
-        id="run_race",
-        binding=AgentBinding(
-            org_id="org_1",
-            extractor_kind="profile",
-            user_id="user_1",
-            request_id="request_race",
-            agent_version="v1",
-            source="api",
-        ),
-        status=AgentRunStatus.FINALIZING,
-        generation_request_snapshot={"request_id": "request_race"},
-    )
-    candidates = [
-        UserProfile(
-            profile_id=f"profile-race-{index}",
-            user_id="user_1",
-            content="User deployment target is AWS ECS.",
-            last_modified_timestamp=1_000,
-            generated_from_request_id="request_race",
-        )
-        for index in range(2)
+    candidate_batches = [
+        [
+            UserProfile(
+                profile_id=f"profile-{worker_index}-{item_index}",
+                user_id="user_1",
+                content=f"Profile candidate {worker_index}-{item_index}.",
+                last_modified_timestamp=1_000 + item_index,
+                generated_from_request_id="request_profile_race",
+            )
+            for item_index in range(2)
+        ]
+        for worker_index in range(2)
     ]
+    outcomes: list[FinalizationResult] = []
     errors: list[BaseException] = []
 
     def finalize(index: int) -> None:
         try:
-            resume_workers[index]._finalize_items(run, [candidates[index]])
+            outcomes.append(
+                resume_workers[index]._finalize_items(run, candidate_batches[index])
+            )
         except BaseException as exc:  # noqa: BLE001 - intentional thread error capture
             errors.append(exc)
 
@@ -775,16 +956,141 @@ def test_two_stale_sqlite_workers_bill_only_the_receipt_winner(tmp_path):
         profile.profile_id for profile in storage_a.get_user_profile("user_1")
     ]
     receipt_ids = storage_a.get_agent_run_finalization_receipt(
-        run_id="run_race", entity_type="profile"
+        run_id=run.id, entity_type="profile"
     )
-    assert len(persisted_ids) == 1
+    assert len(persisted_ids) == 2
     assert receipt_ids == persisted_ids
+    assert [outcome.won_receipt for outcome in outcomes].count(True) == 1
+    assert [outcome.won_receipt for outcome in outcomes].count(False) == 1
+    assert all(outcome.learning_ids == receipt_ids for outcome in outcomes)
+    assert receipt_ids in [
+        [profile.profile_id for profile in batch] for batch in candidate_batches
+    ]
+    wrapper_ids = _profile_service(
+        contexts[0], request_id=run.binding.request_id
+    )._finalize_extracted_items(
+        candidate_batches[1],
+        finalization_run_id=run.id,
+    )
+    assert type(wrapper_ids) is list
+    assert wrapper_ids == receipt_ids
     billing_events = [
         event
         for event in events
         if event.event_name == "learnings_generated" and event.entity_type == "profile"
     ]
     assert [event.entity_id for event in billing_events] == persisted_ids
+
+
+def test_two_stale_playbook_workers_preserve_order_and_dispatch_once(tmp_path):
+    db_path = str(tmp_path / "stale-playbook-finalizers.db")
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage_a = SQLiteStorage(org_id="org_1", db_path=db_path)
+        storage_b = SQLiteStorage(org_id="org_1", db_path=db_path)
+    run = _finalizing_run(
+        run_id="run_playbook_race",
+        extractor_kind="playbook",
+        request_id="request_playbook_race",
+    )
+    storage_a.create_agent_run(run)
+    _gate_initial_receipt_reads((storage_a, storage_b))
+    contexts = [_finalization_context(storage) for storage in (storage_a, storage_b)]
+    resume_workers = [
+        ExtractionResumeWorker(request_context=context, llm_client=MagicMock())
+        for context in contexts
+    ]
+    candidate_batches = [
+        _playbook_candidates(
+            request_id=run.binding.request_id,
+            prefix=f"worker-{worker_index}",
+        )
+        for worker_index in range(2)
+    ]
+    outcomes: list[FinalizationResult] = []
+    errors: list[BaseException] = []
+
+    def finalize(index: int) -> None:
+        try:
+            outcomes.append(
+                resume_workers[index]._finalize_items(run, candidate_batches[index])
+            )
+        except BaseException as exc:  # noqa: BLE001 - intentional thread error capture
+            errors.append(exc)
+
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with (
+            patch.object(
+                PlaybookGenerationService,
+                "_configured_playbook_config",
+                return_value=None,
+            ),
+            patch(
+                "reflexio.server.services.playbook.components.consolidator."
+                "PlaybookConsolidator.deduplicate",
+                side_effect=lambda results, *_args, **_kwargs: (
+                    [playbook for result in results for playbook in result],
+                    [],
+                    [],
+                ),
+            ),
+            patch.object(
+                PlaybookGenerationService,
+                "_enqueue_user_playbook_optimization",
+            ) as optimize,
+            patch.object(
+                PlaybookGenerationService,
+                "_trigger_playbook_aggregation",
+            ) as aggregate,
+        ):
+            threads = [
+                threading.Thread(target=finalize, args=(index,)) for index in range(2)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=10)
+
+            assert all(not thread.is_alive() for thread in threads)
+            assert errors == []
+            receipt_ids = storage_a.get_agent_run_finalization_receipt(
+                run_id=run.id,
+                entity_type="user_playbook",
+            )
+            persisted_ids = [
+                str(row[0])
+                for row in storage_a.conn.execute(
+                    "SELECT user_playbook_id FROM user_playbooks "
+                    "WHERE request_id = ? ORDER BY user_playbook_id ASC",
+                    (run.binding.request_id,),
+                ).fetchall()
+            ]
+            wrapper_ids = _playbook_service(
+                contexts[0], request_id=run.binding.request_id
+            )._finalize_extracted_items(
+                candidate_batches[1],
+                finalization_run_id=run.id,
+            )
+
+            assert len(persisted_ids) == 2
+            assert receipt_ids == persisted_ids
+            assert [outcome.won_receipt for outcome in outcomes].count(True) == 1
+            assert [outcome.won_receipt for outcome in outcomes].count(False) == 1
+            assert all(outcome.learning_ids == receipt_ids for outcome in outcomes)
+            assert type(wrapper_ids) is list
+            assert wrapper_ids == receipt_ids
+            optimize.assert_called_once()
+            aggregate.assert_called_once()
+            billing_ids = [
+                event.entity_id
+                for event in events
+                if event.event_name == "learnings_generated"
+                and event.entity_type == "user_playbook"
+            ]
+            assert billing_ids == receipt_ids
+    finally:
+        configure_usage_event_recorder(None)
 
 
 def test_resume_worker_fails_run_when_step_budget_exhausted(

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -23,6 +23,7 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.deferred_learning_plan import FinalizationResult
 from reflexio.server.services.extraction.resume_worker import (
     ExtractionResumeWorker,
     _run_playbook_contract_selection,
@@ -33,10 +34,6 @@ from reflexio.server.services.playbook.components.consolidator import (
     UnifyDecision,
 )
 from reflexio.server.services.playbook.service import PlaybookGenerationService
-from reflexio.server.services.profile.service import (
-    ProfileGenerationService,
-    ProfileGenerationServiceConfig,
-)
 from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from reflexio.server.services.storage.storage_base import (
     AgentBinding,
@@ -317,7 +314,7 @@ def test_resume_worker_retries_finalization_without_rerunning_agent(
         patch("litellm.completion", side_effect=[response]),
         patch(
             "reflexio.server.services.profile.service."
-            "ProfileGenerationService._finalize_extracted_items",
+            "ProfileGenerationService._finalize_extracted_items_with_outcome",
             side_effect=RuntimeError("storage write failed"),
         ),
     ):
@@ -344,8 +341,8 @@ def test_resume_worker_retries_finalization_without_rerunning_agent(
         ),
         patch(
             "reflexio.server.services.profile.service."
-            "ProfileGenerationService._finalize_extracted_items",
-            return_value=None,
+            "ProfileGenerationService._finalize_extracted_items_with_outcome",
+            return_value=FinalizationResult([], won_receipt=False),
         ) as finalize,
     ):
         resumed = worker.drain(max_runs=1)
@@ -649,22 +646,22 @@ def test_retry_after_billing_reuses_ids_without_replaying_playbook_schedulers(
     }
     assert observed == {
         "profile_persisted": 1,
-        "profile_events": 2,
+        "profile_events": 1,
         "profile_distinct_keys": 1,
         "playbook_persisted": 1,
         "playbook_lineage_events": 1,
-        "playbook_events": 2,
+        "playbook_events": 1,
         "playbook_distinct_keys": 1,
     }
     assert profile_receipt_ids == profile_survivor_ids
-    assert profile_event_ids == profile_survivor_ids * 2
-    assert profile_keys == [f"learn:profile:{profile_survivor_ids[0]}"] * 2
+    assert profile_event_ids == profile_survivor_ids
+    assert profile_keys == [f"learn:profile:{profile_survivor_ids[0]}"]
     assert playbook_receipt_ids == playbook_survivor_ids
-    assert playbook_event_ids == playbook_survivor_ids * 2
-    assert playbook_keys == [f"learn:user_playbook:{playbook_survivor_ids[0]}"] * 2
+    assert playbook_event_ids == playbook_survivor_ids
+    assert playbook_keys == [f"learn:user_playbook:{playbook_survivor_ids[0]}"]
 
 
-def test_two_stale_sqlite_workers_share_one_finalization_receipt(tmp_path):
+def test_two_stale_sqlite_workers_bill_only_the_receipt_winner(tmp_path):
     db_path = str(tmp_path / "stale-finalizers.db")
     with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
         storage_a = SQLiteStorage(org_id="org_1", db_path=db_path)
@@ -686,7 +683,7 @@ def test_two_stale_sqlite_workers_share_one_finalization_receipt(tmp_path):
     )
     barrier = threading.Barrier(2)
 
-    def _service(storage_instance: SQLiteStorage) -> ProfileGenerationService:
+    def _context(storage_instance: SQLiteStorage) -> RequestContext:
         context = RequestContext.__new__(RequestContext)
         context.org_id = "org_1"
         context.storage = storage_instance
@@ -697,18 +694,7 @@ def test_two_stale_sqlite_workers_share_one_finalization_receipt(tmp_path):
                 extraction_definition_prompt="Extract durable user facts.",
             ),
         )
-        service = ProfileGenerationService(
-            llm_client=MagicMock(),
-            request_context=context,
-        )
-        service.service_config = ProfileGenerationServiceConfig(
-            user_id="user_1",
-            request_id="request_race",
-            source="api",
-            auto_run=False,
-            force_extraction=True,
-        )
-        return service
+        return context
 
     def _gate_first_receipt_read(storage_instance: SQLiteStorage) -> None:
         original = storage_instance.get_agent_run_finalization_receipt
@@ -728,7 +714,25 @@ def test_two_stale_sqlite_workers_share_one_finalization_receipt(tmp_path):
 
     _gate_first_receipt_read(storage_a)
     _gate_first_receipt_read(storage_b)
-    services = [_service(storage_a), _service(storage_b)]
+    resume_workers = [
+        ExtractionResumeWorker(
+            request_context=_context(storage), llm_client=MagicMock()
+        )
+        for storage in (storage_a, storage_b)
+    ]
+    run = AgentRunRecord(
+        id="run_race",
+        binding=AgentBinding(
+            org_id="org_1",
+            extractor_kind="profile",
+            user_id="user_1",
+            request_id="request_race",
+            agent_version="v1",
+            source="api",
+        ),
+        status=AgentRunStatus.FINALIZING,
+        generation_request_snapshot={"request_id": "request_race"},
+    )
     candidates = [
         UserProfile(
             profile_id=f"profile-race-{index}",
@@ -739,32 +743,31 @@ def test_two_stale_sqlite_workers_share_one_finalization_receipt(tmp_path):
         )
         for index in range(2)
     ]
-    results: list[list[str]] = []
     errors: list[BaseException] = []
 
     def finalize(index: int) -> None:
         try:
-            results.append(
-                services[index]._finalize_extracted_items(
-                    [candidates[index]],
-                    finalization_run_id="run_race",
-                )
-            )
+            resume_workers[index]._finalize_items(run, [candidates[index]])
         except BaseException as exc:  # noqa: BLE001 - intentional thread error capture
             errors.append(exc)
 
-    with patch(
-        "reflexio.server.services.profile.components.consolidator."
-        "ProfileConsolidator.deduplicate",
-        side_effect=lambda profiles, _user_id, _request_id: (profiles, [], []),
-    ):
-        workers = [
-            threading.Thread(target=finalize, args=(index,)) for index in range(2)
-        ]
-        for worker in workers:
-            worker.start()
-        for worker in workers:
-            worker.join(timeout=10)
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with patch(
+            "reflexio.server.services.profile.components.consolidator."
+            "ProfileConsolidator.deduplicate",
+            side_effect=lambda profiles, _user_id, _request_id: (profiles, [], []),
+        ):
+            workers = [
+                threading.Thread(target=finalize, args=(index,)) for index in range(2)
+            ]
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join(timeout=10)
+    finally:
+        configure_usage_event_recorder(None)
 
     assert all(not worker.is_alive() for worker in workers)
     assert errors == []
@@ -776,7 +779,12 @@ def test_two_stale_sqlite_workers_share_one_finalization_receipt(tmp_path):
     )
     assert len(persisted_ids) == 1
     assert receipt_ids == persisted_ids
-    assert results == [persisted_ids, persisted_ids]
+    billing_events = [
+        event
+        for event in events
+        if event.event_name == "learnings_generated" and event.entity_type == "profile"
+    ]
+    assert [event.entity_id for event in billing_events] == persisted_ids
 
 
 def test_resume_worker_fails_run_when_step_budget_exhausted(

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -972,15 +972,18 @@ def test_empty_playbook_receipt_retries_without_redispatch(storage):
             failed = worker.run_once()
             assert failed is not None
             assert failed.status == AgentRunStatus.FINALIZATION_FAILED
+            schedule_tagging.assert_called_once()
             storage.update_agent_run_status(
                 run.id,
                 AgentRunStatus.FINALIZATION_FAILED,
                 next_resume_at=datetime(2000, 1, 1, tzinfo=UTC),
             )
             retried = worker.run_once()
+            schedule_tagging.assert_called_once()
             wrapper_ids = _playbook_service(
                 context, request_id=run.binding.request_id
             )._finalize_extracted_items([], finalization_run_id=run.id)
+            schedule_tagging.assert_called_once()
 
         assert retried is not None
         assert retried.status == AgentRunStatus.FINALIZED
@@ -993,7 +996,6 @@ def test_empty_playbook_receipt_retries_without_redispatch(storage):
         resolve.assert_called_once()
         optimize.assert_not_called()
         aggregate.assert_not_called()
-        schedule_tagging.assert_called_once()
         assert (
             storage.get_agent_run_finalization_receipt(
                 run_id=run.id, entity_type="user_playbook"

--- a/tests/server/services/extraction/test_resume_worker.py
+++ b/tests/server/services/extraction/test_resume_worker.py
@@ -154,6 +154,22 @@ def _gate_initial_receipt_reads(
         install_gate(storage)
 
 
+def _hide_next_receipt_reads(storage: SQLiteStorage, *, count: int = 2) -> None:
+    original = storage.get_agent_run_finalization_receipt
+    remaining = count
+
+    def stale_read(*, run_id: str, entity_type: str) -> list[str] | None:
+        nonlocal remaining
+        if remaining > 0:
+            remaining -= 1
+            return None
+        return original(run_id=run_id, entity_type=entity_type)
+
+    storage.get_agent_run_finalization_receipt = MagicMock(  # type: ignore[method-assign]
+        side_effect=stale_read
+    )
+
+
 def _profile_service(
     context: RequestContext, *, request_id: str
 ) -> ProfileGenerationService:
@@ -889,6 +905,255 @@ def test_empty_profile_receipt_wins_once_without_billing_or_recompute(storage):
     assert [
         event for event in events if event.event_name == "learnings_generated"
     ] == []
+
+
+def test_empty_playbook_receipt_retries_without_redispatch(storage):
+    run = AgentRunRecord(
+        id="run_empty_playbook",
+        binding=AgentBinding(
+            org_id="org_1",
+            extractor_kind="playbook",
+            user_id="user_1",
+            request_id="request_empty_playbook",
+            agent_version="v1",
+            source="api",
+        ),
+        status=AgentRunStatus.RESUME_READY,
+        generation_request_snapshot={"output_schema_name": "StructuredPlaybookList"},
+        committed_output={"playbooks": []},
+        next_resume_at=datetime(2000, 1, 1, tzinfo=UTC),
+    )
+    storage.create_agent_run(run)
+    context = _finalization_context(storage)
+    worker = ExtractionResumeWorker(request_context=context, llm_client=MagicMock())
+    original_finalize = worker._finalize_items
+    outcomes: list[FinalizationResult] = []
+
+    def tracked_finalize(*args, **kwargs) -> FinalizationResult:
+        outcome = original_finalize(*args, **kwargs)
+        outcomes.append(outcome)
+        return outcome
+
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with (
+            patch.object(storage, "claim_ready_agent_run", return_value=run),
+            patch.object(
+                worker, "_load_resolved_tool_calls", return_value=[MagicMock()]
+            ),
+            patch.object(worker, "_resume_run", return_value=([], [], None)),
+            patch.object(
+                worker, "_items_from_committed_output", return_value=([], [], None)
+            ),
+            patch.object(worker, "_finalize_items", side_effect=tracked_finalize),
+            patch.object(
+                PlaybookGenerationService,
+                "_resolve_write_plan",
+                return_value=None,
+            ) as resolve,
+            patch.object(
+                PlaybookGenerationService,
+                "_enqueue_user_playbook_optimization",
+            ) as optimize,
+            patch.object(
+                PlaybookGenerationService,
+                "_trigger_playbook_aggregation",
+            ) as aggregate,
+            patch(
+                "reflexio.server.services.extraction.resume_worker.schedule_tagging"
+            ) as schedule_tagging,
+            patch.object(
+                storage,
+                "consume_run_tool_dependencies",
+                side_effect=[RuntimeError("failed after finalization"), 0],
+            ),
+        ):
+            failed = worker.run_once()
+            assert failed is not None
+            assert failed.status == AgentRunStatus.FINALIZATION_FAILED
+            storage.update_agent_run_status(
+                run.id,
+                AgentRunStatus.FINALIZATION_FAILED,
+                next_resume_at=datetime(2000, 1, 1, tzinfo=UTC),
+            )
+            retried = worker.run_once()
+            wrapper_ids = _playbook_service(
+                context, request_id=run.binding.request_id
+            )._finalize_extracted_items([], finalization_run_id=run.id)
+
+        assert retried is not None
+        assert retried.status == AgentRunStatus.FINALIZED
+        assert outcomes == [
+            FinalizationResult([], won_receipt=True),
+            FinalizationResult([], won_receipt=False),
+        ]
+        assert type(wrapper_ids) is list
+        assert wrapper_ids == []
+        resolve.assert_called_once()
+        optimize.assert_not_called()
+        aggregate.assert_not_called()
+        schedule_tagging.assert_called_once()
+        assert (
+            storage.get_agent_run_finalization_receipt(
+                run_id=run.id, entity_type="user_playbook"
+            )
+            == []
+        )
+        assert [
+            event for event in events if event.event_name == "learnings_generated"
+        ] == []
+    finally:
+        configure_usage_event_recorder(None)
+
+
+def test_identical_profile_ids_use_atomic_receipt_owner(tmp_path):
+    db_path = str(tmp_path / "identical-profile-receipt.db")
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage_a = SQLiteStorage(org_id="org_1", db_path=db_path)
+        storage_b = SQLiteStorage(org_id="org_1", db_path=db_path)
+    run = _finalizing_run(
+        run_id="run_identical_profile",
+        extractor_kind="profile",
+        request_id="request_identical_profile",
+    )
+    storage_a.create_agent_run(run)
+    contexts = [_finalization_context(item) for item in (storage_a, storage_b)]
+    workers = [
+        ExtractionResumeWorker(request_context=context, llm_client=MagicMock())
+        for context in contexts
+    ]
+    candidate_batches = [
+        [
+            UserProfile(
+                profile_id="profile-shared",
+                user_id="user_1",
+                content=f"Profile content from attempt {index}.",
+                last_modified_timestamp=1_000 + index,
+                generated_from_request_id=run.binding.request_id,
+            )
+        ]
+        for index in range(2)
+    ]
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with patch(
+            "reflexio.server.services.profile.components.consolidator."
+            "ProfileConsolidator.deduplicate",
+            side_effect=lambda profiles, _user_id, _request_id: (profiles, [], []),
+        ):
+            winner = workers[0]._finalize_items(run, candidate_batches[0])
+            _hide_next_receipt_reads(storage_b)
+            loser = workers[1]._finalize_items(run, candidate_batches[1])
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert winner == FinalizationResult(["profile-shared"], won_receipt=True)
+    assert loser == FinalizationResult(["profile-shared"], won_receipt=False)
+    assert [profile.content for profile in storage_a.get_user_profile("user_1")] == [
+        "Profile content from attempt 0."
+    ]
+    assert [
+        event.entity_id
+        for event in events
+        if event.event_name == "learnings_generated" and event.entity_type == "profile"
+    ] == ["profile-shared"]
+
+
+def test_identical_playbook_ids_use_atomic_receipt_owner(tmp_path):
+    db_path = str(tmp_path / "identical-playbook-receipt.db")
+    with patch.object(SQLiteStorage, "_get_embedding", return_value=[0.0] * 512):
+        storage_a = SQLiteStorage(org_id="org_1", db_path=db_path)
+        storage_b = SQLiteStorage(org_id="org_1", db_path=db_path)
+    storage_a.conn.execute(
+        "CREATE TABLE receipt_race_writes (attempt INTEGER NOT NULL, content TEXT NOT NULL)"
+    )
+    storage_a.conn.commit()
+    run = _finalizing_run(
+        run_id="run_identical_playbook",
+        extractor_kind="playbook",
+        request_id="request_identical_playbook",
+    )
+    storage_a.create_agent_run(run)
+    contexts = [_finalization_context(item) for item in (storage_a, storage_b)]
+    workers = [
+        ExtractionResumeWorker(request_context=context, llm_client=MagicMock())
+        for context in contexts
+    ]
+    candidate_batches = [
+        _playbook_candidates(
+            request_id=run.binding.request_id, prefix=f"attempt-{index}"
+        )
+        for index in range(2)
+    ]
+    persist_attempts = iter(range(2))
+
+    def persist_fixed_ids(service, plan) -> None:
+        attempt = next(persist_attempts)
+        for index, playbook in enumerate(plan.new_playbooks):
+            playbook.user_playbook_id = 88 + index
+            service.storage.conn.execute(
+                "INSERT INTO receipt_race_writes (attempt, content) VALUES (?, ?)",
+                (attempt, playbook.content),
+            )
+
+    events: list[UsageEvent] = []
+    configure_usage_event_recorder(events.append)
+    try:
+        with (
+            patch.object(
+                PlaybookGenerationService,
+                "_configured_playbook_config",
+                return_value=None,
+            ),
+            patch(
+                "reflexio.server.services.playbook.components.consolidator."
+                "PlaybookConsolidator.deduplicate",
+                side_effect=lambda results, *_args, **_kwargs: (
+                    [playbook for result in results for playbook in result],
+                    [],
+                    [],
+                ),
+            ),
+            patch.object(
+                PlaybookGenerationService,
+                "_persist_write_plan",
+                autospec=True,
+                side_effect=persist_fixed_ids,
+            ),
+            patch.object(
+                PlaybookGenerationService,
+                "_enqueue_user_playbook_optimization",
+            ) as optimize,
+            patch.object(
+                PlaybookGenerationService,
+                "_trigger_playbook_aggregation",
+            ) as aggregate,
+        ):
+            winner = workers[0]._finalize_items(run, candidate_batches[0])
+            _hide_next_receipt_reads(storage_b)
+            loser = workers[1]._finalize_items(run, candidate_batches[1])
+    finally:
+        configure_usage_event_recorder(None)
+
+    assert winner == FinalizationResult(["88", "89"], won_receipt=True)
+    assert loser == FinalizationResult(["88", "89"], won_receipt=False)
+    persisted_writes = storage_a.conn.execute(
+        "SELECT attempt, content FROM receipt_race_writes ORDER BY content"
+    ).fetchall()
+    assert [(row["attempt"], row["content"]) for row in persisted_writes] == [
+        (0, "Use deployment procedure attempt-0-0."),
+        (0, "Use deployment procedure attempt-0-1."),
+    ]
+    optimize.assert_called_once()
+    aggregate.assert_called_once()
+    assert [
+        event.entity_id
+        for event in events
+        if event.event_name == "learnings_generated"
+        and event.entity_type == "user_playbook"
+    ] == ["88", "89"]
 
 
 def test_two_stale_profile_workers_preserve_order_and_bill_only_winner(tmp_path):

--- a/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
+++ b/tests/server/services/storage/sqlite_storage/test_agent_run_storage.py
@@ -102,13 +102,15 @@ def test_sqlite_agent_run_crud_round_trip(storage):
 def test_finalization_receipt_accepts_empty_ids_idempotently(storage):
     storage.create_agent_run(_agent_run("run_empty", AgentRunStatus.FINALIZING))
 
-    storage.save_agent_run_finalization_receipt(
+    inserted = storage.save_agent_run_finalization_receipt(
         run_id="run_empty", entity_type="profile", learning_ids=[]
     )
-    storage.save_agent_run_finalization_receipt(
+    reused = storage.save_agent_run_finalization_receipt(
         run_id="run_empty", entity_type="profile", learning_ids=[]
     )
 
+    assert inserted is True
+    assert reused is False
     assert (
         storage.get_agent_run_finalization_receipt(
             run_id="run_empty", entity_type="profile"
@@ -196,21 +198,22 @@ def test_finalization_receipt_rolls_back_with_learning(storage):
     )
 
 
-def test_finalization_receipt_rejects_conflicting_immutable_value(storage):
+def test_finalization_receipt_reports_existing_immutable_value(storage):
     storage.create_agent_run(_agent_run("run_immutable", AgentRunStatus.FINALIZING))
-    storage.save_agent_run_finalization_receipt(
+    inserted = storage.save_agent_run_finalization_receipt(
         run_id="run_immutable",
         entity_type="profile",
         learning_ids=["profile-1"],
     )
 
-    with pytest.raises(StorageError, match="immutable"):
-        storage.save_agent_run_finalization_receipt(
-            run_id="run_immutable",
-            entity_type="profile",
-            learning_ids=["profile-2"],
-        )
+    reused = storage.save_agent_run_finalization_receipt(
+        run_id="run_immutable",
+        entity_type="profile",
+        learning_ids=["profile-2"],
+    )
 
+    assert inserted is True
+    assert reused is False
     assert storage.get_agent_run_finalization_receipt(
         run_id="run_immutable", entity_type="profile"
     ) == ["profile-1"]

--- a/tests/server/services/test_non_extraction_learning_metering.py
+++ b/tests/server/services/test_non_extraction_learning_metering.py
@@ -7,6 +7,7 @@ import pytest
 from reflexio.models.api_schema.service_schemas import AgentPlaybook, UserPlaybook
 from reflexio.models.config_schema import PlaybookAggregatorConfig, PlaybookConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.services.deferred_learning_plan import FinalizationResult
 from reflexio.server.services.extraction.resume_worker import ExtractionResumeWorker
 from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
 from reflexio.server.services.playbook.playbook_service_utils import (
@@ -66,9 +67,13 @@ def test_resumable_profile_bills_only_ids_returned_by_finalization() -> None:
     with patch(
         "reflexio.server.services.extraction.resume_worker.ProfileGenerationService"
     ) as service_class:
-        service_class.return_value._finalize_extracted_items.return_value = []
+        finalizer = service_class.return_value._finalize_extracted_items_with_outcome
+        finalizer.return_value = FinalizationResult([], won_receipt=True)
         worker._finalize_items(run, [dropped_candidate])
 
+    finalizer.assert_called_once_with(
+        [dropped_candidate], model_provenance=None, finalization_run_id=run.id
+    )
     assert events == []
 
 
@@ -146,9 +151,13 @@ def test_resumable_playbook_bills_consolidation_replacement_id() -> None:
     with patch(
         "reflexio.server.services.extraction.resume_worker.PlaybookGenerationService"
     ) as service_class:
-        service_class.return_value._finalize_extracted_items.return_value = ["88"]
+        finalizer = service_class.return_value._finalize_extracted_items_with_outcome
+        finalizer.return_value = FinalizationResult(["88"], won_receipt=True)
         worker._finalize_items(run, [original_candidate])
 
+    finalizer.assert_called_once_with(
+        [original_candidate], model_provenance=None, finalization_run_id=run.id
+    )
     assert len(events) == 1
     assert events[0].count_value == 1
     assert events[0].event_key == "learn:user_playbook:88"


### PR DESCRIPTION
## Summary

- make durable finalization receipt insertion atomically identify the sole winning transaction
- emit resumable extraction billing only for the receipt winner
- keep optimizer, aggregation, and tagging dispatch best-effort and at-most-once
- preserve ordered winner IDs, empty receipts, and existing list-returning service wrappers

## Changes

- add an internal `FinalizationResult` carrying learning IDs and receipt ownership
- roll back stale loser writes and reuse the committed winner receipt
- independently isolate optimizer and aggregation scheduling failures
- gate tagging and billing on receipt ownership
- add deterministic retry, empty-receipt, identical-ID race, and scheduler coverage

## Test Plan

- 60 focused shared receipt/resume tests passed
- repeated profile/playbook concurrency regressions passed
- Ruff format/check and focused Pyright passed
- enterprise Supabase/native-Postgres adapter contract is covered in the related enterprise branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resumable extraction finalization to prevent duplicate learning records, tags, and billing events.
  * Added reliable handling for concurrent finalization attempts, preserving the original result and avoiding repeated processing.
  * Scheduler failures are isolated so one failed follow-up task does not disrupt completed finalization.
  * Retry flows now maintain durable learning IDs and consistent outcomes.

* **Reliability**
  * Finalization receipts are now immutable and safely reused across retries and competing workers.
  * Added safeguards for empty or incomplete finalization receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->