### PR TITLE
docs: promote managed Reflexio trial

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
 
 ---
 
+### Try managed Reflexio free
+
+Prefer a hosted experience? **[Start at Reflexio.ai](https://www.reflexio.ai) for free and get a 30-day Pro trial.** Managed Reflexio includes advanced features such as enhanced retrieval and continuous RL-driven improvement—without infrastructure to operate yourself.
+
+---
+
 ### Migration from the removed claude_code integration
 
 The `reflexio setup claude-code` command and its hook files have been removed.


### PR DESCRIPTION
## Summary
- Connect open-source users with the hosted Reflexio platform through a prominent README call to action.
- Make the free entry point and included 30-day Pro trial immediately visible.

## Changes
- Add a top-of-README managed-platform callout linking to Reflexio.ai.
- Highlight enhanced retrieval and continuous RL-driven improvement available on the managed platform.

## Test Plan
- Ran `git diff --check`.
- Reviewed the rendered Markdown structure and verified the CTA link target.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about managed Reflexio.
  * Included a free signup link and details about the 30-day Pro trial.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->