### PR TITLE
feat(lineage): run the missing-vector backfill sweep by default

### DIFF
--- a/reflexio/server/services/lineage/vector_backfill_sweep.py
+++ b/reflexio/server/services/lineage/vector_backfill_sweep.py
@@ -16,10 +16,18 @@ Design:
 - **Bounded**: re-embeds at most ``REFLEXIO_MISSING_VECTOR_BACKFILL_CAP``
   interactions per org per tick (prior art warns unbounded backfills flood
   logs / embedding cost — see ``llm/_litellm_embedding.py``).
-- **Opt-in**: only registered when ``REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED``
-  is truthy, so a default OSS deployment is byte-for-byte unchanged (the
-  scheduler does not start on this hook alone). The enable flag is re-read every
-  tick so a live disable is honoured without a restart.
+- **On by default**: registered unless ``REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED``
+  is explicitly falsey. It was opt-in originally so that a deployment which had
+  not asked for it was byte-for-byte unchanged; that turned out to be the wrong
+  default, because the hole it repairs is opened silently by the ingest path and
+  is permanent while nothing sweeps. An operator who wants the old behaviour
+  sets the flag to ``false``. The flag is re-read every tick, so a live disable
+  is honoured without a restart.
+
+  Registering any per-org hook starts the shared ``LineageGCScheduler`` even
+  when no bootstrap-org flag is set, so this default also starts that loop where
+  it previously would not have. Other sweep classes keep their own config gates
+  and do not begin running as a result -- only this hook does.
 - **Fail-safe**: the storage layer catches ``EmbeddingUnavailableError`` and
   returns 0 (work left for the next tick); this closure additionally captures
   any unexpected error as an anomaly and returns the count so far, so one org's
