### PR TITLE
test: stabilize cross-platform release gates

### DIFF
--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import signal
 import socket
+import sys
 import tempfile
 import threading
 from pathlib import Path
@@ -150,8 +151,8 @@ def test_find_pids_on_port_falls_back_to_ss(monkeypatch) -> None:
 
 
 @pytest.mark.skipif(
-    shutil.which("lsof") is None and shutil.which("ss") is None,
-    reason="neither lsof nor ss is available",
+    shutil.which("ss" if sys.platform.startswith("linux") else "lsof") is None,
+    reason="the platform's bound-socket inspection tool is unavailable",
 )
 def test_find_pids_on_port_detects_bound_socket_without_listen() -> None:
     # Regression: an orphaned process can hold a port bound without listening

--- a/tests/models/test_storage_config_union.py
+++ b/tests/models/test_storage_config_union.py
@@ -241,16 +241,12 @@ class TestTypeTagCompatibility:
         self, label: str, payload: dict[str, object]
     ) -> None:
         """Persisted documents must not gain a key from this change."""
-        dumped = _ADAPTER.dump_python(
-            _ADAPTER.validate_python(payload), mode="json"
-        )
+        dumped = _ADAPTER.dump_python(_ADAPTER.validate_python(payload), mode="json")
         assert "type" not in dumped, (
             f"{label}: serializing the tag would rewrite every org's stored "
             f"config blob at the next boot upgrade"
         )
-        assert set(dumped) == set(payload) | {
-            k for k in dumped if dumped[k] is None
-        }
+        assert set(dumped) == set(payload) | {k for k in dumped if dumped[k] is None}
 
 
 def test_round_trip_preserves_the_backend() -> None:

--- a/tests/server/llm/test_embedding_service_rerank.py
+++ b/tests/server/llm/test_embedding_service_rerank.py
@@ -4,6 +4,7 @@ import logging
 
 from fastapi.testclient import TestClient
 
+from reflexio.server.llm import embedding_service
 from reflexio.server.llm.embedding_service import create_embedding_app
 from reflexio.server.llm.rerank.common import (
     MULTILINGUAL_RERANK_MODEL,
@@ -140,6 +141,7 @@ def test_service_lifespan_prewarms_runner_directly() -> None:
 def test_service_lifespan_logs_operator_model_and_device_contract(
     monkeypatch, caplog
 ) -> None:
+    monkeypatch.setattr(embedding_service, "_ACTIVE_MODEL", None)
     monkeypatch.setenv("NOMIC_EMBED_DEVICE", "cuda")
     monkeypatch.setenv("REFLEXIO_RERANK_DEVICE", "cuda")
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")


### PR DESCRIPTION
## Summary

- Restore a reliable green release gate before the Google Analytics redeploy.
- Make the bound-socket integration test depend on the inspection tool that can actually observe that socket state on each platform.
- Isolate the embedding lifespan contract test from process-global model state left by earlier tests.

## Changes

- Require `ss` for the Linux bound-but-not-listening socket integration test and `lsof` elsewhere.
- Reset `_ACTIVE_MODEL` through `monkeypatch` in the operator contract test; production model-conflict behavior is unchanged.
- Apply the repository formatter to the storage config union test found by the full format gate.

## Test Plan

- `uv run pytest tests/ -m 'not requires_credentials' -o 'addopts=' -n auto --dist worksteal --timeout=120 -q` — 6,268 passed, 57 skipped, 6 subtests passed.
- `uv run pytest tests/cli/test_utils.py tests/server/llm/test_embedding_service_model_contract.py tests/server/llm/test_embedding_service_rerank.py -o 'addopts=' -q` — 32 passed.
- Same scoped tests with CI parallelism (`-n auto --dist worksteal`) — 32 passed.
- `uv run ruff check reflexio tests`
- `uv run ruff format --check reflexio tests`
- `uv run pyright --threads 4` — 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved platform-specific handling for socket inspection checks, including clearer availability messages.
  * Stabilized embedding service lifecycle logging tests by resetting active model state.
  * Reformatted storage configuration serialization test code without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->