### PR TITLE
feat: separate system errors from agent behavior

### DIFF
--- a/reflexio/lib/_dashboard.py
+++ b/reflexio/lib/_dashboard.py
@@ -10,6 +10,7 @@ from reflexio.models.api_schema.braintrust_schema import (
     SyncBraintrustResponse,
 )
 from reflexio.models.api_schema.eval_overview_schema import (
+    BehaviorSuccessMetric,
     ContextTile,
     GetEvaluationOverviewRequest,
     GetEvaluationOverviewResponse,
@@ -252,6 +253,7 @@ def _empty_overview_response() -> GetEvaluationOverviewResponse:
         ),
         context_tiles=ContextTile(
             success=PercentWithDelta(current=0.0, delta_pp=0.0),
+            behavior_success=BehaviorSuccessMetric(),
             corrections=NumberWithDelta(current=0.0, delta=0.0),
             turns=NumberWithDelta(current=0.0, delta=0.0),
             escalation=PercentWithDelta(current=0.0, delta_pp=0.0),

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -63,15 +63,32 @@ class PercentWithDelta(BaseModel):
     delta_pp: float
 
 
+class BehaviorSuccessMetric(BaseModel):
+    """Agent-behavior success after excluding system reliability failures.
+
+    ``current`` is nullable because a window containing only ``system_error``
+    rows has no behavior-evaluable sessions. ``delta_pp`` is nullable whenever
+    either the current or prior seven-day window has no eligible denominator.
+    Counts describe the current seven-day window shown by the metric tile.
+    """
+
+    current: float | None = Field(default=None, ge=0.0, le=100.0)
+    delta_pp: float | None = None
+    eligible_sessions: int = Field(default=0, ge=0)
+    excluded_system_errors: int = Field(default=0, ge=0)
+
+
 class ContextTile(BaseModel):
-    """Wrapper for the four mini-tiles in the context band.
+    """Wrapper for the session-level metric tiles in the context band.
 
     Each tile is rendered with an absolute value + a delta vs the previous
     7d window. Percent-shaped values carry `delta_pp` (percentage points);
-    raw counts carry `delta` (absolute difference).
+    raw counts carry `delta` (absolute difference). Behavior success excludes
+    rows classified as ``system_error`` while task success does not.
     """
 
     success: PercentWithDelta
+    behavior_success: BehaviorSuccessMetric
     corrections: NumberWithDelta
     turns: NumberWithDelta
     escalation: PercentWithDelta

--- a/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.2.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.2.0.prompt.md
@@ -1,7 +1,7 @@
 ---
-active: false
-description: "Evaluates session success, escalation, and corrective user turns"
-changelog: "v1.1.0: adds a required count of corrective user turns, distinguishes revisions from new intents, and keeps correction count independent from final task success."
+active: true
+description: "Evaluates session success, failure origin, escalation, and corrective user turns"
+changelog: "v1.2.0: separates system reliability failures from agent behavior failures with the system_error failure type."
 variables:
   - agent_context_prompt
   - success_definition_prompt
@@ -12,16 +12,19 @@ variables:
 
 [Instruction]
 Given the interactions above, evaluate if the agent has successfully completed the user's primary requested task by the end of the session, based on the success definition below.
-The agent may make mistakes or take wrong actions during the session. The user may provide corrections or ask the agent to try differently. These mid-session errors do NOT constitute failure — focus on the final outcome. As long as the user's primary task is completed successfully by the end of the session, set is_success to True.
+The agent may make mistakes or take wrong actions during the session. The user may provide corrections or ask the agent to try differently. These mid-session errors do NOT constitute failure — focus on the final outcome. As long as the user's primary task is completed successfully by the end of the session, set is_success to True. A transient system error that the agent recovers from also does not constitute failure.
 
 Step 1: Identify the user's primary task from the interactions. Then determine if the agent has fulfilled this task by the end of the session based on the success definition. If so, set is_success to True. Otherwise set is_success to False and continue to the next step.
 
 Step 2: If the agent did not complete the primary task by the end of the session, determine the failure type and failure reason.
-There are four types of failures:
+There are five types of failures:
+- 'system_error': A system reliability or availability problem prevented completion, rather than an agent decision or answer. Examples include the agent hanging or never responding, persistent provider or tool timeouts, HTTP 5xx errors, unavailable services, and quota or insufficient-credit errors.
 - 'missing_tool': Agent does not have the right tool or action that it can take to get sufficient information to answer the user's request.
 - 'wrong_tool': Tools or actions are available, but the agent did not use the right tool or perform the right action.
-- 'insufficient_info_from_tool': Agent performed the right action and tool use, but the tool or action did not provide enough or correct information to answer successfully.
+- 'insufficient_info_from_tool': Agent performed the right action and tool use, and the tool completed normally, but it did not provide enough or correct information to answer successfully.
 - 'wrong_answer': Agent had enough information but still did not answer successfully.
+
+Use 'system_error' only when the system condition caused the final failure. Do not use it for wrong tool selection, wrong arguments, poor sequencing, inadequate reasoning, or a failure to use available information; classify those as agent behavior failures. If the correct tool completed normally but its information was insufficient, use 'insufficient_info_from_tool', not 'system_error'.
 
 Step 3: Determine if the user was escalated (handed off to a human agent or another agent). Set is_escalated to True if so, False otherwise. Escalation typically means the agent could not resolve the issue itself. Escalated sessions are likely unsuccessful, but unsuccessful sessions are not necessarily escalated.
 
@@ -86,14 +89,14 @@ Generate the output in valid JSON format using the following schema.
 ```
 
 # failure case example
-`failure_type` must be one of `missing_tool`, `wrong_tool`, `insufficient_info_from_tool`, or `wrong_answer`; this example uses `missing_tool`.
+`failure_type` must be one of `system_error`, `missing_tool`, `wrong_tool`, `insufficient_info_from_tool`, or `wrong_answer`; this example uses `system_error`.
 
 ```json
 {{
     "is_success": false,
-    "failure_type": "missing_tool",
-    "failure_reason": "explain the reason for failure and what the agent needs to do differently",
-    "is_escalated": true,
-    "number_of_correction_per_session": 1
+    "failure_type": "system_error",
+    "failure_reason": "A persistent provider timeout prevented the agent from returning a response.",
+    "is_escalated": false,
+    "number_of_correction_per_session": 0
 }}
 ```

--- a/reflexio/server/services/agent_success_evaluation/README.md
+++ b/reflexio/server/services/agent_success_evaluation/README.md
@@ -14,6 +14,15 @@ Session-level agent success evaluation module.
 - `agent_success_evaluation_constants.py`: prompt/model output constants.
 - `agent_success_evaluation_utils.py`: request DTO and prompt-message construction helpers.
 
+## Failure Classification
+
+Unsuccessful sessions use `system_error`, `missing_tool`, `wrong_tool`,
+`insufficient_info_from_tool`, or `wrong_answer`. `system_error` is reserved for
+reliability and availability failures outside agent behavior, including hangs,
+missing responses, persistent timeouts or 5xx responses, unavailable services,
+and quota or credit failures. The evaluation overview keeps these rows in task
+success while excluding them from the separate behavior-success denominator.
+
 ## Prompt IDs
 
 - Owns `agent_success_evaluation`, `retrieved_learning_relevance`, and `retrieved_learning_impact`.

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_constants.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_constants.py
@@ -25,7 +25,9 @@ class AgentSuccessEvaluationOutput(StrictStructuredOutput):
 
     Attributes:
         is_success (bool): Indicates whether the agent successfully responded to the user
-        failure_type (Optional[str]): Type of failure - 'missing_tool', 'wrong_tool', 'insufficient_info_from_tool', or 'wrong_answer'. Required when is_success=False
+        failure_type (Optional[str]): Type of failure - 'system_error',
+            'missing_tool', 'wrong_tool', 'insufficient_info_from_tool', or
+            'wrong_answer'. Required when is_success=False
         failure_reason (Optional[str]): Explanation for the failure and what the agent needs to do differently. Required when is_success=False
         number_of_correction_per_session (int): Number of user turns that corrected or redirected an earlier agent response.
     """
@@ -35,12 +37,23 @@ class AgentSuccessEvaluationOutput(StrictStructuredOutput):
     )
     failure_type: (
         Literal[
-            "missing_tool", "wrong_tool", "insufficient_info_from_tool", "wrong_answer"
+            "system_error",
+            "missing_tool",
+            "wrong_tool",
+            "insufficient_info_from_tool",
+            "wrong_answer",
         ]
         | None
     ) = Field(
         default=None,
-        description="Type of improvement the agent needs: 'missing_tool' (agent lacks necessary tools), 'wrong_tool' (agent used incorrect tool), 'insufficient_info_from_tool' (tool lacks necessary information), 'wrong_answer' (agent had info but answered incorrectly). Required when is_success=False",
+        description=(
+            "Cause of failure: 'system_error' (platform, provider, service, quota, "
+            "or reliability failure outside agent behavior), 'missing_tool' (agent "
+            "lacks necessary tools), 'wrong_tool' (agent used an incorrect available "
+            "tool), 'insufficient_info_from_tool' (the correct tool returned "
+            "insufficient information), or 'wrong_answer' (agent had enough "
+            "information but answered incorrectly). Required when is_success=False"
+        ),
     )
     failure_reason: str | None = Field(
         default=None,

--- a/reflexio/server/services/evaluation_overview/README.md
+++ b/reflexio/server/services/evaluation_overview/README.md
@@ -6,4 +6,10 @@ Read-side aggregation module for `POST /api/get_evaluation_overview`.
 - `components/` contains pure read-side aggregation helpers used by the service and focused tests.
 - `eval_sampler.py` stays at the package root because regenerate jobs also use it to sample evaluation sessions.
 
+The overview reports task success across every evaluated session and a separate
+behavior-success metric that excludes `failure_type=system_error` rows from
+both numerator and denominator. A window with no behavior-evaluable rows
+returns a null behavior rate plus eligible/excluded counts for honest UI
+rendering.
+
 This module mutates no core state. Keep response-shape changes in API schema tests and service integration tests.

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -22,6 +22,7 @@ from reflexio.models.api_schema.domain.entities import (
     AgentSuccessEvaluationResult,
 )
 from reflexio.models.api_schema.eval_overview_schema import (
+    BehaviorSuccessMetric,
     BraintrustTileRow,
     BucketLiteral,
     ContextTile,
@@ -242,6 +243,7 @@ class EvaluationOverviewService:
     ) -> ContextTile:
         cur_success = _success_rate(current) * 100
         prev_success = _success_rate(previous) * 100
+        behavior_success = _behavior_success_metric(current, previous)
         cur_corr = _mean(r.number_of_correction_per_session for r in current)
         prev_corr = _mean(r.number_of_correction_per_session for r in previous)
         cur_turns = _mean(
@@ -260,6 +262,7 @@ class EvaluationOverviewService:
             success=PercentWithDelta(
                 current=cur_success, delta_pp=cur_success - prev_success
             ),
+            behavior_success=behavior_success,
             corrections=NumberWithDelta(current=cur_corr, delta=cur_corr - prev_corr),
             turns=NumberWithDelta(current=cur_turns, delta=cur_turns - prev_turns),
             escalation=PercentWithDelta(current=cur_esc, delta_pp=cur_esc - prev_esc),
@@ -526,6 +529,37 @@ def _success_rate(results: list[AgentSuccessEvaluationResult]) -> float:
     if not results:
         return 0.0
     return sum(1 for r in results if r.is_success) / len(results)
+
+
+def _behavior_success_metric(
+    current: list[AgentSuccessEvaluationResult],
+    previous: list[AgentSuccessEvaluationResult],
+) -> BehaviorSuccessMetric:
+    """Return behavior-only success, excluding canonical system-error rows."""
+    current_eligible = [r for r in current if not _is_system_error(r)]
+    previous_eligible = [r for r in previous if not _is_system_error(r)]
+    current_rate = _success_rate(current_eligible) * 100 if current_eligible else None
+    previous_rate = (
+        _success_rate(previous_eligible) * 100 if previous_eligible else None
+    )
+    delta_pp = (
+        current_rate - previous_rate
+        if current_rate is not None and previous_rate is not None
+        else None
+    )
+    return BehaviorSuccessMetric(
+        current=current_rate,
+        delta_pp=delta_pp,
+        eligible_sessions=len(current_eligible),
+        excluded_system_errors=len(current) - len(current_eligible),
+    )
+
+
+def _is_system_error(result: AgentSuccessEvaluationResult) -> bool:
+    return (
+        not result.is_success
+        and (result.failure_type or "").strip().lower() == "system_error"
+    )
 
 
 def _escalation_rate(results: list[AgentSuccessEvaluationResult]) -> float:

--- a/tests/models/api_schema/test_eval_overview_schema_groups.py
+++ b/tests/models/api_schema/test_eval_overview_schema_groups.py
@@ -1,6 +1,7 @@
 """Tests for evaluation overview source-set schema behavior."""
 
 from reflexio.models.api_schema.eval_overview_schema import (
+    BehaviorSuccessMetric,
     ContextTile,
     EvaluationSourceSetRequest,
     GetEvaluationOverviewRequest,
@@ -26,6 +27,7 @@ def _minimal_response_kwargs() -> dict:
         ),
         "context_tiles": ContextTile(
             success=PercentWithDelta(current=0.0, delta_pp=0.0),
+            behavior_success=BehaviorSuccessMetric(),
             corrections=NumberWithDelta(current=0.0, delta=0.0),
             turns=NumberWithDelta(current=0.0, delta=0.0),
             escalation=PercentWithDelta(current=0.0, delta_pp=0.0),

--- a/tests/models/test_eval_overview_schema.py
+++ b/tests/models/test_eval_overview_schema.py
@@ -39,6 +39,12 @@ def test_response_round_trips_full_payload() -> None:
         },
         "context_tiles": {
             "success": {"current": 87.4, "delta_pp": 6.2},
+            "behavior_success": {
+                "current": 91.2,
+                "delta_pp": 7.1,
+                "eligible_sessions": 96,
+                "excluded_system_errors": 4,
+            },
             "corrections": {"current": 0.4, "delta": -0.7},
             "turns": {"current": 3.2, "delta": -1.4},
             "escalation": {"current": 4.1, "delta_pp": -6.9},
@@ -62,5 +68,7 @@ def test_response_round_trips_full_payload() -> None:
     resp = GetEvaluationOverviewResponse(**payload)
     assert resp.hero.state == "full"
     assert resp.context_tiles.success.current == 87.4
+    assert resp.context_tiles.behavior_success.current == 91.2
+    assert resp.context_tiles.behavior_success.excluded_system_errors == 4
     assert resp.rule_attribution[0].net_sessions == 38
     assert resp.score_distribution.labels == ["0", "1", "2", "3", "4", "5+"]

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
@@ -31,7 +31,7 @@ def _render_agent_success_prompt() -> str:
 def test_agent_success_prompt_v1_1_0_is_active_and_renders() -> None:
     prompt_manager = PromptManager()
 
-    assert prompt_manager.get_active_version("agent_success_evaluation") == "1.1.0"
+    assert prompt_manager.get_active_version("agent_success_evaluation") == "1.2.0"
     assert "Step 4: Count corrective user turns" in _render_agent_success_prompt()
 
 

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py
@@ -419,6 +419,16 @@ class TestCorrectionCount:
                 number_of_correction_per_session=-1,
             )
 
+    def test_output_accepts_system_error_failure_type(self):
+        output = AgentSuccessEvaluationOutput(
+            is_success=False,
+            failure_type="system_error",
+            failure_reason="The agent never responded after a provider timeout.",
+            number_of_correction_per_session=0,
+        )
+
+        assert output.failure_type == "system_error"
+
     @pytest.mark.parametrize("invalid_count", ["1", 1.5])
     def test_output_rejects_non_integer_correction_count(self, invalid_count):
         with pytest.raises(ValidationError):

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 from unittest.mock import MagicMock
 
+import pytest
+
 from reflexio.models.api_schema.domain.entities import AgentSuccessEvaluationResult
 from reflexio.models.api_schema.eval_overview_schema import (
     EvaluationSourceSetRequest,
@@ -27,6 +29,7 @@ def _eval_result(
     is_success: bool,
     user_id: str = "u1",
     corrections: int = 0,
+    failure_type: str | None = None,
     created_at: int = 1700000000,
 ) -> AgentSuccessEvaluationResult:
     return AgentSuccessEvaluationResult(
@@ -35,6 +38,7 @@ def _eval_result(
         agent_version="v_e2e",
         session_id=session_id,
         is_success=is_success,
+        failure_type=failure_type,
         evaluation_name="overall",
         created_at=created_at,
         number_of_correction_per_session=corrections,
@@ -140,6 +144,71 @@ def test_service_reports_single_recent_success_as_100_percent() -> None:
     assert response.hero.state == "shadow_off"
     assert response.hero.regular_success_rate_pp == 100.0
     assert response.context_tiles.success.current == 100.0
+
+
+def test_service_reports_task_and_behavior_success_separately() -> None:
+    now = int(time.time())
+    storage = _storage_with_results(
+        [
+            _eval_result(
+                result_id=1,
+                session_id="success",
+                is_success=True,
+                created_at=now - 60,
+            ),
+            _eval_result(
+                result_id=2,
+                session_id="agent-failure",
+                is_success=False,
+                failure_type="wrong_answer",
+                created_at=now - 60,
+            ),
+            _eval_result(
+                result_id=3,
+                session_id="system-failure",
+                is_success=False,
+                failure_type="system_error",
+                created_at=now - 60,
+            ),
+        ]
+    )
+    config = Config(storage_config=StorageConfigSQLite())
+
+    response = EvaluationOverviewService(storage=storage, config=config).run(
+        GetEvaluationOverviewRequest(from_ts=now - 3600, to_ts=now, bucket="day")
+    )
+
+    assert response.hero.regular_success_rate_pp == pytest.approx(100 / 3)
+    assert response.context_tiles.success.current == pytest.approx(100 / 3)
+    assert response.context_tiles.behavior_success.current == 50.0
+    assert response.context_tiles.behavior_success.eligible_sessions == 2
+    assert response.context_tiles.behavior_success.excluded_system_errors == 1
+
+
+def test_behavior_success_is_null_when_all_rows_are_system_errors() -> None:
+    now = int(time.time())
+    storage = _storage_with_results(
+        [
+            _eval_result(
+                result_id=1,
+                session_id="system-failure",
+                is_success=False,
+                failure_type="SYSTEM_ERROR",
+                created_at=now - 60,
+            )
+        ]
+    )
+    config = Config(storage_config=StorageConfigSQLite())
+
+    response = EvaluationOverviewService(storage=storage, config=config).run(
+        GetEvaluationOverviewRequest(from_ts=now - 3600, to_ts=now)
+    )
+
+    assert response.context_tiles.success.current == 0.0
+    assert response.context_tiles.behavior_success.current is None
+    assert response.context_tiles.behavior_success.delta_pp is None
+    assert response.context_tiles.behavior_success.eligible_sessions == 0
+    assert response.context_tiles.behavior_success.excluded_system_errors == 1
 
 
 def test_service_shows_recent_evaluations_immediately() -> None:

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -46,7 +46,7 @@ PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     "profile_should_generate_override": ("v1.0.0", "boolean_evaluation"),
     "profile_deduplication": ("v1.0.0", "profile_deduplication"),
     "tagging": ("v1.0.0", "tagging"),
-    "agent_success_evaluation": ("v1.1.0", "agent_success_evaluation"),
+    "agent_success_evaluation": ("v1.2.0", "agent_success_evaluation"),
     # Retrieved-learning judges — per-learning relevance/impact verdicts for
     # sessions publishing interactions with ``retrieved_learnings``.
     "retrieved_learning_relevance": ("v1.0.0", "retrieved_learning_relevance"),


### PR DESCRIPTION
## Summary
- distinguish system reliability failures from agent behavior failures with a canonical `system_error` classification
- preserve task success as the primary all-session metric while adding behavior success that excludes failed `system_error` rows
- make behavior success nullable when no sessions are behavior-evaluable, avoiding a misleading 0% rate

## Changes
- activate agent-success prompt v1.2.0 with explicit reliability-versus-behavior classification guidance
- extend structured evaluation output with `system_error`
- add `BehaviorSuccessMetric` to evaluation-overview responses, including eligible and excluded counts
- calculate current and prior behavior-success windows independently from the unchanged task-success calculation
- document the metric contract and add schema, prompt, and service regression coverage

## Test Plan
- `uv run pytest tests/server/services/agent_success_evaluation/test_agent_success_evaluator.py tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py tests/server/services/test_prompt_model_mapping.py tests/server/services/evaluation_overview/test_service_integration.py tests/models/test_eval_overview_schema.py tests/models/api_schema/test_eval_overview_schema_groups.py -q -o 'addopts='` — 101 passed, 2 skipped
- staged Python files: Ruff check/format passed
- staged Python files: Pyright passed with 0 errors
- live SQLite API verification: 1 success + 1 `wrong_answer` + 1 `system_error` returned 33.3% task success and 50.0% behavior success with 1 excluded system error
