### PR TITLE
fix(lineage-gc): treat an injected org-id provider as actually authoritative

### DIFF
--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -216,17 +216,33 @@ class LineageGCScheduler(ThreadedScheduler):
         logger.info("event=lineage_gc_scheduler_stopped")
 
     def _discover_org_ids(self, bootstrap_ctx: RequestContext) -> list[str]:
-        """Return every known org, always including the bootstrap org.
+        """Return the orgs this tick should sweep.
 
         When an ``org_id_provider`` was injected (managed/multi-tenant mode), it
-        is the authoritative org-id source and ``storage.list_org_ids()`` is not
-        consulted. Otherwise the OSS single-tenant path is used unchanged
-        (``storage.list_org_ids()`` with a visible NotImplementedError fallback).
-        The bootstrap org is always unioned in either way.
+        is the authoritative org-id source: ``storage.list_org_ids()`` is not
+        consulted and the bootstrap org is NOT unioned in. Otherwise the OSS
+        single-tenant path is used unchanged (``storage.list_org_ids()`` with a
+        visible NotImplementedError fallback), and the bootstrap org is unioned
+        because there it is genuinely the only org GC would otherwise reach.
+
+        The bootstrap org is a *discovery seed*, resolved by the lowest org id
+        with no predicate — so in a managed deployment it can easily be an
+        abandoned unverified signup. Unioning it back after a provider has
+        deliberately filtered it re-admits an org the provider judged
+        unsweepable, and sweeping such an org raises PostgREST ``PGRST106``
+        ("Invalid schema") on every tick, because a tenant schema is only
+        exposed once its org is verified. That is not hypothetical: it ran in
+        production against ``org_23`` (see ``expiry_reclamation.org_enumeration``,
+        whose ``_is_sweepable`` docstring warns against exactly this caller).
+
+        A provider that returns an EMPTY list is still authoritative — "nothing
+        is sweepable" is a legitimate answer and must not be overridden by the
+        seed. Only a provider that *raised* falls back to the bootstrap org,
+        which is a deliberate, logged degradation.
         """
         if self.org_id_provider is not None:
             try:
-                org_ids = list(self.org_id_provider())
+                return list(self.org_id_provider())
             except Exception:
                 capture_anomaly(
                     "lineage.gc.org_id_provider_failed",
@@ -237,21 +253,21 @@ class LineageGCScheduler(ThreadedScheduler):
                     "— falling back to bootstrap org only",
                     self.bootstrap_org_id,
                 )
+                return [bootstrap_ctx.org_id]
+
+        storage = getattr(bootstrap_ctx, "storage", None)
+        org_ids: list[str] = []
+        if storage is not None:
+            try:
+                org_ids = storage.list_org_ids()
+            except NotImplementedError:
+                logger.warning(
+                    "event=lineage_gc_list_org_ids_not_implemented "
+                    "backend=%s bootstrap_org_id=%s — GC will only process bootstrap org",
+                    type(storage).__name__,
+                    bootstrap_ctx.org_id,
+                )
                 org_ids = []
-        else:
-            storage = getattr(bootstrap_ctx, "storage", None)
-            org_ids = []
-            if storage is not None:
-                try:
-                    org_ids = storage.list_org_ids()
-                except NotImplementedError:
-                    logger.warning(
-                        "event=lineage_gc_list_org_ids_not_implemented "
-                        "backend=%s bootstrap_org_id=%s — GC will only process bootstrap org",
-                        type(storage).__name__,
-                        bootstrap_ctx.org_id,
-                    )
-                    org_ids = []
         if bootstrap_ctx.org_id not in org_ids:
             org_ids = [bootstrap_ctx.org_id, *org_ids]
         return org_ids

--- a/tests/server/services/lineage/test_gc_scheduler_multitenant_integration.py
+++ b/tests/server/services/lineage/test_gc_scheduler_multitenant_integration.py
@@ -264,3 +264,97 @@ def test_maybe_start_lineage_gc_reads_module_provider_hook(tmp_path):
     finally:
         set_org_id_provider(None)
     assert gc_module._org_id_provider_hook is None
+
+
+# ---------------------------------------------------------------------------
+# The injected provider is AUTHORITATIVE: the bootstrap seed must not be
+# unioned back in after the provider deliberately filtered it out.
+#
+# The seed is resolved by lowest org id with no predicate, so in a managed
+# deployment it is routinely an abandoned unverified signup whose tenant schema
+# is never exposed to PostgREST. Re-adding it made every tick sweep an org the
+# provider had judged unsweepable, raising PGRST106 forever (prod, org_23).
+# ---------------------------------------------------------------------------
+
+
+def test_provider_result_is_not_polluted_by_an_unsweepable_bootstrap():
+    """A seed the provider excluded must NOT come back via the bootstrap union.
+
+    This is the regression: `enumerate_active_org_ids` correctly dropped the
+    unverified seed, and `_discover_org_ids` put it straight back.
+    """
+    bootstrap_ctx = RequestContext.__new__(RequestContext)
+    bootstrap_ctx.org_id = "org_unverified_seed"
+    bootstrap_ctx.storage = MagicMock()
+
+    sched = LineageGCScheduler(
+        request_context_factory=lambda _org_id: bootstrap_ctx,
+        bootstrap_org_id="org_unverified_seed",
+        # The enterprise enumeration filtered the seed out on purpose.
+        org_id_provider=lambda: ["org_b"],
+    )
+
+    org_ids = sched._discover_org_ids(bootstrap_ctx)
+
+    assert org_ids == ["org_b"], (
+        "the injected provider is authoritative; an org it excluded must not be "
+        f"re-added as the bootstrap seed (got {org_ids})"
+    )
+    assert "org_unverified_seed" not in org_ids
+
+
+def test_empty_provider_result_is_respected():
+    """'Nothing is sweepable' is a legitimate answer, not a reason to use the seed."""
+    bootstrap_ctx = RequestContext.__new__(RequestContext)
+    bootstrap_ctx.org_id = "org_unverified_seed"
+    bootstrap_ctx.storage = MagicMock()
+
+    sched = LineageGCScheduler(
+        request_context_factory=lambda _org_id: bootstrap_ctx,
+        bootstrap_org_id="org_unverified_seed",
+        org_id_provider=list,
+    )
+
+    assert sched._discover_org_ids(bootstrap_ctx) == []
+
+
+def test_provider_failure_still_falls_back_to_the_bootstrap_org():
+    """A RAISING provider keeps the seed fallback -- a deliberate, logged degradation.
+
+    Distinct from an empty result: here we have no information, so sweeping the
+    seed is better than sweeping nothing.
+    """
+    bootstrap_ctx = RequestContext.__new__(RequestContext)
+    bootstrap_ctx.org_id = "org_bootstrap"
+    bootstrap_ctx.storage = MagicMock()
+
+    def exploding_provider() -> list[str]:
+        raise RuntimeError("control-plane unreachable")
+
+    sched = LineageGCScheduler(
+        request_context_factory=lambda _org_id: bootstrap_ctx,
+        bootstrap_org_id="org_bootstrap",
+        org_id_provider=exploding_provider,
+    )
+
+    assert sched._discover_org_ids(bootstrap_ctx) == ["org_bootstrap"]
+
+
+def test_oss_single_tenant_path_still_unions_the_bootstrap_org():
+    """Without a provider the seed is still unioned -- OSS GC must not regress.
+
+    There `list_org_ids()` can be empty or NotImplementedError, and the
+    bootstrap org is genuinely the only org GC would otherwise reach.
+    """
+    storage = MagicMock()
+    storage.list_org_ids.return_value = []
+    bootstrap_ctx = RequestContext.__new__(RequestContext)
+    bootstrap_ctx.org_id = "org_only"
+    bootstrap_ctx.storage = storage
+
+    sched = LineageGCScheduler(
+        request_context_factory=lambda _org_id: bootstrap_ctx,
+        bootstrap_org_id="org_only",
+    )
+
+    assert sched._discover_org_ids(bootstrap_ctx) == ["org_only"]


### PR DESCRIPTION
## Summary

`_discover_org_ids` described the injected `org_id_provider` as **"the authoritative org-id source"** — and then overrode it on the very next line:

```python
if bootstrap_ctx.org_id not in org_ids:
    org_ids = [bootstrap_ctx.org_id, *org_ids]   # ← re-adds what the provider excluded
```

The bootstrap org is a discovery *seed*, resolved by lowest org id with **no predicate**, so in a managed deployment it is routinely an abandoned unverified signup. A tenant schema is only exposed to PostgREST once its org is verified, so sweeping one raises `PGRST106` ("Invalid schema") on every tick — indefinitely.

## This ran in production

```
_resolve_lineage_gc_bootstrap_org_id()  → org 23  (is_active=True, is_verified=False)
        ▼
enumerate_active_org_ids(seed=23)
    _is_sweepable(org_23) → False       → correctly EXCLUDED ✅
        ▼
_discover_org_ids()                     → org 23 RE-ADDED ❌
        ▼
_sweep_org(23) → PostgREST → PGRST106 → governance_retention_org_failed
```

Confirmed against the live control plane: **all 12** unexposed org schemas are `is_verified = False`, and **zero** verified orgs are unexposed. The exposure list was correct the whole time; the scheduler was sweeping an org it had been told not to.

It had been failing since at least **2026-08-19** and went unnoticed because Sentry ingestion has been quota-exhausted since 08-13.

The enterprise side was already doing its job — and `org_enumeration._is_sweepable` names this exact hazard in prose:

> Do not add a caller that trusts this id as sweepable without applying that predicate.

This method was that caller.

## Change

A provider that **returns** is now trusted verbatim — including an **empty list**, since "nothing is sweepable" is a legitimate answer and not a reason to fall back to the seed. Only a provider that **raised** degrades to the bootstrap org, which remains a deliberate, already-logged fallback.

The OSS single-tenant path is untouched: there `list_org_ids()` can be empty or `NotImplementedError`, and the bootstrap org genuinely is the only org GC would otherwise reach.

## Why the existing tests missed it

`test_unsweepable_bootstrap_org_is_excluded` exists on the enterprise side and **passed throughout** — because it asserts against `enumerate_active_org_ids`, the helper, which was already correct. Nothing exercised `_discover_org_ids`, the seam that actually carries the behaviour.

The four new tests go on that seam:

| Test | Asserts |
| --- | --- |
| `..._not_polluted_by_an_unsweepable_bootstrap` | provider `["org_b"]` + seed `org_a` → `["org_b"]`, **fails today** |
| `test_empty_provider_result_is_respected` | empty provider result is honoured, not overridden |
| `..._provider_failure_still_falls_back...` | raising provider → seed fallback preserved |
| `..._oss_single_tenant_path_still_unions...` | no-provider path unchanged |

## Verification

- OSS unit tier: **4892 passed**.
- One unrelated failure, `test_scheduler_drain_waits_for_scheduled_callback` — I reverted this change and re-ran the identical command: it fails the same way at baseline. A load-sensitive flake in the tagging scheduler, not caused here.
- **Mutation-verified**: restoring the union turns the new tests red.
- `ruff check` / `ruff format` / pyright clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lineage garbage-collection organization discovery when an organization provider is configured.
  - Provider results are now respected exactly, including empty results, without automatically adding the bootstrap organization.
  - Provider failures continue to fall back safely to the bootstrap organization.
  - Storage-based discovery retains existing bootstrap-organization behavior when no provider is configured.

- **Tests**
  - Added regression coverage for provider results, empty responses, provider failures, and the standard single-tenant path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->