### PR TITLE
docs: call Reflexio a learning platform, not a layer

### DIFF
--- a/AI_AGENT_INTEGRATION.md
+++ b/AI_AGENT_INTEGRATION.md
@@ -162,7 +162,7 @@ REFLEXIO_API_KEY="..."
 ```
 
 Implementation rule: if Reflexio is unavailable, the agent must continue
-normally. Treat Reflexio as a best-effort learning layer, not as a dependency
+normally. Treat Reflexio as a best-effort learning platform, not as a dependency
 that can break user work.
 
 ## Configure an LLM Provider

--- a/benchmark/gdpval/RESULTS.md
+++ b/benchmark/gdpval/RESULTS.md
@@ -5,10 +5,10 @@
 Modern AI agents already try to improve themselves between runs: they
 cache skills, remember prior plans, and get faster on tasks they have
 seen before. This raises a pointed question: **is there still room
-for an external self-improvement layer to add measurable value on top
+for an external learning platform to add measurable value on top
 of an agent that is already self-improving?**
 
-We test **Reflexio**, a layer that reads a completed run of a task
+We test **Reflexio**, a learning platform that reads a completed run of a task
 and produces a concrete, copy-pasteable recipe for the next run of
 the same task, on **five real knowledge-work tasks** from the public
 OpenAI GDPVal benchmark. These five tasks were selected because the

--- a/client_dist/README.md
+++ b/client_dist/README.md
@@ -5,7 +5,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green)](https://github.com/ReflexioAI/reflexio/blob/main/LICENSE)
 [![Downloads](https://static.pepy.tech/badge/reflexio-ai/month)](https://pepy.tech/project/reflexio-ai)
 
-The official Python SDK for [Reflexio](https://www.reflexio.ai/) — the adaptive memory layer for AI agents. Reflexio automatically extracts user profiles, generates playbooks, and evaluates agent performance from conversation data. This client provides type-safe, sync-first access to the full Reflexio API. For source code and contributions, see the [GitHub repository](https://github.com/ReflexioAI/reflexio).
+The official Python SDK for [Reflexio](https://www.reflexio.ai/) — the learning platform for AI agents. Reflexio automatically extracts user profiles, generates playbooks, and evaluates agent performance from conversation data. This client provides type-safe, sync-first access to the full Reflexio API. For source code and contributions, see the [GitHub repository](https://github.com/ReflexioAI/reflexio).
 
 ## Table of Contents
 


### PR DESCRIPTION
## What

The team standardised on **"learning platform"** as Reflexio's product category — not "learning layer", "self-improving layer/platform", or "self-learning platform". This updates the two places in this repo that named it something else.

| File | Was | Now |
| --- | --- | --- |
| `AI_AGENT_INTEGRATION.md` | "best-effort learning **layer**" | "best-effort learning **platform**" |
| `benchmark/gdpval/RESULTS.md` | "an external self-improvement **layer**" | "an external learning **platform**" |
| `benchmark/gdpval/RESULTS.md` | "Reflexio, **a layer** that reads a completed run" | "Reflexio, **a learning platform** that reads a completed run" |

## Deliberately left unchanged

`RESULTS.md` also contains *"an agent that is already self-improving"*. That is a claim about the **customer's agent**, not about Reflexio's category, and it is load-bearing for the benchmark's framing — the whole research question is whether an external platform adds measurable value on top of an agent that already improves itself. Renaming it would break the argument.

The `benchmark/gdpval/memory/` module name is code structure, not marketing, and is untouched.

## Related

The enterprise repo carries the same terminology change across the website, docs, and email templates. The superproject's gitlink bump follows once this merges.

Docs only — no code paths affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated integration guidance to describe Reflexio as a best-effort learning platform.
  - Refined benchmark documentation to present Reflexio as a learning platform that adds measurable value to already self-improving agents.
  - Updated client documentation to describe Reflexio as a learning platform for AI agents.
  - Improved consistency in how Reflexio’s capabilities and positioning are described across public-facing technical materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->