### PR TITLE
Fix all 235 pyright errors in tests (typed test helpers, no config changes)

### DIFF
--- a/reflexio/test_support/typing_helpers.py
+++ b/reflexio/test_support/typing_helpers.py
@@ -1,0 +1,58 @@
+"""Typed helpers for tests that need static narrowing, not runtime changes.
+
+These helpers exist purely to satisfy the type checker at test call sites:
+``require_storage`` narrows the optional ``RequestContext.storage`` attribute,
+and ``as_mock`` views a spec'd mock held behind a real-class-typed attribute
+as the ``MagicMock`` it actually is at runtime.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+if TYPE_CHECKING:
+    from reflexio.lib.reflexio_lib import Reflexio
+    from reflexio.server.services.storage.storage_base import BaseStorage
+
+
+def require_storage(instance: Reflexio) -> BaseStorage:
+    """
+    Return the instance's storage, asserting it is configured.
+
+    ``RequestContext.storage`` is typed ``BaseStorage | None`` because storage
+    creation can legitimately fail at runtime. Tests that operate on a fully
+    configured instance use this helper to narrow away the ``None`` branch once
+    instead of sprinkling ``assert`` statements at every access site.
+
+    Args:
+        instance (Reflexio): A Reflexio instance whose storage must be configured.
+
+    Returns:
+        BaseStorage: The configured storage backend.
+
+    Raises:
+        AssertionError: If storage is not configured on the instance.
+    """
+    storage = instance.request_context.storage
+    if storage is None:
+        raise AssertionError("test requires a configured storage backend")
+    return storage
+
+
+def as_mock(obj: object) -> MagicMock:
+    """
+    View a runtime mock behind a real-class-typed attribute as a MagicMock.
+
+    Tests that build objects with ``Mock(spec=SomeClass)`` collaborators access
+    mock-only attributes (``return_value``, ``side_effect``, ``assert_called_*``)
+    through attributes the type checker sees as the real class. This cast makes
+    the runtime reality visible to the checker without changing behavior.
+
+    Args:
+        obj (object): An object that is a Mock/MagicMock at runtime.
+
+    Returns:
+        MagicMock: The same object, typed as MagicMock.
+    """
+    return cast(MagicMock, obj)

--- a/tests/client/test_operation_status_polling.py
+++ b/tests/client/test_operation_status_polling.py
@@ -1,10 +1,14 @@
 """Unit tests for ReflexioClient operation-status polling."""
 
+import pytest
+
 from reflexio.client import ReflexioClient
 from reflexio.models.api_schema.domain.enums import OperationStatus
 
 
-def test_poll_operation_status_accepts_one_second_started_at_skew():
+def test_poll_operation_status_accepts_one_second_started_at_skew(
+    monkeypatch: pytest.MonkeyPatch,
+):
     client = ReflexioClient.__new__(ReflexioClient)
 
     def fake_make_request(method: str, path: str, **kwargs):
@@ -25,7 +29,7 @@ def test_poll_operation_status_accepts_one_second_started_at_skew():
             },
         }
 
-    client._make_request = fake_make_request
+    monkeypatch.setattr(client, "_make_request", fake_make_request)
 
     response = client._poll_operation_status(
         "profile_generation",

--- a/tests/e2e_tests/test_configuration.py
+++ b/tests/e2e_tests/test_configuration.py
@@ -84,6 +84,9 @@ def test_set_config_end_to_end(
     current_config = reflexio.request_context.configurator.get_config()
     assert current_config is not None
     assert current_config.profile_extractor_config is not None
+    assert current_config.profile_extractor_config.context_prompt is not None
+    assert new_config.profile_extractor_config is not None
+    assert new_config.profile_extractor_config.context_prompt is not None
     assert (
         current_config.profile_extractor_config.context_prompt.strip()
         == new_config.profile_extractor_config.context_prompt.strip()
@@ -127,7 +130,7 @@ def test_set_config_end_to_end(
     assert updated_config.profile_extractor_config is not None
     assert (
         "Updated test configuration from dict"
-        in updated_config.profile_extractor_config.context_prompt
+        in (updated_config.profile_extractor_config.context_prompt or "")
     )
     assert updated_config.user_playbook_extractor_config is not None
     assert (
@@ -144,7 +147,7 @@ def test_set_config_end_to_end(
         invalid_config = {"invalid_field": "invalid_value"}
         error_response = reflexio.set_config(invalid_config)
         assert error_response.success is False
-        assert "Failed to set configuration" in error_response.msg
+        assert "Failed to set configuration" in (error_response.msg or "")
     except Exception:  # noqa: S110
         # If an exception is thrown instead of returning error response, that's also acceptable
         pass
@@ -208,7 +211,9 @@ def test_get_config_end_to_end(
 
     # Verify profile extractor config
     assert retrieved_config.profile_extractor_config is not None
-    assert "Get config test" in retrieved_config.profile_extractor_config.context_prompt
+    assert "Get config test" in (
+        retrieved_config.profile_extractor_config.context_prompt or ""
+    )
 
     # Verify agent playbook config
     assert retrieved_config.user_playbook_extractor_config is not None

--- a/tests/e2e_tests/test_configuration.py
+++ b/tests/e2e_tests/test_configuration.py
@@ -128,9 +128,8 @@ def test_set_config_end_to_end(
     updated_config = reflexio.request_context.configurator.get_config()
     assert updated_config is not None
     assert updated_config.profile_extractor_config is not None
-    assert (
-        "Updated test configuration from dict"
-        in (updated_config.profile_extractor_config.context_prompt or "")
+    assert "Updated test configuration from dict" in (
+        updated_config.profile_extractor_config.context_prompt or ""
     )
     assert updated_config.user_playbook_extractor_config is not None
     assert (

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -35,7 +35,7 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.services.configurator.configurator import DefaultConfigurator
-from tests.server.test_utils import skip_in_precommit
+from tests.server.test_utils import require_storage, skip_in_precommit
 
 pytestmark = pytest.mark.e2e
 
@@ -149,7 +149,7 @@ def _make_reflexio_with_profile(
 
 def _cleanup(instance: Reflexio, playbook_name: str | None = None) -> None:
     """Delete all test data created by an instance."""
-    storage = instance.request_context.storage
+    storage = require_storage(instance)
     try:
         if playbook_name:
             storage.delete_all_user_playbooks_by_playbook_name(playbook_name)
@@ -215,7 +215,7 @@ class TestOpenClawMultiUser:
         to test playbook isolation.
         """
         instance = openclaw_playbook_instance
-        storage = instance.request_context.storage
+        storage = require_storage(instance)
 
         alpha_turns = _make_correction_interactions("file formatting")
         beta_turns = _make_correction_interactions("code review comments")
@@ -299,7 +299,7 @@ class TestOpenClawMultiUser:
         that get_user_profile scopes correctly by user_id.
         """
         instance = openclaw_profile_instance
-        storage = instance.request_context.storage
+        storage = require_storage(instance)
 
         # Seed a profile directly for instance-alpha
         import uuid
@@ -346,7 +346,7 @@ class TestAgentPlaybookAggregation:
         Uses mock LLM mode for clustering (avoids needing real embeddings).
         """
         instance = openclaw_playbook_instance
-        storage = instance.request_context.storage
+        storage = require_storage(instance)
 
         # Seed user playbooks directly (bypassing extraction stride gate)
         # to test aggregation scoping across multiple users

--- a/tests/e2e_tests/test_openclaw_integration.py
+++ b/tests/e2e_tests/test_openclaw_integration.py
@@ -6,6 +6,7 @@ returns both user and agent playbooks.
 """
 
 import os
+from collections.abc import Iterator
 
 import pytest
 
@@ -171,7 +172,7 @@ def _cleanup(instance: Reflexio, playbook_name: str | None = None) -> None:
 def openclaw_playbook_instance(
     sqlite_storage_config: StorageConfigSQLite,
     test_org_id: str,
-) -> Reflexio:
+) -> Iterator[Reflexio]:
     """Reflexio instance configured for OpenClaw playbook extraction."""
     instance = _make_reflexio_with_playbook(test_org_id, sqlite_storage_config)
     _cleanup(instance, _PLAYBOOK_NAME)
@@ -183,7 +184,7 @@ def openclaw_playbook_instance(
 def openclaw_profile_instance(
     sqlite_storage_config: StorageConfigSQLite,
     test_org_id: str,
-) -> Reflexio:
+) -> Iterator[Reflexio]:
     """Reflexio instance configured for OpenClaw profile extraction."""
     instance = _make_reflexio_with_profile(test_org_id, sqlite_storage_config)
     _cleanup(instance)
@@ -250,13 +251,17 @@ class TestOpenClawMultiUser:
         # to verify playbook scoping by user_id
         from reflexio.models.api_schema.service_schemas import UserPlaybook
 
+        alpha_request_id = alpha_resp.request_id
+        beta_request_id = beta_resp.request_id
+        assert alpha_request_id is not None
+        assert beta_request_id is not None
         alpha_pb = UserPlaybook(
             user_id=_ALPHA_USER,
             agent_version=_AGENT_VERSION,
             playbook_name=_PLAYBOOK_NAME,
             content="Always ask for file formatting preference first",
             trigger="file formatting",
-            request_id=alpha_resp.request_id,
+            request_id=alpha_request_id,
         )
         beta_pb = UserPlaybook(
             user_id=_BETA_USER,
@@ -264,7 +269,7 @@ class TestOpenClawMultiUser:
             playbook_name=_PLAYBOOK_NAME,
             content="Always ask for code review style preference first",
             trigger="code review",
-            request_id=beta_resp.request_id,
+            request_id=beta_request_id,
         )
         storage.save_user_playbooks([alpha_pb, beta_pb])
 

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -25,7 +25,11 @@ from reflexio.models.api_schema.service_schemas import (
 )
 from reflexio.models.config_schema import SINGLETON_USER_PLAYBOOK_NAME, SearchMode
 from tests.e2e_tests.conftest import save_user_playbooks
-from tests.server.test_utils import skip_in_precommit, skip_low_priority
+from tests.server.test_utils import (
+    require_storage,
+    skip_in_precommit,
+    skip_low_priority,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -60,13 +64,13 @@ def test_publish_interaction_playbook_only(
 
     # Verify interactions were added to storage
     final_interactions = (
-        reflexio_instance_playbook_only.request_context.storage.get_all_interactions()
+        require_storage(reflexio_instance_playbook_only).get_all_interactions()
     )
     assert len(final_interactions) == len(sample_interaction_requests)
 
     # Verify playbooks were generated and stored
     user_playbooks = (
-        reflexio_instance_playbook_only.request_context.storage.get_user_playbooks(
+        require_storage(reflexio_instance_playbook_only).get_user_playbooks(
             playbook_name=SINGLETON_USER_PLAYBOOK_NAME
         )
     )
@@ -75,7 +79,7 @@ def test_publish_interaction_playbook_only(
 
     # No agent success evaluation results — this fixture does not configure
     # agent_success_config, and group evaluation is never triggered in this flow.
-    agent_success_results = reflexio_instance_playbook_only.request_context.storage.get_agent_success_evaluation_results(
+    agent_success_results = require_storage(reflexio_instance_playbook_only).get_agent_success_evaluation_results(
         agent_version=agent_version
     )
     assert len(agent_success_results) == 0
@@ -107,14 +111,14 @@ def test_run_playbook_aggregation_end_to_end(
         assert True
 
         user_playbooks = (
-            reflexio_instance_playbook_only.request_context.storage.get_user_playbooks(
+            require_storage(reflexio_instance_playbook_only).get_user_playbooks(
                 playbook_name=playbook_name
             )
         )
         assert len(user_playbooks) == 20
 
         agent_playbooks = (
-            reflexio_instance_playbook_only.request_context.storage.get_agent_playbooks(
+            require_storage(reflexio_instance_playbook_only).get_agent_playbooks(
                 playbook_name=playbook_name,
                 playbook_status_filter=[PlaybookStatus.PENDING],
             )
@@ -143,7 +147,7 @@ def test_get_agent_playbooks_with_playbook_status_filter(
     """
     agent_version = "1.0.0"
     playbook_name = "test_playbook"
