### PR TITLE
feat: tag agent success evaluations

### DIFF
--- a/docs/lib/config-schema.ts
+++ b/docs/lib/config-schema.ts
@@ -56,7 +56,7 @@ export interface ProfileExtractorConfig {
   extractor_name: string;
   extraction_definition_prompt: string;
   context_prompt: string | null;
-  metadata_definition_prompt: string | null;
+  tagging_definition_prompt: string | null;
   manual_trigger: boolean;
   window_size_override: number | null;
   stride_size_override: number | null;
@@ -78,7 +78,7 @@ export interface UserPlaybookExtractorConfig {
   extractor_name: string;
   extraction_definition_prompt: string;
   context_prompt: string | null;
-  metadata_definition_prompt: string | null;
+  tagging_definition_prompt: string | null;
   aggregation_config: PlaybookAggregatorConfig;
   deduplication_config: DeduplicationConfig | null;
   window_size_override: number | null;
@@ -88,7 +88,7 @@ export interface UserPlaybookExtractorConfig {
 export interface AgentSuccessConfig {
   evaluation_name: string;
   success_definition_prompt: string;
-  metadata_definition_prompt: string | null;
+  tagging_definition_prompt: string | null;
   sampling_rate: number;
   window_size_override: number | null;
   stride_size_override: number | null;
@@ -152,7 +152,7 @@ export function defaultProfileExtractor(): ProfileExtractorConfig {
     extractor_name: "new_profile_extractor",
     extraction_definition_prompt: "",
     context_prompt: null,
-    metadata_definition_prompt: null,
+    tagging_definition_prompt: null,
     manual_trigger: false,
     window_size_override: null,
     stride_size_override: null,
@@ -164,7 +164,7 @@ export function defaultPlaybookExtractor(): UserPlaybookExtractorConfig {
     extractor_name: "new_playbook_extractor",
     extraction_definition_prompt: "",
     context_prompt: null,
-    metadata_definition_prompt: null,
+    tagging_definition_prompt: null,
     aggregation_config: {
       min_cluster_size: 2,
       reaggregation_trigger_count: 2,
@@ -181,7 +181,7 @@ export function defaultAgentSuccess(): AgentSuccessConfig {
   return {
     evaluation_name: "new_evaluation",
     success_definition_prompt: "",
-    metadata_definition_prompt: null,
+    tagging_definition_prompt: null,
     sampling_rate: 1.0,
     window_size_override: null,
     stride_size_override: null,
@@ -256,7 +256,7 @@ export function serializeConfig(config: ReflexioConfig): unknown {
     T extends {
       extraction_definition_prompt: string;
       context_prompt: string | null;
-      metadata_definition_prompt: string | null;
+      tagging_definition_prompt: string | null;
     },
   >(
     extractor: T | null,
@@ -267,7 +267,7 @@ export function serializeConfig(config: ReflexioConfig): unknown {
     return {
       ...extractor,
       context_prompt: clean(extractor.context_prompt),
-      metadata_definition_prompt: clean(extractor.metadata_definition_prompt),
+      tagging_definition_prompt: clean(extractor.tagging_definition_prompt),
     };
   };
 

--- a/docs/lib/config-schema.ts
+++ b/docs/lib/config-schema.ts
@@ -271,6 +271,18 @@ export function serializeConfig(config: ReflexioConfig): unknown {
     };
   };
 
+  const cleanAgentSuccess = (
+    agentSuccess: AgentSuccessConfig | null,
+  ): AgentSuccessConfig | null => {
+    if (!agentSuccess) return null;
+    return {
+      ...agentSuccess,
+      tagging_definition_prompt: clean(
+        agentSuccess.tagging_definition_prompt,
+      ),
+    };
+  };
+
   return {
     storage_config: config.storage_config
       ? { db_path: clean(config.storage_config.db_path) }
@@ -281,7 +293,7 @@ export function serializeConfig(config: ReflexioConfig): unknown {
     user_playbook_extractor_config: cleanExtractor(
       config.user_playbook_extractor_config,
     ),
-    agent_success_config: config.agent_success_config,
+    agent_success_config: cleanAgentSuccess(config.agent_success_config),
     extraction_preset: config.extraction_preset,
     window_size: config.window_size,
     stride_size: config.stride_size,

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -622,6 +622,7 @@ class AgentSuccessEvaluationResult(BaseModel):
     )
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
+    tags: list[str] | None = None
     embedding: EmbeddingVector = []
 
 

--- a/reflexio/models/api_schema/ui/converters.py
+++ b/reflexio/models/api_schema/ui/converters.py
@@ -160,6 +160,7 @@ def to_evaluation_result_view(
         number_of_correction_per_session=result.number_of_correction_per_session,
         user_turns_to_resolution=result.user_turns_to_resolution,
         is_escalated=result.is_escalated,
+        tags=result.tags,
     )
 
 

--- a/reflexio/models/api_schema/ui/entities.py
+++ b/reflexio/models/api_schema/ui/entities.py
@@ -134,6 +134,7 @@ class EvaluationResultView(BaseModel):
     )
     user_turns_to_resolution: int | None = None
     is_escalated: bool = False
+    tags: list[str] | None = None
 
 
 class ProfileChangeLogView(BaseModel):

--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -517,7 +517,7 @@ class AgentSuccessConfig(_ExtractorWindowOverrideCompatMixin, BaseModel):
     # (one agent-success evaluator per org), so the name is accepted but ignored.
     evaluation_name: NonEmptyStr | None = None
     success_definition_prompt: SanitizedNonEmptyStr
-    metadata_definition_prompt: str | None = None
+    tagging_definition_prompt: str | None = None
     request_sources_enabled: list[str] | None = (
         None  # default enabled for all sources, if set, only evaluate requests from the enabled request sources
     )

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -421,7 +421,7 @@ Key files:
 - `components/retrieved_learning_evaluator.py`: `RetrievedLearningEvaluator` - per-learning relevance/impact judges over `Interaction.retrieved_learnings`; results replace the session's `retrieved_learning_evaluation` snapshot atomically (generation + session-fingerprint fenced, see `services/storage/storage_base/retrieved_learning_state.py`)
 - `services/storage/storage_base/evaluation_state_keys.py`: single source of truth for the three evaluation `_operation_state` key formats (agent-success marker, grade-on-demand cache, retrieved-learning state) shared by producers and governance erasure
 
-**Flow**: Interactions → `agent_success_evaluation/scheduler.py` → `agent_success_evaluation/runner.py` → `agent_success_evaluation/service.py` → `agent_success_evaluation/components/evaluator.py` → `AgentSuccessEvaluationResult` → Storage
+**Flow**: Interactions → `agent_success_evaluation/scheduler.py` → `agent_success_evaluation/runner.py` → `agent_success_evaluation/service.py` → `agent_success_evaluation/components/evaluator.py` → `AgentSuccessEvaluationResult` → Storage → deferred `tagging/` pass when `AgentSuccessConfig.tagging_definition_prompt` is configured
 
 **Session-Level Evaluation**: Evaluator treats one user's `request_interaction_data_models` in a session as a single conversation. Sampling rate checked once per session (not per-request). Results are keyed by `(user_id, session_id, evaluation_name)` so reused session IDs across users do not clobber each other.
 

--- a/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.3.0.prompt.md
+++ b/reflexio/server/prompt/prompt_bank/agent_success_evaluation/v1.3.0.prompt.md
@@ -1,11 +1,11 @@
 ---
+active: true
 description: "Evaluates session success, failure origin, escalation, and corrective user turns"
-changelog: "v1.2.0: separates system reliability failures from agent behavior failures with the system_error failure type."
+changelog: "v1.3.0: removes the obsolete metadata-definition input; classification now runs asynchronously through the shared tagging service."
 variables:
   - agent_context_prompt
   - success_definition_prompt
   - tool_can_use
-  - metadata_definition_prompt
   - interactions
 ---
 
@@ -71,9 +71,6 @@ User and agent interactions:
 
 [Tools]
 {tool_can_use}
-
-[Metadata Definition]
-{metadata_definition_prompt}
 
 [Output]
 Generate the output in valid JSON format using the following schema.

--- a/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
+++ b/reflexio/server/services/agent_success_evaluation/agent_success_evaluation_utils.py
@@ -32,7 +32,6 @@ def construct_agent_success_evaluation_messages_from_sessions(
     agent_context_prompt: str,
     success_definition_prompt: str,
     tool_can_use: str,
-    metadata_definition_prompt: str | None = None,
 ) -> list[dict]:
     """
     Construct LLM messages for agent success evaluation from request interaction groups.
@@ -46,8 +45,6 @@ def construct_agent_success_evaluation_messages_from_sessions(
         agent_context_prompt: Context about the agent
         success_definition_prompt: Definition of what constitutes agent success
         tool_can_use: Description of tools available to the agent
-        metadata_definition_prompt: Optional additional metadata definition
-
     Returns:
         list[dict]: List of messages ready for agent success evaluation
     """
@@ -59,7 +56,6 @@ def construct_agent_success_evaluation_messages_from_sessions(
             "agent_context_prompt": agent_context_prompt,
             "success_definition_prompt": success_definition_prompt,
             "tool_can_use": tool_can_use,
-            "metadata_definition_prompt": metadata_definition_prompt or "",
             "interactions": format_sessions_to_history_string(
                 request_interaction_data_models
             ),

--- a/reflexio/server/services/agent_success_evaluation/components/evaluator.py
+++ b/reflexio/server/services/agent_success_evaluation/components/evaluator.py
@@ -193,11 +193,6 @@ class AgentSuccessEvaluator:
                 else ""
             ),
             tool_can_use=tool_can_use_str,
-            metadata_definition_prompt=(
-                self.config.metadata_definition_prompt.strip()
-                if self.config.metadata_definition_prompt
-                else None
-            ),
         )
         messages_dict = messages
 

--- a/reflexio/server/services/agent_success_evaluation/service.py
+++ b/reflexio/server/services/agent_success_evaluation/service.py
@@ -18,6 +18,7 @@ from reflexio.server.services.extractor_interaction_utils import (
     filter_interactions_by_source,
     get_effective_source_filter,
 )
+from reflexio.server.services.tagging.tagging_scheduler import schedule_tagging
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +213,24 @@ class AgentSuccessEvaluationService(
                     self.service_config.session_id,  # type: ignore[reportOptionalMemberAccess]
                     attempt,
                 )
+            else:
+                service_config = self.service_config
+                if service_config is not None:
+                    try:
+                        schedule_tagging(
+                            org_id=self.request_context.org_id,
+                            user_id=service_config.user_id,
+                            agent_version=service_config.agent_version,
+                            request_context=self.request_context,
+                            llm_client=self.client,
+                        )
+                    except Exception:
+                        # Tagging is a deferred best-effort side effect. A scheduler
+                        # failure must not retry or invalidate the durable result.
+                        logger.exception(
+                            "Failed to schedule tagging for agent success evaluation session %s",
+                            service_config.session_id,
+                        )
 
     def _resolve_write_plan(self, results: list) -> None:
         """Compute-half — write the evaluation results HERE (never durable-split).

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -591,6 +591,7 @@ def _row_to_eval_result(row: sqlite3.Row) -> AgentSuccessEvaluationResult:
         number_of_correction_per_session=d.get("number_of_correction_per_session") or 0,
         user_turns_to_resolution=d.get("user_turns_to_resolution"),
         is_escalated=bool(d.get("is_escalated", False)),
+        tags=_json_loads(d.get("tags")),
         embedding=[],
     )
 
@@ -1244,7 +1245,12 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
 
     def _migrate_tags(self) -> None:
         """Add tags column if missing."""
-        for table in ("profiles", "user_playbooks", "agent_playbooks"):
+        for table in (
+            "profiles",
+            "user_playbooks",
+            "agent_playbooks",
+            "agent_success_evaluation_result",
+        ):
             cols = {
                 row["name"]
                 for row in self.conn.execute(f"PRAGMA table_info({table})").fetchall()
@@ -2676,6 +2682,7 @@ CREATE TABLE IF NOT EXISTS agent_success_evaluation_result (
     number_of_correction_per_session INTEGER NOT NULL DEFAULT 0,
     user_turns_to_resolution INTEGER,
     is_escalated INTEGER NOT NULL DEFAULT 0,
+    tags TEXT,
     embedding TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_eval_agent_version ON agent_success_evaluation_result(agent_version);

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
@@ -72,8 +72,8 @@ class AgentEvaluationResultStoreMixin:
                            (user_id, session_id, agent_version, evaluation_name, is_success,
                             failure_type, failure_reason, regular_vs_shadow,
                             number_of_correction_per_session, user_turns_to_resolution,
-                            is_escalated, embedding, created_at, governance_subject_ref)
-                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                            is_escalated, tags, embedding, created_at, governance_subject_ref)
+                           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
                         (
                             result.user_id,
                             result.session_id,
@@ -88,6 +88,9 @@ class AgentEvaluationResultStoreMixin:
                             result.number_of_correction_per_session,
                             result.user_turns_to_resolution,
                             int(result.is_escalated),
+                            _json_dumps(result.tags)
+                            if result.tags is not None
+                            else None,
                             _json_dumps(result.embedding) if result.embedding else None,
                             created_at_iso,
                             subject_ref,
@@ -100,17 +103,61 @@ class AgentEvaluationResultStoreMixin:
 
     @SQLiteStorageBase.handle_exceptions
     def get_agent_success_evaluation_results(
-        self, limit: int = 100, agent_version: str | None = None
+        self,
+        limit: int = 100,
+        agent_version: str | None = None,
+        user_id: str | None = None,
+        only_untagged: bool = False,
     ) -> list[AgentSuccessEvaluationResult]:
         sql = "SELECT * FROM agent_success_evaluation_result"
         params: list[Any] = []
+        clauses: list[str] = []
         if agent_version is not None:
-            sql += " WHERE agent_version = ?"
+            clauses.append("agent_version = ?")
             params.append(agent_version)
+        if user_id is not None:
+            clauses.append("user_id = ?")
+            params.append(user_id)
+        if only_untagged:
+            clauses.append("tags IS NULL")
+        if clauses:
+            sql += " WHERE " + " AND ".join(clauses)
         sql += " ORDER BY created_at DESC LIMIT ?"
         params.append(limit)
         rows = self._fetchall(sql, params)
         return [_row_to_eval_result(r) for r in rows]
+
+    @SQLiteStorageBase.handle_exceptions
+    def update_agent_success_evaluation_result_tags(
+        self,
+        result_id: int,
+        tags: list[str],
+        *,
+        expected_result: AgentSuccessEvaluationResult,
+    ) -> bool:
+        cursor = self._execute(
+            """UPDATE agent_success_evaluation_result
+               SET tags = ?
+               WHERE result_id = ?
+                 AND tags IS NULL
+                 AND is_success = ?
+                 AND failure_type IS ?
+                 AND failure_reason IS ?
+                 AND number_of_correction_per_session = ?
+                 AND user_turns_to_resolution IS ?
+                 AND is_escalated = ?""",
+            (
+                _json_dumps(tags),
+                result_id,
+                int(expected_result.is_success),
+                expected_result.failure_type,
+                expected_result.failure_reason,
+                expected_result.number_of_correction_per_session,
+                expected_result.user_turns_to_resolution,
+                int(expected_result.is_escalated),
+            ),
+        )
+        return cursor.rowcount == 1
 
     @SQLiteStorageBase.handle_exceptions
     def get_agent_success_evaluation_results_in_window(

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
@@ -135,29 +135,55 @@ class AgentEvaluationResultStoreMixin:
         *,
         expected_result: AgentSuccessEvaluationResult,
     ) -> bool:
-        cursor = self._execute(
-            """UPDATE agent_success_evaluation_result
-               SET tags = ?
-               WHERE result_id = ?
-                 AND tags IS NULL
-                 AND is_success = ?
-                 AND failure_type IS ?
-                 AND failure_reason IS ?
-                 AND number_of_correction_per_session = ?
-                 AND user_turns_to_resolution IS ?
-                 AND is_escalated = ?""",
-            (
-                _json_dumps(tags),
-                result_id,
-                int(expected_result.is_success),
-                expected_result.failure_type,
-                expected_result.failure_reason,
-                expected_result.number_of_correction_per_session,
-                expected_result.user_turns_to_resolution,
-                int(expected_result.is_escalated),
-            ),
-        )
-        return cursor.rowcount == 1
+        with self._lock:
+            try:
+                self.conn.execute("BEGIN IMMEDIATE")
+                row = self.conn.execute(
+                    """SELECT user_id, governance_subject_ref
+                       FROM agent_success_evaluation_result
+                       WHERE result_id = ?""",
+                    (result_id,),
+                ).fetchone()
+                if row is None:
+                    self.conn.rollback()
+                    return False
+                subject_ref = row["governance_subject_ref"] or (
+                    self._subject_ref_for_user_id(row["user_id"])
+                )
+                self._assert_subject_writable_locked(subject_ref)
+                cursor = self.conn.execute(
+                    """UPDATE agent_success_evaluation_result
+                       SET tags = ?
+                       WHERE result_id = ?
+                         AND tags IS NULL
+                         AND agent_version = ?
+                         AND is_success = ?
+                         AND failure_type IS ?
+                         AND failure_reason IS ?
+                         AND regular_vs_shadow IS ?
+                         AND number_of_correction_per_session = ?
+                         AND user_turns_to_resolution IS ?
+                         AND is_escalated = ?""",
+                    (
+                        _json_dumps(tags),
+                        result_id,
+                        expected_result.agent_version,
+                        int(expected_result.is_success),
+                        expected_result.failure_type,
+                        expected_result.failure_reason,
+                        expected_result.regular_vs_shadow.value
+                        if expected_result.regular_vs_shadow
+                        else None,
+                        expected_result.number_of_correction_per_session,
+                        expected_result.user_turns_to_resolution,
+                        int(expected_result.is_escalated),
+                    ),
+                )
+                self.conn.commit()
+                return cursor.rowcount == 1
+            except Exception:
+                self.conn.rollback()
+                raise
 
     @SQLiteStorageBase.handle_exceptions
     def get_agent_success_evaluation_results_in_window(

--- a/reflexio/server/services/storage/storage_base/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_eval_results.py
@@ -35,17 +35,34 @@ class AgentEvaluationResultStoreMixin:
 
     @abstractmethod
     def get_agent_success_evaluation_results(
-        self, limit: int = 100, agent_version: str | None = None
+        self,
+        limit: int = 100,
+        agent_version: str | None = None,
+        user_id: str | None = None,
+        only_untagged: bool = False,
     ) -> list[AgentSuccessEvaluationResult]:
         """Get agent success evaluation results from storage.
 
         Args:
             limit (int): Maximum number of results to return
             agent_version (str, optional): The agent version to filter by. If None, returns all results.
+            user_id (str, optional): The user id to filter by. If None, returns all users.
+            only_untagged (bool): When true, return only rows awaiting tagging.
 
         Returns:
             list[AgentSuccessEvaluationResult]: List of agent success evaluation result objects
         """
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_agent_success_evaluation_result_tags(
+        self,
+        result_id: int,
+        tags: list[str],
+        *,
+        expected_result: AgentSuccessEvaluationResult,
+    ) -> bool:
+        """Update tags only if the persisted tagging summary is unchanged."""
         raise NotImplementedError
 
     def get_agent_success_evaluation_results_in_window(

--- a/reflexio/server/services/tagging/README.md
+++ b/reflexio/server/services/tagging/README.md
@@ -2,7 +2,10 @@
 
 Compact post-generation entity tagging capability.
 
-- `service.py` tags profiles and playbooks with the configured tagging prompts.
-- `tagging_scheduler.py` debounces post-publish tagging and rebuilds request context for background execution.
+- `service.py` tags profiles, playbooks, and persisted agent-success evaluation
+  summaries with their configured tagging prompts. Evaluation tagging receives
+  summary fields only; it never reloads transcripts or includes identifiers.
+- `tagging_scheduler.py` coalesces tagging by organization, user, and agent
+  version, then rebuilds request context for background execution.
 
 This package intentionally does not use `components/`: the service and scheduler are the only module responsibilities.

--- a/reflexio/server/services/tagging/service.py
+++ b/reflexio/server/services/tagging/service.py
@@ -7,6 +7,7 @@ from pydantic import ConfigDict, Field
 
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
+    AgentSuccessEvaluationResult,
     UserPlaybook,
     UserProfile,
 )
@@ -67,6 +68,7 @@ class TaggingService:
         agent_version: str,
         tag_profiles: bool = True,
         tag_playbooks: bool = True,
+        tag_evaluations: bool = True,
     ) -> None:
         if self.storage is None:
             return
@@ -80,6 +82,9 @@ class TaggingService:
         )
         user_playbook_prompt = getattr(
             config.user_playbook_extractor_config, "tagging_definition_prompt", None
+        )
+        evaluation_prompt = getattr(
+            config.agent_success_config, "tagging_definition_prompt", None
         )
 
         if tag_profiles and profile_prompt:
@@ -95,6 +100,38 @@ class TaggingService:
             self._tag_agent_playbooks(
                 agent_version=agent_version,
                 tagging_definition_prompt=user_playbook_prompt,
+            )
+        if tag_evaluations and evaluation_prompt:
+            self._tag_evaluations(
+                user_id=user_id,
+                agent_version=agent_version,
+                tagging_definition_prompt=evaluation_prompt,
+            )
+
+    def _tag_evaluations(
+        self,
+        *,
+        user_id: str,
+        agent_version: str,
+        tagging_definition_prompt: str,
+    ) -> None:
+        evaluations = self.storage.get_agent_success_evaluation_results(  # type: ignore[union-attr]
+            limit=_TAGGING_FETCH_LIMIT,
+            user_id=user_id,
+            agent_version=agent_version,
+            only_untagged=True,
+        )
+        for evaluation in evaluations:
+            if evaluation.tags is not None:
+                continue
+            tags = self._generate_tags(
+                tagging_definition_prompt=tagging_definition_prompt,
+                content=self._evaluation_content(evaluation),
+            )
+            self.storage.update_agent_success_evaluation_result_tags(  # type: ignore[union-attr]
+                evaluation.result_id,
+                tags,
+                expected_result=evaluation,
             )
 
     def _tag_profiles(self, *, user_id: str, tagging_definition_prompt: str) -> None:
@@ -198,3 +235,20 @@ class TaggingService:
         if playbook.rationale:
             parts.append(f"Rationale: {playbook.rationale}")
         return "\n".join(part for part in parts if part)
+
+    @staticmethod
+    def _evaluation_content(evaluation: AgentSuccessEvaluationResult) -> str:
+        parts = [f"Outcome: {'success' if evaluation.is_success else 'failure'}"]
+        if evaluation.failure_type:
+            parts.append(f"Failure type: {evaluation.failure_type}")
+        if evaluation.failure_reason:
+            parts.append(f"Failure reason: {evaluation.failure_reason}")
+        parts.append(f"Escalated: {'yes' if evaluation.is_escalated else 'no'}")
+        parts.append(
+            f"Corrective user turns: {evaluation.number_of_correction_per_session}"
+        )
+        if evaluation.user_turns_to_resolution is not None:
+            parts.append(
+                f"User turns to resolution: {evaluation.user_turns_to_resolution}"
+            )
+        return "\n".join(parts)

--- a/reflexio/server/services/tagging/tagging_scheduler.py
+++ b/reflexio/server/services/tagging/tagging_scheduler.py
@@ -1,10 +1,10 @@
-"""Singleton scheduler for deferred, off-publish-path entity tagging.
+"""Singleton scheduler for deferred, off-request-path entity tagging.
 
-Tagging runs an LLM call per newly generated profile/playbook, so it must not
-block the publish request. This scheduler mirrors
+Tagging runs an LLM call per newly generated profile, playbook, or evaluation,
+so it must not block the publish or evaluation request. This scheduler mirrors
 :class:`GroupEvaluationScheduler`: a single daemon thread with a min-heap, where
-each publish upserts the fire time for its ``(org_id, user_id, agent_version)``
-key. Rapid successive publishes for the same key debounce into a single tagging
+each enqueue upserts the fire time for its ``(org_id, user_id, agent_version)``
+key. Rapid successive enqueues for the same key debounce into a single tagging
 pass; when the timer fires, the tagging callback runs on its own daemon thread.
 
 Tagging is idempotent (already-tagged entities are skipped), so a deferred pass

--- a/reflexio/server/services/tagging/tagging_scheduler.py
+++ b/reflexio/server/services/tagging/tagging_scheduler.py
@@ -15,6 +15,7 @@ happens when a tagging definition is first configured.
 from __future__ import annotations
 
 import heapq
+import itertools
 import logging
 import os
 import threading
@@ -55,8 +56,9 @@ class TaggingScheduler:
         return cls._instance
 
     def __init__(self) -> None:
-        self._scheduled: dict[TaggingKey, tuple[float, Callable]] = {}
-        self._heap: list[tuple[float, TaggingKey]] = []
+        self._scheduled: dict[TaggingKey, tuple[float, int, Callable]] = {}
+        self._heap: list[tuple[float, int, TaggingKey]] = []
+        self._sequence = itertools.count()
         self._mutex = threading.Lock()
         self._wake_event = threading.Event()
         self._thread = threading.Thread(
@@ -69,8 +71,9 @@ class TaggingScheduler:
         """Schedule or reschedule a tagging pass for ``key`` (slides the fire time forward)."""
         fire_time = time.monotonic() + _EFFECTIVE_DELAY_SECONDS
         with self._mutex:
-            self._scheduled[key] = (fire_time, callback)
-            heapq.heappush(self._heap, (fire_time, key))
+            sequence = next(self._sequence)
+            self._scheduled[key] = (fire_time, sequence, callback)
+            heapq.heappush(self._heap, (fire_time, sequence, key))
         self._wake_event.set()
 
     def drain(self, *, timeout_seconds: float = 5.0) -> bool:
@@ -106,13 +109,13 @@ class TaggingScheduler:
 
                 with self._mutex:
                     while self._heap and self._heap[0][0] <= time.monotonic():
-                        fire_time, key = heapq.heappop(self._heap)
+                        _fire_time, sequence, key = heapq.heappop(self._heap)
 
                         current = self._scheduled.get(key)
                         if current is None:
                             continue
-                        current_fire_time, callback = current
-                        if abs(current_fire_time - fire_time) > 0.001:
+                        _current_fire_time, current_sequence, callback = current
+                        if current_sequence != sequence:
                             # Superseded by a newer schedule for the same key.
                             continue
 

--- a/tests/models/test_agent_success_config.py
+++ b/tests/models/test_agent_success_config.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from reflexio.models.config_schema import (
+    AgentSuccessConfig,
+    Config,
+    validate_stored_config,
+)
+
+
+def test_agent_success_tagging_prompt_round_trip() -> None:
+    config = AgentSuccessConfig(
+        success_definition_prompt="success rules",
+        tagging_definition_prompt="tag by support topic",
+    )
+
+    assert config.model_dump()["tagging_definition_prompt"] == "tag by support topic"
+
+
+def test_legacy_agent_success_metadata_is_ignored_only_for_stored_config() -> None:
+    stored = validate_stored_config(
+        {
+            "storage_config": {"db_path": None},
+            "agent_context_prompt": "preserve me",
+            "window_size": 23,
+            "agent_success_config": {
+                "success_definition_prompt": "preserve success rules",
+                "metadata_definition_prompt": "do not migrate me",
+                "sampling_rate": 0.75,
+            },
+        }
+    )
+
+    assert stored.agent_context_prompt == "preserve me"
+    assert stored.window_size == 23
+    assert stored.agent_success_config is not None
+    assert (
+        stored.agent_success_config.success_definition_prompt
+        == "preserve success rules"
+    )
+    assert stored.agent_success_config.sampling_rate == 0.75
+    assert stored.agent_success_config.tagging_definition_prompt is None
+    assert "metadata_definition_prompt" not in stored.agent_success_config.model_dump()
+
+    with pytest.raises(ValidationError):
+        Config.model_validate(
+            {
+                "storage_config": {"db_path": None},
+                "agent_success_config": {
+                    "success_definition_prompt": "success rules",
+                    "metadata_definition_prompt": "retired",
+                },
+            },
+            extra="forbid",
+        )

--- a/tests/models/test_view_models.py
+++ b/tests/models/test_view_models.py
@@ -302,6 +302,7 @@ class TestToEvaluationResultView:
             number_of_correction_per_session=3,
             user_turns_to_resolution=7,
             is_escalated=True,
+            tags=["support", "escalated"],
             embedding=_FAKE_EMBEDDING,
         )
         view = to_evaluation_result_view(result)
@@ -317,6 +318,7 @@ class TestToEvaluationResultView:
         assert view.number_of_correction_per_session == 3
         assert view.user_turns_to_resolution == 7
         assert view.is_escalated is True
+        assert view.tags == ["support", "escalated"]
 
 
 class TestToProfileChangeLogView:

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
@@ -423,7 +423,6 @@ def test_with_tool_configs(mock_chat_completion):
         success_config = AgentSuccessConfig(
             evaluation_name="tool_usage_evaluation",
             success_definition_prompt="Evaluate if the agent used tools effectively",
-            tagging_definition_prompt="Include tool usage",
         )
         agent_success_service.configurator.set_config_by_name(
             "agent_success_config", success_config

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_services.py
@@ -423,7 +423,7 @@ def test_with_tool_configs(mock_chat_completion):
         success_config = AgentSuccessConfig(
             evaluation_name="tool_usage_evaluation",
             success_definition_prompt="Evaluate if the agent used tools effectively",
-            metadata_definition_prompt="Include tool usage statistics",
+            tagging_definition_prompt="Include tool usage",
         )
         agent_success_service.configurator.set_config_by_name(
             "agent_success_config", success_config

--- a/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
+++ b/tests/server/services/agent_success_evaluation/test_agent_success_evaluation_utils.py
@@ -22,17 +22,17 @@ def _render_agent_success_prompt() -> str:
             "agent_context_prompt": "Test agent",
             "success_definition_prompt": "Complete the requested task",
             "tool_can_use": "No tools",
-            "metadata_definition_prompt": "No metadata",
             "interactions": "user: ```hello```",
         },
     )
 
 
-def test_agent_success_prompt_v1_1_0_is_active_and_renders() -> None:
+def test_agent_success_prompt_v1_3_0_is_active_and_renders() -> None:
     prompt_manager = PromptManager()
 
-    assert prompt_manager.get_active_version("agent_success_evaluation") == "1.2.0"
+    assert prompt_manager.get_active_version("agent_success_evaluation") == "1.3.0"
     assert "Step 4: Count corrective user turns" in _render_agent_success_prompt()
+    assert "[Metadata Definition]" not in _render_agent_success_prompt()
 
 
 def test_agent_success_prompt_examples_are_valid_json() -> None:
@@ -132,7 +132,6 @@ def test_construct_agent_success_evaluation_messages_with_sessions():
         agent_context_prompt="Test agent context",
         success_definition_prompt="Evaluate if the agent successfully completed the task",
         tool_can_use="search, calculator",
-        metadata_definition_prompt="Include tool usage statistics",
     )
 
     # Validate that messages were created
@@ -213,7 +212,6 @@ def test_construct_agent_success_evaluation_messages_with_empty_sessions():
         agent_context_prompt="Test agent context",
         success_definition_prompt="Evaluate if the agent successfully completed the task",
         tool_can_use="search, calculator",
-        metadata_definition_prompt="Include tool usage statistics",
     )
 
     # Should still create messages (user message with prompt)

--- a/tests/server/services/agent_success_evaluation/test_save_retry.py
+++ b/tests/server/services/agent_success_evaluation/test_save_retry.py
@@ -17,7 +17,11 @@ def _make_service_with_storage(storage_mock):
     svc.last_run_save_failed = False
     svc._last_extractor_run_stats = {"failed": 0}
     svc.storage = storage_mock
-    svc.service_config = MagicMock(session_id="sess_test")
+    svc.service_config = MagicMock(
+        session_id="sess_test", user_id="user-1", agent_version="agent-1"
+    )
+    svc.request_context = MagicMock(org_id="org-1")
+    svc.client = MagicMock()
     return svc
 
 
@@ -31,6 +35,11 @@ def test_save_retried_three_times_with_backoff(monkeypatch) -> None:
         "reflexio.server.services.agent_success_evaluation.service.time.sleep",
         lambda s: slept.append(s),
     )
+    schedule_tagging = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.agent_success_evaluation.service.schedule_tagging",
+        schedule_tagging,
+    )
 
     svc = _make_service_with_storage(storage)
     fake_result = MagicMock()
@@ -39,6 +48,7 @@ def test_save_retried_three_times_with_backoff(monkeypatch) -> None:
     assert storage.save_agent_success_evaluation_results.call_count == 3
     assert slept == [1, 4]  # backoffs *between* attempts (no sleep after final)
     assert svc.last_run_save_failed is True
+    schedule_tagging.assert_not_called()
     assert _eval_health.get_status()["producer_failures_24h"] == 1
 
 
@@ -57,6 +67,11 @@ def test_save_succeeds_on_second_attempt(monkeypatch) -> None:
         "reflexio.server.services.agent_success_evaluation.service.time.sleep",
         lambda _: None,
     )
+    schedule_tagging = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.agent_success_evaluation.service.schedule_tagging",
+        schedule_tagging,
+    )
 
     svc = _make_service_with_storage(storage)
     fake_result = MagicMock()
@@ -65,4 +80,34 @@ def test_save_succeeds_on_second_attempt(monkeypatch) -> None:
     assert calls["n"] == 2
     assert svc.last_run_save_failed is False
     assert svc.last_run_saved_result_count == 1
+    schedule_tagging.assert_called_once_with(
+        org_id="org-1",
+        user_id="user-1",
+        agent_version="agent-1",
+        request_context=svc.request_context,
+        llm_client=svc.client,
+    )
+    assert _eval_health.get_status()["producer_failures_24h"] == 0
+
+
+def test_tagging_schedule_failure_does_not_retry_successful_save(monkeypatch) -> None:
+    _eval_health._HEALTH.__init__()
+    storage = MagicMock()
+    monkeypatch.setattr(
+        "reflexio.server.services.agent_success_evaluation.service.time.sleep",
+        lambda _: None,
+    )
+    schedule_tagging = MagicMock(side_effect=RuntimeError("scheduler unavailable"))
+    monkeypatch.setattr(
+        "reflexio.server.services.agent_success_evaluation.service.schedule_tagging",
+        schedule_tagging,
+    )
+
+    svc = _make_service_with_storage(storage)
+    svc._process_results([[MagicMock()]])
+
+    storage.save_agent_success_evaluation_results.assert_called_once()
+    schedule_tagging.assert_called_once()
+    assert svc.last_run_saved_result_count == 1
+    assert svc.last_run_save_failed is False
     assert _eval_health.get_status()["producer_failures_24h"] == 0

--- a/tests/server/services/governance/test_subject_write_barrier_sqlite.py
+++ b/tests/server/services/governance/test_subject_write_barrier_sqlite.py
@@ -216,6 +216,41 @@ def test_barrier_blocks_playbook_eval_and_source_window_writes(
         )
 
 
+def test_barrier_blocks_deferred_evaluation_tag_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    storage = _storage(tmp_path, monkeypatch)
+    subject_ref = governance_subject_ref("org-barrier", "alice", "barrier-secret")
+    result = AgentSuccessEvaluationResult(
+        user_id="alice",
+        session_id="sess-before-barrier",
+        agent_version="agent-v1",
+        evaluation_name="barrier-test",
+        is_success=True,
+    )
+    storage.save_agent_success_evaluation_results([result])
+    persisted = storage.get_agent_success_evaluation_results(user_id="alice")[0]
+    purge = storage.begin_purge_operation(
+        purge_id="purge_deferred_tag_write",
+        idempotency_key="idem_deferred_tag_write",
+        operation_type="user_erasure",
+        scope_type="user",
+        subject_ref=subject_ref,
+        request_ref="reqref_v1_11111111111111111111111111111112",
+    )
+    storage.begin_subject_erasure_barrier(subject_ref, purge.purge_id)
+
+    with pytest.raises(SubjectWriteBarrierError):
+        storage.update_agent_success_evaluation_result_tags(
+            persisted.result_id,
+            ["blocked"],
+            expected_result=persisted,
+        )
+
+    assert storage.get_agent_success_evaluation_results(user_id="alice")[0].tags is None
+
+
 def test_begin_subject_erasure_barrier_requires_matching_purge(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/services/storage/sqlite_storage/test_eval_result_user_id_migration.py
+++ b/tests/server/services/storage/sqlite_storage/test_eval_result_user_id_migration.py
@@ -61,7 +61,7 @@ def _eval_columns(db_path: str) -> set[str]:
         conn.close()
 
 
-def test_migrate_adds_user_id_on_legacy_eval_table(tmp_path):
+def test_migrate_adds_user_id_and_tags_on_legacy_eval_table(tmp_path):
     db_path = str(tmp_path / "legacy.db")
     _seed_legacy_db(db_path)
 
@@ -70,6 +70,7 @@ def test_migrate_adds_user_id_on_legacy_eval_table(tmp_path):
 
     cols = _eval_columns(db_path)
     assert "user_id" in cols  # backfill ran
+    assert "tags" in cols
     # Existing row preserved with the NOT NULL DEFAULT '' backfill value.
     conn = sqlite3.connect(db_path)
     try:
@@ -89,3 +90,4 @@ def test_migrate_is_idempotent_on_legacy_eval_table(tmp_path):
     SQLiteStorage(org_id="0", db_path=db_path)  # second boot must not raise
 
     assert "user_id" in _eval_columns(db_path)
+    assert "tags" in _eval_columns(db_path)

--- a/tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py
@@ -474,6 +474,36 @@ class TestDeleteAllAgentSuccessEvaluationResults:
             expected_result=regenerated,
         )
 
+        s.conn.execute(
+            "UPDATE agent_success_evaluation_result "
+            "SET tags = NULL, agent_version = ?, regular_vs_shadow = ? "
+            "WHERE result_id = ?",
+            ("v2", "tied", regenerated.result_id),
+        )
+        s.conn.commit()
+
+        assert not s.update_agent_success_evaluation_result_tags(
+            regenerated.result_id,
+            ["stale-version"],
+            expected_result=regenerated,
+        )
+        current = s.get_agent_success_evaluation_results(
+            user_id="u2", agent_version="v2"
+        )[0]
+        assert current.tags is None
+        assert current.regular_vs_shadow is not None
+        stale_mode = current.model_copy(update={"regular_vs_shadow": None})
+        assert not s.update_agent_success_evaluation_result_tags(
+            current.result_id,
+            ["stale-mode"],
+            expected_result=stale_mode,
+        )
+        assert s.update_agent_success_evaluation_result_tags(
+            current.result_id,
+            ["current"],
+            expected_result=current,
+        )
+
     def test_idempotent_on_empty_table(self, tmp_path):
         """Calling on an empty table raises no error and leaves the table empty."""
         s = _store(tmp_path)

--- a/tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py
+++ b/tests/server/services/storage/sqlite_storage/test_playbook_remaining_methods_integration.py
@@ -411,6 +411,69 @@ class TestDeleteAllAgentSuccessEvaluationResults:
 
         assert s.get_agent_success_evaluation_results(limit=100) == []
 
+    def test_tags_round_trip_and_user_scope(self, tmp_path):
+        s = _store(tmp_path)
+        s.save_agent_success_evaluation_results(
+            [
+                _make_eval_result(user_id="u1", session_id="s1"),
+                _make_eval_result(user_id="u2", session_id="s2"),
+            ]
+        )
+
+        u1_results = s.get_agent_success_evaluation_results(
+            limit=100, agent_version="v1", user_id="u1"
+        )
+        assert len(u1_results) == 1
+        assert u1_results[0].tags is None
+
+        assert s.update_agent_success_evaluation_result_tags(
+            u1_results[0].result_id,
+            [],
+            expected_result=u1_results[0],
+        )
+        assert s.get_agent_success_evaluation_results(user_id="u1")[0].tags == []
+        assert (
+            s.get_agent_success_evaluation_results(user_id="u1", only_untagged=True)
+            == []
+        )
+        pending = s.get_agent_success_evaluation_results(
+            limit=1,
+            agent_version="v1",
+            only_untagged=True,
+        )
+        assert [result.user_id for result in pending] == ["u2"]
+
+        u2_result = s.get_agent_success_evaluation_results(user_id="u2")[0]
+        assert s.update_agent_success_evaluation_result_tags(
+            u2_result.result_id,
+            ["support"],
+            expected_result=u2_result,
+        )
+        assert s.get_agent_success_evaluation_results(user_id="u2")[0].tags == [
+            "support"
+        ]
+
+        s.conn.execute(
+            "UPDATE agent_success_evaluation_result "
+            "SET tags = NULL, failure_reason = ? WHERE result_id = ?",
+            ("regenerated", u2_result.result_id),
+        )
+        s.conn.commit()
+
+        assert not s.update_agent_success_evaluation_result_tags(
+            u2_result.result_id,
+            ["stale"],
+            expected_result=u2_result,
+        )
+        regenerated = s.get_agent_success_evaluation_results(user_id="u2")[0]
+        assert regenerated.tags is None
+        assert regenerated.failure_reason == "regenerated"
+        assert s.update_agent_success_evaluation_result_tags(
+            regenerated.result_id,
+            ["retagged"],
+            expected_result=regenerated,
+        )
+
     def test_idempotent_on_empty_table(self, tmp_path):
         """Calling on an empty table raises no error and leaves the table empty."""
         s = _store(tmp_path)

--- a/tests/server/services/tagging/test_tagging_scheduler.py
+++ b/tests/server/services/tagging/test_tagging_scheduler.py
@@ -38,14 +38,23 @@ def test_scheduler_drain_waits_for_scheduled_callback(monkeypatch: Any) -> None:
 
 
 def test_scheduler_coalesces_same_scope_to_latest_callback(monkeypatch: Any) -> None:
-    monkeypatch.setattr(tagging_scheduler, "_EFFECTIVE_DELAY_SECONDS", 0.02)
+    now = [100.0]
+    monkeypatch.setattr(tagging_scheduler, "_EFFECTIVE_DELAY_SECONDS", 10.0)
+    monkeypatch.setattr(tagging_scheduler.time, "monotonic", lambda: now[0])
     first_fired = threading.Event()
     latest_fired = threading.Event()
-    scheduler = TaggingScheduler.get_instance()
+    scheduler = TaggingScheduler()
 
     scheduler.schedule(("org", "coalesced-user", "v1"), first_fired.set)
     scheduler.schedule(("org", "coalesced-user", "v1"), latest_fired.set)
 
+    with scheduler._mutex:
+        first_entry, latest_entry = scheduler._heap
+        assert first_entry[0] == latest_entry[0]
+        assert first_entry[1] != latest_entry[1]
+
+    now[0] = 111.0
+    scheduler._wake_event.set()
     assert latest_fired.wait(timeout=5)
     assert not first_fired.is_set()
 

--- a/tests/server/services/tagging/test_tagging_scheduler.py
+++ b/tests/server/services/tagging/test_tagging_scheduler.py
@@ -37,6 +37,19 @@ def test_scheduler_drain_waits_for_scheduled_callback(monkeypatch: Any) -> None:
     assert fired.is_set()
 
 
+def test_scheduler_coalesces_same_scope_to_latest_callback(monkeypatch: Any) -> None:
+    monkeypatch.setattr(tagging_scheduler, "_EFFECTIVE_DELAY_SECONDS", 0.02)
+    first_fired = threading.Event()
+    latest_fired = threading.Event()
+    scheduler = TaggingScheduler.get_instance()
+
+    scheduler.schedule(("org", "coalesced-user", "v1"), first_fired.set)
+    scheduler.schedule(("org", "coalesced-user", "v1"), latest_fired.set)
+
+    assert latest_fired.wait(timeout=5)
+    assert not first_fired.is_set()
+
+
 def test_schedule_tagging_skips_when_no_user(monkeypatch: Any) -> None:
     scheduled: list[tuple[Any, Any]] = []
     monkeypatch.setattr(

--- a/tests/server/services/tagging/test_tagging_service.py
+++ b/tests/server/services/tagging/test_tagging_service.py
@@ -4,10 +4,12 @@ from typing import Any
 
 from reflexio.models.api_schema.domain.entities import (
     AgentPlaybook,
+    AgentSuccessEvaluationResult,
     UserPlaybook,
     UserProfile,
 )
 from reflexio.models.config_schema import (
+    AgentSuccessConfig,
     Config,
     LLMConfig,
     ProfileExtractorConfig,
@@ -48,9 +50,24 @@ class FakeStorage:
                 rationale="It helps reviewers trust the change.",
             )
         ]
+        self.evaluations = [
+            AgentSuccessEvaluationResult(
+                result_id=30,
+                user_id="user-1",
+                agent_version="agent-1",
+                session_id="session-1",
+                is_success=False,
+                failure_type="wrong_answer",
+                failure_reason="The response omitted the rollback steps.",
+                number_of_correction_per_session=2,
+                user_turns_to_resolution=4,
+                is_escalated=True,
+            )
+        ]
         self.profile_updates: list[tuple[str, str, list[str]]] = []
         self.user_playbook_updates: list[tuple[int, list[str] | None]] = []
         self.agent_playbook_updates: list[tuple[int, list[str] | None]] = []
+        self.evaluation_updates: list[tuple[int, list[str]]] = []
 
     def get_user_profile(self, user_id: str) -> list[UserProfile]:
         assert user_id == "user-1"
@@ -87,6 +104,33 @@ class FakeStorage:
         self, agent_playbook_id: int, *, tags: list[str] | None = None, **_: Any
     ) -> None:
         self.agent_playbook_updates.append((agent_playbook_id, tags))
+
+    def get_agent_success_evaluation_results(
+        self,
+        *,
+        limit: int = 100,
+        user_id: str | None = None,
+        agent_version: str | None = None,
+        only_untagged: bool = False,
+    ) -> list[AgentSuccessEvaluationResult]:
+        assert limit == 1000
+        assert (user_id, agent_version) == ("user-1", "agent-1")
+        assert only_untagged is True
+        evaluations = self.evaluations
+        if only_untagged:
+            evaluations = [item for item in evaluations if item.tags is None]
+        return evaluations[:limit]
+
+    def update_agent_success_evaluation_result_tags(
+        self,
+        result_id: int,
+        tags: list[str],
+        *,
+        expected_result: AgentSuccessEvaluationResult,
+    ) -> bool:
+        assert expected_result.result_id == result_id
+        self.evaluation_updates.append((result_id, tags))
+        return True
 
 
 class FakeConfigurator:
@@ -127,6 +171,7 @@ def make_config(
     *,
     profile_tagging_prompt: str | None = "profile tagging rules",
     playbook_tagging_prompt: str | None = "playbook tagging rules",
+    evaluation_tagging_prompt: str | None = None,
 ) -> Config:
     return Config(
         storage_config=StorageConfigSQLite(db_path=":memory:"),
@@ -137,6 +182,10 @@ def make_config(
         user_playbook_extractor_config=UserPlaybookExtractorConfig(
             extraction_definition_prompt="playbook extraction rules",
             tagging_definition_prompt=playbook_tagging_prompt,
+        ),
+        agent_success_config=AgentSuccessConfig(
+            success_definition_prompt="success rules",
+            tagging_definition_prompt=evaluation_tagging_prompt,
         ),
         llm_config=LLMConfig(generation_model_name="test-model"),
     )
@@ -159,6 +208,7 @@ def test_tagging_updates_profiles_and_playbooks(monkeypatch: Any) -> None:
     assert storage.profile_updates == [("user-1", "profile-1", ["profile-tag"])]
     assert storage.user_playbook_updates == [(10, ["user-playbook-tag"])]
     assert storage.agent_playbook_updates == [(20, ["agent-playbook-tag"])]
+    assert storage.evaluation_updates == []
     assert [call[0] for call in context.prompt_manager.calls] == [
         "tagging",
         "tagging",
@@ -197,6 +247,7 @@ def test_tagging_skips_entity_types_without_tagging_prompts(
     assert storage.profile_updates == []
     assert storage.user_playbook_updates == []
     assert storage.agent_playbook_updates == []
+    assert storage.evaluation_updates == []
     assert context.prompt_manager.calls == []
     assert client.calls == []
 
@@ -220,6 +271,7 @@ def test_tagging_can_scope_to_profiles_only(monkeypatch: Any) -> None:
     assert storage.profile_updates == [("user-1", "profile-1", ["profile-tag"])]
     assert storage.user_playbook_updates == []
     assert storage.agent_playbook_updates == []
+    assert storage.evaluation_updates == []
     assert len(context.prompt_manager.calls) == 1
 
 
@@ -243,5 +295,91 @@ def test_tagging_skips_already_tagged_entities(monkeypatch: Any) -> None:
     assert storage.profile_updates == []
     assert storage.user_playbook_updates == []
     assert storage.agent_playbook_updates == []
+    assert storage.evaluation_updates == []
     assert context.prompt_manager.calls == []
     assert client.calls == []
+
+
+def test_tagging_updates_evaluation_from_persisted_summary(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    context = FakeRequestContext(
+        make_config(
+            profile_tagging_prompt=None,
+            playbook_tagging_prompt=None,
+            evaluation_tagging_prompt="evaluation tagging rules",
+        ),
+        storage,
+    )
+    client = FakeLLMClient([["needs-rollback"]])
+
+    TaggingService(client, context).run(user_id="user-1", agent_version="agent-1")  # type: ignore[arg-type]
+
+    assert storage.evaluation_updates == [(30, ["needs-rollback"])]
+    assert context.prompt_manager.calls == [
+        (
+            "tagging",
+            {
+                "tagging_definition_prompt": "evaluation tagging rules",
+                "content": (
+                    "Outcome: failure\n"
+                    "Failure type: wrong_answer\n"
+                    "Failure reason: The response omitted the rollback steps.\n"
+                    "Escalated: yes\n"
+                    "Corrective user turns: 2\n"
+                    "User turns to resolution: 4"
+                ),
+            },
+        )
+    ]
+
+
+def test_tagging_persists_empty_evaluation_tags(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    context = FakeRequestContext(
+        make_config(
+            profile_tagging_prompt=None,
+            playbook_tagging_prompt=None,
+            evaluation_tagging_prompt="evaluation tagging rules",
+        ),
+        storage,
+    )
+
+    TaggingService(FakeLLMClient([[]]), context).run(  # type: ignore[arg-type]
+        user_id="user-1", agent_version="agent-1"
+    )
+
+    assert storage.evaluation_updates == [(30, [])]
+
+
+def test_tagging_skips_already_tagged_evaluation(monkeypatch: Any) -> None:
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+    monkeypatch.setattr(
+        "reflexio.server.services.tagging.service.SiteVarManager.get_site_var",
+        lambda *_: {},
+    )
+    storage = FakeStorage()
+    storage.evaluations[0].tags = []
+    context = FakeRequestContext(
+        make_config(
+            profile_tagging_prompt=None,
+            playbook_tagging_prompt=None,
+            evaluation_tagging_prompt="evaluation tagging rules",
+        ),
+        storage,
+    )
+
+    TaggingService(FakeLLMClient([]), context).run(  # type: ignore[arg-type]
+        user_id="user-1", agent_version="agent-1"
+    )
+
+    assert storage.evaluation_updates == []

--- a/tests/server/services/test_prompt_model_mapping.py
+++ b/tests/server/services/test_prompt_model_mapping.py
@@ -46,7 +46,7 @@ PROMPT_VERSION_MAP: dict[str, tuple[str, str | None]] = {
     "profile_should_generate_override": ("v1.0.0", "boolean_evaluation"),
     "profile_deduplication": ("v1.0.0", "profile_deduplication"),
     "tagging": ("v1.0.0", "tagging"),
-    "agent_success_evaluation": ("v1.2.0", "agent_success_evaluation"),
+    "agent_success_evaluation": ("v1.3.0", "agent_success_evaluation"),
     # Retrieved-learning judges — per-learning relevance/impact verdicts for
     # sessions publishing interactions with ``retrieved_learnings``.
     "retrieved_learning_relevance": ("v1.0.0", "retrieved_learning_relevance"),


### PR DESCRIPTION
## Summary

- Replace the evaluator's obsolete metadata prompt with the same deferred tagging pipeline used by profiles and playbooks.
- Preserve legacy stored-config compatibility while ensuring new writes use `tagging_definition_prompt` only.
- Add nullable tags to agent-success results and reset them when regenerated summaries require retagging.

## Changes

- Added evaluator prompt `v1.3.0` without metadata prompt plumbing and kept historical prompt versions intact.
- Extended agent-success domain and UI models with `tags: list[str] | None`.
- Added SQLite tag persistence, scoped untagged scans, compare-and-set tag updates, and legacy schema upgrade coverage.
- Extended `TaggingService` and `TaggingScheduler` to process persisted evaluation summaries without transcripts or identifiers.
- Scheduled deferred tagging only after successful evaluation persistence and protected regenerated results from stale tag writes.
- Updated generated schema sources, service code maps, and regression tests.

- Hardened SQLite tag-only writes with subject-erasure barriers and full mutable-summary compare-and-set predicates.
- Replaced debounce timestamp tolerance with exact scheduler generations and normalized blank evaluator tag prompts.

## Test Plan

- `uv run ruff check` and `uv run ruff format` on changed Python files
- `uv run pyright` on changed Python files
- Focused review regressions: 74 passed
- `npm run lint -- lib/config-schema.ts` and `npx tsc --noEmit` in `docs/`
- Full OSS unit/integration suite: 5,543 passed
- OSS E2E suite: 47 passed
- Live platform flow: configure tagging, publish a session, grade it, wait for deferred tagging, and verify serialized tags


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent success evaluations can now receive and display generated tags.
  * Evaluation results support filtering for a specific user and untagged results.
  * Tagging is scheduled automatically after successful evaluation saves.

* **Improvements**
  * Updated evaluation prompts to provide clearer failure classification and corrective-turn guidance.
  * Renamed the configuration option to `tagging_definition_prompt`.

* **Documentation**
  * Updated tagging and evaluation workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->