### PR TITLE
feat(extraction): resume a run under the project that owns it

### DIFF
--- a/reflexio/server/services/extraction/resume_worker.py
+++ b/reflexio/server/services/extraction/resume_worker.py
@@ -84,6 +84,7 @@ from reflexio.server.services.storage.storage_base import (
 from reflexio.server.services.tagging.tagging_scheduler import schedule_tagging
 from reflexio.server.site_var.site_var_manager import SiteVarManager
 from reflexio.server.usage_metrics import UsageEventDeliveryStatus
+from reflexio.server.work_scope import WorkScope, bind_work_scope
 
 logger = logging.getLogger(__name__)
 
@@ -301,7 +302,39 @@ class ExtractionResumeWorker:
         )
         return replace(run, binding=replace(run.binding, user_id=user_id))
 
+    def _scope_for(self, run: AgentRunRecord) -> WorkScope:
+        """The tenant scope this run's writes must be attributed to.
+
+        Taken from the RUN ROW, not from ambient context: the scheduler resumes
+        work long after the request that created it returned, so there is no
+        request-scoped project to inherit. ``_agent_runs.project_id`` is stamped
+        at insert time by the storage chokepoint, which makes the row itself the
+        carrier -- the same reasoning ``work_scope`` records for job payloads.
+
+        A run whose ``project_id`` is NULL predates the project write path. The
+        provider REFUSES that rather than defaulting to the org's default
+        project, and the run is escalated and skipped. Such rows are fixed as
+        DATA, by the existing corpus-derived backfill (enterprise's
+        ``backfill_project_id_tenant_rows``, which already covers ``_agent_runs``
+        and its children) -- not by guessing a project at run time.
+
+        Args:
+            run (AgentRunRecord): The claimed run.
+
+        Returns:
+            WorkScope: Scope to bind for the duration of this run's processing.
+        """
+        return WorkScope(org_id=self.request_context.org_id, project_id=run.project_id)
+
     def run_once(self) -> AgentRunRecord | None:
+        """Claim one run and process it under the project that owns it.
+
+        The two claims are deliberately OUTSIDE the scope. They are org-keyed
+        RPCs (``claim_ready_agent_run`` / ``claim_finalization_failed_agent_run``
+        select on ``org_id`` alone) and run as SECURITY DEFINER, so they neither
+        consult nor need a bound project. Everything downstream of a claim
+        writes project-scoped tenant tables and does.
+        """
         config = self.request_context.configurator.get_config()
         pending_config = config.pending_tool_call_config
         finalization_retry = self.storage.claim_finalization_failed_agent_run(
@@ -310,7 +343,8 @@ class ExtractionResumeWorker:
             claim_ttl_seconds=pending_config.resume_claim_ttl_seconds,
         )
         if finalization_retry is not None:
