### PR TITLE
fix(env,log): promote legacy DSN alias before .env load; surface suppressed duplicates

### DIFF
--- a/reflexio/cli/env_loader.py
+++ b/reflexio/cli/env_loader.py
@@ -204,6 +204,42 @@ def _load_dotenv_pruned(path: Path, *, override: bool = False) -> None:
             os.environ.pop(key, None)
 
 
+def promote_legacy_env_aliases() -> None:
+    """Fill a blank/unset canonical env var from its legacy alias.
+
+    Must run BEFORE any ``.env`` file is loaded. Those files load with
+    ``override=False``, which only protects a canonical name that is ALREADY
+    set in the process environment — it does nothing when the environment
+    supplied the LEGACY name and a ``.env`` file supplies the CANONICAL one.
+    In that case the file's value silently wins, so a process handed a real
+    DSN under the legacy name can end up reading a developer's local DSN
+    while reporting success. That shipped: a prod deploy's post-deploy grant
+    check verified the operator's local Supabase for exactly this reason.
+
+    ``DATA_DB_URL`` is canonical; ``DATA_SUPABASE_DB_URL`` is the legacy name
+    (see ``.env.template``). Deployments whose secret store we do not control
+    — a self-host customer's, for instance — may legitimately supply only the
+    legacy one, so this must work whichever name arrives.
+
+    Deliberately conservative: promotion is skipped when the canonical name
+    already carries a value, and when ``POSTGRES_DB_URL`` is set or the
+    storage backend is ``postgres``. In those cases the legacy Supabase name
+    is not necessarily the intended DSN, and the existing storage-aware
+    resolver should decide instead of this loader pre-empting it.
+    """
+    if os.environ.get("DATA_DB_URL", "").strip():
+        return
+    legacy = os.environ.get("DATA_SUPABASE_DB_URL", "").strip()
+    if not legacy:
+        return
+    if os.environ.get("POSTGRES_DB_URL", "").strip():
+        return
+    if os.environ.get("REFLEXIO_STORAGE", "").strip().lower() == "postgres":
+        return
+    os.environ["DATA_DB_URL"] = legacy
+    _logger.debug("Promoted legacy DATA_SUPABASE_DB_URL to canonical DATA_DB_URL")
+
+
 def load_reflexio_env(
     *,
     package_data_module: str = "reflexio.data",
@@ -227,6 +263,7 @@ def load_reflexio_env(
         Path to the loaded .env file, or None if no .env was found/created.
     """
     global _loaded_env_path
+    promote_legacy_env_aliases()
     for env_path in _env_search_paths():
         if env_path.exists():
             _load_dotenv_pruned(env_path)
@@ -309,6 +346,7 @@ def load_reflexio_env_for_mode(
         Path to the loaded mode env file, or None if nothing was found/created.
     """
     global _loaded_env_path
+    promote_legacy_env_aliases()
     mode = resolve_mode(cli_mode)
     if mode is None:
         return load_reflexio_env(

--- a/reflexio/cli/log_format.py
+++ b/reflexio/cli/log_format.py
@@ -157,11 +157,22 @@ class DuplicateFilter(logging.Filter):
     def __init__(self, window_seconds: int = 5) -> None:
         super().__init__()
         self._recent: dict[tuple[str, str], float] = {}
+        self._suppressed: dict[tuple[str, str], int] = {}
         self._window = window_seconds
         self._lock = threading.Lock()
 
     def filter(self, record: logging.LogRecord) -> bool:
-        """Return False to suppress duplicate messages within the time window."""
+        """Return False to suppress duplicate messages within the time window.
+
+        Keying on the template means a per-entity line emitted in a loop (one
+        warning per org, per schema, ...) collapses to roughly one record per
+        window, because every iteration shares one template. Silently dropping
+        those reads as full coverage: a fleet-wide problem affecting 19 orgs
+        printed as 7, which is how a real migration audit got under-reported.
+        So when a record does get through, it carries a count of what was
+        dropped for that key since the last one — the suppression stays, but
+        it stops being invisible.
+        """
         # record.msg can be any object (callers sometimes pass a list/dict
         # directly to logger.warning). Stringify so the key is always
         # hashable — otherwise this filter raises TypeError and crashes
@@ -178,9 +189,21 @@ class DuplicateFilter(logging.Filter):
 
             last_seen = self._recent.get(key)
             if last_seen is not None and now - last_seen < self._window:
+                self._suppressed[key] = self._suppressed.get(key, 0) + 1
                 return False
             self._recent[key] = now
-            return True
+            dropped = self._suppressed.pop(key, 0)
+
+        if dropped:
+            # Format now and clear args: the suffix must survive the handler's
+            # own `record.getMessage()` %-substitution, which would otherwise
+            # re-apply args to a template that no longer matches them.
+            record.msg = (
+                f"{record.getMessage()} "
+                f"[+{dropped} similar suppressed in the last {self._window}s]"
+            )
+            record.args = None
+        return True
 
 
 def print_startup_banner(

--- a/tests/cli/test_env_loader_alias_promotion.py
+++ b/tests/cli/test_env_loader_alias_promotion.py
@@ -1,0 +1,85 @@
+"""Legacy DSN alias promotion — see ``env_loader.promote_legacy_env_aliases``.
+
+The bug this guards: ``.env`` files load with ``override=False``, which only
+protects a canonical name already present in the process environment. It does
+nothing when the environment supplied the LEGACY name and the file supplies the
+CANONICAL one — the file wins, so a process handed a real prod DSN as
+``DATA_SUPABASE_DB_URL`` silently reads the developer's local ``DATA_DB_URL``.
+"""
+
+import os
+
+import pytest
+
+from reflexio.cli import env_loader
+
+_PROD = "postgresql://u:p@prod-db.example.com:5432/reflexio"
+_LOCAL = "postgresql://postgres:postgres@127.0.0.1:54322/postgres"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "DATA_DB_URL",
+        "DATA_SUPABASE_DB_URL",
+        "POSTGRES_DB_URL",
+        "REFLEXIO_STORAGE",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_promotes_legacy_when_canonical_unset(monkeypatch):
+    monkeypatch.setenv("DATA_SUPABASE_DB_URL", _PROD)
+    env_loader.promote_legacy_env_aliases()
+    assert os.environ["DATA_DB_URL"] == _PROD
+
+
+def test_a_dotenv_canonical_value_can_no_longer_shadow_the_legacy_one(
+    monkeypatch, tmp_path
+):
+    """The actual regression: legacy injected, canonical only in the .env file.
+
+    Promotion runs first, so the file's ``override=False`` load can no longer
+    replace the injected value — which is what silently redirected a prod
+    verification at a local database.
+    """
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"DATA_DB_URL={_LOCAL}\n")
+    monkeypatch.setenv("DATA_SUPABASE_DB_URL", _PROD)
+
+    env_loader.promote_legacy_env_aliases()
+    env_loader._load_dotenv_pruned(env_file)
+
+    assert os.environ["DATA_DB_URL"] == _PROD, "local .env shadowed the injected DSN"
+
+
+def test_never_overwrites_an_explicit_canonical_value(monkeypatch):
+    monkeypatch.setenv("DATA_DB_URL", _PROD)
+    monkeypatch.setenv("DATA_SUPABASE_DB_URL", _LOCAL)
+    env_loader.promote_legacy_env_aliases()
+    assert os.environ["DATA_DB_URL"] == _PROD
+
+
+def test_blank_canonical_is_treated_as_unset(monkeypatch):
+    """``.env.self_host`` ships ``DATA_DB_URL=`` — blank must not block promotion."""
+    monkeypatch.setenv("DATA_DB_URL", "")
+    monkeypatch.setenv("DATA_SUPABASE_DB_URL", _PROD)
+    env_loader.promote_legacy_env_aliases()
+    assert os.environ["DATA_DB_URL"] == _PROD
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("POSTGRES_DB_URL", _LOCAL), ("REFLEXIO_STORAGE", "postgres")],
+)
+def test_defers_to_the_storage_aware_resolver_when_ambiguous(monkeypatch, key, value):
+    """Postgres in play → the Supabase alias is not necessarily the intended DSN."""
+    monkeypatch.setenv("DATA_SUPABASE_DB_URL", _PROD)
+    monkeypatch.setenv(key, value)
+    env_loader.promote_legacy_env_aliases()
+    assert os.environ.get("DATA_DB_URL", "") == ""
+
+
+def test_no_legacy_value_is_a_noop():
+    env_loader.promote_legacy_env_aliases()
+    assert "DATA_DB_URL" not in os.environ

--- a/tests/cli/test_log_format.py
+++ b/tests/cli/test_log_format.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
 import pytest
 
 from reflexio.cli.log_format import (
     _LEVEL_COLORS,
+    DuplicateFilter,
     format_service_line,
     highlight_log_level,
 )
@@ -82,3 +84,67 @@ class TestFormatServiceLine:
         with patch("reflexio.cli.log_format.sys.stdout.isatty", return_value=False):
             out = format_service_line("backend", "ERROR: port in use")
         assert out == "[backend ] ERROR: port in use"
+
+
+class TestDuplicateFilterSuppressionIsVisible:
+    """A per-entity warning loop must not silently under-report its scope.
+
+    ``DuplicateFilter`` keys on the message TEMPLATE, so N per-org warnings
+    emitted in a loop share one key and collapse to roughly one per window.
+    Dropping the rest silently reads as full coverage — a real migration audit
+    affecting 19 orgs printed as 7 for exactly this reason.
+    """
+
+    def _record(self, msg: str, args: tuple = ()) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="t",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg=msg,
+            args=args,
+            exc_info=None,
+        )
+
+    def test_suppressed_count_is_reported_on_the_next_emitted_record(self):
+        filt = DuplicateFilter(window_seconds=300)
+        first = self._record("org %s is wedged", ("org_1",))
+        assert filt.filter(first) is True
+        assert "suppressed" not in first.getMessage()
+
+        for org in ("org_2", "org_3", "org_4"):
+            assert filt.filter(self._record("org %s is wedged", (org,))) is False
+
+        filt._recent.clear()  # simulate the window elapsing
+        later = self._record("org %s is wedged", ("org_5",))
+        assert filt.filter(later) is True
+        assert "+3 similar suppressed" in later.getMessage()
+
+    def test_emitted_message_survives_handler_reformatting(self):
+        """The suffix must not be destroyed by the handler's own %-substitution."""
+        filt = DuplicateFilter(window_seconds=300)
+        assert filt.filter(self._record("org %s is wedged", ("org_1",))) is True
+        assert filt.filter(self._record("org %s is wedged", ("org_2",))) is False
+        filt._recent.clear()
+        rec = self._record("org %s is wedged", ("org_3",))
+        filt.filter(rec)
+        # getMessage() is what handlers call; calling it twice must be stable
+        # and must not raise on a template whose args were cleared.
+        assert rec.getMessage() == rec.getMessage()
+        assert "org_3" in rec.getMessage()
+        assert "+1 similar suppressed" in rec.getMessage()
+
+    def test_distinct_templates_do_not_share_a_suppression_count(self):
+        filt = DuplicateFilter(window_seconds=300)
+        assert filt.filter(self._record("alpha %s", ("a",))) is True
+        assert filt.filter(self._record("alpha %s", ("b",))) is False
+        beta = self._record("beta %s", ("c",))
+        assert filt.filter(beta) is True
+        assert "suppressed" not in beta.getMessage()
+
+    def test_unsuppressed_records_are_left_untouched(self):
+        filt = DuplicateFilter(window_seconds=300)
+        rec = self._record("solo %s", ("x",))
+        assert filt.filter(rec) is True
+        assert rec.getMessage() == "solo x"
+        assert rec.args == ("x",)


