### PR TITLE
fix(config): stop StorageConfig silently reinterpreting a malformed config

### DIFF
--- a/reflexio/models/config_schema.py
+++ b/reflexio/models/config_schema.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum, StrEnum
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
 from .api_schema.validators import (
     NonEmptyStr,
@@ -198,14 +198,48 @@ class StorageConfigTest(IntEnum):
 
 
 class StorageConfigSQLite(BaseModel):
-    """SQLite storage configuration."""
+    """SQLite storage configuration.
 
+    ``extra="forbid"`` is load-bearing, not stylistic. ``StorageConfig`` is an
+    *untagged* union and this is its only member with no required fields, so
+    without it this model is a catch-all: any payload that fails the stricter
+    members silently lands here instead of raising. A Supabase config that lost
+    its ``db_url`` used to validate as SQLite, dropping ``url``/``key``/``schema``
+    on the floor -- which routed a managed tenant to a local file, produced a
+    storage object with no ``_rpc``, and surfaced only as a background sweep
+    erroring every few seconds (org 56, 2026-08).
+
+    An empty payload still resolves here on purpose: that is the legitimate OSS
+    local-mode default (``local_file_config_storage._default_storage_config``).
+    """
+
+    model_config = ConfigDict(
+        populate_by_name=True, serialize_by_alias=True, extra="forbid"
+    )
+
+    # Declared so the union is discriminated by tag where a tag is present, and
+    # so the ``type`` the config API emits round-trips back in. Defaulted
+    # because blobs persisted before this field existed do not carry it, and
+    # excluded from serialization so the persisted document shape is unchanged
+    # -- the boot-time config upgrade rewrites every org's blob, and this is not
+    # the change that should alter what it writes.
+    storage_type: Literal["sqlite"] = Field(
+        default="sqlite", alias="type", exclude=True
+    )
     db_path: str | None = None  # None = use LOCAL_STORAGE_PATH env var default
 
 
 class StorageConfigSupabase(BaseModel):
-    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+    # extra="forbid" keeps this distinguishable from the other union members --
+    # see StorageConfigSQLite for why an untagged union needs it.
+    model_config = ConfigDict(
+        populate_by_name=True, serialize_by_alias=True, extra="forbid"
+    )
 
+    # Accepted on input, excluded from output -- see StorageConfigSQLite.
+    storage_type: Literal["supabase"] = Field(
+        default="supabase", alias="type", exclude=True
+    )
     url: NonEmptyStr
     key: NonEmptyStr
     db_url: NonEmptyStr
@@ -215,7 +249,13 @@ class StorageConfigSupabase(BaseModel):
 
 
 class StorageConfigPostgres(BaseModel):
-    model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
+    # extra="forbid" keeps this distinguishable from the other union members --
+    # see StorageConfigSQLite for why an untagged union needs it. Without it a
+    # Supabase config missing only its ``key`` validated as Postgres and
+    # connected by a path nobody intended.
+    model_config = ConfigDict(
+        populate_by_name=True, serialize_by_alias=True, extra="forbid"
+    )
 
     storage_type: Literal["postgres"] = Field(default="postgres", alias="type")
     db_url: NonEmptyStr
@@ -243,6 +283,10 @@ StorageConfig = (
     | StorageConfigManagedSupabase
     | None
 )
+
+# Used by validate_stored_config to check storage_config strictly, outside the
+# lenient whole-Config pass that would otherwise relax these models' extra rules.
+_STORAGE_CONFIG_ADAPTER: TypeAdapter[StorageConfig] = TypeAdapter(StorageConfig)
 
 
 class AzureOpenAIConfig(BaseModel):
@@ -1048,4 +1092,14 @@ def validate_stored_config(data: dict[str, Any]) -> Config:
     the model's strict ``extra="forbid"`` behavior.
     """
     normalized = normalize_legacy_config_shape(data)
+    # Validate storage_config on its own, strictly, BEFORE the lenient pass
+    # below. ``extra="ignore"`` cascades into nested models, so it overrides each
+    # StorageConfig member's ``extra="forbid"`` -- without this pre-check a
+    # Supabase config that lost its ``db_url`` validates as SQLite here and the
+    # org is silently rerouted to a local file. Schema-evolution leniency is
+    # meant for Config's own retired fields, not for reinterpreting which
+    # storage backend an org is on.
+    storage_config = normalized.get("storage_config")
+    if isinstance(storage_config, dict):
+        _STORAGE_CONFIG_ADAPTER.validate_python(storage_config)
     return Config.model_validate(normalized, extra="ignore")

--- a/tests/models/test_storage_config_union.py
+++ b/tests/models/test_storage_config_union.py
@@ -1,0 +1,273 @@
+"""``StorageConfig`` must not silently reinterpret a malformed config.
+
+``StorageConfig`` is an *untagged* union. ``StorageConfigSQLite`` is its only
+member with no required fields, so unless every member forbids extra keys it
+becomes a catch-all: any payload failing the stricter members lands there
+instead of raising.
+
+That is not hypothetical. A managed tenant's Supabase config lost its
+``db_url`` and validated as SQLite -- dropping ``url``/``key``/``schema`` --
+which routed the org to a local file, produced a storage object with no
+``_rpc``, and turned a background sweep into an error every few seconds for a
+week (org 56, 2026-08). A config missing only ``key`` was worse still: it
+validated as *Postgres* and connected successfully by a path nobody intended.
+
+The invariant these tests defend:
+
+    A storage config that loses a field fails loudly, rather than becoming a
+    different backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from reflexio.models.config_schema import (
+    StorageConfig,
+    StorageConfigPostgres,
+    StorageConfigSQLite,
+    StorageConfigSupabase,
+    validate_stored_config,
+)
+
+_ADAPTER: TypeAdapter[StorageConfig] = TypeAdapter(StorageConfig)
+
+# The exact shape every managed org carries in production (verified 2026-08-20
+# across the whole fleet: 29 managed orgs, all identical, zero extra keys).
+_PROD_SUPABASE = {
+    "url": "https://example.supabase.co",
+    "key": "service-role-key",
+    "db_url": "postgresql://user:pw@host:5432/postgres",
+    "schema": "org_56",
+    "read_url": "https://example-read.supabase.co",
+    "read_key": "read-key",
+}
+
+
+@pytest.mark.parametrize(
+    ("label", "payload", "expected"),
+    [
+        ("prod supabase shape", _PROD_SUPABASE, StorageConfigSupabase),
+        (
+            "supabase without optional read replica",
+            {k: v for k, v in _PROD_SUPABASE.items() if not k.startswith("read_")},
+            StorageConfigSupabase,
+        ),
+        # An empty payload resolving to SQLite is deliberate: it is the OSS
+        # local-mode default (local_file_config_storage._default_storage_config).
+        ("empty payload (OSS default)", {}, StorageConfigSQLite),
+        (
+            "sqlite with explicit path",
+            {"db_path": "/var/lib/reflexio.db"},
+            StorageConfigSQLite,
+        ),
+        (
+            "postgres",
+            {
+                "type": "postgres",
+                "db_url": "postgresql://u:p@h:5432/db",
+                "schema": "org_1",
+            },
+            StorageConfigPostgres,
+        ),
+    ],
+)
+def test_valid_configs_resolve_to_their_own_backend(
+    label: str, payload: dict[str, object], expected: type
+) -> None:
+    """Legitimate configs must keep resolving to the backend they name."""
+    resolved = _ADAPTER.validate_python(payload)
+    assert type(resolved) is expected, (
+        f"{label}: expected {expected.__name__}, got {type(resolved).__name__}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        # The org 56 shape: without extra="forbid" this validated as
+        # StorageConfigSQLite and discarded url/key/schema in silence.
+        (
+            "supabase missing db_url",
+            {k: v for k, v in _PROD_SUPABASE.items() if k != "db_url"},
+        ),
+        # Worse than the SQLite case: this validated as StorageConfigPostgres,
+        # which then connects successfully via an unintended path.
+        (
+            "supabase missing key",
+            {k: v for k, v in _PROD_SUPABASE.items() if k != "key"},
+        ),
+        (
+            "supabase with empty-string key",
+            {**_PROD_SUPABASE, "key": ""},
+        ),
+        (
+            "supabase missing url",
+            {k: v for k, v in _PROD_SUPABASE.items() if k != "url"},
+        ),
+        ("unrecognised payload", {"nonsense": 1}),
+        ("supabase field misspelled", {**_PROD_SUPABASE, "db_urls": "x"}),
+    ],
+)
+def test_malformed_configs_are_rejected_not_reinterpreted(
+    label: str, payload: dict[str, object]
+) -> None:
+    """A config that loses or misspells a field must raise, not change backend."""
+    with pytest.raises(ValidationError):
+        _ADAPTER.validate_python(payload)
+
+
+def test_sqlite_does_not_absorb_a_supabase_payload() -> None:
+    """The specific coercion behind the org 56 outage, asserted directly.
+
+    Constructing the SQLite model straight from a Supabase payload used to
+    succeed by ignoring every key, yielding ``db_path=None``.
+    """
+    with pytest.raises(ValidationError):
+        StorageConfigSQLite.model_validate(_PROD_SUPABASE)
+
+
+def test_postgres_does_not_absorb_a_supabase_payload() -> None:
+    """The sibling coercion -- same class of defect, different member."""
+    with pytest.raises(ValidationError):
+        StorageConfigPostgres.model_validate(_PROD_SUPABASE)
+
+
+class TestThroughValidateStoredConfig:
+    """The same invariant, asserted at the seam production actually uses.
+
+    Every stored config is loaded through ``validate_stored_config``, not
+    through the union adapter directly. That function passes ``extra="ignore"``
+    for schema-evolution read compatibility, and pydantic cascades that setting
+    into nested models -- so it silently overrode each StorageConfig member's
+    ``extra="forbid"``. Asserting only against the adapter passes while the real
+    load path stays broken.
+    """
+
+    @pytest.mark.parametrize(
+        ("label", "storage_config"),
+        [
+            (
+                "supabase missing db_url",
+                {k: v for k, v in _PROD_SUPABASE.items() if k != "db_url"},
+            ),
+            (
+                "supabase missing key",
+                {k: v for k, v in _PROD_SUPABASE.items() if k != "key"},
+            ),
+            ("unrecognised payload", {"nonsense": 1}),
+        ],
+    )
+    def test_malformed_storage_config_is_rejected_on_the_load_path(
+        self, label: str, storage_config: dict[str, object]
+    ) -> None:
+        with pytest.raises(ValidationError):
+            validate_stored_config({"storage_config": storage_config})
+
+    def test_valid_storage_configs_survive_the_load_path(self) -> None:
+        for storage_config, expected in (
+            (_PROD_SUPABASE, StorageConfigSupabase),
+            ({"db_path": "/var/lib/reflexio.db"}, StorageConfigSQLite),
+            (
+                {"type": "postgres", "db_url": "postgresql://u:p@h:5432/db"},
+                StorageConfigPostgres,
+            ),
+        ):
+            loaded = validate_stored_config({"storage_config": storage_config})
+            assert type(loaded.storage_config) is expected
+
+    def test_storage_config_none_still_means_deployment_managed(self) -> None:
+        """Self-host orgs persist None; it must stay None, not become SQLite."""
+        assert validate_stored_config({"storage_config": None}).storage_config is None
+
+    def test_retired_top_level_fields_are_still_ignored(self) -> None:
+        """The leniency this function exists for must survive the new strictness.
+
+        Schema evolution applies to Config's own retired fields -- not to
+        reinterpreting which storage backend an org is on.
+        """
+        loaded = validate_stored_config(
+            {"storage_config": None, "a_field_retired_three_releases_ago": 123}
+        )
+        assert loaded.storage_config is None
+
+
+class TestTypeTagCompatibility:
+    """The ``type`` tag must be accepted on input but absent from output.
+
+    Two constraints pull in opposite directions and both are load-bearing:
+
+    * The config API emits ``type`` alongside the storage config. Tightening the
+      models without accepting it made a response from ``/get_config`` invalid
+      to post back to ``/set_config`` -- a 422 on an unmodified round trip.
+    * The boot-time config upgrade rewrites every org's persisted blob. Adding
+      ``type`` to what the models serialize would change that document for the
+      whole fleet, which this change has no business doing.
+    """
+
+    @pytest.mark.parametrize(
+        ("tag", "payload", "expected"),
+        [
+            ("sqlite", {"db_path": None}, StorageConfigSQLite),
+            ("supabase", _PROD_SUPABASE, StorageConfigSupabase),
+            (
+                "postgres",
+                {"db_url": "postgresql://u:p@h:5432/db"},
+                StorageConfigPostgres,
+            ),
+        ],
+    )
+    def test_tagged_payload_is_accepted(
+        self, tag: str, payload: dict[str, object], expected: type
+    ) -> None:
+        """Exactly what the config API hands back to a client."""
+        resolved = _ADAPTER.validate_python({**payload, "type": tag})
+        assert type(resolved) is expected
+
+    def test_a_wrong_tag_is_rejected(self) -> None:
+        """The tag must agree with the shape, not override it."""
+        with pytest.raises(ValidationError):
+            _ADAPTER.validate_python({**_PROD_SUPABASE, "type": "sqlite"})
+
+    @pytest.mark.parametrize(
+        ("label", "payload"),
+        [
+            ("supabase", _PROD_SUPABASE),
+            ("sqlite", {"db_path": "/var/lib/reflexio.db"}),
+        ],
+    )
+    def test_serialized_shape_carries_no_type_tag(
+        self, label: str, payload: dict[str, object]
+    ) -> None:
+        """Persisted documents must not gain a key from this change."""
+        dumped = _ADAPTER.dump_python(
+            _ADAPTER.validate_python(payload), mode="json"
+        )
+        assert "type" not in dumped, (
+            f"{label}: serializing the tag would rewrite every org's stored "
+            f"config blob at the next boot upgrade"
+        )
+        assert set(dumped) == set(payload) | {
+            k for k in dumped if dumped[k] is None
+        }
+
+
+def test_round_trip_preserves_the_backend() -> None:
+    """Serialising and revalidating must not change which backend a config is.
+
+    Config blobs are persisted as JSON and reloaded on every request, so a
+    round trip that drifts would reintroduce the same silent degradation.
+    """
+    for payload in (
+        _PROD_SUPABASE,
+        {},
+        {"db_path": "/var/lib/reflexio.db"},
+        {"type": "postgres", "db_url": "postgresql://u:p@h:5432/db"},
+    ):
+        original = _ADAPTER.validate_python(payload)
+        reloaded = _ADAPTER.validate_python(_ADAPTER.dump_python(original, mode="json"))
+        assert type(reloaded) is type(original), (
+            f"round trip changed backend: {type(original).__name__} -> "
+            f"{type(reloaded).__name__}"
+        )


