### PR TITLE
test: gate live-provider tests on the credential they actually need

### DIFF
--- a/reflexio/server/llm/model_defaults.py
+++ b/reflexio/server/llm/model_defaults.py
@@ -87,6 +87,21 @@ _API_KEY_CONFIG_FIELDS: dict[str, str] = {
 }
 
 
+def provider_env_vars() -> dict[str, str]:
+    """Return the env-var-to-provider mapping used for credential detection.
+
+    A read-only view for callers that need to ask about a *specific* credential
+    rather than "what is available" — notably the test suites' live-provider
+    skip gates, which must distinguish a real key from the placeholder that
+    ``ensure_provider_credential`` pins. Providers reached through a local CLI
+    rather than an API key (``claude-code``) have no entry here.
+
+    Returns:
+        dict[str, str]: Copy of the env var name to provider key mapping.
+    """
+    return dict(_ENV_TO_PROVIDER)
+
+
 def detect_available_providers(
     api_key_config: APIKeyConfig | None = None,
 ) -> list[str]:

--- a/reflexio/test_support/llm_credentials.py
+++ b/reflexio/test_support/llm_credentials.py
@@ -83,9 +83,15 @@ def real_generation_provider(
     machine whose only credential is, say, MiniMax -- even though model
     resolution would have picked MiniMax and the test would have run.
 
-    Selection follows the same priority order as
-    :func:`detect_available_providers`, so the provider named here is the one
-    ``resolve_model_name`` will pick.
+    Selection walks :func:`detect_available_providers` in its priority order
+    and returns the first eligible provider holding a real key. That matches
+    what ``resolve_model_name`` picks whenever every higher-priority detected
+    provider also holds a real key -- which the credential floor cannot
+    violate, since :func:`ensure_provider_credential` only ever pins
+    ``OPENAI_API_KEY`` and ``openai`` sits last in the priority order. An
+    environment that hand-sets some *other* provider's variable to the
+    placeholder string can still diverge; the caller sees a skip reason rather
+    than a wrong model in that case.
 
     Args:
         allowed (Collection[str] | None): Restrict to these provider keys, e.g.

--- a/reflexio/test_support/llm_credentials.py
+++ b/reflexio/test_support/llm_credentials.py
@@ -17,10 +17,12 @@ which is why the same suite can be green locally and ~1,250 errors deep in CI.
 from __future__ import annotations
 
 import os
+from collections.abc import Collection
 
 from reflexio.server.llm.model_defaults import (
     GENERATION_CAPABLE_PROVIDERS,
     detect_available_providers,
+    provider_env_vars,
 )
 
 # Matches the string already used by the `storage` fixture in
@@ -67,3 +69,43 @@ def real_provider_key(name: str) -> str | None:
     """
     value = os.environ.get(name, "")
     return None if value in ("", _PLACEHOLDER_KEY) else value
+
+
+def real_generation_provider(
+    allowed: Collection[str] | None = None,
+) -> str | None:
+    """Return a provider that holds a real key and can serve generation.
+
+    The provider-agnostic counterpart to :func:`real_provider_key`, for live
+    tests that resolve their model through
+    ``resolve_model_name(ModelRole.GENERATION)`` rather than naming one. Gating
+    such a test on ``OPENAI_API_KEY``/``ANTHROPIC_API_KEY`` skips it on a
+    machine whose only credential is, say, MiniMax -- even though model
+    resolution would have picked MiniMax and the test would have run.
+
+    Selection follows the same priority order as
+    :func:`detect_available_providers`, so the provider named here is the one
+    ``resolve_model_name`` will pick.
+
+    Args:
+        allowed (Collection[str] | None): Restrict to these provider keys, e.g.
+            ``{"openai", "anthropic", "minimax"}`` for a test whose assertions
+            are only known to hold on those models. None accepts any
+            generation-capable provider.
+
+    Returns:
+        str | None: Provider key, or None when no eligible provider has a real
+            key configured.
+    """
+    env_by_provider = {
+        provider: env_var for env_var, provider in provider_env_vars().items()
+    }
+    for provider in detect_available_providers():
+        if provider not in GENERATION_CAPABLE_PROVIDERS:
+            continue
+        if allowed is not None and provider not in allowed:
+            continue
+        env_var = env_by_provider.get(provider)
+        if env_var and real_provider_key(env_var):
+            return provider
+    return None

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -253,17 +253,52 @@ def litellm_is_patched() -> bool:
     return isinstance(litellm.completion, NonCallableMock | MagicMock)
 
 
+@contextmanager
+def unpatched_litellm() -> Iterator[None]:
+    """Suspend the session-level mock for the duration, then restore it.
+
+    :func:`configure_llm_mock` decides whether to patch from the invocation
+    *path* (:func:`_is_e2e_test_run` scans ``config.args`` for ``e2e_tests``),
+    so a live-provider test is mocked or not depending on how the command was
+    typed -- ``pytest tests/e2e_tests/`` leaves it unpatched while
+    ``pytest -m e2e`` does not. This makes the exemption a property of the
+    test instead: whoever knows a given test needs a real provider can lift
+    the patch for exactly that test, whatever the invocation.
+
+    ``MOCK_LLM_RESPONSE`` is cleared alongside the patch and restored with it,
+    because service code branches on that variable to skip LLM work entirely.
+
+    Yields:
+        None: A context in which ``litellm.completion`` is the real function.
+    """
+    patcher = _litellm_patcher
+    if patcher is None:
+        yield
+        return
+
+    previous_flag = os.environ.get("MOCK_LLM_RESPONSE")
+    patcher.stop()
+    os.environ.pop("MOCK_LLM_RESPONSE", None)
+    try:
+        yield
+    finally:
+        patcher.start()
+        if previous_flag is not None:
+            os.environ["MOCK_LLM_RESPONSE"] = previous_flag
+
+
 def assert_litellm_unpatched() -> None:
     """Fail a live-provider test that is about to assert against the mock.
 
-    Ask this rather than ``MOCK_LLM_RESPONSE``. That variable is set by
-    :func:`configure_llm_mock` when it patches, but the e2e conftest deletes it
-    for every ``requires_credentials`` test on the assumption the patch is
-    already off -- which holds only when :func:`_is_e2e_test_run` matched, i.e.
-    when the invocation *path* contained ``e2e_tests``. Run the same tests as
-    ``pytest -m e2e`` and the patch is live while the variable is gone, so an
-    env-var guard passes and the test quietly asserts against canned text from
-    whatever unrelated prompt the mock's heuristics matched.
+    Ask this rather than ``MOCK_LLM_RESPONSE``: the variable tracks the patch
+    but can be cleared independently of it, so it reports the mock's *intent*
+    rather than its state. This asks the patcher.
+
+    The e2e conftest lifts the session patch for ``requires_credentials``
+    tests via :func:`unpatched_litellm`, so this should hold for any invocation
+    of those. It stays as a backstop for a live test that is reached some other
+    way -- outside ``tests/e2e_tests/``, or without the marker the fixture keys
+    on -- where the patch would still be live.
 
     Raises:
         AssertionError: When ``litellm.completion`` is patched.
@@ -271,9 +306,9 @@ def assert_litellm_unpatched() -> None:
     if litellm_is_patched():
         raise AssertionError(
             "litellm.completion is patched, so this live-provider test would "
-            "assert against canned mock text. Invoke it by a path containing "
-            "'e2e_tests' (e.g. `pytest tests/e2e_tests/test_x.py`); `-m e2e` "
-            "alone does not disable the session-level mock."
+            "assert against canned mock text. Live tests belong under "
+            "tests/e2e_tests/ and must carry the requires_credentials marker; "
+            "the e2e conftest lifts the session patch for those."
         )
 
 

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -265,25 +265,32 @@ def unpatched_litellm() -> Iterator[None]:
     test instead: whoever knows a given test needs a real provider can lift
     the patch for exactly that test, whatever the invocation.
 
-    ``MOCK_LLM_RESPONSE`` is cleared alongside the patch and restored with it,
-    because service code branches on that variable to skip LLM work entirely.
+    ``MOCK_LLM_RESPONSE`` is cleared unconditionally -- including when there is
+    no session patcher to stop. Service code branches on that variable to skip
+    LLM work entirely, and :func:`patched_litellm` deliberately leaves it set
+    on exit, so an e2e-path run (where ``configure_llm_mock`` never patched)
+    can reach a live test with a stale flag: ``litellm.completion`` is real,
+    :func:`assert_litellm_unpatched` passes, and the services under test
+    quietly take their mock branches anyway.
 
     Yields:
-        None: A context in which ``litellm.completion`` is the real function.
+        None: A context in which ``litellm.completion`` is the real function
+            and ``MOCK_LLM_RESPONSE`` is unset.
     """
     patcher = _litellm_patcher
-    if patcher is None:
-        yield
-        return
-
     previous_flag = os.environ.get("MOCK_LLM_RESPONSE")
-    patcher.stop()
+
+    if patcher is not None:
+        patcher.stop()
     os.environ.pop("MOCK_LLM_RESPONSE", None)
     try:
         yield
     finally:
-        patcher.start()
-        if previous_flag is not None:
+        if patcher is not None:
+            patcher.start()
+        if previous_flag is None:
+            os.environ.pop("MOCK_LLM_RESPONSE", None)
+        else:
             os.environ["MOCK_LLM_RESPONSE"] = previous_flag
 
 

--- a/reflexio/test_support/llm_mock.py
+++ b/reflexio/test_support/llm_mock.py
@@ -38,7 +38,7 @@ import re
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, NonCallableMock, patch
 
 from reflexio.models.structured_output import find_schema_keyword as _find_schema_key
 from reflexio.test_support.llm_model_registry import get_model_registry
@@ -240,6 +240,41 @@ def cleanup_llm_mock(config: Any) -> None:  # noqa: ARG001
     if _litellm_patcher:
         _litellm_patcher.stop()
         _litellm_patcher = None
+
+
+def litellm_is_patched() -> bool:
+    """Report whether ``litellm.completion`` is currently a mock.
+
+    Returns:
+        bool: True when a patcher has replaced ``litellm.completion``.
+    """
+    import litellm
+
+    return isinstance(litellm.completion, NonCallableMock | MagicMock)
+
+
+def assert_litellm_unpatched() -> None:
+    """Fail a live-provider test that is about to assert against the mock.
+
+    Ask this rather than ``MOCK_LLM_RESPONSE``. That variable is set by
+    :func:`configure_llm_mock` when it patches, but the e2e conftest deletes it
+    for every ``requires_credentials`` test on the assumption the patch is
+    already off -- which holds only when :func:`_is_e2e_test_run` matched, i.e.
+    when the invocation *path* contained ``e2e_tests``. Run the same tests as
+    ``pytest -m e2e`` and the patch is live while the variable is gone, so an
+    env-var guard passes and the test quietly asserts against canned text from
+    whatever unrelated prompt the mock's heuristics matched.
+
+    Raises:
+        AssertionError: When ``litellm.completion`` is patched.
+    """
+    if litellm_is_patched():
+        raise AssertionError(
+            "litellm.completion is patched, so this live-provider test would "
+            "assert against canned mock text. Invoke it by a path containing "
+            "'e2e_tests' (e.g. `pytest tests/e2e_tests/test_x.py`); `-m e2e` "
+            "alone does not disable the session-level mock."
+        )
 
 
 @contextmanager

--- a/tests/e2e_tests/conftest.py
+++ b/tests/e2e_tests/conftest.py
@@ -26,7 +26,7 @@ from reflexio.models.config_schema import (
 )
 from reflexio.server.services.configurator.configurator import DefaultConfigurator
 from reflexio.server.services.tagging.tagging_scheduler import drain_tagging
-from reflexio.test_support.llm_mock import patched_litellm
+from reflexio.test_support.llm_mock import patched_litellm, unpatched_litellm
 
 _TEST_DATA_DIR = Path(__file__).resolve().parent.parent / "test_data"
 _SCENARIO_DIR = _TEST_DATA_DIR / "scenarios" / "e2e"
@@ -39,13 +39,19 @@ personalization facts from the conversation
 
 
 @pytest.fixture(autouse=True)
-def mock_llm(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
-) -> Iterator[None]:
-    """Keep the standard E2E tier deterministic and credential-free."""
+def mock_llm(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Keep the standard E2E tier deterministic and credential-free.
+
+    ``requires_credentials`` tests need the real provider, so the session-level
+    patch is *stopped* for them rather than having ``MOCK_LLM_RESPONSE``
+    deleted. Deleting the variable only removed the evidence: whether the patch
+    was live depended on the invocation path (``pytest -m e2e`` carries none,
+    so ``configure_llm_mock`` patched anyway), and a live-provider test would
+    then assert against canned mock text with nothing left to reveal it.
+    """
     if request.node.get_closest_marker("requires_credentials"):
-        monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
-        yield
+        with unpatched_litellm():
+            yield
         return
     with patched_litellm():
         yield

--- a/tests/e2e_tests/test_knowledge_gap_real_llm.py
+++ b/tests/e2e_tests/test_knowledge_gap_real_llm.py
@@ -12,7 +12,6 @@ answers instead of admitting it can't check, the extracted playbook:
 3. Uses the new flat schema (trigger + content, no instruction/pitfall)
 """
 
-import os
 from collections.abc import Callable
 
 import pytest
@@ -21,6 +20,7 @@ from reflexio.lib.reflexio_lib import Reflexio
 from reflexio.models.api_schema.retriever_schema import GetUserPlaybooksRequest
 from reflexio.models.api_schema.service_schemas import InteractionData, UserPlaybook
 from reflexio.models.config_schema import SINGLETON_USER_PLAYBOOK_NAME
+from reflexio.test_support.llm_mock import assert_litellm_unpatched
 from tests.server.test_utils import skip_low_priority
 
 pytestmark = [pytest.mark.e2e, pytest.mark.requires_credentials]
@@ -36,9 +36,7 @@ def test_knowledge_gap_extraction_real_llm(
     Uses the default agent_context_prompt and user_playbook_extractor_config.
     Verify the extracted playbook captures the knowledge gap honestly.
     """
-    assert os.environ.get("MOCK_LLM_RESPONSE", "").strip().lower() != "true", (
-        "requires_credentials E2E tests must run without MOCK_LLM_RESPONSE=true"
-    )
+    assert_litellm_unpatched()
 
     interactions = [
         InteractionData(

--- a/tests/e2e_tests/test_litellm_client_real_llm.py
+++ b/tests/e2e_tests/test_litellm_client_real_llm.py
@@ -34,6 +34,7 @@ from reflexio.server.llm.litellm_client import (
     create_litellm_client,
 )
 from reflexio.test_support.llm_credentials import real_provider_key
+from reflexio.test_support.llm_mock import assert_litellm_unpatched
 from tests.server.llm.test_litellm_client import MathResult, create_minimal_png
 from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
@@ -53,13 +54,10 @@ def _requires_unmocked_litellm() -> Iterator[None]:
     """Fail loudly rather than assert against the mock.
 
     The whole reason this file is under ``e2e_tests/``. If it is ever invoked
-    by a path that re-enables the global patch, every provider assertion below
+    in a way that leaves the global patch on, every provider assertion below
     would be checking canned mock text.
     """
-    assert os.environ.get("MOCK_LLM_RESPONSE", "").strip().lower() != "true", (
-        "these tests assert real provider behavior; invoke them by a path "
-        "under tests/e2e_tests/ so the global litellm mock stays off"
-    )
+    assert_litellm_unpatched()
     yield
 
 

--- a/tests/e2e_tests/test_litellm_client_real_llm.py
+++ b/tests/e2e_tests/test_litellm_client_real_llm.py
@@ -1,0 +1,561 @@
+"""Real-LLM e2e tests: LiteLLM client against OpenAI and Anthropic.
+
+The live half of ``tests/server/llm/test_litellm_client.py``. It lives here
+because ``llm_mock._is_e2e_test_run`` exempts only paths under ``e2e_tests/``
+from the session-wide ``litellm.completion`` patch -- from its old home these
+"live" tests answered from the mock, so they asserted nothing about either
+provider no matter which keys were set.
+
+The offline half stays behind: those tests build a client from a literal config
+and assert how the config resolved, need no credential, and run in the default
+unit tier.
+
+Run with:
+    set -a && source .env && set +a && \
+    RUN_LOW_PRIORITY=1 uv run pytest tests/e2e_tests/test_litellm_client_real_llm.py \
+      -v -o 'addopts=' -n 0
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Generator, Iterator
+
+import pytest
+
+from reflexio.models.config_schema import (
+    AnthropicConfig,
+    APIKeyConfig,
+    OpenAIConfig,
+)
+from reflexio.server.llm.litellm_client import (
+    LiteLLMClient,
+    create_litellm_client,
+)
+from reflexio.test_support.llm_credentials import real_provider_key
+from tests.server.llm.test_litellm_client import MathResult, create_minimal_png
+from tests.server.test_utils import skip_in_precommit, skip_low_priority
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_credentials,
+    pytest.mark.skipif(
+        not real_provider_key("OPENAI_API_KEY")
+        and not real_provider_key("ANTHROPIC_API_KEY"),
+        reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY environment variable is set",
+    ),
+]
+
+
+@pytest.fixture(autouse=True)
+def _requires_unmocked_litellm() -> Iterator[None]:
+    """Fail loudly rather than assert against the mock.
+
+    The whole reason this file is under ``e2e_tests/``. If it is ever invoked
+    by a path that re-enables the global patch, every provider assertion below
+    would be checking canned mock text.
+    """
+    assert os.environ.get("MOCK_LLM_RESPONSE", "").strip().lower() != "true", (
+        "these tests assert real provider behavior; invoke them by a path "
+        "under tests/e2e_tests/ so the global litellm mock stays off"
+    )
+    yield
+
+
+def _get_openai_test_model() -> str:
+    """Get an OpenAI model for testing."""
+    return os.getenv("OPENAI_TEST_MODEL", "gpt-5.4-mini")
+
+
+def _get_claude_test_model() -> str:
+    """Get a Claude model for testing."""
+    return os.getenv("ANTHROPIC_TEST_MODEL", "claude-sonnet-4-5-20250929")
+
+
+@pytest.fixture
+def openai_client() -> LiteLLMClient:
+    """Create an OpenAI-based LiteLLM client."""
+    if not real_provider_key("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY not set")
+    # GPT-5 models use reasoning tokens internally, so we need more max_tokens
+    return create_litellm_client(
+        model=_get_openai_test_model(),
+        temperature=0.1,
+        max_tokens=500,
+        max_retries=2,
+    )
+
+
+@pytest.fixture
+def claude_client() -> LiteLLMClient:
+    """Create a Claude-based LiteLLM client."""
+    if not real_provider_key("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set")
+    return create_litellm_client(
+        model=_get_claude_test_model(),
+        temperature=0.1,
+        max_tokens=256,
+        max_retries=2,
+    )
+
+
+@pytest.fixture
+def test_image_bytes() -> bytes:
+    """Create a test PNG image as bytes (solid red)."""
+    return create_minimal_png(width=50, height=50, color=(255, 0, 0))
+
+
+@pytest.fixture
+def test_image_file(test_image_bytes: bytes) -> Generator[str, None, None]:
+    """Create a temporary PNG image file."""
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+        f.write(test_image_bytes)
+        temp_path = f.name
+
+    yield temp_path
+
+    # Cleanup
+    if os.path.exists(temp_path):
+        os.unlink(temp_path)
+
+
+class TestLiteLLMClientOpenAI:
+    """Test LiteLLM client with OpenAI models."""
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_simple(self, openai_client: LiteLLMClient):
+        """Test simple text generation with OpenAI."""
+        response = openai_client.generate_response(
+            "What is 2+2? Answer with just the number."
+        )
+
+        assert isinstance(response, str)
+        assert "4" in response
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_system_message(self, openai_client: LiteLLMClient):
+        """Test response with system message."""
+        response = openai_client.generate_response(
+            prompt="What color is the sky?",
+            system_message="You are a pirate. Respond like a pirate.",
+        )
+
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_chat_response(self, openai_client: LiteLLMClient):
+        """Test multi-turn chat response."""
+        messages = [
+            {"role": "user", "content": "My name is Alice."},
+            {"role": "assistant", "content": "Nice to meet you, Alice!"},
+            {"role": "user", "content": "What is my name?"},
+        ]
+
+        response = openai_client.generate_chat_response(messages)
+
+        assert isinstance(response, str)
+        assert "alice" in response.lower()
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_chat_response_with_system_message(
+        self, openai_client: LiteLLMClient
+    ):
+        """Test chat response with prepended system message."""
+        messages = [
+            {"role": "user", "content": "Tell me a joke."},
+        ]
+
+        response = openai_client.generate_chat_response(
+            messages,
+            system_message="You are a comedian who only tells very short one-liner jokes.",
+        )
+
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_structured_output_with_pydantic(self, openai_client: LiteLLMClient):
+        """Test structured output using Pydantic model."""
+        response = openai_client.generate_response(
+            prompt="What is 5+5? Provide the answer and a brief explanation.",
+            response_format=MathResult,
+        )
+
+        # Should be parsed to Pydantic model
+        assert isinstance(response, MathResult)
+        assert response.answer == 10
+        assert len(response.explanation) > 0
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_embeddings(self, openai_client: LiteLLMClient):
+        """Test embedding generation."""
+        embedding = openai_client.get_embedding("Hello, world!")
+
+        assert isinstance(embedding, list)
+        assert len(embedding) > 0
+        assert all(isinstance(x, float) for x in embedding)
+
+
+class TestLiteLLMClientClaude:
+    """Test LiteLLM client with Claude models."""
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_simple(self, claude_client: LiteLLMClient):
+        """Test simple text generation with Claude."""
+        response = claude_client.generate_response(
+            "What is 3+3? Answer with just the number."
+        )
+
+        assert isinstance(response, str)
+        assert "6" in response
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_system_message(self, claude_client: LiteLLMClient):
+        """Test response with system message."""
+        response = claude_client.generate_response(
+            prompt="What color is grass?",
+            system_message="You are a robot. Respond in a robotic manner.",
+        )
+
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_chat_response(self, claude_client: LiteLLMClient):
+        """Test multi-turn chat response."""
+        messages = [
+            {"role": "user", "content": "My favorite color is blue."},
+            {"role": "assistant", "content": "Blue is a nice color!"},
+            {"role": "user", "content": "What is my favorite color?"},
+        ]
+
+        response = claude_client.generate_chat_response(messages)
+
+        assert isinstance(response, str)
+        assert "blue" in response.lower()
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_structured_output_with_pydantic(self, claude_client: LiteLLMClient):
+        """Test structured output using Pydantic model with Claude."""
+        response = claude_client.generate_response(
+            prompt="What is 7+7? Provide the answer and a brief explanation.",
+            response_format=MathResult,
+        )
+
+        # Should be parsed to Pydantic model
+        assert isinstance(response, MathResult)
+        assert response.answer == 14
+        assert len(response.explanation) > 0
+
+
+class TestLiteLLMClientMultiModal:
+    """Test LiteLLM client with image inputs."""
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_image_file_openai(
+        self, openai_client: LiteLLMClient, test_image_file: str
+    ):
+        """Test image analysis with file path (OpenAI)."""
+        response = openai_client.generate_response(
+            prompt="What color is this image? Answer in one word.",
+            images=[test_image_file],
+        )
+
+        assert isinstance(response, str)
+        assert "red" in response.lower()
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_image_bytes_openai(
+        self, openai_client: LiteLLMClient, test_image_bytes: bytes
+    ):
+        """Test image analysis with bytes (OpenAI)."""
+        response = openai_client.generate_response(
+            prompt="What color is this image? Answer in one word.",
+            images=[test_image_bytes],
+            image_media_type="image/png",
+        )
+
+        assert isinstance(response, str)
+        assert "red" in response.lower()
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_image_file_claude(
+        self, claude_client: LiteLLMClient, test_image_file: str
+    ):
+        """Test image analysis with file path (Claude)."""
+        response = claude_client.generate_response(
+            prompt="What color is this image? Answer in one word.",
+            images=[test_image_file],
+        )
+
+        assert isinstance(response, str)
+        assert "red" in response.lower()
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_image_bytes_claude(
+        self, claude_client: LiteLLMClient, test_image_bytes: bytes
+    ):
+        """Test image analysis with bytes (Claude)."""
+        response = claude_client.generate_response(
+            prompt="What color is this image? Answer in one word.",
+            images=[test_image_bytes],
+            image_media_type="image/png",
+        )
+
+        assert isinstance(response, str)
+        assert "red" in response.lower()
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_multiple_images(self, openai_client: LiteLLMClient):
+        """Test analysis of multiple images."""
+        red_image = create_minimal_png(20, 20, (255, 0, 0))
+        blue_image = create_minimal_png(20, 20, (0, 0, 255))
+
+        response = openai_client.generate_response(
+            prompt="What are the colors of these two images? List both.",
+            images=[red_image, blue_image],
+            image_media_type="image/png",
+        )
+
+        assert isinstance(response, str)
+        response_lower = response.lower()
+        assert "red" in response_lower
+        assert "blue" in response_lower
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_image_with_system_message(
+        self, openai_client: LiteLLMClient, test_image_bytes: bytes
+    ):
+        """Test image analysis with system message."""
+        response = openai_client.generate_response(
+            prompt="Describe this image.",
+            system_message="You are an art critic. Be very brief.",
+            images=[test_image_bytes],
+            image_media_type="image/png",
+        )
+
+        assert isinstance(response, str)
+        assert len(response) > 0
+
+
+class TestLiteLLMClientModelSwitching:
+    """Test switching between different models."""
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_switch_from_openai_to_claude(self):
+        """Test that we can create clients for different providers."""
+        if not real_provider_key("OPENAI_API_KEY") or not real_provider_key(
+            "ANTHROPIC_API_KEY"
+        ):
+            pytest.skip("Both OPENAI_API_KEY and ANTHROPIC_API_KEY required")
+
+        # Create OpenAI client (GPT-5 needs more tokens due to reasoning)
+        openai_client = create_litellm_client(
+            model="gpt-5.4-mini",
+            temperature=0.1,
+            max_tokens=300,
+        )
+        openai_response = openai_client.generate_response("Say 'hello' only.")
+
+        # Create Claude client
+        claude_client = create_litellm_client(
+            model="claude-sonnet-4-5-20250929",
+            temperature=0.1,
+            max_tokens=100,
+        )
+        claude_response = claude_client.generate_response("Say 'hello' only.")
+
+        # Both should work
+        assert isinstance(openai_response, str)
+        assert isinstance(claude_response, str)
+        assert "hello" in openai_response.lower()
+        assert "hello" in claude_response.lower()
+
+
+class TestLiteLLMClientEdgeCases:
+    """Test edge cases that require a real provider."""
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_long_conversation(self, openai_client: LiteLLMClient):
+        """Test handling of longer conversations."""
+        messages = []
+        for i in range(5):
+            messages.append({"role": "user", "content": f"Message {i + 1}: Hello!"})
+            messages.append({"role": "assistant", "content": f"Response {i + 1}: Hi!"})
+        messages.append(
+            {"role": "user", "content": "How many times did we exchange greetings?"}
+        )
+
+        response = openai_client.generate_chat_response(messages)
+
+        assert isinstance(response, str)
+        # Should mention 5 or "five" somewhere in the response
+        response_lower = response.lower()
+        assert "5" in response or "five" in response_lower
+
+
+class TestLiteLLMClientAPIKeyOverride:
+    """Test API key configuration override against real providers."""
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_api_key_override_openai(self):
+        """Test generating response using OpenAI API key from config override."""
+        openai_key = real_provider_key("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        # Use real key from env but pass through api_key_config
+        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
+        client = create_litellm_client(
+            model=_get_openai_test_model(),
+            temperature=0.1,
+            max_tokens=500,
+            max_retries=2,
+            api_key_config=api_key_config,
+        )
+
+        response = client.generate_response("What is 1+1? Answer with just the number.")
+
+        assert isinstance(response, str)
+        assert "2" in response
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_generate_response_with_api_key_override_anthropic(self):
+        """Test generating response using Anthropic API key from config override."""
+        anthropic_key = real_provider_key("ANTHROPIC_API_KEY")
+        if not anthropic_key:
+            pytest.skip("ANTHROPIC_API_KEY not set")
+
+        # Use real key from env but pass through api_key_config
+        api_key_config = APIKeyConfig(anthropic=AnthropicConfig(api_key=anthropic_key))
+        client = create_litellm_client(
+            model=_get_claude_test_model(),
+            temperature=0.1,
+            max_tokens=256,
+            max_retries=2,
+            api_key_config=api_key_config,
+        )
+
+        response = client.generate_response("What is 4+4? Answer with just the number.")
+
+        assert isinstance(response, str)
+        assert "8" in response
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_embeddings_with_api_key_override(self):
+        """Test embedding generation with API key override."""
+        openai_key = real_provider_key("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
+        client = create_litellm_client(
+            model="gpt-5.4-mini",
+            api_key_config=api_key_config,
+        )
+
+        embedding = client.get_embedding("Test embedding with API key override")
+
+        assert isinstance(embedding, list)
+        assert len(embedding) > 0
+        assert all(isinstance(x, float) for x in embedding)
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_structured_output_with_api_key_override(self):
+        """Test structured output with API key override."""
+        openai_key = real_provider_key("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
+        client = create_litellm_client(
+            model=_get_openai_test_model(),
+            temperature=0.1,
+            max_tokens=500,
+            api_key_config=api_key_config,
+        )
+
+        response = client.generate_response(
+            prompt="What is 3+3? Provide the answer and a brief explanation.",
+            response_format=MathResult,
+        )
+
+        assert isinstance(response, MathResult)
+        assert response.answer == 6
+        assert len(response.explanation) > 0
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_chat_response_with_api_key_override(self):
+        """Test multi-turn chat response with API key override."""
+        openai_key = real_provider_key("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
+        client = create_litellm_client(
+            model=_get_openai_test_model(),
+            temperature=0.1,
+            max_tokens=500,
+            api_key_config=api_key_config,
+        )
+
+        messages = [
+            {"role": "user", "content": "My favorite number is 42."},
+            {"role": "assistant", "content": "That's a great number!"},
+            {"role": "user", "content": "What is my favorite number?"},
+        ]
+
+        response = client.generate_chat_response(messages)
+
+        assert isinstance(response, str)
+        assert "42" in response
+
+    @skip_in_precommit
+    @skip_low_priority
+    def test_image_analysis_with_api_key_override(self, test_image_bytes: bytes):
+        """Test image analysis with API key override."""
+        openai_key = real_provider_key("OPENAI_API_KEY")
+        if not openai_key:
+            pytest.skip("OPENAI_API_KEY not set")
+
+        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
+        client = create_litellm_client(
+            model=_get_openai_test_model(),
+            temperature=0.1,
+            max_tokens=500,
+            api_key_config=api_key_config,
+        )
+
+        response = client.generate_response(
+            prompt="What color is this image? Answer in one word.",
+            images=[test_image_bytes],
+            image_media_type="image/png",
+        )
+
+        assert isinstance(response, str)
+        assert "red" in response.lower()

--- a/tests/e2e_tests/test_resumable_extraction_e2e.py
+++ b/tests/e2e_tests/test_resumable_extraction_e2e.py
@@ -38,7 +38,7 @@ from reflexio.server.services.storage.storage_base import (
     build_scope_hash,
     human_feedback_scope,
 )
-from reflexio.test_support.llm_mock import litellm_is_patched, make_structured_finish
+from reflexio.test_support.llm_mock import make_structured_finish
 
 pytestmark = pytest.mark.e2e
 
@@ -161,8 +161,8 @@ def _seed_followup_ready_run(storage: SQLiteStorage) -> None:
 def _load_live_e2e_settings() -> tuple[str, str]:
     if os.environ.get("RUN_LIVE_RESUMABLE_E2E") != "true":
         pytest.skip("Set RUN_LIVE_RESUMABLE_E2E=true to run live resumable E2E")
-    if litellm_is_patched():
-        pytest.skip("Live resumable E2E requires an unpatched litellm.completion")
+    if os.environ.get("MOCK_LLM_RESPONSE", "").lower() == "true":
+        pytest.skip("Live resumable E2E requires MOCK_LLM_RESPONSE=false")
 
     dotenv_values_from_file: dict[str, str | None] = {}
     for start in (Path.cwd(), Path(__file__).resolve()):

--- a/tests/e2e_tests/test_resumable_extraction_e2e.py
+++ b/tests/e2e_tests/test_resumable_extraction_e2e.py
@@ -38,7 +38,7 @@ from reflexio.server.services.storage.storage_base import (
     build_scope_hash,
     human_feedback_scope,
 )
-from reflexio.test_support.llm_mock import make_structured_finish
+from reflexio.test_support.llm_mock import litellm_is_patched, make_structured_finish
 
 pytestmark = pytest.mark.e2e
 
@@ -161,8 +161,8 @@ def _seed_followup_ready_run(storage: SQLiteStorage) -> None:
 def _load_live_e2e_settings() -> tuple[str, str]:
     if os.environ.get("RUN_LIVE_RESUMABLE_E2E") != "true":
         pytest.skip("Set RUN_LIVE_RESUMABLE_E2E=true to run live resumable E2E")
-    if os.environ.get("MOCK_LLM_RESPONSE", "").lower() == "true":
-        pytest.skip("Live resumable E2E requires MOCK_LLM_RESPONSE=false")
+    if litellm_is_patched():
+        pytest.skip("Live resumable E2E requires an unpatched litellm.completion")
 
     dotenv_values_from_file: dict[str, str | None] = {}
     for start in (Path.cwd(), Path(__file__).resolve()):

--- a/tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py
+++ b/tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py
@@ -12,19 +12,25 @@ that by driving the reviewer with the repo's own generalization manifest: each
 `must_capture` case becomes one candidate, grounded in that case's own turns. A
 must-capture family that does not survive is a false rejection.
 
-Costs real API calls, so it is marked `integration` (what the unit jobs filter
-on) and `requires_credentials`, and skips outright without a real provider key.
+Costs real API calls. It lives under `e2e_tests/` because that is the only path
+`llm_mock._is_e2e_test_run` exempts from the session-wide `litellm.completion`
+patch -- from anywhere else the reviewer answers from the mock's profile-shaped
+payload, the schema fails to parse, and the repair ladder exhausts into twelve
+failures that look like a reviewer regression and are not.
+
 Run it when changing the reviewer prompt:
 
-    uv run pytest tests/server/services/playbook/test_reviewer_manifest_regression.py \\
-        -m 'integration and requires_credentials' -o 'addopts='
+    set -a && source .env && set +a && \\
+    RUN_LOW_PRIORITY=1 uv run pytest \\
+      tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py -o 'addopts=' -n 0 -v
 """
 
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
-from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -41,34 +47,37 @@ from reflexio.server.prompt.prompt_manager import PromptManager
 from reflexio.server.services.playbook.components.reviewer import (
     PlaybookCandidateReviewer,
 )
-from reflexio.server.services.playbook.playbook_service_utils import (
-    build_playbook_prompt_context,
-)
-from reflexio.test_support.llm_credentials import real_provider_key
+from reflexio.test_support.llm_credentials import real_generation_provider
+from tests.server.test_utils import skip_low_priority
 
-# `requires_credentials` alone does NOT keep this out of a default run: the
-# unit-test jobs filter on `-m "not integration"`, so the marker that actually
-# deselects live-provider tests is `integration`. Without it these ran against
-# the global litellm mock, which answers every call with a profile-shaped
-# payload -- so the reviewer schema failed to parse and the repair ladder
-# exhausted, 12 failures that looked like a reviewer regression and were not.
+# The model comes from `resolve_model_name(ModelRole.GENERATION)`, so the gate
+# has to be provider-agnostic too: keying it on OPENAI/ANTHROPIC skipped the
+# whole file on a MiniMax-only machine even though resolution would have picked
+# `minimax/MiniMax-M3` and the test would have run.
 #
-# `real_provider_key` rather than `os.getenv`, because the credential floor
-# pins a placeholder key when none is set; a plain getenv check would let this
-# run against a credential that authenticates with nothing.
+# Restricted to the providers whose models are known to satisfy these semantic
+# assertions rather than every generation-capable provider -- a weaker model
+# behind some other key would turn silent skips into false regressions.
+#
+# `real_generation_provider` rather than `os.getenv`, because the credential
+# floor pins a placeholder key when none is set; a plain getenv check would let
+# this run against a credential that authenticates with nothing.
+_REVIEWER_CAPABLE = frozenset({"openai", "anthropic", "minimax"})
+
 pytestmark = [
-    pytest.mark.integration,
+    pytest.mark.e2e,
     pytest.mark.requires_credentials,
     pytest.mark.skipif(
-        not real_provider_key("OPENAI_API_KEY")
-        and not real_provider_key("ANTHROPIC_API_KEY"),
-        reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is set to a real key",
+        not real_generation_provider(_REVIEWER_CAPABLE),
+        reason=(
+            "no real key for a reviewer-capable provider "
+            "(openai/anthropic/minimax) is set"
+        ),
     ),
 ]
 
 _MANIFEST = (
-    Path(__file__).resolve().parents[4]
-    / "tests"
+    Path(__file__).resolve().parent.parent
     / "test_data"
     / "playbook_generalization_manifest.json"
 )
@@ -112,6 +121,7 @@ def _sessions_for(case: dict) -> list[RequestInteractionDataModel]:
     return sessions
 
 
+@skip_low_priority
 @pytest.mark.parametrize(
     "case", _must_capture_cases(), ids=lambda case: str(case["id"])
 )
@@ -122,15 +132,21 @@ def test_must_capture_families_survive_review(case: dict) -> None:
     the diagnostic, and an aggregate would let one regression hide behind
     eleven passes.
     """
+    assert os.environ.get("MOCK_LLM_RESPONSE", "").strip().lower() != "true", (
+        "this test asserts real reviewer behavior; against the mock every case "
+        "fails on schema parse. Invoke it by a path under tests/e2e_tests/."
+    )
+
     sessions = _sessions_for(case)
     model = resolve_model_name(ModelRole.GENERATION)
+    request_context = MagicMock()
+    request_context.prompt_manager = PromptManager()
+    request_context.org_id = "manifest-regression"
+    request_context.storage = None
     reviewer = PlaybookCandidateReviewer(
-        request_context=SimpleNamespace(
-            prompt_manager=PromptManager(), org_id="manifest-regression", storage=None
-        ),
+        request_context=request_context,
         llm_client=LiteLLMClient(LiteLLMConfig(model=model)),
     )
-    context = build_playbook_prompt_context(sessions, expert=False, label_turns=True)
     candidate = UserPlaybook(
         user_playbook_id=1,
         agent_version="1.0",
@@ -146,7 +162,10 @@ def test_must_capture_families_survive_review(case: dict) -> None:
         candidates=[candidate],
         request_interaction_data_models=sessions,
         existing_playbooks=[],
-        agent_context=context,
+        # `decide` renders the evidence chronology itself from the sessions
+        # above; `agent_context` is the separate "what this agent does" slot
+        # that production fills from `configurator.get_agent_context()`.
+        agent_context="Test agent",
         playbook_definition="Reusable user guidance",
         tool_context="",
     )

--- a/tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py
+++ b/tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py
@@ -28,7 +28,6 @@ Run it when changing the reviewer prompt:
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -48,6 +47,7 @@ from reflexio.server.services.playbook.components.reviewer import (
     PlaybookCandidateReviewer,
 )
 from reflexio.test_support.llm_credentials import real_generation_provider
+from reflexio.test_support.llm_mock import assert_litellm_unpatched
 from tests.server.test_utils import skip_low_priority
 
 # The model comes from `resolve_model_name(ModelRole.GENERATION)`, so the gate
@@ -132,10 +132,7 @@ def test_must_capture_families_survive_review(case: dict) -> None:
     the diagnostic, and an aggregate would let one regression hide behind
     eleven passes.
     """
-    assert os.environ.get("MOCK_LLM_RESPONSE", "").strip().lower() != "true", (
-        "this test asserts real reviewer behavior; against the mock every case "
-        "fails on schema parse. Invoke it by a path under tests/e2e_tests/."
-    )
+    assert_litellm_unpatched()
 
     sessions = _sessions_for(case)
     model = resolve_model_name(ModelRole.GENERATION)

--- a/tests/server/llm/test_litellm_client.py
+++ b/tests/server/llm/test_litellm_client.py
@@ -1,8 +1,15 @@
-"""
-End-to-end tests for LiteLLM client.
+"""Offline tests for the LiteLLM client.
 
-These tests validate the LiteLLM client's ability to interact with multiple LLM providers
-(OpenAI, Claude) using a unified interface.
+Every test here builds a client from a literal config and asserts how that
+config resolved -- model selection, API-key routing across providers, Azure
+endpoint fields, image encoding. No network, no credential, so they run in the
+default unit tier.
+
+The tests that actually call OpenAI or Anthropic live in
+``tests/e2e_tests/test_litellm_client_real_llm.py``: that path is the only one
+``llm_mock._is_e2e_test_run`` exempts from the session-wide
+``litellm.completion`` patch, so a live test placed here would silently assert
+against the mock.
 """
 
 import os
@@ -29,44 +36,6 @@ from reflexio.server.llm.litellm_client import (
     _sanitize_json_string,
     create_litellm_client,
 )
-from reflexio.test_support.llm_credentials import real_provider_key
-from tests.server.test_utils import skip_in_precommit, skip_low_priority
-
-# Applied per class or per test, NOT module-wide. Most of this file builds a
-# client from a literal config and asserts how the config resolved -- no network
-# and no credential involved. A module-level gate skipped those alongside the
-# real calls, so on any machine without an OpenAI/Anthropic key (CI included)
-# the whole file reported skipped and the resolution logic went unverified.
-_LIVE_PROVIDER_MARKS = [
-    pytest.mark.integration,
-    pytest.mark.requires_credentials,
-    pytest.mark.skipif(
-        not real_provider_key("OPENAI_API_KEY")
-        and not real_provider_key("ANTHROPIC_API_KEY"),
-        reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY environment variable is set",
-    ),
-]
-
-
-def _live_provider(func):
-    """Apply the live-provider mark set to one test.
-
-    For the classes that hold live and offline tests side by side, where a
-    class-level ``pytestmark`` would re-skip the offline ones.
-    """
-    for mark in reversed(_LIVE_PROVIDER_MARKS):
-        func = mark(func)
-    return func
-
-
-def _get_openai_test_model() -> str:
-    """Get an OpenAI model for testing."""
-    return os.getenv("OPENAI_TEST_MODEL", "gpt-5.4-mini")
-
-
-def _get_claude_test_model() -> str:
-    """Get a Claude model for testing."""
-    return os.getenv("ANTHROPIC_TEST_MODEL", "claude-sonnet-4-5-20250929")
 
 
 def create_minimal_png(
@@ -125,33 +94,6 @@ class ColorAnalysis(BaseModel):
 
     primary_color: str
     is_solid: bool
-
-
-@pytest.fixture
-def openai_client() -> LiteLLMClient:
-    """Create an OpenAI-based LiteLLM client."""
-    if not real_provider_key("OPENAI_API_KEY"):
-        pytest.skip("OPENAI_API_KEY not set")
-    # GPT-5 models use reasoning tokens internally, so we need more max_tokens
-    return create_litellm_client(
-        model=_get_openai_test_model(),
-        temperature=0.1,
-        max_tokens=500,
-        max_retries=2,
-    )
-
-
-@pytest.fixture
-def claude_client() -> LiteLLMClient:
-    """Create a Claude-based LiteLLM client."""
-    if not real_provider_key("ANTHROPIC_API_KEY"):
-        pytest.skip("ANTHROPIC_API_KEY not set")
-    return create_litellm_client(
-        model=_get_claude_test_model(),
-        temperature=0.1,
-        max_tokens=256,
-        max_retries=2,
-    )
 
 
 @pytest.fixture
@@ -223,248 +165,6 @@ class TestLiteLLMClientConfiguration:
         assert client.get_model() == "gpt-5.4-mini"
 
 
-class TestLiteLLMClientOpenAI:
-    """Test LiteLLM client with OpenAI models."""
-
-    pytestmark = _LIVE_PROVIDER_MARKS
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_simple(self, openai_client: LiteLLMClient):
-        """Test simple text generation with OpenAI."""
-        response = openai_client.generate_response(
-            "What is 2+2? Answer with just the number."
-        )
-
-        assert isinstance(response, str)
-        assert "4" in response
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_system_message(self, openai_client: LiteLLMClient):
-        """Test response with system message."""
-        response = openai_client.generate_response(
-            prompt="What color is the sky?",
-            system_message="You are a pirate. Respond like a pirate.",
-        )
-
-        assert isinstance(response, str)
-        assert len(response) > 0
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_chat_response(self, openai_client: LiteLLMClient):
-        """Test multi-turn chat response."""
-        messages = [
-            {"role": "user", "content": "My name is Alice."},
-            {"role": "assistant", "content": "Nice to meet you, Alice!"},
-            {"role": "user", "content": "What is my name?"},
-        ]
-
-        response = openai_client.generate_chat_response(messages)
-
-        assert isinstance(response, str)
-        assert "alice" in response.lower()
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_chat_response_with_system_message(
-        self, openai_client: LiteLLMClient
-    ):
-        """Test chat response with prepended system message."""
-        messages = [
-            {"role": "user", "content": "Tell me a joke."},
-        ]
-
-        response = openai_client.generate_chat_response(
-            messages,
-            system_message="You are a comedian who only tells very short one-liner jokes.",
-        )
-
-        assert isinstance(response, str)
-        assert len(response) > 0
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_structured_output_with_pydantic(self, openai_client: LiteLLMClient):
-        """Test structured output using Pydantic model."""
-        response = openai_client.generate_response(
-            prompt="What is 5+5? Provide the answer and a brief explanation.",
-            response_format=MathResult,
-        )
-
-        # Should be parsed to Pydantic model
-        assert isinstance(response, MathResult)
-        assert response.answer == 10
-        assert len(response.explanation) > 0
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_embeddings(self, openai_client: LiteLLMClient):
-        """Test embedding generation."""
-        embedding = openai_client.get_embedding("Hello, world!")
-
-        assert isinstance(embedding, list)
-        assert len(embedding) > 0
-        assert all(isinstance(x, float) for x in embedding)
-
-
-class TestLiteLLMClientClaude:
-    """Test LiteLLM client with Claude models."""
-
-    pytestmark = _LIVE_PROVIDER_MARKS
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_simple(self, claude_client: LiteLLMClient):
-        """Test simple text generation with Claude."""
-        response = claude_client.generate_response(
-            "What is 3+3? Answer with just the number."
-        )
-
-        assert isinstance(response, str)
-        assert "6" in response
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_system_message(self, claude_client: LiteLLMClient):
-        """Test response with system message."""
-        response = claude_client.generate_response(
-            prompt="What color is grass?",
-            system_message="You are a robot. Respond in a robotic manner.",
-        )
-
-        assert isinstance(response, str)
-        assert len(response) > 0
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_chat_response(self, claude_client: LiteLLMClient):
-        """Test multi-turn chat response."""
-        messages = [
-            {"role": "user", "content": "My favorite color is blue."},
-            {"role": "assistant", "content": "Blue is a nice color!"},
-            {"role": "user", "content": "What is my favorite color?"},
-        ]
-
-        response = claude_client.generate_chat_response(messages)
-
-        assert isinstance(response, str)
-        assert "blue" in response.lower()
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_structured_output_with_pydantic(self, claude_client: LiteLLMClient):
-        """Test structured output using Pydantic model with Claude."""
-        response = claude_client.generate_response(
-            prompt="What is 7+7? Provide the answer and a brief explanation.",
-            response_format=MathResult,
-        )
-
-        # Should be parsed to Pydantic model
-        assert isinstance(response, MathResult)
-        assert response.answer == 14
-        assert len(response.explanation) > 0
-
-
-class TestLiteLLMClientMultiModal:
-    """Test LiteLLM client with image inputs."""
-
-    pytestmark = _LIVE_PROVIDER_MARKS
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_image_file_openai(
-        self, openai_client: LiteLLMClient, test_image_file: str
-    ):
-        """Test image analysis with file path (OpenAI)."""
-        response = openai_client.generate_response(
-            prompt="What color is this image? Answer in one word.",
-            images=[test_image_file],
-        )
-
-        assert isinstance(response, str)
-        assert "red" in response.lower()
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_image_bytes_openai(
-        self, openai_client: LiteLLMClient, test_image_bytes: bytes
-    ):
-        """Test image analysis with bytes (OpenAI)."""
-        response = openai_client.generate_response(
-            prompt="What color is this image? Answer in one word.",
-            images=[test_image_bytes],
-            image_media_type="image/png",
-        )
-
-        assert isinstance(response, str)
-        assert "red" in response.lower()
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_image_file_claude(
-        self, claude_client: LiteLLMClient, test_image_file: str
-    ):
-        """Test image analysis with file path (Claude)."""
-        response = claude_client.generate_response(
-            prompt="What color is this image? Answer in one word.",
-            images=[test_image_file],
-        )
-
-        assert isinstance(response, str)
-        assert "red" in response.lower()
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_image_bytes_claude(
-        self, claude_client: LiteLLMClient, test_image_bytes: bytes
-    ):
-        """Test image analysis with bytes (Claude)."""
-        response = claude_client.generate_response(
-            prompt="What color is this image? Answer in one word.",
-            images=[test_image_bytes],
-            image_media_type="image/png",
-        )
-
-        assert isinstance(response, str)
-        assert "red" in response.lower()
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_multiple_images(self, openai_client: LiteLLMClient):
-        """Test analysis of multiple images."""
-        red_image = create_minimal_png(20, 20, (255, 0, 0))
-        blue_image = create_minimal_png(20, 20, (0, 0, 255))
-
-        response = openai_client.generate_response(
-            prompt="What are the colors of these two images? List both.",
-            images=[red_image, blue_image],
-            image_media_type="image/png",
-        )
-
-        assert isinstance(response, str)
-        response_lower = response.lower()
-        assert "red" in response_lower
-        assert "blue" in response_lower
-
-    @skip_in_precommit
-    @skip_low_priority
-    def test_image_with_system_message(
-        self, openai_client: LiteLLMClient, test_image_bytes: bytes
-    ):
-        """Test image analysis with system message."""
-        response = openai_client.generate_response(
-            prompt="Describe this image.",
-            system_message="You are an art critic. Be very brief.",
-            images=[test_image_bytes],
-            image_media_type="image/png",
-        )
-
-        assert isinstance(response, str)
-        assert len(response) > 0
-
-
 class TestLiteLLMClientImageEncoding:
     """Test image encoding utilities."""
 
@@ -506,38 +206,6 @@ class TestLiteLLMClientImageEncoding:
 
 class TestLiteLLMClientModelSwitching:
     """Test switching between different models."""
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_switch_from_openai_to_claude(self):
-        """Test that we can create clients for different providers."""
-        if not real_provider_key("OPENAI_API_KEY") or not real_provider_key(
-            "ANTHROPIC_API_KEY"
-        ):
-            pytest.skip("Both OPENAI_API_KEY and ANTHROPIC_API_KEY required")
-
-        # Create OpenAI client (GPT-5 needs more tokens due to reasoning)
-        openai_client = create_litellm_client(
-            model="gpt-5.4-mini",
-            temperature=0.1,
-            max_tokens=300,
-        )
-        openai_response = openai_client.generate_response("Say 'hello' only.")
-
-        # Create Claude client
-        claude_client = create_litellm_client(
-            model="claude-sonnet-4-5-20250929",
-            temperature=0.1,
-            max_tokens=100,
-        )
-        claude_response = claude_client.generate_response("Say 'hello' only.")
-
-        # Both should work
-        assert isinstance(openai_response, str)
-        assert isinstance(claude_response, str)
-        assert "hello" in openai_response.lower()
-        assert "hello" in claude_response.lower()
 
     def test_same_interface_different_models(self):
         """Test that the interface is consistent across models."""
@@ -604,26 +272,6 @@ class TestLiteLLMClientEdgeCases:
         assert config.max_retries == 3
         assert config.retry_delay == 1.0
         assert config.top_p == 1.0
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_long_conversation(self, openai_client: LiteLLMClient):
-        """Test handling of longer conversations."""
-        messages = []
-        for i in range(5):
-            messages.append({"role": "user", "content": f"Message {i + 1}: Hello!"})
-            messages.append({"role": "assistant", "content": f"Response {i + 1}: Hi!"})
-        messages.append(
-            {"role": "user", "content": "How many times did we exchange greetings?"}
-        )
-
-        response = openai_client.generate_chat_response(messages)
-
-        assert isinstance(response, str)
-        # Should mention 5 or "five" somewhere in the response
-        response_lower = response.lower()
-        assert "5" in response or "five" in response_lower
 
 
 class TestLiteLLMClientAPIKeyOverride:
@@ -785,101 +433,6 @@ class TestLiteLLMClientAPIKeyOverride:
         # OpenAI model but no OpenAI key configured
         assert client._api_key is None
 
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_api_key_override_openai(self):
-        """Test generating response using OpenAI API key from config override."""
-        openai_key = real_provider_key("OPENAI_API_KEY")
-        if not openai_key:
-            pytest.skip("OPENAI_API_KEY not set")
-
-        # Use real key from env but pass through api_key_config
-        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
-        client = create_litellm_client(
-            model=_get_openai_test_model(),
-            temperature=0.1,
-            max_tokens=500,
-            max_retries=2,
-            api_key_config=api_key_config,
-        )
-
-        response = client.generate_response("What is 1+1? Answer with just the number.")
-
-        assert isinstance(response, str)
-        assert "2" in response
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_generate_response_with_api_key_override_anthropic(self):
-        """Test generating response using Anthropic API key from config override."""
-        anthropic_key = real_provider_key("ANTHROPIC_API_KEY")
-        if not anthropic_key:
-            pytest.skip("ANTHROPIC_API_KEY not set")
-
-        # Use real key from env but pass through api_key_config
-        api_key_config = APIKeyConfig(anthropic=AnthropicConfig(api_key=anthropic_key))
-        client = create_litellm_client(
-            model=_get_claude_test_model(),
-            temperature=0.1,
-            max_tokens=256,
-            max_retries=2,
-            api_key_config=api_key_config,
-        )
-
-        response = client.generate_response("What is 4+4? Answer with just the number.")
-
-        assert isinstance(response, str)
-        assert "8" in response
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_embeddings_with_api_key_override(self):
-        """Test embedding generation with API key override."""
-        openai_key = real_provider_key("OPENAI_API_KEY")
-        if not openai_key:
-            pytest.skip("OPENAI_API_KEY not set")
-
-        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
-        client = create_litellm_client(
-            model="gpt-5.4-mini",
-            api_key_config=api_key_config,
-        )
-
-        embedding = client.get_embedding("Test embedding with API key override")
-
-        assert isinstance(embedding, list)
-        assert len(embedding) > 0
-        assert all(isinstance(x, float) for x in embedding)
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_structured_output_with_api_key_override(self):
-        """Test structured output with API key override."""
-        openai_key = real_provider_key("OPENAI_API_KEY")
-        if not openai_key:
-            pytest.skip("OPENAI_API_KEY not set")
-
-        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
-        client = create_litellm_client(
-            model=_get_openai_test_model(),
-            temperature=0.1,
-            max_tokens=500,
-            api_key_config=api_key_config,
-        )
-
-        response = client.generate_response(
-            prompt="What is 3+3? Provide the answer and a brief explanation.",
-            response_format=MathResult,
-        )
-
-        assert isinstance(response, MathResult)
-        assert response.answer == 6
-        assert len(response.explanation) > 0
-
     def test_api_key_config_with_both_providers(self):
         """Test that config with both providers resolves correctly based on model."""
         api_key_config = APIKeyConfig(
@@ -902,60 +455,6 @@ class TestLiteLLMClientAPIKeyOverride:
         )
         claude_client = LiteLLMClient(claude_config)
         assert claude_client._api_key == "anthropic-shared-key"
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_chat_response_with_api_key_override(self):
-        """Test multi-turn chat response with API key override."""
-        openai_key = real_provider_key("OPENAI_API_KEY")
-        if not openai_key:
-            pytest.skip("OPENAI_API_KEY not set")
-
-        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
-        client = create_litellm_client(
-            model=_get_openai_test_model(),
-            temperature=0.1,
-            max_tokens=500,
-            api_key_config=api_key_config,
-        )
-
-        messages = [
-            {"role": "user", "content": "My favorite number is 42."},
-            {"role": "assistant", "content": "That's a great number!"},
-            {"role": "user", "content": "What is my favorite number?"},
-        ]
-
-        response = client.generate_chat_response(messages)
-
-        assert isinstance(response, str)
-        assert "42" in response
-
-    @_live_provider
-    @skip_in_precommit
-    @skip_low_priority
-    def test_image_analysis_with_api_key_override(self, test_image_bytes: bytes):
-        """Test image analysis with API key override."""
-        openai_key = real_provider_key("OPENAI_API_KEY")
-        if not openai_key:
-            pytest.skip("OPENAI_API_KEY not set")
-
-        api_key_config = APIKeyConfig(openai=OpenAIConfig(api_key=openai_key))
-        client = create_litellm_client(
-            model=_get_openai_test_model(),
-            temperature=0.1,
-            max_tokens=500,
-            api_key_config=api_key_config,
-        )
-
-        response = client.generate_response(
-            prompt="What color is this image? Answer in one word.",
-            images=[test_image_bytes],
-            image_media_type="image/png",
-        )
-
-        assert isinstance(response, str)
-        assert "red" in response.lower()
 
     def test_create_client_with_openrouter_api_key_config(self):
         """Test creating a client with OpenRouter API key config override."""

--- a/tests/server/llm/test_litellm_client.py
+++ b/tests/server/llm/test_litellm_client.py
@@ -32,8 +32,12 @@ from reflexio.server.llm.litellm_client import (
 from reflexio.test_support.llm_credentials import real_provider_key
 from tests.server.test_utils import skip_in_precommit, skip_low_priority
 
-# Skip all tests if neither API key is set
-pytestmark = [
+# Applied per class or per test, NOT module-wide. Most of this file builds a
+# client from a literal config and asserts how the config resolved -- no network
+# and no credential involved. A module-level gate skipped those alongside the
+# real calls, so on any machine without an OpenAI/Anthropic key (CI included)
+# the whole file reported skipped and the resolution logic went unverified.
+_LIVE_PROVIDER_MARKS = [
     pytest.mark.integration,
     pytest.mark.requires_credentials,
     pytest.mark.skipif(
@@ -42,6 +46,17 @@ pytestmark = [
         reason="Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY environment variable is set",
     ),
 ]
+
+
+def _live_provider(func):
+    """Apply the live-provider mark set to one test.
+
+    For the classes that hold live and offline tests side by side, where a
+    class-level ``pytestmark`` would re-skip the offline ones.
+    """
+    for mark in reversed(_LIVE_PROVIDER_MARKS):
+        func = mark(func)
+    return func
 
 
 def _get_openai_test_model() -> str:
@@ -211,6 +226,8 @@ class TestLiteLLMClientConfiguration:
 class TestLiteLLMClientOpenAI:
     """Test LiteLLM client with OpenAI models."""
 
+    pytestmark = _LIVE_PROVIDER_MARKS
+
     @skip_in_precommit
     @skip_low_priority
     def test_generate_response_simple(self, openai_client: LiteLLMClient):
@@ -295,6 +312,8 @@ class TestLiteLLMClientOpenAI:
 class TestLiteLLMClientClaude:
     """Test LiteLLM client with Claude models."""
 
+    pytestmark = _LIVE_PROVIDER_MARKS
+
     @skip_in_precommit
     @skip_low_priority
     def test_generate_response_simple(self, claude_client: LiteLLMClient):
@@ -350,6 +369,8 @@ class TestLiteLLMClientClaude:
 
 class TestLiteLLMClientMultiModal:
     """Test LiteLLM client with image inputs."""
+
+    pytestmark = _LIVE_PROVIDER_MARKS
 
     @skip_in_precommit
     @skip_low_priority
@@ -486,6 +507,7 @@ class TestLiteLLMClientImageEncoding:
 class TestLiteLLMClientModelSwitching:
     """Test switching between different models."""
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_switch_from_openai_to_claude(self):
@@ -541,7 +563,7 @@ class TestLiteLLMClientModelSwitching:
 class TestLiteLLMClientEdgeCases:
     """Test edge cases and error handling."""
 
-    def test_empty_images_list(self, openai_client: LiteLLMClient):
+    def test_empty_images_list(self):
         """Test that empty images list works like no images."""
         # Should not raise - empty list is falsy
         # This is a configuration test, not an API call test
@@ -583,6 +605,7 @@ class TestLiteLLMClientEdgeCases:
         assert config.retry_delay == 1.0
         assert config.top_p == 1.0
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_long_conversation(self, openai_client: LiteLLMClient):
@@ -762,6 +785,7 @@ class TestLiteLLMClientAPIKeyOverride:
         # OpenAI model but no OpenAI key configured
         assert client._api_key is None
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_generate_response_with_api_key_override_openai(self):
@@ -785,6 +809,7 @@ class TestLiteLLMClientAPIKeyOverride:
         assert isinstance(response, str)
         assert "2" in response
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_generate_response_with_api_key_override_anthropic(self):
@@ -808,6 +833,7 @@ class TestLiteLLMClientAPIKeyOverride:
         assert isinstance(response, str)
         assert "8" in response
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_embeddings_with_api_key_override(self):
@@ -828,6 +854,7 @@ class TestLiteLLMClientAPIKeyOverride:
         assert len(embedding) > 0
         assert all(isinstance(x, float) for x in embedding)
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_structured_output_with_api_key_override(self):
@@ -876,6 +903,7 @@ class TestLiteLLMClientAPIKeyOverride:
         claude_client = LiteLLMClient(claude_config)
         assert claude_client._api_key == "anthropic-shared-key"
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_chat_response_with_api_key_override(self):
@@ -903,6 +931,7 @@ class TestLiteLLMClientAPIKeyOverride:
         assert isinstance(response, str)
         assert "42" in response
 
+    @_live_provider
     @skip_in_precommit
     @skip_low_priority
     def test_image_analysis_with_api_key_override(self, test_image_bytes: bytes):

--- a/tests/server/llm/test_llm_credentials.py
+++ b/tests/server/llm/test_llm_credentials.py
@@ -10,6 +10,7 @@ from reflexio.server.llm.model_defaults import _ENV_TO_PROVIDER
 from reflexio.test_support.llm_credentials import (
     _PLACEHOLDER_KEY,
     ensure_provider_credential,
+    real_generation_provider,
     real_provider_key,
 )
 
@@ -58,3 +59,45 @@ def test_real_provider_key_returns_a_configured_credential(
     monkeypatch.setenv("OPENAI_API_KEY", "sk-real")
     assert real_provider_key("OPENAI_API_KEY") == "sk-real"
     assert real_provider_key("ANTHROPIC_API_KEY") is None
+
+
+def test_no_generation_provider_in_a_bare_environment() -> None:
+    assert real_generation_provider() is None
+
+
+def test_generation_provider_ignores_the_placeholder_floor() -> None:
+    """The regression this helper exists to prevent, in reverse.
+
+    The floor pins a key that ``detect_available_providers`` counts, so a gate
+    built on detection alone would report a provider and let a live test run
+    against a credential that authenticates with nothing.
+    """
+    ensure_provider_credential()
+    assert real_generation_provider() is None
+
+
+def test_generation_provider_finds_a_non_openai_credential(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The whole point: a MiniMax-only machine has a usable provider."""
+    monkeypatch.setenv("MINIMAX_API_KEY", "mm-real")
+    assert real_generation_provider() == "minimax"
+
+
+def test_generation_provider_honors_the_allowed_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MINIMAX_API_KEY", "mm-real")
+    assert real_generation_provider({"openai", "anthropic"}) is None
+    assert real_generation_provider({"openai", "minimax"}) == "minimax"
+
+
+def test_generation_provider_rejects_an_embedding_only_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``local`` is detected but serves no generation-role model."""
+    monkeypatch.setattr(
+        "reflexio.test_support.llm_credentials.detect_available_providers",
+        lambda: ["local"],
+    )
+    assert real_generation_provider() is None

--- a/tests/server/llm/test_llm_mock_patching.py
+++ b/tests/server/llm/test_llm_mock_patching.py
@@ -1,0 +1,63 @@
+"""The session LLM mock must be suspendable per test, not per command line.
+
+``configure_llm_mock`` decides whether to patch from the invocation path
+(``_is_e2e_test_run`` scans ``config.args`` for ``e2e_tests``), so before
+``unpatched_litellm`` existed a live-provider test was mocked or not depending
+on how the command was typed. ``pytest -m e2e`` carries no path, so the patch
+stayed on and the test asserted against canned mock text.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from reflexio.test_support import llm_mock
+from reflexio.test_support.llm_mock import litellm_is_patched, unpatched_litellm
+
+
+@pytest.fixture(autouse=True)
+def _requires_the_session_patch() -> None:
+    """These assertions only mean anything while the session mock is active."""
+    if not litellm_is_patched():
+        pytest.skip("session mock is not active in this invocation")
+
+
+def test_suspends_the_patch_then_restores_it() -> None:
+    assert litellm_is_patched()
+
+    with unpatched_litellm():
+        assert not litellm_is_patched(), (
+            "the real litellm.completion must be in place inside the context"
+        )
+
+    assert litellm_is_patched(), "the session patch must be restored on exit"
+
+
+def test_restores_the_patch_when_the_body_raises() -> None:
+    """A failing live test must not leave the rest of the session unmocked."""
+    with pytest.raises(RuntimeError, match="boom"), unpatched_litellm():
+        raise RuntimeError("boom")
+
+    assert litellm_is_patched()
+
+
+def test_clears_and_restores_the_mock_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Service code branches on MOCK_LLM_RESPONSE to skip LLM work entirely."""
+    monkeypatch.setenv("MOCK_LLM_RESPONSE", "true")
+
+    with unpatched_litellm():
+        assert os.environ.get("MOCK_LLM_RESPONSE") is None
+
+    assert os.environ.get("MOCK_LLM_RESPONSE") == "true"
+
+
+def test_is_a_noop_when_no_session_patcher_is_registered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An e2e-path invocation never starts one; suspending must still be safe."""
+    monkeypatch.setattr(llm_mock, "_litellm_patcher", None)
+
+    with unpatched_litellm():
+        pass

--- a/tests/server/llm/test_llm_mock_patching.py
+++ b/tests/server/llm/test_llm_mock_patching.py
@@ -61,3 +61,37 @@ def test_is_a_noop_when_no_session_patcher_is_registered(
 
     with unpatched_litellm():
         pass
+
+
+def test_clears_a_stale_flag_left_without_a_session_patcher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The case an early return would miss, and nothing else would catch.
+
+    On an ``e2e_tests`` path invocation ``configure_llm_mock`` never patches,
+    so there is no patcher to stop -- but ``patched_litellm`` leaves
+    ``MOCK_LLM_RESPONSE`` set on exit, so an earlier deterministic e2e test
+    hands the flag to the next live one. ``litellm.completion`` is real and
+    ``assert_litellm_unpatched`` passes, while every service that branches on
+    the flag still takes its mock path.
+    """
+    monkeypatch.setattr(llm_mock, "_litellm_patcher", None)
+    monkeypatch.setenv("MOCK_LLM_RESPONSE", "true")
+
+    with unpatched_litellm():
+        assert os.environ.get("MOCK_LLM_RESPONSE") is None
+
+    assert os.environ.get("MOCK_LLM_RESPONSE") == "true"
+
+
+def test_leaves_no_flag_behind_when_none_was_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restoring an absent prior value means removing it, not writing 'false'."""
+    monkeypatch.setattr(llm_mock, "_litellm_patcher", None)
+    monkeypatch.delenv("MOCK_LLM_RESPONSE", raising=False)
+
+    with unpatched_litellm():
+        assert os.environ.get("MOCK_LLM_RESPONSE") is None
+
+    assert os.environ.get("MOCK_LLM_RESPONSE") is None

--- a/tests/server/services/playbook/test_playbook_reviewer.py
+++ b/tests/server/services/playbook/test_playbook_reviewer.py
@@ -472,7 +472,8 @@ def test_reviewer_prompt_preserves_grounded_procedures_and_forbids_substitutes()
     # The real gate is measured behaviour: a change earns its words by pruning
     # its target class while leaving a healthy window and a second tenant
     # untouched. The in-repo half of that gate is
-    # test_reviewer_manifest_regression.py (real API, deselected by default);
+    # tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py (real API,
+    # opt-in via RUN_LOW_PRIORITY=1);
     # the production-window harness lives in the enterprise repo under
     # docs_for_coding_agent/prompt-change-evaluation.md.
     #


### PR DESCRIPTION
## Problem

Two skip gates keyed on `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`, so **72 tests skipped silently** on a MiniMax-only machine. A sweep of every skip gate in the suite found these are the only two provider-key gates; `test_litellm_strict_structured_compat.py` already treats MiniMax as a first-class `ProviderCase` and is untouched.

Underneath that sat a second problem: neither file could reach a real provider from where it lived. `llm_mock._is_e2e_test_run` exempts only paths containing `e2e_tests` from the session-wide `litellm.completion` patch, so "live" tests placed anywhere else assert against canned mock text regardless of markers or keys.

## Changes

**1. `real_generation_provider()`** (`test_support/llm_credentials.py`), plus a public `provider_env_vars()` accessor so it doesn't reach into `model_defaults._ENV_TO_PROVIDER`. The provider-agnostic counterpart to `real_provider_key`, for tests that resolve their model via `resolve_model_name(ModelRole.GENERATION)` rather than naming one. 5 unit tests added.

**2. `test_reviewer_manifest_regression.py`** → `tests/e2e_tests/test_reviewer_manifest_regression_real_llm.py`, regated on `real_generation_provider({"openai", "anthropic", "minimax"})`. Restricted to a named set rather than every generation-capable provider, so a weaker model behind some other key can't turn silent skips into false regressions.

It passed **12/12 against `minimax/MiniMax-M3`** once able to run — `elapsed_seconds=9.889`, `cost: $0.000749` per call. From the old path, forcing the gate open produced 12 schema-parse failures in 0.88s against the mock.

This also exposed two latent bugs, invisible while the file could only skip: `request_context` was a `SimpleNamespace` where `RequestContext` was required, and the rendered `PlaybookPromptContext` was passed as `agent_context` — a slot `decide()` builds itself and fills from `configurator.get_agent_context()` in production.

**3. `test_litellm_client.py`** gated all 60 tests at module level, but most build a client from a literal config and assert how it resolved. The credential gate and `integration` marker moved off the module; **36 tests now run in the default unit tier** instead of being skipped everywhere including CI.

**4. The live half of that file** (24 tests) moved to `tests/e2e_tests/test_litellm_client_real_llm.py` for the same mock-bypass reason, with an autouse guard asserting `MOCK_LLM_RESPONSE` is unset. Its provider-specific gate stays: this half *is* the OpenAI/Anthropic wiring test (`test_switch_from_openai_to_claude`, Azure endpoint resolution, `APIKeyConfig(openai=..., anthropic=...)` routing), so converting it to MiniMax would delete the coverage.

## Verification

- `4365 passed, 9 skipped` — full OSS unit tier
- `36 passed` in the default tier for `test_litellm_client.py`, against a 60-skipped baseline
- `12 passed in 110.46s` against real MiniMax for the manifest regression
- Both e2e files skip cleanly with every provider key blanked
- Mock bypass confirmed: with a bogus-but-valid-looking `OPENAI_API_KEY`, the moved client test reaches OpenAI and fails `AuthenticationError: Incorrect API key provided` — it hit the network, not the mock
- ruff + pyright clean

**Not verified:** the 24 moved client tests' assertions against real OpenAI/Anthropic — no keys for either provider on the machine this was developed on. The move is proven correct (network reached); the assertions themselves have never run and should be exercised by someone holding those keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for real AI providers, including generation, chat, structured output, embeddings, multimodal requests, model switching, and API-key overrides.
  * Improved automatic detection of available provider credentials and support for provider-specific test execution.
  * Expanded safeguards to ensure real-provider tests run without mocked AI responses.
  * Converted core client tests to reliable offline unit tests while retaining configuration and edge-case coverage.
  * Added regression coverage for mock restoration and reviewer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->