### PR TITLE
fix(llm): surface the repair-turn helpers on the public client module

### DIFF
--- a/reflexio/server/llm/litellm_client.py
+++ b/reflexio/server/llm/litellm_client.py
@@ -63,10 +63,20 @@ from reflexio.server.llm._litellm_subprocess import (
     _PromptTokenDetailsSnapshot as _PromptTokenDetailsSnapshot,
 )
 from reflexio.server.llm._litellm_text_generation import (
+    # Re-exported for the enterprise repair-ladder tests, which assert their own
+    # budget against this one. It stays underscore-named because it is internal
+    # to `_litellm_text_generation`; the `as` form is how this file already
+    # surfaces `_litellm_completion_worker`, and it keeps the name out of
+    # `__all__`.
+    _LADDER_WALL_CLOCK_BUDGET_SECONDS as _LADDER_WALL_CLOCK_BUDGET_SECONDS,
+)
+from reflexio.server.llm._litellm_text_generation import (
+    STRUCTURED_OUTPUT_CORRECTION_PREFIX,
     ProviderRequestGuardError,
     StructuredOutputValidator,
     TextGenerationMixin,
     is_structured_output_correction_turn,
+    structured_output_correction_turn,
     structured_output_repair_idempotency_key,
 )
 from reflexio.server.llm._litellm_types import (
@@ -97,8 +107,16 @@ _register_claude_code()
 _register_openclaw()
 
 # Public importer surface (the #1 invariant of the Tier-2.5 decomposition). These
-# five names — plus the test-imported internals re-exported below the split — must
-# stay importable from ``reflexio.server.llm.litellm_client`` for all ~102 importers.
+# names — plus the test-imported internals re-exported below the split — must
+# stay importable from ``reflexio.server.llm.litellm_client`` for all ~102
+# importers.
+#
+# `structured_output_correction_turn` and `STRUCTURED_OUTPUT_CORRECTION_PREFIX`
+# joined them because the enterprise open-world analyst reaches for the repair
+# turn directly, and its boundary guard forbids importing
+# `_litellm_text_generation` (a private module) from enterprise code. Surfacing
+# them here is the sanctioned route: the allowlist in that guard is documented
+# as only ever SHRINKING.
 __all__ = [
     "LiteLLMClient",
     "LiteLLMConfig",
@@ -108,7 +126,9 @@ __all__ = [
     "StructuredOutputValidator",
     "ToolCallingChatResponse",
     "create_litellm_client",
+    "STRUCTURED_OUTPUT_CORRECTION_PREFIX",
     "is_structured_output_correction_turn",
+    "structured_output_correction_turn",
     "structured_output_repair_idempotency_key",
 ]
 

--- a/tests/server/api_endpoints/test_applied_learnings_metering.py
+++ b/tests/server/api_endpoints/test_applied_learnings_metering.py
@@ -267,10 +267,10 @@ def test_metering_failure_does_not_break_search_response() -> None:
     otherwise undetectable: the caller ignores the helper's return value, and
     ``_worker_loop``'s own ``search.metering.job_failed`` capture can never fire
     because this handler swallows the exception first. A ``logger.warning`` does
-    not close that gap -- the enterprise Sentry integration is wired at
-    ``event_level=logging.ERROR`` with Sentry Logs off, so a warning produces no
-    event at all, and searching for one returns a false clean whether or not the
-    drop is happening.
+    not close that gap -- downstream error reporting is wired at
+    ``logging.ERROR`` with log forwarding off, so a warning produces no event at
+    all, and searching for one returns a false clean whether or not the drop is
+    happening.
     """
     events = _capture()
     profiles = [_make_profile_view("u1")]


### PR DESCRIPTION
Both changes fix tests that are **red on `main`** — surfaced by the enterprise repo's OSS/enterprise boundary guard.

## 1. Promote the repair-turn helpers to the public client module

The enterprise open-world analyst imports `structured_output_correction_turn` from `reflexio.server.llm._litellm_text_generation` — a private module. Its two test files reach into the same module for `STRUCTURED_OUTPUT_CORRECTION_PREFIX` and `_LADDER_WALL_CLOCK_BUDGET_SECONDS`.

`test_enterprise_imports_only_oss_public_modules` fails on all of it. Its allowlist is documented as one that *only ever shrinks* — "Adding an entry to grow the allowlist is itself a review-blocking change" — so allowlisting was the wrong direction.

`litellm_client.py` already exists to be this surface. Its own comment:

> Public importer surface (the #1 invariant of the Tier-2.5 decomposition). These names — **plus the test-imported internals re-exported below the split** — must stay importable from `reflexio.server.llm.litellm_client`

and it already re-exports `_litellm_completion_worker` and `_PromptTokenDetailsSnapshot` by exactly this route.

- `structured_output_correction_turn` and `STRUCTURED_OUTPUT_CORRECTION_PREFIX` join `__all__`.
- `_LADDER_WALL_CLOCK_BUDGET_SECONDS` keeps its underscore and uses the `as` idiom, staying out of `__all__` — it remains internal to `_litellm_text_generation` and is surfaced only so the enterprise repair-ladder tests can assert their own budget against it.

No behaviour changes; these are re-exports.

## 2. Drop a vendor name from a test docstring

`test_applied_learnings_metering.py` named Sentry while explaining why a `logger.warning` is insufficient. Sentry is Enterprise-only, and `test_oss_packages_have_no_enterprise_error_vendor_concept` fails on it appearing anywhere in OSS source, tests, docs, or dependency metadata.

The sentence's point survives intact — a warning raises no alarm because downstream error reporting is wired at `logging.ERROR` with log forwarding off, so searching for an event returns a false clean whether or not usage is being dropped.

## Verification

- `reflexio_ext/tests/test_oss_enterprise_boundary_guard.py` — **15 passed** (was 2 failed)
- The three enterprise files that switched imports — **88 passed**
- `reflexio_ext/tests/server/services/offline_tuner/open_world/` under the CI marker selection — **970 passed, 0 failed**
- All three names verified importable from the public path

Paired with the enterprise PR that switches the imports and bumps the submodule pointer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved access to shared language-model processing utilities for compatible integrations.

- **Documentation**
  - Clarified that downstream error reporting uses error-level logging and does not forward events to external monitoring services.

- **Tests**
  - Updated test documentation to reflect the current error-reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
