### PR TITLE
fix: preserve offline tuner exposure evidence

### DIFF
--- a/reflexio/server/services/search_exposure.py
+++ b/reflexio/server/services/search_exposure.py
@@ -34,6 +34,7 @@ class SearchExposureBatch:
         object.__setattr__(
             self, "session_id", _normalize_correlation_id(self.session_id)
         )
+        object.__setattr__(self, "user_id", _normalize_correlation_id(self.user_id))
         if self.interaction_id is not None and self.interaction_id <= 0:
             object.__setattr__(self, "interaction_id", None)
 

--- a/reflexio/server/services/search_exposure.py
+++ b/reflexio/server/services/search_exposure.py
@@ -46,12 +46,14 @@ class UserPlaybookExposureEvent:
     request_id: str | None
     session_id: str | None
     user_id: str | None
+    playbook_owner_user_id: str | None
     user_playbook_id: int | None
     served_semantic_digest: str | None
     served_full_version_fingerprint: str | None
     exposed_at: int | None
     ingested_at: int
     governance_subject_ref: str | None
+    playbook_owner_governance_subject_ref: str | None
 
 
 @dataclass(frozen=True)
@@ -107,8 +109,14 @@ def build_user_playbook_exposure_event(
     exposed_at: int,
     ingested_at: int,
     governance_subject_ref: str | None,
+    playbook_owner_governance_subject_ref: str | None,
 ) -> UserPlaybookExposureEvent:
     """Build one deterministic event identity from retrieval-owned correlation."""
