### PR TITLE
fix(test): mark the manifest regression test integration, and skip without a real key

### DIFF
--- a/tests/server/services/playbook/test_reviewer_manifest_regression.py
+++ b/tests/server/services/playbook/test_reviewer_manifest_regression.py
@@ -12,11 +12,12 @@ that by driving the reviewer with the repo's own generalization manifest: each
 `must_capture` case becomes one candidate, grounded in that case's own turns. A
 must-capture family that does not survive is a false rejection.
 
-Costs real API calls, so it is marked `requires_credentials` and excluded from
-default runs. Run it when changing the reviewer prompt:
+Costs real API calls, so it is marked `integration` (what the unit jobs filter
+on) and `requires_credentials`, and skips outright without a real provider key.
+Run it when changing the reviewer prompt:
 
     uv run pytest tests/server/services/playbook/test_reviewer_manifest_regression.py \\
-        -m requires_credentials -o 'addopts='
+        -m 'integration and requires_credentials' -o 'addopts='
 """
 
 from __future__ import annotations
@@ -43,8 +44,27 @@ from reflexio.server.services.playbook.components.reviewer import (
 from reflexio.server.services.playbook.playbook_service_utils import (
     build_playbook_prompt_context,
 )
+from reflexio.test_support.llm_credentials import real_provider_key
 
-pytestmark = pytest.mark.requires_credentials
+# `requires_credentials` alone does NOT keep this out of a default run: the
+# unit-test jobs filter on `-m "not integration"`, so the marker that actually
+# deselects live-provider tests is `integration`. Without it these ran against
+# the global litellm mock, which answers every call with a profile-shaped
+# payload -- so the reviewer schema failed to parse and the repair ladder
+# exhausted, 12 failures that looked like a reviewer regression and were not.
+#
+# `real_provider_key` rather than `os.getenv`, because the credential floor
+# pins a placeholder key when none is set; a plain getenv check would let this
+# run against a credential that authenticates with nothing.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_credentials,
+    pytest.mark.skipif(
+        not real_provider_key("OPENAI_API_KEY")
+        and not real_provider_key("ANTHROPIC_API_KEY"),
+        reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is set to a real key",
+    ),
+]
 
 _MANIFEST = (
     Path(__file__).resolve().parents[4]


### PR DESCRIPTION
Follow-up to #426. The test it added broke enterprise CI (`os-unit-tests`), which surfaced on the enterprise submodule bump.

## What went wrong

`test_reviewer_manifest_regression.py` carried only `pytest.mark.requires_credentials`. That marker **deselects nothing** — the unit jobs filter on:

```
pytest tests/ --ignore=tests/e2e_tests/ -m "not integration"
```

So all 12 cases ran, hit the **global litellm mock**, and got a profile-shaped payload back:

```
schema=PlaybookCandidateReviewOutput
errors=id: missing,decision: missing,reason_code: missing,profiles: extra_forbidden
-> StructuredOutputRepairError: Structured output repair exhausted
```

12 failures that read as a reviewer regression and were not one. My mistake in #426: I verified "deselected by default" against the OSS default `addopts` and never against the job command that actually runs it.

## Fix

Adopts the pattern already used by `tests/server/llm/test_litellm_client.py`:

- adds `pytest.mark.integration` — the marker that actually gates live-provider tests
- adds a `real_provider_key` skipif, rather than `os.getenv`, because the credential floor pins a placeholder key when none is set. `real_provider_key`'s own docstring warns about exactly this: a `requires_credentials` test that would skip cleanly on a bare machine instead runs "against a credential that authenticates with nothing."

## Verification

Reproduced CI's exact command locally rather than the file in isolation:

```
pytest tests/ --ignore=tests/e2e_tests/ -m "not integration"
-> 4252 passed, 3 skipped, 1304 deselected
```

The 12 cases are among the deselected. ruff check + format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved regression-test coverage for reviewer manifest behavior.
  * Tests now clearly identify integration and credential requirements.
  * Added validation to skip runs when configured provider credentials are unavailable.
  * Updated test documentation and execution guidance to support integration-test filtering.
  * No end-user product behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->