### PR TITLE
docs: fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ We welcome contributions! Please see [developer.md](developer.md) for guidelines
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=ReflexioAI/reflexio&type=Date)](https://star-history.com/#ReflexioAI/reflexio&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=ReflexioAI/reflexio&type=Date)](https://star-history.dera.page/#ReflexioAI/reflexio&Date)
 
 ## License
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This updates the chart links to a working alternative so the project's growth is visible again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History badge and link in the README to use the new Star History domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->