@@ -78,7 +86,7 @@ def missing_vector_backfill_sweep(org_id: str, _now: int) -> int:
     Returns:
         int: Number of interactions whose vector was backfilled (0 on skip/error).
     """
-    if not env_truthy(env_str(ENABLE_ENV_VAR, "false")):
+    if not env_truthy(env_str(ENABLE_ENV_VAR, "true")):
         return 0
 
     # Imported lazily so importing this module never drags in the request stack.
@@ -106,13 +114,16 @@ def missing_vector_backfill_sweep(org_id: str, _now: int) -> int:
 
 
 def install_missing_vector_backfill_sweep() -> None:
-    """Register the backfill sweep on the OSS lineage GC scheduler when enabled.
+    """Register the backfill sweep on the OSS lineage GC scheduler unless disabled.
 
-    Only registers when ``REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED`` is truthy,
-    so an OSS deployment that has not opted in keeps its scheduler start
-    conditions unchanged. Idempotent: a second call in the same process is a
-    no-op. Non-fatal: a registration failure logs and skips rather than aborting
-    app startup.
+    Registers unless ``REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED`` is explicitly
+    falsey. Because a registered per-org hook is itself a scheduler start
+    condition, this means the shared ``LineageGCScheduler`` now starts even when
+    no bootstrap-org flag is set. That is intended: the durability hole this
+    repairs is permanent while nothing sweeps.
+
+    Idempotent: a second call in the same process is a no-op. Non-fatal: a
+    registration failure logs and skips rather than aborting app startup.
 
     Call this before ``maybe_start_lineage_gc`` so the registered hook is
     visible when the scheduler evaluates its start conditions.
@@ -120,7 +131,7 @@ def install_missing_vector_backfill_sweep() -> None:
     global _installed  # noqa: PLW0603
     if _installed:
         return
-    if not env_truthy(env_str(ENABLE_ENV_VAR, "false")):
+    if not env_truthy(env_str(ENABLE_ENV_VAR, "true")):
         return
     try:
         from reflexio.server.services.lineage.gc_scheduler import (

--- a/tests/server/services/storage/test_missing_vector_backfill_integration.py
+++ b/tests/server/services/storage/test_missing_vector_backfill_integration.py
@@ -284,22 +284,51 @@ def test_backfill_text_matches_the_ingest_derivation(
 # ---------------------------------------------------------------------------
 
 
-def test_sweep_disabled_by_default_does_not_touch_storage(
-    tmp_path, worker_id, monkeypatch
+@pytest.mark.parametrize(
+    ("flag", "expect_run"),
+    [(None, True), ("false", False), ("0", False), ("true", True)],
+    ids=[
+        "unset_runs",
+        "explicit_false_skips",
+        "explicit_zero_skips",
+        "explicit_true_runs",
+    ],
+)
+def test_sweep_runs_unless_explicitly_disabled(
+    tmp_path, worker_id, monkeypatch, flag: str | None, expect_run: bool
 ) -> None:
+    """The sweep is on by default; only an explicit falsey value disables it.
+
+    Parametrised over unset and explicit-false together because the default is
+    the whole point: asserting only the enabled case would still pass if the
+    flag were ignored, and asserting only the disabled case would still pass
+    under the old opt-in default.
+    """
     from reflexio.server.services.lineage import vector_backfill_sweep as vbs
 
-    monkeypatch.delenv("REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED", raising=False)
+    if flag is None:
+        monkeypatch.delenv("REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED", flag)
 
-    # RequestContext must never be constructed when the flag is off.
-    def _boom(*_a, **_k):  # pragma: no cover - asserts it is never called
-        raise AssertionError("RequestContext built while sweep disabled")
+    built: list[str] = []
+
+    def _fake_request_context(**kwargs):
+        built.append(str(kwargs.get("org_id")))
+        ctx = MagicMock()
+        ctx.storage.backfill_missing_interaction_vectors.return_value = 0
+        return ctx
 
     monkeypatch.setattr(
-        "reflexio.server.api_endpoints.request_context.RequestContext", _boom
+        "reflexio.server.api_endpoints.request_context.RequestContext",
+        _fake_request_context,
     )
 
-    assert vbs.missing_vector_backfill_sweep("some-org", 0) == 0
+    vbs.missing_vector_backfill_sweep("some-org", 0)
+
+    # Reaching storage at all is the observable difference; a disabled sweep
+    # must not even construct a RequestContext.
+    assert bool(built) is expect_run
 
 
 def test_sweep_enabled_backfills_via_storage(tmp_path, worker_id, monkeypatch) -> None:


### PR DESCRIPTION
Follows the embedding investigation (#431, #432).

## Why

The sweep repairs interactions whose embedding vector was never persisted. Its own docstring calls that state **"a latent durability hole"** where rows are **"invisible to vector/hybrid search forever"** — and it was opt-in, so by default nothing repaired it.

That default was defensible in isolation: a deployment that had not asked for the sweep stayed byte-for-byte unchanged. It is wrong in context. The hole is opened *silently* by the ingest path, which stores an empty vector and returns success when embedding is unavailable. Nothing surfaces it at write time, so an operator gets no signal telling them to opt in — **the deployments that most need the sweep are exactly the ones that never enable it.**

## What changed

Both gates (registration, and the per-tick read) now default to `true`. Setting `REFLEXIO_MISSING_VECTOR_BACKFILL_ENABLED=false` restores the previous behaviour, and the flag is still re-read every tick, so a live disable needs no restart.

## Known consequence — intended, and the reason this is not a one-line change

A registered per-org hook **is itself a `LineageGCScheduler` start condition**. So the shared scheduler now starts in deployments where no bootstrap-org flag is set and it previously would not have.

- Other sweep classes keep their own config gates and do **not** begin running as a result — only this hook does.
- Work stays bounded by `REFLEXIO_MISSING_VECTOR_BACKFILL_CAP` (default 200 per org per tick).
- The sweep is idempotent and fail-safe: `EmbeddingUnavailableError` returns 0 and leaves work for the next tick.

I have called this out in the module docstring and the enterprise `.env.template` rather than leaving it to be discovered.

## Test

Parametrised over **unset / explicit-false / explicit-zero / explicit-true together**, because the default is the whole claim — asserting only the enabled case would pass even if the flag were ignored, and asserting only the disabled case would pass under the old default.

Mutation-checked: restoring the `false` default fails the `unset_runs` case.

```
tests/server/services/lineage/ + backfill integration -> 74 passed
tests/ (unit tier)                                    -> 4252 passed, 3 skipped
```

## Companion

Enterprise PR updates `.env.template` (`=true`, with the scheduler-start caveat documented).