+    if batch.user_id is not None and playbook.user_id != batch.user_id:
+        raise ValueError(
+            "served playbook owner does not match retrieval subject: "
+            f"user_playbook_id={playbook.user_playbook_id}"
+        )
     identity: dict[str, object] = {
         "schema_version": "user-playbook-exposure-event-v1",
         "org_id": batch.org_id,
@@ -128,7 +136,8 @@ def build_user_playbook_exposure_event(
         exposure_event_id=sha256(canonical_json_bytes(identity)).hexdigest(),
         request_id=batch.request_id,
         session_id=batch.session_id,
-        user_id=playbook.user_id,
+        user_id=batch.user_id,
+        playbook_owner_user_id=playbook.user_id,
         user_playbook_id=playbook.user_playbook_id,
         served_semantic_digest=incumbent_user_playbook_semantic_digest(
             content_digest=content_digest,
@@ -140,6 +149,7 @@ def build_user_playbook_exposure_event(
         exposed_at=exposed_at,
         ingested_at=ingested_at,
         governance_subject_ref=governance_subject_ref,
+        playbook_owner_governance_subject_ref=(playbook_owner_governance_subject_ref),
     )
 
 

--- a/reflexio/server/services/storage/retention.py
+++ b/reflexio/server/services/storage/retention.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 DEFAULT_ROW_RETENTION_LIMIT = 250_000
 ROW_RETENTION_DELETE_FRACTION = 0.20
+OPEN_WORLD_EVIDENCE_RETENTION_WINDOW_SECONDS = 14 * 24 * 60 * 60
 TOMBSTONE_STATUSES = ("archived", "merged", "superseded", "expired")
 
 
@@ -20,6 +21,7 @@ class RetentionTarget:
     order_column: str
     id_columns: tuple[str, ...]
     priority_statuses: tuple[str, ...] = ()
+    minimum_age_seconds: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,6 +143,7 @@ RETENTION_TARGETS: tuple[RetentionTarget, ...] = (
         "user_playbook_exposure_events",
         "ingested_at",
         ("exposure_event_id",),
+        minimum_age_seconds=OPEN_WORLD_EVIDENCE_RETENTION_WINDOW_SECONDS,
     ),
     RetentionTarget("skills", "skills", "created_at", ("skill_id",)),
 )

--- a/reflexio/server/services/storage/retention_mixin.py
+++ b/reflexio/server/services/storage/retention_mixin.py
@@ -9,6 +9,7 @@ delete — cannot drift across the three backends.
 
 from __future__ import annotations
 
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from typing import Any
@@ -98,7 +99,16 @@ class RetentionMixin(ABC):
         target = get_retention_target(target_name)
         if not self._retention_table_exists(target.table_name):
             return 0
-        keys = self._retention_select_keys(target, count)
+        older_than_epoch = (
+            int(time.time()) - target.minimum_age_seconds
+            if target.minimum_age_seconds > 0
+            else None
+        )
+        keys = self._retention_select_keys(
+            target,
+            count,
+            older_than_epoch=older_than_epoch,
+        )
         if not keys:
             return 0
         self._retention_perform_delete(target, keys)
@@ -137,7 +147,11 @@ class RetentionMixin(ABC):
         return 0
 
     def _retention_select_keys(
-        self, target: RetentionTarget, count: int
+        self,
+        target: RetentionTarget,
+        count: int,
+        *,
+        older_than_epoch: int | None,
     ) -> list[tuple[Any, ...]]:
         """Select tombstones first, then oldest rows when a target opts in.
 
@@ -147,16 +161,27 @@ class RetentionMixin(ABC):
         table holds that many rows.
         """
         if not target.priority_statuses:
-            return self._retention_select_oldest_keys(target, count)
+            return self._retention_select_oldest_keys(
+                target,
+                count,
+                older_than_epoch=older_than_epoch,
+            )
 
         keys = self._retention_select_oldest_keys(
-            target, count, statuses=target.priority_statuses
+            target,
+            count,
+            statuses=target.priority_statuses,
+            older_than_epoch=older_than_epoch,
         )
         if len(keys) >= count:
             return keys
 
         seen = set(keys)
-        for key in self._retention_select_oldest_keys(target, count):
+        for key in self._retention_select_oldest_keys(
+            target,
+            count,
+            older_than_epoch=older_than_epoch,
+        ):
             if key not in seen:
                 keys.append(key)
                 seen.add(key)
@@ -194,6 +219,7 @@ class RetentionMixin(ABC):
         target: RetentionTarget,
         count: int,
         statuses: tuple[str, ...] | None = None,
+        older_than_epoch: int | None = None,
     ) -> list[tuple[Any, ...]]:
         """Return up to ``count`` oldest key tuples for ``target``.
 

--- a/reflexio/server/services/storage/sqlite_storage/base/_deletion.py
+++ b/reflexio/server/services/storage/sqlite_storage/base/_deletion.py
@@ -50,16 +50,21 @@ class SQLiteDeletionMixin:
         target: RetentionTarget,
         count: int,
         statuses: tuple[str, ...] | None = None,
+        older_than_epoch: int | None = None,
     ) -> list[tuple[Any, ...]]:
         if statuses is not None and not statuses:
             return []
         id_sql = ", ".join(target.id_columns)
-        where_sql = ""
+        predicates: list[str] = []
         params: list[Any] = []
         if statuses:
             placeholders = ", ".join("?" for _ in statuses)
-            where_sql = f"WHERE status IN ({placeholders}) "
+            predicates.append(f"status IN ({placeholders})")
             params.extend(statuses)
+        if older_than_epoch is not None:
+            predicates.append(f"{target.order_column} < ?")
+            params.append(older_than_epoch)
+        where_sql = f"WHERE {' AND '.join(predicates)} " if predicates else ""
         params.append(count)
         rows = self._fetchall(
             f"SELECT {id_sql} FROM {target.table_name} {where_sql}"  # noqa: S608

--- a/tests/server/services/storage/test_storage_contract_retention.py
+++ b/tests/server/services/storage/test_storage_contract_retention.py
@@ -1,6 +1,8 @@
 """Contract tests for generic row-retention storage methods."""
 
 from datetime import UTC, datetime
+from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 
@@ -186,6 +188,50 @@ def test_retention_request_cascade_cleans_interaction_fts(
         "SELECT rowid FROM interactions_fts WHERE rowid = 3"
     ).fetchall()
     assert len(fts_kept) == 1, "fts row for surviving interaction must remain"
+
+
+def test_retention_exposure_age_boundary_is_strict(storage: BaseStorage) -> None:
+    """Only exposure evidence strictly older than 14 days is row-cap eligible."""
+    from reflexio.server.services.storage.retention import (
+        OPEN_WORLD_EVIDENCE_RETENTION_WINDOW_SECONDS,
+    )
+
+    now = 2_000_000_000
+    cutoff = now - OPEN_WORLD_EVIDENCE_RETENTION_WINDOW_SECONDS
+    conn = storage.conn  # type: ignore[attr-defined]
+    conn.execute(
+        """CREATE TABLE user_playbook_exposure_events (
+            exposure_event_id TEXT PRIMARY KEY,
+            ingested_at INTEGER NOT NULL
+        )"""
+    )
+    conn.executemany(
+        """INSERT INTO user_playbook_exposure_events
+           (exposure_event_id, ingested_at)
+           VALUES (?, ?)""",
+        [
+            ("older", cutoff - 1),
+            ("exact", cutoff),
+            ("newer", cutoff + 1),
+        ],
+    )
+    conn.commit()
+
+    retention_storage = cast(Any, storage)
+    with patch(
+        "reflexio.server.services.storage.retention_mixin.time.time",
+        return_value=now,
+    ):
+        deleted = retention_storage.delete_oldest_retention_target_rows(
+            "user_playbook_exposure_events", 3
+        )
+
+    assert deleted == 1
+    remaining = conn.execute(
+        "SELECT exposure_event_id FROM user_playbook_exposure_events "
+        "ORDER BY exposure_event_id"
+    ).fetchall()
+    assert [row["exposure_event_id"] for row in remaining] == ["exact", "newer"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/test_search_exposure.py
+++ b/tests/server/services/test_search_exposure.py
@@ -69,6 +69,7 @@ def _event(batch: SearchExposureBatch, playbook: UserPlaybook):
         exposed_at=1_700_000_100,
         ingested_at=1_700_000_101,
         governance_subject_ref="user:user-1",
+        playbook_owner_governance_subject_ref="owner:user-1",
     )
 
 
@@ -104,6 +105,33 @@ def test_correlation_free_invocations_get_distinct_exposure_event_ids() -> None:
     )
 
     assert first.exposure_event_id != second.exposure_event_id
+
+
+def test_unscoped_exposure_keeps_unknown_subject_separate_from_playbook_owner() -> None:
+    playbook = _playbook()
+    batch = replace(_batch(playbook), user_id=None)
+
+    event = build_user_playbook_exposure_event(
+        batch,
+        playbook,
+        exposed_at=1_700_000_100,
+        ingested_at=1_700_000_101,
+        governance_subject_ref=None,
+        playbook_owner_governance_subject_ref="owner:user-1",
+    )
+
+    assert event.user_id is None
+    assert event.governance_subject_ref is None
+    assert event.playbook_owner_user_id == "user-1"
+    assert event.playbook_owner_governance_subject_ref == "owner:user-1"
+
+
+def test_scoped_exposure_rejects_a_playbook_owned_by_another_user() -> None:
+    playbook = _playbook().model_copy(update={"user_id": "user-2"})
+    batch = _batch(playbook)
+
+    with pytest.raises(ValueError, match="does not match retrieval subject"):
+        _event(batch, playbook)
 
 
 def test_request_and_session_correlation_ids_normalize_whitespace_consistently() -> (

--- a/tests/server/services/test_search_exposure.py
+++ b/tests/server/services/test_search_exposure.py
@@ -126,6 +126,26 @@ def test_unscoped_exposure_keeps_unknown_subject_separate_from_playbook_owner() 
     assert event.playbook_owner_governance_subject_ref == "owner:user-1"
 
 
+@pytest.mark.parametrize("user_id", ["", " \t\n"], ids=["empty", "whitespace"])
+def test_blank_retrieval_subject_normalizes_to_unscoped(user_id: str) -> None:
+    playbook = _playbook()
+    batch = replace(_batch(playbook), user_id=user_id)
+
+    event = build_user_playbook_exposure_event(
+        batch,
+        playbook,
+        exposed_at=1_700_000_100,
+        ingested_at=1_700_000_101,
+        governance_subject_ref=None,
+        playbook_owner_governance_subject_ref="owner:user-1",
+    )
+
+    assert batch.user_id is None
+    assert event.user_id is None
+    assert event.governance_subject_ref is None
+    assert event.playbook_owner_user_id == "user-1"
+
+
 def test_scoped_exposure_rejects_a_playbook_owned_by_another_user() -> None:
     playbook = _playbook().model_copy(update={"user_id": "user-2"})
     batch = _batch(playbook)


### PR DESCRIPTION
## Summary

- preserve every user-playbook exposure ingested within the fixed 14-day evidence window, even when the generic row cap is exceeded
- separate the optional retrieval subject from the served playbook owner so unscoped searches remain attributable without becoming join-eligible
- normalize blank retrieval subjects to the unscoped representation while retaining fail-closed owner checks for scoped searches

## Why

The Phase 1 offline-tuner evidence foundation requires complete, reviewable exposure evidence. Generic row-cap retention could delete current-window events, and the original exposure envelope overloaded playbook ownership as the retrieval subject for unscoped searches. Both behaviors could distort later evidence eligibility and exact-user governance.

## Behavior

- exposure rows younger than 14 days are protected from row-cap deletion
- an exposure may carry a retrieval subject and a playbook owner independently
- blank or whitespace retrieval subjects become unscoped
- scoped retrieval still rejects a user playbook owned by another user before persistence

## Verification

- 46 shared exposure and retention contract tests passed after rebasing onto current `main`
- final affected enterprise matrix: 164 passed, 9 adapter-applicability skips
- Ruff formatting/lint, Pyright, import, diff, and gitlink checks passed
- correctness, security-resilience, architecture, and verification-testing review lenses are clean

## Related PRs

- Enterprise Phase 1 stack: https://github.com/ReflexioAI/reflexio-enterprise/pull/936


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposure records now preserve the playbook owner separately from the person retrieving it.
  * Blank retrieval identifiers are normalized consistently.
  * Playbook exposure data now includes governance subject references where available.

* **Bug Fixes**
  * Prevented exposure records from being created when a playbook belongs to a different scoped user.
  * Added safeguards for unscoped exposure scenarios.

* **Data Retention**
  * Open-world evidence, including playbook exposure records, is retained for at least 14 days before cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->