### PR TITLE
fix(api): type the public reason_code vocabulary

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -34,6 +34,7 @@ from .enums import (
     PlaybookStatus,
     ProfileTimeToLive,
     RegularVsShadow,
+    ReviewUserPlaybookReasonCode,
     SessionOutcomeFailureReason,
     SessionOutcomeKind,
     Status,
@@ -1782,7 +1783,7 @@ class ReviewUserPlaybookResult(BaseModel):
 
     user_playbook_id: int = Field(gt=0)
     decision: Literal["accept", "edit", "reject", "skip"]
-    reason_code: str
+    reason_code: ReviewUserPlaybookReasonCode
     reason: str | None = None
     edit: ReviewUserPlaybookEdit | None = None
     applied: bool = False

--- a/reflexio/models/api_schema/domain/enums.py
+++ b/reflexio/models/api_schema/domain/enums.py
@@ -1,4 +1,5 @@
 from enum import Enum, StrEnum
+from typing import Literal
 
 from ..common import BlockingIssueKind  # noqa: F401
 
@@ -12,7 +13,40 @@ __all__ = [
     "SessionOutcomeKind",
     "SessionOutcomeFailureReason",
     "BlockingIssueKind",
+    "PlaybookReviewReasonCode",
+    "ReviewUserPlaybookReasonCode",
 ]
+
+#: Why the candidate reviewer decided what it decided.
+#:
+#: Defined here rather than beside the reviewer because the public
+#: ``ReviewUserPlaybookResult`` also has to name this vocabulary, and ``models``
+#: must not import from ``server``. One definition, so the schema the reviewer
+#: enforces and the schema the API advertises cannot drift.
+#:
+#: Adding a member is not self-contained: it must also appear in the active
+#: ``playbook_candidate_review`` prompt's "reason_code is exactly one of" list,
+#: or the model is never told the code exists.
+PlaybookReviewReasonCode = Literal[
+    "grounded_useful",
+    "unsupported_evidence",
+    "generic",
+    "speculative",
+    "unsupported_causality",
+    "unseen_artifact",
+    "redundant",
+    "late_trigger",
+    "compound",
+    "internal_status",
+    "absence_inference",
+    "not_agent_decision",
+]
+
+#: What a re-review can report publicly: every reviewer code, plus the one the
+#: review *service* raises on its own behalf when a row cannot be reviewed at
+#: all. ``evidence_unavailable`` never comes from the model -- it accompanies
+#: ``decision="skip"``, meaning the row's provenance was absent or invalid.
+ReviewUserPlaybookReasonCode = Literal[PlaybookReviewReasonCode, "evidence_unavailable"]
 
 
 class SessionOutcomeKind(StrEnum):

--- a/reflexio/server/services/playbook/components/reviewer.py
+++ b/reflexio/server/services/playbook/components/reviewer.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from reflexio.models.api_schema.domain.entities import UserPlaybook
+from reflexio.models.api_schema.domain.enums import PlaybookReviewReasonCode
 from reflexio.models.api_schema.internal_schema import RequestInteractionDataModel
 from reflexio.models.structured_output import normalize_provider_value
 from reflexio.server.api_endpoints.request_context import RequestContext
@@ -72,20 +73,7 @@ class CandidateReviewDecision(BaseModel):
     # never told it exists. If it names an unsalvageable defect, add it to
     # _FATAL_REASON_CODES and to that prompt's "Always reject" line too.
     # test_prompt_reason_codes_match_the_schema_literal enforces the first.
-    reason_code: Literal[
-        "grounded_useful",
-        "unsupported_evidence",
-        "generic",
-        "speculative",
-        "unsupported_causality",
-        "unseen_artifact",
-        "redundant",
-        "late_trigger",
-        "compound",
-        "internal_status",
-        "absence_inference",
-        "not_agent_decision",
-    ]
+    reason_code: PlaybookReviewReasonCode
     evidence_ids: list[str] = Field(default_factory=list)
     revision: CandidateRevision | None = None
     reason: str | None = None

--- a/tests/server/services/playbook/test_playbook_reviewer.py
+++ b/tests/server/services/playbook/test_playbook_reviewer.py
@@ -789,3 +789,64 @@ def test_fatal_code_backstop_still_raises_when_coercion_is_bypassed():
 
     with pytest.raises(ValueError, match="absence_inference"):
         bypassed.fatal_reason_codes_are_rejects()
+
+
+def test_public_reason_code_vocabulary_is_the_reviewer_set_plus_the_skip_code():
+    """The API must advertise exactly what can be produced -- no more, no less.
+
+    `ReviewUserPlaybookResult.reason_code` was a plain `str`, so the public
+    vocabulary was whatever happened to be emitted: the reviewer's codes plus
+    `evidence_unavailable`, which the review *service* raises on its own behalf
+    for an unreviewable row. Nothing enforced or documented that, so a consumer
+    branching on the value silently gained an unhandled case whenever the
+    reviewer's Literal grew -- as it did when `not_agent_decision` was added.
+
+    Asserted as set equality rather than membership: a subset check would pass
+    while the API under-advertised, and a superset check would pass while it
+    promised codes nothing can emit.
+    """
+    from typing import get_args
+
+    from reflexio.models.api_schema.domain.entities import ReviewUserPlaybookResult
+    from reflexio.server.services.playbook.components.reviewer import (
+        CandidateReviewDecision,
+    )
+
+    reviewer_codes = set(
+        get_args(CandidateReviewDecision.model_fields["reason_code"].annotation)
+    )
+    public_codes = set(
+        get_args(ReviewUserPlaybookResult.model_fields["reason_code"].annotation)
+    )
+
+    assert public_codes == reviewer_codes | {"evidence_unavailable"}
+
+
+def test_public_result_rejects_a_reason_code_nothing_can_emit():
+    """An unknown code must fail validation rather than reach a consumer.
+
+    This is what "typed" buys over documentation: the field cannot carry a value
+    the producers do not produce.
+    """
+    from pydantic import ValidationError
+
+    from reflexio.models.api_schema.domain.entities import ReviewUserPlaybookResult
+
+    # The real skip pairing still validates.
+    skipped = ReviewUserPlaybookResult.model_validate(
+        {
+            "user_playbook_id": 1,
+            "decision": "skip",
+            "reason_code": "evidence_unavailable",
+        }
+    )
+    assert skipped.reason_code == "evidence_unavailable"
+
+    with pytest.raises(ValidationError):
+        ReviewUserPlaybookResult.model_validate(
+            {
+                "user_playbook_id": 1,
+                "decision": "skip",
+                "reason_code": "not_a_real_code",
+            }
+        )


### PR DESCRIPTION
Closes the vocabulary half of #428.

## The problem

`ReviewUserPlaybookResult.reason_code` was a plain `str`. So the public vocabulary was whatever happened to be emitted:

| producer | values |
|---|---|
| the reviewer | its 12 `Literal` codes |
| the review *service* | `evidence_unavailable`, on its own behalf, when a row cannot be reviewed at all |

Nothing enforced that and nothing documented it. A consumer branching on the value silently gained an unhandled case whenever the reviewer's Literal grew — as it did when `not_agent_decision` was added, with no OpenAPI signal.

## The fix

Define the vocabulary **once**, in `models/api_schema/domain/enums.py`:

```python
PlaybookReviewReasonCode      # the 12 the reviewer can decide
ReviewUserPlaybookReasonCode  # those 12 + evidence_unavailable
```

It lives in `models` rather than beside the reviewer because the public entity also has to name it and **`models` must not import from `server`**. The reviewer now imports the Literal it used to declare inline, so the schema the reviewer enforces and the schema the API advertises cannot drift.

Flattened via `Literal[PlaybookReviewReasonCode, ...]` rather than a union, so the JSON schema advertises **one 13-value enum** instead of `anyOf` over two.

## Compatibility

Tightening a **response** type is safe for readers. I checked: nothing in this repo or the enterprise repo branches on the value, and there is no TS type to update. Companion enterprise PR updates the public docs, which declared it as bare `"string"`.

## Tests

Asserted as **set equality**, not membership — a subset check would pass while the API under-advertised, and a superset check would pass while it promised codes nothing can emit.

Mutation-checked both directions: dropping `evidence_unavailable` from the public type fails, and reverting the field to `str` fails.

```
tests/ (unit tier)            -> 4313 passed, 3 skipped
pyright on the changed model  -> 0 errors
public_docs next build        -> clean
```

## Deliberately not fixed

The **MECE half** of #428. `unsupported_evidence` is a genus with five species (`absence_inference`, `unsupported_causality`, `unseen_artifact`, `speculative`, `internal_status`), and `speculative`/`redundant`/`internal_status` have no numbered check defining when they apply — which is why six near-identical candidates once drew four different reject codes plus an `accept`.

Fixing that means changing the prompt, and both reviewer checks are measurably **dose-dependent** — a compressed check 7 went from 36% pruning to inert, and a compressed check 8 fired zero times. So it needs measurement against known-answer windows, not a refactor. **#428 stays open for it.**