### PR TITLE
fix: standardize generated profile IDs as UUIDv4

### DIFF
--- a/reflexio/README.md
+++ b/reflexio/README.md
@@ -37,6 +37,7 @@ Description: Shared data contracts and the Python SDK used by external applicati
 #### Main Entry Points
 - **API Schemas**: `models/api_schema/` - Pydantic request/response models for public API surfaces
 - **Internal Schemas**: `models/api_schema/internal_schema.py` - Storage-facing profile, playbook, request, evaluation, and agent-run models
+- **Profile IDs**: `models/profile_id.py` - Canonical UUIDv4 generation for Reflexio-created profiles
 - **Validators**: `models/api_schema/validators.py` - Cross-schema validation helpers
 
 #### Purpose

--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 import time
-import uuid
 import warnings
 from collections.abc import Callable, Coroutine, Sequence
 from concurrent.futures import ThreadPoolExecutor
@@ -63,6 +62,7 @@ from reflexio.models.api_schema.retriever_schema import (
     UpdateUserPlaybookResponse,
 )
 from reflexio.models.config_schema import SearchMode
+from reflexio.models.profile_id import new_profile_id
 
 IS_TEST_ENV = os.environ.get("IS_TEST_ENV", "false").strip() == "true"
 
@@ -1924,7 +1924,7 @@ class ReflexioClient:
         if isinstance(profile, UserProfile):
             return profile
         data = dict(profile)
-        data.setdefault("profile_id", f"cli-{uuid.uuid4().hex[:12]}")
+        data.setdefault("profile_id", new_profile_id())
         data.setdefault("last_modified_timestamp", int(datetime.now(UTC).timestamp()))
         data.setdefault("generated_from_request_id", "cli-manual")
         data.setdefault("source", "cli-manual")
@@ -1948,8 +1948,8 @@ class ReflexioClient:
                 - user_id (str): The user the profile belongs to.
                 - content (str): The profile content (used for embedding).
                 When passing dicts, missing required fields are auto-populated
-                client-side with sensible defaults: ``profile_id`` becomes
-                ``f"cli-{uuid4.hex[:12]}"``, ``last_modified_timestamp`` is set to
+                client-side with sensible defaults: ``profile_id`` becomes a
+                canonical UUIDv4 string, ``last_modified_timestamp`` is set to
                 ``int(datetime.now(UTC).timestamp())``, and
                 ``generated_from_request_id`` defaults to ``"cli-manual"``.
 

--- a/reflexio/models/profile_id.py
+++ b/reflexio/models/profile_id.py
@@ -1,0 +1,14 @@
+"""Canonical identifiers for user profiles."""
+
+from __future__ import annotations
+
+import uuid
+
+
+def new_profile_id() -> str:
+    """Return a new profile identifier.
+
+    Returns:
+        str: A canonical UUIDv4 string.
+    """
+    return str(uuid.uuid4())

--- a/reflexio/server/services/profile/components/consolidator.py
+++ b/reflexio/server/services/profile/components/consolidator.py
@@ -5,7 +5,6 @@ and against existing profiles in the database using hybrid search and LLM.
 
 import logging
 import os
-import uuid
 from collections import Counter
 from datetime import UTC, datetime
 
@@ -13,6 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from reflexio.models.api_schema.retriever_schema import SearchUserProfileRequest
 from reflexio.models.api_schema.service_schemas import Status, UserProfile
