### PR TITLE
docs: sync README files with latest repo state

### DIFF
--- a/reflexio/integrations/openclaw/README.md
+++ b/reflexio/integrations/openclaw/README.md
@@ -74,8 +74,9 @@ and `openclaw-smart repair`.
   `force_extraction=True` so the session's learnings are available before
   the next openClaw run.
 
-The full design lives in
-[`docs/superpowers/specs/2026-05-19-openclaw-smart-design.md`](../../../../docs/superpowers/specs/2026-05-19-openclaw-smart-design.md).
+The standalone package keeps this README focused on install/runtime behavior; the
+full design note is maintained in Reflexio's internal planning docs rather than
+shipped with the open-source distribution.
 
 ## Skills
 


### PR DESCRIPTION
## Summary
- Removes a broken standalone-package README link to an internal OpenClaw design note that is not shipped with the open-source repository.
- Keeps the OpenClaw integration README focused on install/runtime navigation without restructuring the public root README.

## Repositories/submodules reviewed
- `ReflexioAI/reflexio` submodule: README/link validation focused on `reflexio/integrations/openclaw/README.md` after updating the submodule to latest `origin/main`.
- Parent `ReflexioAI/reflexio-enterprise` was reviewed separately under the same scheduled run.

## README files updated
- `reflexio/integrations/openclaw/README.md`

## Validation
- `git diff --check`
- `python /root/.hermes/skills/github/scheduled-code-map-readme-maintenance/scripts/readme_link_check.py /root/reflexio-enterprise/open_source/reflexio reflexio/integrations/openclaw/README.md`

## Notes/Risks
- Update follows `/root/reflexio-enterprise/how_to_write_readme.md`: concise navigation/link maintenance only, no cosmetic churn.
- No code changes and no parent submodule pointer commit are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OpenClaw integration documentation to focus on package installation and runtime behavior.
  * Removed the link to internal design specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->