### PR DESCRIPTION
## Summary

Two defects that combined to make a **production verification silently measure the wrong database and under-report its own scope**. Both were found while auditing a prod deploy whose post-deploy grant check reported `PASS` after inspecting `127.0.0.1:54322`.

### 1. Legacy alias shadowing (`env_loader.py`)

`.env` files load with `override=False`, which only protects a canonical name **already set** in the process environment. It does nothing when the environment supplied the **legacy** name and a `.env` supplies the **canonical** one — the file wins.

So a process handed a real prod DSN as `DATA_SUPABASE_DB_URL` read the developer's local `DATA_DB_URL` instead, and reported success.

`promote_legacy_env_aliases()` fills a blank/unset `DATA_DB_URL` from `DATA_SUPABASE_DB_URL` **before** any file loads, so `override=False` behaves as it appears to. This is name-agnostic by design: a deployment whose secret store we do not control — a self-host customer's — may legitimately supply only the legacy name, so no rename on our side could fix it.

Deliberately conservative. Promotion is skipped when:
- the canonical name already carries a value (never overwrites an explicit setting), or
- `POSTGRES_DB_URL` is set, or `REFLEXIO_STORAGE=postgres`

In those cases the legacy Supabase name is not necessarily the intended DSN, so the existing storage-aware resolver decides instead of the loader pre-empting it. Blank counts as unset — `.env.self_host` ships `DATA_DB_URL=`, and that must not block promotion.