-    storage = reflexio_instance_playbook_only.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_only)
 
     # First save mock playbooks and run aggregation
     save_user_playbooks(reflexio_instance_playbook_only)
@@ -307,7 +311,7 @@ def test_upgrade_user_playbooks_end_to_end(
     """
     playbook_name = "test_playbook"
     agent_version = "1.0.0"
-    storage = reflexio_instance_playbook_only.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_only)
 
     # Setup: Create user playbooks with different statuses
     # Create CURRENT playbooks (status=None)
@@ -410,7 +414,7 @@ def test_downgrade_user_playbooks_end_to_end(
     """
     playbook_name = "test_playbook"
     agent_version = "1.0.0"
-    storage = reflexio_instance_playbook_only.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_only)
 
     # Setup: Create user playbooks with different statuses
     # Create CURRENT playbooks (status=None)
@@ -486,7 +490,7 @@ def test_upgrade_downgrade_roundtrip(
     """Test that upgrade followed by downgrade restores the original state."""
     playbook_name = "test_playbook"
     agent_version = "1.0.0"
-    storage = reflexio_instance_playbook_only.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_only)
 
     # Setup: Create initial CURRENT playbooks
     current_playbooks = [
@@ -940,7 +944,7 @@ def test_playbook_source_filtering_with_matching_source(
     """
     user_id = "test_user_source_filter"
     agent_version = "test_agent_source"
-    storage = reflexio_instance_playbook_source_filtering.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_source_filtering)
 
     # Step 1: Publish interactions with source="api"
     response_api = reflexio_instance_playbook_source_filtering.publish_interaction(
@@ -983,7 +987,7 @@ def test_playbook_source_filtering_with_non_matching_source(
     """
     user_id = "test_user_source_filter_other"
     agent_version = "test_agent_source_other"
-    storage = reflexio_instance_playbook_source_filtering.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_source_filtering)
 
     # Publish interactions with source="other" (not in request_sources_enabled)
     response = reflexio_instance_playbook_source_filtering.publish_interaction(
@@ -1022,7 +1026,7 @@ def test_playbook_source_filtering_webhook_source(
     """
     user_id = "test_user_source_filter_webhook"
     agent_version = "test_agent_source_webhook"
-    storage = reflexio_instance_playbook_source_filtering.request_context.storage
+    storage = require_storage(reflexio_instance_playbook_source_filtering)
 
     # Publish interactions with source="webhook"
     response = reflexio_instance_playbook_source_filtering.publish_interaction(
@@ -1093,7 +1097,7 @@ def test_manual_playbook_generation_end_to_end(
         )
 
         # Step 3: Verify playbooks were generated with CURRENT status (None)
-        current_playbooks = reflexio_instance_manual_playbook.request_context.storage.get_user_playbooks(
+        current_playbooks = require_storage(reflexio_instance_manual_playbook).get_user_playbooks(
             playbook_name=playbook_name,
             status_filter=[None],
         )
@@ -1101,7 +1105,7 @@ def test_manual_playbook_generation_end_to_end(
         assert isinstance(current_playbooks, list)
 
         # Step 4: Verify NO PENDING playbooks were created (that's rerun behavior)
-        pending_playbooks = reflexio_instance_manual_playbook.request_context.storage.get_user_playbooks(
+        pending_playbooks = require_storage(reflexio_instance_manual_playbook).get_user_playbooks(
             playbook_name=playbook_name,
             status_filter=[Status.PENDING],
         )
@@ -1339,7 +1343,7 @@ def test_rerun_playbook_generation_with_source_filter(
 
     user_id = "test_user_rerun_source_filter"
     agent_version = "test_agent_rerun_source"
-    storage = reflexio_instance_multiple_playbook_extractors.request_context.storage
+    storage = require_storage(reflexio_instance_multiple_playbook_extractors)
 
     # Use mock mode
     original_env = os.environ.get("MOCK_LLM_RESPONSE")
@@ -1442,7 +1446,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
 
     user_id = "test_user_rerun_all_sources"
     agent_version = "test_agent_rerun_all"
-    storage = reflexio_instance_multiple_playbook_extractors.request_context.storage
+    storage = require_storage(reflexio_instance_multiple_playbook_extractors)
 
     # Use mock mode
     original_env = os.environ.get("MOCK_LLM_RESPONSE")
@@ -1546,7 +1550,7 @@ def test_rerun_playbook_generation_with_extractor_names_filter(
     unique_id = uuid.uuid4().hex[:8]
     user_id = f"test_user_rerun_extractor_names_{unique_id}"
     agent_version = f"test_agent_extractor_names_{unique_id}"
-    storage = reflexio_instance_multiple_playbook_extractors.request_context.storage
+    storage = require_storage(reflexio_instance_multiple_playbook_extractors)
 
     # Use mock mode
     original_env = os.environ.get("MOCK_LLM_RESPONSE")

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -63,25 +63,23 @@ def test_publish_interaction_playbook_only(
     assert response.message == "Interaction published successfully"
 
     # Verify interactions were added to storage
-    final_interactions = (
-        require_storage(reflexio_instance_playbook_only).get_all_interactions()
-    )
+    final_interactions = require_storage(
+        reflexio_instance_playbook_only
+    ).get_all_interactions()
     assert len(final_interactions) == len(sample_interaction_requests)
 
     # Verify playbooks were generated and stored
-    user_playbooks = (
-        require_storage(reflexio_instance_playbook_only).get_user_playbooks(
-            playbook_name=SINGLETON_USER_PLAYBOOK_NAME
-        )
-    )
+    user_playbooks = require_storage(
+        reflexio_instance_playbook_only
+    ).get_user_playbooks(playbook_name=SINGLETON_USER_PLAYBOOK_NAME)
     assert len(user_playbooks) > 0 and user_playbooks[0].content.strip() != ""
     assert all(p.playbook_name == SINGLETON_USER_PLAYBOOK_NAME for p in user_playbooks)
 
     # No agent success evaluation results — this fixture does not configure
     # agent_success_config, and group evaluation is never triggered in this flow.
-    agent_success_results = require_storage(reflexio_instance_playbook_only).get_agent_success_evaluation_results(
-        agent_version=agent_version
-    )
+    agent_success_results = require_storage(
+        reflexio_instance_playbook_only
+    ).get_agent_success_evaluation_results(agent_version=agent_version)
     assert len(agent_success_results) == 0
 
 
@@ -110,18 +108,16 @@ def test_run_playbook_aggregation_end_to_end(
         # If we reach here, the operation was successful
         assert True
 
-        user_playbooks = (
-            require_storage(reflexio_instance_playbook_only).get_user_playbooks(
-                playbook_name=playbook_name
-            )
-        )
+        user_playbooks = require_storage(
+            reflexio_instance_playbook_only
+        ).get_user_playbooks(playbook_name=playbook_name)
         assert len(user_playbooks) == 20
 
-        agent_playbooks = (
-            require_storage(reflexio_instance_playbook_only).get_agent_playbooks(
-                playbook_name=playbook_name,
-                playbook_status_filter=[PlaybookStatus.PENDING],
-            )
+        agent_playbooks = require_storage(
+            reflexio_instance_playbook_only
+        ).get_agent_playbooks(
+            playbook_name=playbook_name,
+            playbook_status_filter=[PlaybookStatus.PENDING],
         )
         assert len(agent_playbooks) > 0
     finally:
@@ -1099,7 +1095,9 @@ def test_manual_playbook_generation_end_to_end(
         )
 
         # Step 3: Verify playbooks were generated with CURRENT status (None)
-        current_playbooks = require_storage(reflexio_instance_manual_playbook).get_user_playbooks(
+        current_playbooks = require_storage(
+            reflexio_instance_manual_playbook
+        ).get_user_playbooks(
             playbook_name=playbook_name,
             status_filter=[None],
         )
@@ -1107,7 +1105,9 @@ def test_manual_playbook_generation_end_to_end(
         assert isinstance(current_playbooks, list)
 
         # Step 4: Verify NO PENDING playbooks were created (that's rerun behavior)
-        pending_playbooks = require_storage(reflexio_instance_manual_playbook).get_user_playbooks(
+        pending_playbooks = require_storage(
+            reflexio_instance_manual_playbook
+        ).get_user_playbooks(
             playbook_name=playbook_name,
             status_filter=[Status.PENDING],
         )

--- a/tests/e2e_tests/test_playbook_workflows.py
+++ b/tests/e2e_tests/test_playbook_workflows.py
@@ -811,6 +811,7 @@ def test_rerun_playbook_generation_end_to_end(
             )
         )
         assert rerun_response.success is True
+        assert rerun_response.playbooks_generated is not None
         assert rerun_response.playbooks_generated > 0
 
         # Step 3: Verify PENDING playbooks were created
@@ -901,7 +902,7 @@ def test_rerun_playbook_generation_with_time_filters(
             )
         )
         assert future_response.success is False
-        assert "No interactions found" in future_response.msg
+        assert "No interactions found" in (future_response.msg or "")
 
         # Test with valid time range (past to future)
         past_start = datetime.now(UTC) - timedelta(days=1)
@@ -916,6 +917,7 @@ def test_rerun_playbook_generation_with_time_filters(
             )
         )
         assert valid_response.success is True
+        assert valid_response.playbooks_generated is not None
         assert valid_response.playbooks_generated > 0
 
     finally:
@@ -1402,7 +1404,7 @@ def test_rerun_playbook_generation_with_source_filter(
 
         # Step 5: Verify pending playbooks were created with source="api"
         pending_playbooks = storage.get_user_playbooks(status_filter=[Status.PENDING])
-        if rerun_response.playbooks_generated > 0:
+        if (rerun_response.playbooks_generated or 0) > 0:
             assert len(pending_playbooks) > 0
             for playbook in pending_playbooks:
                 assert playbook.source == "api", (
@@ -1419,7 +1421,7 @@ def test_rerun_playbook_generation_with_source_filter(
             )
         )
         assert rerun_response_invalid.success is False
-        assert "No interactions found" in rerun_response_invalid.msg
+        assert "No interactions found" in (rerun_response_invalid.msg or "")
 
     finally:
         if original_env is None:
@@ -1515,7 +1517,7 @@ def test_rerun_playbook_generation_multiple_extractors_all_sources(
         )
 
         # Step 4: Verify playbooks from multiple extractors
-        if rerun_response.playbooks_generated > 0:
+        if (rerun_response.playbooks_generated or 0) > 0:
             pending_playbooks = storage.get_user_playbooks(
                 status_filter=[Status.PENDING]
             )

--- a/tests/e2e_tests/test_profile_workflows.py
+++ b/tests/e2e_tests/test_profile_workflows.py
@@ -329,6 +329,7 @@ def test_rerun_profile_generation_end_to_end(
         rerun_request
     )
     assert rerun_response.success is True, f"Rerun should succeed: {rerun_response.msg}"
+    assert rerun_response.profiles_generated is not None
     assert rerun_response.profiles_generated > 0, (
         "Rerun should generate at least one profile"
     )
@@ -422,7 +423,7 @@ def test_rerun_profile_generation_with_time_filters(
         rerun_request
     )
     assert rerun_response.success is False
-    assert "No interactions found" in rerun_response.msg
+    assert "No interactions found" in (rerun_response.msg or "")
 
     # Test with time filter that includes all interactions (past to future)
     past_start = datetime.now(UTC) - timedelta(days=1)
@@ -438,6 +439,7 @@ def test_rerun_profile_generation_with_time_filters(
         rerun_request_valid
     )
     assert rerun_response_valid.success is True
+    assert rerun_response_valid.profiles_generated is not None
     assert rerun_response_valid.profiles_generated > 0, (
         "Rerun with valid time filter should generate profiles"
     )
@@ -521,7 +523,7 @@ def test_rerun_profile_generation_with_source_filter(
             user_id, status_filter=[Status.PENDING]
         )
     )
-    if rerun_response_a.profiles_generated > 0:
+    if (rerun_response_a.profiles_generated or 0) > 0:
         assert len(pending_profiles) > 0, (
             "Expected pending profiles when profiles_generated > 0"
         )
@@ -536,7 +538,7 @@ def test_rerun_profile_generation_with_source_filter(
         rerun_request_invalid
     )
     assert rerun_response_invalid.success is False
-    assert "No interactions found" in rerun_response_invalid.msg
+    assert "No interactions found" in (rerun_response_invalid.msg or "")
 
 
 @skip_in_precommit
@@ -723,7 +725,7 @@ def test_status_filter_in_get_profiles_request(
 def _create_test_profile(
     user_id: str,
     request_id: str,
-    status: Status = None,
+    status: Status | None = None,
     content: str = "Test profile content",
 ) -> UserProfile:
     """Helper function to create test profiles with specified status.
@@ -1221,7 +1223,7 @@ def test_rerun_profile_generation_with_extractor_names_filter(
     )
 
     # If profiles were generated, verify they come from allowed extractors
-    if rerun_response.profiles_generated > 0:
+    if (rerun_response.profiles_generated or 0) > 0:
         assert len(pending_profiles) > 0
 
 

--- a/tests/e2e_tests/test_profile_workflows.py
+++ b/tests/e2e_tests/test_profile_workflows.py
@@ -23,7 +23,11 @@ from reflexio.models.api_schema.service_schemas import (
 )
 from reflexio.models.config_schema import SINGLETON_USER_PLAYBOOK_NAME
 from tests.e2e_tests.conftest import scenario_batch_to_interactions
-from tests.server.test_utils import skip_in_precommit, skip_low_priority
+from tests.server.test_utils import (
+    require_storage,
+    skip_in_precommit,
+    skip_low_priority,
+)
 
 pytestmark = pytest.mark.e2e
 
@@ -55,13 +59,13 @@ def test_publish_interaction_profile_only(
 
     # Verify interactions were added to storage
     final_interactions = (
-        reflexio_instance_profile_only.request_context.storage.get_all_interactions()
+        require_storage(reflexio_instance_profile_only).get_all_interactions()
     )
     assert len(final_interactions) == len(sample_interaction_requests)
 
     # Verify profiles were generated and added to storage
     final_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_all_profiles()
+        require_storage(reflexio_instance_profile_only).get_all_profiles()
     )
     assert len(final_profiles) > 0
     assert final_profiles[0].content.strip() != ""
@@ -74,14 +78,14 @@ def test_publish_interaction_profile_only(
 
     # Verify NO playbooks were generated (since playbook config is not enabled)
     user_playbooks = (
-        reflexio_instance_profile_only.request_context.storage.get_user_playbooks(
+        require_storage(reflexio_instance_profile_only).get_user_playbooks(
             user_id=user_id, playbook_name=SINGLETON_USER_PLAYBOOK_NAME
         )
     )
     assert len(user_playbooks) == 0
 
     # Verify NO agent success evaluation results were created (since agent success config is not enabled)
-    agent_success_results = reflexio_instance_profile_only.request_context.storage.get_agent_success_evaluation_results(
+    agent_success_results = require_storage(reflexio_instance_profile_only).get_agent_success_evaluation_results(
         agent_version=agent_version
     )
     assert len(agent_success_results) == 0
@@ -166,7 +170,7 @@ def test_get_profiles_end_to_end(
 
     # Verify profiles were generated and stored
     stored_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_all_profiles()
+        require_storage(reflexio_instance_profile_only).get_all_profiles()
     )
     assert len(stored_profiles) > 0
     # Get the auto-generated request_id
@@ -209,7 +213,7 @@ def test_delete_profile_end_to_end(
 
     # Verify profiles were generated and stored
     initial_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_all_profiles()
+        require_storage(reflexio_instance_profile_only).get_all_profiles()
     )
     assert len(initial_profiles) > 0
 
@@ -230,7 +234,7 @@ def test_delete_profile_end_to_end(
 
     # Verify profile was deleted from storage
     final_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_all_profiles()
+        require_storage(reflexio_instance_profile_only).get_all_profiles()
     )
     assert len(final_profiles) < len(initial_profiles)
 
@@ -306,7 +310,7 @@ def test_rerun_profile_generation_end_to_end(
 
     # Verify profiles were generated with status=None (current)
     current_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_profile_only).get_user_profile(
             user_id, status_filter=[None]
         )
     )
@@ -331,7 +335,7 @@ def test_rerun_profile_generation_end_to_end(
 
     # Step 3: Verify pending profiles were created
     pending_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_profile_only).get_user_profile(
             user_id, status_filter=[Status.PENDING]
         )
     )
@@ -343,7 +347,7 @@ def test_rerun_profile_generation_end_to_end(
 
     # Step 4: Verify current profiles still exist unchanged
     current_profiles_after = (
-        reflexio_instance_profile_only.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_profile_only).get_user_profile(
             user_id, status_filter=[None]
         )
     )
@@ -398,7 +402,7 @@ def test_rerun_profile_generation_with_time_filters(
 
     # Get the interactions to determine their timestamps
     all_interactions = (
-        reflexio_instance_profile_only.request_context.storage.get_user_interaction(
+        require_storage(reflexio_instance_profile_only).get_user_interaction(
             user_id
         )
     )
@@ -440,7 +444,7 @@ def test_rerun_profile_generation_with_time_filters(
 
     # Verify pending profiles were created
     pending_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_profile_only).get_user_profile(
             user_id, status_filter=[Status.PENDING]
         )
     )
@@ -493,7 +497,7 @@ def test_rerun_profile_generation_with_source_filter(
 
     # Verify we have interactions from both sources
     all_interactions = (
-        reflexio_instance_profile_only.request_context.storage.get_user_interaction(
+        require_storage(reflexio_instance_profile_only).get_user_interaction(
             user_id
         )
     )
@@ -513,7 +517,7 @@ def test_rerun_profile_generation_with_source_filter(
 
     # If profiles were generated, verify they are in pending status
     pending_profiles = (
-        reflexio_instance_profile_only.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_profile_only).get_user_profile(
             user_id, status_filter=[Status.PENDING]
         )
     )
@@ -756,7 +760,7 @@ def test_upgrade_profiles_end_to_end(
     3. Promote PENDING profiles (PENDING -> None/CURRENT)
     """
     user_id = "test_user_upgrade"
-    storage = reflexio_instance_profile_only.request_context.storage
+    storage = require_storage(reflexio_instance_profile_only)
 
     # Setup: Create profiles with different statuses
     # Create CURRENT profiles (status=None)
@@ -851,7 +855,7 @@ def test_downgrade_profiles_end_to_end(
     3. Complete archiving (ARCHIVE_IN_PROGRESS -> ARCHIVED)
     """
     user_id = "test_user_downgrade"
-    storage = reflexio_instance_profile_only.request_context.storage
+    storage = require_storage(reflexio_instance_profile_only)
 
     # Setup: Create profiles with different statuses
     # Create CURRENT profiles (status=None)
@@ -922,7 +926,7 @@ def test_upgrade_downgrade_profiles_roundtrip(
 ):
     """Test that upgrade followed by downgrade restores the original profile state."""
     user_id = "test_user_roundtrip"
-    storage = reflexio_instance_profile_only.request_context.storage
+    storage = require_storage(reflexio_instance_profile_only)
 
     # Setup: Create initial CURRENT profiles
     current_profiles = [
@@ -1024,7 +1028,7 @@ def test_manual_profile_generation_end_to_end(
 
     # Step 3: Verify profiles were generated with CURRENT status (None)
     current_profiles = (
-        reflexio_instance_manual_profile.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_manual_profile).get_user_profile(
             user_id, status_filter=[None]
         )
     )
@@ -1034,7 +1038,7 @@ def test_manual_profile_generation_end_to_end(
 
     # Step 4: Verify NO PENDING profiles were created (that's rerun behavior)
     pending_profiles = (
-        reflexio_instance_manual_profile.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_manual_profile).get_user_profile(
             user_id, status_filter=[Status.PENDING]
         )
     )
@@ -1212,7 +1216,7 @@ def test_rerun_profile_generation_with_extractor_names_filter(
 
     # Step 3: Verify profiles were generated (may be 0 depending on LLM response)
     # The main thing is that the operation succeeded
-    pending_profiles = reflexio_instance_multiple_profile_extractors.request_context.storage.get_user_profile(
+    pending_profiles = require_storage(reflexio_instance_multiple_profile_extractors).get_user_profile(
         user_id, status_filter=[Status.PENDING]
     )
 
@@ -1395,7 +1399,7 @@ def test_profile_dedup_resolves_contradiction(
     assert response.success is True, f"batch 1 publish failed: {response.message}"
 
     profiles_after_batch_1 = (
-        reflexio_instance_lifestyle_profile.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_lifestyle_profile).get_user_profile(
             user_id, status_filter=[None]
         )
     )
@@ -1421,7 +1425,7 @@ def test_profile_dedup_resolves_contradiction(
 
     # ---- Verify dedup resolved the contradiction -------------------------
     final_profiles = (
-        reflexio_instance_lifestyle_profile.request_context.storage.get_user_profile(
+        require_storage(reflexio_instance_lifestyle_profile).get_user_profile(
             user_id, status_filter=[None]
         )
     )

--- a/tests/e2e_tests/test_profile_workflows.py
+++ b/tests/e2e_tests/test_profile_workflows.py
@@ -58,15 +58,13 @@ def test_publish_interaction_profile_only(
     assert response.message == "Interaction published successfully"
 
     # Verify interactions were added to storage
-    final_interactions = (
-        require_storage(reflexio_instance_profile_only).get_all_interactions()
-    )
+    final_interactions = require_storage(
+        reflexio_instance_profile_only
+    ).get_all_interactions()
     assert len(final_interactions) == len(sample_interaction_requests)
 
     # Verify profiles were generated and added to storage
-    final_profiles = (
-        require_storage(reflexio_instance_profile_only).get_all_profiles()
-    )
+    final_profiles = require_storage(reflexio_instance_profile_only).get_all_profiles()
     assert len(final_profiles) > 0
     assert final_profiles[0].content.strip() != ""
 
@@ -77,17 +75,15 @@ def test_publish_interaction_profile_only(
     assert len(final_change_logs) > 0
 
     # Verify NO playbooks were generated (since playbook config is not enabled)
-    user_playbooks = (
-        require_storage(reflexio_instance_profile_only).get_user_playbooks(
-            user_id=user_id, playbook_name=SINGLETON_USER_PLAYBOOK_NAME
-        )
+    user_playbooks = require_storage(reflexio_instance_profile_only).get_user_playbooks(
+        user_id=user_id, playbook_name=SINGLETON_USER_PLAYBOOK_NAME
     )
     assert len(user_playbooks) == 0
 
     # Verify NO agent success evaluation results were created (since agent success config is not enabled)
-    agent_success_results = require_storage(reflexio_instance_profile_only).get_agent_success_evaluation_results(
-        agent_version=agent_version
-    )
+    agent_success_results = require_storage(
+        reflexio_instance_profile_only
+    ).get_agent_success_evaluation_results(agent_version=agent_version)
     assert len(agent_success_results) == 0
 
 
@@ -169,9 +165,7 @@ def test_get_profiles_end_to_end(
     )
 
     # Verify profiles were generated and stored
-    stored_profiles = (
-        require_storage(reflexio_instance_profile_only).get_all_profiles()
-    )
+    stored_profiles = require_storage(reflexio_instance_profile_only).get_all_profiles()
     assert len(stored_profiles) > 0
     # Get the auto-generated request_id
     request_id = stored_profiles[0].generated_from_request_id
@@ -212,9 +206,9 @@ def test_delete_profile_end_to_end(
     assert response.success is True
 
     # Verify profiles were generated and stored
-    initial_profiles = (
-        require_storage(reflexio_instance_profile_only).get_all_profiles()
-    )
+    initial_profiles = require_storage(
+        reflexio_instance_profile_only
+    ).get_all_profiles()
     assert len(initial_profiles) > 0
 
     # Get profiles to find profile IDs
@@ -233,9 +227,7 @@ def test_delete_profile_end_to_end(
     assert delete_response.success is True
 
     # Verify profile was deleted from storage
-    final_profiles = (
-        require_storage(reflexio_instance_profile_only).get_all_profiles()
-    )
+    final_profiles = require_storage(reflexio_instance_profile_only).get_all_profiles()
     assert len(final_profiles) < len(initial_profiles)
 
 
@@ -309,10 +301,8 @@ def test_rerun_profile_generation_end_to_end(
     assert response.success is True
 
     # Verify profiles were generated with status=None (current)
-    current_profiles = (
-        require_storage(reflexio_instance_profile_only).get_user_profile(
-            user_id, status_filter=[None]
-        )
+    current_profiles = require_storage(reflexio_instance_profile_only).get_user_profile(
+        user_id, status_filter=[None]
     )
     assert len(current_profiles) > 0, "Should have current profiles"
     for profile in current_profiles:
@@ -335,10 +325,8 @@ def test_rerun_profile_generation_end_to_end(
     )
 
     # Step 3: Verify pending profiles were created
-    pending_profiles = (
-        require_storage(reflexio_instance_profile_only).get_user_profile(
-            user_id, status_filter=[Status.PENDING]
-        )
+    pending_profiles = require_storage(reflexio_instance_profile_only).get_user_profile(
+        user_id, status_filter=[Status.PENDING]
     )
     assert len(pending_profiles) > 0, "Should have pending profiles after rerun"
     for profile in pending_profiles:
@@ -347,11 +335,9 @@ def test_rerun_profile_generation_end_to_end(
         )
 
     # Step 4: Verify current profiles still exist unchanged
-    current_profiles_after = (
-        require_storage(reflexio_instance_profile_only).get_user_profile(
-            user_id, status_filter=[None]
-        )
-    )
+    current_profiles_after = require_storage(
+        reflexio_instance_profile_only
+    ).get_user_profile(user_id, status_filter=[None])
     assert len(current_profiles_after) == initial_profile_count, (
         "Current profiles should remain unchanged"
     )
@@ -402,11 +388,9 @@ def test_rerun_profile_generation_with_time_filters(
     assert response.success is True
 
     # Get the interactions to determine their timestamps
-    all_interactions = (
-        require_storage(reflexio_instance_profile_only).get_user_interaction(
-            user_id
-        )
-    )
+    all_interactions = require_storage(
+        reflexio_instance_profile_only
+    ).get_user_interaction(user_id)
     assert len(all_interactions) == len(sample_interaction_requests)
 
     # Test with time filter that excludes all interactions (future time range)
@@ -445,10 +429,8 @@ def test_rerun_profile_generation_with_time_filters(
     )
 
     # Verify pending profiles were created
-    pending_profiles = (
-        require_storage(reflexio_instance_profile_only).get_user_profile(
-            user_id, status_filter=[Status.PENDING]
-        )
+    pending_profiles = require_storage(reflexio_instance_profile_only).get_user_profile(
+        user_id, status_filter=[Status.PENDING]
     )
     assert len(pending_profiles) > 0
 
@@ -498,11 +480,9 @@ def test_rerun_profile_generation_with_source_filter(
     assert response_b.success is True
 
     # Verify we have interactions from both sources
-    all_interactions = (
-        require_storage(reflexio_instance_profile_only).get_user_interaction(
-            user_id
-        )
-    )
+    all_interactions = require_storage(
+        reflexio_instance_profile_only
+    ).get_user_interaction(user_id)
     assert len(all_interactions) == len(sample_interaction_requests) + 1
 
     # Rerun profile generation for only "test_source_a"
@@ -518,10 +498,8 @@ def test_rerun_profile_generation_with_source_filter(
     assert rerun_response_a.success is True, f"Rerun failed: {rerun_response_a.msg}"
 
     # If profiles were generated, verify they are in pending status
-    pending_profiles = (
-        require_storage(reflexio_instance_profile_only).get_user_profile(
-            user_id, status_filter=[Status.PENDING]
-        )
+    pending_profiles = require_storage(reflexio_instance_profile_only).get_user_profile(
+        user_id, status_filter=[Status.PENDING]
     )
     if (rerun_response_a.profiles_generated or 0) > 0:
         assert len(pending_profiles) > 0, (
@@ -1029,21 +1007,17 @@ def test_manual_profile_generation_end_to_end(
     )
 
     # Step 3: Verify profiles were generated with CURRENT status (None)
-    current_profiles = (
-        require_storage(reflexio_instance_manual_profile).get_user_profile(
-            user_id, status_filter=[None]
-        )
-    )
+    current_profiles = require_storage(
+        reflexio_instance_manual_profile
+    ).get_user_profile(user_id, status_filter=[None])
     # Note: profiles may already exist from publish_interaction,
     # but manual_profile_generation should also generate CURRENT profiles
     assert len(current_profiles) >= 0  # Just verify no errors
 
     # Step 4: Verify NO PENDING profiles were created (that's rerun behavior)
-    pending_profiles = (
-        require_storage(reflexio_instance_manual_profile).get_user_profile(
-            user_id, status_filter=[Status.PENDING]
-        )
-    )
+    pending_profiles = require_storage(
+        reflexio_instance_manual_profile
+    ).get_user_profile(user_id, status_filter=[Status.PENDING])
     assert len(pending_profiles) == 0, (
         "Manual generation should not create PENDING profiles"
     )
@@ -1218,9 +1192,9 @@ def test_rerun_profile_generation_with_extractor_names_filter(
 
     # Step 3: Verify profiles were generated (may be 0 depending on LLM response)
     # The main thing is that the operation succeeded
-    pending_profiles = require_storage(reflexio_instance_multiple_profile_extractors).get_user_profile(
-        user_id, status_filter=[Status.PENDING]
-    )
+    pending_profiles = require_storage(
+        reflexio_instance_multiple_profile_extractors
+    ).get_user_profile(user_id, status_filter=[Status.PENDING])
 
     # If profiles were generated, verify they come from allowed extractors
     if (rerun_response.profiles_generated or 0) > 0:
@@ -1400,11 +1374,9 @@ def test_profile_dedup_resolves_contradiction(
     )
     assert response.success is True, f"batch 1 publish failed: {response.message}"
 
-    profiles_after_batch_1 = (
-        require_storage(reflexio_instance_lifestyle_profile).get_user_profile(
-            user_id, status_filter=[None]
-        )
-    )
+    profiles_after_batch_1 = require_storage(
+        reflexio_instance_lifestyle_profile
+    ).get_user_profile(user_id, status_filter=[None])
     assert profiles_after_batch_1, "expected initial profiles from batch 1"
     batch_1_text = " ".join(p.content.lower() for p in profiles_after_batch_1)
     sanity_terms = [term.lower() for term in scenario["batch_1_sanity_terms"]]
@@ -1426,9 +1398,7 @@ def test_profile_dedup_resolves_contradiction(
     assert response.success is True, f"batch 2 publish failed: {response.message}"
 
     # ---- Verify dedup resolved the contradiction -------------------------
-    final_profiles = (
-        require_storage(reflexio_instance_lifestyle_profile).get_user_profile(
-            user_id, status_filter=[None]
-        )
-    )
+    final_profiles = require_storage(
+        reflexio_instance_lifestyle_profile
+    ).get_user_profile(user_id, status_filter=[None])
     _assert_contradiction_resolved(final_profiles, scenario)

--- a/tests/lib/conftest.py
+++ b/tests/lib/conftest.py
@@ -5,7 +5,7 @@ The LLM mock is applied globally in the parent conftest.py.
 """
 
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -28,8 +28,7 @@ def reflexio_mock():
 
     Bypasses __init__ entirely so no real storage/LLM setup is required.
     """
-    with patch.object(Reflexio, "__init__", lambda _self: None):
-        instance = Reflexio()
+    instance = Reflexio.__new__(Reflexio)
     instance.org_id = "test_org"
     instance.request_context = MagicMock()
     instance.request_context.org_id = "test_org"
@@ -42,8 +41,7 @@ def reflexio_mock():
 @pytest.fixture
 def reflexio_no_storage():
     """Reflexio instance where storage is not configured."""
-    with patch.object(Reflexio, "__init__", lambda _self: None):
-        instance = Reflexio()
+    instance = Reflexio.__new__(Reflexio)
     instance.org_id = "test_org"
     instance.request_context = MagicMock()
     instance.request_context.org_id = "test_org"

--- a/tests/lib/test_base_unit.py
+++ b/tests/lib/test_base_unit.py
@@ -13,6 +13,7 @@ from reflexio.lib._base import (
     ReflexioBase,
     _require_storage,
 )
+from reflexio.test_support.typing_helpers import as_mock
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -132,7 +133,7 @@ class TestGetQueryReformulator:
         base = _make_base()
         mock_config = MagicMock()
         mock_config.api_key_config = MagicMock()
-        base.request_context.configurator.get_config.return_value = mock_config
+        as_mock(base.request_context.configurator.get_config).return_value = mock_config
 
         reformulator = base._get_query_reformulator()
 
@@ -145,7 +146,7 @@ class TestGetQueryReformulator:
         base = _make_base()
         mock_config = MagicMock()
         mock_config.api_key_config = MagicMock()
-        base.request_context.configurator.get_config.return_value = mock_config
+        as_mock(base.request_context.configurator.get_config).return_value = mock_config
 
         reformulator1 = base._get_query_reformulator()
         reformulator2 = base._get_query_reformulator()
@@ -159,7 +160,7 @@ class TestGetQueryReformulator:
     def test_handles_no_config(self, mock_reformulator_cls, mock_svm_cls):
         """Handles None config gracefully — auto-detects model from available API keys."""
         base = _make_base()
-        base.request_context.configurator.get_config.return_value = None
+        as_mock(base.request_context.configurator.get_config).return_value = None
         # Site var also returns nothing for pre_retrieval_model_name
         mock_svm_cls.return_value.get_site_var.return_value = {}
 

--- a/tests/lib/test_interactions_unit.py
+++ b/tests/lib/test_interactions_unit.py
@@ -19,6 +19,7 @@ from reflexio.models.api_schema.service_schemas import (
     DeleteSessionRequest,
     DeleteUserInteractionRequest,
     Interaction,
+    InteractionData,
     PublishUserInteractionRequest,
 )
 from reflexio.server.services.generation_service import GenerationServiceResult
@@ -406,7 +407,7 @@ class TestPublishInteraction:
         request = PublishUserInteractionRequest(
             user_id="user1",
             session_id="test_session",
-            interaction_data_list=[{"role": "User", "content": "hi"}],
+            interaction_data_list=[InteractionData(role="User", content="hi")],
         )
         response = mixin.publish_interaction(request)
 
@@ -427,7 +428,7 @@ class TestPublishInteraction:
         request = PublishUserInteractionRequest(
             user_id="user1",
             session_id="test_session",
-            interaction_data_list=[{"role": "User", "content": "hi"}],
+            interaction_data_list=[InteractionData(role="User", content="hi")],
         )
         response = mixin.publish_interaction(request)
 
@@ -464,7 +465,7 @@ class TestPublishInteraction:
     def test_reports_extraction_deltas(self, mock_gen_cls):
         """profiles_added / playbooks_added reflect the before→after delta."""
         mixin = _make_mixin()
-        storage = mixin.request_context.storage
+        storage = _get_storage(mixin)
         # Storage snapshot: 2 profiles before → 5 after; 0 playbooks → 3 after
         as_mock(storage.count_all_profiles).side_effect = [2, 5]
         as_mock(storage.count_user_playbooks).side_effect = [0, 3]
@@ -479,7 +480,7 @@ class TestPublishInteraction:
             PublishUserInteractionRequest(
                 user_id="user1",
                 session_id="test_session",
-                interaction_data_list=[{"role": "User", "content": "hi"}],
+                interaction_data_list=[InteractionData(role="User", content="hi")],
             )
         )
 
@@ -496,7 +497,7 @@ class TestPublishInteraction:
         itself has nothing to do with the counters.
         """
         mixin = _make_mixin()
-        storage = mixin.request_context.storage
+        storage = _get_storage(mixin)
         as_mock(storage.count_all_profiles).side_effect = RuntimeError("db down")
         # count_user_playbooks still works — exercised independently
         as_mock(storage.count_user_playbooks).return_value = 0
@@ -511,7 +512,7 @@ class TestPublishInteraction:
             PublishUserInteractionRequest(
                 user_id="user1",
                 session_id="test_session",
-                interaction_data_list=[{"role": "User", "content": "hi"}],
+                interaction_data_list=[InteractionData(role="User", content="hi")],
             )
         )
 
@@ -532,7 +533,7 @@ class TestPublishInteraction:
         request = PublishUserInteractionRequest(
             user_id="user1",
             session_id="test_session",
-            interaction_data_list=[{"role": "User", "content": "hi"}],
+            interaction_data_list=[InteractionData(role="User", content="hi")],
         )
         response = mixin.publish_interaction(request)
 

--- a/tests/lib/test_interactions_unit.py
+++ b/tests/lib/test_interactions_unit.py
@@ -22,6 +22,7 @@ from reflexio.models.api_schema.service_schemas import (
     PublishUserInteractionRequest,
 )
 from reflexio.server.services.generation_service import GenerationServiceResult
+from reflexio.test_support.typing_helpers import as_mock
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -56,7 +57,7 @@ def _make_mixin(*, storage_configured: bool = True) -> InteractionsMixin:
 
 
 def _get_storage(mixin: InteractionsMixin) -> MagicMock:
-    return mixin.request_context.storage
+    return as_mock(mixin.request_context.storage)
 
 
 def _sample_interaction(**overrides) -> Interaction:
@@ -465,8 +466,8 @@ class TestPublishInteraction:
         mixin = _make_mixin()
         storage = mixin.request_context.storage
         # Storage snapshot: 2 profiles before → 5 after; 0 playbooks → 3 after
-        storage.count_all_profiles.side_effect = [2, 5]
-        storage.count_user_playbooks.side_effect = [0, 3]
+        as_mock(storage.count_all_profiles).side_effect = [2, 5]
+        as_mock(storage.count_user_playbooks).side_effect = [0, 3]
         mock_gen_instance = MagicMock()
         mock_gen_instance.run.return_value = GenerationServiceResult(
             request_id="req-1",
@@ -496,9 +497,9 @@ class TestPublishInteraction:
         """
         mixin = _make_mixin()
         storage = mixin.request_context.storage
-        storage.count_all_profiles.side_effect = RuntimeError("db down")
+        as_mock(storage.count_all_profiles).side_effect = RuntimeError("db down")
         # count_user_playbooks still works — exercised independently
-        storage.count_user_playbooks.return_value = 0
+        as_mock(storage.count_user_playbooks).return_value = 0
         mock_gen_instance = MagicMock()
         mock_gen_instance.run.return_value = GenerationServiceResult(
             request_id="req-ok",

--- a/tests/lib/test_operations_unit.py
+++ b/tests/lib/test_operations_unit.py
@@ -13,6 +13,7 @@ from reflexio.models.api_schema.service_schemas import (
     GetOperationStatusRequest,
     OperationStatus,
 )
+from reflexio.test_support.typing_helpers import as_mock
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,7 +35,7 @@ def _make_mixin(*, storage_configured: bool = True) -> OperationsMixin:
 
 
 def _get_storage(mixin: OperationsMixin) -> MagicMock:
-    return mixin.request_context.storage
+    return as_mock(mixin.request_context.storage)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -223,7 +223,7 @@ def test_search_interactions(reflexio_with_config):
 
     # Search for interactions
     search_request = SearchInteractionRequest(
-        user_id=user_id, query_text="sushi", top_k=10
+        user_id=user_id, query="sushi", top_k=10
     )
 
     response = reflexio.search_interactions(search_request)
@@ -253,7 +253,7 @@ def test_search_profiles_current_only(reflexio_with_config):
 
     # Search profiles (default: current only)
     search_request = SearchUserProfileRequest(
-        user_id=user_id, query_text="sushi", top_k=10
+        user_id=user_id, query="sushi", top_k=10
     )
 
     response = reflexio.search_user_profiles(search_request)
@@ -283,7 +283,7 @@ def test_search_profiles_with_status_filter(reflexio_with_config):
 
     # Search with status filter including PENDING
     search_request = SearchUserProfileRequest(
-        user_id=user_id, query_text="test", top_k=10
+        user_id=user_id, query="test", top_k=10
     )
 
     response = reflexio.search_user_profiles(
@@ -532,7 +532,7 @@ def test_rerun_profile_generation_empty_interactions(temp_storage):
     response = reflexio.rerun_profile_generation(rerun_request)
 
     assert response.success is False
-    assert "No interactions found" in response.msg
+    assert "No interactions found" in (response.msg or "")
     assert response.profiles_generated == 0
 
 

--- a/tests/lib/test_profile_workflows_unit.py
+++ b/tests/lib/test_profile_workflows_unit.py
@@ -222,9 +222,7 @@ def test_search_interactions(reflexio_with_config):
     reflexio.publish_interaction(publish_request)
 
     # Search for interactions
-    search_request = SearchInteractionRequest(
-        user_id=user_id, query="sushi", top_k=10
-    )
+    search_request = SearchInteractionRequest(user_id=user_id, query="sushi", top_k=10)
 
     response = reflexio.search_interactions(search_request)
 
@@ -252,9 +250,7 @@ def test_search_profiles_current_only(reflexio_with_config):
     reflexio.publish_interaction(publish_request)
 
     # Search profiles (default: current only)
-    search_request = SearchUserProfileRequest(
-        user_id=user_id, query="sushi", top_k=10
-    )
+    search_request = SearchUserProfileRequest(user_id=user_id, query="sushi", top_k=10)
 
     response = reflexio.search_user_profiles(search_request)
 
@@ -282,9 +278,7 @@ def test_search_profiles_with_status_filter(reflexio_with_config):
     reflexio.publish_interaction(publish_request)
 
     # Search with status filter including PENDING
-    search_request = SearchUserProfileRequest(
-        user_id=user_id, query="test", top_k=10
-    )
+    search_request = SearchUserProfileRequest(user_id=user_id, query="test", top_k=10)
 
     response = reflexio.search_user_profiles(
         search_request, status_filter=[None, Status.PENDING]

--- a/tests/server/llm/test_provenance_forwarding.py
+++ b/tests/server/llm/test_provenance_forwarding.py
@@ -18,6 +18,7 @@ call test pins the specific regression.
 """
 
 import inspect
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -62,7 +63,7 @@ def test_plain_entry_point_forwards_every_declared_option(option):
     did with `provider_request_guard`.
     """
     inst = TextGenerationMixin.__new__(TextGenerationMixin)
-    sentinel = object()
+    sentinel: Any = object()
     with patch.object(
         TextGenerationMixin, "generate_chat_response_with_provenance"
     ) as p:
@@ -82,7 +83,7 @@ def test_provenance_entry_point_forwards_every_declared_option(option):
     from the signature raises NameError here rather than in production.
     """
     inst = TextGenerationMixin.__new__(TextGenerationMixin)
-    sentinel = object()
+    sentinel: Any = object()
     with patch.object(TextGenerationMixin, "_make_request", return_value="ok") as m:
         PROVENANCE(inst, [{"role": "user", "content": "hi"}], **{option: sentinel})
     assert m.call_args.kwargs.get(option) is sentinel, (
@@ -110,7 +111,12 @@ def test_provenance_call_without_a_guard_does_not_raise_nameerror():
 def test_provenance_call_forwards_the_guard_when_supplied():
     inst = TextGenerationMixin.__new__(TextGenerationMixin)
 
-    def guard(_params):
+    def guard(
+        _params: dict[str, Any],
+        _timeout: float,
+        _models: tuple[str, ...],
+        _flag: bool,
+    ) -> None:
         return None
 
     with patch.object(
@@ -131,7 +137,12 @@ def test_plain_entry_point_does_not_silently_drop_the_guard():
     """
     inst = TextGenerationMixin.__new__(TextGenerationMixin)
 
-    def guard(_params):
+    def guard(
+        _params: dict[str, Any],
+        _timeout: float,
+        _models: tuple[str, ...],
+        _flag: bool,
+    ) -> None:
         return None
 
     with patch.object(

--- a/tests/server/services/braintrust/test_client.py
+++ b/tests/server/services/braintrust/test_client.py
@@ -61,7 +61,7 @@ def test_list_projects_unwraps_bare_list() -> None:
 
 def test_list_experiments_passes_since_param() -> None:
     """The `since` query param is included only when provided."""
-    seen_params: list[dict[str, list[str]]] = []
+    seen_params: list[dict[str, str]] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen_params.append(dict(request.url.params.multi_items()))

--- a/tests/server/services/evaluation_overview/test_rule_attribution.py
+++ b/tests/server/services/evaluation_overview/test_rule_attribution.py
@@ -1,14 +1,16 @@
 """Compute net sessions per rule by joining PlaybookApplicationStat with success outcomes."""
 
 from reflexio.server.services.evaluation_overview.components.rule_attribution import (
+    CitationKey,
     RuleAttribution,
+    SessionIdentity,
     compute_net_sessions,
 )
 
 
 def test_basic_join_one_rule_two_successes_one_failure() -> None:
     """Net = successes_with_rule_fired - failures_with_rule_fired."""
-    citations_by_session = {
+    citations_by_session: dict[SessionIdentity, list[CitationKey]] = {
         ("u1", "sess_a"): [("playbook", "rule_42")],
         ("u1", "sess_b"): [("playbook", "rule_42")],
         ("u1", "sess_c"): [("playbook", "rule_42")],
@@ -18,7 +20,7 @@ def test_basic_join_one_rule_two_successes_one_failure() -> None:
         ("u1", "sess_b"): True,
         ("u1", "sess_c"): False,
     }
-    rule_titles = {("playbook", "rule_42"): "Confirm address before checkout"}
+    rule_titles: dict[CitationKey, str] = {("playbook", "rule_42"): "Confirm address before checkout"}
 
     attribs = compute_net_sessions(
         citations_by_session=citations_by_session,
@@ -39,7 +41,7 @@ def test_basic_join_one_rule_two_successes_one_failure() -> None:
 
 def test_ranks_by_net_sessions_descending_and_caps_at_top_n() -> None:
     """Top-N ordering by net_sessions desc; ties broken by total fires desc."""
-    citations_by_session = {
+    citations_by_session: dict[SessionIdentity, list[CitationKey]] = {
         ("u1", "s1"): [("playbook", "good")],
         ("u1", "s2"): [("playbook", "good")],
         ("u1", "s3"): [("playbook", "good")],
@@ -55,7 +57,7 @@ def test_ranks_by_net_sessions_descending_and_caps_at_top_n() -> None:
         ("u1", "s5"): False,
         ("u1", "s6"): True,
     }
-    rule_titles = {
+    rule_titles: dict[CitationKey, str] = {
         ("playbook", "good"): "good",
         ("playbook", "ugly"): "ugly",
         ("playbook", "meh"): "meh",
@@ -78,12 +80,12 @@ def test_session_missing_from_success_map_is_skipped() -> None:
     """If a citation references a session we have no AgentSuccessEvaluationResult
     for, treat it as unknown and don't count it on either side."""
     _ = RuleAttribution  # imported for export sanity; no-op
-    citations_by_session = {
+    citations_by_session: dict[SessionIdentity, list[CitationKey]] = {
         ("u1", "sess_known"): [("playbook", "r1")],
         ("u1", "sess_orphan"): [("playbook", "r1")],
     }
     is_success_by_session = {("u1", "sess_known"): True}
-    rule_titles = {("playbook", "r1"): "r1"}
+    rule_titles: dict[CitationKey, str] = {("playbook", "r1"): "r1"}
 
     attribs = compute_net_sessions(
         citations_by_session=citations_by_session,
@@ -100,7 +102,7 @@ def test_session_missing_from_success_map_is_skipped() -> None:
 
 def test_cited_session_ids_populated_for_each_rule() -> None:
     """Each RuleAttribution row carries the session ids that cited the rule."""
-    citations_by_session = {
+    citations_by_session: dict[SessionIdentity, list[CitationKey]] = {
         ("u1", "sess_alpha"): [("playbook", "rule_a"), ("playbook", "rule_b")],
         ("u1", "sess_beta"): [("playbook", "rule_a")],
         ("u1", "sess_gamma"): [("playbook", "rule_b")],
@@ -110,7 +112,7 @@ def test_cited_session_ids_populated_for_each_rule() -> None:
         ("u1", "sess_beta"): False,
         ("u1", "sess_gamma"): True,
     }
-    rule_titles = {("playbook", "rule_a"): "A", ("playbook", "rule_b"): "B"}
+    rule_titles: dict[CitationKey, str] = {("playbook", "rule_a"): "A", ("playbook", "rule_b"): "B"}
 
     rows = compute_net_sessions(
         citations_by_session=citations_by_session,
@@ -128,7 +130,7 @@ def test_cited_session_ids_populated_for_each_rule() -> None:
 
 def test_cited_session_ids_excludes_sessions_with_no_outcome() -> None:
     """Sessions absent from is_success_by_session are skipped on both sides."""
-    citations_by_session = {
+    citations_by_session: dict[SessionIdentity, list[CitationKey]] = {
         ("u1", "graded"): [("playbook", "rule_x")],
         ("u1", "ungraded"): [("playbook", "rule_x")],
     }
@@ -147,7 +149,7 @@ def test_cited_session_ids_excludes_sessions_with_no_outcome() -> None:
 
 def test_cited_session_ids_dedupes_within_same_session() -> None:
     """A rule cited multiple times in the same session yields a single session entry."""
-    citations_by_session = {
+    citations_by_session: dict[SessionIdentity, list[CitationKey]] = {
         ("u1", "sess_a"): [
             ("playbook", "rule_x"),
             ("playbook", "rule_x"),

--- a/tests/server/services/evaluation_overview/test_rule_attribution.py
+++ b/tests/server/services/evaluation_overview/test_rule_attribution.py
@@ -20,7 +20,9 @@ def test_basic_join_one_rule_two_successes_one_failure() -> None:
         ("u1", "sess_b"): True,
         ("u1", "sess_c"): False,
     }
-    rule_titles: dict[CitationKey, str] = {("playbook", "rule_42"): "Confirm address before checkout"}
+    rule_titles: dict[CitationKey, str] = {
+        ("playbook", "rule_42"): "Confirm address before checkout"
+    }
 
     attribs = compute_net_sessions(
         citations_by_session=citations_by_session,
@@ -112,7 +114,10 @@ def test_cited_session_ids_populated_for_each_rule() -> None:
         ("u1", "sess_beta"): False,
         ("u1", "sess_gamma"): True,
     }
-    rule_titles: dict[CitationKey, str] = {("playbook", "rule_a"): "A", ("playbook", "rule_b"): "B"}
+    rule_titles: dict[CitationKey, str] = {
+        ("playbook", "rule_a"): "A",
+        ("playbook", "rule_b"): "B",
+    }
 
     rows = compute_net_sessions(
         citations_by_session=citations_by_session,

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -39,6 +39,7 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.services.configurator.configurator import DefaultConfigurator
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
 from tests.server.test_utils import require_storage
 
 pytestmark = pytest.mark.integration
@@ -79,7 +80,7 @@ def reflexio_instance(tmp_path: pathlib.Path, worker_id: str) -> Reflexio:
     return Reflexio(org_id=org_id, configurator=configurator)
 
 
-def _publish_and_get_profile(reflexio: Reflexio) -> object:
+def _publish_and_get_profile(reflexio: Reflexio) -> UserProfile:
     """Publish one interaction through the real extraction path and return the profile.
 
     The mock LLM returns ``time_to_live: "one_month"`` for profile extraction,
@@ -226,6 +227,7 @@ def test_pre_fix_pathology_active_expired_is_not_gc_eligible_until_swept(
         "it is NOT yet a tombstone"
     )
     # retired_at is storage-internal (not on the domain model) — read via direct SQL.
+    assert isinstance(storage, SQLiteStorage)
     raw_retired_at = storage.conn.execute(
         "SELECT retired_at FROM profiles WHERE profile_id = ?",
         (profile.profile_id,),

--- a/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
+++ b/tests/server/services/lineage/test_profile_expiry_reclamation_integration.py
@@ -39,6 +39,7 @@ from reflexio.models.config_schema import (
     StorageConfigSQLite,
 )
 from reflexio.server.services.configurator.configurator import DefaultConfigurator
+from tests.server.test_utils import require_storage
 
 pytestmark = pytest.mark.integration
 
@@ -106,7 +107,7 @@ def _publish_and_get_profile(reflexio: Reflexio) -> object:
         }
     )
     assert response.success, f"publish_interaction failed: {response.message}"
-    storage = reflexio.request_context.storage
+    storage = require_storage(reflexio)
     profiles = storage.get_user_profile(user_id)
     assert len(profiles) == 1, (
         "publish_interaction must produce exactly one profile via the real "
@@ -133,7 +134,7 @@ def test_ttl_expired_active_profile_is_physically_reclaimed(
       4. get_profile_by_id(include_tombstones=True) → None (row is gone).
       5. Lineage events contain both ``status_change`` (reason ttl-expired) and ``hard_delete``.
     """
-    storage = reflexio_instance.request_context.storage
+    storage = require_storage(reflexio_instance)
     profile = _publish_and_get_profile(reflexio_instance)
 
     # The mock LLM returns one_month TTL → real expiration_timestamp, not the sentinel.
@@ -198,7 +199,7 @@ def test_pre_fix_pathology_active_expired_is_not_gc_eligible_until_swept(
     We monkeypatch ``_epoch_now`` — used by ``get_user_profile``'s expiry filter —
     to simulate being past the profile's expiration, without touching the wall clock.
     """
-    storage = reflexio_instance.request_context.storage
+    storage = require_storage(reflexio_instance)
     profile = _publish_and_get_profile(reflexio_instance)
 
     assert profile.expiration_timestamp != NEVER_EXPIRES_TIMESTAMP
@@ -268,7 +269,7 @@ def test_expiry_sweep_does_not_break_concurrent_supersede(
 
     Guards spec RD-ADV-005: the sweep must not corrupt dedup lineage.
     """
-    storage = reflexio_instance.request_context.storage
+    storage = require_storage(reflexio_instance)
     profile = _publish_and_get_profile(reflexio_instance)
 
     assert profile.expiration_timestamp != NEVER_EXPIRES_TIMESTAMP

--- a/tests/server/services/lineage/test_reclamation_class_b_integration.py
+++ b/tests/server/services/lineage/test_reclamation_class_b_integration.py
@@ -12,6 +12,7 @@ Both are gated independently:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -46,7 +47,7 @@ def _make_ctx_factory(
     *,
     lineage_gc_enabled: bool,
     expiry_reclamation_enabled: bool,
-) -> tuple[SQLiteStorage, object]:
+) -> tuple[SQLiteStorage, Callable[[str], RequestContext]]:
     """Build (storage, factory) pair for the given flag combination."""
     storage = SQLiteStorage(org_id=_ORG_ID, db_path=str(tmp_path / "gc_b_test.db"))
     cfg = SimpleNamespace(
@@ -153,7 +154,7 @@ def test_scheduler_does_not_start_when_both_disabled(tmp_path, org_id):
         lineage_gc_enabled=False,
         expiry_reclamation_enabled=False,
     )
-    result = maybe_start_lineage_gc(factory, bootstrap_org_id=org_id)  # type: ignore[arg-type]
+    result = maybe_start_lineage_gc(factory, bootstrap_org_id=org_id)
     assert result is None, (
         "Scheduler must not start when lineage_gc.enabled=False and "
         "expiry_reclamation.enabled=False"
@@ -173,7 +174,7 @@ def test_scheduler_starts_when_only_expiry_reclamation_enabled(tmp_path, org_id)
         lineage_gc_enabled=False,
         expiry_reclamation_enabled=True,
     )
-    sched = maybe_start_lineage_gc(factory, bootstrap_org_id=org_id)  # type: ignore[arg-type]
+    sched = maybe_start_lineage_gc(factory, bootstrap_org_id=org_id)
     assert sched is not None, (
         "Scheduler must start when expiry_reclamation.enabled=True "
         "(even with lineage_gc.enabled=False)"

--- a/tests/server/services/lineage/test_resolve_current.py
+++ b/tests/server/services/lineage/test_resolve_current.py
@@ -34,6 +34,7 @@ def test_merged_resolves_to_survivor(tmp_path):
         context=LineageContext(op_kind="merge", actor="t", request_id="r"),
     )
     ref = resolve_current(s, "user_playbook", src.user_playbook_id)
+    assert ref is not None
     assert str(ref.id) == str(surv.user_playbook_id)
 
 

--- a/tests/server/services/playbook/test_playbook_service_utils.py
+++ b/tests/server/services/playbook/test_playbook_service_utils.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 
 import pytest
 
+from reflexio.models.api_schema.common import ToolUsed
 from reflexio.models.api_schema.domain.entities import UserPlaybook
 from reflexio.models.api_schema.domain.enums import UserActionType
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
@@ -203,7 +204,7 @@ def test_prompt_context_maps_one_turn_reference_to_all_visible_sources():
         request_id="request",
         content="First paragraph.\n\nSecond paragraph.",
         role="assistant",
-        tools_used=[{"tool_name": "lookup", "tool_data": {"key": "value"}}],
+        tools_used=[ToolUsed(tool_name="lookup", tool_data={"key": "value"})],
         user_action=UserActionType.CLICK,
         user_action_description="confirm",
     )

--- a/tests/server/services/storage/test_storage_contract_operations.py
+++ b/tests/server/services/storage/test_storage_contract_operations.py
@@ -106,6 +106,7 @@ class TestPendingRequestQueue:
         assert result["acquired"] is False
 
         state = self._state(storage, "svc_lock_2")
+        assert state is not None
         queue = state.get("pending_request_queue", [])
         assert len(queue) == 1
         assert queue[0]["request_id"] == "req_2"
@@ -121,6 +122,7 @@ class TestPendingRequestQueue:
         )
 
         state = self._state(storage, "svc_lock_3")
+        assert state is not None
         queue = state.get("pending_request_queue", [])
         assert [q["request_id"] for q in queue] == ["req_2", "req_3"]
         assert queue[0]["payload"] == {"user_id": "user_b"}
@@ -139,6 +141,7 @@ class TestPendingRequestQueue:
         )
 
         state = self._state(storage, "svc_lock_4")
+        assert state is not None
         queue = state.get("pending_request_queue", [])
         # Only one entry for req_2 — second attempt is a noop.
         assert [q["request_id"] for q in queue] == ["req_2"]
@@ -151,6 +154,7 @@ class TestPendingRequestQueue:
         assert result["acquired"] is True
 
         state = self._state(storage, "svc_lock_5")
+        assert state is not None
         assert state.get("pending_request_queue", []) == []
 
     def test_lock_stays_held_across_a_handover(self, storage):
@@ -191,6 +195,7 @@ class TestPendingRequestQueue:
             "handover disagree about which key means 'held'"
         )
         state = self._state(storage, "svc_handover")
+        assert state is not None
         assert state.get("current_request_id") == "req_2"
 
     def test_a_legacy_status_keyed_lock_is_still_honoured(self, storage):
@@ -212,7 +217,9 @@ class TestPendingRequestQueue:
 
         result = storage.try_acquire_in_progress_lock("svc_legacy", "req_new")
         assert result["acquired"] is False
-        assert self._state(storage, "svc_legacy").get("current_request_id") == "req_old"
+        legacy_state = self._state(storage, "svc_legacy")
+        assert legacy_state is not None
+        assert legacy_state.get("current_request_id") == "req_old"
 
     def test_a_rejected_acquire_does_not_extend_the_holders_lock(self, storage):
         """Contention must not refresh the staleness clock.
@@ -227,6 +234,7 @@ class TestPendingRequestQueue:
         # Backdate the holder well past any plausible staleness window, leaving
         # the row's own updated_at fresh — exactly the post-contention shape.
         state = self._state(storage, "svc_stale")
+        assert state is not None
         state["started_at"] = int(time.time()) - 10_000
         storage.upsert_operation_state("svc_stale", state)
 
@@ -247,6 +255,7 @@ class TestPendingRequestQueue:
         """
         storage.try_acquire_in_progress_lock("svc_started_at", "req_1")
         state = self._state(storage, "svc_started_at")
+        assert state is not None
         assert state.get("in_progress") is True
         assert isinstance(state.get("started_at"), int)
         assert state["started_at"] > 0

--- a/tests/server/services/test_document_expander.py
+++ b/tests/server/services/test_document_expander.py
@@ -67,7 +67,9 @@ class TestExpand(unittest.TestCase):
     def test_expand_llm_failure_returns_empty(self):
         """When the LLM raises an exception, expand() returns empty result."""
         expander = _make_expander()
-        as_mock(expander.llm_client.generate_response).side_effect = RuntimeError("LLM down")
+        as_mock(expander.llm_client.generate_response).side_effect = RuntimeError(
+            "LLM down"
+        )
 
         result = expander.expand("some content")
 
@@ -78,9 +80,9 @@ class TestExpand(unittest.TestCase):
     def test_expand_invalid_json_returns_empty(self):
         """When the LLM returns non-JSON text, expand() returns empty result."""
         expander = _make_expander()
-        as_mock(expander.llm_client.generate_response).return_value = (
-            "Here are some synonyms for you"
-        )
+        as_mock(
+            expander.llm_client.generate_response
+        ).return_value = "Here are some synonyms for you"
 
         result = expander.expand("some content")
 

--- a/tests/server/services/test_document_expander.py
+++ b/tests/server/services/test_document_expander.py
@@ -14,6 +14,7 @@ from reflexio.server.services.pre_retrieval._document_expander import (
     DocumentExpander,
     ExpansionResult,
 )
+from reflexio.test_support.typing_helpers import as_mock
 
 
 def _make_expander(mock_llm=None, mock_pm=None):
@@ -44,7 +45,7 @@ class TestExpand(unittest.TestCase):
         """LLM returns valid JSON; verify ExpansionResult fields."""
         expander = _make_expander()
         llm_json = json.dumps({"backup": ["sync", "replication"]})
-        expander.llm_client.generate_response.return_value = llm_json
+        as_mock(expander.llm_client.generate_response).return_value = llm_json
 
         result = expander.expand("We need a backup strategy")
 
@@ -56,7 +57,7 @@ class TestExpand(unittest.TestCase):
         """Empty string content triggers LLM call but produces empty result on empty LLM output."""
         expander = _make_expander()
         # LLM returns non-string (None) for empty content
-        expander.llm_client.generate_response.return_value = None
+        as_mock(expander.llm_client.generate_response).return_value = None
 
         result = expander.expand("")
 
@@ -66,7 +67,7 @@ class TestExpand(unittest.TestCase):
     def test_expand_llm_failure_returns_empty(self):
         """When the LLM raises an exception, expand() returns empty result."""
         expander = _make_expander()
-        expander.llm_client.generate_response.side_effect = RuntimeError("LLM down")
+        as_mock(expander.llm_client.generate_response).side_effect = RuntimeError("LLM down")
 
         result = expander.expand("some content")
 
@@ -77,7 +78,7 @@ class TestExpand(unittest.TestCase):
     def test_expand_invalid_json_returns_empty(self):
         """When the LLM returns non-JSON text, expand() returns empty result."""
         expander = _make_expander()
-        expander.llm_client.generate_response.return_value = (
+        as_mock(expander.llm_client.generate_response).return_value = (
             "Here are some synonyms for you"
         )
 

--- a/tests/server/services/test_pre_retrieval.py
+++ b/tests/server/services/test_pre_retrieval.py
@@ -16,6 +16,7 @@ from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.pre_retrieval._query_reformulator import (
     QueryReformulator,
 )
+from reflexio.test_support.typing_helpers import as_mock
 
 
 def _make_reformulator(mock_llm=None, mock_pm=None):
@@ -40,22 +41,22 @@ class TestRewrite(unittest.TestCase):
     def test_without_conversation_history_llm_reformulates_query(self):
         """LLM reformulates the query when no conversation history is given."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(standalone_query="expanded search query")
         )
 
         result = reformulator.rewrite("search query")
 
         self.assertEqual(result.standalone_query, "expanded search query")
-        reformulator.prompt_manager.render_prompt.assert_called_once()
-        call_args = reformulator.prompt_manager.render_prompt.call_args
+        as_mock(reformulator.prompt_manager.render_prompt).assert_called_once()
+        call_args = as_mock(reformulator.prompt_manager.render_prompt).call_args
         variables = call_args[0][1]
         self.assertEqual(variables["conversation_context_block"], "")
 
     def test_with_conversation_history_context_included_in_prompt(self):
         """Conversation context is formatted and included in prompt variables."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(standalone_query="standalone query")
         )
         history = [
@@ -66,7 +67,7 @@ class TestRewrite(unittest.TestCase):
         result = reformulator.rewrite("follow up question", history)
 
         self.assertEqual(result.standalone_query, "standalone query")
-        call_args = reformulator.prompt_manager.render_prompt.call_args
+        call_args = as_mock(reformulator.prompt_manager.render_prompt).call_args
         variables = call_args[0][1]
         self.assertIn("Conversation context:", variables["conversation_context_block"])
         self.assertIn("[user]: hello", variables["conversation_context_block"])
@@ -74,7 +75,7 @@ class TestRewrite(unittest.TestCase):
     def test_llm_failure_falls_back_to_original_query(self):
         """When the LLM raises an exception, the original query is returned."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.side_effect = RuntimeError(
+        as_mock(reformulator.llm_client.generate_chat_response).side_effect = RuntimeError(
             "LLM down"
         )
 
@@ -85,7 +86,7 @@ class TestRewrite(unittest.TestCase):
     def test_empty_llm_response_falls_back_to_original(self):
         """When the LLM returns a non-string (None), original query is used."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = None
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = None
 
         result = reformulator.rewrite("original query")
 
@@ -94,7 +95,7 @@ class TestRewrite(unittest.TestCase):
     def test_invalid_unsafe_llm_output_falls_back_to_original(self):
         """When the LLM returns an unsafe phrase, the original query is used."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(
                 standalone_query="Here is the reformulated query for you"
             )
@@ -260,7 +261,7 @@ class TestSearch(unittest.TestCase):
     def test_calls_search_fn_with_reformulated_query(self):
         """search_fn receives the reformulated query, not the original."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(standalone_query="reformulated")
         )
         search_fn = Mock(return_value=["result1", "result2"])
@@ -274,7 +275,7 @@ class TestSearch(unittest.TestCase):
     def test_deduplicates_results_with_dedup_key(self):
         """Duplicate items are removed based on the dedup_key function."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(standalone_query="query")
         )
 
@@ -297,7 +298,7 @@ class TestSearch(unittest.TestCase):
     def test_handles_search_fn_failure_gracefully(self):
         """When search_fn raises, result.items is an empty list."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(standalone_query="query")
         )
         search_fn = Mock(side_effect=RuntimeError("search failed"))
@@ -310,7 +311,7 @@ class TestSearch(unittest.TestCase):
     def test_returns_all_results_without_dedup_key(self):
         """Without a dedup_key, all results are returned including duplicates."""
         reformulator = _make_reformulator()
-        reformulator.llm_client.generate_chat_response.return_value = (
+        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
             ReformulationResult(standalone_query="query")
         )
 

--- a/tests/server/services/test_pre_retrieval.py
+++ b/tests/server/services/test_pre_retrieval.py
@@ -42,9 +42,9 @@ class TestRewrite(unittest.TestCase):
     def test_without_conversation_history_llm_reformulates_query(self):
         """LLM reformulates the query when no conversation history is given."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(standalone_query="expanded search query")
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(standalone_query="expanded search query")
 
         result = reformulator.rewrite("search query")
 
@@ -57,9 +57,9 @@ class TestRewrite(unittest.TestCase):
     def test_with_conversation_history_context_included_in_prompt(self):
         """Conversation context is formatted and included in prompt variables."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(standalone_query="standalone query")
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(standalone_query="standalone query")
         history = [
             ConversationTurn(role="user", content="hello"),
             ConversationTurn(role="agent", content="hi there"),
@@ -76,9 +76,9 @@ class TestRewrite(unittest.TestCase):
     def test_llm_failure_falls_back_to_original_query(self):
         """When the LLM raises an exception, the original query is returned."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).side_effect = RuntimeError(
-            "LLM down"
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).side_effect = RuntimeError("LLM down")
 
         result = reformulator.rewrite("original query")
 
@@ -96,10 +96,10 @@ class TestRewrite(unittest.TestCase):
     def test_invalid_unsafe_llm_output_falls_back_to_original(self):
         """When the LLM returns an unsafe phrase, the original query is used."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(
-                standalone_query="Here is the reformulated query for you"
-            )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(
+            standalone_query="Here is the reformulated query for you"
         )
 
         result = reformulator.rewrite("original query")
@@ -130,7 +130,9 @@ class TestExtractReformulatedQuery(unittest.TestCase):
         """Empty or whitespace-only input returns None."""
         self.assertIsNone(QueryReformulator._extract_reformulated_query(""))
         self.assertIsNone(QueryReformulator._extract_reformulated_query("   "))
-        self.assertIsNone(QueryReformulator._extract_reformulated_query(cast(str, None)))
+        self.assertIsNone(
+            QueryReformulator._extract_reformulated_query(cast(str, None))
+        )
 
     def test_returns_none_for_too_long_output(self):
         """Output exceeding MAX_REFORMULATION_LENGTH (512) returns None."""
@@ -264,9 +266,9 @@ class TestSearch(unittest.TestCase):
     def test_calls_search_fn_with_reformulated_query(self):
         """search_fn receives the reformulated query, not the original."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(standalone_query="reformulated")
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(standalone_query="reformulated")
         search_fn = Mock(return_value=["result1", "result2"])
 
         result = reformulator.search("original", search_fn)
@@ -278,9 +280,9 @@ class TestSearch(unittest.TestCase):
     def test_deduplicates_results_with_dedup_key(self):
         """Duplicate items are removed based on the dedup_key function."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(standalone_query="query")
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(standalone_query="query")
 
         items = [
             {"id": "a", "text": "first"},
@@ -301,9 +303,9 @@ class TestSearch(unittest.TestCase):
     def test_handles_search_fn_failure_gracefully(self):
         """When search_fn raises, result.items is an empty list."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(standalone_query="query")
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(standalone_query="query")
         search_fn = Mock(side_effect=RuntimeError("search failed"))
 
         result = reformulator.search("original", search_fn)
@@ -314,9 +316,9 @@ class TestSearch(unittest.TestCase):
     def test_returns_all_results_without_dedup_key(self):
         """Without a dedup_key, all results are returned including duplicates."""
         reformulator = _make_reformulator()
-        as_mock(reformulator.llm_client.generate_chat_response).return_value = (
-            ReformulationResult(standalone_query="query")
-        )
+        as_mock(
+            reformulator.llm_client.generate_chat_response
+        ).return_value = ReformulationResult(standalone_query="query")
 
         items = ["a", "b", "a", "c"]
         search_fn = Mock(return_value=items)

--- a/tests/server/services/test_pre_retrieval.py
+++ b/tests/server/services/test_pre_retrieval.py
@@ -5,6 +5,7 @@ _extract_reformulated_query(), and _format_conversation_context().
 """
 
 import unittest
+from typing import cast
 from unittest.mock import Mock
 
 from reflexio.models.api_schema.retriever_schema import (
@@ -129,7 +130,7 @@ class TestExtractReformulatedQuery(unittest.TestCase):
         """Empty or whitespace-only input returns None."""
         self.assertIsNone(QueryReformulator._extract_reformulated_query(""))
         self.assertIsNone(QueryReformulator._extract_reformulated_query("   "))
-        self.assertIsNone(QueryReformulator._extract_reformulated_query(None))
+        self.assertIsNone(QueryReformulator._extract_reformulated_query(cast(str, None)))
 
     def test_returns_none_for_too_long_output(self):
         """Output exceeding MAX_REFORMULATION_LENGTH (512) returns None."""
@@ -238,7 +239,9 @@ class TestFormatConversationContext(unittest.TestCase):
             {"role": "user", "content": "dict-based question"},
             {"role": "agent", "content": "dict-based answer"},
         ]
-        result = QueryReformulator._format_conversation_context(history)
+        result = QueryReformulator._format_conversation_context(
+            cast("list[ConversationTurn]", history)
+        )
         self.assertIn("[user]: dict-based question", result)
         self.assertIn("[agent]: dict-based answer", result)
 

--- a/tests/server/test_correlation.py
+++ b/tests/server/test_correlation.py
@@ -37,8 +37,8 @@ class TestCorrelationIdFilter:
             CorrelationIdFilter().filter(record)
         finally:
             correlation_id_var.reset(token)
-        assert record.correlation_id == ""
-        assert record.correlation_tag == ""
+        assert getattr(record, "correlation_id", None) == ""
+        assert getattr(record, "correlation_tag", None) == ""
 
     def test_formats_tag_when_cid_present(self) -> None:
         record = _make_record()
@@ -47,8 +47,8 @@ class TestCorrelationIdFilter:
             CorrelationIdFilter().filter(record)
         finally:
             correlation_id_var.reset(token)
-        assert record.correlation_id == "abc12345"
-        assert record.correlation_tag == "[abc12345] "
+        assert getattr(record, "correlation_id", None) == "abc12345"
+        assert getattr(record, "correlation_tag", None) == "[abc12345] "
 
     def test_format_string_renders_cleanly_without_cid(self) -> None:
         """Integration: format a record through the real format string."""

--- a/tests/server/test_utils.py
+++ b/tests/server/test_utils.py
@@ -5,5 +5,12 @@ from reflexio.test_support.skip_decorators import (
     skip_in_precommit,
     skip_low_priority,
 )
+from reflexio.test_support.typing_helpers import as_mock, require_storage
 
-__all__ = ["encode_image_to_base64", "skip_in_precommit", "skip_low_priority"]
+__all__ = [
+    "as_mock",
+    "encode_image_to_base64",
+    "require_storage",
+    "skip_in_precommit",
+    "skip_low_priority",
+]


### PR DESCRIPTION
## Summary

`uv run pyright` (basic mode, `pyrightconfig.json` unchanged) reported **235 errors** on main, all in `tests/`. This PR drives the count to **0** by fixing tests by error class, without weakening the pyright config and without changing what any test executes or asserts.

- **Optional-storage narrowing (~130)** — new `reflexio/test_support/typing_helpers.py` provides `require_storage(instance)` (narrows `RequestContext.storage: BaseStorage | None`), re-exported via `tests/server/test_utils`; per-site `assert x is not None` where a single access exists.
- **Mock typing (~35)** — `as_mock(...)` (also in `typing_helpers`) at `return_value`/`side_effect`/`assert_called_*` sites reached through real-class-typed attributes; `monkeypatch.setattr` instead of method assignment; `Reflexio.__new__` instead of patching `__init__` in `tests/lib/conftest.py`.
- **Argument types (~35)** — construct real models (`InteractionData`, `ToolUsed`) instead of raw dicts; annotate `CitationKey`/`SessionIdentity` dicts; type the provenance sentinel/guard and the reclamation factory; fix the stale `query_text=` kwarg to the real `query` field (it was previously silently ignored by pydantic). Tests that deliberately pass invalid input keep their runtime behavior via targeted `cast(...)`.
- **Misc (~25)** — `Iterator[Reflexio]` on yield-fixtures; `getattr` for filter-injected `LogRecord` attrs; `-> UserProfile` on `_publish_and_get_profile` (was `-> object`); `isinstance` narrowing for SQLite-only `.conn`; Optional response-field narrowing before `in`/`>`.

## Verification (observed counts)

- pyright: **235 → 0 errors**, warnings unchanged (36 → 36)
- `ruff check .`: clean; `ruff format --check tests/ reflexio/`: clean
- unit tier (`-m "not integration and not e2e"`): **4301 passed, 9 skipped**
- integration tier: **1245 passed, 64 skipped** (one pre-existing flake, `test_evaluation_only_publish_waits_and_batches_followup_session_requests`, passes in isolation; dir untouched by this PR)
- e2e tier: **47 passed, 51 skipped**

Pre-existing, out of scope: `ruff format` drift in `benchmark/` and `notebooks/`; flaky `test_exactly_once_under_claim_race` under xdist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typed testing helpers for safely accessing storage and working with mocks.

* **Tests**
  * Improved type annotations across unit, integration, and end-to-end tests.
  * Strengthened assertions for optional values, missing messages, operation states, request IDs, and generated counts.
  * Updated tests to use typed request and metadata models.
  * Improved fixture setup and mocking practices without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->