+from reflexio.models.profile_id import new_profile_id
 from reflexio.models.structured_output import StrictStructuredOutput
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.error_reporting import capture_anomaly
@@ -826,7 +826,7 @@ class ProfileConsolidator(BaseDeduplicator):
                 )
 
             merged_profile = UserProfile(
-                profile_id=str(uuid.uuid4()),
+                profile_id=new_profile_id(),
                 user_id=user_id,
                 content=group.merged_content,
                 last_modified_timestamp=now_ts,

--- a/reflexio/server/services/profile/components/extractor.py
+++ b/reflexio/server/services/profile/components/extractor.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -11,6 +10,7 @@ from reflexio.models.api_schema.service_schemas import (
     UserProfile,
 )
 from reflexio.models.config_schema import ProfileExtractorConfig
+from reflexio.models.profile_id import new_profile_id
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.llm.litellm_client import LiteLLMClient
 from reflexio.server.llm.token_accounting import RunTokenTotals, sum_trace_tokens
@@ -50,19 +50,6 @@ PROFILE_EXTRACTION_MAX_RETRIES = 2
 
 # Maximum number of existing profiles to include in extraction prompt for context
 MAX_EXISTING_PROFILES_FOR_CONTEXT = 5
-
-
-def new_profile_id() -> str:
-    """Generate a short (12-char hex) profile id.
-
-    Format chosen for LLM copy fidelity: full ``str(uuid.uuid4())`` is 36
-    characters of hex+dashes, error-prone for smaller LLMs to copy verbatim.
-    Twelve hex chars is short enough for high-fidelity copy and long enough
-    that birthday-paradox collision probability is vanishingly small at any
-    realistic per-user scale (16^12 ~= 2.8e14 unique values; PRIMARY KEY
-    constraint catches the rare collision).
-    """
-    return uuid.uuid4().hex[:12]
 
 
 class ProfileExtractor:

--- a/tests/client/test_profile_client.py
+++ b/tests/client/test_profile_client.py
@@ -1,0 +1,32 @@
+"""Profile client behavior tests."""
+
+from unittest.mock import patch
+from uuid import UUID
+
+from reflexio.client import ReflexioClient
+
+
+def test_add_user_profile_defaults_to_uuidv4_and_preserves_supplied_id() -> None:
+    client = ReflexioClient(api_key="test_key", url_endpoint="http://localhost:8000")
+
+    with patch.object(
+        client,
+        "_make_request",
+        return_value={"success": True, "added_count": 2},
+    ) as make_request:
+        client.add_user_profile(
+            [
+                {"user_id": "user-1", "content": "Prefers dark mode"},
+                {
+                    "profile_id": "legacy-custom-id",
+                    "user_id": "user-1",
+                    "content": "Uses Python",
+                },
+            ]
+        )
+
+    payload = make_request.call_args.kwargs["json"]
+    generated_id = payload["user_profiles"][0]["profile_id"]
+    assert UUID(generated_id).version == 4
+    assert str(UUID(generated_id)) == generated_id
+    assert payload["user_profiles"][1]["profile_id"] == "legacy-custom-id"

--- a/tests/e2e_tests/test_profile_workflows.py
+++ b/tests/e2e_tests/test_profile_workflows.py
@@ -76,6 +76,10 @@ def test_publish_interaction_profile_only(
     final_profiles = require_storage(reflexio_instance_profile_only).get_all_profiles()
     assert len(final_profiles) > 0
     assert final_profiles[0].content.strip() != ""
+    for profile in final_profiles:
+        parsed_profile_id = uuid.UUID(profile.profile_id)
+        assert parsed_profile_id.version == 4
+        assert str(parsed_profile_id) == profile.profile_id
 
     # Verify profile change logs were created
     final_change_logs = (

--- a/tests/server/services/profile/test_profile_consolidator.py
+++ b/tests/server/services/profile/test_profile_consolidator.py
@@ -635,6 +635,8 @@ class TestBuildDeduplicatedResults:
             None,
         )
         assert merged_profile is not None
+        assert uuid.UUID(merged_profile.profile_id).version == 4
+        assert str(uuid.UUID(merged_profile.profile_id)) == merged_profile.profile_id
         assert merged_profile.profile_time_to_live == ProfileTimeToLive.ONE_MONTH
 
     def test_build_deduplicated_results_preserves_unique(

--- a/tests/server/services/profile/test_profile_extractor.py
+++ b/tests/server/services/profile/test_profile_extractor.py
@@ -13,6 +13,7 @@ import os
 import tempfile
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
+from uuid import UUID
 
 import pytest
 
@@ -896,6 +897,10 @@ class TestConvertRawToUserProfiles:
         )
 
         assert len(result) == 2
+        assert all(UUID(profile.profile_id).version == 4 for profile in result)
+        assert all(
+            str(UUID(profile.profile_id)) == profile.profile_id for profile in result
+        )
         assert result[0].content == "User prefers dark mode"
         assert result[0].user_id == "test_user"
         # Singleton extraction no longer records per-extractor provenance.


### PR DESCRIPTION
## Summary
- Standardize every Reflexio-generated profile identifier on canonical UUIDv4 strings.
- Remove the mixed 12-character and prefixed client ID formats while preserving caller-supplied identifiers for backward compatibility.

## Changes
- Add a shared `new_profile_id()` helper for canonical UUIDv4 generation.
- Use the helper for extracted profiles, consolidated profiles, and client-side defaults.
- Add unit and publish-to-storage regression coverage for the UUIDv4 invariant and custom-ID compatibility.
- Document the new helper in the package code map.

## Test Plan
- `uv run ruff check` and `uv run ruff format --check` on affected Python files.
- `uv run pyright` on affected Python files: 0 errors and 0 warnings.
- Focused profile unit and E2E tests: 88 passed.
- Full OSS unit/integration suite: 6,222 passed, 14 skipped.
- Full OSS E2E suite: 47 passed, 87 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically generated profile IDs now use standard canonical UUIDv4 format.
  * Custom profile IDs remain unchanged when provided.

* **Bug Fixes**
  * Profile IDs generated during profile creation, extraction, and merging now follow a consistent format.

* **Tests**
  * Added validation ensuring generated IDs are valid, canonical UUIDv4 values across supported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->