### PR TITLE
fix(reviewer): coerce a contradictory fatal-code decision instead of failing the batch

### DIFF
--- a/reflexio/server/services/playbook/components/reviewer.py
+++ b/reflexio/server/services/playbook/components/reviewer.py
@@ -92,15 +92,20 @@ class CandidateReviewDecision(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     @model_validator(mode="after")
-    def fatal_reason_codes_must_reject(self) -> CandidateReviewDecision:
-        """A defect with no salvageable core cannot be narrowed into a survivor.
+    def fatal_reason_codes_are_rejects(self) -> CandidateReviewDecision:
+        """A defect with no salvageable core can never end up a survivor.
 
         The prompt instructs the reviewer to reject these outright, but a prompt
         instruction is not an invariant: a response pairing one of these codes
         with ``accept`` or ``revise`` otherwise validates cleanly, and revision
         would launder the defect into tidier prose rather than removing it. That
-        pairing has been observed in practice, so enforce it structurally rather
-        than by wording alone.
+        pairing has been observed in practice, so it is enforced structurally.
+
+        Enforcement is the coercion in ``normalize_known_provider_shape``; this
+        is the backstop that makes the invariant total. It is reachable only via
+        a construction path that skips that coercion, so it raises rather than
+        coercing a second time -- at that point the caller is our own code with a
+        bug, not a provider, and no batch is at stake.
 
         Deliberately narrow. ``internal_status`` is NOT listed: an entry that
         merely rests on an internal event as evidence usually has a grounded
@@ -174,6 +179,35 @@ class CandidateReviewDecision(BaseModel):
                 if data["decision"] == "reject"
                 else "grounded_useful"
             )
+
+        # A fatal code paired with accept/revise is self-contradictory: the code
+        # asserts nothing salvageable remains, and the decision tries to keep it.
+        # Coerce to the decision the code already implies, rather than raising.
+        #
+        # Raising here was worse than it looked. This runs during PARSE of the
+        # whole PlaybookCandidateReviewOutput, so one contradictory decision
+        # invalidated every decision in the batch -- and the repair turn could
+        # not fix it, because `_safe_validation_errors` deliberately drops the
+        # message (Customer Content) and forwards only `decisions.N:
+        # value_error`. The constraint is also absent from the JSON schema, since
+        # a model_validator does not serialize, so the model was never told the
+        # rule it had just broken. One slip therefore cost the whole review, with
+        # a repair round-trip spent on an uninformative message.
+        if data.get("reason_code") in _FATAL_REASON_CODES and data.get("decision") in {
+            "accept",
+            "revise",
+        }:
+            logger.warning(
+                "event=playbook_review_fatal_code_coerced reason_code=%s from=%s",
+                data.get("reason_code"),
+                data.get("decision"),
+            )
+            data["decision"] = "reject"
+            # A reject must retain no evidence and carry no revision, so clear
+            # both -- otherwise the coerced object fails semantic validation and
+            # reintroduces the batch loss by another route.
+            data["revision"] = None
+            data["evidence_ids"] = []
         return data
 
 

--- a/reflexio/server/services/playbook/components/reviewer.py
+++ b/reflexio/server/services/playbook/components/reviewer.py
@@ -57,7 +57,8 @@ class CandidateRevision(BaseModel):
 
 #: Reason codes naming a defect with no salvageable core, so the only coherent
 #: decision is ``reject``. Enforced structurally by
-#: :meth:`CandidateReviewDecision.fatal_reason_codes_must_reject`.
+#: :meth:`CandidateReviewDecision.fatal_reason_codes_are_rejects`, and applied
+#: by the coercion in `normalize_known_provider_shape`.
 _FATAL_REASON_CODES = frozenset({"absence_inference", "not_agent_decision"})
 
 

