### PR TITLE
test: cap local xdist worker count via pytest_xdist_auto_num_workers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,6 +74,21 @@ from reflexio.test_support.llm_mock import cleanup_llm_mock, configure_llm_mock
 ensure_provider_credential()
 
 
+# ``addopts`` passes ``-n auto``, which xdist resolves to the machine's full CPU count.
+# Every worker imports torch/chromadb/sentence-transformers and runs real embeddings, so on
+# a developer laptop that saturates each core and freezes the desktop. CI runners have the
+# box to themselves and want the full count, so the cap is local-only.
+_LOCAL_MAX_XDIST_WORKERS = 4
+
+
+@pytest.hookimpl
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
+    """Cap what ``-n auto`` expands to locally; return None in CI to keep xdist's default."""
+    if os.environ.get("CI"):
+        return None
+    return min(_LOCAL_MAX_XDIST_WORKERS, os.cpu_count() or 1)
+
+
 def pytest_configure(config):
     configure_llm_mock(config)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,14 @@ _LOCAL_MAX_XDIST_WORKERS = 4
 
 @pytest.hookimpl
 def pytest_xdist_auto_num_workers(config: pytest.Config) -> int | None:
-    """Cap what ``-n auto`` expands to locally; return None in CI to keep xdist's default."""
+    """Cap what ``-n auto``/``-n logical`` expand to locally; None in CI keeps xdist's default.
+
+    xdist calls this for both modes and for neither when an explicit ``-n <N>`` is given
+    (``xdist/plugin.py``: ``if config.option.numprocesses in ("auto", "logical")``), so an
+    explicit count is already the caller's own choice. Capping ``logical`` too is
+    deliberate — it asks for *more* workers than physical cores, so exempting it would
+    reopen the all-cores local run this cap exists to prevent.
+    """
     if os.environ.get("CI"):
         return None
     return min(_LOCAL_MAX_XDIST_WORKERS, os.cpu_count() or 1)

--- a/tests/test_xdist_worker_cap.py
+++ b/tests/test_xdist_worker_cap.py
@@ -1,0 +1,60 @@
+"""Regression guard for the local xdist worker cap in ``tests/conftest.py``.
+
+xdist dispatches ``pytest_xdist_auto_num_workers`` for **both** ``-n auto`` and
+``-n logical``, and for neither when an explicit ``-n <N>`` is given::
+
+    # xdist/plugin.py
+    if config.option.numprocesses in ("auto", "logical"):
+        auto_num_cpus = config.hook.pytest_xdist_auto_num_workers(config=config)
+
+Capping ``logical`` as well as ``auto`` is deliberate, not an oversight: ``logical`` asks
+for *more* workers than physical cores, so exempting it would reopen the all-cores local
+run the cap exists to prevent. This file exists because "only cap ``auto``" is a natural
+looking change to propose.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_CONFTEST_PATH = Path(__file__).resolve().parent / "conftest.py"
+
+
+def _conftest_plugin(config: pytest.Config):
+    """The already-registered conftest module — not a fresh import (it has import-time side effects)."""
+    for plugin in config.pluginmanager.get_plugins():
+        plugin_file = getattr(plugin, "__file__", None)
+        if plugin_file and Path(plugin_file).resolve() == _CONFTEST_PATH:
+            return plugin
+    pytest.fail(f"conftest at {_CONFTEST_PATH} is not a registered plugin")
+
+
+def _fake_config(mode: str) -> SimpleNamespace:
+    return SimpleNamespace(option=SimpleNamespace(numprocesses=mode))
+
+
+@pytest.mark.parametrize("mode", ["auto", "logical"])
+def test_local_run_is_capped(
+    request: pytest.FixtureRequest, monkeypatch, mode: str
+) -> None:
+    monkeypatch.delenv("CI", raising=False)
+    conftest = _conftest_plugin(request.config)
+
+    workers = conftest.pytest_xdist_auto_num_workers(_fake_config(mode))
+
+    assert workers is not None, (
+        f"-n {mode} must be capped locally, not deferred to xdist"
+    )
+    assert workers <= conftest._LOCAL_MAX_XDIST_WORKERS
+
+
+@pytest.mark.parametrize("mode", ["auto", "logical"])
+def test_ci_run_defers_to_xdist(
+    request: pytest.FixtureRequest, monkeypatch, mode: str
+) -> None:
+    monkeypatch.setenv("CI", "true")
+    conftest = _conftest_plugin(request.config)
+
+    # None lets xdist's own impl win the firstresult chain, i.e. CI keeps every core.
+    assert conftest.pytest_xdist_auto_num_workers(_fake_config(mode)) is None


### PR DESCRIPTION
## Summary

`[tool.pytest.ini_options] addopts` passes `-n auto`, which pytest-xdist resolves to the
machine's full CPU count — 18 workers on a developer laptop. Every worker imports the test
conftest, and the suite runs real embeddings, so a bare `uv run pytest <path>` fanned out
across every core and made the desktop unresponsive.

This caps what `-n auto` expands to **locally only**. CI is deliberately untouched: it has
the box to itself and wants every core.

## Changes

`tests/conftest.py` implements xdist's `pytest_xdist_auto_num_workers` hook:

- Locally → `min(4, os.cpu_count())`.
- Under `CI` → returns `None`, so xdist falls through to its own full-CPU default.

`addopts` is left exactly as-is, so no invocation anywhere has to change — the hook only
intercepts what `auto` resolves to. GitHub Actions always sets `CI=true`.

## Test Plan

Verified with `--maxprocesses 6` as a safety net, so a non-functioning hook would show as 6
rather than silently spawning 18:

| Invocation | Workers created |
| --- | --- |
| `-n auto` (local) | **4** — the hook decided it, not the net |
| `CI=true` `-n auto` | **6** — hook returned `None` and deferred to xdist |

Both runs passed their tests. `ruff check` / `ruff format --check` clean; `pyright` reports
0 errors, 0 warnings on the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved local test execution by limiting automatic parallel test runs to a maximum of four workers.
  * Preserved the existing automatic worker behavior in CI environments.
  * Adjusted the limit for machines with fewer available CPU cores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->