### PR TITLE
feat(playbook): refresh incremental cluster centroids

### DIFF
--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -349,7 +349,7 @@ Key files:
 
 **Flow**:
 - Interactions → PlaybookExtractor (extraction-only) → PlaybookConsolidator (consolidates new vs existing DB playbooks) → UserPlaybook (with optional `blocking_issue`) → Storage
-- UserPlaybook write → durable due-now signal → PlaybookAggregationScheduler → same-version centroid match → bounded residual clustering → AgentPlaybook → Storage
+- UserPlaybook write → durable hourly-coalesced signal → PlaybookAggregationScheduler → fixed-page invalidation drain → same-version centroid match → one current-agent-plus-bounded-delta refresh per changed cluster → bounded residual clustering → AgentPlaybook → Storage
 - `POST /api/run_playbook_aggregation` → fenced, capped administrative full rerun
 
 **Tool Analysis**: PlaybookExtractor reads `tool_can_use` from root `Config` and passes it to prompts for tool usage analysis and blocking issue detection.
@@ -359,10 +359,13 @@ Key files:
 **Durable Playbook Aggregation** (`aggregation_scheduler.py`, `components/aggregator.py`):
 
 Automatic aggregation never rescans the full corpus. Each fenced unit admits
-undisposed CURRENT rows, attaches compatible rows to existing centroids for the
-same `agent_version`, and clusters only unmatched residuals. A drained version
-uses the configured one-hour idle minimum; new writes pull it due immediately,
-and unfinished backlog continues promptly. `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS`
+undisposed CURRENT rows, batches compatible rows by same-version agent-playbook
+centroid, regenerates each changed agent playbook once from its current text plus
+at most 100 newest delta members, attaches the complete delta, and clusters only
+unmatched residuals. The replacement embedding
+becomes the next centroid. A drained version uses the configured one-hour
+minimum; new writes preserve that due time and coalesce, while unfinished backlog
+continues promptly. `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS`
 is the scheduled unit budget and the administrative rerun safety cap, not a
 maximum supported corpus size. See the [playbook service map](services/playbook/README.md)
 for storage contracts and failure dispositions.

--- a/reflexio/server/prompt/prompt_bank/playbook_aggregation/v2.4.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/playbook_aggregation/v2.4.0.prompt.md
@@ -1,7 +1,7 @@
 ---
 active: true
 description: "Generates agent playbook entries from user playbook entries by combining them into actionable policies — structured trigger + markdown-bullet content"
-changelog: "v2.4.0: adds the decision-point/AND-OR trigger rule — consolidated triggers must be evaluable at the earliest decision point and never narrowed by 'and'-conjoining incidental session details; later-turn symptoms may only appear as 'or' broadenings. No output schema change. v2.3.0: adds antecedent-not-reaction trigger guidance so aggregated policies retrieve before the omission or correction has already happened. (in-place 2026-06-18: make consolidated triggers future-user-query-like retrieval keys.) v2.2: preserve distinct orientations when merging — never collapse a do-rule and an avoid-rule (opposite orientations) into a single rule; keep both as separate rules in the merged multi-rule content. This replaces the retired mechanical whole-content polarity-bucketing gate (infer_playbook_polarity) in the aggregator; orientation now lives in rule wording and is the model's judgment (Option B). v2.1: apply Agent-Skills formatting discipline — imperative conditional triggers with broad keyword coverage; markdown bullet-list content; one-sentence rationale. Matches extraction prompt v1.4.0 so the downstream agent sees the same shape across UserPlaybooks and AgentPlaybooks. (in-place 2026-05-30: deprecated and removed blocking_issue.)"
+changelog: "In-place 2026-08-03: merge a CURRENT CANONICAL PLAYBOOK TO UPDATE with its newly matched delta and return the complete replacement. v2.4.0: adds the decision-point/AND-OR trigger rule — consolidated triggers must be evaluable at the earliest decision point and never narrowed by 'and'-conjoining incidental session details; later-turn symptoms may only appear as 'or' broadenings. No output schema change. v2.3.0: adds antecedent-not-reaction trigger guidance so aggregated policies retrieve before the omission or correction has already happened. (in-place 2026-06-18: make consolidated triggers future-user-query-like retrieval keys.) v2.2: preserve distinct orientations when merging — never collapse a do-rule and an avoid-rule (opposite orientations) into a single rule; keep both as separate rules in the merged multi-rule content. This replaces the retired mechanical whole-content polarity-bucketing gate (infer_playbook_polarity) in the aggregator; orientation now lives in rule wording and is the model's judgment (Option B). v2.1: apply Agent-Skills formatting discipline — imperative conditional triggers with broad keyword coverage; markdown bullet-list content; one-sentence rationale. Matches extraction prompt v1.4.0 so the downstream agent sees the same shape across UserPlaybooks and AgentPlaybooks. (in-place 2026-05-30: deprecated and removed blocking_issue.)"
 variables:
   - user_playbooks
   - existing_approved_playbooks
@@ -21,6 +21,14 @@ Your job is to generate a NEW canonical playbook rule that:
 - Consolidates all items into one coherent policy
 - Covers policy gaps NOT already handled by approved playbooks
 - Prevents recurrence of the same class of agent mistakes
+
+When the clustered input starts with `CURRENT CANONICAL PLAYBOOK TO UPDATE`,
+this is an incremental refresh rather than a brand-new rule. Treat that current
+canonical playbook as the base, merge the `NEWLY MATCHED RAW PLAYBOOKS` into it,
+and return the complete replacement rule. Preserve every still-valid distinct
+instruction from the current canonical playbook. Do not return null merely
+because the new sources overlap the current canonical playbook; it is the update
+target, not an entry in the approved-playbook deduplication gate.
 
 ━━━━━━━━━━━━━━━━━━━━━━
 ## Input Format

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -35,7 +35,7 @@ Interactions
     -> PlaybookCandidateReviewer (normal strict-evidence candidates only)
       -> PlaybookConsolidator (consolidates reviewed vs existing DB playbooks)
         -> UserPlaybook (validated evidence + persisted provenance) -> Storage
-        -> Durable aggregation signal (pulls new work due now)
+        -> Durable aggregation signal (coalesces new work into the hourly window)
           -> PlaybookAggregationScheduler (bounded work; hourly idle minimum)
             -> PlaybookAggregator (incremental clustering)
               -> AgentPlaybook (aggregated insights) -> Storage
@@ -101,25 +101,43 @@ earlier decisions.
 Normal generation durably schedules bounded incremental aggregation through
 `aggregation_trigger.py`; `aggregation_scheduler.py` claims due work across
 processes. A successful drained run waits at least
-`REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS` (default 3600) before an idle retry;
-a new durable signal pulls the version due immediately, and a remaining backlog
-continues in bounded follow-up units. The manual
+`REFLEXIO_AGGREGATION_MIN_INTERVAL_SECONDS` (default 3600) before the next
+scheduled cycle; new durable signals preserve that due time so changes coalesce,
+while a remaining backlog continues in bounded follow-up units. The manual
 `/api/run_playbook_aggregation` route remains a fenced administrative full rerun.
 
 Incremental work is isolated by `agent_version`:
 
-1. Admit CURRENT, nonempty rows that have no durable disposition.
+1. Admit only the newest configured window of CURRENT, nonempty rows that have
+   no durable disposition; rows that fall below its monotonic cutoff never re-enter.
 2. Match embedded residuals against active centroids for that version only.
-3. Attach matches without regenerating their agent playbook.
+3. Group matches per cluster and make one LLM call with the current agent
+   playbook plus at most the 100 newest members of that run's newly matched
+   delta; the complete delta still receives durable membership.
 4. Cluster only unmatched residuals: agglomerative below 50 rows, HDBSCAN at 50 or more.
-5. Commit generated agent playbooks, lineage, cluster membership, centroid updates, and supersessions atomically.
+5. Embed each generated agent playbook and use that embedding—not a mean of user
+   embeddings—as the cluster centroid for future matches.
+6. Commit replacement, lineage, membership, centroid swap, and supersession atomically.
 
-`REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` (default 20,000) is the shared row budget
-for one scheduled unit, including intake and invalidations. It is also the
-fail-before-mutation total-input cap for an administrative full rerun; it no
-longer prevents an organization with a larger corpus from making incremental
-progress. Retryable LLM outcomes stay residual, semantic-null outcomes become
-terminal no-ops, and missing embeddings remain pending for a later unit.
+`REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` (default 20,000) is the maximum recent
+unclustered discovery window for scheduled work. Older unclustered rows are
+intentionally ignored rather than backfilled later. Invalidation repair is a
+separate path whose generation input is capped at the 100 most recent retained
+sources per affected cluster. New-cluster generation similarly uses at most 100
+centroid-representative sources while retaining the complete discovered
+membership. The setting is also the fail-before-mutation
+total-input cap for an administrative full rerun; it no longer prevents an
+organization with a larger corpus from making incremental progress. Retryable
+LLM outcomes stay residual. A semantic-null update attaches the delta but keeps
+the current agent playbook and centroid; semantic-null output for a new cluster
+becomes a terminal no-op. Missing embeddings remain pending.
+
+Creating a user playbook only arms intake discovery; it does not add a no-op
+invalidation event. If the current agent playbook for an active cluster is
+edited, rejected, archived, or deleted outside aggregation, that cluster is
+retired atomically and its members return to residual discovery. This prevents
+a stale centroid or rejected canonical rule from becoming the base of a later
+incremental refresh.
 
 The portable state contract is
 `storage/storage_base/playbook/_aggregation.py`; SQLite implements it in
@@ -138,9 +156,15 @@ post-processes generated outputs before storage or model-response logging.
 **Requirements / Problems to Avoid**:
 
 - Never cluster, centroid-match, or attach rows across agent versions.
+- Always keep an active cluster's centroid equal to its current agent playbook embedding.
+- Rebuild lifecycle-invalidated clusters from the 100 most recent remaining
+  CURRENT members (including a single member), never from the invalidated agent
+  text, then restore every retained membership before superseding the prior agent.
 - Never rediscover the full corpus on the scheduled path; use durable dispositions and bounded anti-join intake.
 - Never hold `commit_scope()` while embedding, clustering, or calling the LLM.
 - Do not clear pending state on partial failure, limiter deferral, or a lost lease.
+- Drain lifecycle invalidations in fixed 100-event pages before model work, and
+  retry failed repairs on the cluster clock rather than member clocks.
 
 ### Playbook Consolidation (`components/consolidator.py`)
 

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -119,6 +119,10 @@ Incremental work is isolated by `agent_version`:
    embeddings—as the cluster centroid for future matches.
 6. Commit replacement, lineage, membership, centroid swap, and supersession atomically.
 
+Each refresh or rebuild cluster owns that atomic scope independently. If its
+expected agent changes after generation, only that cluster rolls back and its
+selected members return to residual work; unrelated generated clusters still commit.
+
 `REFLEXIO_MAX_CLUSTERING_PLAYBOOKS` (default 20,000) is the maximum recent
 unclustered discovery window for scheduled work. Older unclustered rows are
 intentionally ignored rather than backfilled later. Invalidation repair is a

--- a/reflexio/server/services/playbook/aggregation_scheduler.py
+++ b/reflexio/server/services/playbook/aggregation_scheduler.py
@@ -32,6 +32,7 @@ _POLL_SECONDS = 10.0
 AGGREGATION_LEASE_SECONDS = 300
 AGGREGATION_RETRY_SECONDS = 60
 AGGREGATION_BACKLOG_RETRY_SECONDS = 1
+AGGREGATION_INVALIDATION_BATCH_SIZE = 100
 _REPAIR_INTERVAL_SECONDS = 300.0
 
 
@@ -169,43 +170,56 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
         after = None
         try:
             budget = _aggregation_budget()
-            invalidations = storage.get_playbook_aggregation_invalidations(
-                claim.agent_version, limit=max(1, budget // 4)
+            invalidation_page = storage.get_playbook_aggregation_invalidations(
+                claim.agent_version, limit=AGGREGATION_INVALIDATION_BATCH_SIZE + 1
             )
+            invalidations = invalidation_page[:AGGREGATION_INVALIDATION_BATCH_SIZE]
             if invalidations and not storage.apply_playbook_aggregation_invalidations(
                 claim, [item.invalidation_id for item in invalidations]
             ):
                 raise RuntimeError("playbook aggregation invalidation fence was lost")
-            from reflexio.lib.generation_client import (
-                create_generation_litellm_client,
-            )
+            if len(invalidation_page) > AGGREGATION_INVALIDATION_BATCH_SIZE:
+                logger.info(
+                    "event=playbook_aggregation_progress "
+                    "state=draining_invalidations org_id=%s agent_version=%s "
+                    "fence=%s processed=%s",
+                    context.org_id,
+                    claim.agent_version,
+                    claim.fence,
+                    len(invalidations),
+                )
+                result = {"invalidations_processed": len(invalidations)}
+            else:
+                from reflexio.lib.generation_client import (
+                    create_generation_litellm_client,
+                )
 
-            kwargs: dict[str, Any] = {}
-            processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
-            if processor is not None:
-                kwargs["aggregation_prompt_processor"] = processor
-            aggregator = PlaybookAggregator(
-                llm_client=create_generation_litellm_client(context),
-                request_context=context,
-                agent_version=claim.agent_version,
-                aggregation_claim=claim,
-                work_budget=max(0, budget - len(invalidations)),
-                **kwargs,
-            )
-            logger.info(
-                "event=playbook_aggregation_progress state=started org_id=%s "
-                "agent_version=%s fence=%s",
-                context.org_id,
-                claim.agent_version,
-                claim.fence,
-            )
-            result = run_with_operation_limit(
-                org_id=context.org_id,
-                operation="aggregation",
-                fn=lambda: aggregator.run(
-                    PlaybookAggregatorRequest(agent_version=claim.agent_version)
-                ),
-            )
+                kwargs: dict[str, Any] = {}
+                processor = get_service(AGGREGATION_PROMPT_PROCESSOR)
+                if processor is not None:
+                    kwargs["aggregation_prompt_processor"] = processor
+                aggregator = PlaybookAggregator(
+                    llm_client=create_generation_litellm_client(context),
+                    request_context=context,
+                    agent_version=claim.agent_version,
+                    aggregation_claim=claim,
+                    residual_batch_limit=budget,
+                    **kwargs,
+                )
+                logger.info(
+                    "event=playbook_aggregation_progress state=started org_id=%s "
+                    "agent_version=%s fence=%s",
+                    context.org_id,
+                    claim.agent_version,
+                    claim.fence,
+                )
+                result = run_with_operation_limit(
+                    org_id=context.org_id,
+                    operation="aggregation",
+                    fn=lambda: aggregator.run(
+                        PlaybookAggregatorRequest(agent_version=claim.agent_version)
+                    ),
+                )
             heartbeat.require_live()
             success = True
             after = storage.get_playbook_aggregation_backlog(claim.agent_version)

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -233,6 +233,10 @@ class _RebuildWork:
     members: list[UserPlaybook]
 
 
+class _AggregationClusterUnavailableError(RuntimeError):
+    """A cluster changed after its generation inputs were selected."""
+
+
 class PlaybookAggregator:
     def __init__(
         self,
@@ -572,11 +576,14 @@ class PlaybookAggregator:
         save_generated: Callable[
             [AggregationGenerationOutcome, list[int]], AgentPlaybook
         ],
-    ) -> tuple[list[AgentPlaybook], set[int], int]:
+        *,
+        run_id: str,
+    ) -> tuple[list[AgentPlaybook], int, int, int]:
         """Finalize bounded repair prompts against complete stored membership."""
         saved_playbooks: list[AgentPlaybook] = []
-        replaced_agent_ids: set[int] = set()
         rebuilt_member_count = 0
+        supersessions = 0
+        fence_losses = 0
         for work, outcome in zip(rebuild_work, outcomes, strict=True):
             sample = work.sample
             member_ids = [
@@ -584,41 +591,154 @@ class PlaybookAggregator:
                 for item in outcome.source_cluster
                 if item.user_playbook_id is not None
             ]
-            if outcome.status == "retryable_failure":
-                self.storage.defer_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
-                    cluster_id=sample.cluster_id,
-                    agent_version=self.agent_version,
-                    expected_agent_playbook_id=sample.agent_playbook_id,
+            saved: AgentPlaybook | None = None
+            rebuilt = 0
+            try:
+                with self.storage.commit_scope():  # type: ignore[attr-defined]
+                    self._require_live_aggregation_claim()
+                    if outcome.status == "retryable_failure":
+                        try:
+                            self.storage.defer_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
+                                cluster_id=sample.cluster_id,
+                                agent_version=self.agent_version,
+                                expected_agent_playbook_id=sample.agent_playbook_id,
+                                reason="llm_retryable_failure",
+                            )
+                        except RuntimeError as exc:
+                            raise _AggregationClusterUnavailableError from exc
+                    elif outcome.status == "semantic_null":
+                        try:
+                            rebuilt = self.storage.discard_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
+                                cluster_id=sample.cluster_id,
+                                agent_version=self.agent_version,
+                                expected_agent_playbook_id=sample.agent_playbook_id,
+                                reason="semantic_null_rebuild",
+                            )
+                        except RuntimeError as exc:
+                            raise _AggregationClusterUnavailableError from exc
+                        supersessions += self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+                            [sample.agent_playbook_id], request_id=run_id
+                        )
+                    else:
+                        saved = save_generated(outcome, member_ids)
+                        if not saved.embedding:
+                            raise RuntimeError(
+                                "rebuilt agent playbook has no centroid embedding"
+                            )
+                        try:
+                            rebuilt = self.storage.complete_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
+                                cluster_id=sample.cluster_id,
+                                agent_version=self.agent_version,
+                                expected_agent_playbook_id=sample.agent_playbook_id,
+                                replacement_agent_playbook_id=saved.agent_playbook_id,
+                                centroid_embedding=saved.embedding,
+                                embedding_model=self.storage.embedding_model_name,
+                            )
+                        except RuntimeError as exc:
+                            raise _AggregationClusterUnavailableError from exc
+                        supersessions += self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+                            [sample.agent_playbook_id], request_id=run_id
+                        )
+                    self._require_live_aggregation_claim()
+            except _AggregationClusterUnavailableError:
+                self._mark_aggregation_members_unavailable(member_ids)
+                fence_losses += 1
+                continue
+
+            rebuilt_member_count += rebuilt
+            if outcome.status == "semantic_null":
+                continue
+            if saved is not None:
+                saved_playbooks.append(saved)
+        return (
+            saved_playbooks,
+            rebuilt_member_count,
+            supersessions,
+            fence_losses,
+        )
+
+    def _mark_aggregation_members_unavailable(self, member_ids: list[int]) -> None:
+        """Return one stale cluster's selected members to durable residual work."""
+        with self.storage.commit_scope():  # type: ignore[attr-defined]
+            self._require_live_aggregation_claim()
+            self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                self.agent_version,
+                member_ids,
+                disposition="residual",
+                reason="cluster_agent_unavailable",
+            )
+            self._require_live_aggregation_claim()
+
+    def _apply_refresh_outcome(
+        self,
+        work: _IncrementalRefreshWork,
+        outcome: AggregationGenerationOutcome,
+        save_generated: Callable[
+            [AggregationGenerationOutcome, list[int]], AgentPlaybook
+        ],
+        *,
+        run_id: str,
+    ) -> tuple[AgentPlaybook | None, int, int, int]:
+        """Commit one refresh independently so a stale cluster cannot waste peers."""
+        member_ids = [
+            int(item.user_playbook_id)
+            for item in outcome.source_cluster
+            if item.user_playbook_id is not None
+        ]
+        if outcome.status == "retryable_failure":
+            with self.storage.commit_scope():  # type: ignore[attr-defined]
+                self._require_live_aggregation_claim()
+                self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                    self.agent_version,
+                    member_ids,
+                    disposition="residual",
                     reason="llm_retryable_failure",
                 )
-                continue
-            if outcome.status == "semantic_null":
-                rebuilt_member_count += (
-                    self.storage.discard_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
-                        cluster_id=sample.cluster_id,
+                self._require_live_aggregation_claim()
+            return None, 0, 0, 0
+
+        saved: AgentPlaybook | None = None
+        supersessions = 0
+        try:
+            with self.storage.commit_scope():  # type: ignore[attr-defined]
+                self._require_live_aggregation_claim()
+                try:
+                    self.storage.attach_playbook_aggregation_items(  # type: ignore[attr-defined]
                         agent_version=self.agent_version,
-                        expected_agent_playbook_id=sample.agent_playbook_id,
-                        reason="semantic_null_rebuild",
+                        attachments=[
+                            (item_id, work.cluster_id) for item_id in member_ids
+                        ],
                     )
-                )
-                replaced_agent_ids.add(sample.agent_playbook_id)
-                continue
-            saved = save_generated(outcome, member_ids)
-            if not saved.embedding:
-                raise RuntimeError("rebuilt agent playbook has no centroid embedding")
-            rebuilt_member_count += (
-                self.storage.complete_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
-                    cluster_id=sample.cluster_id,
-                    agent_version=self.agent_version,
-                    expected_agent_playbook_id=sample.agent_playbook_id,
-                    replacement_agent_playbook_id=saved.agent_playbook_id,
-                    centroid_embedding=saved.embedding,
-                    embedding_model=self.storage.embedding_model_name,
-                )
-            )
-            saved_playbooks.append(saved)
-            replaced_agent_ids.add(sample.agent_playbook_id)
-        return saved_playbooks, replaced_agent_ids, rebuilt_member_count
+                except RuntimeError as exc:
+                    raise _AggregationClusterUnavailableError from exc
+                if outcome.status == "generated":
+                    saved = save_generated(outcome, member_ids)
+                    if not saved.embedding:
+                        raise RuntimeError(
+                            "replacement agent playbook has no centroid embedding"
+                        )
+                    try:
+                        self.storage.replace_playbook_aggregation_cluster_agent(  # type: ignore[attr-defined]
+                            cluster_id=work.cluster_id,
+                            agent_version=self.agent_version,
+                            expected_agent_playbook_id=(
+                                work.current_agent.agent_playbook_id
+                            ),
+                            replacement_agent_playbook_id=saved.agent_playbook_id,
+                            centroid_embedding=saved.embedding,
+                            embedding_model=self.storage.embedding_model_name,
+                        )
+                    except RuntimeError as exc:
+                        raise _AggregationClusterUnavailableError from exc
+                    supersessions = self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+                        [work.current_agent.agent_playbook_id], request_id=run_id
+                    )
+                self._require_live_aggregation_claim()
+        except _AggregationClusterUnavailableError:
+            self._mark_aggregation_members_unavailable(member_ids)
+            return None, 0, 0, 1
+
+        return saved, len(member_ids), supersessions, 0
 
     def _run_incremental(
         self,
@@ -759,7 +879,6 @@ class PlaybookAggregator:
             if item.status == "retryable_failure"
         ]
         saved_playbooks: list[AgentPlaybook] = []
-        replaced_agent_ids: set[int] = set()
         generated_playbooks = [
             item.playbook
             for item in [*refresh_outcomes, *rebuild_outcomes, *new_cluster_outcomes]
@@ -806,6 +925,8 @@ class PlaybookAggregator:
             )[0]
 
         attached_count = 0