--- a/tests/server/services/playbook/test_playbook_reviewer.py
+++ b/tests/server/services/playbook/test_playbook_reviewer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import ValidationError
 
 from reflexio.models.api_schema.domain.entities import (
     Interaction,
@@ -599,14 +598,32 @@ def test_fatal_reason_codes_require_reject(code: str):
     assert ok.decision == "reject"
 
     for bad in ("accept", "revise"):
-        # Match both the offending code and the decision. The code name is what
-        # an operator reads in a failed run; pinning the decision catches
-        # suffix-concatenating phrasings, which previously rendered "acceptd".
-        with pytest.raises(ValidationError, match=code) as excinfo:
-            CandidateReviewDecision.model_validate(
-                {"id": "C1", "decision": bad, "reason_code": code}
-            )
-        assert f"decision={bad!r} is invalid" in str(excinfo.value)
+        # Coerced, not rejected outright. This validation runs during parse of
+        # the WHOLE review output, so raising here invalidated every decision in
+        # the batch over one self-contradictory entry -- and the repair turn
+        # could not fix it, because the message is stripped to
+        # "decisions.N: value_error" and the constraint never reaches the JSON
+        # schema. The code already asserts nothing salvageable remains, so
+        # reject is the decision it implies.
+        coerced = CandidateReviewDecision.model_validate(
+            {
+                "id": "C1",
+                "decision": bad,
+                "reason_code": code,
+                "evidence_ids": ["C1-E1"],
+                "revision": {
+                    "content": "c",
+                    "trigger": "t",
+                    "rationale": "r",
+                },
+            }
+        )
+        assert coerced.decision == "reject"
+        # A reject must retain no evidence and carry no revision; leaving either
+        # in place would fail semantic validation and reintroduce the batch loss
+        # by another route.
+        assert coerced.evidence_ids == []
+        assert coerced.revision is None
 
     # Other codes are unaffected: revise remains available to them.
     # `internal_status` in particular MUST stay non-fatal. Folding check 8 into
@@ -672,3 +689,97 @@ def test_prompt_reason_codes_match_the_schema_literal():
         f"prompt-only: {sorted(prompt_codes - literal_codes)}; "
         f"schema-only: {sorted(literal_codes - prompt_codes)}"
     )
+
+
+def test_one_fatal_code_slip_does_not_cost_the_whole_batch():
+    """A self-contradictory decision must not invalidate its siblings.
+
+    This is the defect the coercion exists to prevent, asserted end-to-end
+    rather than on the model alone. The pairing raised during parse of the whole
+    PlaybookCandidateReviewOutput, so a single slip lost every candidate in the
+    request -- including healthy ones -- and `service.py` reviews all candidates
+    for a request in one call. The repair turn could not recover it either: the
+    error text is reduced to "decisions.N: value_error" before it reaches the
+    model, and a model_validator never appears in the JSON schema, so the rule
+    it broke was never stated to it.
+
+    Asserts the survivor by content, not by count, so the test cannot pass by
+    dropping the wrong candidate.
+    """
+    interactions = [
+        _interaction_model(201, "The user corrected the agent's assumption."),
+        _interaction_model(202, "Notification failed status=FAILED."),
+    ]
+    candidates = [
+        _candidate(
+            201,
+            "The user corrected the agent's assumption.",
+            content="Honor the stated correction.",
+        ),
+        _candidate(
+            202,
+            "Notification failed status=FAILED.",
+            content="Do not echo the raw failure line.",
+        ),
+    ]
+    output = PlaybookCandidateReviewOutput(
+        decisions=[
+            CandidateReviewDecision(
+                id="C1",
+                decision="accept",
+                reason_code="grounded_useful",
+                evidence_ids=["C1-E1"],
+            ),
+            # The slip: a fatal code the model paired with `revise`.
+            CandidateReviewDecision.model_validate(
+                {
+                    "id": "C2",
+                    "decision": "revise",
+                    "reason_code": "not_agent_decision",
+                    "evidence_ids": ["C2-E1"],
+                    "revision": {
+                        "content": "Report the failure plainly.",
+                        "trigger": "When the notification fails",
+                        "rationale": "The cited turn shows the failure.",
+                    },
+                }
+            ),
+        ]
+    )
+    reviewer, _client = _reviewer(output)
+
+    result = reviewer.review(
+        candidates=candidates,
+        request_interaction_data_models=interactions,
+        existing_playbooks=[],
+        agent_context="Test agent",
+        playbook_definition="Reusable user guidance",
+        tool_context="",
+    )
+
+    assert [item.content for item in result] == ["Honor the stated correction."]
+
+
+def test_fatal_code_backstop_still_raises_when_coercion_is_bypassed():
+    """The invariant holds even on a path that skips normalization.
+
+    Coercion in `normalize_known_provider_shape` is the enforcement; this
+    validator is the backstop that makes "a fatal code is always a reject"
+    total rather than merely usual. It is unreachable through normal
+    construction, so it is exercised directly -- otherwise it would be an
+    untestable guard, and an untestable guard is how the original gap survived.
+
+    It raises rather than coercing a second time: reaching it means the caller
+    is our own code bypassing normalization, where a loud failure is right and
+    no provider batch is at stake.
+    """
+    from reflexio.server.services.playbook.components.reviewer import (
+        CandidateReviewDecision,
+    )
+
+    bypassed = CandidateReviewDecision.model_construct(
+        candidate_id="C1", decision="accept", reason_code="absence_inference"
+    )
+
+    with pytest.raises(ValueError, match="absence_inference"):
+        bypassed.fatal_reason_codes_are_rejects()

