### PR TITLE
fix(lineage): sweep once per project, not once per org

### DIFF
--- a/reflexio/server/services/lineage/gc_scheduler.py
+++ b/reflexio/server/services/lineage/gc_scheduler.py
@@ -27,12 +27,15 @@ import logging
 import time
 from collections.abc import Callable
 
+from reflexio.models.config_schema import Config
 from reflexio.server.api_endpoints.request_context import RequestContext
 from reflexio.server.auth import DEFAULT_ORG_ID
 from reflexio.server.env_utils import env_str
 from reflexio.server.error_reporting import capture_anomaly
 from reflexio.server.org_fanout import iterate_orgs_bounded
 from reflexio.server.scheduling import LeaderGate, ThreadedScheduler
+from reflexio.server.services.storage.storage_base import BaseStorage
+from reflexio.server.work_scope import WorkScope, WorkScopeError, bind_work_scope
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +80,34 @@ def set_org_id_provider(provider: Callable[[], list[str]] | None) -> None:
     """
     global _org_id_provider_hook  # noqa: PLW0603
     _org_id_provider_hook = provider
+
+
+# Injection seam: a deployment with projects registers a per-org project
+# enumerator here, so each org's sweeps run once per project with that project
+# bound. Without it (OSS default) `_project_ids_for` yields a single `None`,
+# `bind_work_scope(None)` is a no-op, and the tick is byte-for-byte what it was.
+#
+# This exists because the sweeps below write project-scoped tables. An org-only
+# context passes no project, and under the enterprise row-level policies the
+# reads then return ZERO ROWS rather than failing -- so lineage GC ran every
+# tick and deleted nothing, silently, which is how it went unnoticed.
+_project_id_provider_hook: Callable[[str], list[str]] | None = None
+
+
+def set_project_id_provider(provider: Callable[[str], list[str]] | None) -> None:
+    """Register the per-org project enumerator consulted by ``_sweep_org``.
+
+    Deployments that have projects call this at app-composition time so each
+    org's sweeps run once per project, with that project bound. ``None`` (OSS
+    default) keeps the single unscoped pass. Pass ``None`` to clear the hook
+    (used by tests to restore OSS defaults).
+
+    Args:
+        provider (Callable[[str], list[str]] | None): Callable taking an org id
+            and returning that org's project ids, or ``None`` to clear.
+    """
+    global _project_id_provider_hook  # noqa: PLW0603
+    _project_id_provider_hook = provider
 
 
 # Injection seam: enterprise sets the fleet leader gate here at composition
@@ -292,11 +323,98 @@ class LineageGCScheduler(ThreadedScheduler):
             logger.exception("event=lineage_gc_org_failed org_id=%s", org_id)
             return
 
+        # One pass per project, not one per org. Everything below writes
+        # project-scoped tables; with no project bound the enterprise row-level
+        # policies match nothing, so the sweep deleted nothing and said so only
+        # through an `unbound_app_credential` probe warning.
+        #
+        # `cfg` is read once, outside the loop, on purpose: `lineage_gc` and
+        # `expiry_reclamation` are deliberately NOT project-overridable, so
+        # there is one window per org and re-reading it per project would imply
+        # a per-project value that cannot exist.
+        for project_id in self._project_ids_for(org_id):
+            scope = (
+                None
+                if project_id is None
+                else WorkScope(org_id=org_id, project_id=project_id)
+            )
+            try:
+                with bind_work_scope(scope):
+                    self._sweep_project_data(org_id, ctx.storage, cfg)
+            except WorkScopeError:
+                # A project that vanished between enumeration and binding.
+                # Escalate and keep going: letting this out of the loop would
+                # skip every remaining project's cleanup for one stale id.
+                capture_anomaly(
+                    "lineage.gc.scope_failed", org_id=org_id, project_id=project_id
+                )
+                logger.exception(
+                    "event=lineage_gc_scope_failed org_id=%s project_id=%s",
+                    org_id,
+                    project_id,
+                )
+
+        # Per-org sweeps: invoked unconditionally once per org (the real gate
+        # lives in each enterprise closure). Extracted to keep _gc_tick's
+        # cyclomatic complexity in check and to mirror _run_global_sweeps.
+        self._run_per_org_sweeps(org_id)
+
+    def _project_ids_for(self, org_id: str) -> list[str | None]:
+        """Return the project ids to sweep for ``org_id``.
+
+        Without a registered provider (OSS) this is a single ``None``, which
+        makes ``bind_work_scope`` a no-op and preserves the original single
+        unscoped pass exactly.
+
+        Args:
+            org_id (str): The org being swept this tick.
+
+        Returns:
+            list[str | None]: Project ids, or ``[None]`` when unscoped.
+        """
+        if _project_id_provider_hook is None:
+            return [None]
+        try:
+            project_ids: list[str | None] = list(_project_id_provider_hook(org_id))
+        except Exception:
+            # Enumeration is the whole tick for this org; a failure here must
+            # not silently degrade to an unscoped pass that deletes nothing.
+            capture_anomaly("lineage.gc.project_enumeration_failed", org_id=org_id)
+            logger.exception(
+                "event=lineage_gc_project_enumeration_failed org_id=%s", org_id
+            )
+            return []
+        if not project_ids:
+            # NOT a fallback to one unscoped pass. Under project row-level
+            # policies an unscoped sweep matches nothing anyway, so the fallback
+            # would do no work while re-emitting the very unbound-credential
+            # warning this change exists to clear. Skipping says the same thing
+            # honestly. Mirrors the aggregation capability, which skips an org
+            # with no project to attribute its work to.
+            logger.warning(
+                "event=lineage_gc_no_projects org_id=%s -- skipping; the sweeps "
+                "are project-scoped and this org has no project to bind",
+                org_id,
+            )
+        return project_ids
+
+    def _sweep_project_data(
+        self, org_id: str, storage: BaseStorage, cfg: Config
+    ) -> None:
+        """Run the Class A and Class B sweeps for the bound project.
+
+        Called once per project with that project bound; see ``_sweep_org``.
+
+        Args:
+            org_id (str): Org being swept, for log/anomaly attribution.
+            storage (BaseStorage): The org's storage, already known non-None.
+            cfg (Config): The org config resolved once by ``_sweep_org``.
+        """
         # Class A: profile expiry sweep (requires PII/grace sign-off; gated on
         # lineage_gc.enabled independently of Class B).
         if cfg.lineage_gc.enabled:
             try:
-                expired_tombstoned = ctx.storage.expire_active_profiles(
+                expired_tombstoned = storage.expire_active_profiles(
                     now=int(time.time())
                 )
                 if expired_tombstoned:
@@ -323,7 +441,7 @@ class LineageGCScheduler(ThreadedScheduler):
                 )
                 tombstone_deleted = 0
                 for entity_type in _ENTITY_TYPES:
-                    tombstone_deleted += ctx.storage.gc_expired_tombstones(
+                    tombstone_deleted += storage.gc_expired_tombstones(
                         entity_type=entity_type,
                         older_than_epoch=older_than_epoch,
                     )
@@ -354,7 +472,7 @@ class LineageGCScheduler(ThreadedScheduler):
         ):
             now = int(time.time())
             for method_name, grace, limit in _CLASS_B_SWEEPS:
-                method = getattr(ctx.storage, method_name, None)
+                method = getattr(storage, method_name, None)
                 if method is None:
                     continue
                 try:
@@ -377,11 +495,6 @@ class LineageGCScheduler(ThreadedScheduler):
                         org_id,
                         method_name,
                     )
-
-        # Per-org sweeps: invoked unconditionally once per org (the real gate
-        # lives in each enterprise closure). Extracted to keep _gc_tick's
-        # cyclomatic complexity in check and to mirror _run_global_sweeps.
-        self._run_per_org_sweeps(org_id)
 
     def _gc_tick(self, org_ids: list[str], *, max_workers: int = 1) -> None:
         """Run one GC pass across the given org IDs.

