### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -7,6 +7,7 @@ Describe the code structure and component dependencies for source code of reflex
 - [models and client](#models-and-client)
 - [cli](#cli)
 - [reflexio_lib](#reflexio_lib)
+- [mem0](#mem0)
 - [server](#server)
 - [data](#data)
 - [See Also](#see-also)
@@ -25,6 +26,7 @@ Reflexio is a user profiling and agent playbook system with three main access pa
 - `server` - FastAPI backend with LLM-based processing services
 - `data` - Bundled configs and local fixtures
 - `docs` - Next.js API documentation site
+- `mem0` - Optional mem0 hosted-client compatibility wrapper that mirrors learning into Reflexio
 
 ## models and client
 Description: Shared data contracts and the Python SDK used by external applications, the CLI, and server endpoint helpers
@@ -95,6 +97,24 @@ Direct programmatic access without HTTP/API layer:
 
 ### Architecture Pattern
 Creates `RequestContext` and directly calls `GenerationService` - bypasses FastAPI layer. Methods are **synchronous** unlike `ReflexioClient`.
+
+## mem0
+Description: Optional compatibility layer for hosted mem0 clients that preserves mem0 behavior while adding Reflexio learning.
+
+**Detailed Documentation**: See [`reflexio/mem0/README.md`](mem0/README.md) for wrapper internals, identity scoping, and failure-mode contracts.
+
+### Main Entry Points
+- **Public exports**: `mem0/__init__.py` - `MemoryClient`, `AsyncMemoryClient`, local `Memory`/`AsyncMemory` re-exports, and Reflexio helper classes.
+- **Hosted wrappers**: `mem0/_wrapper.py` - Sync/async mem0 client subclasses that mirror `add()` calls and optionally enrich `search()`.
+- **Lifecycle facade**: `mem0/_facade.py` - Explicit `client.reflexio` cleanup/delete operations scoped to mem0 identities.
+
+### Purpose
+1. **One-import migration** - mem0 users can install `reflexio-ai[mem0]` and switch imports to `reflexio.mem0`.
+2. **Best-effort learning mirror** - mem0 writes remain primary; Reflexio publish/search side effects are optional and fail-open.
+3. **Scoped operations** - `user_id`, `app_id`, `agent_id`, and `run_id` are mapped into deterministic Reflexio user/session scopes.
+
+### Architecture Pattern
+Pass-through wrapper around mem0 hosted clients. Reflexio is configured via environment, inline kwargs, or injected `ReflexioClient`; absent Reflexio configuration leaves mem0 behavior unchanged. `search()` is mem0-only unless `include_reflexio=True`, which reserves a `reflexio` namespace on returned results.
 
 ## server
 Description: FastAPI backend server that processes user interactions to generate profiles, extract playbooks, and evaluate agent success
@@ -191,3 +211,4 @@ Referenced by `SimpleConfigurator` for loading configs and by database operation
 - [Site Variables README](server/site_var/README.md) -- global configuration and feature flags
 - [Retrieval Latency Benchmarks](benchmarks/retrieval_latency/README.md) -- search performance benchmarking
 - [OpenClaw Integration](integrations/openclaw/README.md) -- federated OpenClaw plugin setup and behavior
+- [mem0 Wrapper](mem0/README.md) -- hosted mem0 compatibility wrapper and Reflexio mirroring contracts

--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -114,7 +114,7 @@ Description: Optional compatibility layer for hosted mem0 clients that preserves
 3. **Scoped operations** - `user_id`, `app_id`, `agent_id`, and `run_id` are mapped into deterministic Reflexio user/session scopes.
 
 ### Architecture Pattern
-Pass-through wrapper around mem0 hosted clients. Reflexio is configured via environment, inline kwargs, or injected `ReflexioClient`; absent Reflexio configuration leaves mem0 behavior unchanged. `search()` is mem0-only unless `include_reflexio=True`, which reserves a `reflexio` namespace on returned results.
+Pass-through wrapper around mem0-hosted clients. Reflexio is configured via environment, inline kwargs, or injected `ReflexioClient`; absent Reflexio configuration leaves mem0 behavior unchanged. `search()` is mem0-only unless `include_reflexio=True`, which reserves a `reflexio` namespace on returned results.
 
 ## server
 Description: FastAPI backend server that processes user interactions to generate profiles, extract playbooks, and evaluate agent success

--- a/reflexio/mem0/README.md
+++ b/reflexio/mem0/README.md
@@ -1,0 +1,27 @@
+# reflexio/mem0
+Description: Drop-in mem0 hosted-client wrappers that keep mem0 behavior while mirroring learning events into Reflexio.
+
+## Main Entry Points
+
+- **Public exports**: `__init__.py` - Re-exports `MemoryClient`, `AsyncMemoryClient`, `Memory`, `AsyncMemory`, and Reflexio helper/failure classes for `from reflexio.mem0 import ...` imports.
+- **Hosted wrappers**: `_wrapper.py` - Subclasses mem0 hosted sync/async clients, mirrors `add()` conversations to Reflexio, optionally augments `search()`, and resolves mem0 identity scopes.
+- **Lifecycle facade**: `_facade.py` - Scope-aware Reflexio cleanup methods exposed as `client.reflexio` / async equivalent.
+- **Packaging hooks**: `pyproject.toml` and `client_dist/pyproject.toml` - Declare the `mem0` optional extra and include this package in both full and lightweight client distributions.
+
+## Purpose
+
+1. **One-import migration** - Existing mem0 users switch from `mem0.MemoryClient` to `reflexio.mem0.MemoryClient` without changing normal mem0 calls.
+2. **Best-effort Reflexio learning** - Hosted `add()` calls run mem0 first, then publish normalized user/assistant messages to Reflexio when `REFLEXIO_API_KEY`, `REFLEXIO_URL`, or an injected `ReflexioClient` is configured.
+3. **Opt-in enriched retrieval** - `search()` remains mem0-only unless callers pass `include_reflexio=True`; Reflexio results are returned under a reserved `reflexio` namespace.
+4. **Scoped cleanup** - `client.reflexio` exposes Reflexio delete/clear operations that translate mem0 `user_id`, `app_id`, `agent_id`, and `run_id` into deterministic Reflexio user/session scopes.
+
+## Architecture Pattern
+
+The wrapper is pass-through by default: construction must not fail when Reflexio is absent, and Reflexio failures must not change a successful mem0 result. `_wrapper.py` owns identity extraction from top-level args and simple one-level `AND` filters, message normalization, stable scope hashing, async/sync publish paths, and namespace-collision protection for opted-in search augmentation. `_facade.py` owns explicit Reflexio lifecycle calls and raises `ReflexioNotConfiguredError` only when the caller directly invokes a Reflexio operation without configuration.
+
+## Key Contracts
+
+- Install with `pip install 'reflexio-ai[mem0]'`; the optional extra tracks the certified `mem0ai>=2.0,<2.1` line.
+- `Memory` and `AsyncMemory` local classes are re-exported unchanged from mem0; only hosted `MemoryClient` and `AsyncMemoryClient` are wrapped.
+- Do not let Reflexio publish/search side effects break mem0 compatibility: log or annotate failures while preserving mem0 return values unless the caller opted into a Reflexio-specific operation.
+- Keep the `reflexio` search-result namespace reserved and raise `ReflexioNamespaceCollisionError` when an opted-in mem0 result already owns that key.

--- a/reflexio/mem0/README.md
+++ b/reflexio/mem0/README.md
@@ -17,7 +17,7 @@ Description: Drop-in mem0 hosted-client wrappers that keep mem0 behavior while m
 
 ## Architecture Pattern
 
-The wrapper is pass-through by default: construction must not fail when Reflexio is absent, and Reflexio failures must not change a successful mem0 result. `_wrapper.py` owns identity extraction from top-level args and simple one-level `AND` filters, message normalization, stable scope hashing, async/sync publish paths, and namespace-collision protection for opted-in search augmentation. `_facade.py` owns explicit Reflexio lifecycle calls and raises `ReflexioNotConfiguredError` only when the caller directly invokes a Reflexio operation without configuration.
+The wrapper is pass-through by default: construction must not fail when Reflexio is absent, and Reflexio failures must not change a successful mem0 result. An injected `reflexio_client` cannot be combined with inline Reflexio settings (`reflexio_timeout`, `reflexio_api_key`, or `reflexio_url_endpoint`). `_wrapper.py` owns identity extraction from top-level args and simple one-level `AND` filters, message normalization, stable scope hashing, async/sync publish paths, and namespace-collision protection for opted-in search augmentation. `_facade.py` owns explicit Reflexio lifecycle calls and raises `ReflexioNotConfiguredError` only when the caller directly invokes a Reflexio operation without configuration.
 
 ## Key Contracts
 


### PR DESCRIPTION
## Summary
- Adds a code-map README for `reflexio/mem0/` covering the mem0 wrapper entry points, contracts, and pass-through architecture.
- Updates `reflexio/README.md` so agents can discover the new mem0 compatibility component from the package-level code map.
- Changes follow `/root/reflexio-enterprise/how_to_write_readme.md` and keep the public `open_source/reflexio/README.md` user-facing README untouched.
- Clarifies that injected `reflexio_client` configuration is mutually exclusive with inline Reflexio settings and standardizes `mem0-hosted` wording.

## Repositories/submodules reviewed
- Parent: `ReflexioAI/reflexio-enterprise`
- Submodules: `ReflexioAI/claude-smart`, `ReflexioAI/reflexio`

## README files updated
- `reflexio/README.md`
- `reflexio/mem0/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/README.md reflexio/mem0/README.md`

## Notes/Risks
- Submodule-only documentation update; the parent repository submodule pointer should not be committed for this unmerged docs branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added documentation for the optional mem0 compatibility layer.
  - Documented hosted client wrappers, lifecycle integration, migration behavior, identity scoping, configuration, search augmentation, and failure handling.
  - Added guidance on installation requirements, packaging, exports, and namespace-collision behavior.
  - Linked the new mem0 documentation from the main project README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->