### PR TITLE
style(docs): align the API docs with the landing page and #81B29A

### DIFF
--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -9,6 +9,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-geist-mono);
+  --font-display: var(--font-display);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -54,7 +55,10 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
+  /* Signature sage #81B29A, deepened for light so white text clears AA
+     (6.89:1). See the enterprise `website/app/globals.css` for the measured
+     pair this mirrors. */
+  --primary: oklch(0.458 0.079 159.8);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
@@ -65,7 +69,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --ring: oklch(0.458 0.079 159.8);
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
@@ -74,7 +78,7 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary: oklch(0.458 0.079 159.8);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
@@ -89,7 +93,8 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
+  /* Dark carries the signature #81B29A itself — 7.42:1 on the dark card. */
+  --primary: oklch(0.722 0.063 163.1);
   --primary-foreground: oklch(0.205 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
@@ -100,7 +105,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.722 0.063 163.1);
   --chart-1: oklch(0.809 0.105 251.813);
   --chart-2: oklch(0.623 0.214 259.815);
   --chart-3: oklch(0.546 0.245 262.881);
@@ -108,7 +113,7 @@
   --chart-5: oklch(0.424 0.199 265.638);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary: oklch(0.722 0.063 163.1);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.269 0 0);
   --sidebar-accent-foreground: oklch(0.985 0 0);
@@ -125,5 +130,14 @@
   }
   html {
     @apply font-sans;
+  }
+  /* Headings pick up the marketing serif so the OSS docs, the hosted docs and
+     the landing page read as one product. Scoped to h1/h2 only — h3 and below
+     stay on the sans, which is what the other two surfaces do. */
+  h1,
+  h2 {
+    font-family: var(--font-display), ui-serif, Georgia, serif;
+    font-weight: 500;
+    letter-spacing: -0.015em;
   }
 }

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -1,13 +1,27 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Geist, Geist_Mono, Newsreader } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Sidebar } from "@/components/layout/sidebar";
 import { TopBar } from "@/components/layout/top-bar";
 
-const inter = Inter({
+const bodyFont = Geist({
   variable: "--font-sans",
   subsets: ["latin"],
+});
+
+// `globals.css` has always asked for `--font-geist-mono`; until now nothing
+// defined it, so `font-mono` silently fell back.
+const monoFont = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+// The serif the marketing site sets its headings in.
+const displayFont = Newsreader({
+  variable: "--font-display",
+  subsets: ["latin"],
+  style: ["normal"],
 });
 
 export const metadata: Metadata = {
@@ -24,7 +38,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} h-full`} suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`${bodyFont.variable} ${monoFont.variable} ${displayFont.variable} h-full`}
+      suppressHydrationWarning
+    >
       <body className="h-full flex flex-col antialiased font-sans">
         <Providers>
           <TopBar />

--- a/docs/components/method/json-view.tsx
+++ b/docs/components/method/json-view.tsx
@@ -59,7 +59,7 @@ const colorMap: Record<TokenType, string> = {
   key: "text-blue-700 dark:text-blue-400",
   string: "text-emerald-700 dark:text-emerald-400",
   number: "text-amber-700 dark:text-amber-400",
-  boolean: "text-[#53701A] dark:text-[#A7C957]",
+  boolean: "text-[#296548] dark:text-[#81B29A]",
   null: "text-red-600 dark:text-red-400",
   punctuation: "text-muted-foreground",
 };


### PR DESCRIPTION
## Summary

Brings the OSS API docs onto the same visual system as the marketing site and the hosted docs. They were on stock shadcn neutrals and Inter, so they read as a different product.

Companion to ReflexioAI/reflexio-enterprise#993, which does the same for the website and `public_docs`.

> [!NOTE]
> The signature accent here is **#81B29A**, the colour the team discussed and voted on. This supersedes the leaf pair introduced in #450. @yilu331 for visibility.

## Palette

- `--primary`, `--ring` and `--sidebar-primary` now carry the signature sage.
  - **Light** uses a deepened `#296548` so white text clears AA (**6.89:1**).
  - **Dark** carries `#81B29A` itself (**7.42:1** on the dark card).
  - Converted to `oklch` to match the unit this file already uses, rather than eyeballed.
- The JSON boolean accent in `json-view.tsx` follows, replacing the leaf pair from #450.
- **Chart tokens deliberately untouched** — they are declared in the theme and consumed by nothing, so recolouring them would be churn.

## Type

- Inter → **Geist**, with **Newsreader** for `h1`/`h2`, matching the marketing site. Scoped to h1/h2 only; h3 and below stay on the sans, which is what the other two surfaces do.
- **Geist Mono is now actually loaded.** This is a real bug fix, not just a font swap: `globals.css` has always asked for `var(--font-geist-mono)` and **nothing ever defined it**, so `font-mono` resolved to nothing and every code sample fell back to the browser default.

## Verification

`npm run build` passes. Checked against the built stylesheet rather than assumed:

```
--primary:#296548                                      (light)
--primary:#81b29a                                      (dark)
--font-display:"Newsreader", "Newsreader Fallback"
--font-geist-mono:"Geist Mono", "Geist Mono Fallback"  (previously undefined)
```

`npm run lint` reports 0 errors (3 pre-existing warnings in `methods-list`, `top-bar.tsx` and `code-parser.ts`, none of which this PR touches).