--- a/tests/server/services/playbook/test_playbook_reviewer.py
+++ b/tests/server/services/playbook/test_playbook_reviewer.py
@@ -722,16 +722,21 @@ def test_one_fatal_code_slip_does_not_cost_the_whole_batch():
             content="Do not echo the raw failure line.",
         ),
     ]
-    output = PlaybookCandidateReviewOutput(
-        decisions=[
-            CandidateReviewDecision(
-                id="C1",
-                decision="accept",
-                reason_code="grounded_useful",
-                evidence_ids=["C1-E1"],
-            ),
-            # The slip: a fatal code the model paired with `revise`.
-            CandidateReviewDecision.model_validate(
+    # Parsed from raw dicts through the BATCH model, which is the path a
+    # provider response actually takes. Building the decisions individually
+    # would coerce each one before the output model ever saw it, so the
+    # whole-output parse -- the step that used to lose every sibling decision --
+    # would never be exercised.
+    output = PlaybookCandidateReviewOutput.model_validate(
+        {
+            "decisions": [
+                {
+                    "id": "C1",
+                    "decision": "accept",
+                    "reason_code": "grounded_useful",
+                    "evidence_ids": ["C1-E1"],
+                },
+                # The slip: a fatal code the model paired with `revise`.
                 {
                     "id": "C2",
                     "decision": "revise",
@@ -742,10 +747,11 @@ def test_one_fatal_code_slip_does_not_cost_the_whole_batch():
                         "trigger": "When the notification fails",
                         "rationale": "The cited turn shows the failure.",
                     },
-                }
-            ),
-        ]
+                },
+            ]
+        }
     )
+
     reviewer, _client = _reviewer(output)
 
     result = reviewer.review(


### PR DESCRIPTION
Closes #427.

## The defect

A fatal `reason_code` paired with `accept`/`revise` raised from a pydantic `model_validator`. That validator runs during parse of the **whole** `PlaybookCandidateReviewOutput`, so one self-contradictory decision invalidated **every** decision in the batch — and `service.py` reviews all of a request's candidates in a single call, so a slip on one candidate lost the healthy ones with it.

The repair turn could not recover it either:

```
raw:  not_agent_decision requires decision='reject'; it has no grounded core to narrow...
sent: ('decisions.1: value_error',)
```

`_safe_validation_errors` drops the message as a Customer-Content precaution, and a `model_validator` never reaches the JSON schema — so the model was neither told the rule nor told which rule it broke. The single retry was spent on an uninformative correction request.

## The fix

**Coerce.** The pairing is self-contradictory: the code asserts nothing salvageable remains while the decision tries to keep it. `reject` is the decision the code already implies, so apply it rather than destroying the batch.

Also clears `evidence_ids` and `revision`, since a reject must retain neither — leaving them would fail semantic validation and reintroduce the batch loss by another route. Logs at warning, so a model that starts slipping is visible rather than silent.

## Why not the approach in the issue

#427 suggested moving the check into `_validation_errors`, which would make the repair turn actionable. That is better than today, but it still spends a round-trip re-asking about a decision the model **itself** already classified as unsalvageable — and it drops the structural invariant.

Coercion keeps the invariant, needs no repair turn, and cannot lose the batch.

## The backstop

`fatal_reason_codes_are_rejects` is kept so the invariant is *total* rather than merely usual. It is unreachable through normal construction, so it is exercised by direct call — **an untestable guard is how the original gap survived**, and I did not want to reproduce that.

It raises rather than coercing a second time: reaching it means our own code bypassed normalization, where failing loudly is right and no provider batch is at stake.

## Verification

Mutation-checked: removing the coercion fails `test_one_fatal_code_slip_does_not_cost_the_whole_batch` with exactly the reported symptom, plus both parametrisations of the fatal-code test.

The new batch test asserts the survivor **by content**, not by count, so it cannot pass by dropping the wrong candidate.

```
tests/ (unit tier) -> 4310 passed, 3 skipped, 1235 deselected
```

One unrelated failure, `test_different_orgs_serialize_shared_sqlite_initialization`, is a **pre-existing full-suite flake**: passes 5/5 in isolation, and fails identically on clean `main` (4308 passed, same single failure). Not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of contradictory decisions associated with fatal reason codes.
  - Such decisions are now consistently recorded as rejected, with conflicting revision and evidence details cleared.
  - Valid sibling candidates are preserved when one candidate contains a fatal decision.
  - Added safeguards to maintain consistent validation behavior across supported processing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->