--- a/tests/server/services/lineage/test_gc_scheduler_project_fanout.py
+++ b/tests/server/services/lineage/test_gc_scheduler_project_fanout.py
@@ -1,0 +1,146 @@
+"""``_sweep_org`` fans its data sweeps out over projects, not over orgs.
+
+The sweeps in ``_sweep_project_data`` write project-scoped tables. Run with no
+project bound, a deployment with row-level project policies matches nothing, so
+the sweep deletes nothing and reports success -- which is how lineage GC ran
+every tick for a week while doing no work at all.
+
+What these tests can and cannot show
+------------------------------------
+They pin the FAN-OUT: one pass per enumerated project, one unscoped pass when no
+provider is registered (the OSS default), the per-org hooks still firing exactly
+once, and an enumeration failure not degrading into a silent unscoped pass.
+
+They deliberately do NOT show that the project is actually *bound* to the
+writes. ``bind_work_scope`` is inert in OSS -- no provider is registered, by
+design -- so a version of ``_sweep_org`` with the ``bind_work_scope`` call
+deleted would still pass every test in this file. The binding is asserted where
+a provider exists, in the enterprise two-project integration test. Saying so
+here is the point: a fan-out test read as a binding test is exactly the kind of
+check that cannot fail.
+"""
+
+import types
+
+import pytest
+
+from reflexio.server.services.lineage.gc_scheduler import (
+    LineageGCScheduler,
+    set_project_id_provider,
+)
+
+_ORG = "org-1"
+
+
+def _scheduler(**kwargs) -> LineageGCScheduler:
+    return LineageGCScheduler(
+        request_context_factory=lambda _org_id: types.SimpleNamespace(),  # type: ignore[arg-type]
+        bootstrap_org_id="org-boot",
+        **kwargs,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider():
+    set_project_id_provider(None)
+    yield
+    set_project_id_provider(None)
+
+
+def _record_passes(scheduler: LineageGCScheduler) -> list[object]:
+    """Replace the data sweep with a recorder, returning the recorded calls."""
+    seen: list[object] = []
+    scheduler._sweep_project_data = lambda *args: seen.append(args)  # type: ignore[method-assign]
+    return seen
+
+
+def _ctx():
+    """A context whose storage is present and whose config disables every sweep.
+
+    The sweep body is stubbed out in these tests, so the config only has to be
+    shaped well enough for ``_sweep_org`` to reach the loop.
+    """
+    return types.SimpleNamespace(
+        storage=types.SimpleNamespace(),
+        configurator=types.SimpleNamespace(get_config=lambda: types.SimpleNamespace()),
+    )
+
+
+def test_no_provider_keeps_the_single_unscoped_pass():
+    """The OSS default must be byte-for-byte the old behaviour: exactly one pass."""
+    scheduler = _scheduler()
+    scheduler.request_context_factory = lambda _org: _ctx()  # type: ignore[assignment]
+    seen = _record_passes(scheduler)
+
+    scheduler._sweep_org(_ORG)
+
+    assert len(seen) == 1
+
+
+def test_one_pass_per_enumerated_project():
+    set_project_id_provider(lambda _org: ["prj_a", "prj_b", "prj_c"])
+    scheduler = _scheduler()
+    scheduler.request_context_factory = lambda _org: _ctx()  # type: ignore[assignment]
+    seen = _record_passes(scheduler)
+
+    scheduler._sweep_org(_ORG)
+
+    assert len(seen) == 3
+
+
+def test_the_per_org_hooks_still_run_exactly_once():
+    """Not once per project.
+
+    The registered per-org sweeps reach ``gc_governance_retention``, which is
+    org-level compliance GC and already privileged. Folding it into the
+    per-project loop would multiply it by the project count -- which is why the
+    hook call sits after the loop rather than inside it.
+    """
+    set_project_id_provider(lambda _org: ["prj_a", "prj_b", "prj_c"])
+    scheduler = _scheduler()
+    scheduler.request_context_factory = lambda _org: _ctx()  # type: ignore[assignment]
+    _record_passes(scheduler)
+    hook_calls: list[str] = []
+    scheduler._run_per_org_sweeps = hook_calls.append  # type: ignore[method-assign]
+
+    scheduler._sweep_org(_ORG)
+
+    assert hook_calls == [_ORG]
+
+
+def test_an_org_with_no_projects_is_skipped_not_swept_unscoped():
+    """Falling back to one unscoped pass here would be theatre.
+
+    Under project row-level policies an unscoped sweep matches nothing, so the
+    fallback does no work AND re-emits the unbound-credential warning this
+    change exists to clear. Skipping is the same outcome, said honestly.
+    """
+    set_project_id_provider(lambda _org: [])
+    scheduler = _scheduler()
+    scheduler.request_context_factory = lambda _org: _ctx()  # type: ignore[assignment]
+    seen = _record_passes(scheduler)
+
+    scheduler._sweep_org(_ORG)
+
+    assert seen == []
+
+
+def test_a_failing_enumerator_sweeps_nothing_rather_than_sweeping_unscoped():
+    """The dangerous failure is the quiet one.
+
+    Falling back to an unscoped pass here would look like work and do none,
+    reproducing the exact defect this change exists to fix. Zero passes is the
+    honest answer; the anomaly is what carries the signal.
+    """
+
+    def _boom(_org: str) -> list[str]:
+        raise RuntimeError("control plane unreachable")
+
+    set_project_id_provider(_boom)
+    scheduler = _scheduler()
+    scheduler.request_context_factory = lambda _org: _ctx()  # type: ignore[assignment]
+    seen = _record_passes(scheduler)
+
+    scheduler._sweep_org(_ORG)
+
+    assert seen == []


### PR DESCRIPTION
## The bug

`LineageGCScheduler._sweep_org` built an org-only `RequestContext` and handed it to sweeps that write **project-scoped** tables. Bound to no project, a deployment with row-level project policies matches nothing — so lineage GC ran every tick and deleted nothing.

It never raised. The only symptom was this, repeating in self-host staging logs:

```
project.unbound_app_credential: ... operation=lineage_gc_expired_tombstones route=writer org=1
```

That silence is why it survived. Its sibling defect in the extraction resume scheduler announced itself with a `ProjectContextError` and was fixed in #483; this one just quietly stopped collecting garbage.

## The change

Class A (profile expiry, tombstone GC) and Class B (expired plain rows) move into `_sweep_project_data`, run once per project inside `bind_work_scope`. The registered per-org sweep hooks stay **outside** the loop and still run exactly once — they reach org-level compliance GC, and folding them in would multiply that by the project count.

A new `set_project_id_provider` seam mirrors the existing `set_org_id_provider`. OSS registers nothing, so `_project_ids_for` yields a single `None`, `bind_work_scope(None)` is a no-op, and the tick is byte-for-byte what it was.

Two failure paths are deliberately **not** a fallback to an unscoped pass:

| Case | Behaviour |
| --- | --- |
| Enumerator raises | Sweep nothing, capture an anomaly |
| Org has no projects | Skip with a warning |

Under project policies an unscoped pass does no work anyway while re-emitting the very warning this change clears — the fallback would only make the skip harder to see.

## What the tests here can and cannot show

`test_gc_scheduler_project_fanout.py` pins the fan-out. Its docstring says outright that it does **not** prove binding: `bind_work_scope` is inert in OSS by design, so a version with the binding deleted passes every test in the file. The binding is asserted in the paired enterprise PR, where a provider exists.

Saying so is the point — a fan-out test read as a binding test is exactly the check-that-cannot-fail shape.

## Verification

- OSS unit tier: **5053 passed**, exit 0
- Lineage suite: **74 passed** (69 pre-existing, unchanged)
- ruff + pyright clean
- Mutation: forcing the loop to `[None]` kills 2 of the new tests; deleting `bind_work_scope` kills the enterprise binding test. Restores verified by SHA-256, not `git checkout --`.

Paired with the enterprise PR that registers the provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lineage cleanup now supports project-scoped scheduling, running separate cleanup sweeps for each project.
  * Cleanup operations are isolated by organization and project, with failures reported without interrupting other work.
  * Organizations without projects are skipped rather than receiving an unscoped cleanup sweep.
  * Existing organization-level cleanup hooks continue to run once per organization.

* **Bug Fixes**
  * Improved storage handling during scheduled cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
