### PR TITLE
docs: drop Star History, move the claude_code migration notice down

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,6 @@ Prefer a hosted experience? **[Start at Reflexio.ai](https://www.reflexio.ai) fo
 
 ---
 
-### Migration from the removed claude_code integration
-
-The `reflexio setup claude-code` command and its hook files have been removed.
-The replacement is **[claude-smart](https://github.com/ReflexioAI/claude-smart)**,
-a standalone Claude Code plugin distributed via npm.
-
-*This migration only removes the **hook/plugin installation** path. The local
-`claude-code` LLM provider routing (used to call Anthropic via the Claude Code
-CLI binary as a model backend) remains available — only remove obsolete hook
-entries, not your provider configuration.*
-
-**If you had the old integration installed**, your `.claude/settings.json` (per-project)
-or `~/.claude/settings.json` (global) likely has hook entries referencing files that no longer exist.
-Open the file and remove any `hooks` entries that reference paths under `reflexio/integrations/claude_code/`
-or `integrations/claude_code/`. Then run `npx claude-smart install` (or use the Claude Code plugin marketplace)
-for the modern equivalent.
-
----
-
 ## What is Reflexio?
 Reflexio is an **AI agent self-improvement harness** that enables your AI agents to continuously learn from real user interactions. It turns user corrections into persisted behavioral improvements for agents and captures successful execution paths for reuse.
 
@@ -94,7 +75,6 @@ Publish conversations from your agent, and Reflexio closes the self-improvement 
 - [Documentation](#documentation)
 - [Community](#community)
 - [Contributing](#contributing)
-- [Star History](#star-history)
 - [License](#license)
 
 ## Demo
@@ -422,6 +402,23 @@ Copy the skill into the agent application's repository for Codex, Claude Code,
 or Cursor, or point a coding agent at the linked skill while it works in that
 application repository. The skill is not intended to modify Reflexio itself.
 
+## Migration from the removed claude_code integration
+
+The `reflexio setup claude-code` command and its hook files have been removed.
+The replacement is **[claude-smart](https://github.com/ReflexioAI/claude-smart)**,
+a standalone Claude Code plugin distributed via npm.
+
+*This migration only removes the **hook/plugin installation** path. The local
+`claude-code` LLM provider routing (used to call Anthropic via the Claude Code
+CLI binary as a model backend) remains available — only remove obsolete hook
+entries, not your provider configuration.*
+
+**If you had the old integration installed**, your `.claude/settings.json` (per-project)
+or `~/.claude/settings.json` (global) likely has hook entries referencing files that no longer exist.
+Open the file and remove any `hooks` entries that reference paths under `reflexio/integrations/claude_code/`
+or `integrations/claude_code/`. Then run `npx claude-smart install` (or use the Claude Code plugin marketplace)
+for the modern equivalent.
+
 ## Community
 
 Join the Reflexio community on Discord: [discord.gg/7fnCxahase](https://discord.gg/7fnCxahase).
@@ -429,10 +426,6 @@ Join the Reflexio community on Discord: [discord.gg/7fnCxahase](https://discord.
 ## Contributing
 
 We welcome contributions! Please see [developer.md](developer.md) for guidelines.
-
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=ReflexioAI/reflexio&type=Date)](https://star-history.com/#ReflexioAI/reflexio&Date)
 
 ## License
 


### PR DESCRIPTION
Two changes to `README.md`, nothing else. 17 insertions, 24 deletions.

*(This PR previously carried a full first-screen rewrite. Scaled back at the
maintainer's request — the rewrite was a bigger swing than the evidence
justified, and it is dropped entirely rather than partially kept.)*

## 1. Star History removed — the chart was not rendering

Section and Table of Contents entry both.

Worth recording in case anyone wants it back: **the endpoint is not dead.**

```
plain request:      HTTP 301, 0 bytes
following redirect: HTTP 200, 60125 bytes, image/svg+xml
```

The redirect only lowercases the repo path (`ReflexioAI/reflexio` →
`reflexioai/reflexio`). GitHub serves README images through camo, so a
redirecting source is the likely reason it comes out blank. Pointing the URL
straight at the lowercase form would be the one-line alternative to deleting the
section — easy to reverse either way.

## 2. The `claude_code` migration notice moved down

From between the benchmark strip and `## What is Reflexio?` to just above
`## Community`, with the other end-of-file housekeeping. **The text is
unchanged.**

It is addressed to people who already use the project, so it was taking up the
first screen for the one audience that doesn't need it. It was also a bare `###`
with no `##` parent, which made it the first entry in GitHub's generated heading
outline — the repo's machine-readable table of contents opened with "Migration
from the removed claude_code integration". It is an `##` now so it sits as a
sibling of the sections around it, rather than reading as a subsection of
Documentation.

## Verified

- Every relative link and in-page anchor still resolves (9 file links, 0 broken
  anchors) — the removed `#star-history` TOC entry was the only one pointing at a
  section that no longer exists.
- Section order after the move: … Architecture → Documentation → **Migration** →
  Community → Contributing → License.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Claude Code migration guidance into a standalone section alongside the documentation content.
  * Preserved the existing migration guidance while improving its placement and discoverability.
  * Removed the Star History section and its corresponding table-of-contents entry.
  * No changes were made to the migration guidance itself or to publicly available interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->