### 2. Silent duplicate suppression (`log_format.py`)

`DuplicateFilter` keys on the message **template**, not the formatted output. A per-entity warning loop (one line per org) therefore shares one key and collapses to roughly one record per 5s window — the rest disappear with no trace.

A real migration audit affecting **19** orgs printed **7**. Silent truncation reads as full coverage, and the survivors were every 3rd org purely because iteration rate happened to line up with the window.

The filter now counts what it drops and appends `[+N similar suppressed in the last Xs]` to the next record that gets through. The 5s window and template keying are unchanged — the filter exists to stop genuine per-org spam, and widening it to formatted messages would restore that.

## Changes

- `reflexio/cli/env_loader.py` — add `promote_legacy_env_aliases()`; call it at the top of both `load_reflexio_env()` and `load_reflexio_env_for_mode()`, before any file load
- `reflexio/cli/log_format.py` — `DuplicateFilter` tracks suppressed counts per key and annotates the next emitted record; clears `record.args` when rewriting so the handler's own `%`-substitution cannot destroy the suffix
- `tests/cli/test_env_loader_alias_promotion.py` — new
- `tests/cli/test_log_format.py` — new `TestDuplicateFilterSuppressionIsVisible`

## Test Plan

**The bug was reproduced before the fix**, not just asserted after:

```
WITHOUT promotion -> DATA_DB_URL = postgresql://postgres:postgres@127.0.0.1:54322/postgres
  => bug reproduced: local .env shadowed the injected prod DSN
WITH promotion    -> DATA_DB_URL = postgresql://u:p@prod-db.example.com:5432/reflexio
  => fixed: injected prod DSN survives the .env load
```

Coverage includes both directions and the paths that must **not** change: an explicit canonical value is never overwritten; blank canonical is treated as unset (the `.env.self_host` case); and promotion defers to the storage-aware resolver when `POSTGRES_DB_URL` / `REFLEXIO_STORAGE=postgres` is in play. One `DuplicateFilter` test specifically asserts the annotated message survives a second `getMessage()` call, since handlers re-format records.

Gates run, with observed counts:

- `tests/cli/` — **348 passed**
- OSS unit tier (`-m "not integration and not e2e and not requires_credentials"`) — **4312 passed, 9 skipped, 8 snapshots passed**
- `ruff check` + `ruff format --check` clean; `pyright` 0 errors

## Downstream

A companion enterprise PR pins this commit and aggregates the per-schema migration warnings at the call site; the two fixes are complementary (this one bounds the damage for any future per-entity loop).
