### PR TITLE
fix: recover schedulers after empty-fleet startup

### DIFF
--- a/reflexio/server/api.py
+++ b/reflexio/server/api.py
@@ -361,6 +361,7 @@ def create_app(  # noqa: C901
     app_context_factory: "Callable[[], AppContext] | None" = None,
     profile: "DeploymentProfile | None" = None,
     durable_org_ids_provider: Callable[[], Iterable[str]] | None = None,
+    resume_org_ids_provider: Callable[[], list[str]] | None = None,
 ) -> FastAPI:
     """Factory to create a FastAPI app.
 
@@ -412,6 +413,10 @@ def create_app(  # noqa: C901
             logic. It is only consulted when ``REFLEXIO_DURABLE_LEARNING_QUEUE`` is
             on — when the flag is off ``maybe_start_durable_learning`` returns None
             without ever calling the provider.
+        resume_org_ids_provider: Optional zero-arg callable used only when the
+            bootstrap org is not available yet. This lets a multi-tenant deployment
+            defer the resume scheduler on an empty fleet and adopt its first real
+            org without restarting. The OSS default remains unchanged.
 
     Returns:
         Configured FastAPI application.
@@ -495,6 +500,7 @@ def create_app(  # noqa: C901
             scheduler = maybe_start_resume_scheduler(
                 lambda org_id: RequestContext(org_id=org_id),
                 bootstrap_org_id=bootstrap_org_id,
+                org_id_provider=resume_org_ids_provider,
             )
             # Register the missing-vector backfill sweep (opt-in via
             # REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED) BEFORE starting the GC

--- a/reflexio/server/services/extraction/resume_scheduler.py
+++ b/reflexio/server/services/extraction/resume_scheduler.py
@@ -15,6 +15,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.auth import DEFAULT_ORG_ID
 from reflexio.server.error_reporting import error_tags
 from reflexio.server.scheduling import ThreadedScheduler
 from reflexio.server.services.extraction.resumable_agent import (
@@ -35,11 +36,13 @@ class ExtractionResumeScheduler(ThreadedScheduler):
         *,
         request_context_factory: Callable[[str], RequestContext],
         bootstrap_org_id: str,
+        org_id_provider: Callable[[], list[str]] | None = None,
         max_runs_per_tick: int = 10,
     ) -> None:
         super().__init__(thread_name="reflexio-extraction-resume-scheduler")
         self.request_context_factory = request_context_factory
         self.bootstrap_org_id = bootstrap_org_id
+        self.org_id_provider = org_id_provider
         self.max_runs_per_tick = max_runs_per_tick
 
     def _on_started(self) -> None:
@@ -105,6 +108,18 @@ class ExtractionResumeScheduler(ThreadedScheduler):
     def _run_once(self) -> float:
         poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
         try:
+            if (
+                self.bootstrap_org_id == DEFAULT_ORG_ID
+                and self.org_id_provider is not None
+            ):
+                org_ids = [
+                    org_id
+                    for org_id in self.org_id_provider()
+                    if org_id != DEFAULT_ORG_ID
+                ]
+                if not org_ids:
+                    return poll_interval
+                self.bootstrap_org_id = org_ids[0]
             bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
             config = bootstrap_ctx.configurator.get_config()
             poll_interval = config.pending_tool_call_config.resume_poll_interval_seconds
@@ -127,6 +142,7 @@ def maybe_start_resume_scheduler(
     request_context_factory: Callable[[str], RequestContext],
     *,
     bootstrap_org_id: str,
+    org_id_provider: Callable[[], list[str]] | None = None,
 ) -> ExtractionResumeScheduler | None:
     """Start the scheduler only when the bootstrap-org config enables the feature.
 
