### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -35,7 +35,7 @@ Description: Shared data contracts and the Python SDK used by external applicati
 **Path**: `models/`
 
 #### Main Entry Points
-- **API Schemas**: `models/api_schema/` - Pydantic request/response models for public API surfaces
+- **API Schemas**: `models/api_schema/` - Pydantic request/response models for public API surfaces, including source-aware profile/playbook search requests in `retriever_schema.py`
 - **Internal Schemas**: `models/api_schema/internal_schema.py` - Storage-facing profile, playbook, request, evaluation, and agent-run models
 - **Validators**: `models/api_schema/validators.py` - Cross-schema validation helpers
 
@@ -57,7 +57,7 @@ Description: Python SDK for interacting with Reflexio API remotely
 #### Purpose
 Remote API client for applications to:
 1. **Publish interactions** - Send user interactions to server for processing
-2. **Search/retrieve data** - Query profiles, interactions, playbooks, evaluations, and context
+2. **Search/retrieve data** - Query profiles, interactions, playbooks, evaluations, and context; profile/user-playbook/agent-playbook searches accept source filters when callers need source-scoped retrieval
 3. **Track deferred learning** - Poll `get_learning_status(request_id)` after `publish_interaction(..., wait_for_response=False)` queues extraction
 4. **Manage profiles/playbooks** - Delete, regenerate, and update status where supported by API endpoints
 5. **Configure** - Set/get organization configuration

--- a/reflexio/server/README.md
+++ b/reflexio/server/README.md
@@ -89,7 +89,7 @@ Description: FastAPI backend server that processes user interactions to generate
 - **Identity/config**: `GET /api/whoami`, `GET /api/my_config`, `GET /api/get_config`, `POST /api/set_config`, `POST /api/update_config`
 - **Publish/direct writes**: `POST /api/publish_interaction`, `POST /api/add_user_profile`, `POST /api/add_user_playbook`, `POST /api/add_agent_playbook`
 - **Retrieval**: `POST /api/get_requests`, `POST /api/get_interactions`, `GET /api/get_all_interactions`, `GET /api/learning_status`, `POST /api/get_profiles`, `GET /api/get_all_profiles`, `POST /api/get_user_playbooks`, `POST /api/get_agent_playbooks`, `POST /api/get_agent_success_evaluation_results`, `POST /api/get_retrieved_learning_evaluation_results`
-- **Search/stats**: `POST /api/search`, `POST /api/search_profiles`, `POST /api/rerank_user_profiles`, `POST /api/search_interactions`, `POST /api/search_user_playbooks`, `POST /api/search_agent_playbooks`, `GET /api/storage_stats`, `GET /api/get_profile_statistics`, `POST /api/get_dashboard_stats`, `POST /api/get_playbook_application_stats`
+- **Search/stats**: `POST /api/search`, `POST /api/search_profiles`, `POST /api/rerank_user_profiles`, `POST /api/search_interactions`, `POST /api/search_user_playbooks`, `POST /api/search_agent_playbooks`, `GET /api/storage_stats`, `GET /api/get_profile_statistics`, `POST /api/get_dashboard_stats`, `POST /api/get_playbook_application_stats` (profile/user-playbook/agent-playbook search requests support source filters)
 - **Retrieval experiments**: `GET/POST /api/retrieval_experiments`, `POST /api/retrieval_experiments/stop`, `GET /api/retrieval_experiments/{experiment_id}/results`
 - **Profile lifecycle**: `POST /api/rerun_profile_generation`, `POST /api/manual_profile_generation`, `POST /api/upgrade_all_profiles`, `POST /api/downgrade_all_profiles`, `GET /api/profile_change_log`, `PUT /api/update_user_profile`, `DELETE /api/delete_profile`, `DELETE /api/delete_profiles_by_ids`, `DELETE /api/delete_all_profiles`
 - **Playbook lifecycle**: `POST /api/review_user_playbooks`, `POST /api/rerun_playbook_generation`, `POST /api/manual_playbook_generation`, `POST /api/run_playbook_aggregation`, `GET /api/playbook_aggregation_change_logs`, `POST /api/upgrade_all_user_playbooks`, `POST /api/downgrade_all_user_playbooks`, `PUT /api/update_agent_playbook_status`, `PUT /api/update_agent_playbook`, `PUT /api/update_user_playbook`, `DELETE /api/delete_agent_playbook`, `DELETE /api/delete_user_playbook`, `DELETE /api/delete_agent_playbooks_by_ids`, `DELETE /api/delete_user_playbooks_by_ids`, `DELETE /api/delete_all_playbooks`, `DELETE /api/delete_all_user_playbooks`, `DELETE /api/delete_all_agent_playbooks`
@@ -508,7 +508,7 @@ Reformulates user search queries into clean, normalized natural language for imp
 
 **File**: `services/unified_search_service.py` - `run_unified_search()`
 
