### PR TITLE
fix: send reasoning_effort="none" so gpt-5.6 models accept function tools

### DIFF
--- a/reflexio/server/llm/_litellm_text_generation.py
+++ b/reflexio/server/llm/_litellm_text_generation.py
@@ -225,6 +225,17 @@ class TextGenerationMixin:
         "gemini-3-pro-preview",
     }
 
+    # Models that reject function tools on /v1/chat/completions while reasoning is
+    # on. The API answers 400 with:
+    #   "Function tools with reasoning_effort are not supported for gpt-5.6-luna
+    #    in /v1/chat/completions. To use function tools, use /v1/responses or set
+    #    reasoning_effort to 'none'."
+    # Sending reasoning_effort="none" alongside the tools keeps these models usable
+    # on the completions path.
+    TOOLS_REQUIRE_REASONING_DISABLED_MODELS = {
+        "gpt-5.6",
+    }
+
     # Base-owned attributes these methods read (init'd in the facade ``__init__``).
     config: "LiteLLMConfig"
     logger: logging.Logger
@@ -569,6 +580,10 @@ class TextGenerationMixin:
             params["allowed_openai_params"] = allowed_openai_params
         if tools is not None:
             params["tools"] = tools
+            if self._tools_require_reasoning_disabled(actual_model):
+                # setdefault, and placed before params.update(kwargs), so an
+                # explicit caller-supplied reasoning_effort still wins.
+                params.setdefault("reasoning_effort", "none")
         if tool_choice is not None:
             params["tool_choice"] = tool_choice
 
@@ -1736,6 +1751,24 @@ class TextGenerationMixin:
             return _encode_image_to_base64(image_path)
         except ImageEncodingError as exc:
             raise LiteLLMClientError(str(exc)) from exc
