### PR TITLE
fix(playbook): don't abort a rerun aggregation when mock mode has no centroid

### DIFF
--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -1769,26 +1769,37 @@ class PlaybookAggregator:
                         playbook_aggregator_request.rerun
                         and self.aggregation_claim is not None
                     ):
-                        if not saved_fb.embedding:
+                        # Mock mode clusters by trigger rather than by vector
+                        # (see the MOCK_LLM_RESPONSE branch in
+                        # ``get_clusters``), so no centroid exists
+                        # to persist and cluster bookkeeping is skipped. Every
+                        # other caller still aborts on a missing embedding: a
+                        # centroid-less cluster row would silently break the
+                        # incremental re-aggregation this table exists to feed.
+                        if (
+                            not saved_fb.embedding
+                            and os.getenv("MOCK_LLM_RESPONSE", "").lower() != "true"
+                        ):
                             raise RuntimeError(
                                 "rerun agent playbook has no centroid embedding"
                             )
-                        cluster_id = self._stable_aggregation_cluster_id(fp_key)
-                        self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
-                            cluster_id=cluster_id,
-                            agent_version=self.agent_version,
-                            agent_playbook_id=saved_fb.agent_playbook_id,
-                            centroid_embedding=saved_fb.embedding,
-                            member_count=len(raw_ids),
-                            embedding_model=self.storage.embedding_model_name,
-                        )
-                        self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
-                            self.agent_version,
-                            raw_ids,
-                            disposition="cluster_member",
-                            cluster_id=cluster_id,
-                            reason="full_rerun",
-                        )
+                        if saved_fb.embedding:
+                            cluster_id = self._stable_aggregation_cluster_id(fp_key)
+                            self.storage.create_playbook_aggregation_cluster(  # type: ignore[attr-defined]
+                                cluster_id=cluster_id,
+                                agent_version=self.agent_version,
+                                agent_playbook_id=saved_fb.agent_playbook_id,
+                                centroid_embedding=saved_fb.embedding,
+                                member_count=len(raw_ids),
+                                embedding_model=self.storage.embedding_model_name,
+                            )
+                            self.storage.set_playbook_aggregation_disposition(  # type: ignore[attr-defined]
+                                self.agent_version,
+                                raw_ids,
+                                disposition="cluster_member",
+                                cluster_id=cluster_id,
+                                reason="full_rerun",
+                            )
                     for prev_fp in previous_fingerprints_for_changed_clusters.get(
                         fp_key, {}
                     ):

--- a/tests/server/services/playbook/test_cluster_change_detection.py
+++ b/tests/server/services/playbook/test_cluster_change_detection.py
@@ -5,6 +5,7 @@ Tests fingerprint computation, change detection logic, selective LLM invocation,
 and clustering stability.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -944,6 +945,101 @@ class TestClusteringStability:
         # Group B membership should be unchanged
         if group_b_cluster_members is not None and group_b_cluster_members2 is not None:
             assert group_b_cluster_members == group_b_cluster_members2
+
+
+class TestRerunCentroidRequirement:
+    """The rerun path persists a cluster centroid, so it needs an embedding.
+
+    The invariant was added when local embeddings were computed in-process, so
+    ``saved_fb.embedding`` was always populated and the raise was unreachable
+    outside a genuine bug. Once local inference moved behind a separate
+    service, an unreachable embedder became a normal runtime state: storage
+    logs "continuing without vector" and saves the playbook with no embedding,
+    and the invariant fired on infrastructure rather than on a bug -- rolling
+    back every ``run_playbook_aggregation`` call, which always sets
+    ``rerun=True``. Mock mode clusters by trigger and has no centroid to
+    persist at all, so it must skip the bookkeeping rather than abort.
+    """
+
+    def _run_rerun_aggregation(self, *, embedding):
+        group_a = create_similar_embeddings(3, base_seed=42)
+        group_b = create_similar_embeddings(3, base_seed=100)
+        user_playbooks = create_user_playbooks_with_embeddings(group_a + group_b)
+        # Mock mode clusters by trigger, not by vector, so a shared trigger is
+        # what groups these there. Vector clustering ignores the field.
+        for playbook in user_playbooks:
+            playbook.trigger = "When something happens"
+
+        config = PlaybookAggregatorConfig(
+            min_cluster_size=2, reaggregation_trigger_count=1
+        )
+        mock_ctx = MagicMock()
+        mock_ctx.storage = MagicMock()
+        mock_ctx.configurator = MagicMock()
+        temp = PlaybookAggregator(MagicMock(), mock_ctx, "1.0")
+        prev_fingerprints = {}
+        for cluster_id, cluster_playbooks in temp.get_clusters(
+            user_playbooks, config
+        ).items():
+            fp = PlaybookAggregator._compute_cluster_fingerprint(cluster_playbooks)
+            prev_fingerprints[fp] = {
+                "agent_playbook_id": cluster_id + 100,
+                "user_playbook_ids": sorted(
+                    fb.user_playbook_id for fb in cluster_playbooks
+                ),
+            }
+
+        harness = TestAggregatorRunWithChangeDetection()
+        aggregator, mock_storage, _llm = harness._setup_aggregator_for_run(
+            user_playbooks=user_playbooks,
+            operation_state=prev_fingerprints,
+            config=config,
+        )
+        # The centroid branch is reached only under a held aggregation claim,
+        # and that path sources its corpus from the rerun snapshot rather than
+        # from get_user_playbooks.
+        aggregator.aggregation_claim = MagicMock()
+        mock_storage.capture_playbook_aggregation_rerun_snapshot.return_value = (
+            SimpleNamespace(
+                user_playbooks=user_playbooks,
+                user_high_watermark=max(fb.user_playbook_id for fb in user_playbooks),
+                invalidation_ids=[],
+            )
+        )
+
+        saved_count = [0]
+
+        def save_side_effect(playbooks, **_kwargs):  # noqa: ANN001
+            saved_count[0] += 1
+            playbook = playbooks[0]
+            playbook.agent_playbook_id = saved_count[0]
+            playbook.embedding = embedding
+            return [playbook]
+
+        mock_storage.save_agent_playbooks.side_effect = save_side_effect
+
+        aggregator.run(PlaybookAggregatorRequest(agent_version="1.0", rerun=True))
+        return mock_storage
+
+    def test_missing_centroid_aborts_the_rerun(self):
+        """Outside mock mode a centroid-less cluster row must never be written."""
+        with pytest.raises(RuntimeError, match="no centroid embedding"):
+            self._run_rerun_aggregation(embedding=None)
+
+    def test_mock_mode_skips_cluster_bookkeeping(self, monkeypatch):
+        """Mock mode reaches the save, then skips the centroid write."""
+        monkeypatch.setenv("MOCK_LLM_RESPONSE", "true")
+
+        mock_storage = self._run_rerun_aggregation(embedding=None)
+
+        mock_storage.save_agent_playbooks.assert_called()
+        mock_storage.create_playbook_aggregation_cluster.assert_not_called()
+
+    def test_present_centroid_persists_the_cluster(self):
+        """The happy path still records the cluster."""
+        mock_storage = self._run_rerun_aggregation(embedding=[0.1] * 8)
+
+        mock_storage.create_playbook_aggregation_cluster.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

