### PR TITLE
fix(test): mark the manifest regression test integration (cherry-pick of #429)

### DIFF
--- a/tests/server/services/playbook/test_reviewer_manifest_regression.py
+++ b/tests/server/services/playbook/test_reviewer_manifest_regression.py
@@ -12,11 +12,12 @@ that by driving the reviewer with the repo's own generalization manifest: each
 `must_capture` case becomes one candidate, grounded in that case's own turns. A
 must-capture family that does not survive is a false rejection.
 
-Costs real API calls, so it is marked `requires_credentials` and excluded from
-default runs. Run it when changing the reviewer prompt:
+Costs real API calls, so it is marked `integration` (what the unit jobs filter
+on) and `requires_credentials`, and skips outright without a real provider key.
+Run it when changing the reviewer prompt:
 
     uv run pytest tests/server/services/playbook/test_reviewer_manifest_regression.py \\
-        -m requires_credentials -o 'addopts='
+        -m 'integration and requires_credentials' -o 'addopts='
 """
 
 from __future__ import annotations
@@ -43,8 +44,27 @@ from reflexio.server.services.playbook.components.reviewer import (
 from reflexio.server.services.playbook.playbook_service_utils import (
     build_playbook_prompt_context,
 )
+from reflexio.test_support.llm_credentials import real_provider_key
 
-pytestmark = pytest.mark.requires_credentials
+# `requires_credentials` alone does NOT keep this out of a default run: the
+# unit-test jobs filter on `-m "not integration"`, so the marker that actually
+# deselects live-provider tests is `integration`. Without it these ran against
+# the global litellm mock, which answers every call with a profile-shaped
+# payload -- so the reviewer schema failed to parse and the repair ladder
+# exhausted, 12 failures that looked like a reviewer regression and were not.
+#
+# `real_provider_key` rather than `os.getenv`, because the credential floor
+# pins a placeholder key when none is set; a plain getenv check would let this
+# run against a credential that authenticates with nothing.
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_credentials,
+    pytest.mark.skipif(
+        not real_provider_key("OPENAI_API_KEY")
+        and not real_provider_key("ANTHROPIC_API_KEY"),
+        reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is set to a real key",
+    ),
+]
 
 _MANIFEST = (
     Path(__file__).resolve().parents[4]


### PR DESCRIPTION
Cherry-pick of #429 onto `codex/service-only-inference`, which enterprise `main` is currently pinned to.

## Why this branch and not main

#429 is already on OSS `main`. But enterprise `main` pins `75627df2` on this branch, which contains #426 (the test) **without** #429 (its marker fix). So enterprise picks up the broken form.

## What breaks without it

`test_reviewer_manifest_regression.py` carried only `requires_credentials`, which deselects nothing — the unit jobs filter on `-m "not integration"`. The 12 cases run against the global litellm mock and get a profile-shaped payload:

```
schema=PlaybookCandidateReviewOutput
errors=id: missing,decision: missing,reason_code: missing,profiles: extra_forbidden
-> StructuredOutputRepairError: Structured output repair exhausted
```

Observed on enterprise PR #960 as 12 `os-unit-tests` failures. It does not show on enterprise `main` because `CI Full`'s `os-tests` job excludes real-API tests, while `CI Fast`'s `os-unit-tests` does not — so it hits every **pull request** against main until this lands.

This becomes redundant the moment `codex/service-only-inference` merges to OSS main (which already has #429); it is only needed while enterprise is pinned to this branch.

## Verification

```
pytest tests/server/services/playbook/test_reviewer_manifest_regression.py -m "not integration"
-> 12 deselected
```