+
+    def _tools_require_reasoning_disabled(self, model: str) -> bool:
+        """Check whether a model needs reasoning off to accept function tools.
+
+        Args:
+            model: Model name to check.
+
+        Returns:
+            True if the model rejects function tools unless reasoning_effort is
+            "none" on the chat/completions path.
+        """
+        model_lower = model.lower()
+        # Strip provider routing prefixes (e.g., "openrouter/openai/gpt-5.6-luna").
+        model_name = model_lower.rsplit("/", 1)[-1]
+        return any(
+            model_name.startswith(restricted) or model_name == restricted
+            for restricted in self.TOOLS_REQUIRE_REASONING_DISABLED_MODELS
+        )
 
     def _is_temperature_restricted_model(self, model: str) -> bool:
         """

--- a/tests/server/llm/test_litellm_client_unit.py
+++ b/tests/server/llm/test_litellm_client_unit.py
@@ -4510,3 +4510,93 @@ class TestSafeValidationErrors:
 
         assert errors == ("count: int_parsing",)
         assert all("customer data" not in error for error in errors)
+
+
+# ===================================================================
+# Function tools on models that reject reasoning
+# ===================================================================
+
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "finish",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+class TestToolsRequireReasoningDisabled:
+    """Tests for _tools_require_reasoning_disabled and its param injection."""
+
+    @pytest.fixture()
+    def client(self):
+        return _build_client()
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5.6",
+            "gpt-5.6-luna",
+            "gpt-5.6-terra",
+            "gpt-5.6-sol",
+            "GPT-5.6-Luna",
+        ],
+    )
+    def test_affected_models(self, client, model):
+        assert client._tools_require_reasoning_disabled(model) is True
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gpt-5.5",
+            "gpt-5.4-mini",
+            "gpt-5-nano",
+            "gpt-4o",
+            "claude-3-5-sonnet",
+            "gemini-3-flash-preview",
+        ],
+    )
+    def test_unaffected_models(self, client, model):
+        assert client._tools_require_reasoning_disabled(model) is False
+
+    def test_provider_prefix_stripped(self, client):
+        assert (
+            client._tools_require_reasoning_disabled("openrouter/openai/gpt-5.6-luna")
+            is True
+        )
+
+    def _capture(self, model, **call_kwargs):
+        calls: list[dict[str, Any]] = []
+
+        def fake_completion(**kwargs):
+            calls.append(kwargs)
+            return _make_completion_response("ok")
+
+        client = _build_client(LiteLLMConfig(model=model))
+        with patch("litellm.completion", side_effect=fake_completion):
+            client.generate_chat_response(
+                messages=[{"role": "user", "content": "test"}], **call_kwargs
+            )
+        assert len(calls) == 1
+        return calls[0]
+
+    def test_tools_on_affected_model_disable_reasoning(self):
+        kwargs = self._capture("gpt-5.6-luna", tools=_TOOLS)
+        assert kwargs["reasoning_effort"] == "none"
+
+    def test_no_tools_leaves_reasoning_alone(self):
+        """Only the tools path is affected — plain calls keep reasoning enabled."""
+        kwargs = self._capture("gpt-5.6-luna")
+        assert "reasoning_effort" not in kwargs
+
+    def test_unaffected_model_with_tools_is_untouched(self):
+        kwargs = self._capture("gpt-5.5", tools=_TOOLS)
+        assert "reasoning_effort" not in kwargs
+
+    def test_explicit_reasoning_effort_wins(self):
+        """setdefault, not assignment: a caller-supplied value must survive."""
+        kwargs = self._capture("gpt-5.6-luna", tools=_TOOLS, reasoning_effort="low")
+        assert kwargs["reasoning_effort"] == "low"


### PR DESCRIPTION
## The problem

OpenAI rejects function tools on `/v1/chat/completions` for every `gpt-5.6` variant while reasoning is on:

> Function tools with reasoning_effort are not supported for gpt-5.6-luna in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

The extraction agent is a tool loop on chat/completions, so this makes the whole gpt-5.6 family unusable for extraction — and there is currently no way to reach `reasoning_effort` from configuration (no `LLMConfig` field, no `extra_body`, no kwargs passthrough).

Two things make it unpleasant to diagnose:

1. **It looks partial.** Non-tool calls to the same model keep succeeding, so generation and evaluation appear healthy while every extraction fails.
2. **LiteLLM hides the cause.** It masks the provider message behind a `TypeError` of its own — `BadRequestError.__init__() missing 2 required positional arguments: 'model' and 'llm_provider'` — so the logs never show the sentence above.

I hit this on a self-hosted deployment: pointing the org config at `gpt-5.6-luna` failed 9 extraction runs in ~9 minutes before I rolled back, with only that TypeError to go on.

## The fix

Follows the existing `TEMPERATURE_RESTRICTED_MODELS` idiom rather than inventing a new one:

- `TOOLS_REQUIRE_REASONING_DISABLED_MODELS = {"gpt-5.6"}`, declared next to `TEMPERATURE_RESTRICTED_MODELS` with the API error quoted in a comment.
- `_tools_require_reasoning_disabled()`, mirroring `_is_temperature_restricted_model()` — same prefix-strip for provider routing (`openrouter/openai/gpt-5.6-luna`), same `startswith` matching.
- In `_build_completion_params`, when the request carries `tools` and the model matches, default `reasoning_effort` to `"none"`.

Scope is deliberately narrow:

- `setdefault`, placed **before** `params.update(kwargs)`, so an explicit caller-supplied `reasoning_effort` still wins.
- Non-tool calls to gpt-5.6 keep reasoning enabled — only the tools path is affected.
- No other model is touched.

## Verification

Against the live OpenAI API through LiteLLM (1.89.3), using the same `drop_params=True` the client sets — that mattered, because if LiteLLM stripped the parameter the fix would be inert:

| call | result |
|---|---|
| `gpt-5.6-luna` + tools + `reasoning_effort="none"` | tool call returned |
| `gpt-5.6-luna` + tools, no `reasoning_effort` | the 400 above |
| `gpt-5.6-terra` + tools, no `reasoning_effort` | the same 400 |
| `gpt-5.5` + tools | unaffected, works either way |

Added 16 unit tests in `TestToolsRequireReasoningDisabled`, mirroring `TestTemperatureRestriction`: affected/unaffected model matching, provider-prefix stripping, and four param-level tests driving `generate_chat_response` through a patched `litellm.completion` — tools set it, no-tools does not, unaffected models are untouched, and an explicit caller value survives.

`pytest tests/server/llm/` → **719 passed**, all 16 new tests among them.

Two caveats on my local run, since I would rather state them than let them look like passes:

- `test_litellm_client.py::test_installed_litellm_transport_round_trip` fails on a clean checkout of `main` here too — pre-existing in my environment, unrelated.
- `test_embedding_service_model_contract.py` failures vary between runs in my environment (1 of 3 on clean `main`, 3 of 3 with this branch, **0 of 3 in isolation on both**). They also collect *before* the file I touched, so they cannot be affected by these tests. I believe it is local flakiness around the HF model download, but I could not fully rule it out locally — worth a glance at CI.

## Alternatives considered

- **Routing gpt-5.6 tool calls to `/v1/responses`**, as the error suggests. Correct long-term, but a much larger change than making the completions path work.
- **Exposing `reasoning_effort` as an `LLMConfig` field.** Useful on its own, but it would leave the default broken — callers would have to know to set it. Happy to add it as well, or instead, if you would prefer that shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with GPT-5.6 models when function tools are used.
  * Reasoning is automatically disabled in affected tool-enabled requests when no explicit setting is provided.
  * Explicit reasoning preferences remain unchanged, and unaffected models and requests without tools continue to behave as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->