-Searches across all entity types (profiles, agent_playbooks, user_playbooks) in parallel via a two-phase approach:
+Searches across all entity types (profiles, agent_playbooks, user_playbooks) in parallel via a two-phase approach. Entity-specific search requests can carry source filters; agent-playbook filtering matches playbooks linked to at least one user playbook from that exact source.
 
 - **Phase A**: Query rewriting + embedding generation (parallel via ThreadPoolExecutor)
 - **Phase B**: Entity searches across all types (parallel via ThreadPoolExecutor, 3 workers)

--- a/reflexio/server/services/README.md
+++ b/reflexio/server/services/README.md
@@ -57,7 +57,7 @@ strings before deleting old import paths in the same PR.
 | `governance/` | Subject-reference and retention/barrier policy contracts: `config.py`, `service.py`, `subject_refs.py`. Storage and lineage code use these helpers to preserve governance constraints during writes, supersedes, and cleanup. |
 | `pre_retrieval/` | `QueryReformulator` (`_query_reformulator.py`) + `DocumentExpander` (`_document_expander.py`) - query rewrite and doc expansion for recall. Compact by design; see [README](pre_retrieval/README.md). |
 | `tagging/` | `TaggingService` (`service.py`) + deferred `tagging_scheduler.py` - post-generation profile/playbook tagging. Compact by design; see [README](tagging/README.md). |
-| `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks. |
+| `unified_search_service.py` | `run_unified_search()` — two-phase parallel search across profiles / agent playbooks / user playbooks; forwards entity-specific source filters, with agent-playbook source matching through linked source user playbooks. |
 | `search_exposure.py` | Optional synchronous recorder contract for final user-playbook result sets. Enterprise capability registration installs the recorder and makes authenticated unified/direct search fail closed before metering/response. Shared `create_app()` has no default recorder; other constructions persist exposures only when they register one. Direct search omits empty batches. |
 | `retrieval/` | `relevance_floor.py` — result relevance thresholding. `temporal.py` — temporal post-processing driven by reformulation signals: query time windows → per-arm SQL filters, near-duplicate freshness collapse for current-value questions, timestamp ordering for latest-value questions. `user_context_guard.py` — high-precision detection of explicit personalization opt-outs, including Simplified and Traditional Chinese, before user-context retrieval. (Superseded/expired rows are already excluded by storage search SQL.) |
 
@@ -65,7 +65,7 @@ strings before deleting old import paths in the same PR.
 
 | Path | Purpose |
 |------|---------|
-| `storage/` | `storage_base/` and `sqlite_storage/` keep legacy domain facades while focused subpackages own `profiles/`, `playbook/`, `agent_run/`, `governance`, durable `learning_jobs`, and SQLite `base/` helpers. SQLite hybrid search preserves Porter FTS for ASCII and adds bounded Unicode substring candidates only when a query contains at least one non-ASCII alphanumeric character, including mixed-script queries; emoji-only and punctuation-only queries are ineligible. `storage_base/playbook/_aggregation.py` defines fenced aggregation state; SQLite implements it in the matching playbook package. Access via `request_context.storage` only. |
+| `storage/` | `storage_base/` and `sqlite_storage/` keep legacy domain facades while focused subpackages own `profiles/`, `playbook/`, `agent_run/`, `governance`, durable `learning_jobs`, and SQLite `base/` helpers. SQLite hybrid search preserves Porter FTS for ASCII, adds bounded Unicode substring candidates only for queries with at least one non-ASCII alphanumeric character, and honors profile/playbook source filters; emoji-only and punctuation-only queries are ineligible. `storage_base/playbook/_aggregation.py` defines fenced aggregation state; SQLite implements it in the matching playbook package. Access via `request_context.storage` only. |
 | `configurator/` | `DefaultConfigurator` — loads YAML config and creates the storage backend. |
 
 ## Key Rules


### PR DESCRIPTION
## Summary
- Updates OSS code-map READMEs for the latest source-scoped search behavior.
- Documents that profile/user-playbook/agent-playbook search paths carry source filters and how agent-playbook source matching is resolved.
- Follows the parent repository policy in `how_to_write_readme.md`: concise, navigation-focused README changes only.

## Repositories/submodules reviewed
- `ReflexioAI/reflexio` (`open_source/reflexio` submodule)
- Parent `ReflexioAI/reflexio-enterprise` reviewed separately in this scheduled run.

## README files updated
- `reflexio/README.md`
- `reflexio/server/README.md`
- `reflexio/server/services/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/README.md reflexio/server/README.md reflexio/server/services/README.md`

## Notes/Risks
- README-only change.
- `open_source/reflexio/README.md` is user-facing/public and was intentionally left untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented source-filter support for profile, user-playbook, and agent-playbook searches.
  - Clarified that agent-playbook results match playbooks linked to user playbooks from the requested source.
  - Updated unified search documentation to describe source-filter forwarding.
  - Clarified Unicode substring search behavior for queries containing non-ASCII letters or numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->