### PR TITLE
perf: streamline evaluation overview reads

### DIFF
--- a/reflexio/lib/_search.py
+++ b/reflexio/lib/_search.py
@@ -58,11 +58,14 @@ class SearchMixin(ReflexioBase):
                         ),
                         limit=request.limit or 100,
                         agent_version=request.agent_version,
+                        include_embedding=False,
                     )
                 )
             else:
                 results = self._get_storage().get_agent_success_evaluation_results(
-                    limit=request.limit or 100, agent_version=request.agent_version
+                    limit=request.limit or 100,
+                    agent_version=request.agent_version,
+                    include_embedding=False,
                 )
             return GetAgentSuccessEvaluationResultsResponse(
                 success=True,

--- a/reflexio/models/api_schema/eval_overview_schema.py
+++ b/reflexio/models/api_schema/eval_overview_schema.py
@@ -12,6 +12,7 @@ from typing import Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from reflexio.models.api_schema.domain import CitationKind
+from reflexio.models.api_schema.ui.entities import EvaluationResultView
 from reflexio.models.api_schema.validators import NonEmptyStr
 from reflexio.models.structured_output import StrictStructuredOutput
 
@@ -277,10 +278,26 @@ class SourceSetEvaluationMetrics(BaseModel):
     braintrust_tiles: list[BraintrustTileRow] = Field(default_factory=list)
 
 
+class EvaluationSessionKey(BaseModel):
+    """Collision-safe identity for one evaluated user session."""
+
+    user_id: str
+    session_id: str
+
+
+class SourceSessions(BaseModel):
+    """Evaluated session IDs grouped by their first request source."""
+
+    source: str
+    session_ids: list[str] = Field(default_factory=list)
+    sessions: list[EvaluationSessionKey] = Field(default_factory=list)
+
+
 class SourceSetComparison(BaseModel):
     """Comparison payload for request-source cohorts."""
 
     available_sources: list[str] = Field(default_factory=list)
+    source_sessions: list[SourceSessions] = Field(default_factory=list)
     sets: list[SourceSetEvaluationMetrics] = Field(default_factory=list)
     unmatched_session_count: int = Field(default=0, ge=0)
 
@@ -294,6 +311,7 @@ class GetEvaluationOverviewResponse(BaseModel):
     shadow_win_rate_trend: ShadowWinRateTrend = Field(
         default_factory=ShadowWinRateTrend
     )
+    recent_results: list[EvaluationResultView] = Field(default_factory=list)
     source_set_comparison: SourceSetComparison = Field(
         default_factory=SourceSetComparison
     )

--- a/reflexio/server/services/evaluation_overview/service.py
+++ b/reflexio/server/services/evaluation_overview/service.py
@@ -26,6 +26,7 @@ from reflexio.models.api_schema.eval_overview_schema import (
     BraintrustTileRow,
     BucketLiteral,
     ContextTile,
+    EvaluationSessionKey,
     EvaluationSourceSetRequest,
     GetEvaluationOverviewRequest,
     GetEvaluationOverviewResponse,
@@ -36,9 +37,11 @@ from reflexio.models.api_schema.eval_overview_schema import (
     RuleAttributionRow,
     ScoreDistribution,
     ShadowWinRateTrend,
+    SourceSessions,
     SourceSetComparison,
     SourceSetEvaluationMetrics,
 )
+from reflexio.models.api_schema.ui.converters import to_evaluation_result_view
 from reflexio.models.config_schema import Config
 from reflexio.server.services.evaluation_overview.components.distribution import (
     BUCKET_LABELS,
@@ -91,6 +94,8 @@ class EvaluationOverviewService:
             always be empty, so every tile would display "no baseline"
             regardless of how much data the org has.
         """
+        total_started_at = time.perf_counter()
+
         # Tile + distribution baselines are always last-7d-vs-prior-7d,
         # anchored to ``request.to_ts`` (which is "now" from the frontend's
         # perspective).
@@ -104,6 +109,7 @@ class EvaluationOverviewService:
             from_ts=load_from,
             to_ts=request.to_ts,
             agent_version=None,
+            include_embedding=False,
         )
         self._log_phase("eval_results", start, rows=len(all_results))
 
@@ -190,15 +196,35 @@ class EvaluationOverviewService:
             prior_scores=prior_scores,
         )
 
-        return GetEvaluationOverviewResponse(
+        recent_results = [
+            to_evaluation_result_view(result)
+            for result in sorted(
+                results,
+                key=lambda result: (result.created_at, result.result_id),
+                reverse=True,
+            )[:100]
+        ]
+        response = GetEvaluationOverviewResponse(
             hero=hero,
             context_tiles=tiles,
             rule_attribution=attribution,
             score_distribution=distribution,
             braintrust_tiles=braintrust_tiles,
             shadow_win_rate_trend=shadow_win_rate_trend,
+            recent_results=recent_results,
             source_set_comparison=source_set_comparison,
         )
+        response_size_bytes = len(response.model_dump_json().encode("utf-8"))
+        self._log_phase(
+            "total",
+            total_started_at,
+            from_ts=request.from_ts,
+            to_ts=request.to_ts,
+            results=len(results),
+            sources=len(source_set_comparison.available_sources),
+            response_bytes=response_size_bytes,
+        )
+        return response
 
     # --- private helpers ---
 
@@ -385,8 +411,29 @@ class EvaluationOverviewService:
         available_sources = sorted(
             {session_sources.get((r.user_id, r.session_id), "") for r in results}
         )
+        sessions_by_source: dict[str, set[ResultKey]] = defaultdict(set)
+        for result in results:
+            if result.session_id:
+                source = session_sources.get((result.user_id, result.session_id), "")
+                sessions_by_source[source].add((result.user_id, result.session_id))
+        source_sessions = [
+            SourceSessions(
+                source=source,
+                session_ids=sorted(
+                    {session_id for _, session_id in sessions_by_source[source]}
+                ),
+                sessions=[
+                    EvaluationSessionKey(user_id=user_id, session_id=session_id)
+                    for user_id, session_id in sorted(sessions_by_source[source])
+                ],
+            )
+            for source in available_sources
+        ]
         if not source_sets:
-            return SourceSetComparison(available_sources=available_sources)
+            return SourceSetComparison(
+                available_sources=available_sources,
+                source_sessions=source_sessions,
+            )
 
         requested_sources = {source for s in source_sets for source in s.sources}
         unmatched = sum(
@@ -438,6 +485,7 @@ class EvaluationOverviewService:
             )
         return SourceSetComparison(
             available_sources=available_sources,
+            source_sessions=source_sessions,
             sets=rows,
             unmatched_session_count=unmatched,
         )

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -864,7 +864,9 @@ def _row_to_agent_playbook(row: sqlite3.Row) -> AgentPlaybook:
     )
 
 
-def _row_to_eval_result(row: sqlite3.Row) -> AgentSuccessEvaluationResult:
+def _row_to_eval_result(
+    row: sqlite3.Row, *, include_embedding: bool = True
+) -> AgentSuccessEvaluationResult:
     d = dict(row)
     return AgentSuccessEvaluationResult(
         result_id=d["result_id"],
@@ -885,7 +887,7 @@ def _row_to_eval_result(row: sqlite3.Row) -> AgentSuccessEvaluationResult:
         user_turns_to_resolution=d.get("user_turns_to_resolution"),
         is_escalated=bool(d.get("is_escalated", False)),
         tags=_json_loads(d.get("tags")),
-        embedding=[],
+        embedding=(_json_loads(d.get("embedding")) or [] if include_embedding else []),
     )
 
 

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_eval_results.py
@@ -29,6 +29,13 @@ from .._base import (
     _row_to_eval_result,
 )
 
+_EVAL_RESULT_COLUMNS = (
+    "result_id, user_id, session_id, agent_version, evaluation_name, is_success, "
+    "failure_type, failure_reason, regular_vs_shadow, "
+    "number_of_correction_per_session, user_turns_to_resolution, is_escalated, "
+    "tags, created_at"
+)
+
 
 class AgentEvaluationResultStoreMixin:
     """Mixin providing agent success evaluation result CRUD for SQLite storage."""
@@ -108,8 +115,14 @@ class AgentEvaluationResultStoreMixin:
         agent_version: str | None = None,
         user_id: str | None = None,
         only_untagged: bool = False,
+        include_embedding: bool = True,
     ) -> list[AgentSuccessEvaluationResult]:
-        sql = "SELECT * FROM agent_success_evaluation_result"
+        columns = (
+            f"{_EVAL_RESULT_COLUMNS}, embedding"
+            if include_embedding
+            else _EVAL_RESULT_COLUMNS
+        )
+        sql = f"SELECT {columns} FROM agent_success_evaluation_result"
         params: list[Any] = []
         clauses: list[str] = []
         if agent_version is not None:
@@ -125,7 +138,9 @@ class AgentEvaluationResultStoreMixin:
         sql += " ORDER BY created_at DESC LIMIT ?"
         params.append(limit)
         rows = self._fetchall(sql, params)
-        return [_row_to_eval_result(r) for r in rows]
+        return [
+            _row_to_eval_result(r, include_embedding=include_embedding) for r in rows
+        ]
 
     @SQLiteStorageBase.handle_exceptions
     def update_agent_success_evaluation_result_tags(
@@ -192,9 +207,15 @@ class AgentEvaluationResultStoreMixin:
         to_ts: int,
         agent_version: str | None = None,
         limit: int | None = None,
+        include_embedding: bool = True,
     ) -> list[AgentSuccessEvaluationResult]:
-        sql = """SELECT * FROM agent_success_evaluation_result
-                 WHERE created_at >= ? AND created_at <= ?"""
+        columns = (
+            f"{_EVAL_RESULT_COLUMNS}, embedding"
+            if include_embedding
+            else _EVAL_RESULT_COLUMNS
+        )
+        sql = f"""SELECT {columns} FROM agent_success_evaluation_result
+                  WHERE created_at >= ? AND created_at <= ?"""
         params: list[Any] = [_epoch_to_iso(from_ts), _epoch_to_iso(to_ts)]
         if agent_version is not None:
             sql += " AND agent_version = ?"
@@ -204,7 +225,9 @@ class AgentEvaluationResultStoreMixin:
             sql += " LIMIT ?"
             params.append(limit)
         rows = self._fetchall(sql, params)
-        return [_row_to_eval_result(r) for r in rows]
+        return [
+            _row_to_eval_result(r, include_embedding=include_embedding) for r in rows
+        ]
 
     @SQLiteStorageBase.handle_exceptions
     def get_agent_success_evaluation_result_ids(

--- a/reflexio/server/services/storage/storage_base/playbook/_eval_results.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_eval_results.py
@@ -40,6 +40,7 @@ class AgentEvaluationResultStoreMixin:
         agent_version: str | None = None,
         user_id: str | None = None,
         only_untagged: bool = False,
+        include_embedding: bool = True,
     ) -> list[AgentSuccessEvaluationResult]:
         """Get agent success evaluation results from storage.
 
@@ -48,6 +49,7 @@ class AgentEvaluationResultStoreMixin:
             agent_version (str, optional): The agent version to filter by. If None, returns all results.
             user_id (str, optional): The user id to filter by. If None, returns all users.
             only_untagged (bool): When true, return only rows awaiting tagging.
+            include_embedding (bool): When false, omit embedding data from the read.
 
         Returns:
             list[AgentSuccessEvaluationResult]: List of agent success evaluation result objects
@@ -71,6 +73,7 @@ class AgentEvaluationResultStoreMixin:
         to_ts: int,
         agent_version: str | None = None,
         limit: int | None = None,
+        include_embedding: bool = True,
     ) -> list[AgentSuccessEvaluationResult]:
         """Return eval results in ``[from_ts, to_ts]``.
 
@@ -81,6 +84,7 @@ class AgentEvaluationResultStoreMixin:
         rows = self.get_agent_success_evaluation_results(
             limit=limit or 10_000,
             agent_version=agent_version,
+            include_embedding=include_embedding,
         )
         return [r for r in rows if from_ts <= r.created_at <= to_ts]
 

--- a/tests/lib/test_search_unit.py
+++ b/tests/lib/test_search_unit.py
@@ -69,6 +69,13 @@ class TestGetAgentSuccessEvaluationResults:
 
         assert response.success is True
         assert len(response.agent_success_evaluation_results) == 1
+        _get_storage(
+            mixin
+        ).get_agent_success_evaluation_results.assert_called_once_with(
+            limit=50,
+            agent_version=None,
+            include_embedding=False,
+        )
 
     def test_storage_not_configured(self):
         """Returns empty list when storage is not configured."""

--- a/tests/server/llm/test_litellm_client.py
+++ b/tests/server/llm/test_litellm_client.py
@@ -315,8 +315,14 @@ class TestLiteLLMClientAPIKeyOverride:
         assert client._api_base is None
         assert client._api_version is None
 
-    def test_create_client_with_azure_openai_config(self):
+    def test_create_client_with_azure_openai_config(self, monkeypatch):
         """Test creating a client with Azure OpenAI configuration."""
+        monkeypatch.setattr(
+            "reflexio.models.api_schema.validators.socket.getaddrinfo",
+            lambda _host, port, *_args, **_kwargs: [
+                (2, 1, 0, "", ("93.184.216.34", port or 443))
+            ],
+        )
         api_key_config = APIKeyConfig(
             openai=OpenAIConfig(
                 azure_config=AzureOpenAIConfig(

--- a/tests/server/services/evaluation_overview/test_service_integration.py
+++ b/tests/server/services/evaluation_overview/test_service_integration.py
@@ -120,6 +120,40 @@ def test_service_returns_empty_state_when_no_results() -> None:
     assert response.hero.state == "empty"
     assert response.context_tiles.success.current == 0.0
     assert response.rule_attribution == []
+    assert response.recent_results == []
+
+
+def test_service_returns_newest_100_embedding_free_results() -> None:
+    results = [
+        _eval_result(
+            result_id=index,
+            session_id=f"s{index}",
+            is_success=index % 2 == 0,
+            created_at=1_700_000_000 + index,
+        )
+        for index in range(1, 106)
+    ]
+    for result in results:
+        result.embedding = [0.25] * 512
+    storage = _storage_with_results(list(reversed(results[::2])) + results[1::2])
+    config = Config(storage_config=StorageConfigSQLite())
+
+    response = EvaluationOverviewService(storage=storage, config=config).run(
+        GetEvaluationOverviewRequest(
+            from_ts=1_700_000_000,
+            to_ts=1_700_000_200,
+            include_shadow=False,
+        )
+    )
+
+    assert [row.result_id for row in response.recent_results] == list(range(105, 5, -1))
+    assert all("embedding" not in row.model_dump() for row in response.recent_results)
+    storage.get_agent_success_evaluation_results_in_window.assert_called_once_with(
+        from_ts=1_699_395_200,
+        to_ts=1_700_000_200,
+        agent_version=None,
+        include_embedding=False,
+    )
 
 
 def test_service_reports_single_recent_success_as_100_percent() -> None:
@@ -342,9 +376,125 @@ def test_service_limits_source_lookup_to_window_when_no_source_sets() -> None:
     )
 
     assert response.source_set_comparison.available_sources == ["current-source"]
+    assert [
+        group.model_dump() for group in response.source_set_comparison.source_sessions
+    ] == [
+        {
+            "source": "current-source",
+            "session_ids": ["current"],
+            "sessions": [{"user_id": "u1", "session_id": "current"}],
+        }
+    ]
     storage.get_first_requests_by_user_session_pairs.assert_called_once_with(
         [("u1", "current")]
     )
+
+
+def test_service_groups_source_sessions_without_duplicate_session_ids() -> None:
+    now = int(time.time())
+    results = [
+        _eval_result(result_id=1, session_id="shared", is_success=True, created_at=now),
+        _eval_result(
+            result_id=2, session_id="shared", is_success=False, created_at=now
+        ),
+        _eval_result(result_id=3, session_id="other", is_success=True, created_at=now),
+    ]
+    storage = _storage_with_results(results)
+    storage.get_first_requests_by_user_session_pairs.return_value = {
+        ("u1", "shared"): SessionFirstRequest(
+            session_id="shared",
+            user_id="u1",
+            source="api",
+            created_at=now,
+        ),
+        ("u1", "other"): SessionFirstRequest(
+            session_id="other",
+            user_id="u1",
+            source="web",
+            created_at=now,
+        ),
+    }
+
+    response = EvaluationOverviewService(
+        storage=storage,
+        config=Config(storage_config=StorageConfigSQLite()),
+    ).run(
+        GetEvaluationOverviewRequest(
+            from_ts=now - 60,
+            to_ts=now,
+            include_shadow=False,
+        )
+    )
+
+    assert [
+        group.model_dump() for group in response.source_set_comparison.source_sessions
+    ] == [
+        {
+            "source": "api",
+            "session_ids": ["shared"],
+            "sessions": [{"user_id": "u1", "session_id": "shared"}],
+        },
+        {
+            "source": "web",
+            "session_ids": ["other"],
+            "sessions": [{"user_id": "u1", "session_id": "other"}],
+        },
+    ]
+
+
+def test_service_preserves_user_identity_when_session_ids_collide() -> None:
+    now = int(time.time())
+    results = [
+        _eval_result(
+            result_id=1,
+            user_id="user-api",
+            session_id="shared",
+            is_success=True,
+            created_at=now,
+        ),
+        _eval_result(
+            result_id=2,
+            user_id="user-web",
+            session_id="shared",
+            is_success=False,
+            created_at=now,
+        ),
+    ]
+    storage = _storage_with_results(results)
+    storage.get_first_requests_by_user_session_pairs.return_value = {
+        ("user-api", "shared"): SessionFirstRequest(
+            session_id="shared",
+            user_id="user-api",
+            source="api",
+            created_at=now,
+        ),
+        ("user-web", "shared"): SessionFirstRequest(
+            session_id="shared",
+            user_id="user-web",
+            source="web",
+            created_at=now,
+        ),
+    }
+
+    response = EvaluationOverviewService(
+        storage=storage,
+        config=Config(storage_config=StorageConfigSQLite()),
+    ).run(
+        GetEvaluationOverviewRequest(
+            from_ts=now - 60,
+            to_ts=now,
+            include_shadow=False,
+        )
+    )
+
+    groups = {
+        group.source: [session.model_dump() for session in group.sessions]
+        for group in response.source_set_comparison.source_sessions
+    }
+    assert groups == {
+        "api": [{"user_id": "user-api", "session_id": "shared"}],
+        "web": [{"user_id": "user-web", "session_id": "shared"}],
+    }
 
 
 def test_service_loads_baseline_sources_when_source_sets_requested() -> None:

--- a/tests/server/services/storage/test_session_window_contract.py
+++ b/tests/server/services/storage/test_session_window_contract.py
@@ -337,6 +337,45 @@ def test_eval_result_window_read_filters_in_storage_contract(
     assert {r.session_id for r in v1_inside} == {"inside"}
 
 
+def test_eval_result_reads_can_omit_embeddings_without_changing_default(
+    storage: BaseStorage,
+) -> None:
+    embedding = [0.25] * 512
+    storage.save_agent_success_evaluation_results(
+        [
+            AgentSuccessEvaluationResult(
+                user_id="u1",
+                session_id="embedding-contract",
+                agent_version="v1",
+                evaluation_name="overall_success",
+                is_success=False,
+                failure_type="wrong_answer",
+                failure_reason="incorrect",
+                embedding=embedding,
+                created_at=200,
+            )
+        ]
+    )
+    sqlite_storage = cast(SQLiteStorage, storage)
+
+    default_rows = storage.get_agent_success_evaluation_results_in_window(150, 250)
+    with patch.object(
+        sqlite_storage,
+        "_fetchall",
+        wraps=sqlite_storage._fetchall,
+    ) as fetchall:
+        lightweight_rows = storage.get_agent_success_evaluation_results_in_window(
+            150,
+            250,
+            include_embedding=False,
+        )
+
+    assert default_rows[0].embedding == embedding
+    assert lightweight_rows[0].embedding == []
+    selected_columns = str(fetchall.call_args.args[0]).split("FROM", maxsplit=1)[0]
+    assert "embedding" not in selected_columns
+
+
 def test_targeted_eval_result_id_lookup(
     storage: BaseStorage,
 ) -> None:


### PR DESCRIPTION
## Summary
- Make the evaluation overview the dashboard's single critical data source.
- Avoid reading and serializing unused 512-dimensional embeddings on UI-facing evaluation queries.
- Return recent evaluation summaries and collision-safe source/session memberships in the overview response.

## Changes
- Add `recent_results` and source-grouped session memberships to the evaluation overview schema and service.
- Add opt-out embedding projections for SQLite storage while preserving embedding inclusion by default.
- Make the public raw-results read use the lightweight embedding-free path.
- Extend overview phase logging with request, row-count, source-count, response-size, and total-duration context.
- Cover result ordering, embedding omission, source grouping, duplicate sessions, and cross-user session-ID collisions.

## Test Plan
- `uv run ruff check open_source/reflexio/reflexio/ reflexio_ext/`
- `uv run pyright --threads 4`
- `uv run pytest tests/ --ignore=tests/e2e_tests/ -q -o 'addopts='` (6172 passed, 14 skipped)
- `uv run pytest tests/e2e_tests/ -q -o 'addopts='` (47 passed, 87 skipped)
- `uv run pytest tests/server/services/evaluation_overview/test_service_integration.py -q -o 'addopts='` (16 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evaluation overviews now include the 100 most recent evaluation results, ordered newest first.
  * Source-session comparisons now preserve user identity and prevent collisions when session IDs overlap.

* **Bug Fixes**
  * Evaluation overview results no longer load embeddings unnecessarily, improving response efficiency.
  * Storage reads can selectively include or omit embeddings while preserving existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->