4 e2e tests fail on `main`:

```
RuntimeError: rerun agent playbook has no centroid embedding
aggregator.py:1773
```

- `test_playbook_workflows.py` — 3 tests
- `test_openclaw_integration.py` — 1 test

They pass at `b0e0755` and fail from `c24e1e7` onward, so this is a regression, not an environment quirk.

## Root cause

Two changes that were each fine alone.

**`159d8ab` (#410)** added the invariant: on the rerun path, a saved agent playbook must carry an embedding to persist as a cluster centroid. Safe at the time — local embeddings were computed **in-process**, so `saved_fb.embedding` was always populated and the raise was unreachable outside a genuine bug.

**`c24e1e7` (#425)** removed in-process local inference ("service-only inference boundary"). `embedding_provider_mode` now returns `local_service` for any local model with no env vars set, so embedding goes over HTTP to `127.0.0.1:8072`.

With the embedder unreachable, `SQLiteStorage` deliberately degrades:

```
Embedding unavailable for document text; continuing without vector
```

…and saves the playbook with `embedding=None`. The invariant then fires and rolls back the entire aggregation. An assertion written to catch a *programming error* now trips on an *infrastructure state*.

This is not narrow: `reflexio/lib/_generation.py:73` sets `rerun=True` for every `run_playbook_aggregation()` call, so the branch is the normal path, not an edge case.

## Why it wasn't caught

- This repo runs no CI workflows.
- Enterprise `ci-fast.yml:104` runs `--ignore=tests/e2e_tests/`.
- The e2e tier only runs in `release.yml`.
- The invariant had **no test coverage at all** — `grep 'no centroid embedding' tests/` returns nothing.

## Fix

Mock mode is the case that has no centroid *by construction*: it clusters by trigger rather than by vector (the `MOCK_LLM_RESPONSE` branch in `get_clusters`), so a centroid was never meaningful there. Skip the cluster bookkeeping instead of aborting.

Every other caller still raises — a centroid-less cluster row would silently break the incremental re-aggregation that table exists to feed. Production behaviour outside mock mode is unchanged.

Adds the three cases the invariant never had:
- the raise still fires outside mock mode
- mock mode reaches the save, then skips the centroid write
- the happy path still records the cluster

Verified the new tests fail against the pre-fix aggregator with the exact `RuntimeError`.

## Verification

- OSS e2e tier: **47 passed, 87 skipped** (was 4 failed / 43 passed)
- OSS unit tier: **4368 passed, 9 skipped**
- ruff + pyright clean

## Worth a second opinion

The mock-mode carve-out fixes the tests, but the underlying mismatch is broader: storage treats a missing embedding as *degrade and continue*, while the aggregator treats it as *fatal*. In any deployment where the embedding service is unreachable, `run_playbook_aggregation()` now hard-fails and rolls back rather than degrading. That may well be intended — failing loudly beats silently writing a useless centroid — but it changed behaviour without discussion when #425 landed, so the owners of #410/#425 should confirm which semantics they want.