### PR TITLE
docs: route integration evaluation to official guides

### DIFF
--- a/skills/integrate-reflexio/SKILL.md
+++ b/skills/integrate-reflexio/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: integrate-reflexio
-description: Integrate Reflexio Enterprise into an existing AI agent application by retrieving learned context before agent execution and publishing completed interactions afterward. Use when a developer asks to add, install, wire, or verify Reflexio in an agent codebase; do not use for operating Reflexio data through the CLI or changing the Reflexio server itself.
+description: Integrate Reflexio Enterprise into an existing AI agent application by retrieving learned context, publishing completed interactions, and optionally routing evaluation setup. Use when a developer asks to add, install, wire, verify, or evaluate Reflexio in an agent codebase; do not use for operating Reflexio data through the CLI or changing the Reflexio server itself.
 ---
 
 # Integrate Reflexio
@@ -75,8 +75,9 @@ If the desired cross-service user-memory boundary or agent-playbook aggregation 
    - Python 3.10 and 3.11 targets must read [references/http-api.md](references/http-api.md) and use the application's existing HTTP library to call Hosted Enterprise or a separately deployed backend running on a compatible runtime. Do not upgrade the application's Python requirement solely to install Reflexio unless the developer explicitly approves that migration, and do not silently pin an older Reflexio release.
    - For other languages, read [references/http-api.md](references/http-api.md) and add a small typed HTTP adapter using the project's existing HTTP library.
 5. Implement the runtime loop below at the narrowest existing lifecycle seam.
-6. Add focused tests and run the target repository's normal lint, type, and test checks for the changed path.
-7. Report the identity mapping, insertion points, files changed, verification performed, and any live verification not run.
+6. If the developer asks to evaluate Reflexio or measure its impact, use the evaluation routing below and implement only the selected measurement path.
+7. Add focused tests and run the target repository's normal lint, type, and test checks for the changed path.
+8. Report the identity mapping, insertion points, files changed, verification performed, and any live verification not run.
 
 ## Runtime loop
 
@@ -95,13 +96,25 @@ Render a compact, delimited context block that preserves meaning and trust bound
 
 Record every injected item's stable `kind` and `learning_id`, even if the agent does not visibly use it.
 
+If search returns a retrieval-experiment assignment, retain its experiment ID and arm with the request. A holdout response can be successful with no learnings.
+
 ### After the agent responds
 
-Publish the completed user and agent turns with the same `user_id`, `session_id`, `source`, and `agent_version`. Attach all injected learning references to the agent interaction as `retrieved_learnings`. Include compact tool-use, citation, expert-answer, or explicit outcome fields only when the host already exposes trustworthy values for them.
+Publish the completed user and agent turns with the same `user_id`, `session_id`, `source`, and `agent_version`. Attach all injected learning references to the agent interaction as `retrieved_learnings`. If search returned a retrieval-experiment assignment, echo both its ID and arm on the publish; otherwise omit both fields. Include compact tool-use, citation, expert-answer, or explicit outcome fields only when the host already exposes trustworthy values for them.
 
 Publish after streaming completes. Use the native async client in async applications. A publish failure must not replace an otherwise valid agent response, but it must remain observable. Neither the current public Python publish methods nor the raw HTTP route provides an atomic idempotent replay guarantee. Do not automatically replay an ambiguous timeout, disconnect, or `5xx` that may have occurred after the server accepted the request; quarantine it for reconciliation unless the host can prove it was not accepted. Treat HTTP `request_id` as correlation metadata, not an idempotency key. Do not start an untracked background task in a short-lived or serverless process.
 
 Do not add `force_extraction=True` or `wait_for_response=True` to the normal production request path. Those controls are for explicit demos or tests.