### PR DESCRIPTION
## Summary

`StorageConfig` is an untagged union, and `StorageConfigSQLite` was its only member with no required fields and no `extra` restriction. That made it a catch-all: any payload failing the stricter members landed there instead of raising.

Measured against the real schema, **before** this change:

| stored blob | resolved as | should be |
| --- | --- | --- |
| supabase missing `db_url` | **SQLite** (url/key/schema dropped) | error |
| supabase missing `key` | **Postgres** (connects anyway) | error |
| supabase with empty-string `key` | **Postgres** | error |
| `{"nonsense": 1}` | **SQLite** | error |
| full supabase | Supabase ✅ | ✅ |
| `{}` | SQLite ✅ (OSS local default) | ✅ |

The first row is how a managed tenant ended up pointed at a local SQLite file: its storage object had no `_rpc`, a background sweep raised every few seconds for a week, and the resulting error volume exhausted the Sentry quota fleet-wide (org 56, 2026-08). The second row is arguably worse — it *succeeds*, connecting by a path nobody intended.

## Changes

**1. `extra="forbid"` on the SQLite, Supabase and Postgres members.** A config that loses or misspells a field now raises instead of changing backend.

**2. `validate_stored_config` validates `storage_config` strictly, before the lenient pass.** This is the fix that actually reaches production, and it is easy to miss:

