### PR TITLE
fix(playbook): report embedding-starved aggregation runs distinctly

### DIFF
--- a/reflexio/server/services/playbook/aggregation_scheduler.py
+++ b/reflexio/server/services/playbook/aggregation_scheduler.py
@@ -263,7 +263,7 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
                     "agent_version=%s fence=%s pending=%s undisposed=%s residual=%s "
                     "invalidations=%s oldest_residual_age_seconds=%s "
                     "dirty_repairs=%s duration_ms=%s creations=%s supersessions=%s "
-                    "retryable_failures=%s",
+                    "retryable_failures=%s embedding_pending=%s",
                     context.org_id,
                     claim.agent_version,
                     claim.fence,
@@ -277,6 +277,7 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
                     result.get("playbooks_generated", 0),
                     result.get("supersessions", 0),
                     result.get("retryable_failures", 0),
+                    result.get("embedding_pending", 0),
                 )
 
     def _run_once(self) -> float:

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -1055,6 +1055,12 @@ class PlaybookAggregator:
             "retryable_failures": len(retryable_outcomes) + cluster_fence_losses,
             "cluster_fence_losses": cluster_fence_losses,
             "selected_rebuild_members": rebuilding_residual_count,
+            # Deferred for want of a vector, not for want of work. These are
+            # already dispositioned residual/embedding_pending, but `residual`
+            # sums three unrelated reasons, so a run starved of embeddings is
+            # indistinguishable from an idle one at the log line. Reported
+            # separately so "succeeded, created nothing" can be read correctly.
+            "embedding_pending": len(missing_embedding_ids),
         }
         self._enqueue_playbook_optimization(saved_playbooks)
         record_usage_event(

--- a/tests/server/services/playbook/test_aggregation_scheduler.py
+++ b/tests/server/services/playbook/test_aggregation_scheduler.py
@@ -239,3 +239,61 @@ def test_scheduler_keeps_sqlite_work_pending_when_vector_index_is_unavailable(
     assert state is not None and int(state[0]) == 1
     assert storage.supports_incremental_playbook_aggregation is False
     assert "blocked_missing_vector_index" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("run_result", "expected"),
+    [
+        ({"playbooks_generated": 0}, "embedding_pending=0"),
+        ({"playbooks_generated": 0, "embedding_pending": 2}, "embedding_pending=2"),
+    ],
+    ids=["idle_run", "starved_run"],
+)
+def test_succeeded_log_distinguishes_a_starved_run_from_an_idle_one(
+    monkeypatch, caplog, run_result: dict[str, int], expected: str
+) -> None:
+    """A run that created nothing for want of vectors must not read as idle.
+
+    Candidates without an embedding are dispositioned residual/embedding_pending,
+    but `residual` sums three unrelated reasons, so at the log line a run starved
+    of embeddings looked exactly like one with no work: `state=succeeded
+    creations=0`. That is the shape an embedding outage takes in the logs, so it
+    has to be readable there.
+    """
+    claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
+    storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.repair_playbook_aggregation_pending_state.return_value = []
+    storage.claim_due_playbook_aggregation.return_value = claim
+    storage.get_playbook_aggregation_backlog.return_value = PlaybookAggregationBacklog(
+        4, 1, 0, residual_retry_after_seconds=60
+    )
+    storage.get_playbook_aggregation_invalidations.return_value = []
+    storage.finish_playbook_aggregation_claim.return_value = True
+
+    class Aggregator:
+        def __init__(self, **kwargs: object) -> None: ...
+
+        def run(self, _request: object) -> dict[str, int]:
+            return run_result
+
+    monkeypatch.setattr(aggregation_scheduler, "PlaybookAggregator", Aggregator)
+    monkeypatch.setattr(aggregation_scheduler, "_aggregation_budget", lambda: 8)
+    monkeypatch.setattr(
+        "reflexio.lib.generation_client.create_generation_litellm_client",
+        lambda _context: MagicMock(),
+    )
+    monkeypatch.setattr(
+        aggregation_scheduler,
+        "run_with_operation_limit",
+        lambda *, fn, **_kwargs: fn(),
+    )
+    caplog.set_level(logging.INFO, logger=aggregation_scheduler.logger.name)
+
+    scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
+        context_provider=lambda: [], worker_id="worker"
+    )
+    scheduler._run_context(_context(storage))
+
+    assert "state=succeeded" in caplog.text
+    assert "creations=0" in caplog.text
+    assert expected in caplog.text


### PR DESCRIPTION
Third of three from the enterprise-CI embedding investigation (after #431, and the enterprise-side test stub).

## The problem

A run whose candidates all lacked vectors created nothing and logged:

```
state=succeeded ... residual=2 creations=0
```

That is indistinguishable from a run with no work to do — and it is exactly the shape an embedding outage takes in the logs.

## What was actually wrong

Not missing tracking. **Collapsed** tracking. Candidates without an embedding are already dispositioned `residual` / `embedding_pending`, but `residual` sums three unrelated reasons:

| reason | means |
|---|---|
| `embedding_pending` | no vector — cannot cluster |
| `cluster_agent_unavailable` | cluster owner gone |
| `llm_retryable_failure` | transient LLM error |

So `residual=2` could not answer *waiting on what?*

## The change

Surface the per-run count the aggregator already computes (`missing_embedding_ids`) as `embedding_pending`, in the result dict and the succeeded log line.

No new tracking, no storage change, **no behaviour change** — only the reason becomes legible.

## Why it matters more than a log tweak

The ingest path stores an empty vector and returns success when embedding is unavailable, and the sweep that repairs those rows is **opt-in** (`REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED`). `vector_backfill_sweep.py` calls that state "a latent durability hole" where rows are "invisible to vector/hybrid search forever". With the sweep off, this log line is the only place the resulting starvation surfaces.

## Test

Parametrised over the idle and starved runs **together**, because the defect is that the two were identical — asserting the starved case alone would pass against a hardcoded field.

Mutation-checked: removing the log argument fails both parametrisations; restoring it passes.

```
tests/ (unit tier) -> 4254 passed, 3 skipped, 1304 deselected
```

## Deliberately not included

Making the SQLite document path fail loud (to match postgres/supabase). I built it and backed it out: it breaks 46 OSS tests, and more importantly it contradicts a documented design — `backfill_missing_interaction_vectors` is on the storage base protocol, implemented for SQLite and Supabase, and swept by `vector_backfill_sweep`. Tolerate-at-ingest and repair-by-sweep is the chosen strategy; switching SQLite to fail-closed is a separate decision, not a drive-by.