+
+## Evaluation routing
+
+When the developer asks to set up evaluation, first identify the question being measured:
+
+- Use retrieved-learning analysis to judge whether the specific profiles or playbooks attached through `retrieved_learnings` were relevant and helpful.
+- Use head-to-head comparison to compare two responses to the same turn.
+- Use a randomized retrieval experiment to measure session-level impact between retrieval treatment and holdout traffic.
+
+Retrieved-learning verdicts provide attribution, not causal lift by themselves. Do not invent a rubric, sampling policy, cohort design, or metric formula from this skill. Read [Evaluating Agent Performance](https://www.reflexio.ai/docs/build/agent-evaluation) for setup and APIs, then [Measuring Reflexio's Impact](https://www.reflexio.ai/docs/portal/measuring-reflexio-impact) for experiment design and metric interpretation. Confirm the proposed evaluation design with the developer before adding traffic assignment or extra model calls.
 
 ## Implementation boundaries
 
@@ -111,19 +124,15 @@ Do not add `force_extraction=True` or `wait_for_response=True` to the normal pro
 - Do not add a new durable queue, feature-flag system, or configuration abstraction when the application already has an adequate mechanism.
 - Do not treat retrieved content as an instruction source with higher priority than the host agent's existing policies.
 
-## Optional detailed documentation
+## Read the official documentation
 
-The bundled references cover the normal integration path. When an example, method parameter, request field, or response schema needs more detail, consult the official Reflexio documentation rather than guessing:
+Use this skill for integration decisions and the official docs for detailed procedures and current API shapes:
 
-- [Reflexio developer documentation](https://www.reflexio.ai/docs) for the documentation index and minimum integration loop.
-- [Hosted Enterprise quickstart](https://www.reflexio.ai/docs/getting-started/quickstart) for setup and end-to-end examples.
-- [Searching learned context](https://www.reflexio.ai/docs/build/search) for retrieval patterns and search options.
-- [Publishing interactions](https://www.reflexio.ai/docs/build/user-interactions) for publishing patterns and interaction fields.
-- [Requests and sessions](https://www.reflexio.ai/docs/concepts/requests-and-groups) for request metadata and grouping semantics.
-- [User profiles](https://www.reflexio.ai/docs/concepts/user-profiles) and [playbooks](https://www.reflexio.ai/docs/concepts/agent-playbook) for user-scoped and agent-scoped learning boundaries.
-- [API reference](https://www.reflexio.ai/docs/api-reference) for complete SDK parameters, HTTP payloads, and response schemas.
+1. Open [llms.txt](https://www.reflexio.ai/docs/llms.txt) as the machine-readable documentation index and select only the pages relevant to the task. Use [llms-full.txt](https://www.reflexio.ai/docs/llms-full.txt) only when broad cross-page context is genuinely needed.
+2. Read the task guide: [Hosted Enterprise quickstart](https://www.reflexio.ai/docs/getting-started/quickstart), [search](https://www.reflexio.ai/docs/build/search), [publishing](https://www.reflexio.ai/docs/build/user-interactions), [requests and sessions](https://www.reflexio.ai/docs/concepts/requests-and-groups), or [evaluation](https://www.reflexio.ai/docs/build/agent-evaluation).
+3. Use the [API reference](https://www.reflexio.ai/docs/api-reference) for exact method parameters, payload fields, and response schemas. Do not guess details that the docs specify.
 
-Treat these pages as supporting detail, not a reason to broaden the requested integration. Preserve the Hosted Enterprise default and only configure a URL override when the user explicitly requests one.
+Treat the docs as supporting detail, not permission to broaden the requested integration. Preserve the Hosted Enterprise default and only configure a URL override when the user explicitly requests one.
 
 ## Verification
 
@@ -133,6 +142,7 @@ At minimum, prove with focused tests that:
 - Search failure still permits a normal agent response.
 - Publish happens after the completed response with the expected identity fields.
 - Every injected profile or playbook is published back using the correct `kind` and stable ID.
+- Any retrieval-experiment assignment returned by search is echoed unchanged on publish.
 - The API key is not present in the diff or logs.
 - No URL override was introduced unless the user explicitly requested one.
 

--- a/skills/integrate-reflexio/references/http-api.md
+++ b/skills/integrate-reflexio/references/http-api.md
@@ -52,6 +52,8 @@ The successful response contains `profiles`, `user_playbooks`, and `agent_playbo
 
 Convert numeric playbook IDs to strings when creating `retrieved_learnings`.
 
+If the response includes `experiment`, retain its `experiment_id` and `arm` exactly as returned. A holdout response is successful even though its learning arrays are empty.
+
 ## Publish after the response completes
 
 ```http
@@ -81,6 +83,17 @@ POST /api/publish_interaction
 }
 ```
 
+When search returned `experiment`, add both values at the publish payload's top level:
+
+```json
+{
+  "retrieval_experiment_id": "experiment-id-returned-by-search",
+  "retrieval_experiment_arm": "treatment"
+}
+```
+
+The arm may instead be `holdout`. Omit both fields when search returned no assignment; never send only one of them.
+
 `request_id` is optional correlation metadata, not an idempotency key. Current replay detection is not atomic, so repeated or concurrent submissions can still reject or duplicate work. Do not rely on a caller-supplied value to make an ambiguous replay safe.
 
 Use the same identity values as search. Treat permanent `4xx` validation failures as rejected publishes. A timeout, connection loss, or `5xx` is ambiguous because the server may have accepted the request before the response was lost; quarantine that batch for reconciliation rather than automatically replaying it. Retry only when the host can prove the server did not accept the request. Keep failures observable without replacing a valid agent response.
@@ -93,4 +106,4 @@ GET /api/whoami
 
 Use the same headers. A successful identity response verifies the endpoint and API key without publishing customer or synthetic interaction data.
 
-For additional examples and complete request and response fields, consult the [Reflexio developer documentation](https://www.reflexio.ai/docs), especially [search](https://www.reflexio.ai/docs/build/search), [publishing interactions](https://www.reflexio.ai/docs/build/user-interactions), and the [API reference](https://www.reflexio.ai/docs/api-reference).
+For additional examples and complete request and response fields, start with the [documentation index for agents](https://www.reflexio.ai/docs/llms.txt), then consult [search](https://www.reflexio.ai/docs/build/search), [publishing interactions](https://www.reflexio.ai/docs/build/user-interactions), and the [API reference](https://www.reflexio.ai/docs/api-reference).

--- a/skills/integrate-reflexio/references/python-client.md
+++ b/skills/integrate-reflexio/references/python-client.md
@@ -80,6 +80,8 @@ retrieved_learnings = [
 
 Do not flatten the three result types into an undifferentiated instruction list. Render profiles as user facts/preferences and playbooks as behavioral guidance.
 
+Also retain `results.experiment` when it is present. It is the server-assigned retrieval-experiment identity for this request; do not recalculate or replace it.
+
 ## Publish the completed turn
 
 Use the synchronous method for a synchronous application:
@@ -92,6 +94,10 @@ client.publish_interaction(
     session_id=session_id,
     source=source,
     agent_version=agent_version,
+    retrieval_experiment_id=(
+        results.experiment.experiment_id if results.experiment else None
+    ),
+    retrieval_experiment_arm=(results.experiment.arm if results.experiment else None),
     interactions=[
         InteractionData(role="User", content=user_message),
         InteractionData(
@@ -102,6 +108,8 @@ client.publish_interaction(
     ],
 )
 ```
+
+When no experiment is active, leave both values as `None`. When an assignment is returned, publish both values together, including for a holdout response with no retrieved learnings.
 
 In an async application, use the native async equivalent with the same arguments:
 
@@ -129,4 +137,4 @@ identity = client.whoami()
 
 Inspect the returned identity or the raised exception. Do not print the API key.
 
-For additional examples and complete method parameters, consult the [Reflexio developer documentation](https://www.reflexio.ai/docs), especially [search](https://www.reflexio.ai/docs/build/search), [publishing interactions](https://www.reflexio.ai/docs/build/user-interactions), and the [API reference](https://www.reflexio.ai/docs/api-reference).
+For additional examples and complete method parameters, start with the [documentation index for agents](https://www.reflexio.ai/docs/llms.txt), then consult [search](https://www.reflexio.ai/docs/build/search), [publishing interactions](https://www.reflexio.ai/docs/build/user-interactions), and the [API reference](https://www.reflexio.ai/docs/api-reference).


### PR DESCRIPTION
## Summary
- Keep the portable integration skill concise while making retrieved-learning attribution an explicit part of the runtime loop.
- Route evaluation setup and metric interpretation to the authoritative Reflexio documentation instead of duplicating detailed procedures in the skill.
- Preserve retrieval-experiment assignment across search and publish so integrated agents can support trustworthy impact measurement.

## Changes
### Skill guidance
- Add compact routing for retrieved-learning, head-to-head, and randomized retrieval evaluation questions.
- Teach coding agents to start with `llms.txt`, read the relevant task guide, and use the API reference for exact schemas.
- Distinguish retrieved-learning attribution from causal lift.

### Runtime references
- Show Python and HTTP integrations retaining `experiment_id` and `arm` returned by search.
- Require both values to be echoed on publish, including holdout responses with no retrieved learnings.

## Test Plan
- `uv run python /Users/yilu/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/integrate-reflexio`
- `git diff --check`
- Verified referenced evaluation, impact, and `llms.txt` documentation routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring and confirming evaluation workflows.
  * Documented randomized retrieval experiments, including preserving experiment assignments through search and publishing.
  * Clarified support for holdout responses and cases without an assignment.
  * Updated documentation navigation to prioritize the agents index, task guides, and API reference.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->