### PR TITLE
fix(llm): list the promoted names in the facade surface guard

### DIFF
--- a/reflexio/server/llm/__init__.py
+++ b/reflexio/server/llm/__init__.py
@@ -6,6 +6,7 @@ for OpenAI, Claude, Azure OpenAI, and other LLM providers.
 """
 
 from .litellm_client import (
+    STRUCTURED_OUTPUT_CORRECTION_PREFIX,
     LiteLLMClient,
     LiteLLMClientError,
     LiteLLMConfig,
@@ -15,6 +16,7 @@ from .litellm_client import (
     ToolCallingChatResponse,
     create_litellm_client,
     is_structured_output_correction_turn,
+    structured_output_correction_turn,
     structured_output_repair_idempotency_key,
 )
 from .model_defaults import (
@@ -33,8 +35,10 @@ __all__ = [
     "ModelRole",
     "ToolCallingChatResponse",
     "create_litellm_client",
+    "STRUCTURED_OUTPUT_CORRECTION_PREFIX",
     "is_structured_output_correction_turn",
     "resolve_model_name",
+    "structured_output_correction_turn",
     "structured_output_repair_idempotency_key",
     "validate_llm_availability",
 ]

--- a/tests/server/llm/test_litellm_client_surface.py
+++ b/tests/server/llm/test_litellm_client_surface.py
@@ -42,6 +42,11 @@ PUBLIC_SYMBOLS = [
     # re-implementing either.
     "is_structured_output_correction_turn",
     "structured_output_repair_idempotency_key",
+    # The repair turn itself, plus the prefix that identifies one. Promoted for
+    # the enterprise open-world analyst, whose boundary guard forbids importing
+    # `_litellm_text_generation` directly and whose allowlist only ever shrinks.
+    "STRUCTURED_OUTPUT_CORRECTION_PREFIX",
+    "structured_output_correction_turn",
 ]
 
 # Test-imported internals that ImportError at collection if dropped. AST-scanned
@@ -55,6 +60,11 @@ INTERNAL_SYMBOLS = [
     "_litellm_completion_worker",
     "_truncate_for_embedding",
     "_TRUNCATION_WARNED_MODELS",
+    # Surfaced (underscore intact, out of `__all__`) so the enterprise
+    # repair-ladder tests can assert their own budget against it. Listed here so
+    # a future move that drops the re-export fails loudly, which is what this
+    # list exists for.
+    "_LADDER_WALL_CLOCK_BUDGET_SECONDS",
 ]
 
 # Sibling leaf/mixin modules the split introduces. Each must cold-import cleanly


### PR DESCRIPTION
**Fixes `os-tests`, red on `main` since #489.** My regression.

#489 added `structured_output_correction_turn` and `STRUCTURED_OUTPUT_CORRECTION_PREFIX` to `litellm_client.__all__` without updating `test_litellm_client_surface.py`, which pins that surface:

```
test_all_equals_public_surface
Extra items in the left set:
  'STRUCTURED_OUTPUT_CORRECTION_PREFIX'
  'structured_output_correction_turn'
```

The guard did exactly what it exists for — it turns "a move dropped a re-export" into one failing assertion instead of a scattered ImportError hunt, and it caught a surface change that had only done half the contract.

Adding the names to `PUBLIC_SYMBOLS` then surfaced the **other** half: `__all__` membership also requires re-export from `reflexio/server/llm/__init__.py`, which #489 missed too (`test_package_init_reexports_public_surface`). Both halves are done here.

`_LADDER_WALL_CLOCK_BUDGET_SECONDS` joins `INTERNAL_SYMBOLS` — it is re-exported with its underscore intact and deliberately kept out of `__all__`, so the internal list is where a future move that drops it should fail loudly.

## Cause

I changed OSS code and verified only the *enterprise* gate that motivated the change, never this package's own suite. The enterprise boundary guard went green and I stopped there.

## Verification

- `tests/server/llm/test_litellm_client_surface.py` — **39 passed** (was 1 failed)
- `tests/server/llm/` — **733 passed, 2 skipped**
- Full OSS suite (`-m "not integration and not e2e"`) — **5069 passed, 10 skipped, 0 failed**
- `ruff check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed structured-output correction utilities through the LLM package’s public interface.
  * Made the LLM client’s wall-clock budget constant available through its supported interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
