### PR TITLE
fix: preserve profile provenance during consolidation

### DIFF
--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -813,6 +813,13 @@ class ProfileConsolidator(BaseDeduplicator):
             metadata_sources = group_new_profiles or group_existing_profiles
             merged_custom_features = self._merge_custom_features(metadata_sources)
             merged_extractor_names = self._merge_extractor_names(metadata_sources)
+            merged_source_interaction_ids = list(
+                dict.fromkeys(
+                    source_id
+                    for profile in group_new_profiles + group_existing_profiles
+                    for source_id in profile.source_interaction_ids
+                )
+            )
 
             # Determine TTL
             try:
@@ -837,6 +844,7 @@ class ProfileConsolidator(BaseDeduplicator):
                 source=template_profile.source,
                 status=template_profile.status,
                 extractor_names=merged_extractor_names,
+                source_interaction_ids=merged_source_interaction_ids,
             )
             self.consolidated_output_indices.add(len(result_profiles))
             result_profiles.append(merged_profile)

--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -721,6 +721,7 @@ class ProfileConsolidator(BaseDeduplicator):
         for group in dedup_output.duplicate_groups:
             group_new_indices: list[int] = []
             group_existing_indices: list[int] = []
+            group_profiles_in_item_order: list[UserProfile] = []
 
             for item_id in group.item_ids:
                 parsed = parse_item_id(item_id)
@@ -729,8 +730,12 @@ class ProfileConsolidator(BaseDeduplicator):
                 prefix, idx = parsed
                 if prefix == "NEW":
                     group_new_indices.append(idx)
+                    if 0 <= idx < len(new_profiles):
+                        group_profiles_in_item_order.append(new_profiles[idx])
                 elif prefix == "EXISTING":
                     group_existing_indices.append(idx)
+                    if 0 <= idx < len(existing_profiles):
+                        group_profiles_in_item_order.append(existing_profiles[idx])
 
             # Reject groups that overlap with profiles already consumed by a
             # deletion directive. Merging such a group would write a
@@ -816,7 +821,7 @@ class ProfileConsolidator(BaseDeduplicator):
             merged_source_interaction_ids = list(
                 dict.fromkeys(
                     source_id
-                    for profile in group_new_profiles + group_existing_profiles
+                    for profile in group_profiles_in_item_order
                     for source_id in profile.source_interaction_ids
                 )
             )

--- a/tests/server/services/profile/test_profile_consolidator.py
+++ b/tests/server/services/profile/test_profile_consolidator.py
@@ -639,6 +639,73 @@ class TestBuildDeduplicatedResults:
         assert str(uuid.UUID(merged_profile.profile_id)) == merged_profile.profile_id
         assert merged_profile.profile_time_to_live == ProfileTimeToLive.ONE_MONTH
 
+    @pytest.mark.parametrize(
+        ("item_ids", "expected_source_ids"),
+        [
+            (["NEW-0", "NEW-1"], [101, 102, 103]),
+            (["EXISTING-0", "EXISTING-1"], [102, 201, 202, 203]),
+            (["NEW-0", "EXISTING-0"], [101, 102, 201]),
+        ],
+        ids=["new-only", "existing-only", "mixed"],
+    )
+    def test_merged_profile_preserves_source_interaction_ids(
+        self,
+        mock_request_context,
+        mock_llm_client,
+        mock_site_var_manager,
+        sample_profiles,
+        item_ids,
+        expected_source_ids,
+    ):
+        """Merged profiles retain the ordered union of member provenance."""
+        sample_profiles[0].source_interaction_ids = [101, 102]
+        sample_profiles[1].source_interaction_ids = [102, 103]
+        existing_profiles = [
+            UserProfile(
+                profile_id="existing-0",
+                user_id="test_user",
+                content="Existing profile zero",
+                last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+                generated_from_request_id="existing-request",
+                source_interaction_ids=[102, 201],
+            ),
+            UserProfile(
+                profile_id="existing-1",
+                user_id="test_user",
+                content="Existing profile one",
+                last_modified_timestamp=int(datetime.now(UTC).timestamp()),
+                generated_from_request_id="existing-request",
+                source_interaction_ids=[201, 202, 203],
+            ),
+        ]
+        dedup_output = ProfileDeduplicationOutput(
+            duplicate_groups=[
+                ProfileDuplicateGroup(
+                    item_ids=item_ids,
+                    merged_content="Merged profile",
+                    merged_time_to_live="one_month",
+                )
+            ],
+        )
+
+        result_profiles, _, _ = ProfileConsolidator(
+            request_context=mock_request_context,
+            llm_client=mock_llm_client,
+        )._build_deduplicated_results(
+            new_profiles=sample_profiles,
+            existing_profiles=existing_profiles,
+            dedup_output=dedup_output,
+            user_id="test_user",
+            request_id="test_request",
+        )
+
+        merged_profile = next(
+            profile
+            for profile in result_profiles
+            if profile.content == "Merged profile"
+        )
+        assert merged_profile.source_interaction_ids == expected_source_ids
+
     def test_build_deduplicated_results_preserves_unique(
         self,
         mock_request_context,

--- a/tests/server/services/profile/test_profile_consolidator.py
+++ b/tests/server/services/profile/test_profile_consolidator.py
@@ -645,8 +645,9 @@ class TestBuildDeduplicatedResults:
             (["NEW-0", "NEW-1"], [101, 102, 103]),
             (["EXISTING-0", "EXISTING-1"], [102, 201, 202, 203]),
             (["NEW-0", "EXISTING-0"], [101, 102, 201]),
+            (["EXISTING-0", "NEW-0"], [102, 201, 101]),
         ],
-        ids=["new-only", "existing-only", "mixed"],
+        ids=["new-only", "existing-only", "mixed", "mixed-reversed"],
     )
     def test_merged_profile_preserves_source_interaction_ids(
         self,


### PR DESCRIPTION
## Summary
- Preserve interaction-level provenance when deduplication generates a merged user profile.
- Prevent generated profiles from silently defaulting `source_interaction_ids` to an empty list.
- Retain a stable, deduplicated union across new-only, existing-only, and mixed consolidation groups.

## Changes
- Resolve every duplicate-group member in `ProfileDuplicateGroup.item_ids` order before collecting provenance.
- Pass the ordered, deduplicated union into the merged `UserProfile` while retaining existing template and metadata precedence.
- Add parameterized regression coverage for new-only, existing-only, forward-mixed, and reverse-mixed consolidation groups.

## Test Plan
- `uv run ruff check reflexio/server/services/profile/components/consolidator.py tests/server/services/profile/test_profile_consolidator.py`
- `uv run pyright reflexio/server/services/profile/components/consolidator.py tests/server/services/profile/test_profile_consolidator.py --threads 4`
- `uv run pytest tests/server/services/profile/test_profile_consolidator.py -o 'addopts='` (72 passed)
- Full OSS suite: 6,224 passed, 14 skipped.
- OSS E2E suite: 47 passed, 87 skipped.
- Real HTTP lifecycle against an isolated self-host PostgreSQL deployment: two published interaction batches consolidated into a profile whose persisted/API provenance spanned both batches; the IDs survived update and service restart, and the profile completed hard-delete lifecycle with lineage audit events retained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Merged profiles now retain all unique source interaction IDs from their contributing profiles.
  - Interaction IDs preserve their original order and remain deduplicated, including when profiles are merged from mixed sources.

- **Tests**
  - Added coverage for new-only, existing-only, and mixed profile merge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
