### PR TITLE
fix(embedding): honour provider=off in service capability discovery

### DIFF
--- a/reflexio/server/llm/providers/embedding_service_provider.py
+++ b/reflexio/server/llm/providers/embedding_service_provider.py
@@ -169,7 +169,21 @@ def resolve_service_configured_reranker_model() -> str:
 
 
 def resolve_inference_service_capabilities() -> InferenceServiceCapabilities:
-    """Discover and process-cache both models with one ``/health`` request."""
+    """Discover and process-cache both models with one ``/health`` request.
+
+    Raises:
+        EmbeddingUnavailableError: If the provider is ``off``, or the service
+            cannot be reached.
+    """
+    # Honour an explicit `off` before deriving a service mode. Deriving one
+    # unconditionally made `off` unreachable here: the caller got a connection
+    # error against a service it had just disabled, rather than being told the
+    # provider is off.
+    if embedding_provider_mode() == "off":
+        raise EmbeddingUnavailableError(
+            f"Embedding provider is disabled ({_ENV_PROVIDER}=off); "
+            "no service model can be discovered"
+        )
     mode: EmbeddingProviderMode = (
         "internal_service"
         if os.environ.get(_ENV_SERVICE_URL, "").strip()

--- a/tests/server/llm/test_embedding_service_provider.py
+++ b/tests/server/llm/test_embedding_service_provider.py
@@ -237,3 +237,26 @@ def test_malformed_embedding_response_fails_closed(monkeypatch, data: Any) -> No
 
     with pytest.raises(EmbeddingUnavailableError):
         get_service_embeddings(["text"], model="local/minilm-l6-v2")
+
+
+def test_capability_discovery_honours_off_mode(monkeypatch) -> None:
+    """`off` must short-circuit discovery, not attempt a connection.
+
+    The mode was derived locally here, so `off` -- a validated member of
+    _VALID_MODES -- could not reach this path: callers that had explicitly
+    disabled embedding still got a connection error against the service they
+    had just turned off. Asserts on the message because the failure mode being
+    guarded is a *misleading* error, not merely an error.
+    """
+    from reflexio.server.llm.providers import embedding_service_provider as provider
+
+    monkeypatch.setattr(provider, "_configured_model_cache", {})
+    monkeypatch.setenv("REFLEXIO_EMBEDDING_PROVIDER", "off")
+
+    def _fail_if_called(*args, **kwargs):  # pragma: no cover - must not run
+        raise AssertionError("discovery attempted an HTTP call while provider=off")
+
+    monkeypatch.setattr(provider, "_http_client", _fail_if_called)
+
+    with pytest.raises(provider.EmbeddingUnavailableError, match="disabled"):
+        provider.resolve_inference_service_capabilities()


### PR DESCRIPTION
Found while investigating enterprise `main` unit-test failures (6 failed / 97 errors, all `EmbeddingUnavailableError` against `127.0.0.1:8099/health`).

## The bug

`resolve_inference_service_capabilities()` derived its own mode instead of asking `embedding_provider_mode()`:

```python
mode = "internal_service" if os.environ.get(_ENV_SERVICE_URL, "").strip() else "local_service"
```

So `off` — a validated member of `_VALID_MODES` — could never reach this path. Anyone who explicitly disabled embedding still got a connection attempt, and an error blaming the service they had just turned off:

```
embedding_provider_mode() -> off
resolve_service_configured_model("custom") -> EmbeddingUnavailableError:
    Could not discover embedding model from http://127.0.0.1:8099/health:
    [Errno 111] Connection refused
```

That is also why `REFLEXIO_EMBEDDING_PROVIDER=off` did not work as a mitigation for the enterprise failures.

## The fix

Check `embedding_provider_mode()` first and raise a message naming the cause, consistent with how `_litellm_embedding` reports a disabled provider.

**No behaviour change for any configured mode** — `off` was the only unreachable branch. It does make `off` a usable escape hatch, which it was documented to be.

## Test

`test_capability_discovery_honours_off_mode` asserts on the *message*, not just the exception type — the defect is a misleading error, not the absence of one. It also fails if any HTTP client is constructed while `off`.

Mutation-checked: removing the guard fails the test; restoring it passes.

```
tests/server/llm/  ->  632 passed, 1 skipped, 69 deselected
```

## Not fixed here

This does not unbreak enterprise CI on its own — enterprise defaults to the `custom` sentinel, so it resolves via the service by design. That is handled separately with a test-level stub. And a second, distinct issue remains: the SQLite document path swallows `EmbeddingUnavailableError` and stores an empty vector, after which aggregation reports `state=succeeded creations=0`. Filed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the embedding provider is disabled.
  * Capability checks now report a clear unavailable status without attempting a connection.
  * Prevented unnecessary health-check requests for disabled providers.

* **Tests**
  * Added regression coverage for disabled-provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->