### PR TITLE
docs(storage): say why the learning-state key carries no org or project

### DIFF
--- a/reflexio/server/services/storage/storage_base/retrieved_learning_state.py
+++ b/reflexio/server/services/storage/storage_base/retrieved_learning_state.py
@@ -104,8 +104,27 @@ def build_retrieved_learning_state_key(user_id: str, session_id: str) -> str:
     """Build the ``_operation_state`` key for one session's evaluation state.
 
     Length-prefixed (following the grade_on_demand cache-key precedent) so a
-    crafted user/session pair cannot collide with another pair. Org scoping is
-    unnecessary: ``_operation_state`` is already org-scoped on every backend.
+    crafted user/session pair cannot collide with another pair.
+
+    The key carries neither the org nor the project, and both omissions are
+    deliberate because the isolation is STRUCTURAL rather than encoded in the
+    string:
+
+    * org -- every org has its own storage (a schema on the Postgres/Supabase
+      backends, its own file on SQLite), so two orgs' keys never meet.
+    * project -- on the enterprise backends ``_operation_state`` carries a
+      ``project_id`` column with a row-level policy over it and a
+      ``UNIQUE (project_id, service_name)`` key, so two projects hold separate
+      rows for one key by construction. SQLite is single-tenant and has no
+      such column.
+
+    This paragraph previously said only "org scoping is unnecessary:
+    ``_operation_state`` is already org-scoped on every backend", which was
+    true but incomplete once the table became project-scoped, and read as
+    though the key were the only thing keeping tenants apart. Do NOT add an org
+    or project component here to "make it safe": that would denormalise
+    ownership into a string, where it can disagree with the column the policy
+    actually filters on.
 
     Args:
         user_id (str): Session owner.


### PR DESCRIPTION
`build_retrieved_learning_state_key`'s docstring said:

> Org scoping is unnecessary: `_operation_state` is already org-scoped on every backend.

True, and now incomplete: on the enterprise backends the table also carries a `project_id` column with a row-level policy over it and a `UNIQUE (project_id, service_name)` key, so it is project-scoped as well.

## Why incomplete matters here

The sentence offers **one** reason the key is safe without an org component. That invites the inference that the key *string* is what keeps tenants apart — and the obvious "fix" following from that reading is to add an org or project component to the key.

That would be a real regression. It denormalises ownership into a string, where it can disagree with the column the policy actually filters on, and where nothing enforces the agreement. So the docstring now names both structural mechanisms and says explicitly not to do it:

- **org** — every org has its own storage (a schema on Postgres/Supabase, its own file on SQLite)
- **project** — the `project_id` column plus its policy on the enterprise backends; SQLite is single-tenant and has no such column

## Scope

Comment only — the returned key is byte-for-byte identical. OSS unit tier: 5048 passed. ruff clean.

No enterprise gitlink bump needed; it gets picked up on any future submodule bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation for retrieved learning state storage keys.
  - Clarified how storage is organized across backends, including project-level constraints and SQLite’s single-tenant model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
