### PR TITLE
docs: replace violet syntax accent with leaf

### DIFF
--- a/docs/components/method/json-view.tsx
+++ b/docs/components/method/json-view.tsx
@@ -59,7 +59,7 @@ const colorMap: Record<TokenType, string> = {
   key: "text-blue-700 dark:text-blue-400",
   string: "text-emerald-700 dark:text-emerald-400",
   number: "text-amber-700 dark:text-amber-400",
-  boolean: "text-purple-700 dark:text-purple-400",
+  boolean: "text-[#53701A] dark:text-[#A7C957]",
   null: "text-red-600 dark:text-red-400",
   punctuation: "text-muted-foreground",
 };


### PR DESCRIPTION
## Summary
- align the OSS API documentation with Reflexio's new leaf-green learning accent
- replace the remaining violet boolean syntax color with accessible leaf values for light and dark themes

## Changes
- use `#53701A` for light-theme boolean tokens
- use `#A7C957` for dark-theme boolean tokens

## Test Plan
- `npm run lint -- components/method/json-view.tsx`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated boolean values in JSON views to use olive-green highlighting in both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->