```python
return Config.model_validate(normalized, extra="ignore")
```

`extra="ignore"` **cascades into nested models**, so it overrode the members' `extra="forbid"` entirely. Change 1 alone was cosmetic on the only path that mattered — every stored config is loaded through this function. Schema-evolution leniency for `Config`'s own retired fields is preserved; it just no longer extends to reinterpreting which storage backend an org is on.

**3. `type` is now a declared field on the SQLite and Supabase members**, matching what `StorageConfigPostgres` already did — accepted on input, `exclude=True` on output.

- *Accepting* it is required: the config API emits `type`, so tightening the models without it made an unmodified `/get_config` → `/set_config` round trip fail with a 422.
- *Not serializing* it keeps the persisted document byte-identical. The boot-time config upgrade rewrites every org's blob, and this change has no business altering what it writes.

An empty payload still resolves to SQLite on purpose — that is the OSS local-mode default in `local_file_config_storage`.

## Verification

- **20 tests** in `tests/models/test_storage_config_union.py`, covering the union adapter, the `validate_stored_config` load path, the type-tag round trip, and the unchanged serialized shape.
- **Mutation-verified**: reverting each of the four guards individually turns the suite red. My first version of these tests asserted only against the union adapter and passed while the real load path stayed broken — the `validate_stored_config` cases exist specifically because of that.
- OSS unit tier: **4893 passed**.
- **Checked against production before landing**: all 29 managed orgs carry one identical 6-key shape with no extra keys and still resolve to `StorageConfigSupabase` under the new schema; the 2 self-host orgs carry `None`. Nothing is rejected. Blast radius is zero.

## Related

Paired with the enterprise-side change that closes the path which produced the malformed config in the first place, and refuses SQLite for a platform-managed tenant.

## Note for the reviewer

This branch is stacked on `5e186cc1` ("filter playbook search by source"), which is the commit enterprise `main` currently points at but which is **not yet on this repo's `main`** — it lives on `origin/codex/explain-interaction-source-field`. Branching off `main` instead would have reverted that feature on the enterprise side. Once that PR merges this should rebase cleanly; if it squash-merges, this branch needs `rebase --onto`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage configuration validation to reject malformed, incomplete, or unrecognized backend settings.
  * Prevented invalid configurations from being interpreted as a different storage type.
  * Preserved valid backend settings during configuration loading and serialization.
  * Continued supporting omitted values and retired top-level fields where applicable.

* **Tests**
  * Added comprehensive coverage for SQLite, Postgres, and Supabase configuration validation and round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->