### PR TITLE
feat: filter playbook search by source

### DIFF
--- a/docs/lib/methods/agent-playbooks.ts
+++ b/docs/lib/methods/agent-playbooks.ts
@@ -79,6 +79,13 @@ export const agentPlaybookMethods: MethodDef[] = [
         description: "Filter by playbook name",
       },
       {
+        name: "source",
+        type: "string",
+        required: false,
+        description:
+          "Match agent playbooks linked to at least one user playbook with this exact source",
+      },
+      {
         name: "start_time",
         type: "datetime",
         required: false,
@@ -94,7 +101,7 @@ export const agentPlaybookMethods: MethodDef[] = [
         name: "status_filter",
         type: "json",
         required: false,
-        description: `Status filter as JSON array. Values: ${STATUS_ENUM.join(", ")}, null (for current)`,
+        description: `Lifecycle status filter as JSON array. Values: ${STATUS_ENUM.join(", ")}, null (for current). Defaults to current and pending`,
       },
       {
         name: "playbook_status_filter",

--- a/docs/lib/methods/unified-search.ts
+++ b/docs/lib/methods/unified-search.ts
@@ -54,6 +54,13 @@ export const unifiedSearchMethods: MethodDef[] = [
           "Filter by user ID (profiles, user_playbooks), at most 255 characters",
       },
       {
+        name: "source",
+        type: "string",
+        required: false,
+        description:
+          "Filter every selected entity by exact source; agent playbooks match through linked user playbooks",
+      },
+      {
         name: "entity_types",
         type: "json",
         required: false,

--- a/docs/lib/methods/user-playbooks.ts
+++ b/docs/lib/methods/user-playbooks.ts
@@ -95,6 +95,12 @@ export const userPlaybookMethods: MethodDef[] = [
         description: "Filter by playbook name",
       },
       {
+        name: "source",
+        type: "string",
+        required: false,
+        description: "Filter by exact interaction source",
+      },
+      {
         name: "start_time",
         type: "datetime",
         required: false,

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -887,6 +887,7 @@ class ReflexioClient:
         user_id: str | None = None,
         agent_version: str | None = None,
         playbook_name: str | None = None,
+        source: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         status_filter: list[Status | None] | None = None,
@@ -906,6 +907,7 @@ class ReflexioClient:
             user_id (Optional[str]): Filter by user (via request_id linkage to requests table)
             agent_version (Optional[str]): Filter by agent version
             playbook_name (Optional[str]): Filter by playbook name
+            source (Optional[str]): Filter by exact interaction source.
             start_time (Optional[datetime]): Start time for created_at filter
             end_time (Optional[datetime]): End time for created_at filter
             status_filter (Optional[list[Optional[Status]]]): Filter by status (None for CURRENT, PENDING, ARCHIVED)
@@ -929,6 +931,7 @@ class ReflexioClient:
             user_id=user_id,
             agent_version=agent_version,
             playbook_name=playbook_name,
+            source=source,
             start_time=start_time,
             end_time=end_time,
             status_filter=status_filter,
@@ -953,6 +956,7 @@ class ReflexioClient:
         user_id: str | None = None,
         agent_version: str | None = None,
         playbook_name: str | None = None,
+        source: str | None = None,
         start_time: datetime | None = None,
         end_time: datetime | None = None,
         status_filter: list[Status | None] | None = None,
@@ -972,9 +976,12 @@ class ReflexioClient:
                 retrieval-experiment assignment; it does not filter agent playbooks.
             agent_version (Optional[str]): Filter by agent version
             playbook_name (Optional[str]): Filter by playbook name
+            source (Optional[str]): Match agent playbooks linked to at least one
+                user playbook with this exact source.
             start_time (Optional[datetime]): Start time for created_at filter
             end_time (Optional[datetime]): End time for created_at filter
-            status_filter (Optional[list[Optional[Status]]]): Filter by status (None for CURRENT, PENDING, ARCHIVED)
+            status_filter (Optional[list[Optional[Status]]]): Filter by lifecycle status.
+                Defaults to CURRENT and PENDING when omitted.
             playbook_status_filter (Optional[PlaybookStatus]): Filter by playbook status (PENDING, APPROVED, REJECTED)
             tags (Optional[list[str]]): Match playbooks having any of these tags.
             top_k (Optional[int]): Maximum number of results to return (default: 10)
@@ -992,6 +999,7 @@ class ReflexioClient:
             user_id=user_id,
             agent_version=agent_version,
             playbook_name=playbook_name,
+            source=source,
             start_time=start_time,
             end_time=end_time,
             status_filter=status_filter,
@@ -2820,6 +2828,7 @@ class ReflexioClient:
         agent_version: str | None = None,
         playbook_name: str | None = None,
         user_id: str | None = None,
+        source: str | None = None,
         tags: list[str] | None = None,
         entity_types: list[str] | None = None,
         agent_playbook_status_filter: list[PlaybookStatus | str] | None = None,
@@ -2847,6 +2856,8 @@ class ReflexioClient:
             playbook_name (Optional[str]): Filter by playbook name (agent_playbooks, user_playbooks)
             user_id (Optional[str]): Filter by user ID (profiles, user_playbooks),
                 at most 255 characters.
+            source (Optional[str]): Filter every selected entity type by exact
+                source. Agent playbooks match through linked user playbooks.
             tags (Optional[list[str]]): Match entities having any requested tag.
             entity_types (Optional[list[str]]): Entity types to search. Valid values:
                 "profiles", "user_playbooks", "agent_playbooks".
@@ -2881,6 +2892,7 @@ class ReflexioClient:
             agent_version=agent_version,
             playbook_name=playbook_name,
             user_id=user_id,
+            source=source,
             tags=tags,
             entity_types=entity_types,
             agent_playbook_status_filter=agent_playbook_status_filter,
@@ -2907,6 +2919,7 @@ class ReflexioClient:
         agent_version: str | None = None,
         playbook_name: str | None = None,
         user_id: str | None = None,
+        source: str | None = None,
         tags: list[str] | None = None,
         entity_types: list[str] | None = None,
         agent_playbook_status_filter: list[PlaybookStatus | str] | None = None,
@@ -2928,6 +2941,7 @@ class ReflexioClient:
             agent_version=agent_version,
             playbook_name=playbook_name,
             user_id=user_id,
+            source=source,
             tags=tags,
             entity_types=entity_types,
             agent_playbook_status_filter=agent_playbook_status_filter,

--- a/reflexio/models/api_schema/retriever_schema.py
+++ b/reflexio/models/api_schema/retriever_schema.py
@@ -316,6 +316,7 @@ class SearchUserPlaybookRequest(BaseModel):
         user_id (str, optional): Filter by user (via request_id linkage to requests table)
         agent_version (str, optional): Filter by agent version
         playbook_name (str, optional): Filter by playbook name
+        source (str, optional): Filter by exact interaction source
         start_time (datetime, optional): Start time for created_at filter
         end_time (datetime, optional): End time for created_at filter
         status_filter (list[Optional[Status]], optional): Filter by status (None for CURRENT, PENDING, ARCHIVED)
@@ -328,6 +329,7 @@ class SearchUserPlaybookRequest(BaseModel):
     user_id: str | None = Field(default=None, max_length=255)
     agent_version: str | None = None
     playbook_name: str | None = None
+    source: SessionOutcomeSource | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
@@ -372,9 +374,12 @@ class SearchAgentPlaybookRequest(BaseModel):
             assignment when an experiment is active.
         agent_version (str, optional): Filter by agent version
         playbook_name (str, optional): Filter by playbook name
+        source (str, optional): Match agent playbooks linked to at least one
+            user playbook with this exact source
         start_time (datetime, optional): Start time for created_at filter
         end_time (datetime, optional): End time for created_at filter
-        status_filter (list[Optional[Status]], optional): Filter by status (None for CURRENT, PENDING, ARCHIVED)
+        status_filter (list[Optional[Status]], optional): Filter by lifecycle status.
+            Defaults to CURRENT and PENDING when omitted.
         playbook_status_filter (PlaybookStatus | list[PlaybookStatus], optional):
             Filter by playbook approval status. Accepts either a single
             ``PlaybookStatus`` (matched with ``=``) or a list (matched with
@@ -390,6 +395,7 @@ class SearchAgentPlaybookRequest(BaseModel):
     user_id: NonEmptyStr | None = None
     agent_version: str | None = None
     playbook_name: str | None = None
+    source: SessionOutcomeSource | None = None
     start_time: datetime | None = None
     end_time: datetime | None = None
     status_filter: list[Status | None] | None = None
@@ -802,6 +808,8 @@ class UnifiedSearchRequest(BaseModel):
         agent_version (str, optional): Filter by agent version (agent_playbooks, user_playbooks)
         playbook_name (str, optional): Filter by playbook name (agent_playbooks, user_playbooks)
         user_id (str, optional): Filter by user ID (profiles, user_playbooks)
+        source (str, optional): Filter all selected entity types by exact
+            source. Agent playbooks match through linked user playbooks.
         tags (list[str], optional): Match entities having any requested tag.
         entity_types (list[str], optional): Entity types to search. When omitted,
             searches profiles, user_playbooks, and agent_playbooks.
@@ -819,6 +827,7 @@ class UnifiedSearchRequest(BaseModel):
     agent_version: str | None = None
     playbook_name: str | None = None
     user_id: str | None = Field(default=None, max_length=255)
+    source: SessionOutcomeSource | None = None
     tags: list[str] | None = None
     entity_types: list[UnifiedSearchEntityType] | None = None
     agent_playbook_status_filter: list[PlaybookStatus] | None = None

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_agent.py
@@ -913,6 +913,17 @@ class AgentPlaybookStoreMixin:
         if playbook_name:
             conditions.append("ap.playbook_name = ?")
             params.append(playbook_name)
+        if request.source:
+            conditions.append(
+                "EXISTS ("
+                "SELECT 1 FROM agent_playbook_source_user_playbooks apsup "
+                "JOIN user_playbooks source_up "
+                "ON source_up.user_playbook_id = apsup.user_playbook_id "
+                "WHERE apsup.agent_playbook_id = ap.agent_playbook_id "
+                "AND source_up.source = ?"
+                ")"
+            )
+            params.append(request.source)
         if start_time:
             conditions.append("ap.created_at >= ?")
             params.append(_epoch_to_iso(start_time))
@@ -935,9 +946,8 @@ class AgentPlaybookStoreMixin:
             conditions.append(frag)
             params.extend(sparams)
         else:
-            _ph = ",".join("?" * len(_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES))
-            conditions.append(f"(ap.status IS NULL OR ap.status NOT IN ({_ph}))")
-            params.extend(_AGENT_PLAYBOOK_DEFAULT_EXCLUDED_STATUSES)
+            conditions.append("(ap.status IS NULL OR ap.status = ?)")
+            params.append(Status.PENDING.value)
         tag_frag, tag_params = _build_tags_sql("ap", request.tags)
         if tag_frag:
             conditions.append(tag_frag)

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_user.py
@@ -1372,6 +1372,9 @@ class UserPlaybookStoreMixin:
         if playbook_name:
             conditions.append("up.playbook_name = ?")
             params.append(playbook_name)
+        if request.source:
+            conditions.append("up.source = ?")
+            params.append(request.source)
         if start_time:
             conditions.append("up.created_at >= ?")
             params.append(_epoch_to_iso(start_time))

--- a/reflexio/server/services/storage/sqlite_storage/profiles/_search.py
+++ b/reflexio/server/services/storage/sqlite_storage/profiles/_search.py
@@ -222,7 +222,7 @@ class ProfileSearchMixin:
             conditions.append("p.last_modified_timestamp <= ?")
             params.append(int(req.end_time.timestamp()))
         if req.source:
-            conditions.append("LOWER(p.source) = LOWER(?)")
+            conditions.append("p.source = ?")
             params.append(req.source)
         if status_filter is not None:
             frag, sparams = _build_status_sql(status_filter)

--- a/reflexio/server/services/unified_search_service.py
+++ b/reflexio/server/services/unified_search_service.py
@@ -516,6 +516,7 @@ def _run_phase_b(
                     start_time,
                     end_time,
                     tags=request.tags,
+                    source=request.source,
                 )
                 if "profiles" in entity_types
                 else None
@@ -535,6 +536,7 @@ def _run_phase_b(
                     start_time,
                     end_time,
                     tags=request.tags,
+                    source=request.source,
                 )
                 if "agent_playbooks" in entity_types
                 else None
@@ -545,6 +547,7 @@ def _run_phase_b(
                     user_id=request.user_id,
                     agent_version=request.agent_version,
                     playbook_name=request.playbook_name,
+                    source=request.source,
                     tags=request.tags,
                     status_filter=None,
                     threshold=threshold,
@@ -652,6 +655,7 @@ def _run_phase_b_single_rpc(
         user_id=request.user_id,
         agent_version=request.agent_version,
         playbook_name=request.playbook_name,
+        source=request.source,
         tags=request.tags,
         agent_playbook_statuses=statuses,
         search_mode=search_mode,
@@ -920,6 +924,7 @@ def _search_agent_playbooks_via_storage(
     start_time: datetime | None = None,
     end_time: datetime | None = None,
     tags: list[str] | None = None,
+    source: str | None = None,
 ) -> list[AgentPlaybook]:
     """Search agent playbooks, restricted to one or more approval statuses.
 
@@ -945,6 +950,7 @@ def _search_agent_playbooks_via_storage(
             query=query,
             agent_version=agent_version,
             playbook_name=playbook_name,
+            source=source,
             tags=tags,
             status_filter=[None],
             playbook_status_filter=statuses,
@@ -978,6 +984,7 @@ def _search_profiles_via_storage(
     start_time: datetime | None = None,
     end_time: datetime | None = None,
     tags: list[str] | None = None,
+    source: str | None = None,
 ) -> list[UserProfile]:
     """Search profiles via storage.search_user_profile, returning [] on error or missing user_id.
 
@@ -1014,6 +1021,7 @@ def _search_profiles_via_storage(
                     top_k=top_k,
                     threshold=threshold,
                     tags=tags,
+                    source=source,
                     search_mode=search_mode,
                     start_time=start_time,
                     end_time=end_time,

--- a/tests/client/test_search.py
+++ b/tests/client/test_search.py
@@ -106,6 +106,57 @@ async def test_unified_search_async_uses_native_transport(monkeypatch) -> None:
     assert captured["json"]["top_k"] == 4
 
 
+def test_playbook_and_unified_searches_serialize_source(monkeypatch) -> None:
+    client = ReflexioClient(api_key="test-key", url_endpoint="http://localhost:8000")
+    payloads: dict[str, dict[str, Any]] = {}
+
+    def fake_make_request(method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        payloads[path] = kwargs["json"]
+        if path == "/api/search_user_playbooks":
+            return {"success": True, "user_playbooks": []}
+        if path == "/api/search_agent_playbooks":
+            return {"success": True, "agent_playbooks": []}
+        return {
+            "success": True,
+            "profiles": [],
+            "agent_playbooks": [],
+            "user_playbooks": [],
+        }
+
+    monkeypatch.setattr(client, "_make_request", fake_make_request)
+
+    client.search_user_playbooks(query="billing", source="api")
+    client.search_agent_playbooks(query="billing", source="api")
+    client.search(query="billing", source="api")
+
+    assert payloads["/api/search_user_playbooks"]["source"] == "api"
+    assert payloads["/api/search_agent_playbooks"]["source"] == "api"
+    assert payloads["/api/search"]["source"] == "api"
+
+
+@pytest.mark.asyncio
+async def test_unified_search_async_serializes_source(monkeypatch) -> None:
+    client = ReflexioClient(api_key="test-key", url_endpoint="http://localhost:8000")
+    captured: dict[str, Any] = {}
+
+    async def fake_make_async_request(
+        method: str, path: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {
+            "success": True,
+            "profiles": [],
+            "agent_playbooks": [],
+            "user_playbooks": [],
+        }
+
+    monkeypatch.setattr(client, "_make_async_request", fake_make_async_request)
+
+    await client.search_async(query="billing", source="webhook")
+
+    assert captured["json"]["source"] == "webhook"
+
+
 def test_unified_search_docs_track_schema_contract() -> None:
     top_k_schema = _non_null_schema("top_k")
     identifier_limit = _non_null_schema("request_id")["maxLength"]

--- a/tests/models/api_schema/test_retriever_schema.py
+++ b/tests/models/api_schema/test_retriever_schema.py
@@ -7,7 +7,15 @@ context. These tests pin the contract.
 
 from __future__ import annotations
 
-from reflexio.models.api_schema.retriever_schema import UnifiedSearchResponse
+import pytest
+from pydantic import ValidationError
+
+from reflexio.models.api_schema.retriever_schema import (
+    SearchAgentPlaybookRequest,
+    SearchUserPlaybookRequest,
+    UnifiedSearchRequest,
+    UnifiedSearchResponse,
+)
 
 
 def test_unified_search_response_accepts_msg():
@@ -45,3 +53,40 @@ def test_unified_search_response_msg_roundtrips_through_json():
     restored = UnifiedSearchResponse.model_validate_json(r.model_dump_json())
     assert restored.msg == "partial: some agents timed out"
     assert restored.reformulated_query == "q"
+
+
+@pytest.mark.parametrize(
+    "search_request",
+    [
+        SearchUserPlaybookRequest(source="api"),
+        SearchAgentPlaybookRequest(source="webhook"),
+        UnifiedSearchRequest(query="billing", source="workflow:v1"),
+    ],
+)
+def test_search_requests_accept_valid_source(search_request):
+    assert search_request.source is not None
+
+
+@pytest.mark.parametrize(
+    ("model", "kwargs"),
+    [
+        (SearchUserPlaybookRequest, {}),
+        (SearchAgentPlaybookRequest, {}),
+        (UnifiedSearchRequest, {"query": "billing"}),
+    ],
+)
+def test_search_requests_reject_invalid_source(model, kwargs):
+    with pytest.raises(ValidationError):
+        model(source="Contains Spaces", **kwargs)
+
+
+@pytest.mark.parametrize(
+    "search_request",
+    [
+        SearchUserPlaybookRequest(source=""),
+        SearchAgentPlaybookRequest(source=""),
+        UnifiedSearchRequest(query="billing", source=""),
+    ],
+)
+def test_empty_search_source_is_accepted_as_no_filter(search_request):
+    assert search_request.source == ""

--- a/tests/server/services/storage/test_sqlite_storage.py
+++ b/tests/server/services/storage/test_sqlite_storage.py
@@ -15,6 +15,7 @@ from reflexio.models.api_schema.retriever_schema import (
 from reflexio.models.api_schema.service_schemas import (
     AgentPlaybook,
     ProfileTimeToLive,
+    Status,
     UserPlaybook,
     UserProfile,
 )
@@ -522,6 +523,151 @@ def test_search_agent_playbooks_with_agent_version_filter(storage):
     )
     assert len(results) == 1
     assert results[0].agent_version == "v2"
+
+
+def test_playbook_search_filters_by_exact_source_and_agent_provenance(storage):
+    user_playbooks = [
+        UserPlaybook(
+            user_id="user1",
+            agent_version="v1",
+            request_id="r-api",
+            content="resolve billing issue",
+            source="api",
+        ),
+        UserPlaybook(
+            user_id="user1",
+            agent_version="v1",
+            request_id="r-webhook",
+            content="resolve billing issue",
+            source="webhook",
+        ),
+    ]
+    storage.save_user_playbooks(user_playbooks)
+    agent_playbooks = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(agent_version="v1", content="api billing guidance"),
+            AgentPlaybook(agent_version="v1", content="webhook billing guidance"),
+            AgentPlaybook(agent_version="v1", content="orphan billing guidance"),
+        ]
+    )
+    storage.set_source_user_playbook_ids_for_agent_playbook(
+        agent_playbooks[0].agent_playbook_id,
+        [user_playbooks[0].user_playbook_id],
+    )
+    storage.set_source_user_playbook_ids_for_agent_playbook(
+        agent_playbooks[1].agent_playbook_id,
+        [user_playbooks[1].user_playbook_id],
+    )
+
+    user_query_results = storage.search_user_playbooks(
+        SearchUserPlaybookRequest(query="billing", source="api", top_k=10)
+    )
+    user_queryless_results = storage.search_user_playbooks(
+        SearchUserPlaybookRequest(source="webhook", top_k=10)
+    )
+    agent_query_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(query="billing", source="api", top_k=10)
+    )
+    agent_queryless_results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(source="webhook", top_k=10)
+    )
+
+    assert [item.request_id for item in user_query_results] == ["r-api"]
+    assert [item.request_id for item in user_queryless_results] == ["r-webhook"]
+    assert [item.agent_playbook_id for item in agent_query_results] == [
+        agent_playbooks[0].agent_playbook_id
+    ]
+    assert [item.agent_playbook_id for item in agent_queryless_results] == [
+        agent_playbooks[1].agent_playbook_id
+    ]
+
+
+@pytest.mark.parametrize("query", [None, "lifecycle default"])
+@pytest.mark.parametrize("source", [None, "api"])
+def test_agent_playbook_search_defaults_to_current_and_pending(storage, query, source):
+    user_playbook = UserPlaybook(
+        user_id="user1",
+        agent_version="v1",
+        request_id="r-api-lifecycle",
+        content="lifecycle source",
+        source="api",
+    )
+    storage.save_user_playbooks([user_playbook])
+    agent_playbooks = storage.save_agent_playbooks(
+        [
+            AgentPlaybook(
+                agent_version="v1",
+                content="lifecycle default current",
+            ),
+            AgentPlaybook(
+                agent_version="v1",
+                content="lifecycle default pending",
+                status=Status.PENDING,
+            ),
+            AgentPlaybook(
+                agent_version="v1",
+                content="lifecycle default archived",
+                status=Status.ARCHIVED,
+            ),
+        ]
+    )
+    for playbook in agent_playbooks:
+        storage.set_source_user_playbook_ids_for_agent_playbook(
+            playbook.agent_playbook_id,
+            [user_playbook.user_playbook_id],
+        )
+
+    results = storage.search_agent_playbooks(
+        SearchAgentPlaybookRequest(query=query, source=source, top_k=10)
+    )
+
+    assert {item.status for item in results} == {None, Status.PENDING}
+    assert {item.agent_playbook_id for item in results} == {
+        agent_playbooks[0].agent_playbook_id,
+        agent_playbooks[1].agent_playbook_id,
+    }
+
+
+def test_source_filter_is_applied_before_vector_top_k(storage):
+    playbooks = [
+        UserPlaybook(
+            user_id="user1",
+            agent_version="v1",
+            request_id="r-wrong",
+            content="wrong source",
+            source="webhook",
+        ),
+        UserPlaybook(
+            user_id="user1",
+            agent_version="v1",
+            request_id="r-right",
+            content="right source",
+            source="api",
+        ),
+    ]
+    storage.save_user_playbooks(playbooks)
+    storage.conn.execute(
+        "UPDATE user_playbooks SET embedding = ? WHERE request_id = ?",
+        (json.dumps(_pad_embedding([1.0, 0.0])), "r-wrong"),
+    )
+    storage.conn.execute(
+        "UPDATE user_playbooks SET embedding = ? WHERE request_id = ?",
+        (json.dumps(_pad_embedding([0.5, 0.5])), "r-right"),
+    )
+    storage.conn.commit()
+
+    results = storage.search_user_playbooks(
+        SearchUserPlaybookRequest(
+            query="source",
+            source="api",
+            search_mode=SearchMode.VECTOR,
+            top_k=1,
+            threshold=0.0,
+        ),
+        SearchOptions(query_embedding=_pad_embedding([1.0, 0.0])),
+    )
+
+    assert [item.request_id for item in results] == ["r-right"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/server/services/test_unified_search_service.py
+++ b/tests/server/services/test_unified_search_service.py
@@ -625,6 +625,24 @@ def test_phase_b_passes_tag_filter_to_every_fanout_leg() -> None:
     ]
 
 
+def test_phase_b_passes_source_filter_to_every_fanout_leg() -> None:
+    storage = _fanout_storage()
+
+    _run_phase_b(
+        request=UnifiedSearchRequest(query="billing", user_id="user-1", source="api"),
+        org_id="test-org",
+        storage=storage,
+        embedding=[0.1] * 1536,
+        query="billing",
+        top_k=5,
+        threshold=0.3,
+    )
+
+    assert storage.search_user_profile.call_args.args[0].source == "api"
+    assert storage.search_agent_playbooks.call_args.args[0].source == "api"
+    assert storage.search_user_playbooks.call_args.args[0].source == "api"
+
+
 class TestEmbeddingFailureDegradesToFTS(unittest.TestCase):
     """D2/D3: embedding-generation failure degrades the whole search to FTS."""
 

--- a/tests/server/services/test_unified_search_single_rpc.py
+++ b/tests/server/services/test_unified_search_single_rpc.py
@@ -91,10 +91,13 @@ def _run_phase_b(
     *,
     user_id: str | None = "u",
     tags: list[str] | None = None,
+    source: str | None = None,
     recency_on: bool = False,
 ):
     return uss._run_phase_b(
-        request=UnifiedSearchRequest(query="q", user_id=user_id, tags=tags, top_k=5),
+        request=UnifiedSearchRequest(
+            query="q", user_id=user_id, tags=tags, source=source, top_k=5
+        ),
         org_id="o",
         storage=cast(BaseStorage, storage),
         embedding=[0.1, 0.2],
@@ -150,6 +153,15 @@ def test_single_rpc_passes_tag_filter(monkeypatch):
     _run_phase_b(storage, tags=["billing", "support"])
 
     assert storage.combined_calls[0]["tags"] == ["billing", "support"]
+
+
+def test_single_rpc_passes_source_filter(monkeypatch):
+    monkeypatch.delenv("REFLEXIO_UNIFIED_SEARCH_SINGLE_RPC", raising=False)
+    storage = _CombinedStorage()
+
+    _run_phase_b(storage, source="api")
+
+    assert storage.combined_calls[0]["source"] == "api"
 
 
 def test_single_rpc_passes_tag_filter_on_scored_path(monkeypatch):


### PR DESCRIPTION
## Summary
- Add exact interaction-source filtering to user playbook, agent playbook, and unified search APIs.
- Match agent playbooks through linked contributing user-playbook provenance instead of adding a scalar source field.
- Default direct agent playbook searches to lifecycle-current and lifecycle-pending rows.

## Changes
- Extend public request schemas and sync/async client methods with the optional `source` filter.
- Propagate source through unified-search fanout and combined-storage calls.
- Apply source predicates before ranking and `top_k` in SQLite semantic, lexical, fallback, and queryless paths.
- Add regression coverage for validation, serialization, provenance matching, lifecycle defaults, and filtered ranking.
- Update generated client method documentation.

## Test Plan
- `uv run pytest tests/models/api_schema/test_retriever_schema.py tests/client/test_search.py tests/server/services/storage/test_sqlite_storage.py tests/server/services/test_unified_search_service.py tests/server/services/test_unified_search_single_rpc.py -o 'addopts='`
- `uv run pytest tests/ --ignore=tests/e2e_tests/ -v -o 'addopts='`
- `uv run pytest tests/e2e_tests/ -v -o 'addopts='`
- `uv run ruff check reflexio tests`
- `uv run pyright --threads 4`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional exact source filtering to user playbook, agent playbook, profile, and unified searches.
  * Source filters are supported for both synchronous and asynchronous unified searches.
* **Bug Fixes**
  * Improved default agent playbook results to include current and pending items while excluding archived records.
  * Source matching is now exact and case-sensitive.
* **Tests**
  * Added coverage for source filtering, validation, propagation, and ranking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->