### PR TITLE
feat: admit confirmed_online_support and declare the confirmation seam

### DIFF
--- a/reflexio/server/services/playbook/publication.py
+++ b/reflexio/server/services/playbook/publication.py
@@ -21,11 +21,13 @@ PublicationOutcome = Literal["applied", "incumbent_changed"]
 LIFECYCLE_TERMINAL_STATES: frozenset[str] = frozenset(
     get_args(OpenWorldDeploymentLifecycleState)
 ) - {"provisional"}
-# Mirrors user_playbook_deployment_lifecycles_terminal_reason_check
-# (20260827040000). 'observed_regression' is Phase 6's and 'governed_erasure'
-# is the live governance erase path's; both are accepted here because a
-# terminal tuple READ BACK from an idempotent replay may legitimately carry
-# either. The restoration RPC itself accepts a strictly narrower set.
+# Mirrors user_playbook_deployment_lifecycles_terminal_reason_check, which is
+# now NINE values wide (20260827070000). 'governed_erasure' is the live
+# governance erase path's, and 'observed_regression' and
+# 'confirmed_online_support' are Phase 6's two opposite outcomes; all are
+# accepted here because a terminal tuple READ BACK from an idempotent replay may
+# legitimately carry any of them. The restoration RPC accepts a strictly
+# narrower set, and the confirm RPC accepts exactly one.
 LIFECYCLE_TERMINAL_REASONS: frozenset[str] = frozenset(
     {
         "insufficient_online_support",
@@ -36,6 +38,7 @@ LIFECYCLE_TERMINAL_REASONS: frozenset[str] = frozenset(
         "stale_incumbent",
         "observed_regression",
         "governed_erasure",
+        "confirmed_online_support",
     }
 )
 PublishableOptimizerKind = Literal[

--- a/reflexio/server/services/playbook/publication.py
+++ b/reflexio/server/services/playbook/publication.py
@@ -661,6 +661,29 @@ class UserPlaybookLifecycleTerminationStore(Protocol):
         """Reselect the retained predecessor and terminalize, under a fence."""
         ...
 
+    def confirm_user_playbook_provisional_publication(
+        self,
+        *,
+        lifecycle_id: int,
+        expected_fence: int,
+        expected_successor_fingerprint: str,
+        support_session_count: int,
+        refute_session_count: int,
+        global_coverage_numerator: int,
+        global_coverage_denominator: int,
+        target_coverage_numerator: int,
+        target_coverage_denominator: int,
+    ) -> LifecycleTerminalResult:
+        """Keep the successor and terminalize as confirmed, under a fence.
+
+        No ``reason`` parameter: ``confirmed_online_support`` is the only reason
+        this transition can record, so passing it would create a second place
+        the pairing could drift. The six counts are the evidence the boundary
+        decided on; the RPC re-checks the arithmetic itself and refuses an
+        inadmissible set rather than obeying it.
+        """
+        ...
+
     def displace_user_playbook_provisional_publication(
         self, *, lifecycle_id: int
     ) -> LifecycleTerminalResult:

--- a/reflexio/server/services/storage/storage_base/playbook/_user.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_user.py
@@ -121,6 +121,32 @@ class UserPlaybookStoreMixin:
             "Storage backend does not support provisional user-playbook restoration"
         )
 
+    def confirm_user_playbook_provisional_publication(
+        self,
+        *,
+        lifecycle_id: int,
+        expected_fence: int,
+        expected_successor_fingerprint: str,
+        support_session_count: int,
+        refute_session_count: int,
+        global_coverage_numerator: int,
+        global_coverage_denominator: int,
+        target_coverage_numerator: int,
+        target_coverage_denominator: int,
+    ) -> "LifecycleTerminalResult":
+        """Atomically keep the successor and terminalize as confirmed.
+
+        Declared here, alongside restore and displace, rather than as an
+        enterprise-only extra: the three are one termination triple over the
+        same lifecycle row, and their shared Protocol
+        (``UserPlaybookLifecycleTerminationStore``) lives in the OSS package. A
+        backend that satisfied two thirds of it would be a surface every reader
+        has to special-case.
+        """
+        raise NotImplementedError(
+            "Storage backend does not support provisional user-playbook confirmation"
+        )
+
     def displace_user_playbook_provisional_publication(
         self, *, lifecycle_id: int
     ) -> "LifecycleTerminalResult":

--- a/tests/server/services/playbook/test_publication_models.py
+++ b/tests/server/services/playbook/test_publication_models.py
@@ -11,6 +11,7 @@ from reflexio.models.api_schema.domain import (
     UserPlaybook,
 )
 from reflexio.server.services.playbook.publication import (
+    LIFECYCLE_TERMINAL_REASONS,
     LIFECYCLE_TERMINAL_STATES,
     DecisionProofEnvelope,
     LifecycleTerminalResult,
@@ -56,6 +57,23 @@ def test_lifecycle_terminal_result_is_derived_from_the_state_literal() -> None:
             state="restored",
             terminal_reason="not_a_reason",
             terminal_at=1_700_000_000,
+        )
+    # Phase 6 made 'confirmed' representable: the SQL CHECK
+    # (20260827070000) admits 'confirmed_online_support', so a terminal tuple
+    # read back from an idempotent replay may carry it and this set must too.
+    confirmed = LifecycleTerminalResult(
+        lifecycle_id=1,
+        state="confirmed",
+        terminal_reason="confirmed_online_support",
+        terminal_at=1,
+    )
+    assert confirmed.terminal_reason in LIFECYCLE_TERMINAL_REASONS
+    with pytest.raises(ValueError, match="reason is not enumerated"):
+        LifecycleTerminalResult(
+            lifecycle_id=1,
+            state="confirmed",
+            terminal_reason="confirmed_because_i_said_so",
+            terminal_at=1,
         )
 
 


### PR DESCRIPTION
Adds the open-source half of Phase 6 (passive confirmation): a ninth lifecycle terminal reason and the storage seam the enterprise confirm path implements.

Stacked on ReflexioAI/reflexio#473 (Phase 5). Review only the two commits above that base.

## What this adds

- `LIFECYCLE_TERMINAL_REASONS` gains `confirmed_online_support` — nine values, mirroring the tenant CHECK. Phase 5's note that Phase 6 would need no contract migration is true of the *restore* half and false of the *confirm* half: every one of the previous eight reasons describes why a successor was **pulled**, so `state = 'confirmed'` was unrepresentable.
- `confirm_user_playbook_provisional_publication` declared on the `UserPlaybookStoreMixin`, beside `restore_` and `displace_`, raising `NotImplementedError` on backends that do not support provisional confirmation.

## Why the seam lives here rather than in the enterprise allowlist

`_ENTERPRISE_ONLY_METHODS` is for methods absent from the OSS ABC. This one is present on it, exactly like its two siblings — registering it in the allowlist would have failed `test_storage_public_method_surface_matches`.

## Scope

Contract only. Nothing in this repository calls the new method, and the OSS backends inherit the `NotImplementedError`. The enterprise counterpart carries the RPC, the day-14 boundary, and the memo intake.

## Rollout note for whoever composes this later

The reason-set widening must be fully **deployed** — all tasks on the new image — before the confirm path is wired, not merely merged. During a rollout the first new task widens the SQL CHECK while old-image tasks still hold the eight-value set, and an old task reading back a confirmed lifecycle would raise `lifecycle terminal result reason is not enumerated`. Unreachable today, since nothing can commit a confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for confirming provisional playbook publications after online support validation.
  * Confirmation now records session evidence and coverage metrics.
  * Added validation to ensure submitted evidence totals are consistent.
  * Added a new terminal lifecycle status reason for confirmed online support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->