### PR TITLE
test: give the OSS suite a deterministic embedding source

### DIFF
--- a/reflexio/test_support/embedding_mock.py
+++ b/reflexio/test_support/embedding_mock.py
@@ -1,0 +1,104 @@
+"""Deterministic embedding stub for reflexio test suites.
+
+Companion to :mod:`llm_mock`, which does the same for ``litellm.completion``.
+Patches the shared embedding dispatch so unit tests get a vector without a
+running inference service.
+
+Why this exists: embeddings used to be computed in-process during tests, so
+storage writes got real vectors for free. That path was removed when local
+inference moved behind a service, and nothing replaced it for tests -- the
+suite kept passing only because the SQLite ingest path swallows
+``EmbeddingUnavailableError`` and stores an empty vector. So the write
+succeeded, the row was silently unsearchable, and any assertion about vector
+search or clustering downstream of it was passing vacuously.
+
+The vectors are deterministic but **not semantic**: they are derived from a
+hash of the text, so identical text embeds identically and different text
+embeds differently, and that is all. Do not use them to assert that related
+phrasings cluster together -- for that, place vectors explicitly, as
+``test_missing_vector_backfill_integration`` does.
+
+Usage in conftest.py::
+
+    from reflexio.test_support.embedding_mock import patch_embeddings
+
+    @pytest.fixture(autouse=True)
+    def _deterministic_embeddings():
+        with patch_embeddings():
+            yield
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from reflexio.models.config_schema import EMBEDDING_DIMENSIONS
+
+__all__ = ["deterministic_embedding", "patch_embeddings"]
+
+
+def deterministic_embedding(text: str, dimensions: int | None = None) -> list[float]:
+    """Return a stable unit vector derived from ``text``.
+
+    Args:
+        text (str): Text to embed.
+        dimensions (int | None): Vector length. Defaults to the project-wide
+            ``EMBEDDING_DIMENSIONS``, which is what storage validates against.
+
+    Returns:
+        list[float]: A unit-norm vector of length ``dimensions``. The same text
+            always yields the same vector; different text yields a different
+            one.
+    """
+    dims = dimensions or EMBEDDING_DIMENSIONS
+    # Expand the digest by counter until it covers `dims` floats. Hash-derived
+    # rather than PRNG-seeded so the vector does not depend on the interpreter's
+    # random implementation, which would make fixtures non-portable.
+    raw = b""
+    counter = 0
+    while len(raw) < dims * 4:
+        raw += hashlib.sha256(f"{counter}:{text}".encode()).digest()
+        counter += 1
+    values = [
+        # Map each 4-byte word to [-1, 1); the exact distribution does not
+        # matter, only that it is stable and spreads distinct texts apart.
+        (struct.unpack_from(">I", raw, i * 4)[0] / 0x7FFFFFFF) - 1.0
+        for i in range(dims)
+    ]
+    norm = math.sqrt(sum(value * value for value in values))
+    if norm == 0.0:  # pragma: no cover - only reachable if every word is 2^31
+        return [1.0] + [0.0] * (dims - 1)
+    return [value / norm for value in values]
+
+
+@contextmanager
+def patch_embeddings() -> Iterator[None]:
+    """Patch the shared embedding dispatch with deterministic vectors.
+
+    Patches ``LiteLLMClient._embed_texts`` -- the single seam both
+    ``get_embedding`` and ``get_embeddings`` route through -- so batch and
+    single paths cannot diverge.
+
+    A test that installs its own client (``storage.llm_client = MagicMock()``)
+    is unaffected: this patches the class method, and such a test never reaches
+    it. A test that wants a real failure can still patch the client to raise.
+    """
+    from reflexio.server.llm.litellm_client import LiteLLMClient
+
+    def _embed_texts(
+        _self: LiteLLMClient,
+        texts: list[str],
+        _model: str | None,
+        dimensions: int | None,
+        *,
+        batch: bool,  # noqa: ARG001 - signature parity with the real method
+    ) -> list[list[float]]:
+        return [deterministic_embedding(text, dimensions) for text in texts]
+
+    with patch.object(LiteLLMClient, "_embed_texts", _embed_texts):
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,7 @@ from reflexio.server.extensions import reset_services  # noqa: E402
 
 _test_server.LOCAL_STORAGE_PATH = os.environ["LOCAL_STORAGE_PATH"]
 
+from reflexio.test_support.embedding_mock import patch_embeddings  # noqa: E402
 from reflexio.test_support.llm_credentials import (  # noqa: E402
     ensure_provider_credential,
 )
@@ -111,6 +112,36 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
 
 def pytest_unconfigure(config):
     cleanup_llm_mock(config)
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_embeddings(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Give every non-e2e test a vector source, so storage writes are real writes.
+
+    Embeddings were computed in-process until local inference moved behind a
+    service; nothing replaced that for tests. The suite kept passing only
+    because the SQLite ingest path swallows EmbeddingUnavailableError and stores
+    an empty vector -- so rows were written unsearchable, and assertions about
+    vector search or clustering downstream of them passed vacuously.
+
+    Two carve-outs, both "do not stub the thing under test":
+
+    - ``e2e_tests`` exercise the real stack, the same reason they bypass the
+      LLM mock.
+    - ``server/llm`` owns the embedding dispatch this patches. Stubbing
+      ``_embed_texts`` there would replace the unit under test, so those suites
+      keep the real implementation and mock the provider beneath it instead.
+
+    The vectors are deterministic but NOT semantic (hash-derived), so this makes
+    write paths real without making similarity assertions meaningful -- place
+    vectors explicitly for those.
+    """
+    parts = Path(str(request.node.path)).parts
+    if "e2e_tests" in parts or ("llm" in parts and "server" in parts):
+        yield
+        return
+    with patch_embeddings():
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/server/services/test_deterministic_embedding_fixture.py
+++ b/tests/server/services/test_deterministic_embedding_fixture.py
@@ -1,0 +1,78 @@
+"""Guard that the autouse embedding fake is actually in effect.
+
+Without this, the fixture is unfalsifiable. Removing it breaks nothing visible:
+the ingest path swallows ``EmbeddingUnavailableError`` and stores an empty
+vector, so every other test still passes -- writing rows that are silently
+unsearchable. That is the exact state this fixture exists to end, and it is
+invisible unless something asserts on the stored vector.
+
+Verified by mutation: disabling the fixture leaves ``test_sqlite_storage``'s 80
+tests green, and fails only this module.
+"""
+
+from __future__ import annotations
+
+from reflexio.models.config_schema import EMBEDDING_DIMENSIONS
+from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
+from reflexio.test_support.embedding_mock import deterministic_embedding
+
+
+def _client() -> LiteLLMClient:
+    return LiteLLMClient(LiteLLMConfig(model="test-model"))
+
+
+def test_embedding_calls_return_a_real_vector_without_a_service() -> None:
+    """A plain embed call must yield a usable vector, not [] and not an error.
+
+    No inference service runs in the unit tier, so before the fixture this
+    raised EmbeddingUnavailableError at the client and degraded to [] at the
+    storage layer.
+    """
+    vector = _client().get_embedding("a stored document")
+
+    assert vector, "embedding must not be empty -- the fake is not in effect"
+    assert len(vector) == EMBEDDING_DIMENSIONS
+
+
+def test_batch_and_single_paths_agree() -> None:
+    """Both public entry points route through one patched seam.
+
+    Patching them separately would let batch and single drift, which is the
+    defect the shared ``_embed_texts`` seam exists to prevent.
+    """
+    client = _client()
+    texts = ["alpha", "beta"]
+
+    assert client.get_embeddings(texts) == [client.get_embedding(t) for t in texts]
+
+
+def test_same_text_embeds_identically_and_different_text_does_not() -> None:
+    """Determinism is what makes fixtures reproducible across runs and workers.
+
+    Asserted together with distinctness because a constant vector would satisfy
+    determinism alone while making every row identical -- which would quietly
+    ruin any clustering assertion built on top.
+    """
+    client = _client()
+
+    assert client.get_embedding("same") == client.get_embedding("same")
+    assert client.get_embedding("same") != client.get_embedding("different")
+
+
+def test_vectors_are_not_semantic() -> None:
+    """Pin the documented limitation so nobody builds similarity tests on it.
+
+    The vectors are hash-derived, so related phrasings are no closer than
+    unrelated ones. A test that needs semantic structure must place vectors
+    explicitly rather than rely on this fixture.
+    """
+    near = deterministic_embedding("cancel my order")
+    paraphrase = deterministic_embedding("cancel my order please")
+    unrelated = deterministic_embedding("what is the weather")
+
+    def cosine(a: list[float], b: list[float]) -> float:
+        return sum(x * y for x, y in zip(a, b, strict=True))
+
+    # Both are near-orthogonal; the paraphrase enjoys no advantage.
+    assert abs(cosine(near, paraphrase)) < 0.5
+    assert abs(cosine(near, unrelated)) < 0.5


