### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -74,8 +74,7 @@ and `openclaw-smart repair`.
   `force_extraction=True` so the session's learnings are available before
   the next openClaw run.
 
-The full design lives in
-[`docs/superpowers/specs/2026-05-19-openclaw-smart-design.md`](../../../../docs/superpowers/specs/2026-05-19-openclaw-smart-design.md).
+A detailed design note also exists in Reflexio's private enterprise planning docs; it is not part of this standalone open-source package.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Removes a broken standalone README link from the OpenClaw integration README.
- Replaces it with a concise note that the detailed design note lives in private enterprise planning docs.

## Repositories/submodules reviewed
- Parent: `ReflexioAI/reflexio-enterprise`
- Submodule: `ReflexioAI/reflexio`
- Submodule: `ReflexioAI/claude-smart`

## README files updated
- `reflexio/integrations/openclaw/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/integrations/openclaw/README.md`

## Notes/Risks
- Update follows `/root/reflexio-enterprise/how_to_write_readme.md` and preserves `open_source/reflexio/README.md` as the public user-facing README.
- README-only change; no code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the integration documentation to clarify that detailed design information is maintained in private planning materials and is not included in the open-source package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->