+        supersessions = 0
+        cluster_fence_losses = 0
         with self.storage.commit_scope():  # type: ignore[attr-defined]
             self._require_live_aggregation_claim()
             self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
@@ -820,67 +941,49 @@ class PlaybookAggregator:
                 disposition="residual",
                 reason="cluster_agent_unavailable",
             )
-            for work, outcome in zip(refresh_work, refresh_outcomes, strict=True):
-                members = outcome.source_cluster
-                member_ids = [
-                    int(item.user_playbook_id)
-                    for item in members
-                    if item.user_playbook_id is not None
-                ]
-                if outcome.status == "retryable_failure":
-                    self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
-                        self.agent_version,
-                        member_ids,
-                        disposition="residual",
-                        reason="llm_retryable_failure",
-                    )
-                    continue
-                self.storage.attach_playbook_aggregation_items(  # type: ignore[attr-defined]
-                    agent_version=self.agent_version,
-                    attachments=[(item_id, work.cluster_id) for item_id in member_ids],
-                )
-                attached_count += len(member_ids)
-                if outcome.status == "semantic_null":
-                    continue
-                saved = save_generated_outcome(
-                    outcome, member_ids, reason="incremental_refresh"
-                )
-                if not saved.embedding:
-                    raise RuntimeError(
-                        "replacement agent playbook has no centroid embedding"
-                    )
-                self.storage.replace_playbook_aggregation_cluster_agent(  # type: ignore[attr-defined]
-                    cluster_id=work.cluster_id,
-                    agent_version=self.agent_version,
-                    expected_agent_playbook_id=work.current_agent.agent_playbook_id,
-                    replacement_agent_playbook_id=saved.agent_playbook_id,
-                    centroid_embedding=saved.embedding,
-                    embedding_model=self.storage.embedding_model_name,
-                )
-                saved_playbooks.append(saved)
-                replaced_agent_ids.add(work.current_agent.agent_playbook_id)
+            self._require_live_aggregation_claim()
 
-            (
-                rebuilt_playbooks,
-                rebuilt_agent_ids,
-                rebuilt_member_count,
-            ) = self._apply_rebuild_outcomes(
-                rebuild_work,
-                rebuild_outcomes,
-                lambda outcome, member_ids: save_generated_outcome(
-                    outcome, member_ids, reason="invalidation_rebuild"
+        for work, outcome in zip(refresh_work, refresh_outcomes, strict=True):
+            saved, attached, replaced, fence_losses = self._apply_refresh_outcome(
+                work,
+                outcome,
+                lambda generated, member_ids: save_generated_outcome(
+                    generated, member_ids, reason="incremental_refresh"
                 ),
+                run_id=run_id,
             )
-            saved_playbooks.extend(rebuilt_playbooks)
-            replaced_agent_ids.update(rebuilt_agent_ids)
+            attached_count += attached
+            supersessions += replaced
+            cluster_fence_losses += fence_losses
+            if saved is not None:
+                saved_playbooks.append(saved)
 
-            for outcome in new_cluster_outcomes:
-                members = outcome.source_cluster
-                member_ids = [
-                    int(item.user_playbook_id)
-                    for item in members
-                    if item.user_playbook_id is not None
-                ]
+        (
+            rebuilt_playbooks,
+            rebuilt_member_count,
+            rebuild_supersessions,
+            rebuild_fence_losses,
+        ) = self._apply_rebuild_outcomes(
+            rebuild_work,
+            rebuild_outcomes,
+            lambda outcome, member_ids: save_generated_outcome(
+                outcome, member_ids, reason="invalidation_rebuild"
+            ),
+            run_id=run_id,
+        )
+        saved_playbooks.extend(rebuilt_playbooks)
+        supersessions += rebuild_supersessions
+        cluster_fence_losses += rebuild_fence_losses
+
+        for outcome in new_cluster_outcomes:
+            members = outcome.source_cluster
+            member_ids = [
+                int(item.user_playbook_id)
+                for item in members
+                if item.user_playbook_id is not None
+            ]
+            with self.storage.commit_scope():  # type: ignore[attr-defined]
+                self._require_live_aggregation_claim()
                 if outcome.status == "retryable_failure":
                     self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
                         self.agent_version,
@@ -888,48 +991,51 @@ class PlaybookAggregator:
                         disposition="residual",
                         reason="llm_retryable_failure",
                     )
-                    continue
-                if outcome.status == "semantic_null":
+                elif outcome.status == "semantic_null":
                     self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
                         self.agent_version,
                         member_ids,
                         disposition="terminal_noop",
                         reason="semantic_null",
                     )
-                    continue
-                saved = save_generated_outcome(
-                    outcome, member_ids, reason="incremental"
-                )
-                if not saved.embedding:
-                    raise RuntimeError(
-                        "generated agent playbook has no centroid embedding"
+                else:
+                    saved = save_generated_outcome(
+                        outcome, member_ids, reason="incremental"
                     )
-                saved_playbooks.append(saved)
-                cluster_id = self._stable_aggregation_cluster_id(
-                    self._compute_cluster_fingerprint(members)
-                )
-                self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
-                    cluster_id=cluster_id,
-                    agent_version=self.agent_version,
-                    agent_playbook_id=saved.agent_playbook_id,
-                    centroid_embedding=saved.embedding,
-                    member_count=len(member_ids),
-                    embedding_model=self.storage.embedding_model_name,
-                )
-                self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
-                    self.agent_version,
-                    member_ids,
-                    disposition="cluster_member",
-                    cluster_id=cluster_id,
-                    reason="generated",
-                )
-            replaced_agent_ids.update(
+                    if not saved.embedding:
+                        raise RuntimeError(
+                            "generated agent playbook has no centroid embedding"
+                        )
+                    cluster_id = self._stable_aggregation_cluster_id(
+                        self._compute_cluster_fingerprint(members)
+                    )
+                    self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
+                        cluster_id=cluster_id,
+                        agent_version=self.agent_version,
+                        agent_playbook_id=saved.agent_playbook_id,
+                        centroid_embedding=saved.embedding,
+                        member_count=len(member_ids),
+                        embedding_model=self.storage.embedding_model_name,
+                    )
+                    self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                        self.agent_version,
+                        member_ids,
+                        disposition="cluster_member",
+                        cluster_id=cluster_id,
+                        reason="generated",
+                    )
+                    saved_playbooks.append(saved)
+                self._require_live_aggregation_claim()
+
+        with self.storage.commit_scope():  # type: ignore[attr-defined]
+            self._require_live_aggregation_claim()
+            orphaned_agent_ids = (
                 self.storage.delete_orphaned_playbook_aggregation_clusters(  # type: ignore[attr-defined]
                     self.agent_version
                 )
             )
-            supersessions = self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
-                sorted(replaced_agent_ids), request_id=run_id
+            supersessions += self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+                sorted(orphaned_agent_ids), request_id=run_id
             )
             self._require_live_aggregation_claim()
 
@@ -946,7 +1052,8 @@ class PlaybookAggregator:
             "attachments": attached_count,
             "rebuilt_members": rebuilt_member_count,
             "supersessions": supersessions,
-            "retryable_failures": len(retryable_outcomes),
+            "retryable_failures": len(retryable_outcomes) + cluster_fence_losses,
+            "cluster_fence_losses": cluster_fence_losses,
             "selected_rebuild_members": rebuilding_residual_count,
         }
         self._enqueue_playbook_optimization(saved_playbooks)
@@ -957,7 +1064,11 @@ class PlaybookAggregator:
             pipeline="playbook",
             playbook_name=SINGLETON_USER_PLAYBOOK_NAME,
             agent_version=self.agent_version,
-            outcome="partial_failure" if retryable_outcomes else "success",
+            outcome=(
+                "partial_failure"
+                if retryable_outcomes or cluster_fence_losses
+                else "success"
+            ),
             count_value=len(saved_playbooks),
             duration_ms=int((time.perf_counter() - aggregation_start) * 1000),
             metadata=stats,
@@ -971,6 +1082,50 @@ class PlaybookAggregator:
                 f"{self.request_context.org_id}:{self.agent_version}:{fingerprint}",
             )
         )
+
+    def _resolve_legacy_agent_centroid(
+        self,
+        agent_playbook_id: int,
+        legacy_agent: AgentPlaybook | None,
+        embed: object,
+    ) -> list[float] | None:
+        """Return a canonical legacy-agent embedding or skip one bad fingerprint."""
+        if legacy_agent is None:
+            logger.warning(
+                "Skipping legacy aggregation fingerprint because agent playbook "
+                "%s no longer exists",
+                agent_playbook_id,
+            )
+            return None
+        expected_dimension = int(
+            self.storage.embedding_dimensions  # type: ignore[attr-defined]
+        )
+        if len(legacy_agent.embedding) == expected_dimension:
+            return legacy_agent.embedding
+        try:
+            if not callable(embed):
+                raise RuntimeError("aggregation storage cannot embed agents")
+            centroid = cast(Callable[[str], list[float]], embed)(
+                embedding_text(legacy_agent)
+            )
+        except Exception:  # noqa: BLE001 - skip one corrupt legacy record
+            logger.warning(
+                "Skipping legacy aggregation fingerprint because agent playbook "
+                "%s could not be re-embedded",
+                agent_playbook_id,
+                exc_info=True,
+            )
+            return None
+        if len(centroid) != expected_dimension:
+            logger.warning(
+                "Skipping legacy aggregation fingerprint because agent playbook "
+                "%s produced embedding dimension %s instead of %s",
+                agent_playbook_id,
+                len(centroid),
+                expected_dimension,
+            )
+            return None
+        return centroid
 
     def _adopt_legacy_aggregation_state(self, *, budget: int) -> tuple[int, bool]:
         """Rebuild legacy fingerprint centroids in bounded, resumable pages."""
@@ -1010,11 +1165,15 @@ class PlaybookAggregator:
             legacy_agents = self.storage.get_agent_playbooks_by_ids(  # type: ignore[attr-defined]
                 [agent_playbook_id], include_inactive=True, include_embedding=True
             )