@@ -139,16 +155,23 @@ def maybe_start_resume_scheduler(
         if not pending_tool_calls_enabled(ctx):
             return None
     except Exception as exc:
-        logger.warning(
-            "event=extraction_resume_scheduler_start_skipped error_type=%s error=%s",
-            type(exc).__name__,
-            exc,
-        )
-        return None
+        if bootstrap_org_id == DEFAULT_ORG_ID and org_id_provider is not None:
+            logger.info(
+                "event=extraction_resume_scheduler_start_deferred "
+                "reason=no_organizations"
+            )
+        else:
+            logger.warning(
+                "event=extraction_resume_scheduler_start_skipped error_type=%s error=%s",
+                type(exc).__name__,
+                exc,
+            )
+            return None
 
     scheduler = ExtractionResumeScheduler(
         request_context_factory=request_context_factory,
         bootstrap_org_id=bootstrap_org_id,
+        org_id_provider=org_id_provider,
     )
     scheduler.start()
     return scheduler

--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -28,6 +28,7 @@ import time
 from collections.abc import Callable
 
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.auth import DEFAULT_ORG_ID
 from reflexio.server.env_utils import env_str
 from reflexio.server.error_reporting import capture_anomaly
 from reflexio.server.org_fanout import iterate_orgs_bounded
@@ -37,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_POLL_INTERVAL_SECONDS = 86400
 _MIN_POLL_SECONDS = 1
+_BOOTSTRAP_RETRY_INTERVAL_SECONDS = 5
 _ORG_SWEEP_TIMEOUT_SECONDS = 60.0
 _DEFAULT_ORG_FANOUT_WORKERS = 8
 
@@ -448,6 +450,18 @@ class LineageGCScheduler(ThreadedScheduler):
     def _run_once(self) -> float:
         poll_interval = _DEFAULT_POLL_INTERVAL_SECONDS
         try:
+            if (
+                self.bootstrap_org_id == DEFAULT_ORG_ID
+                and self.org_id_provider is not None
+            ):
+                org_ids = [
+                    org_id
+                    for org_id in self.org_id_provider()
+                    if org_id != DEFAULT_ORG_ID
+                ]
+                if not org_ids:
+                    return _BOOTSTRAP_RETRY_INTERVAL_SECONDS
+                self.bootstrap_org_id = org_ids[0]
             bootstrap_ctx = self.request_context_factory(self.bootstrap_org_id)
             cfg = bootstrap_ctx.configurator.get_config()
             poll_interval = cfg.lineage_gc.poll_interval_seconds
@@ -513,6 +527,10 @@ def maybe_start_lineage_gc(
         LineageGCScheduler: The started scheduler, or ``None`` if no start
         condition holds (see the startup criteria above).
     """
+    effective_org_id_provider = (
+        org_id_provider if org_id_provider is not None else _org_id_provider_hook
+    )
+
     # Registered sweeps carry their own per-org gates, so they must start the
     # scheduler whether or not the bootstrap org's config is readable. Evaluate
     # that first: the config read below needs a real org, and a failure there
@@ -569,12 +587,17 @@ def maybe_start_lineage_gc(
                 exc,
             )
             return None
-        logger.warning(
-            "event=lineage_gc_config_read_failed error_type=%s error=%s "
-            "starting anyway: registered sweeps gate themselves per-org",
-            type(exc).__name__,
-            exc,
-        )
+        if bootstrap_org_id == DEFAULT_ORG_ID and effective_org_id_provider is not None:
+            logger.info(
+                "event=lineage_gc_scheduler_start_deferred reason=no_organizations"
+            )
+        else:
+            logger.warning(
+                "event=lineage_gc_config_read_failed error_type=%s error=%s "
+                "starting anyway: registered sweeps gate themselves per-org",
+                type(exc).__name__,
+                exc,
+            )
         config_enabled = False
 
     # Also start when any reclamation sweep has been registered — registered
@@ -588,9 +611,7 @@ def maybe_start_lineage_gc(
     scheduler = LineageGCScheduler(
         request_context_factory=request_context_factory,
         bootstrap_org_id=bootstrap_org_id,
-        org_id_provider=(
-            org_id_provider if org_id_provider is not None else _org_id_provider_hook
-        ),
+        org_id_provider=effective_org_id_provider,
         leader_gate=leader_gate if leader_gate is not None else _leader_gate_hook,
     )
     scheduler.start()

--- a/tests/server/services/extraction/test_resume_scheduler.py
+++ b/tests/server/services/extraction/test_resume_scheduler.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 
 from reflexio.models.config_schema import PendingToolCallConfig
 from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.auth import DEFAULT_ORG_ID
 from reflexio.server.services.extraction import resume_scheduler
 
 
@@ -40,6 +41,54 @@ def test_maybe_start_resume_scheduler_skips_when_feature_disabled(monkeypatch):
     )
 
     assert scheduler is None
+
+
+def test_resume_scheduler_recovers_when_first_org_appears(monkeypatch):
+    org_ids = [DEFAULT_ORG_ID]
+    factory_calls: list[str] = []
+
+    def factory(org_id: str):
+        factory_calls.append(org_id)
+        if org_id == DEFAULT_ORG_ID:
+            raise RuntimeError("organization not found")
+        return _request_context(org_id)
+
+    monkeypatch.setattr(
+        resume_scheduler,
+        "pending_tool_calls_enabled",
+        lambda _ctx: True,
+    )
+    monkeypatch.setattr(
+        resume_scheduler.ExtractionResumeScheduler,
+        "start",
+        lambda _self: None,
+    )
+
+    def drain(_self, *, max_runs: int) -> int:
+        assert max_runs == 10
+        return 0
+
+    monkeypatch.setattr(
+        resume_scheduler.ExtractionResumeWorker,
+        "drain",
+        drain,
+    )
+
+    scheduler = resume_scheduler.maybe_start_resume_scheduler(
+        cast(Callable[[str], RequestContext], factory),
+        bootstrap_org_id=DEFAULT_ORG_ID,
+        org_id_provider=lambda: list(org_ids),
+    )
+
+    assert scheduler is not None
+    factory_calls.clear()
+    assert scheduler._run_once() == 5.0
+    assert factory_calls == []
+
+    org_ids[:] = ["org_1"]
+    assert scheduler._run_once() == 0.01
+    assert scheduler.bootstrap_org_id == "org_1"
+    assert factory_calls == ["org_1", "org_1"]
 
 
 def test_resume_scheduler_drains_all_orgs_and_stops_cleanly(monkeypatch):

--- a/tests/server/services/lineage/test_gc_scheduler.py
+++ b/tests/server/services/lineage/test_gc_scheduler.py
@@ -11,11 +11,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from reflexio.models.config_schema import LineageGCConfig
+from reflexio.server.auth import DEFAULT_ORG_ID
 from reflexio.server.scheduling import LeaderGate
 from reflexio.server.services.lineage import gc_scheduler
 from reflexio.server.services.lineage import gc_scheduler as gc_mod
 from reflexio.server.services.lineage.gc_scheduler import (
     _DEFAULT_ORG_FANOUT_WORKERS,
+    _DEFAULT_POLL_INTERVAL_SECONDS,
     _ENTITY_TYPES,
     _HIGH_VOLUME_THRESHOLD,
     _MIN_POLL_SECONDS,
@@ -313,6 +315,32 @@ def test_maybe_start_lineage_gc_returns_scheduler_when_enabled():
     sched.stop(timeout_seconds=1.0)
 
 
+def test_gc_scheduler_recovers_when_first_org_appears():
+    org_ids = [DEFAULT_ORG_ID]
+    factory_calls: list[str] = []
+
+    def factory(org_id: str):
+        factory_calls.append(org_id)
+        return _make_ctx(org_id, lineage_gc=LineageGCConfig(enabled=True))
+
+    scheduler = LineageGCScheduler(
+        request_context_factory=factory,  # type: ignore[arg-type]
+        bootstrap_org_id=DEFAULT_ORG_ID,
+        org_id_provider=lambda: list(org_ids),
+    )
+    scheduler._gc_tick = MagicMock()  # type: ignore[method-assign]
+    scheduler._run_global_sweeps = MagicMock()  # type: ignore[method-assign]
+
+    assert scheduler._run_once() == 5
+    assert factory_calls == []
+
+    org_ids[:] = ["org_1"]
+    assert scheduler._run_once() == _DEFAULT_POLL_INTERVAL_SECONDS
+    assert scheduler.bootstrap_org_id == "org_1"
+    assert factory_calls == ["org_1"]
+    scheduler._gc_tick.assert_called_once()  # type: ignore[attr-defined]
+
+
 def test_maybe_start_lineage_gc_returns_none_on_factory_error():
     def bad_factory(org_id: str):
         raise RuntimeError("can't build context")
@@ -346,6 +374,30 @@ def test_maybe_start_lineage_gc_starts_when_config_unreadable_but_sweeps_registe
 
     assert "lineage_gc_config_read_failed" in caplog.text
     assert "lineage_gc_scheduler_start_skipped" not in caplog.text
+
+
+def test_maybe_start_lineage_gc_defers_empty_enterprise_fleet(caplog):
+    def bad_factory(_org_id: str):
+        raise RuntimeError("Organization self-host-org not found")
+
+    register_per_org_sweep(lambda _org_id, _budget: 0)
+    gc_scheduler.set_org_id_provider(lambda: [DEFAULT_ORG_ID])
+    try:
+        with (
+            patch.object(LineageGCScheduler, "start"),
+            caplog.at_level(logging.INFO),
+        ):
+            scheduler = maybe_start_lineage_gc(
+                bad_factory,
+                bootstrap_org_id=DEFAULT_ORG_ID,
+            )
+        assert scheduler is not None
+    finally:
+        gc_scheduler.set_org_id_provider(None)
+        clear_per_org_sweeps()
+
+    assert "lineage_gc_scheduler_start_deferred" in caplog.text
+    assert "lineage_gc_config_read_failed" not in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Keep lineage GC and extraction-resume schedulers alive when an enterprise deployment starts before any organization exists.
- Poll the injected tenant provider and adopt the first real organization without requiring a service restart.
- Preserve the existing OSS startup behavior when no provider is supplied.

## Changes
- Thread an optional resume org provider through `create_app`.
- Defer bootstrap work while only the default sentinel org exists.
- Add regression coverage for empty-fleet startup and first-org recovery.

## Test Plan
- `uv run ruff check` on all changed Python files.
- `uv run pyright` on all changed Python files: 0 errors.
- Focused scheduler tests: 41 passed.
- Full OSS non-e2e suite: 5,538 passed, 73 skipped.
- OSS e2e suite: 47 passed, 51 skipped.
- Local enterprise stack: start with an empty org fleet, add a real org without restarting, and verify pending-tool-call expiry plus lineage profile expiry run for the new org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering organizations during scheduler startup.
  * Schedulers now defer startup when no organizations are available and automatically recover when one appears.
  * Provider-backed deployments can select an available organization as the initial scheduler context.

* **Bug Fixes**
  * Improved scheduler startup handling when the initial organization is unavailable.
  * Prevented unnecessary configuration warnings during deferred startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->