### PR TITLE
test: gate bound-socket probe on ss metadata

### DIFF
--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -161,7 +161,18 @@ def test_find_pids_on_port_detects_bound_socket_without_listen() -> None:
         sock.bind(("127.0.0.1", 0))
         port = sock.getsockname()[1]
 
-        assert os.getpid() in utils.find_pids_on_port(port)
+        detected = utils.find_pids_on_port(port)
+        if sys.platform.startswith("linux") and os.getpid() not in detected:
+            probe = utils.subprocess.run(
+                ["ss", "-tanpH", "sport", "=", f":{port}"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if f"pid={os.getpid()}" not in probe.stdout:
+                pytest.skip("ss cannot expose process metadata for this socket")
+
+        assert os.getpid() in detected
 
 
 def test_requested_port_conflicts_detect_duplicate_service_ports(


### PR DESCRIPTION
## Summary

- Restore the exact-merge release gate blocked by Linux runners whose `ss` binary cannot expose process-owner metadata.
- Preserve regression coverage: the integration test still fails when raw `ss` output contains the PID but Reflexio's parser misses it.

## Changes

- Probe raw `ss` output after an unsuccessful Linux integration lookup.
- Skip only when the host itself omits the current process PID.
- Leave the deterministic `ss` parser unit test and production implementation unchanged.

## Test Plan

- `uv run pytest tests/cli/test_utils.py -o 'addopts=' -q` — 19 passed.
- `uv run pytest tests/ -m 'not requires_credentials' -o 'addopts=' -n auto --dist worksteal --timeout=120 -q` — 6,268 passed, 57 skipped, 6 subtests passed.
- `uv run ruff check tests/cli/test_utils.py`
- `uv run ruff format --check tests/cli/test_utils.py`
- `uv run pyright --threads 4 tests/cli/test_utils.py` — 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of bound-socket detection tests on Linux.
  * Tests now skip appropriately when socket process metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->