-            return self._retry_finalization(finalization_retry)
+            with bind_work_scope(self._scope_for(finalization_retry)):
+                return self._retry_finalization(finalization_retry)
 
         run = self.storage.claim_ready_agent_run(
             org_id=self.request_context.org_id,
@@ -320,6 +354,18 @@ class ExtractionResumeWorker:
         if run is None:
             return None
 
+        with bind_work_scope(self._scope_for(run)):
+            return self._process_claimed_run(run, pending_config)
+
+    def _process_claimed_run(
+        self, run: AgentRunRecord, pending_config: Any
+    ) -> AgentRunRecord | None:
+        """Resume and finalize one claimed run. Runs under the run's project.
+
+        Body moved verbatim out of ``run_once`` so a single ``with`` can cover
+        every tenant write it makes -- the resume, the finalization, and each of
+        the four ``update_agent_run_status`` exit paths.
+        """
         if run.max_steps_remaining is not None and run.max_steps_remaining <= 0:
             return self.storage.update_agent_run_status(
                 run.id,

--- a/reflexio/server/services/storage/storage_base/agent_run/_models.py
+++ b/reflexio/server/services/storage/storage_base/agent_run/_models.py
@@ -91,6 +91,18 @@ class AgentRunRecord:
     updated_at: datetime | None = None
     expires_at: datetime | None = None
     last_error: str | None = None
+    #: Tenant project this run belongs to, read back from the row.
+    #:
+    #: READ-SIDE ONLY. Nothing writes it from here: the storage chokepoint
+    #: stamps ``project_id`` on insert, and a second writer would collide with
+    #: it. The field exists so a background worker resuming this run long after
+    #: its request returned can recover the scope from the ROW -- see
+    #: ``ExtractionResumeWorker._scope_for``.
+    #:
+    #: ``None`` in OSS (no projects) and on rows written before the project
+    #: write path shipped. Enterprise refuses to process the latter rather than
+    #: guessing a project; they are fixed by backfill, not at run time.
+    project_id: str | None = None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## The defect

The extraction resume scheduler writes project-scoped tenant tables with no project bound. `_drain_org` builds an org-only `RequestContext` and calls `ExtractionResumeWorker(...).drain(...)`, which reaches the finalization-receipt write and raises:

```
ProjectContextError: No project bound for a write to project-scoped tenant
table '_agent_run_finalization_receipts'
```

It is **latent, not live** — it needs a paused run, and neither staging environment has one. It fails closed the first time one resumes off the scheduler. Eighteen enterprise integration tests reproduce it.

This is the same class as the playbook-aggregation scheduler, on a second background writer.

## The fix

**The scope comes from the row.** A resumed run is decoupled in time from the request that created it, so there is no request-scoped project to inherit — exactly the problem `reflexio.server.work_scope` already exists to solve, and this reuses that seam rather than inventing one. The durable-learning worker binds from `job.project_id` the same way.

`_agent_runs.project_id` is stamped at insert by the storage chokepoint, which makes the row the only carrier the attribution survives on. So `AgentRunRecord` reads it back and `_scope_for(run)` turns it into a `WorkScope`.

**Read-side only on the record.** Nothing here writes `project_id`: the insert path is already stamped, and a second writer for one column is how a conflicting explicit value gets refused.

**The claims stay outside the scope, deliberately.** `claim_ready_agent_run` and `claim_finalization_failed_agent_run` are org-keyed SECURITY DEFINER RPCs that select on `org_id` alone — they neither consult nor need a bound project. Everything downstream of a claim writes project-scoped tables and does, so `run_once` binds once around `_process_claimed_run`, covering the resume, the finalization, and all four `update_agent_run_status` exit paths rather than being sprinkled through them.

**The body was moved, not retyped.** `_process_claimed_run` is byte-identical to the old `run_once` tail, extracted by script with the boundaries asserted — hand-copying eighty lines of retry/finalization branching is how a subtle behaviour change gets in.

## Runs with no project

A run whose `project_id` is NULL predates the project write path. The enterprise provider **refuses** it rather than defaulting to the org's default project, and the worker loop escalates and moves on. Those rows are fixed as *data*: the existing corpus-derived backfill already covers `_agent_runs`, `_agent_run_finalization_receipts` and `_pending_tool_calls` — verified, not assumed, so no new backfill was written.

In OSS this is all inert: `bind_work_scope` is a no-op with no provider registered, and a bare install has one org and no projects.

## Compatibility

`project_id` is appended at the **end** of the `AgentRunRecord` field list, not beside the other required fields, so positional construction is unaffected.

## Verification

- 100 passed across `tests/server/services/extraction` and `tests/server/services/durable_learning`.
- Enterprise receipt suite: **18 failed → 29 passed** (that half ships in the enterprise PR).
- ruff clean, pyright 0.
- Rebased onto current `main` and re-verified after the rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when resuming interrupted runs and retrying finalization.
  - Ensured run processing and status updates consistently use the associated project context.
  - Improved handling of older or standalone run records without project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