-            if not legacy_agents or not legacy_agents[0].embedding:
-                # Do not activate a user-embedding mean as a centroid. The
-                # canonical agent embedding is the durable matching invariant.
-                return consumed, False
-            centroid_embedding = legacy_agents[0].embedding
+            embed = getattr(self.storage, "_get_embedding", None)
+            embed_fn = cast(Callable[[str], list[float]], embed)
+            centroid_embedding = self._resolve_legacy_agent_centroid(
+                agent_playbook_id,
+                legacy_agents[0] if legacy_agents else None,
+                embed,
+            )
+            if centroid_embedding is None:
+                continue
             cluster_id = self._stable_aggregation_cluster_id(fingerprint)
             progress = self.storage.get_playbook_aggregation_cluster_rebuild_cursor(  # type: ignore[attr-defined]
                 cluster_id
@@ -1041,10 +1200,8 @@ class PlaybookAggregator:
             member_embeddings: list[tuple[int, list[float]]] = []
             rebuild_cursor = cursor
             blocked = False
-            embed = getattr(self.storage, "_get_embedding", None)
             if not callable(embed) and page_ids:
                 raise RuntimeError("aggregation storage cannot re-embed legacy members")
-            embed_fn = cast(Callable[[str], list[float]], embed)
             for user_playbook_id in page_ids:
                 item = rows_by_id.get(user_playbook_id)
                 if item is None or not item.content or not item.content.strip():

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -60,6 +60,8 @@ from reflexio.server.services.service_utils import log_model_response
 from reflexio.server.services.storage.storage_base import AGGREGATE_REASON_PREFIX
 from reflexio.server.services.storage.storage_base.playbook import (
     PlaybookAggregationClaim,
+    PlaybookAggregationClusterMatch,
+    PlaybookAggregationRebuildSample,
 )
 from reflexio.server.usage_metrics import record_usage_event
 
@@ -71,6 +73,8 @@ logger = logging.getLogger(__name__)
 _AGGREGATION_PLAYBOOK_PAGE_SIZE = 500
 _SIGNED_BIGINT_MAX = (1 << 63) - 1
 _MAX_EXISTING_PLAYBOOKS_PER_PROMPT = 20
+_REPAIR_SOURCE_LIMIT = 100
+_GENERATION_SOURCE_LIMIT = 100
 
 
 def _select_relevant_existing_playbooks(
@@ -113,6 +117,52 @@ def _select_relevant_existing_playbooks(
     ranked = [(score(item), item) for item in existing]
     ranked.sort(key=lambda pair: (-pair[0][0], pair[0][1]))
     return [item for _rank, item in ranked[:_MAX_EXISTING_PLAYBOOKS_PER_PROMPT]]
+
+
+def _select_generation_prompt_sources(
+    cluster: list[UserPlaybook], *, is_incremental_refresh: bool
+) -> list[UserPlaybook]:
+    """Bound LLM input while leaving durable cluster membership unchanged."""
+    if len(cluster) <= _GENERATION_SOURCE_LIMIT:
+        return cluster
+    if is_incremental_refresh:
+        return sorted(
+            cluster,
+            key=lambda item: (item.created_at, int(item.user_playbook_id or 0)),
+            reverse=True,
+        )[:_GENERATION_SOURCE_LIMIT]
+
+    embeddings = [item.embedding for item in cluster if item.embedding]
+    dimension = len(embeddings[0]) if embeddings else 0
+    if not dimension or any(len(value) != dimension for value in embeddings):
+        return sorted(
+            cluster,
+            key=lambda item: (item.created_at, int(item.user_playbook_id or 0)),
+            reverse=True,
+        )[:_GENERATION_SOURCE_LIMIT]
+    centroid = [
+        sum(values) / len(embeddings) for values in zip(*embeddings, strict=True)
+    ]
+    centroid_norm = math.sqrt(sum(value * value for value in centroid))
+
+    def score(item: UserPlaybook) -> tuple[float, int]:
+        if not item.embedding or len(item.embedding) != dimension or not centroid_norm:
+            return -1.0, int(item.user_playbook_id or 0)
+        item_norm = math.sqrt(sum(value * value for value in item.embedding))
+        similarity = (
+            sum(
+                left * right
+                for left, right in zip(centroid, item.embedding, strict=True)
+            )
+            / (centroid_norm * item_norm)
+            if item_norm
+            else -1.0
+        )
+        return similarity, int(item.user_playbook_id or 0)
+
+    ranked = [(score(item), item) for item in cluster]
+    ranked.sort(key=lambda pair: (-pair[0][0], pair[0][1]))
+    return [item for _rank, item in ranked[:_GENERATION_SOURCE_LIMIT]]
 
 
 def _read_all_pages[T](
@@ -166,6 +216,23 @@ class AggregationGenerationOutcome:
     provenance: ModelProvenance | None = None
 
 
+@dataclass(frozen=True)
+class _IncrementalRefreshWork:
+    """One active cluster plus the newly matched delta for this run."""
+
+    cluster_id: str
+    current_agent: AgentPlaybook
+    members: list[UserPlaybook]
+
+
+@dataclass(frozen=True)
+class _RebuildWork:
+    """One invalidated cluster plus its bounded recent-source sample."""
+
+    sample: PlaybookAggregationRebuildSample
+    members: list[UserPlaybook]
+
+
 class PlaybookAggregator:
     def __init__(
         self,
@@ -175,7 +242,7 @@ class PlaybookAggregator:
         aggregation_prompt_processor: AggregationPromptProcessor | None = None,
         effect_coordinator: AggregationEffectCoordinator | None = None,
         aggregation_claim: PlaybookAggregationClaim | None = None,
-        work_budget: int | None = None,
+        residual_batch_limit: int | None = None,
     ) -> None:
         self.client = llm_client
         storage = request_context.storage
@@ -188,7 +255,7 @@ class PlaybookAggregator:
         self.aggregation_prompt_processor = aggregation_prompt_processor
         self.effect_coordinator = effect_coordinator
         self.aggregation_claim = aggregation_claim
-        self.work_budget = work_budget
+        self.residual_batch_limit = residual_batch_limit
         # Cohesive pre/post-processing component (the enterprise redaction
         # Protocol seam). Constructed from the SAME injected instance stored
         # above — do NOT re-resolve the AGGREGATION_PROMPT_PROCESSOR ServiceKey.
@@ -384,6 +451,175 @@ class PlaybookAggregator:
     # public methods
     # ===============================
 
+    def _partition_incremental_matches(
+        self,
+        user_playbooks: list[UserPlaybook],
+        matches: dict[int, PlaybookAggregationClusterMatch],
+        *,
+        similarity_threshold: float,
+    ) -> tuple[list[_IncrementalRefreshWork], list[UserPlaybook], list[int]]:
+        """Batch matched deltas by cluster and load current agents in one read."""
+        matched_by_cluster: dict[str, list[UserPlaybook]] = {}
+        matched_agent_id_by_cluster: dict[str, int] = {}
+        unmatched_playbooks: list[UserPlaybook] = []
+        for item in user_playbooks:
+            if item.user_playbook_id is None or not item.embedding:
+                continue
+            match = matches.get(int(item.user_playbook_id))
+            if match is None or match.similarity < similarity_threshold:
+                unmatched_playbooks.append(item)
+                continue
+            matched_by_cluster.setdefault(match.cluster_id, []).append(item)
+            prior_agent_id = matched_agent_id_by_cluster.setdefault(
+                match.cluster_id, match.agent_playbook_id
+            )
+            if prior_agent_id != match.agent_playbook_id:
+                raise RuntimeError(
+                    "aggregation cluster matched multiple current agents"
+                )
+
+        current_agents = self.storage.get_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+            sorted(set(matched_agent_id_by_cluster.values())),
+            status_filter=[None],
+            include_embedding=True,
+        )
+        current_agents_by_id = {item.agent_playbook_id: item for item in current_agents}
+        refresh_work: list[_IncrementalRefreshWork] = []
+        unavailable_matched_ids: list[int] = []
+        for cluster_id in sorted(matched_by_cluster):
+            members = matched_by_cluster[cluster_id]
+            current_agent = current_agents_by_id.get(
+                matched_agent_id_by_cluster[cluster_id]
+            )
+            if current_agent is None:
+                unavailable_matched_ids.extend(
+                    int(item.user_playbook_id)
+                    for item in members
+                    if item.user_playbook_id is not None
+                )
+                continue
+            refresh_work.append(
+                _IncrementalRefreshWork(
+                    cluster_id=cluster_id,
+                    current_agent=current_agent,
+                    members=members,
+                )
+            )
+        return refresh_work, unmatched_playbooks, unavailable_matched_ids
+
+    def _partition_rebuilding_members(
+        self, user_playbooks: list[UserPlaybook], *, max_clusters: int
+    ) -> tuple[list[_RebuildWork], list[UserPlaybook], int]:
+        """Load recent repair inputs without loading every cluster member."""
+        rebuild_cluster_by_item = (
+            self.storage.get_playbook_aggregation_rebuild_cluster_ids(  # type: ignore[attr-defined]
+                self.agent_version,
+                [
+                    int(item.user_playbook_id)
+                    for item in user_playbooks
+                    if item.user_playbook_id is not None
+                ],
+            )
+        )
+        rebuilding_residual_count = 0
+        rebuild_cluster_ids: set[str] = set()
+        matchable_playbooks: list[UserPlaybook] = []
+        for item in user_playbooks:
+            rebuild_cluster_id = rebuild_cluster_by_item.get(
+                int(item.user_playbook_id or 0)
+            )
+            if rebuild_cluster_id is None:
+                matchable_playbooks.append(item)
+            else:
+                rebuild_cluster_ids.add(rebuild_cluster_id)
+                rebuilding_residual_count += 1
+        selected_cluster_ids = sorted(rebuild_cluster_ids)[:max_clusters]
+        rebuild_samples = self.storage.get_playbook_aggregation_rebuild_samples(  # type: ignore[attr-defined]
+            self.agent_version,
+            selected_cluster_ids,
+            limit_per_cluster=_REPAIR_SOURCE_LIMIT,
+        )
+        sample_ids = [
+            item_id for sample in rebuild_samples for item_id in sample.member_ids
+        ]
+        sample_playbooks = self.storage.get_user_playbooks_by_ids_any_user(  # type: ignore[call-arg]
+            sample_ids,
+            status_filter=[None],
+            include_embedding=True,
+        )
+        sample_playbooks_by_id = {
+            int(item.user_playbook_id): item
+            for item in sample_playbooks
+            if item.user_playbook_id is not None
+        }
+        rebuild_work = [
+            _RebuildWork(
+                sample=sample,
+                members=[
+                    sample_playbooks_by_id[item_id]
+                    for item_id in sample.member_ids
+                    if item_id in sample_playbooks_by_id
+                ],
+            )
+            for sample in rebuild_samples
+        ]
+        return rebuild_work, matchable_playbooks, rebuilding_residual_count
+
+    def _apply_rebuild_outcomes(
+        self,
+        rebuild_work: list[_RebuildWork],
+        outcomes: list[AggregationGenerationOutcome],
+        save_generated: Callable[
+            [AggregationGenerationOutcome, list[int]], AgentPlaybook
+        ],
+    ) -> tuple[list[AgentPlaybook], set[int], int]:
+        """Finalize bounded repair prompts against complete stored membership."""
+        saved_playbooks: list[AgentPlaybook] = []
+        replaced_agent_ids: set[int] = set()
+        rebuilt_member_count = 0
+        for work, outcome in zip(rebuild_work, outcomes, strict=True):
+            sample = work.sample
+            member_ids = [
+                int(item.user_playbook_id)
+                for item in outcome.source_cluster
+                if item.user_playbook_id is not None
+            ]
+            if outcome.status == "retryable_failure":
+                self.storage.defer_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
+                    cluster_id=sample.cluster_id,
+                    agent_version=self.agent_version,
+                    expected_agent_playbook_id=sample.agent_playbook_id,
+                    reason="llm_retryable_failure",
+                )
+                continue
+            if outcome.status == "semantic_null":
+                rebuilt_member_count += (
+                    self.storage.discard_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
+                        cluster_id=sample.cluster_id,
+                        agent_version=self.agent_version,
+                        expected_agent_playbook_id=sample.agent_playbook_id,
+                        reason="semantic_null_rebuild",
+                    )
+                )
+                replaced_agent_ids.add(sample.agent_playbook_id)
+                continue
+            saved = save_generated(outcome, member_ids)
+            if not saved.embedding:
+                raise RuntimeError("rebuilt agent playbook has no centroid embedding")
+            rebuilt_member_count += (
+                self.storage.complete_playbook_aggregation_cluster_rebuild(  # type: ignore[attr-defined]
+                    cluster_id=sample.cluster_id,
+                    agent_version=self.agent_version,
+                    expected_agent_playbook_id=sample.agent_playbook_id,
+                    replacement_agent_playbook_id=saved.agent_playbook_id,
+                    centroid_embedding=saved.embedding,
+                    embedding_model=self.storage.embedding_model_name,
+                )
+            )
+            saved_playbooks.append(saved)
+            replaced_agent_ids.add(sample.agent_playbook_id)
+        return saved_playbooks, replaced_agent_ids, rebuilt_member_count
+
     def _run_incremental(
         self,
         *,
@@ -394,8 +630,8 @@ class PlaybookAggregator:
         """Process one durable, bounded residual batch without touching old clusters."""
         budget = (
             aggregator_clustering.max_clustering_playbooks()
-            if self.work_budget is None
-            else max(0, self.work_budget)
+            if self.residual_batch_limit is None
+            else max(0, self.residual_batch_limit)
         )
         bootstrap_work, bootstrap_complete = self._adopt_legacy_aggregation_state(
             budget=budget
@@ -410,16 +646,14 @@ class PlaybookAggregator:
                 "attachments": 0,
                 "skipped": "legacy cluster adoption pending",
             }
-        # Intake and residual processing share the same row budget. Reserve
-        # half for anti-join admission when there is undisposed work; unused
-        # capacity is naturally borrowed by residual processing.
-        intake_limit = (budget + 1) // 2
+        intake_window_limit = aggregator_clustering.max_clustering_playbooks()
         staged_ids = self.storage.stage_playbook_aggregation_intake(  # type: ignore[attr-defined]
-            self.agent_version, limit=intake_limit
+            self.agent_version,
+            limit=budget,
+            window_limit=intake_window_limit,
         )
-        residual_limit = max(0, budget - len(staged_ids))
         residual_ids = self.storage.get_playbook_aggregation_residual_ids(  # type: ignore[attr-defined]
-            self.agent_version, limit=residual_limit
+            self.agent_version, limit=budget
         )
         user_playbooks = self.storage.get_user_playbooks_by_ids_any_user(  # type: ignore[call-arg]
             residual_ids,
@@ -429,6 +663,12 @@ class PlaybookAggregator:
         user_playbooks = [
             item for item in user_playbooks if item.content and item.content.strip()
         ]
+        rebuild_work, matchable_playbooks, rebuilding_residual_count = (
+            self._partition_rebuilding_members(
+                user_playbooks,
+                max_clusters=max(1, budget // _REPAIR_SOURCE_LIMIT),
+            )
+        )
         trigger_count = max(2, config.reaggregation_trigger_count)
 
         # Bound the dedup prompt as well. Existing agent playbooks are context,
@@ -443,11 +683,9 @@ class PlaybookAggregator:
             config.clustering_similarity,
             model_name=self.storage.embedding_model_name,
         )
-        attachments: list[tuple[UserPlaybook, str]] = []
-        stage_b_playbooks: list[UserPlaybook] = []
         missing_embedding_ids: list[int] = []
         candidates: list[tuple[int, list[float]]] = []
-        for item in user_playbooks:
+        for item in matchable_playbooks:
             if item.user_playbook_id is None:
                 continue
             item_id = int(item.user_playbook_id)
@@ -461,50 +699,113 @@ class PlaybookAggregator:
             embedding_model=self.storage.embedding_model_name,
             limit=budget,
         )
-        for item in user_playbooks:
-            if item.user_playbook_id is None or not item.embedding:
-                continue
-            match = matches.get(int(item.user_playbook_id))
-            if match is not None and match.similarity >= similarity_threshold:
-                attachments.append((item, match.cluster_id))
-            else:
-                stage_b_playbooks.append(item)
+        refresh_work, unmatched_playbooks, unavailable_matched_ids = (
+            self._partition_incremental_matches(
+                matchable_playbooks,
+                matches,
+                similarity_threshold=similarity_threshold,
+            )
+        )
+        refresh_clusters = {
+            index: work.members for index, work in enumerate(refresh_work)
+        }
+        refresh_current_agents = {
+            index: work.current_agent for index, work in enumerate(refresh_work)
+        }
 
-        clusters = (
-            self.get_clusters(stage_b_playbooks, config)
-            if len(stage_b_playbooks) >= trigger_count
+        refresh_outcomes = (
+            self._generate_playbook_outcomes_with_source_clusters(
+                refresh_clusters,
+                existing_playbooks,
+                direction_overlap_threshold=config.direction_overlap_threshold,
+                current_agent_playbooks=refresh_current_agents,
+            )
+            if refresh_clusters
+            else []
+        )
+        new_clusters = (
+            self.get_clusters(unmatched_playbooks, config)
+            if len(unmatched_playbooks) >= trigger_count
             else {}
         )
-        outcomes = self._generate_playbook_outcomes_with_source_clusters(
-            clusters,
-            existing_playbooks,
-            direction_overlap_threshold=config.direction_overlap_threshold,
+        rebuild_clusters = {
+            index: work.members for index, work in enumerate(rebuild_work)
+        }
+        rebuild_outcomes = (
+            self._generate_playbook_outcomes_with_source_clusters(
+                rebuild_clusters,
+                existing_playbooks,
+                direction_overlap_threshold=config.direction_overlap_threshold,
+                excluded_existing_playbook_ids={
+                    index: {work.sample.agent_playbook_id}
+                    for index, work in enumerate(rebuild_work)
+                },
+            )
+            if rebuild_clusters
+            else []
+        )
+        new_cluster_outcomes = (
+            self._generate_playbook_outcomes_with_source_clusters(
+                new_clusters,
+                existing_playbooks,
+                direction_overlap_threshold=config.direction_overlap_threshold,
+            )
+            if new_clusters
+            else []
         )
         retryable_outcomes = [
-            item for item in outcomes if item.status == "retryable_failure"
+            item
+            for item in [*refresh_outcomes, *rebuild_outcomes, *new_cluster_outcomes]
+            if item.status == "retryable_failure"
         ]
         saved_playbooks: list[AgentPlaybook] = []
-        replacement_agent_ids_by_outcome = {
-            index: self.storage.get_playbook_aggregation_replacement_agent_ids(  # type: ignore[attr-defined]
-                self.agent_version,
-                [
-                    int(item.user_playbook_id)
-                    for item in outcome.source_cluster
-                    if item.user_playbook_id is not None
-                ],
-            )
-            for index, outcome in enumerate(outcomes)
-            if outcome.status == "generated"
-        }
         replaced_agent_ids: set[int] = set()
         generated_playbooks = [
             item.playbook
-            for item in outcomes
+            for item in [*refresh_outcomes, *rebuild_outcomes, *new_cluster_outcomes]
             if item.status == "generated" and item.playbook is not None
         ]
         prepare = getattr(type(self.storage), "prepare_agent_playbooks_for_save", None)
         if callable(prepare):
             prepare(self.storage, generated_playbooks)
+
+        def save_generated_outcome(
+            outcome: AggregationGenerationOutcome,
+            member_ids: list[int],
+            *,
+            reason: str,
+        ) -> AgentPlaybook:
+            if outcome.playbook is None:
+                raise RuntimeError("generated outcome is missing its playbook")
+            lineage_contexts = [
+                LineageContext(
+                    op_kind="aggregate",
+                    actor="aggregator",
+                    request_id=run_id,
+                    source_ids=[str(value) for value in member_ids],
+                    reason=f"{AGGREGATE_REASON_PREFIX}{reason}",
+                    model_name=(
+                        outcome.provenance.model_name if outcome.provenance else None
+                    ),
+                    provider=(
+                        outcome.provenance.provider if outcome.provenance else None
+                    ),
+                )
+            ]
+            prepared_save = getattr(
+                type(self.storage), "save_prepared_agent_playbooks", None
+            )
+            if callable(prepared_save):
+                return prepared_save(  # pyright: ignore[reportIndexIssue]
+                    self.storage,
+                    [outcome.playbook],
+                    lineage_contexts=lineage_contexts,
+                )[0]
+            return self.storage.save_agent_playbooks(  # type: ignore[attr-defined]
+                [outcome.playbook], lineage_contexts=lineage_contexts
+            )[0]
+
+        attached_count = 0
         with self.storage.commit_scope():  # type: ignore[attr-defined]
             self._require_live_aggregation_claim()
             self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
@@ -513,15 +814,67 @@ class PlaybookAggregator:
                 disposition="residual",
                 reason="embedding_pending",
             )
-            self.storage.attach_playbook_aggregation_items(  # type: ignore[attr-defined]
-                agent_version=self.agent_version,
-                attachments=[
-                    (int(item.user_playbook_id), cluster_id, item.embedding)
-                    for item, cluster_id in attachments
-                    if item.user_playbook_id is not None and item.embedding
-                ],
+            self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                self.agent_version,
+                unavailable_matched_ids,
+                disposition="residual",
+                reason="cluster_agent_unavailable",
             )
-            for outcome_index, outcome in enumerate(outcomes):
+            for work, outcome in zip(refresh_work, refresh_outcomes, strict=True):
+                members = outcome.source_cluster
+                member_ids = [
+                    int(item.user_playbook_id)
+                    for item in members
+                    if item.user_playbook_id is not None
+                ]
+                if outcome.status == "retryable_failure":
+                    self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                        self.agent_version,
+                        member_ids,
+                        disposition="residual",
+                        reason="llm_retryable_failure",
+                    )
+                    continue
+                self.storage.attach_playbook_aggregation_items(  # type: ignore[attr-defined]
+                    agent_version=self.agent_version,
+                    attachments=[(item_id, work.cluster_id) for item_id in member_ids],
+                )
+                attached_count += len(member_ids)
+                if outcome.status == "semantic_null":
+                    continue
+                saved = save_generated_outcome(
+                    outcome, member_ids, reason="incremental_refresh"
+                )
+                if not saved.embedding:
+                    raise RuntimeError(
+                        "replacement agent playbook has no centroid embedding"
+                    )
+                self.storage.replace_playbook_aggregation_cluster_agent(  # type: ignore[attr-defined]
+                    cluster_id=work.cluster_id,
+                    agent_version=self.agent_version,
+                    expected_agent_playbook_id=work.current_agent.agent_playbook_id,
+                    replacement_agent_playbook_id=saved.agent_playbook_id,
+                    centroid_embedding=saved.embedding,
+                    embedding_model=self.storage.embedding_model_name,
+                )
+                saved_playbooks.append(saved)
+                replaced_agent_ids.add(work.current_agent.agent_playbook_id)
+
+            (
+                rebuilt_playbooks,
+                rebuilt_agent_ids,
+                rebuilt_member_count,
+            ) = self._apply_rebuild_outcomes(
+                rebuild_work,
+                rebuild_outcomes,
+                lambda outcome, member_ids: save_generated_outcome(
+                    outcome, member_ids, reason="invalidation_rebuild"
+                ),
+            )
+            saved_playbooks.extend(rebuilt_playbooks)
+            replaced_agent_ids.update(rebuilt_agent_ids)
+
+            for outcome in new_cluster_outcomes:
                 members = outcome.source_cluster
                 member_ids = [
                     int(item.user_playbook_id)
@@ -544,43 +897,14 @@ class PlaybookAggregator:
                         reason="semantic_null",
                     )
                     continue
-                if outcome.playbook is None:
-                    raise RuntimeError("generated outcome is missing its playbook")
-                lineage_contexts = [
-                    LineageContext(
-                        op_kind="aggregate",
-                        actor="aggregator",
-                        request_id=run_id,
-                        source_ids=[str(value) for value in member_ids],
-                        reason=f"{AGGREGATE_REASON_PREFIX}incremental",
-                        model_name=(
-                            outcome.provenance.model_name
-                            if outcome.provenance
-                            else None
-                        ),
-                        provider=(
-                            outcome.provenance.provider if outcome.provenance else None
-                        ),
+                saved = save_generated_outcome(
+                    outcome, member_ids, reason="incremental"
+                )
+                if not saved.embedding:
+                    raise RuntimeError(
+                        "generated agent playbook has no centroid embedding"
                     )
-                ]
-                prepared_save = getattr(
-                    type(self.storage), "save_prepared_agent_playbooks", None
-                )
-                if callable(prepared_save):
-                    saved = prepared_save(  # pyright: ignore[reportIndexIssue]
-                        self.storage,
-                        [outcome.playbook],
-                        lineage_contexts=lineage_contexts,
-                    )[0]
-                else:
-                    saved = self.storage.save_agent_playbooks(  # type: ignore[attr-defined]
-                        [outcome.playbook], lineage_contexts=lineage_contexts
-                    )[0]
                 saved_playbooks.append(saved)
-                replaced_agent_ids.update(
-                    replacement_agent_ids_by_outcome[outcome_index]
-                )
-                embeddings = [item.embedding for item in members if item.embedding]
                 cluster_id = self._stable_aggregation_cluster_id(
                     self._compute_cluster_fingerprint(members)
                 )
@@ -588,7 +912,8 @@ class PlaybookAggregator:
                     cluster_id=cluster_id,
                     agent_version=self.agent_version,
                     agent_playbook_id=saved.agent_playbook_id,
-                    embeddings=embeddings,
+                    centroid_embedding=saved.embedding,
+                    member_count=len(member_ids),
                     embedding_model=self.storage.embedding_model_name,
                 )
                 self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
@@ -598,22 +923,31 @@ class PlaybookAggregator:
                     cluster_id=cluster_id,
                     reason="generated",
                 )
+            replaced_agent_ids.update(
+                self.storage.delete_orphaned_playbook_aggregation_clusters(  # type: ignore[attr-defined]
+                    self.agent_version
+                )
+            )
             supersessions = self.storage.supersede_agent_playbooks_by_ids(  # type: ignore[attr-defined]
                 sorted(replaced_agent_ids), request_id=run_id
-            )
-            self.storage.delete_orphaned_playbook_aggregation_clusters(  # type: ignore[attr-defined]
-                self.agent_version
             )
             self._require_live_aggregation_claim()
 
         stats = {
-            "clusters_found": len(clusters),
-            "user_playbooks_processed": len(user_playbooks),
+            "clusters_found": (
+                len(rebuild_clusters) + len(new_clusters) + len(refresh_clusters)
+            ),
+            "user_playbooks_processed": (
+                len(matchable_playbooks)
+                + sum(len(work.members) for work in rebuild_work)
+            ),
             "playbooks_generated": len(saved_playbooks),
             "staged": len(staged_ids),
-            "attachments": len(attachments),
+            "attachments": attached_count,
+            "rebuilt_members": rebuilt_member_count,
             "supersessions": supersessions,
             "retryable_failures": len(retryable_outcomes),
+            "selected_rebuild_members": rebuilding_residual_count,
         }
         self._enqueue_playbook_optimization(saved_playbooks)
         record_usage_event(
@@ -673,6 +1007,14 @@ class PlaybookAggregator:
                 # Empty legacy fingerprints have no centroid to adopt and must not
                 # become active clusters that nearest-centroid lookup cannot find.
                 continue
+            legacy_agents = self.storage.get_agent_playbooks_by_ids(  # type: ignore[attr-defined]
+                [agent_playbook_id], include_inactive=True, include_embedding=True
+            )
+            if not legacy_agents or not legacy_agents[0].embedding:
+                # Do not activate a user-embedding mean as a centroid. The
+                # canonical agent embedding is the durable matching invariant.
+                return consumed, False
+            centroid_embedding = legacy_agents[0].embedding
             cluster_id = self._stable_aggregation_cluster_id(fingerprint)
             progress = self.storage.get_playbook_aggregation_cluster_rebuild_cursor(  # type: ignore[attr-defined]
                 cluster_id
@@ -726,6 +1068,7 @@ class PlaybookAggregator:
                         cluster_id=cluster_id,
                         agent_version=self.agent_version,
                         agent_playbook_id=agent_playbook_id,
+                        centroid_embedding=centroid_embedding,
                         member_embeddings=member_embeddings,
                         embedding_model=self.storage.embedding_model_name,
                         embedding_dimension=int(
@@ -1258,27 +1601,26 @@ class PlaybookAggregator:
                         playbook_aggregator_request.rerun
                         and self.aggregation_claim is not None
                     ):
-                        cluster_embeddings = [
-                            item.embedding
-                            for item in cluster_playbooks
-                            if item.embedding
-                        ]
-                        if cluster_embeddings:
-                            cluster_id = self._stable_aggregation_cluster_id(fp_key)
-                            self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
-                                cluster_id=cluster_id,
-                                agent_version=self.agent_version,
-                                agent_playbook_id=saved_fb.agent_playbook_id,
-                                embeddings=cluster_embeddings,
-                                embedding_model=self.storage.embedding_model_name,
+                        if not saved_fb.embedding:
+                            raise RuntimeError(
+                                "rerun agent playbook has no centroid embedding"
                             )
-                            self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
-                                self.agent_version,
-                                raw_ids,
-                                disposition="cluster_member",
-                                cluster_id=cluster_id,
-                                reason="full_rerun",
-                            )
+                        cluster_id = self._stable_aggregation_cluster_id(fp_key)
+                        self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
+                            cluster_id=cluster_id,
+                            agent_version=self.agent_version,
+                            agent_playbook_id=saved_fb.agent_playbook_id,
+                            centroid_embedding=saved_fb.embedding,
+                            member_count=len(raw_ids),
+                            embedding_model=self.storage.embedding_model_name,
+                        )
+                        self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                            self.agent_version,
+                            raw_ids,
+                            disposition="cluster_member",
+                            cluster_id=cluster_id,
+                            reason="full_rerun",
+                        )
                     for prev_fp in previous_fingerprints_for_changed_clusters.get(
                         fp_key, {}
                     ):
@@ -1663,13 +2005,32 @@ class PlaybookAggregator:
         clusters: dict[int, list[UserPlaybook]],
         existing_approved_playbooks: list[AgentPlaybook],
         direction_overlap_threshold: float = 0.6,
+        current_agent_playbooks: dict[int, AgentPlaybook] | None = None,
+        excluded_existing_playbook_ids: dict[int, set[int]] | None = None,
     ) -> list[AggregationGenerationOutcome]:
         """Return one tagged outcome for every selected source cluster."""
         outcomes: list[AggregationGenerationOutcome] = []
-        for cluster_playbooks in clusters.values():
+        for cluster_key, cluster_playbooks in clusters.items():
+            current_agent_playbook = (current_agent_playbooks or {}).get(cluster_key)
             relevant_existing = _select_relevant_existing_playbooks(
                 cluster_playbooks, existing_approved_playbooks
             )
+            excluded_ids = (excluded_existing_playbook_ids or {}).get(
+                cluster_key, set()
+            )
+            if excluded_ids:
+                relevant_existing = [
+                    item
+                    for item in relevant_existing
+                    if item.agent_playbook_id not in excluded_ids
+                ]
+            if current_agent_playbook is not None:
+                relevant_existing = [
+                    item
+                    for item in relevant_existing
+                    if item.agent_playbook_id
+                    != current_agent_playbook.agent_playbook_id
+                ]
             approved_playbooks_str = (
                 "\n".join(f"- {item.content}" for item in relevant_existing)
                 if relevant_existing
@@ -1682,14 +2043,18 @@ class PlaybookAggregator:
                     "org_id": self.request_context.org_id,
                 }
             )
+            selected_prompt_sources = _select_generation_prompt_sources(
+                cluster_playbooks,
+                is_incremental_refresh=current_agent_playbook is not None,
+            )
             if self.aggregation_prompt_processor is None:
-                prompt_cluster_playbooks = cluster_playbooks
+                prompt_cluster_playbooks = selected_prompt_sources
             else:
                 prompt_cluster_playbooks = [
                     self._postproc._preprocess_user_playbook_for_prompt(
                         playbook, shared_state, processing_context
                     )
-                    for playbook in cluster_playbooks
+                    for playbook in selected_prompt_sources
                 ]
 
             generated = self._generate_playbook_from_cluster_outcome(
@@ -1697,6 +2062,7 @@ class PlaybookAggregator:
                 approved_playbooks_str,
                 direction_overlap_threshold=direction_overlap_threshold,
                 processing_context=processing_context,
+                current_agent_playbook=current_agent_playbook,
             )
             outcomes.append(
                 AggregationGenerationOutcome(
@@ -1771,6 +2137,7 @@ class PlaybookAggregator:
         existing_approved_playbooks_str: str,
         direction_overlap_threshold: float = 0.6,
         processing_context: AggregationPromptProcessingContext | None = None,
+        current_agent_playbook: AgentPlaybook | None = None,
     ) -> AggregationGenerationOutcome:
         """
         Generate a playbook from a cluster using structured JSON output.
@@ -1800,8 +2167,15 @@ class PlaybookAggregator:
                     "retryable_failure", cluster_playbooks
                 )
 
-            # Build content directly as a freeform summary
+            # Build content directly as a freeform summary. Incremental refreshes
+            # retain the current canonical rule and add the newly matched delta.
             content_text = f"When {trigger}, {first_content}."
+            if current_agent_playbook is not None:
+                content_text = (
+                    f"{current_agent_playbook.content.rstrip()}\n"
+                    f"- {first_content.rstrip('.')}"
+                )
+                trigger = current_agent_playbook.trigger or trigger
 
             response = PlaybookAggregationOutput(
                 playbook=StructuredPlaybookContent(
@@ -1832,6 +2206,15 @@ class PlaybookAggregator:
             cluster_playbooks,
             direction_overlap_threshold=direction_overlap_threshold,
         )
+        if current_agent_playbook is not None:
+            raw_playbooks_str = (
+                "CURRENT CANONICAL PLAYBOOK TO UPDATE:\n"
+                f"Trigger: {current_agent_playbook.trigger or '(none)'}\n"
+                f"Content: {current_agent_playbook.content}\n"
+                f"Rationale: {current_agent_playbook.rationale or '(none)'}\n\n"
+                "NEWLY MATCHED RAW PLAYBOOKS:\n"
+                f"{raw_playbooks_str}"
+            )
 
         messages = [
             {

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -853,6 +853,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         if self._has_sqlite_vec:
             self._create_vec_tables()
             self._migrate_vec_tables()
+            self._migrate_playbook_aggregation_agent_centroids()
         # Run after DDL so tables exist on fresh databases
         self._migrate_agent_runs_schema()
         self._migrate_pending_tool_calls_schema()
@@ -923,6 +924,36 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
         """
         with self._lock:
             self.conn.executescript(vec_ddl)
+            self.conn.commit()
+
+    def _migrate_playbook_aggregation_agent_centroids(self) -> None:
+        """Replace legacy user-vector means with canonical agent embeddings."""
+        rows = self.conn.execute(
+            "SELECT c.cluster_id, c.index_rowid, a.embedding "
+            "FROM playbook_aggregation_cluster c JOIN agent_playbooks a "
+            "ON a.agent_playbook_id=c.agent_playbook_id "
+            "WHERE c.vector_sum IS NOT NULL AND a.embedding IS NOT NULL "
+            "AND trim(a.embedding) NOT IN ('', '[]')"
+        ).fetchall()
+        with self._lock:
+            for row in rows:
+                embedding = json.loads(row[2])
+                if not embedding:
+                    continue
+                self.conn.execute(
+                    "UPDATE playbook_aggregation_cluster SET centroid=?, "
+                    "vector_sum=NULL, embedding_dimension=? WHERE cluster_id=?",
+                    (json.dumps(embedding), len(embedding), str(row[0])),
+                )
+                self.conn.execute(
+                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                    (int(row[1]),),
+                )
+                self.conn.execute(
+                    "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
+                    "VALUES (?, ?)",
+                    (int(row[1]), json.dumps(embedding)),
+                )
             self.conn.commit()
 
     def _migrate_vec_tables(self) -> None:

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -932,13 +932,21 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             "SELECT c.cluster_id, c.index_rowid, a.embedding "
             "FROM playbook_aggregation_cluster c JOIN agent_playbooks a "
             "ON a.agent_playbook_id=c.agent_playbook_id "
-            "WHERE c.vector_sum IS NOT NULL AND a.embedding IS NOT NULL "
+            "WHERE c.vector_sum IS NOT NULL AND c.index_rowid IS NOT NULL "
+            "AND a.embedding IS NOT NULL "
             "AND trim(a.embedding) NOT IN ('', '[]')"
         ).fetchall()
         with self._lock:
             for row in rows:
-                embedding = json.loads(row[2])
-                if not embedding:
+                try:
+                    embedding = json.loads(row[2])
+                except (json.JSONDecodeError, TypeError):
+                    continue
+                if (
+                    not isinstance(embedding, list)
+                    or len(embedding) != self.embedding_dimensions
+                    or not all(isinstance(value, int | float) for value in embedding)
+                ):
                     continue
                 self.conn.execute(
                     "UPDATE playbook_aggregation_cluster SET centroid=?, "

--- a/reflexio/server/services/storage/sqlite_storage/_lineage.py
+++ b/reflexio/server/services/storage/sqlite_storage/_lineage.py
@@ -128,17 +128,25 @@ def _append_event_stmt(
                 for value in source_id_values
                 if candidate_version_by_id.get(value) == agent_version
             ]
-            conn.execute(
-                "INSERT INTO playbook_aggregation_invalidation "
-                "(agent_version, operation, entity_id, source_ids) VALUES (?, ?, ?, ?)",
-                (agent_version, op, parsed_entity_id, json.dumps(version_source_ids)),
-            )
+            # Creation only makes new intake discoverable. It cannot invalidate
+            # existing membership, so putting it on the invalidation queue would
+            # force the scheduler to drain one no-op event per new playbook.
+            if op != "create":
+                conn.execute(
+                    "INSERT INTO playbook_aggregation_invalidation "
+                    "(agent_version, operation, entity_id, source_ids) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        agent_version,
+                        op,
+                        parsed_entity_id,
+                        json.dumps(version_source_ids),
+                    ),
+                )
             conn.execute(
                 "INSERT INTO playbook_aggregation_state "
                 "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
-                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
-                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
-                "excluded.next_attempt_at)",
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1",
                 (agent_version,),
             )
     return cursor

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -36,6 +36,7 @@ from .._base import (
     _epoch_now,
     _epoch_to_iso,
     _json_dumps,
+    _json_loads,
     _row_to_agent_playbook,
     _sanitize_fts_query,
     _true_rrf_merge,
@@ -340,6 +341,7 @@ class AgentPlaybookStoreMixin:
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
         include_inactive: bool = False,
+        include_embedding: bool = False,
     ) -> list[AgentPlaybook]:
         validate_include_inactive(
             include_inactive=include_inactive,
@@ -370,7 +372,11 @@ class AgentPlaybookStoreMixin:
                     query += f" AND playbook_status IN ({status_placeholders})"
                     params.extend(status.value for status in playbook_status_filter)
             rows.extend(self._fetchall(query, params))
-        return [_row_to_agent_playbook(row) for row in rows]
+        result = [_row_to_agent_playbook(row) for row in rows]
+        if include_embedding:
+            for playbook, row in zip(result, rows, strict=True):
+                playbook.embedding = _json_loads(row["embedding"]) or []
+        return result
 
     @SQLiteStorageBase.handle_exceptions
     def delete_all_agent_playbooks(self) -> None:

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
@@ -61,6 +61,9 @@ CREATE TABLE IF NOT EXISTS playbook_aggregation_cluster (
 );
 CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_cluster_version
     ON playbook_aggregation_cluster(agent_version, state, cluster_id);
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_cluster_agent
+    ON playbook_aggregation_cluster(agent_playbook_id)
+    WHERE agent_playbook_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS playbook_aggregation_item (
     agent_version TEXT NOT NULL,
@@ -266,6 +269,18 @@ class PlaybookAggregationStoreMixin:
         if limit <= 0:
             return []
         with self._lock:
+            if self._has_sqlite_vec:
+                orphaned_vectors = self.conn.execute(
+                    "SELECT rowid FROM playbook_aggregation_clusters_vec "
+                    "WHERE rowid NOT IN (SELECT index_rowid FROM "
+                    "playbook_aggregation_cluster WHERE index_rowid IS NOT NULL) "
+                    "LIMIT ?",
+                    (limit,),
+                ).fetchall()
+                self.conn.executemany(
+                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                    [(int(row[0]),) for row in orphaned_vectors],
+                )
             self.conn.execute(
                 "DELETE FROM playbook_aggregation_invalidation "
                 "WHERE processed_at IS NOT NULL AND processed_at < unixepoch()-?",
@@ -612,7 +627,7 @@ class PlaybookAggregationStoreMixin:
             raise ValueError("legacy cluster embedding dimension changed")
         with self._lock:
             row = self.conn.execute(
-                "SELECT index_rowid, vector_sum, member_count, state, "
+                "SELECT index_rowid, member_count, state, "
                 "embedding_model, embedding_dimension "
                 "FROM playbook_aggregation_cluster WHERE cluster_id=?",
                 (cluster_id,),
@@ -639,21 +654,15 @@ class PlaybookAggregationStoreMixin:
                     ),
                 )
                 index_rowid = next_rowid
-                vector_sum = [0.0] * embedding_dimension
                 member_count = 0
             else:
-                if str(row[3]) == "active":
+                if str(row[2]) == "active":
                     return
-                if row[4] != embedding_model or int(row[5]) != embedding_dimension:
+                if row[3] != embedding_model or int(row[4]) != embedding_dimension:
                     raise RuntimeError("legacy cluster embedding provenance changed")
                 index_rowid = int(row[0])
-                vector_sum = (
-                    [float(value) for value in json.loads(row[1])]
-                    if row[1]
-                    else [0.0] * embedding_dimension
-                )
-                member_count = int(row[2])
-            for user_playbook_id, embedding in member_embeddings:
+                member_count = int(row[1])
+            for user_playbook_id, _embedding in member_embeddings:
                 inserted = self.conn.execute(
                     "INSERT OR IGNORE INTO playbook_aggregation_item "
                     "(agent_version, user_playbook_id, disposition, cluster_id, reason) "
@@ -661,17 +670,12 @@ class PlaybookAggregationStoreMixin:
                     (agent_version, user_playbook_id, cluster_id),
                 )
                 if inserted.rowcount == 1:
-                    vector_sum = [
-                        left + right
-                        for left, right in zip(vector_sum, embedding, strict=True)
-                    ]
                     member_count += 1
             centroid = centroid_embedding if complete and member_count else None
             self.conn.execute(
-                "UPDATE playbook_aggregation_cluster SET vector_sum=?, centroid=?, "
+                "UPDATE playbook_aggregation_cluster SET vector_sum=NULL, centroid=?, "
                 "member_count=?, rebuild_cursor=?, state=? WHERE cluster_id=?",
                 (
-                    None if complete else json.dumps(vector_sum),
                     json.dumps(centroid) if centroid is not None else None,
                     member_count,
                     rebuild_cursor,
@@ -1203,6 +1207,15 @@ class PlaybookAggregationStoreMixin:
         expected_agent_playbook_id: int,
         reason: str,
     ) -> None:
+        if self._own_transaction():
+            with self.commit_scope():
+                self.defer_playbook_aggregation_cluster_rebuild(
+                    cluster_id=cluster_id,
+                    agent_version=agent_version,
+                    expected_agent_playbook_id=expected_agent_playbook_id,
+                    reason=reason,
+                )
+            return
         with self._lock:
             updated = self.conn.execute(
                 "UPDATE playbook_aggregation_cluster SET "
@@ -1227,8 +1240,6 @@ class PlaybookAggregationStoreMixin:
                 "AND cluster_id=? AND disposition='residual'",
                 (reason, agent_version, cluster_id),
             )
-            if self._own_transaction():
-                self.conn.commit()
 
     def complete_playbook_aggregation_cluster_rebuild(
         self,
@@ -1242,6 +1253,16 @@ class PlaybookAggregationStoreMixin:
     ) -> int:
         if not centroid_embedding:
             raise ValueError("cluster centroid embedding must be non-empty")
+        if self._own_transaction():
+            with self.commit_scope():
+                return self.complete_playbook_aggregation_cluster_rebuild(
+                    cluster_id=cluster_id,
+                    agent_version=agent_version,
+                    expected_agent_playbook_id=expected_agent_playbook_id,
+                    replacement_agent_playbook_id=replacement_agent_playbook_id,
+                    centroid_embedding=centroid_embedding,
+                    embedding_model=embedding_model,
+                )
         with self._lock:
             row = self.conn.execute(
                 "SELECT index_rowid, embedding_dimension FROM "
@@ -1296,8 +1317,6 @@ class PlaybookAggregationStoreMixin:
                 "VALUES (?, ?)",
                 (rowid, json.dumps(centroid_embedding)),
             )
-            if self._own_transaction():
-                self.conn.commit()
             return member_count
 
     def discard_playbook_aggregation_cluster_rebuild(
@@ -1308,6 +1327,14 @@ class PlaybookAggregationStoreMixin:
         expected_agent_playbook_id: int,
         reason: str,
     ) -> int:
+        if self._own_transaction():
+            with self.commit_scope():
+                return self.discard_playbook_aggregation_cluster_rebuild(
+                    cluster_id=cluster_id,
+                    agent_version=agent_version,
+                    expected_agent_playbook_id=expected_agent_playbook_id,
+                    reason=reason,
+                )
         with self._lock:
             row = self.conn.execute(
                 "SELECT index_rowid FROM playbook_aggregation_cluster WHERE "
@@ -1334,8 +1361,6 @@ class PlaybookAggregationStoreMixin:
             )
             if deleted.rowcount != 1:
                 raise RuntimeError("aggregation rebuilding cluster changed")
-            if self._own_transaction():
-                self.conn.commit()
             return int(updated.rowcount)
 
     def delete_orphaned_playbook_aggregation_clusters(

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
@@ -16,6 +16,7 @@ from reflexio.server.services.storage.storage_base.playbook import (
     PlaybookAggregationClaim,
     PlaybookAggregationClusterMatch,
     PlaybookAggregationInvalidation,
+    PlaybookAggregationRebuildSample,
     PlaybookAggregationRerunSnapshot,
 )
 
@@ -27,7 +28,8 @@ CREATE TABLE IF NOT EXISTS playbook_aggregation_state (
     next_attempt_at INTEGER NOT NULL DEFAULT (unixepoch()),
     state_version INTEGER NOT NULL DEFAULT 0,
     retry_cursor INTEGER NOT NULL DEFAULT 0,
-    bootstrap_status TEXT NOT NULL DEFAULT 'pending'
+    bootstrap_status TEXT NOT NULL DEFAULT 'pending',
+    intake_floor_user_playbook_id INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_state_due
     ON playbook_aggregation_state(pending, next_attempt_at, agent_version);
@@ -53,7 +55,9 @@ CREATE TABLE IF NOT EXISTS playbook_aggregation_cluster (
     normalization TEXT NOT NULL DEFAULT 'l2',
     state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'rebuilding')),
     dirty INTEGER NOT NULL DEFAULT 0 CHECK (dirty IN (0, 1)),
-    rebuild_cursor INTEGER NOT NULL DEFAULT 0
+    rebuild_cursor INTEGER NOT NULL DEFAULT 0,
+    rebuild_attempt_count INTEGER NOT NULL DEFAULT 0,
+    rebuild_next_attempt_at INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_cluster_version
     ON playbook_aggregation_cluster(agent_version, state, cluster_id);
@@ -80,6 +84,12 @@ CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_item_residual
 CREATE INDEX IF NOT EXISTS idx_user_playbooks_aggregation_intake
     ON user_playbooks(agent_version, user_playbook_id)
     WHERE status IS NULL AND trim(content) <> '' AND trim(agent_version) <> '';
+CREATE INDEX IF NOT EXISTS idx_user_playbooks_aggregation_rebuild
+    ON user_playbooks(agent_version, created_at DESC, user_playbook_id DESC)
+    WHERE status IS NULL AND trim(content) <> '' AND trim(agent_version) <> '';
+CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_item_rebuild
+    ON playbook_aggregation_item(agent_version, cluster_id, user_playbook_id DESC)
+    WHERE disposition = 'residual' AND cluster_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS playbook_aggregation_invalidation (
     invalidation_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -97,7 +107,8 @@ CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_invalidation_retention
     ON playbook_aggregation_invalidation(processed_at)
     WHERE processed_at IS NOT NULL;
 
-CREATE TRIGGER IF NOT EXISTS capture_playbook_aggregation_hard_delete
+DROP TRIGGER IF EXISTS capture_playbook_aggregation_hard_delete;
+CREATE TRIGGER capture_playbook_aggregation_hard_delete
 BEFORE DELETE ON user_playbooks
 WHEN OLD.status IS NULL AND trim(OLD.agent_version) <> ''
 BEGIN
@@ -107,15 +118,109 @@ BEGIN
     INSERT INTO playbook_aggregation_state(
         agent_version, pending, next_attempt_at
     ) VALUES (OLD.agent_version, 1, unixepoch())
-    ON CONFLICT(agent_version) DO UPDATE SET pending=1,
-        next_attempt_at=min(playbook_aggregation_state.next_attempt_at,
-                            excluded.next_attempt_at);
+    ON CONFLICT(agent_version) DO UPDATE SET pending=1;
+END;
+
+DROP TRIGGER IF EXISTS retire_playbook_aggregation_cluster_on_agent_update;
+CREATE TRIGGER retire_playbook_aggregation_cluster_on_agent_update
+AFTER UPDATE OF status, playbook_status, content, trigger, rationale, embedding
+ON agent_playbooks
+WHEN (
+    (NEW.status IS NOT OLD.status AND NEW.status IS NOT NULL)
+    OR (
+        NEW.playbook_status IS NOT OLD.playbook_status
+        AND NEW.playbook_status = 'rejected'
+    )
+    OR NEW.content IS NOT OLD.content
+    OR NEW.trigger IS NOT OLD.trigger
+    OR NEW.rationale IS NOT OLD.rationale
+    OR NEW.embedding IS NOT OLD.embedding
+)
+BEGIN
+    UPDATE playbook_aggregation_item
+    SET disposition = 'residual', cluster_id = NULL,
+        reason = 'agent_playbook_changed', attempt_count = 0,
+        last_attempt_at = NULL, updated_at = unixepoch()
+    WHERE cluster_id IN (
+        SELECT cluster_id FROM playbook_aggregation_cluster
+        WHERE agent_playbook_id = OLD.agent_playbook_id
+    );
+    INSERT OR IGNORE INTO playbook_aggregation_state(
+        agent_version, pending, next_attempt_at
+    )
+    SELECT DISTINCT agent_version, 1, unixepoch()
+    FROM playbook_aggregation_cluster
+    WHERE agent_playbook_id = OLD.agent_playbook_id;
+    UPDATE playbook_aggregation_state
+    SET pending = 1
+    WHERE agent_version IN (
+        SELECT agent_version FROM playbook_aggregation_cluster
+        WHERE agent_playbook_id = OLD.agent_playbook_id
+    );
+    DELETE FROM playbook_aggregation_cluster
+    WHERE agent_playbook_id = OLD.agent_playbook_id;
+END;
+
+DROP TRIGGER IF EXISTS retire_playbook_aggregation_cluster_on_agent_delete;
+CREATE TRIGGER retire_playbook_aggregation_cluster_on_agent_delete
+BEFORE DELETE ON agent_playbooks
+BEGIN
+    UPDATE playbook_aggregation_item
+    SET disposition = 'residual', cluster_id = NULL,
+        reason = 'agent_playbook_deleted', attempt_count = 0,
+        last_attempt_at = NULL, updated_at = unixepoch()
+    WHERE cluster_id IN (
+        SELECT cluster_id FROM playbook_aggregation_cluster
+        WHERE agent_playbook_id = OLD.agent_playbook_id
+    );
+    INSERT OR IGNORE INTO playbook_aggregation_state(
+        agent_version, pending, next_attempt_at
+    )
+    SELECT DISTINCT agent_version, 1, unixepoch()
+    FROM playbook_aggregation_cluster
+    WHERE agent_playbook_id = OLD.agent_playbook_id;
+    UPDATE playbook_aggregation_state
+    SET pending = 1
+    WHERE agent_version IN (
+        SELECT agent_version FROM playbook_aggregation_cluster
+        WHERE agent_playbook_id = OLD.agent_playbook_id
+    );
+    DELETE FROM playbook_aggregation_cluster
+    WHERE agent_playbook_id = OLD.agent_playbook_id;
 END;
 """
 
 
 def init_playbook_aggregation_tables(conn: sqlite3.Connection) -> None:
     conn.executescript(AGGREGATION_DDL)
+    state_columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(playbook_aggregation_state)")
+    }
+    if "intake_floor_user_playbook_id" not in state_columns:
+        conn.execute(
+            "ALTER TABLE playbook_aggregation_state ADD COLUMN "
+            "intake_floor_user_playbook_id INTEGER NOT NULL DEFAULT 0"
+        )
+    cluster_columns = {
+        str(row[1])
+        for row in conn.execute("PRAGMA table_info(playbook_aggregation_cluster)")
+    }
+    if "rebuild_attempt_count" not in cluster_columns:
+        conn.execute(
+            "ALTER TABLE playbook_aggregation_cluster ADD COLUMN "
+            "rebuild_attempt_count INTEGER NOT NULL DEFAULT 0"
+        )
+    if "rebuild_next_attempt_at" not in cluster_columns:
+        conn.execute(
+            "ALTER TABLE playbook_aggregation_cluster ADD COLUMN "
+            "rebuild_next_attempt_at INTEGER NOT NULL DEFAULT 0"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_playbook_aggregation_cluster_rebuild_due "
+        "ON playbook_aggregation_cluster(agent_version, rebuild_next_attempt_at, "
+        "cluster_id) WHERE state = 'rebuilding'"
+    )
 
 
 class PlaybookAggregationStoreMixin:
@@ -149,9 +254,7 @@ class PlaybookAggregationStoreMixin:
                 "INSERT INTO playbook_aggregation_state "
                 "(agent_version, pending, next_attempt_at) "
                 "VALUES (?, 1, unixepoch()) "
-                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
-                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
-                "excluded.next_attempt_at)",
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1",
                 (agent_version,),
             )
             if self._own_transaction():
@@ -170,8 +273,12 @@ class PlaybookAggregationStoreMixin:
             )
             rows = self.conn.execute(
                 "WITH work(agent_version) AS ("
-                "SELECT p.agent_version FROM user_playbooks p WHERE p.status IS NULL "
+                "SELECT p.agent_version FROM user_playbooks p LEFT JOIN "
+                "playbook_aggregation_state ps ON ps.agent_version=p.agent_version "
+                "WHERE p.status IS NULL "
                 "AND trim(p.content) <> '' AND trim(p.agent_version) <> '' "
+                "AND p.user_playbook_id >= "
+                "COALESCE(ps.intake_floor_user_playbook_id, 0) "
                 "AND NOT EXISTS (SELECT 1 FROM playbook_aggregation_item i WHERE "
                 "i.agent_version=p.agent_version AND "
                 "i.user_playbook_id=p.user_playbook_id) UNION "
@@ -190,9 +297,7 @@ class PlaybookAggregationStoreMixin:
             self.conn.executemany(
                 "INSERT INTO playbook_aggregation_state "
                 "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
-                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
-                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
-                "excluded.next_attempt_at)",
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1",
                 [(version,) for version in versions],
             )
             if self._own_transaction():
@@ -382,20 +487,62 @@ class PlaybookAggregationStoreMixin:
             return True
 
     def stage_playbook_aggregation_intake(
-        self, agent_version: str, *, limit: int
+        self, agent_version: str, *, limit: int, window_limit: int = 20_000
     ) -> list[int]:
-        if limit <= 0:
+        if limit <= 0 or window_limit <= 0:
             return []
         with self._lock:
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_state "
+                "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
+                "ON CONFLICT(agent_version) DO NOTHING",
+                (agent_version,),
+            )
+            old_floor = int(
+                self.conn.execute(
+                    "SELECT intake_floor_user_playbook_id FROM "
+                    "playbook_aggregation_state WHERE agent_version=?",
+                    (agent_version,),
+                ).fetchone()[0]
+            )
+            cutoff_row = self.conn.execute(
+                "SELECT p.user_playbook_id FROM user_playbooks p LEFT JOIN "
+                "playbook_aggregation_item i ON i.agent_version=? AND "
+                "i.user_playbook_id=p.user_playbook_id WHERE p.agent_version=? "
+                "AND p.status IS NULL AND trim(p.content) <> '' "
+                "AND p.user_playbook_id>=? AND (i.user_playbook_id IS NULL OR "
+                "(i.disposition='residual' AND i.cluster_id IS NULL)) "
+                "ORDER BY p.user_playbook_id DESC LIMIT 1 OFFSET ?",
+                (agent_version, agent_version, old_floor, window_limit - 1),
+            ).fetchone()
+            intake_floor = max(
+                old_floor, int(cutoff_row[0]) if cutoff_row is not None else old_floor
+            )
+            if intake_floor != old_floor:
+                self.conn.execute(
+                    "UPDATE playbook_aggregation_state SET "
+                    "intake_floor_user_playbook_id=? WHERE agent_version=?",
+                    (intake_floor, agent_version),
+                )
+                self.conn.execute(
+                    "UPDATE playbook_aggregation_item SET "
+                    "disposition='terminal_noop', cluster_id=NULL, "
+                    "reason='outside_recent_clustering_window', "
+                    "updated_at=unixepoch() WHERE agent_version=? "
+                    "AND disposition='residual' AND cluster_id IS NULL "
+                    "AND user_playbook_id<?",
+                    (agent_version, intake_floor),
+                )
             rows = self.conn.execute(
                 "SELECT p.user_playbook_id FROM user_playbooks p "
                 "WHERE p.agent_version=? AND p.status IS NULL "
-                "AND trim(p.content) <> '' AND NOT EXISTS ("
+                "AND trim(p.content) <> '' AND p.user_playbook_id>=? "
+                "AND NOT EXISTS ("
                 " SELECT 1 FROM playbook_aggregation_item i "
                 " WHERE i.agent_version=? "
                 " AND i.user_playbook_id=p.user_playbook_id) "
-                "ORDER BY p.user_playbook_id LIMIT ?",
-                (agent_version, agent_version, limit),
+                "ORDER BY p.user_playbook_id DESC LIMIT ?",
+                (agent_version, intake_floor, agent_version, limit),
             ).fetchall()
             ids = [int(row[0]) for row in rows]
             self.conn.executemany(
@@ -452,13 +599,16 @@ class PlaybookAggregationStoreMixin:
         cluster_id: str,
         agent_version: str,
         agent_playbook_id: int,
+        centroid_embedding: list[float],
         member_embeddings: list[tuple[int, list[float]]],
         embedding_model: str,
         embedding_dimension: int,
         rebuild_cursor: int,
         complete: bool,
     ) -> None:
-        if any(len(value) != embedding_dimension for _, value in member_embeddings):
+        if len(centroid_embedding) != embedding_dimension or any(
+            len(value) != embedding_dimension for _, value in member_embeddings
+        ):
             raise ValueError("legacy cluster embedding dimension changed")
         with self._lock:
             row = self.conn.execute(
@@ -516,14 +666,12 @@ class PlaybookAggregationStoreMixin:
                         for left, right in zip(vector_sum, embedding, strict=True)
                     ]
                     member_count += 1
-            centroid = (
-                [value / member_count for value in vector_sum] if member_count else None
-            )
+            centroid = centroid_embedding if complete and member_count else None
             self.conn.execute(
                 "UPDATE playbook_aggregation_cluster SET vector_sum=?, centroid=?, "
                 "member_count=?, rebuild_cursor=?, state=? WHERE cluster_id=?",
                 (
-                    json.dumps(vector_sum) if member_count else None,
+                    None if complete else json.dumps(vector_sum),
                     json.dumps(centroid) if centroid is not None else None,
                     member_count,
                     rebuild_cursor,
@@ -566,6 +714,11 @@ class PlaybookAggregationStoreMixin:
             )
             self.conn.execute(
                 "DELETE FROM playbook_aggregation_cluster WHERE agent_version=?",
+                (agent_version,),
+            )
+            self.conn.execute(
+                "UPDATE playbook_aggregation_state SET "
+                "intake_floor_user_playbook_id=0 WHERE agent_version=?",
                 (agent_version,),
             )
             self.set_playbook_aggregation_bootstrap_status(agent_version, "complete")
@@ -659,17 +812,24 @@ class PlaybookAggregationStoreMixin:
             fresh_quota = (limit + 1) // 2
             retry_quota = limit - fresh_quota
             fresh_rows = self.conn.execute(
-                "SELECT user_playbook_id FROM playbook_aggregation_item "
-                "WHERE agent_version=? AND disposition='residual' AND attempt_count=0 "
-                "ORDER BY user_playbook_id LIMIT ?",
+                "SELECT i.user_playbook_id FROM playbook_aggregation_item i "
+                "WHERE i.agent_version=? AND i.disposition='residual' "
+                "AND i.attempt_count=0 AND NOT EXISTS (SELECT 1 FROM "
+                "playbook_aggregation_cluster c WHERE c.agent_version=i.agent_version "
+                "AND c.cluster_id=i.cluster_id AND c.state='rebuilding' "
+                "AND c.rebuild_next_attempt_at>unixepoch()) "
+                "ORDER BY i.user_playbook_id LIMIT ?",
                 (agent_version, fresh_quota),
             ).fetchall()
             retry_rows = self.conn.execute(
-                "SELECT user_playbook_id FROM playbook_aggregation_item "
-                "WHERE agent_version=? AND disposition='residual' AND attempt_count>0 "
-                "AND last_attempt_at+min(?, ?*(1 << min(max(attempt_count-1, 0), 6))) "
-                "<= unixepoch() "
-                "ORDER BY last_attempt_at, user_playbook_id LIMIT ?",
+                "SELECT i.user_playbook_id FROM playbook_aggregation_item i "
+                "WHERE i.agent_version=? AND i.disposition='residual' "
+                "AND i.attempt_count>0 AND i.last_attempt_at+min(?, ?*(1 << "
+                "min(max(i.attempt_count-1, 0), 6))) <= unixepoch() "
+                "AND NOT EXISTS (SELECT 1 FROM playbook_aggregation_cluster c "
+                "WHERE c.agent_version=i.agent_version AND c.cluster_id=i.cluster_id "
+                "AND c.state='rebuilding' AND c.rebuild_next_attempt_at>unixepoch()) "
+                "ORDER BY i.last_attempt_at, i.user_playbook_id LIMIT ?",
                 (
                     agent_version,
                     AGGREGATION_RETRY_MAX_SECONDS,
@@ -684,13 +844,17 @@ class PlaybookAggregationStoreMixin:
                     f"AND user_playbook_id NOT IN ({placeholders})" if ids else ""
                 )
                 fill = self.conn.execute(
-                    "SELECT user_playbook_id FROM playbook_aggregation_item "
-                    "WHERE agent_version=? AND disposition='residual' "
-                    "AND (attempt_count=0 OR last_attempt_at IS NULL OR "
-                    "last_attempt_at+min(?, ?*(1 << min(max(attempt_count-1, 0), 6))) "
-                    "<= unixepoch()) "
-                    f"{exclusion} ORDER BY COALESCE(last_attempt_at, 0), "
-                    "user_playbook_id LIMIT ?",
+                    "SELECT i.user_playbook_id FROM playbook_aggregation_item i "
+                    "WHERE i.agent_version=? AND i.disposition='residual' "
+                    "AND (i.attempt_count=0 OR i.last_attempt_at IS NULL OR "
+                    "i.last_attempt_at+min(?, ?*(1 << min(max(i.attempt_count-1, 0), "
+                    "6))) <= unixepoch()) AND NOT EXISTS (SELECT 1 FROM "
+                    "playbook_aggregation_cluster c WHERE "
+                    "c.agent_version=i.agent_version AND c.cluster_id=i.cluster_id "
+                    "AND c.state='rebuilding' AND "
+                    "c.rebuild_next_attempt_at>unixepoch()) "
+                    f"{exclusion} ORDER BY COALESCE(i.last_attempt_at, 0), "
+                    "i.user_playbook_id LIMIT ?",
                     (
                         agent_version,
                         AGGREGATION_RETRY_MAX_SECONDS,
@@ -740,11 +904,15 @@ class PlaybookAggregationStoreMixin:
         with self._lock:
             undisposed = int(
                 self.conn.execute(
-                    "SELECT count(*) FROM user_playbooks p WHERE p.agent_version=? "
+                    "SELECT count(*) FROM user_playbooks p LEFT JOIN "
+                    "playbook_aggregation_state s ON s.agent_version=p.agent_version "
+                    "WHERE p.agent_version=? "
                     "AND p.status IS NULL AND trim(p.content) <> '' AND NOT EXISTS ("
                     "SELECT 1 FROM playbook_aggregation_item i "
                     "WHERE i.agent_version=? "
-                    "AND i.user_playbook_id=p.user_playbook_id)",
+                    "AND i.user_playbook_id=p.user_playbook_id) "
+                    "AND p.user_playbook_id>=COALESCE("
+                    "s.intake_floor_user_playbook_id, 0)",
                     (agent_version, agent_version),
                 ).fetchone()[0]
             )
@@ -776,16 +944,25 @@ class PlaybookAggregationStoreMixin:
             )
             residual_retry_after = self.conn.execute(
                 "SELECT COALESCE(MAX(0, MIN(CASE "
-                "WHEN attempt_count <= 0 OR last_attempt_at IS NULL THEN 0 "
-                "ELSE last_attempt_at + MIN(?, ? * (1 << MIN(MAX("
-                "attempt_count - 1, 0), 6))) - unixepoch() END)), 0) "
-                "FROM playbook_aggregation_item WHERE agent_version=? "
-                "AND disposition='residual'",
+                "WHEN c.state='rebuilding' THEN c.rebuild_next_attempt_at-unixepoch() "
+                "WHEN i.attempt_count <= 0 OR i.last_attempt_at IS NULL THEN 0 "
+                "ELSE i.last_attempt_at + MIN(?, ? * (1 << MIN(MAX("
+                "i.attempt_count - 1, 0), 6))) - unixepoch() END)), 0) "
+                "FROM playbook_aggregation_item i LEFT JOIN "
+                "playbook_aggregation_cluster c ON c.agent_version=i.agent_version "
+                "AND c.cluster_id=i.cluster_id WHERE i.agent_version=? "
+                "AND i.disposition='residual'",
                 (
                     AGGREGATION_RETRY_MAX_SECONDS,
                     AGGREGATION_RETRY_BASE_SECONDS,
                     agent_version,
                 ),
+            ).fetchone()[0]
+            repair_retry_after = self.conn.execute(
+                "SELECT COALESCE(MAX(0, MIN(rebuild_next_attempt_at-unixepoch())), 0) "
+                "FROM playbook_aggregation_cluster WHERE agent_version=? "
+                "AND state='rebuilding'",
+                (agent_version,),
             ).fetchone()[0]
         return PlaybookAggregationBacklog(
             undisposed=undisposed,
@@ -796,6 +973,7 @@ class PlaybookAggregationStoreMixin:
             ),
             dirty_repairs=dirty_repairs,
             residual_retry_after_seconds=int(residual_retry_after),
+            repair_retry_after_seconds=int(repair_retry_after),
         )
 
     def append_playbook_aggregation_invalidation(
@@ -815,9 +993,7 @@ class PlaybookAggregationStoreMixin:
             self.conn.execute(
                 "INSERT INTO playbook_aggregation_state "
                 "(agent_version, pending, next_attempt_at) VALUES (?, 1, unixepoch()) "
-                "ON CONFLICT(agent_version) DO UPDATE SET pending=1, "
-                "next_attempt_at=min(playbook_aggregation_state.next_attempt_at, "
-                "excluded.next_attempt_at)",
+                "ON CONFLICT(agent_version) DO UPDATE SET pending=1",
                 (agent_version,),
             )
             if self._own_transaction():
@@ -864,7 +1040,8 @@ class PlaybookAggregationStoreMixin:
                 return False
             placeholders = ",".join("?" for _ in invalidation_ids)
             rows = self.conn.execute(
-                "SELECT entity_id, source_ids FROM playbook_aggregation_invalidation "
+                "SELECT operation, entity_id, source_ids "
+                "FROM playbook_aggregation_invalidation "
                 f"WHERE invalidation_id IN ({placeholders}) AND agent_version=? "
                 "AND processed_at IS NULL",
                 (*invalidation_ids, claim.agent_version),
@@ -872,7 +1049,7 @@ class PlaybookAggregationStoreMixin:
             affected = {
                 int(value)
                 for row in rows
-                for value in [int(row[0]), *json.loads(row[1] or "[]")]
+                for value in [int(row[1]), *json.loads(row[2] or "[]")]
             }
             if affected:
                 item_placeholders = ",".join("?" for _ in affected)
@@ -883,6 +1060,26 @@ class PlaybookAggregationStoreMixin:
                     (claim.agent_version, *sorted(affected)),
                 ).fetchall()
                 cluster_ids = [str(row[0]) for row in cluster_rows]
+                revision_cluster_by_entity: dict[int, str] = {}
+                for operation, entity_id, source_ids_json in rows:
+                    if operation != "revise":
+                        continue
+                    source_ids = [
+                        int(value) for value in json.loads(source_ids_json or "[]")
+                    ]
+                    if not source_ids:
+                        continue
+                    source_placeholders = ",".join("?" for _ in source_ids)
+                    source_clusters = self.conn.execute(
+                        "SELECT DISTINCT cluster_id FROM playbook_aggregation_item "
+                        f"WHERE agent_version=? AND user_playbook_id IN ({source_placeholders}) "
+                        "AND cluster_id IS NOT NULL",
+                        (claim.agent_version, *source_ids),
+                    ).fetchall()
+                    if len(source_clusters) == 1:
+                        revision_cluster_by_entity[int(entity_id)] = str(
+                            source_clusters[0][0]
+                        )
                 if cluster_ids:
                     cluster_placeholders = ",".join("?" for _ in cluster_ids)
                     index_rows = self.conn.execute(
@@ -906,7 +1103,8 @@ class PlaybookAggregationStoreMixin:
                     self.conn.execute(
                         "UPDATE playbook_aggregation_cluster SET state='rebuilding', "
                         "dirty=1, centroid=NULL, vector_sum=NULL, member_count=0, "
-                        "rebuild_cursor=0 "
+                        "rebuild_cursor=0, rebuild_attempt_count=0, "
+                        "rebuild_next_attempt_at=0 "
                         f"WHERE cluster_id IN ({cluster_placeholders})",
                         cluster_ids,
                     )
@@ -915,6 +1113,24 @@ class PlaybookAggregationStoreMixin:
                     f"WHERE agent_version=? AND user_playbook_id IN ({item_placeholders})",
                     (claim.agent_version, *sorted(affected)),
                 )
+                for entity_id, cluster_id in revision_cluster_by_entity.items():
+                    self.conn.execute(
+                        "INSERT INTO playbook_aggregation_item "
+                        "(agent_version, user_playbook_id, disposition, cluster_id, reason) "
+                        "SELECT ?, p.user_playbook_id, 'residual', ?, 'revision_rebuild' "
+                        "FROM user_playbooks p WHERE p.user_playbook_id=? "
+                        "AND p.agent_version=? AND p.status IS NULL "
+                        "AND trim(p.content) <> '' ON CONFLICT(agent_version, "
+                        "user_playbook_id) DO UPDATE SET disposition='residual', "
+                        "cluster_id=excluded.cluster_id, reason=excluded.reason, "
+                        "attempt_count=0, last_attempt_at=NULL, updated_at=unixepoch()",
+                        (
+                            claim.agent_version,
+                            cluster_id,
+                            entity_id,
+                            claim.agent_version,
+                        ),
+                    )
             self.conn.execute(
                 "UPDATE playbook_aggregation_invalidation SET processed_at=unixepoch() "
                 f"WHERE invalidation_id IN ({placeholders}) AND agent_version=? "
@@ -923,27 +1139,212 @@ class PlaybookAggregationStoreMixin:
             )
             return True
 
-    def get_playbook_aggregation_replacement_agent_ids(
+    def get_playbook_aggregation_rebuild_cluster_ids(
         self, agent_version: str, user_playbook_ids: list[int]
-    ) -> list[int]:
+    ) -> dict[int, str]:
         if not user_playbook_ids:
-            return []
+            return {}
         placeholders = ",".join("?" for _ in user_playbook_ids)
         with self._lock:
             rows = self.conn.execute(
-                "SELECT DISTINCT c.agent_playbook_id FROM playbook_aggregation_item i "
-                "JOIN playbook_aggregation_cluster c ON c.cluster_id=i.cluster_id "
-                f"WHERE i.agent_version=? AND i.user_playbook_id IN ({placeholders}) "
-                "AND c.state='rebuilding' AND c.agent_playbook_id IS NOT NULL "
-                "ORDER BY c.agent_playbook_id",
+                "SELECT i.user_playbook_id, i.cluster_id FROM "
+                "playbook_aggregation_item i JOIN playbook_aggregation_cluster c "
+                "ON c.cluster_id=i.cluster_id WHERE i.agent_version=? "
+                f"AND i.user_playbook_id IN ({placeholders}) "
+                "AND i.disposition='residual' AND c.state='rebuilding' "
+                "AND c.rebuild_next_attempt_at<=unixepoch()",
                 (agent_version, *user_playbook_ids),
             ).fetchall()
-        return [int(row[0]) for row in rows]
+        return {int(row[0]): str(row[1]) for row in rows}
 
-    def delete_orphaned_playbook_aggregation_clusters(self, agent_version: str) -> None:
+    def get_playbook_aggregation_rebuild_samples(
+        self, agent_version: str, cluster_ids: list[str], *, limit_per_cluster: int
+    ) -> list[PlaybookAggregationRebuildSample]:
+        if not cluster_ids or limit_per_cluster <= 0:
+            return []
+        placeholders = ",".join("?" for _ in cluster_ids)
+        with self._lock:
+            clusters = self.conn.execute(
+                "SELECT cluster_id, agent_playbook_id FROM "
+                "playbook_aggregation_cluster WHERE agent_version=? "
+                "AND state='rebuilding' AND agent_playbook_id IS NOT NULL "
+                "AND rebuild_next_attempt_at<=unixepoch() "
+                f"AND cluster_id IN ({placeholders}) ORDER BY cluster_id",
+                (agent_version, *cluster_ids),
+            ).fetchall()
+            samples: list[PlaybookAggregationRebuildSample] = []
+            for cluster_id, agent_playbook_id in clusters:
+                rows = self.conn.execute(
+                    "SELECT p.user_playbook_id FROM user_playbooks p INDEXED BY "
+                    "idx_user_playbooks_aggregation_rebuild WHERE p.agent_version=? "
+                    "AND trim(p.agent_version) <> '' AND p.status IS NULL AND "
+                    "trim(p.content) <> '' AND EXISTS (SELECT 1 FROM "
+                    "playbook_aggregation_item i WHERE i.agent_version=? AND "
+                    "i.user_playbook_id=p.user_playbook_id AND i.cluster_id=? AND "
+                    "i.disposition='residual') ORDER BY p.created_at DESC, "
+                    "p.user_playbook_id DESC LIMIT ?",
+                    (agent_version, agent_version, cluster_id, limit_per_cluster),
+                ).fetchall()
+                if rows:
+                    samples.append(
+                        PlaybookAggregationRebuildSample(
+                            cluster_id=str(cluster_id),
+                            agent_playbook_id=int(agent_playbook_id),
+                            member_ids=tuple(int(row[0]) for row in rows),
+                        )
+                    )
+        return samples
+
+    def defer_playbook_aggregation_cluster_rebuild(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        reason: str,
+    ) -> None:
+        with self._lock:
+            updated = self.conn.execute(
+                "UPDATE playbook_aggregation_cluster SET "
+                "rebuild_attempt_count=rebuild_attempt_count+1, "
+                "rebuild_next_attempt_at=unixepoch()+min(?, ?*(1 << "
+                "min(rebuild_attempt_count, 6))) WHERE cluster_id=? "
+                "AND agent_version=? AND state='rebuilding' "
+                "AND agent_playbook_id=?",
+                (
+                    AGGREGATION_RETRY_MAX_SECONDS,
+                    AGGREGATION_RETRY_BASE_SECONDS,
+                    cluster_id,
+                    agent_version,
+                    expected_agent_playbook_id,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise RuntimeError("aggregation rebuilding cluster changed")
+            self.conn.execute(
+                "UPDATE playbook_aggregation_item SET reason=?, attempt_count=0, "
+                "last_attempt_at=NULL, updated_at=unixepoch() WHERE agent_version=? "
+                "AND cluster_id=? AND disposition='residual'",
+                (reason, agent_version, cluster_id),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+
+    def complete_playbook_aggregation_cluster_rebuild(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        replacement_agent_playbook_id: int,
+        centroid_embedding: list[float],
+        embedding_model: str,
+    ) -> int:
+        if not centroid_embedding:
+            raise ValueError("cluster centroid embedding must be non-empty")
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT index_rowid, embedding_dimension FROM "
+                "playbook_aggregation_cluster WHERE cluster_id=? AND agent_version=? "
+                "AND state='rebuilding' AND agent_playbook_id=?",
+                (cluster_id, agent_version, expected_agent_playbook_id),
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("aggregation rebuilding cluster changed")
+            if int(row[1]) != len(centroid_embedding):
+                raise ValueError("aggregation embedding dimension changed")
+            member_count = int(
+                self.conn.execute(
+                    "SELECT count(*) FROM playbook_aggregation_item WHERE "
+                    "agent_version=? AND cluster_id=? AND disposition='residual'",
+                    (agent_version, cluster_id),
+                ).fetchone()[0]
+            )
+            if member_count <= 0:
+                raise RuntimeError("aggregation rebuilding cluster has no members")
+            self.conn.execute(
+                "UPDATE playbook_aggregation_item SET disposition='cluster_member', "
+                "reason='rebuild_complete', updated_at=unixepoch() WHERE "
+                "agent_version=? AND cluster_id=? AND disposition='residual'",
+                (agent_version, cluster_id),
+            )
+            updated = self.conn.execute(
+                "UPDATE playbook_aggregation_cluster SET agent_playbook_id=?, "
+                "centroid=?, vector_sum=NULL, member_count=?, embedding_model=?, "
+                "state='active', dirty=0, rebuild_cursor=0, "
+                "rebuild_attempt_count=0, rebuild_next_attempt_at=0 "
+                "WHERE cluster_id=? "
+                "AND agent_version=? AND state='rebuilding' AND agent_playbook_id=?",
+                (
+                    replacement_agent_playbook_id,
+                    json.dumps(centroid_embedding),
+                    member_count,
+                    embedding_model,
+                    cluster_id,
+                    agent_version,
+                    expected_agent_playbook_id,
+                ),
+            )
+            if updated.rowcount != 1:
+                raise RuntimeError("aggregation rebuilding cluster changed")
+            rowid = int(row[0])
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?", (rowid,)
+            )
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
+                "VALUES (?, ?)",
+                (rowid, json.dumps(centroid_embedding)),
+            )
+            if self._own_transaction():
+                self.conn.commit()
+            return member_count
+
+    def discard_playbook_aggregation_cluster_rebuild(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        reason: str,
+    ) -> int:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT index_rowid FROM playbook_aggregation_cluster WHERE "
+                "cluster_id=? AND agent_version=? AND state='rebuilding' "
+                "AND agent_playbook_id=?",
+                (cluster_id, agent_version, expected_agent_playbook_id),
+            ).fetchone()
+            if row is None:
+                raise RuntimeError("aggregation rebuilding cluster changed")
+            updated = self.conn.execute(
+                "UPDATE playbook_aggregation_item SET disposition='terminal_noop', "
+                "cluster_id=NULL, reason=?, updated_at=unixepoch() WHERE "
+                "agent_version=? AND cluster_id=? AND disposition='residual'",
+                (reason, agent_version, cluster_id),
+            )
+            self.conn.execute(
+                "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                (int(row[0]),),
+            )
+            deleted = self.conn.execute(
+                "DELETE FROM playbook_aggregation_cluster WHERE cluster_id=? "
+                "AND agent_version=? AND state='rebuilding' AND agent_playbook_id=?",
+                (cluster_id, agent_version, expected_agent_playbook_id),
+            )
+            if deleted.rowcount != 1:
+                raise RuntimeError("aggregation rebuilding cluster changed")
+            if self._own_transaction():
+                self.conn.commit()
+            return int(updated.rowcount)
+
+    def delete_orphaned_playbook_aggregation_clusters(
+        self, agent_version: str
+    ) -> list[int]:
         with self._lock:
             rows = self.conn.execute(
-                "SELECT index_rowid FROM playbook_aggregation_cluster c "
+                "SELECT index_rowid, agent_playbook_id "
+                "FROM playbook_aggregation_cluster c "
                 "WHERE c.agent_version=? AND c.state='rebuilding' "
                 "AND NOT EXISTS (SELECT 1 FROM playbook_aggregation_item i "
                 "WHERE i.cluster_id=c.cluster_id)",
@@ -962,6 +1363,7 @@ class PlaybookAggregationStoreMixin:
             )
             if self._own_transaction():
                 self.conn.commit()
+        return [int(row[1]) for row in rows if row[1] is not None]
 
     def find_nearest_playbook_aggregation_clusters(
         self,
@@ -989,12 +1391,13 @@ class PlaybookAggregationStoreMixin:
         with self._lock:
             for item_id, embedding in candidates:
                 row = self.conn.execute(
-                    "SELECT c.cluster_id, v.distance FROM ("
+                    "SELECT c.cluster_id, v.distance, c.agent_playbook_id FROM ("
                     "SELECT rowid, distance FROM playbook_aggregation_clusters_vec "
                     "WHERE embedding MATCH ? AND rowid IN ("
                     "SELECT index_rowid FROM playbook_aggregation_cluster "
                     "WHERE agent_version=? AND embedding_model=? "
-                    "AND embedding_dimension=? AND state='active') "
+                    "AND embedding_dimension=? AND state='active' "
+                    "AND agent_playbook_id IS NOT NULL) "
                     "ORDER BY distance LIMIT ?) v "
                     "JOIN playbook_aggregation_cluster c ON c.index_rowid=v.rowid "
                     "ORDER BY v.distance, c.cluster_id LIMIT 1",
@@ -1008,7 +1411,7 @@ class PlaybookAggregationStoreMixin:
                 ).fetchone()
                 if row is not None:
                     matches[item_id] = PlaybookAggregationClusterMatch(
-                        str(row[0]), 1.0 - float(row[1])
+                        str(row[0]), 1.0 - float(row[1]), int(row[2])
                     )
         return matches
 
@@ -1018,16 +1421,15 @@ class PlaybookAggregationStoreMixin:
         cluster_id: str,
         agent_version: str,
         agent_playbook_id: int | None,
-        embeddings: list[list[float]],
+        centroid_embedding: list[float],
+        member_count: int,
         embedding_model: str,
     ) -> None:
-        if not embeddings:
-            raise ValueError("cluster embeddings must be non-empty")
-        dimension = len(embeddings[0])
-        if any(len(value) != dimension for value in embeddings):
-            raise ValueError("cluster embeddings must share one dimension")
-        vector_sum = [sum(values) for values in zip(*embeddings, strict=True)]
-        centroid = [value / len(embeddings) for value in vector_sum]
+        if not centroid_embedding:
+            raise ValueError("cluster centroid embedding must be non-empty")
+        if member_count <= 0:
+            raise ValueError("cluster member_count must be positive")
+        dimension = len(centroid_embedding)
         with self._lock:
             existing = self.conn.execute(
                 "SELECT index_rowid FROM playbook_aggregation_cluster "
@@ -1051,9 +1453,9 @@ class PlaybookAggregationStoreMixin:
                         next_rowid,
                         agent_version,
                         agent_playbook_id,
-                        json.dumps(centroid),
-                        json.dumps(vector_sum),
-                        len(embeddings),
+                        json.dumps(centroid_embedding),
+                        None,
+                        member_count,
                         embedding_model,
                         dimension,
                     ),
@@ -1068,9 +1470,9 @@ class PlaybookAggregationStoreMixin:
                     (
                         agent_version,
                         agent_playbook_id,
-                        json.dumps(centroid),
-                        json.dumps(vector_sum),
-                        len(embeddings),
+                        json.dumps(centroid_embedding),
+                        None,
+                        member_count,
                         embedding_model,
                         dimension,
                         cluster_id,
@@ -1083,7 +1485,7 @@ class PlaybookAggregationStoreMixin:
             self.conn.execute(
                 "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
                 "VALUES (?, ?)",
-                (next_rowid, json.dumps(centroid)),
+                (next_rowid, json.dumps(centroid_embedding)),
             )
             if self._own_transaction():
                 self.conn.commit()
@@ -1092,16 +1494,16 @@ class PlaybookAggregationStoreMixin:
         self,
         *,
         agent_version: str,
-        attachments: list[tuple[int, str, list[float]]],
+        attachments: list[tuple[int, str]],
     ) -> None:
         if not attachments:
             return
-        item_ids = [item_id for item_id, _cluster_id, _embedding in attachments]
+        item_ids = [item_id for item_id, _cluster_id in attachments]
         if len(item_ids) != len(set(item_ids)):
             raise ValueError("aggregation attachment IDs must be unique")
-        grouped: dict[str, list[tuple[int, list[float]]]] = {}
-        for item_id, cluster_id, embedding in attachments:
-            grouped.setdefault(cluster_id, []).append((item_id, embedding))
+        grouped: dict[str, list[int]] = {}
+        for item_id, cluster_id in attachments:
+            grouped.setdefault(cluster_id, []).append(item_id)
         with self._lock:
             own_transaction = self._own_transaction()
             try:
@@ -1111,8 +1513,7 @@ class PlaybookAggregationStoreMixin:
                     page = cluster_ids[offset : offset + 500]
                     placeholders = ",".join("?" for _value in page)
                     rows = self.conn.execute(
-                        "SELECT cluster_id, index_rowid, vector_sum, member_count, "
-                        "embedding_dimension FROM playbook_aggregation_cluster "
+                        "SELECT cluster_id, member_count FROM playbook_aggregation_cluster "
                         f"WHERE agent_version=? AND state='active' AND cluster_id IN ({placeholders})",
                         (agent_version, *page),
                     ).fetchall()
@@ -1122,35 +1523,10 @@ class PlaybookAggregationStoreMixin:
                         "aggregation cluster is not active for agent version"
                     )
 
-                cluster_updates: list[tuple[str, str, int, str]] = []
-                vector_updates: list[tuple[int, str]] = []
+                cluster_updates: list[tuple[int, str]] = []
                 for cluster_id, members in grouped.items():
                     row = cluster_rows[cluster_id]
-                    vector_sum = [float(value) for value in json.loads(row[2])]
-                    dimension = int(row[4])
-                    if len(vector_sum) != dimension or any(
-                        len(embedding) != dimension for _item_id, embedding in members
-                    ):
-                        raise ValueError("aggregation embedding dimension changed")
-                    batch_sum = [
-                        sum(embedding[index] for _item_id, embedding in members)
-                        for index in range(dimension)
-                    ]
-                    updated_sum = [
-                        left + right
-                        for left, right in zip(vector_sum, batch_sum, strict=True)
-                    ]
-                    count = int(row[3]) + len(members)
-                    centroid = [value / count for value in updated_sum]
-                    cluster_updates.append(
-                        (
-                            json.dumps(updated_sum),
-                            json.dumps(centroid),
-                            count,
-                            cluster_id,
-                        )
-                    )
-                    vector_updates.append((int(row[1]), json.dumps(centroid)))
+                    cluster_updates.append((int(row[1]) + len(members), cluster_id))
 
                 before_changes = self.conn.total_changes
                 self.conn.executemany(
@@ -1160,24 +1536,74 @@ class PlaybookAggregationStoreMixin:
                     "AND disposition='residual'",
                     [
                         (cluster_id, agent_version, item_id)
-                        for item_id, cluster_id, _embedding in attachments
+                        for item_id, cluster_id in attachments
                     ],
                 )
                 if self.conn.total_changes - before_changes != len(attachments):
                     raise RuntimeError("aggregation residual attachment lost its state")
                 self.conn.executemany(
-                    "UPDATE playbook_aggregation_cluster SET vector_sum=?, centroid=?, "
-                    "member_count=? WHERE cluster_id=? AND agent_version=?",
+                    "UPDATE playbook_aggregation_cluster SET member_count=? "
+                    "WHERE cluster_id=? AND agent_version=? AND state='active'",
                     [(*update, agent_version) for update in cluster_updates],
                 )
-                self.conn.executemany(
-                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
-                    [(rowid,) for rowid, _centroid in vector_updates],
+                if own_transaction:
+                    self.conn.commit()
+            except Exception:
+                if own_transaction:
+                    self.conn.rollback()
+                raise
+
+    def replace_playbook_aggregation_cluster_agent(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        replacement_agent_playbook_id: int,
+        centroid_embedding: list[float],
+        embedding_model: str,
+    ) -> None:
+        if not centroid_embedding:
+            raise ValueError("cluster centroid embedding must be non-empty")
+        with self._lock:
+            own_transaction = self._own_transaction()
+            try:
+                row = self.conn.execute(
+                    "SELECT index_rowid, embedding_dimension FROM "
+                    "playbook_aggregation_cluster WHERE cluster_id=? "
+                    "AND agent_version=? AND state='active' "
+                    "AND agent_playbook_id=?",
+                    (cluster_id, agent_version, expected_agent_playbook_id),
+                ).fetchone()
+                if row is None:
+                    raise RuntimeError("aggregation cluster agent changed")
+                if int(row[1]) != len(centroid_embedding):
+                    raise ValueError("aggregation embedding dimension changed")
+                updated = self.conn.execute(
+                    "UPDATE playbook_aggregation_cluster SET agent_playbook_id=?, "
+                    "centroid=?, vector_sum=NULL, embedding_model=?, dirty=0 "
+                    "WHERE cluster_id=? AND agent_version=? AND state='active' "
+                    "AND agent_playbook_id=?",
+                    (
+                        replacement_agent_playbook_id,
+                        json.dumps(centroid_embedding),
+                        embedding_model,
+                        cluster_id,
+                        agent_version,
+                        expected_agent_playbook_id,
+                    ),
                 )
-                self.conn.executemany(
+                if updated.rowcount != 1:
+                    raise RuntimeError("aggregation cluster agent changed")
+                rowid = int(row[0])
+                self.conn.execute(
+                    "DELETE FROM playbook_aggregation_clusters_vec WHERE rowid=?",
+                    (rowid,),
+                )
+                self.conn.execute(
                     "INSERT INTO playbook_aggregation_clusters_vec(rowid, embedding) "
                     "VALUES (?, ?)",
-                    vector_updates,
+                    (rowid, json.dumps(centroid_embedding)),
                 )
                 if own_transaction:
                     self.conn.commit()

--- a/reflexio/server/services/storage/storage_base/playbook/__init__.py
+++ b/reflexio/server/services/storage/storage_base/playbook/__init__.py
@@ -8,6 +8,7 @@ from ._aggregation import (
     PlaybookAggregationClaim,
     PlaybookAggregationClusterMatch,
     PlaybookAggregationInvalidation,
+    PlaybookAggregationRebuildSample,
     PlaybookAggregationRerunSnapshot,
     PlaybookAggregationStoreMixin,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "PlaybookAggregationClaim",
     "PlaybookAggregationClusterMatch",
     "PlaybookAggregationInvalidation",
+    "PlaybookAggregationRebuildSample",
     "PlaybookAggregationRerunSnapshot",
     "PlaybookAggregationStoreMixin",
     "OptimizationJobStoreMixin",

--- a/reflexio/server/services/storage/storage_base/playbook/_agent.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_agent.py
@@ -101,6 +101,7 @@ class AgentPlaybookStoreMixin:
         status_filter: list[Status | None] | None = None,
         playbook_status_filter: list[PlaybookStatus] | None = None,
         include_inactive: bool = False,
+        include_embedding: bool = False,
     ) -> list[AgentPlaybook]:
         """Fetch agent playbooks in bulk with lifecycle filters.
 
@@ -120,6 +121,8 @@ class AgentPlaybookStoreMixin:
                 on ``get_agent_playbook_by_id``, which only unhides
                 MERGED/SUPERSEDED for lineage walks. The default preserves
                 retrieval behavior.
+            include_embedding (bool): Hydrate stored embeddings for callers
+                that need the canonical vector. Defaults to False.
 
         Returns:
             list[AgentPlaybook]: Matching playbooks. Order is unspecified.

--- a/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
@@ -274,7 +274,11 @@ class PlaybookAggregationStoreMixin:
         expected_agent_playbook_id: int,
         reason: str,
     ) -> None:
-        """Apply one durable retry cooldown to an entire rebuilding cluster."""
+        """Apply one durable retry cooldown to an entire rebuilding cluster.
+
+        Raises:
+            RuntimeError: If the expected agent no longer owns the rebuilding cluster.
+        """
         raise NotImplementedError
 
     def complete_playbook_aggregation_cluster_rebuild(
@@ -287,7 +291,13 @@ class PlaybookAggregationStoreMixin:
         centroid_embedding: list[float],
         embedding_model: str,
     ) -> int:
-        """Activate a rebuilt cluster and restore all remaining memberships."""
+        """Activate a rebuilt cluster and restore all remaining memberships.
+
+        Raises:
+            RuntimeError: If the expected agent no longer owns the rebuilding cluster
+                or the cluster has no residual members.
+            ValueError: If the replacement embedding dimension changed.
+        """
         raise NotImplementedError
 
     def discard_playbook_aggregation_cluster_rebuild(
@@ -298,7 +308,11 @@ class PlaybookAggregationStoreMixin:
         expected_agent_playbook_id: int,
         reason: str,
     ) -> int:
-        """Terminalize all remaining members and delete a redundant rebuild."""
+        """Terminalize all remaining members and delete a redundant rebuild.
+
+        Raises:
+            RuntimeError: If the expected agent no longer owns the rebuilding cluster.
+        """
         raise NotImplementedError
 
     def delete_orphaned_playbook_aggregation_clusters(

--- a/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
@@ -35,6 +35,7 @@ class PlaybookAggregationBacklog:
     oldest_residual_age_seconds: int | None = None
     dirty_repairs: int = 0
     residual_retry_after_seconds: int = 0
+    repair_retry_after_seconds: int = 0
 
     @property
     def pending(self) -> bool:
@@ -44,10 +45,15 @@ class PlaybookAggregationBacklog:
 
     @property
     def continuation_delay_seconds(self) -> int:
-        """Delay residual-only work until its durable retry cooldown expires."""
-        if self.undisposed or self.invalidations or self.dirty_repairs:
+        """Delay retry-only work until its earliest durable cooldown expires."""
+        if self.undisposed or self.invalidations:
             return 0
-        return max(0, self.residual_retry_after_seconds) if self.residual else 0
+        delays: list[int] = []
+        if self.residual:
+            delays.append(max(0, self.residual_retry_after_seconds))
+        if self.dirty_repairs:
+            delays.append(max(0, self.repair_retry_after_seconds))
+        return min(delays, default=0)
 
 
 @dataclass(frozen=True)
@@ -63,6 +69,7 @@ class PlaybookAggregationInvalidation:
 class PlaybookAggregationClusterMatch:
     cluster_id: str
     similarity: float
+    agent_playbook_id: int
 
 
 @dataclass(frozen=True)
@@ -73,6 +80,15 @@ class PlaybookAggregationRerunSnapshot:
     invalidation_ids: tuple[int, ...]
     user_high_watermark: int | None
     invalidation_high_watermark: int | None
+
+
+@dataclass(frozen=True)
+class PlaybookAggregationRebuildSample:
+    """Bounded prompt inputs for one invalidated cluster rebuild."""
+
+    cluster_id: str
+    agent_playbook_id: int
+    member_ids: tuple[int, ...]
 
 
 class PlaybookAggregationStoreMixin:
@@ -128,9 +144,9 @@ class PlaybookAggregationStoreMixin:
         raise NotImplementedError
 
     def stage_playbook_aggregation_intake(
-        self, agent_version: str, *, limit: int
+        self, agent_version: str, *, limit: int, window_limit: int = 20_000
     ) -> list[int]:
-        """Anti-join eligible CURRENT rows and durably stage them as residual."""
+        """Stage new rows from the durable newest-N unclustered window."""
         raise NotImplementedError
 
     def get_playbook_aggregation_bootstrap_status(self, agent_version: str) -> str:
@@ -155,6 +171,7 @@ class PlaybookAggregationStoreMixin:
         cluster_id: str,
         agent_version: str,
         agent_playbook_id: int,
+        centroid_embedding: list[float],
         member_embeddings: list[tuple[int, list[float]]],
         embedding_model: str,
         embedding_dimension: int,
@@ -237,14 +254,57 @@ class PlaybookAggregationStoreMixin:
         """Fenced, idempotent removal plus invalidation completion."""
         raise NotImplementedError
 
-    def get_playbook_aggregation_replacement_agent_ids(
+    def get_playbook_aggregation_rebuild_cluster_ids(
         self, agent_version: str, user_playbook_ids: list[int]
-    ) -> list[int]:
-        """Return prior agents for rebuilding clusters touched by these members."""
+    ) -> dict[int, str]:
+        """Map selected residual members back to their rebuilding cluster."""
         raise NotImplementedError
 
-    def delete_orphaned_playbook_aggregation_clusters(self, agent_version: str) -> None:
-        """Delete rebuilding clusters after no item retains their provenance."""
+    def get_playbook_aggregation_rebuild_samples(
+        self, agent_version: str, cluster_ids: list[str], *, limit_per_cluster: int
+    ) -> list[PlaybookAggregationRebuildSample]:
+        """Return recent CURRENT members for each requested rebuilding cluster."""
+        raise NotImplementedError
+
+    def defer_playbook_aggregation_cluster_rebuild(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        reason: str,
+    ) -> None:
+        """Apply one durable retry cooldown to an entire rebuilding cluster."""
+        raise NotImplementedError
+
+    def complete_playbook_aggregation_cluster_rebuild(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        replacement_agent_playbook_id: int,
+        centroid_embedding: list[float],
+        embedding_model: str,
+    ) -> int:
+        """Activate a rebuilt cluster and restore all remaining memberships."""
+        raise NotImplementedError
+
+    def discard_playbook_aggregation_cluster_rebuild(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        reason: str,
+    ) -> int:
+        """Terminalize all remaining members and delete a redundant rebuild."""
+        raise NotImplementedError
+
+    def delete_orphaned_playbook_aggregation_clusters(
+        self, agent_version: str
+    ) -> list[int]:
+        """Delete empty rebuilding clusters and return their former agent IDs."""
         raise NotImplementedError
 
     def find_nearest_playbook_aggregation_clusters(
@@ -264,17 +324,31 @@ class PlaybookAggregationStoreMixin:
         cluster_id: str,
         agent_version: str,
         agent_playbook_id: int | None,
-        embeddings: list[list[float]],
+        centroid_embedding: list[float],
+        member_count: int,
         embedding_model: str,
     ) -> None:
-        """Persist a stable cluster and assign its staged members separately."""
+        """Persist a cluster whose centroid is its current agent embedding."""
         raise NotImplementedError
 
     def attach_playbook_aggregation_items(
         self,
         *,
         agent_version: str,
-        attachments: list[tuple[int, str, list[float]]],
+        attachments: list[tuple[int, str]],
     ) -> None:
-        """Atomically attach residuals and update each affected centroid once."""
+        """Attach residuals without changing the current agent centroid."""
+        raise NotImplementedError
+
+    def replace_playbook_aggregation_cluster_agent(
+        self,
+        *,
+        cluster_id: str,
+        agent_version: str,
+        expected_agent_playbook_id: int,
+        replacement_agent_playbook_id: int,
+        centroid_embedding: list[float],
+        embedding_model: str,
+    ) -> None:
+        """CAS the current agent and its embedding-backed centroid."""
         raise NotImplementedError

--- a/tests/server/services/playbook/test_aggregation_scheduler.py
+++ b/tests/server/services/playbook/test_aggregation_scheduler.py
@@ -15,7 +15,7 @@ from reflexio.server.services.storage.storage_base.playbook import (
 )
 
 
-def _context(storage: MagicMock) -> Any:
+def _context(storage: Any) -> Any:
     aggregation_config = SimpleNamespace()
     config = SimpleNamespace(
         user_playbook_extractor_config=SimpleNamespace(
@@ -29,7 +29,7 @@ def _context(storage: MagicMock) -> Any:
     )
 
 
-def test_scheduler_passes_claim_and_remaining_shared_budget(
+def test_scheduler_keeps_invalidation_and_clustering_budgets_separate(
     monkeypatch, caplog
 ) -> None:
     claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
@@ -72,7 +72,7 @@ def test_scheduler_passes_claim_and_remaining_shared_budget(
     scheduler._run_context(_context(storage))
 
     assert captured["aggregation_claim"] == claim
-    assert captured["work_budget"] == 6
+    assert captured["residual_batch_limit"] == 8
     storage.finish_playbook_aggregation_claim.assert_called_once()
     assert storage.finish_playbook_aggregation_claim.call_args.kwargs["success"] is True
     assert (
@@ -86,6 +86,45 @@ def test_scheduler_passes_claim_and_remaining_shared_budget(
     )
     storage.get_playbook_aggregation_backlog.assert_called_once_with("v1")
     assert "state=succeeded" in caplog.text
+
+
+def test_scheduler_drains_invalidation_page_before_llm_work(
+    monkeypatch, caplog
+) -> None:
+    claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
+    storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.repair_playbook_aggregation_pending_state.return_value = []
+    storage.claim_due_playbook_aggregation.return_value = claim
+    storage.get_playbook_aggregation_invalidations.return_value = [
+        SimpleNamespace(invalidation_id=value)
+        for value in range(
+            1, aggregation_scheduler.AGGREGATION_INVALIDATION_BATCH_SIZE + 2
+        )
+    ]
+    storage.apply_playbook_aggregation_invalidations.return_value = True
+    after = PlaybookAggregationBacklog(0, 0, 1)
+    storage.get_playbook_aggregation_backlog.return_value = after
+    storage.finish_playbook_aggregation_claim.return_value = True
+    run = MagicMock()
+    monkeypatch.setattr(aggregation_scheduler, "run_with_operation_limit", run)
+    caplog.set_level(logging.INFO, logger=aggregation_scheduler.logger.name)
+
+    scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
+        context_provider=lambda: [], worker_id="worker"
+    )
+    scheduler._run_context(_context(storage))
+
+    requested = storage.get_playbook_aggregation_invalidations.call_args.kwargs
+    assert requested["limit"] == (
+        aggregation_scheduler.AGGREGATION_INVALIDATION_BATCH_SIZE + 1
+    )
+    applied_ids = storage.apply_playbook_aggregation_invalidations.call_args.args[1]
+    assert applied_ids == list(
+        range(1, aggregation_scheduler.AGGREGATION_INVALIDATION_BATCH_SIZE + 1)
+    )
+    run.assert_not_called()
+    assert storage.finish_playbook_aggregation_claim.call_args.kwargs["success"] is True
+    assert "state=draining_invalidations" in caplog.text
 
 
 def test_scheduler_keeps_pending_on_limiter_deferral(monkeypatch) -> None:

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -43,6 +43,9 @@ from reflexio.server.services.playbook.playbook_service_utils import (
     PlaybookAggregatorRequest,
     StructuredPlaybookContent,
 )
+from reflexio.server.services.storage.storage_base.playbook import (
+    PlaybookAggregationRebuildSample,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -1891,6 +1894,62 @@ class TestProcessAggregationResponse:
         assert [item.source_cluster for item in outcomes] == [cluster_a, cluster_b]
         assert outcomes[0].source_cluster[0] is cluster_a[0]
         assert outcomes[1].source_cluster[0] is cluster_b[0]
+
+    def test_generation_prompt_is_bounded_without_truncating_membership(self):
+        agg = _make_aggregator()
+        cluster = [_raw(item_id) for item_id in range(1, 151)]
+        captured: list[UserPlaybook] = []
+
+        def generate(prompt_sources, *_args, **_kwargs):
+            captured.extend(prompt_sources)
+            return aggregator_module.AggregationGenerationOutcome(
+                "semantic_null", prompt_sources
+            )
+
+        agg._generate_playbook_from_cluster_outcome = generate  # type: ignore[method-assign]
+        outcomes = agg._generate_playbook_outcomes_with_source_clusters(
+            {0: cluster},
+            [],
+            current_agent_playbooks={0: _agent_playbook()},
+        )
+
+        assert len(captured) == 100
+        assert [item.user_playbook_id for item in captured] == list(range(150, 50, -1))
+        assert outcomes[0].source_cluster == cluster
+
+    def test_rebuild_retry_defers_the_cluster_not_individual_members(self):
+        storage = MagicMock()
+        agg = _make_aggregator(storage=storage)
+        source = _raw(1)
+        work = aggregator_module._RebuildWork(
+            sample=PlaybookAggregationRebuildSample(
+                cluster_id="cluster-a",
+                agent_playbook_id=42,
+                member_ids=(1,),
+            ),
+            members=[source],
+        )
+
+        saved, replaced, rebuilt = agg._apply_rebuild_outcomes(
+            [work],
+            [
+                aggregator_module.AggregationGenerationOutcome(
+                    "retryable_failure", [source]
+                )
+            ],
+            MagicMock(),
+        )
+
+        assert saved == []
+        assert replaced == set()
+        assert rebuilt == 0
+        storage.defer_playbook_aggregation_cluster_rebuild.assert_called_once_with(
+            cluster_id="cluster-a",
+            agent_version="v1",
+            expected_agent_playbook_id=42,
+            reason="llm_retryable_failure",
+        )
+        storage.set_playbook_aggregation_disposition.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/playbook/test_playbook_aggregator.py
+++ b/tests/server/services/playbook/test_playbook_aggregator.py
@@ -1895,7 +1895,10 @@ class TestProcessAggregationResponse:
         assert outcomes[0].source_cluster[0] is cluster_a[0]
         assert outcomes[1].source_cluster[0] is cluster_b[0]
 
-    def test_generation_prompt_is_bounded_without_truncating_membership(self):
+    @pytest.mark.parametrize("is_incremental_refresh", [False, True])
+    def test_generation_prompt_is_bounded_without_truncating_membership(
+        self, is_incremental_refresh: bool
+    ):
         agg = _make_aggregator()
         cluster = [_raw(item_id) for item_id in range(1, 151)]
         captured: list[UserPlaybook] = []
@@ -1910,7 +1913,9 @@ class TestProcessAggregationResponse:
         outcomes = agg._generate_playbook_outcomes_with_source_clusters(
             {0: cluster},
             [],
-            current_agent_playbooks={0: _agent_playbook()},
+            current_agent_playbooks=(
+                {0: _agent_playbook()} if is_incremental_refresh else None
+            ),
         )
 
         assert len(captured) == 100
@@ -1930,7 +1935,7 @@ class TestProcessAggregationResponse:
             members=[source],
         )
 
-        saved, replaced, rebuilt = agg._apply_rebuild_outcomes(
+        saved, rebuilt, supersessions, fence_losses = agg._apply_rebuild_outcomes(
             [work],
             [
                 aggregator_module.AggregationGenerationOutcome(
@@ -1938,11 +1943,13 @@ class TestProcessAggregationResponse:
                 )
             ],
             MagicMock(),
+            run_id="run-1",
         )
 
         assert saved == []
-        assert replaced == set()
         assert rebuilt == 0
+        assert supersessions == 0
+        assert fence_losses == 0
         storage.defer_playbook_aggregation_cluster_rebuild.assert_called_once_with(
             cluster_id="cluster-a",
             agent_version="v1",

--- a/tests/server/services/storage/test_playbook_aggregation_state_integration.py
+++ b/tests/server/services/storage/test_playbook_aggregation_state_integration.py
@@ -14,6 +14,7 @@ from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     PlaybookStatus,
     Status,
+    UserPlaybook,
 )
 from reflexio.models.config_schema import (
     Config,
@@ -24,6 +25,7 @@ from reflexio.models.config_schema import (
 from reflexio.server.services.operation_state_utils import OperationStateManager
 from reflexio.server.services.playbook.components.aggregator import (
     AggregationGenerationOutcome,
+    AggregationGenerationStatus,
     PlaybookAggregator,
 )
 from reflexio.server.services.playbook.playbook_service_utils import (
@@ -122,18 +124,159 @@ def _insert_current(
     store.conn.commit()
 
 
-def test_bounded_antijoin_discovers_late_lower_id(tmp_path) -> None:
+def test_create_schedules_intake_without_queueing_invalidation(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(tmp_path)
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    playbook = UserPlaybook(
+        user_id="new-user",
+        agent_version="v1",
+        request_id="new-request",
+        playbook_name="playbook",
+        content="Newly discovered behavior.",
+        trigger="when new work arrives",
+        source="api",
+    )
+
+    store.save_user_playbooks([playbook])
+
+    assert store.get_playbook_aggregation_invalidations("v1", limit=10) == []
+    assert tuple(
+        store.conn.execute(
+            "SELECT pending, next_attempt_at IS NOT NULL "
+            "FROM playbook_aggregation_state WHERE agent_version='v1'"
+        ).fetchone()
+    ) == (1, 1)
+
+
+@pytest.mark.parametrize(
+    ("operation", "expected_reason"),
+    [
+        ("reject", "agent_playbook_changed"),
+        ("edit", "agent_playbook_changed"),
+        ("archive", "agent_playbook_changed"),
+        ("delete", "agent_playbook_deleted"),
+    ],
+)
+def test_agent_mutation_retires_active_aggregation_cluster(
+    vec_store,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    expected_reason: str,
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    _insert_current(
+        store,
+        1,
+        embedding=json.dumps(embedding),
+        trigger="same trigger",
+    )
+    store.stage_playbook_aggregation_intake("v1", limit=1)
+    agent = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                agent_version="v1",
+                playbook_name="playbook",
+                content="Current aggregate",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    store.create_playbook_aggregation_cluster(
+        cluster_id="mutable-agent-cluster",
+        agent_version="v1",
+        agent_playbook_id=agent.agent_playbook_id,
+        centroid_embedding=agent.embedding,
+        member_count=1,
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1",
+        [1],
+        disposition="cluster_member",
+        cluster_id="mutable-agent-cluster",
+    )
+
+    if operation == "reject":
+        store.update_agent_playbook_status(
+            agent.agent_playbook_id, PlaybookStatus.REJECTED
+        )
+    elif operation == "edit":
+        store.update_agent_playbook(agent.agent_playbook_id, trigger="edited trigger")
+    elif operation == "archive":
+        store.archive_agent_playbooks_by_ids([agent.agent_playbook_id])
+    else:
+        store.delete_agent_playbook(agent.agent_playbook_id)
+
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_cluster"
+        ).fetchone()[0]
+        == 0
+    )
+    assert tuple(
+        store.conn.execute(
+            "SELECT disposition, cluster_id, reason, attempt_count, last_attempt_at "
+            "FROM playbook_aggregation_item WHERE user_playbook_id=1"
+        ).fetchone()
+    ) == ("residual", None, expected_reason, 0, None)
+    assert (
+        store.conn.execute(
+            "SELECT pending FROM playbook_aggregation_state WHERE agent_version='v1'"
+        ).fetchone()[0]
+        == 1
+    )
+
+
+def test_intake_durably_keeps_only_the_newest_unclustered_window(tmp_path) -> None:
     store = _store(tmp_path)
     for item_id in range(10, 17):
         _insert_current(store, item_id)
 
-    assert store.stage_playbook_aggregation_intake("v1", limit=3) == [10, 11, 12]
-    assert store.stage_playbook_aggregation_intake("v1", limit=3) == [13, 14, 15]
+    assert store.stage_playbook_aggregation_intake("v1", limit=3, window_limit=5) == [
+        16,
+        15,
+        14,
+    ]
+    assert store.stage_playbook_aggregation_intake("v1", limit=3, window_limit=5) == [
+        13,
+        12,
+    ]
 
-    # Simulates a lower sequence value whose allocating transaction committed late.
+    # A later low-ID commit is permanently below the cutoff. A genuinely newer
+    # row advances the window and terminalizes the residual that fell out.
     _insert_current(store, 2)
-    assert store.stage_playbook_aggregation_intake("v1", limit=3) == [2, 16]
-    assert store.stage_playbook_aggregation_intake("v1", limit=3) == []
+    _insert_current(store, 17)
+    assert store.stage_playbook_aggregation_intake("v1", limit=3, window_limit=5) == [
+        17
+    ]
+    assert store.stage_playbook_aggregation_intake("v1", limit=3, window_limit=5) == []
+    assert (
+        store.conn.execute(
+            "SELECT intake_floor_user_playbook_id FROM playbook_aggregation_state "
+            "WHERE agent_version='v1'"
+        ).fetchone()[0]
+        == 13
+    )
+    assert tuple(
+        store.conn.execute(
+            "SELECT disposition, reason FROM playbook_aggregation_item "
+            "WHERE agent_version='v1' AND user_playbook_id=12"
+        ).fetchone()
+    ) == ("terminal_noop", "outside_recent_clustering_window")
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_item WHERE user_playbook_id=2"
+        ).fetchone()[0]
+        == 0
+    )
     assert store.get_playbook_aggregation_backlog("v1").undisposed == 0
 
 
@@ -233,7 +376,7 @@ def test_successful_bounded_run_with_backlog_is_due_again_immediately(tmp_path) 
     assert continuation.agent_version == "v1"
 
 
-def test_new_signal_advances_an_idle_version_to_due_now(tmp_path) -> None:
+def test_new_signal_preserves_idle_version_hourly_window(tmp_path) -> None:
     store = _store(tmp_path)
     store.schedule_playbook_aggregation("v1")
     claim = store.claim_due_playbook_aggregation(owner="worker-a", lease_seconds=30)
@@ -250,8 +393,7 @@ def test_new_signal_advances_an_idle_version_to_due_now(tmp_path) -> None:
     store.schedule_playbook_aggregation("v1")
 
     assert (
-        store.claim_due_playbook_aggregation(owner="worker-b", lease_seconds=30)
-        is not None
+        store.claim_due_playbook_aggregation(owner="worker-b", lease_seconds=30) is None
     )
 
 
@@ -511,8 +653,9 @@ def test_sqlite_vec_centroid_lookup_and_attachment(vec_store) -> None:
     store.create_playbook_aggregation_cluster(
         cluster_id=cluster_id,
         agent_version="v1",
-        agent_playbook_id=None,
-        embeddings=[embedding, embedding],
+        agent_playbook_id=101,
+        centroid_embedding=embedding,
+        member_count=2,
         embedding_model=store.embedding_model_name,
     )
     store.set_playbook_aggregation_disposition(
@@ -536,7 +679,7 @@ def test_sqlite_vec_centroid_lookup_and_attachment(vec_store) -> None:
     assert match.similarity > 0.99
     store.attach_playbook_aggregation_items(
         agent_version="v1",
-        attachments=[(3, cluster_id, scaled_embedding)],
+        attachments=[(3, cluster_id)],
     )
     assert (
         store.conn.execute(
@@ -545,6 +688,32 @@ def test_sqlite_vec_centroid_lookup_and_attachment(vec_store) -> None:
         ).fetchone()[0]
         == 3
     )
+    replacement_embedding = [0.0] * store.embedding_dimensions
+    replacement_embedding[1] = 1.0
+    store.replace_playbook_aggregation_cluster_agent(
+        cluster_id=cluster_id,
+        agent_version="v1",
+        expected_agent_playbook_id=101,
+        replacement_agent_playbook_id=102,
+        centroid_embedding=replacement_embedding,
+        embedding_model=store.embedding_model_name,
+    )
+    refreshed = store.conn.execute(
+        "SELECT agent_playbook_id, centroid, vector_sum FROM "
+        "playbook_aggregation_cluster WHERE cluster_id=?",
+        (cluster_id,),
+    ).fetchone()
+    assert refreshed[0] == 102
+    assert json.loads(refreshed[1]) == replacement_embedding
+    assert refreshed[2] is None
+    replacement_match = store.find_nearest_playbook_aggregation_clusters(
+        "v1",
+        [(3, replacement_embedding)],
+        embedding_model=store.embedding_model_name,
+        limit=10,
+    )[3]
+    assert replacement_match.agent_playbook_id == 102
+    assert replacement_match.similarity > 0.99
 
 
 def test_centroid_batches_are_strictly_isolated_by_agent_version(vec_store) -> None:
@@ -559,15 +728,17 @@ def test_centroid_batches_are_strictly_isolated_by_agent_version(vec_store) -> N
     store.create_playbook_aggregation_cluster(
         cluster_id="cluster-v1",
         agent_version="v1",
-        agent_playbook_id=None,
-        embeddings=[embedding],
+        agent_playbook_id=101,
+        centroid_embedding=embedding,
+        member_count=1,
         embedding_model=store.embedding_model_name,
     )
     store.create_playbook_aggregation_cluster(
         cluster_id="cluster-v2",
         agent_version="v2",
-        agent_playbook_id=None,
-        embeddings=[other_embedding],
+        agent_playbook_id=202,
+        centroid_embedding=other_embedding,
+        member_count=1,
         embedding_model=store.embedding_model_name,
     )
     store.set_playbook_aggregation_disposition(
@@ -587,7 +758,7 @@ def test_centroid_batches_are_strictly_isolated_by_agent_version(vec_store) -> N
     with pytest.raises(RuntimeError, match="not active for agent version"):
         store.attach_playbook_aggregation_items(
             agent_version="v2",
-            attachments=[(3, "cluster-v1", embedding)],
+            attachments=[(3, "cluster-v1")],
         )
     disposition = store.conn.execute(
         "SELECT disposition, cluster_id FROM playbook_aggregation_item "
@@ -608,8 +779,9 @@ def test_invalidation_dissolves_cluster_and_requeues_unaffected_members(
     store.create_playbook_aggregation_cluster(
         cluster_id="cluster-to-dissolve",
         agent_version="v1",
-        agent_playbook_id=None,
-        embeddings=[embedding, embedding],
+        agent_playbook_id=101,
+        centroid_embedding=embedding,
+        member_count=2,
         embedding_model=store.embedding_model_name,
     )
     store.set_playbook_aggregation_disposition(
@@ -644,8 +816,9 @@ def test_invalidation_dissolves_cluster_and_requeues_unaffected_members(
     store.create_playbook_aggregation_cluster(
         cluster_id="cluster-to-dissolve",
         agent_version="v1",
-        agent_playbook_id=None,
-        embeddings=[embedding],
+        agent_playbook_id=102,
+        centroid_embedding=embedding,
+        member_count=1,
         embedding_model=store.embedding_model_name,
     )
     rebuilt = store.conn.execute(
@@ -741,7 +914,7 @@ def test_nonnumeric_lineage_entity_does_not_abort_on_numeric_source(tmp_path) ->
     )
 
 
-def test_incremental_run_creates_once_then_attaches_without_replacement(
+def test_incremental_run_refreshes_agent_and_centroid_after_match(
     vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = vec_store
@@ -777,24 +950,40 @@ def test_incremental_run_creates_once_then_attaches_without_replacement(
     assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
 
     _insert_current(store, 3, embedding=encoded, trigger="same trigger")
+    _insert_current(store, 4, embedding=encoded, trigger="same trigger")
     second = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
-    assert second["playbooks_generated"] == 0
-    assert second["attachments"] == 1
-    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
+    assert second["playbooks_generated"] == 1
+    assert second["attachments"] == 2
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 2
     assert (
         store.conn.execute(
             "SELECT member_count FROM playbook_aggregation_cluster"
         ).fetchone()[0]
-        == 3
+        == 4
     )
+    agent_rows = store.conn.execute(
+        "SELECT agent_playbook_id, status FROM agent_playbooks "
+        "ORDER BY agent_playbook_id"
+    ).fetchall()
+    assert agent_rows[0][1] == Status.SUPERSEDED.value
+    assert agent_rows[1][1] is None
+    cluster_agent_id = store.conn.execute(
+        "SELECT agent_playbook_id FROM playbook_aggregation_cluster"
+    ).fetchone()[0]
+    assert cluster_agent_id == agent_rows[1][0]
 
     old_agent_id = int(
         store.conn.execute(
             "SELECT agent_playbook_id FROM agent_playbooks WHERE status IS NULL"
         ).fetchone()[0]
     )
+    store.conn.execute(
+        "UPDATE user_playbooks SET status=? WHERE user_playbook_id=1",
+        (Status.SUPERSEDED.value,),
+    )
+    _insert_current(store, 5, embedding=encoded, trigger="same trigger")
     store.append_playbook_aggregation_invalidation(
-        agent_version="v1", operation="revise", entity_id=1
+        agent_version="v1", operation="revise", entity_id=5, source_ids=[1]
     )
     claim = store.claim_due_playbook_aggregation(owner="replacement", lease_seconds=30)
     assert claim is not None
@@ -808,23 +997,420 @@ def test_incremental_run_creates_once_then_attaches_without_replacement(
         request_context=context,
         agent_version="v1",
         aggregation_claim=claim,
-        work_budget=10,
+        residual_batch_limit=1,
     ).run(PlaybookAggregatorRequest(agent_version="v1"))
     assert replacement["playbooks_generated"] == 1
     assert replacement["supersessions"] == 1
+    assert replacement["rebuilt_members"] == 4
     rows = store.conn.execute(
         "SELECT agent_playbook_id, status FROM agent_playbooks "
         "ORDER BY agent_playbook_id"
     ).fetchall()
-    assert rows[0][0] == old_agent_id
-    assert rows[0][1] == Status.SUPERSEDED.value
-    assert rows[1][1] is None
+    assert rows[1][0] == old_agent_id
+    assert rows[1][1] == Status.SUPERSEDED.value
+    assert rows[2][1] is None
     assert (
         store.conn.execute(
             "SELECT count(*) FROM playbook_aggregation_cluster"
         ).fetchone()[0]
         == 1
     )
+
+    for item_id in (2, 3, 5):
+        assert store.archive_user_playbook_by_id(f"user-{item_id}", item_id)
+    removal_invalidations = store.get_playbook_aggregation_invalidations("v1", limit=10)
+    assert store.apply_playbook_aggregation_invalidations(
+        claim, [item.invalidation_id for item in removal_invalidations]
+    )
+    single_member_rebuild = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=context,
+        agent_version="v1",
+        aggregation_claim=claim,
+        residual_batch_limit=10,
+    ).run(PlaybookAggregatorRequest(agent_version="v1"))
+    assert single_member_rebuild["playbooks_generated"] == 1
+    assert single_member_rebuild["supersessions"] == 1
+    remaining = store.conn.execute(
+        "SELECT i.user_playbook_id, i.disposition, c.member_count "
+        "FROM playbook_aggregation_item i JOIN playbook_aggregation_cluster c "
+        "ON c.cluster_id=i.cluster_id WHERE i.agent_version='v1'"
+    ).fetchall()
+    assert [tuple(row) for row in remaining] == [(4, "cluster_member", 1)]
+
+    current_agent_id = int(
+        store.conn.execute(
+            "SELECT agent_playbook_id FROM agent_playbooks WHERE status IS NULL"
+        ).fetchone()[0]
+    )
+    assert store.archive_user_playbook_by_id("user-4", 4)
+    final_invalidations = store.get_playbook_aggregation_invalidations("v1", limit=10)
+    assert store.apply_playbook_aggregation_invalidations(
+        claim, [item.invalidation_id for item in final_invalidations]
+    )
+    empty_rebuild = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=context,
+        agent_version="v1",
+        aggregation_claim=claim,
+        residual_batch_limit=10,
+    ).run(PlaybookAggregatorRequest(agent_version="v1"))
+    assert empty_rebuild["playbooks_generated"] == 0
+    assert empty_rebuild["supersessions"] == 1
+    assert (
+        store.conn.execute(
+            "SELECT status FROM agent_playbooks WHERE agent_playbook_id=?",
+            (current_agent_id,),
+        ).fetchone()[0]
+        == Status.SUPERSEDED.value
+    )
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_cluster"
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_rebuild_uses_recent_top_100_but_restores_every_member(
+    vec_store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    encoded = json.dumps(embedding)
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    member_ids = list(range(1, 106))
+    for item_id in member_ids:
+        _insert_current(store, item_id, embedding=encoded, trigger="same trigger")
+    store.conn.execute(
+        "UPDATE user_playbooks SET created_at='2026-08-01T00:00:00+00:00' "
+        "WHERE user_playbook_id=1"
+    )
+    store.conn.commit()
+    store.stage_playbook_aggregation_intake("v1", limit=200)
+    current = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Current aggregate",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    store.create_playbook_aggregation_cluster(
+        cluster_id="repair-cluster",
+        agent_version="v1",
+        agent_playbook_id=current.agent_playbook_id,
+        centroid_embedding=current.embedding,
+        member_count=len(member_ids),
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1",
+        member_ids,
+        disposition="cluster_member",
+        cluster_id="repair-cluster",
+    )
+    store.conn.execute(
+        "UPDATE playbook_aggregation_item SET disposition='residual' "
+        "WHERE cluster_id='repair-cluster'"
+    )
+    store.conn.execute(
+        "UPDATE playbook_aggregation_cluster SET state='rebuilding', dirty=1, "
+        "centroid=NULL, member_count=0 WHERE cluster_id='repair-cluster'"
+    )
+    store.conn.commit()
+
+    samples = store.get_playbook_aggregation_rebuild_samples(
+        "v1", ["repair-cluster"], limit_per_cluster=100
+    )
+    assert len(samples) == 1
+    assert samples[0].member_ids == (1, *range(105, 6, -1))
+
+    replacement = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Rebuilt aggregate",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    rebuilt = store.complete_playbook_aggregation_cluster_rebuild(
+        cluster_id="repair-cluster",
+        agent_version="v1",
+        expected_agent_playbook_id=current.agent_playbook_id,
+        replacement_agent_playbook_id=replacement.agent_playbook_id,
+        centroid_embedding=replacement.embedding,
+        embedding_model=store.embedding_model_name,
+    )
+    assert rebuilt == 105
+    assert tuple(
+        store.conn.execute(
+            "SELECT state, member_count, agent_playbook_id FROM "
+            "playbook_aggregation_cluster WHERE cluster_id='repair-cluster'"
+        ).fetchone()
+    ) == ("active", 105, replacement.agent_playbook_id)
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_item WHERE "
+            "cluster_id='repair-cluster' AND disposition='cluster_member'"
+        ).fetchone()[0]
+        == 105
+    )
+
+
+def test_rebuild_failure_defers_the_entire_cluster(
+    vec_store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    encoded = json.dumps(embedding)
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    for item_id in (1, 2):
+        _insert_current(store, item_id, embedding=encoded, trigger="same trigger")
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    current = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Current aggregate",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    store.create_playbook_aggregation_cluster(
+        cluster_id="deferred-repair",
+        agent_version="v1",
+        agent_playbook_id=current.agent_playbook_id,
+        centroid_embedding=current.embedding,
+        member_count=2,
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1",
+        [1, 2],
+        disposition="cluster_member",
+        cluster_id="deferred-repair",
+    )
+    store.conn.execute(
+        "UPDATE playbook_aggregation_item SET disposition='residual' "
+        "WHERE cluster_id='deferred-repair'"
+    )
+    store.conn.execute(
+        "UPDATE playbook_aggregation_cluster SET state='rebuilding', dirty=1 "
+        "WHERE cluster_id='deferred-repair'"
+    )
+    store.conn.commit()
+
+    store.defer_playbook_aggregation_cluster_rebuild(
+        cluster_id="deferred-repair",
+        agent_version="v1",
+        expected_agent_playbook_id=current.agent_playbook_id,
+        reason="llm_retryable_failure",
+    )
+
+    assert store.get_playbook_aggregation_residual_ids("v1", limit=10) == []
+    backlog = store.get_playbook_aggregation_backlog("v1")
+    assert backlog.dirty_repairs == 1
+    assert 1 <= backlog.repair_retry_after_seconds <= 60
+    assert backlog.continuation_delay_seconds == backlog.repair_retry_after_seconds
+    item_rows = store.conn.execute(
+        "SELECT reason, attempt_count, last_attempt_at FROM "
+        "playbook_aggregation_item WHERE cluster_id='deferred-repair'"
+    ).fetchall()
+    assert [tuple(row) for row in item_rows] == [
+        ("llm_retryable_failure", 0, None),
+        ("llm_retryable_failure", 0, None),
+    ]
+
+    store.conn.execute(
+        "UPDATE playbook_aggregation_cluster SET rebuild_next_attempt_at=0 "
+        "WHERE cluster_id='deferred-repair'"
+    )
+    store.conn.commit()
+    assert store.get_playbook_aggregation_residual_ids("v1", limit=10) == [1, 2]
+
+
+def test_rebuild_dedup_context_excludes_the_invalidated_agent(
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    encoded = json.dumps(embedding)
+    _insert_current(store, 1, embedding=encoded, trigger="same trigger")
+    source = store.get_user_playbooks_by_ids_any_user(
+        [1], status_filter=[None], include_embedding=True
+    )[0]
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    current, other = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Guidance that was invalidated",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            ),
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Independent existing guidance",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            ),
+        ]
+    )
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+    )
+    captured: dict[str, str] = {}
+
+    def generate(_cluster, approved_playbooks: str, **_kwargs):
+        captured["approved"] = approved_playbooks
+        return AggregationGenerationOutcome("semantic_null", [source])
+
+    monkeypatch.setattr(aggregator, "_generate_playbook_from_cluster_outcome", generate)
+    aggregator._generate_playbook_outcomes_with_source_clusters(
+        {0: [source]},
+        [current, other],
+        excluded_existing_playbook_ids={0: {current.agent_playbook_id}},
+    )
+
+    assert "Guidance that was invalidated" not in captured["approved"]
+    assert "Independent existing guidance" in captured["approved"]
+
+
+@pytest.mark.parametrize(
+    ("outcome_status", "expected_disposition", "expected_members"),
+    [
+        ("semantic_null", "cluster_member", 3),
+        ("retryable_failure", "residual", 2),
+    ],
+)
+def test_matched_cluster_non_generated_outcomes_preserve_current_agent(
+    vec_store,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    outcome_status: AggregationGenerationStatus,
+    expected_disposition: str,
+    expected_members: int,
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    encoded = json.dumps(embedding)
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    for item_id in (1, 2, 3):
+        _insert_current(store, item_id, embedding=encoded, trigger="same trigger")
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    current = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Current aggregate",
+                trigger="same trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    cluster_id = "stable-cluster"
+    store.create_playbook_aggregation_cluster(
+        cluster_id=cluster_id,
+        agent_version="v1",
+        agent_playbook_id=current.agent_playbook_id,
+        centroid_embedding=current.embedding,
+        member_count=2,
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1", [1, 2], disposition="cluster_member", cluster_id=cluster_id
+    )
+    store.set_playbook_aggregation_bootstrap_status("v1", "complete")
+
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+    )
+
+    def generate_outcomes(
+        clusters,
+        _existing,
+        *,
+        direction_overlap_threshold,
+        current_agent_playbooks=None,
+    ):
+        del direction_overlap_threshold
+        if not clusters:
+            return []
+        assert current_agent_playbooks
+        return [
+            AggregationGenerationOutcome(outcome_status, members)
+            for members in clusters.values()
+        ]
+
+    monkeypatch.setattr(
+        aggregator,
+        "_generate_playbook_outcomes_with_source_clusters",
+        generate_outcomes,
+    )
+    result = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+
+    row = store.conn.execute(
+        "SELECT disposition, cluster_id FROM playbook_aggregation_item "
+        "WHERE user_playbook_id=3"
+    ).fetchone()
+    assert tuple(row) == (
+        expected_disposition,
+        cluster_id if expected_disposition == "cluster_member" else None,
+    )
+    cluster = store.conn.execute(
+        "SELECT agent_playbook_id, centroid, member_count FROM "
+        "playbook_aggregation_cluster WHERE cluster_id=?",
+        (cluster_id,),
+    ).fetchone()
+    assert cluster[0] == current.agent_playbook_id
+    assert json.loads(cluster[1]) == current.embedding
+    assert cluster[2] == expected_members
+    assert result["attachments"] == (1 if outcome_status == "semantic_null" else 0)
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
 
 
 def test_incremental_run_commits_healthy_clusters_when_one_llm_outcome_fails(
@@ -920,6 +1506,7 @@ def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
                 playbook_name="playbook",
                 agent_version="v1",
                 content="Existing aggregate",
+                trigger="same trigger",
                 playbook_status=PlaybookStatus.PENDING,
             )
         ]

--- a/tests/server/services/storage/test_playbook_aggregation_state_integration.py
+++ b/tests/server/services/storage/test_playbook_aggregation_state_integration.py
@@ -203,6 +203,13 @@ def test_agent_mutation_retires_active_aggregation_cluster(
         disposition="cluster_member",
         cluster_id="mutable-agent-cluster",
     )
+    indexes = {
+        str(row[1])
+        for row in store.conn.execute(
+            "PRAGMA index_list(playbook_aggregation_cluster)"
+        ).fetchall()
+    }
+    assert "idx_playbook_aggregation_cluster_agent" in indexes
 
     if operation == "reject":
         store.update_agent_playbook_status(
@@ -232,6 +239,19 @@ def test_agent_mutation_retires_active_aggregation_cluster(
             "SELECT pending FROM playbook_aggregation_state WHERE agent_version='v1'"
         ).fetchone()[0]
         == 1
+    )
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_clusters_vec"
+        ).fetchone()[0]
+        == 1
+    )
+    store.repair_playbook_aggregation_pending_state(limit=1)
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_clusters_vec"
+        ).fetchone()[0]
+        == 0
     )
 
 
@@ -714,6 +734,74 @@ def test_sqlite_vec_centroid_lookup_and_attachment(vec_store) -> None:
     )[3]
     assert replacement_match.agent_playbook_id == 102
     assert replacement_match.similarity > 0.99
+
+
+def test_centroid_migration_skips_unmigratable_legacy_rows(
+    vec_store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    agents = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content=f"legacy agent {index}",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+            for index in range(2)
+        ]
+    )
+    store.conn.execute(
+        "UPDATE agent_playbooks SET embedding=? WHERE agent_playbook_id=?",
+        (json.dumps(embedding), agents[0].agent_playbook_id),
+    )
+    store.conn.execute(
+        "UPDATE agent_playbooks SET embedding='[1.0]' WHERE agent_playbook_id=?",
+        (agents[1].agent_playbook_id,),
+    )
+    store.conn.executemany(
+        "INSERT INTO playbook_aggregation_cluster "
+        "(cluster_id, index_rowid, agent_version, agent_playbook_id, vector_sum, "
+        "member_count, embedding_model, embedding_dimension, state) "
+        "VALUES (?, ?, 'v1', ?, '[1.0]', 1, ?, ?, 'active')",
+        [
+            (
+                "missing-rowid",
+                None,
+                agents[0].agent_playbook_id,
+                store.embedding_model_name,
+                store.embedding_dimensions,
+            ),
+            (
+                "wrong-dimension",
+                4242,
+                agents[1].agent_playbook_id,
+                store.embedding_model_name,
+                store.embedding_dimensions,
+            ),
+        ],
+    )
+    store.conn.commit()
+
+    store._migrate_playbook_aggregation_agent_centroids()
+
+    rows = store.conn.execute(
+        "SELECT cluster_id, centroid, vector_sum FROM "
+        "playbook_aggregation_cluster ORDER BY cluster_id"
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        ("missing-rowid", None, "[1.0]"),
+        ("wrong-dimension", None, "[1.0]"),
+    ]
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_clusters_vec WHERE rowid=4242"
+        ).fetchone()[0]
+        == 0
+    )
 
 
 def test_centroid_batches_are_strictly_isolated_by_agent_version(vec_store) -> None:
@@ -1240,6 +1328,81 @@ def test_rebuild_failure_defers_the_entire_cluster(
     assert store.get_playbook_aggregation_residual_ids("v1", limit=10) == [1, 2]
 
 
+def test_rebuild_completion_rolls_back_items_when_cluster_fence_is_lost(
+    vec_store, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    _insert_current(store, 1, embedding=json.dumps(embedding))
+    store.stage_playbook_aggregation_intake("v1", limit=1)
+    current = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Current aggregate",
+                trigger="current trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    store.create_playbook_aggregation_cluster(
+        cluster_id="rollback-repair",
+        agent_version="v1",
+        agent_playbook_id=current.agent_playbook_id,
+        centroid_embedding=current.embedding,
+        member_count=1,
+        embedding_model=store.embedding_model_name,
+    )
+    store.set_playbook_aggregation_disposition(
+        "v1",
+        [1],
+        disposition="cluster_member",
+        cluster_id="rollback-repair",
+    )
+    store.conn.execute(
+        "UPDATE playbook_aggregation_item SET disposition='residual' "
+        "WHERE cluster_id='rollback-repair'"
+    )
+    store.conn.execute(
+        "UPDATE playbook_aggregation_cluster SET state='rebuilding', dirty=1 "
+        "WHERE cluster_id='rollback-repair'"
+    )
+    store.conn.executescript(
+        "CREATE TRIGGER ignore_rebuild_completion "
+        "BEFORE UPDATE OF agent_playbook_id ON playbook_aggregation_cluster "
+        "WHEN OLD.cluster_id='rollback-repair' AND NEW.state='active' BEGIN "
+        "SELECT RAISE(IGNORE); END;"
+    )
+    store.conn.commit()
+
+    with pytest.raises(RuntimeError, match="aggregation rebuilding cluster changed"):
+        store.complete_playbook_aggregation_cluster_rebuild(
+            cluster_id="rollback-repair",
+            agent_version="v1",
+            expected_agent_playbook_id=current.agent_playbook_id,
+            replacement_agent_playbook_id=current.agent_playbook_id + 1,
+            centroid_embedding=embedding,
+            embedding_model=store.embedding_model_name,
+        )
+
+    assert store.conn.in_transaction is False
+    assert tuple(
+        store.conn.execute(
+            "SELECT disposition, cluster_id FROM playbook_aggregation_item "
+            "WHERE user_playbook_id=1"
+        ).fetchone()
+    ) == ("residual", "rollback-repair")
+    assert tuple(
+        store.conn.execute(
+            "SELECT state, agent_playbook_id FROM playbook_aggregation_cluster "
+            "WHERE cluster_id='rollback-repair'"
+        ).fetchone()
+    ) == ("rebuilding", current.agent_playbook_id)
+
+
 def test_rebuild_dedup_context_excludes_the_invalidated_agent(
     vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1413,6 +1576,163 @@ def test_matched_cluster_non_generated_outcomes_preserve_current_agent(
     assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
 
 
+def test_refresh_fence_loss_does_not_discard_healthy_cluster(
+    vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = vec_store
+    alpha_embedding = [0.0] * store.embedding_dimensions
+    alpha_embedding[0] = 1.0
+    beta_embedding = [0.0] * store.embedding_dimensions
+    beta_embedding[1] = 1.0
+
+    def embed(text: str) -> list[float]:
+        return beta_embedding if "beta" in text.lower() else alpha_embedding
+
+    monkeypatch.setattr(store, "_get_embedding", embed)
+    _insert_current(store, 1, embedding=json.dumps(alpha_embedding))
+    _insert_current(store, 2, embedding=json.dumps(beta_embedding))
+    store.stage_playbook_aggregation_intake("v1", limit=10)
+    alpha_agent, beta_agent = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Alpha guidance",
+                trigger="alpha trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            ),
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Beta guidance",
+                trigger="beta trigger",
+                playbook_status=PlaybookStatus.PENDING,
+            ),
+        ]
+    )
+    for cluster_id, agent, item_id in (
+        ("cluster-alpha", alpha_agent, 1),
+        ("cluster-beta", beta_agent, 2),
+    ):
+        store.create_playbook_aggregation_cluster(
+            cluster_id=cluster_id,
+            agent_version="v1",
+            agent_playbook_id=agent.agent_playbook_id,
+            centroid_embedding=agent.embedding,
+            member_count=1,
+            embedding_model=store.embedding_model_name,
+        )
+        store.set_playbook_aggregation_disposition(
+            "v1",
+            [item_id],
+            disposition="cluster_member",
+            cluster_id=cluster_id,
+        )
+    store.set_playbook_aggregation_bootstrap_status("v1", "complete")
+    _insert_current(store, 3, embedding=json.dumps(alpha_embedding))
+    _insert_current(store, 4, embedding=json.dumps(beta_embedding))
+
+    config = Config(
+        storage_config=StorageConfigSQLite(db_path=str(tmp_path / "state.db")),
+        user_playbook_extractor_config=PlaybookConfig(
+            extractor_name="playbook",
+            extraction_definition_prompt="test",
+            aggregation_config=PlaybookAggregatorConfig(min_cluster_size=2),
+        ),
+    )
+    configurator = MagicMock()
+    configurator.get_config.return_value = config
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(
+            org_id="aggregation-org", storage=store, configurator=configurator
+        ),
+        agent_version="v1",
+    )
+
+    def generate_outcomes(
+        clusters,
+        _existing,
+        *,
+        direction_overlap_threshold,
+        current_agent_playbooks=None,
+    ) -> list[AggregationGenerationOutcome]:
+        del direction_overlap_threshold
+        assert current_agent_playbooks
+        return [
+            AggregationGenerationOutcome(
+                "generated",
+                members,
+                AgentPlaybook(
+                    playbook_name="playbook",
+                    agent_version="v1",
+                    content=(
+                        "Refreshed beta guidance"
+                        if current_agent_playbooks[index].agent_playbook_id
+                        == beta_agent.agent_playbook_id
+                        else "Refreshed alpha guidance"
+                    ),
+                    trigger=(
+                        "refreshed beta trigger"
+                        if current_agent_playbooks[index].agent_playbook_id
+                        == beta_agent.agent_playbook_id
+                        else "refreshed alpha trigger"
+                    ),
+                    playbook_status=PlaybookStatus.PENDING,
+                ),
+            )
+            for index, members in clusters.items()
+        ]
+
+    monkeypatch.setattr(
+        aggregator,
+        "_generate_playbook_outcomes_with_source_clusters",
+        generate_outcomes,
+    )
+    replace_cluster_agent = store.replace_playbook_aggregation_cluster_agent
+
+    def replace_with_one_fence_loss(**kwargs) -> None:
+        if kwargs["cluster_id"] == "cluster-alpha":
+            raise RuntimeError("aggregation cluster agent changed")
+        replace_cluster_agent(**kwargs)
+
+    monkeypatch.setattr(
+        store,
+        "replace_playbook_aggregation_cluster_agent",
+        replace_with_one_fence_loss,
+    )
+
+    result = aggregator.run(PlaybookAggregatorRequest(agent_version="v1"))
+
+    assert result["playbooks_generated"] == 1
+    assert result["attachments"] == 1
+    assert result["supersessions"] == 1
+    assert result["cluster_fence_losses"] == 1
+    assert result["retryable_failures"] == 1
+    items = store.conn.execute(
+        "SELECT user_playbook_id, disposition, cluster_id, reason FROM "
+        "playbook_aggregation_item WHERE user_playbook_id IN (3, 4) "
+        "ORDER BY user_playbook_id"
+    ).fetchall()
+    assert [tuple(row) for row in items] == [
+        (3, "residual", None, "cluster_agent_unavailable"),
+        (4, "cluster_member", "cluster-beta", "centroid_match"),
+    ]
+    clusters = store.conn.execute(
+        "SELECT cluster_id, agent_playbook_id, member_count FROM "
+        "playbook_aggregation_cluster ORDER BY cluster_id"
+    ).fetchall()
+    assert tuple(clusters[0]) == (
+        "cluster-alpha",
+        alpha_agent.agent_playbook_id,
+        1,
+    )
+    assert tuple(clusters[1])[:1] == ("cluster-beta",)
+    assert clusters[1][1] != beta_agent.agent_playbook_id
+    assert clusters[1][2] == 2
+    assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 3
+
+
 def test_incremental_run_commits_healthy_clusters_when_one_llm_outcome_fails(
     vec_store, tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1511,6 +1831,11 @@ def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
             )
         ]
     )[0]
+    store.conn.execute(
+        "UPDATE agent_playbooks SET embedding='[]' WHERE agent_playbook_id=?",
+        (existing.agent_playbook_id,),
+    )
+    store.conn.commit()
     OperationStateManager(
         store, "aggregation-org", "playbook_aggregator"
     ).update_cluster_fingerprints(
@@ -1546,16 +1871,80 @@ def test_legacy_fingerprint_is_reembedded_and_adopted_without_regeneration(
     assert result["playbooks_generated"] == 0
     assert store.conn.execute("SELECT count(*) FROM agent_playbooks").fetchone()[0] == 1
     cluster = store.conn.execute(
-        "SELECT agent_playbook_id, member_count, state, embedding_model "
+        "SELECT agent_playbook_id, member_count, state, embedding_model, "
+        "centroid, vector_sum "
         "FROM playbook_aggregation_cluster"
     ).fetchone()
-    assert tuple(cluster) == (
+    assert tuple(cluster[:4]) == (
         existing.agent_playbook_id,
         2,
         "active",
         store.embedding_model_name,
     )
+    assert json.loads(cluster[4]) == embedding
+    assert cluster[5] is None
     assert store.get_playbook_aggregation_bootstrap_status("v1") == "complete"
+
+
+def test_unembeddable_legacy_agent_does_not_block_bootstrap(
+    vec_store,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = vec_store
+    embedding = [0.0] * store.embedding_dimensions
+    embedding[0] = 1.0
+    monkeypatch.setattr(store, "_get_embedding", lambda _text: embedding)
+    _insert_current(store, 1, trigger="same trigger")
+    existing = store.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                playbook_name="playbook",
+                agent_version="v1",
+                content="Unembeddable legacy aggregate",
+                playbook_status=PlaybookStatus.PENDING,
+            )
+        ]
+    )[0]
+    store.conn.execute(
+        "UPDATE agent_playbooks SET embedding='[]' WHERE agent_playbook_id=?",
+        (existing.agent_playbook_id,),
+    )
+    store.conn.commit()
+    monkeypatch.setattr(
+        store,
+        "_get_embedding",
+        MagicMock(side_effect=RuntimeError("embedding provider unavailable")),
+    )
+    OperationStateManager(
+        store, "aggregation-org", "playbook_aggregator"
+    ).update_cluster_fingerprints(
+        name="playbook",
+        version="v1",
+        fingerprints={
+            "broken-legacy-fingerprint": {
+                "agent_playbook_id": existing.agent_playbook_id,
+                "user_playbook_ids": [1],
+            }
+        },
+    )
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=MagicMock(org_id="aggregation-org", storage=store),
+        agent_version="v1",
+    )
+
+    assert aggregator._adopt_legacy_aggregation_state(budget=10) == (0, True)
+
+    assert store.get_playbook_aggregation_bootstrap_status("v1") == "complete"
+    assert (
+        store.conn.execute(
+            "SELECT count(*) FROM playbook_aggregation_cluster"
+        ).fetchone()[0]
+        == 0
+    )
+    assert str(existing.agent_playbook_id) in caplog.text
+    assert "could not be re-embedded" in caplog.text
 
 
 def test_empty_legacy_fingerprint_is_not_activated(vec_store, tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Keep hourly aggregation bounded as the user-playbook corpus grows: discover at most the newest 20,000 unclustered playbooks and never fall back to a full-corpus recluster.
- Refresh an existing cluster from its current agent playbook plus only the newly attached playbooks from the current run, then use the replacement agent playbook embedding as the centroid for future matching.
- Rebuild invalidated clusters from at most the newest 100 retained members when a source is edited, archived, or deleted.
- Preserve durable, retryable progress across scheduler runs while separating invalidation work from model-generation work.

## Changes

### Aggregation pipeline

- Adds explicit delta-refresh and bounded-repair inputs to the incremental aggregator.
- Supersedes the previous agent playbook atomically after generating and embedding its replacement.
- Keeps partial LLM failures isolated to their retryable members instead of discarding healthy outcomes.
- Bounds residual discovery, prompt grouping, and shared prompt context to avoid repeated quadratic or full-corpus work.

### Scheduling and storage

- Throttles idle repair scans and retains pending work when vector search is unavailable.
- Adds durable cluster retry timing, member selection, cluster replacement, and lifecycle-retirement contracts.
- Implements the contracts and centroid index maintenance for SQLite, including create scheduling without redundant invalidation rows.

### CodeRabbit follow-up

- Makes each cluster mutation its own atomic scope so a stale fence cannot roll back healthy peer clusters.
- Recovers missing or invalid legacy agent centroids by re-embedding the current agent playbook.
- Hardens SQLite centroid migration validation and adds bounded orphan-vector repair plus the cluster-to-agent partial index.
- Makes rebuild disposition transitions atomic when called outside an existing transaction.
- Removes the obsolete legacy `vector_sum` accumulation and expands both refresh and new-cluster prompt-bound coverage.

### Documentation and tests

- Updates the server and playbook code maps with the hourly delta-refresh and bounded-repair invariants.
- Expands scheduler, aggregator, and SQLite integration coverage for retries, discovery limits, invalidation, cluster retirement, stale fences, legacy centroid recovery, and migration repair.

## Diagrams

The hourly run advances clusters without reading their complete membership history.

```mermaid
flowchart LR
    A["Newest unclustered playbooks<br/>up to 20,000"] --> B{"Nearest active centroid?"}
    B -->|"match"| C["Current agent playbook<br/>+ this run's new members"]
    B -->|"no match"| D["Create bounded new clusters"]
    C --> E["Generate replacement agent playbook"]
    E --> F["Embed replacement text"]
    F --> G["Atomically replace agent playbook<br/>and centroid"]
    H["Edited, archived, or deleted source"] --> I["Newest retained members<br/>up to 100"]
    I --> E
```

## Test Plan

- `uv run ruff check` and `uv run ruff format` on every changed Python file.
- `uv run pyright` on every changed Python file: 0 errors.
- Focused aggregation/scheduler/SQLite integration suite after review fixes: 149 passed.
- OSS unit and integration marker suite after review fixes: 1,287 passed, 64 skipped.
- Full OSS suite before the review follow-up: 5,677 passed, 73 skipped, 6 subtests passed.
- OSS end-to-end suite before the review follow-up: 47 passed, 51 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Playbook aggregation now processes updates incrementally, reducing unnecessary reprocessing.
  - Large backlogs are handled in bounded batches, with continued processing scheduled automatically.
  - Invalidated or changed playbooks are repaired more reliably, including retry handling for temporary failures.
  - Aggregated playbooks preserve valid existing guidance while incorporating newly matched information.
  - Clustering and similarity results are more consistent after updates, replacements, and rebuilds.

- **Documentation**
  - Added guidance covering aggregation scheduling, incremental refreshes, retries, invalidation handling, and processing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->