### PR DESCRIPTION
Restores embedding coverage the test suite lost when local inference moved behind a service.

## The problem

Embeddings used to be computed in-process during tests, so storage writes got real vectors for free. That path was removed; nothing replaced it for tests.

The suite kept passing only because the SQLite ingest path swallows `EmbeddingUnavailableError` and stores an empty vector. Writes succeeded, rows were silently unsearchable, and anything asserted downstream about vector search or clustering passed vacuously.

**Measured, and this is the headline:** disabling this fixture leaves `test_sqlite_storage`s **80 tests green**. Nothing in the suite could tell the difference between a stored vector and no vector at all.

## What this adds

`reflexio/test_support/embedding_mock.py` — companion to `llm_mock`, which already fakes `litellm.completion` globally for every OSS test — wired autouse in `tests/conftest.py`.

Patches `LiteLLMClient._embed_texts`, the single seam `get_embedding` and `get_embeddings` both route through, so batch and single paths cannot diverge.

**Two carve-outs, both "do not stub the thing under test":**

| carve-out | why |
|---|---|
| `e2e_tests` | exercise the real stack — same reason they bypass the LLM mock |
| `tests/server/llm` | owns this dispatch; stubbing it replaces the unit under test (verified: fails 19 of their tests) |

## Deliberately not semantic

Vectors are hash-derived: identical text embeds identically, different text does not, and nothing more. Related phrasings are no closer than unrelated ones. A test needing semantic structure must place vectors explicitly, as `test_missing_vector_backfill_integration` does.

That limitation is **pinned by a test**, not left in a comment — otherwise someone will eventually build a similarity assertion on it.

## Nothing ships to production

- the wheel packages only `["reflexio"]`; `tests/` is not in it
- **zero** shipped modules import from `tests/`
- the patch is applied by pytest, inside the test process

## Test plan

```
tests/ (unit tier) -> 4256 passed, 3 skipped, 1304 deselected
```

The new module is mutation-verified: disabling the fixture fails 3 of its 4 tests. Without that guard the fixture would be unfalsifiable — which is precisely how the original gap went unnoticed.

## Why this came up

It is the prerequisite for making the SQLite document path fail closed (matching postgres/supabase). With the fake in place, that change goes from **46 failing tests to 1** — and that one is `test_embedding_unavailable_degrades_to_empty_vector`, which encodes the current policy. So fail-closed becomes a one-test policy decision rather than a broad breakage. Not included here; that decision is separate.