### PR TITLE
feat: persist explicit playbook aggregation operations

### DIFF
--- a/reflexio/client/client.py
+++ b/reflexio/client/client.py
@@ -14,6 +14,10 @@ import requests
 from pydantic import BaseModel, ConfigDict
 
 from reflexio.defaults import DEFAULT_AGENT_VERSION
+from reflexio.models.api_schema.aggregation_operations import (
+    PlaybookAggregationOperation,
+    SubmitPlaybookAggregationRequest,
+)
 from reflexio.models.api_schema.eval_overview_schema import (
     GradeOnDemandRequest,
     GradeOnDemandResponse,
@@ -2758,6 +2762,30 @@ class ReflexioClient:
             playbook_name=playbook_name,
         )
         self._fire_and_forget(self._manual_playbook_generation_async, req)
+
+    def submit_playbook_aggregation(
+        self, *, request_id: str, agent_version: str
+    ) -> PlaybookAggregationOperation:
+        """Durably submit an idempotent full aggregation; return after admission."""
+        payload = SubmitPlaybookAggregationRequest(
+            request_id=request_id, agent_version=agent_version
+        )
+        response = self._make_request(
+            "POST", "/api/playbook_aggregation_operations", json=payload.model_dump()
+        )
+        return PlaybookAggregationOperation.model_validate(response)
+
+    def get_playbook_aggregation_operation(
+        self, operation_id: str
+    ) -> PlaybookAggregationOperation:
+        """Read committed status for a previously submitted operation."""
+        from urllib.parse import quote
+
+        response = self._make_request(
+            "GET",
+            f"/api/playbook_aggregation_operations/{quote(operation_id, safe='')}",
+        )
+        return PlaybookAggregationOperation.model_validate(response)
 
     def _run_playbook_aggregation_sync(
         self, request: RunPlaybookAggregationRequest

--- a/reflexio/models/api_schema/aggregation_operations.py
+++ b/reflexio/models/api_schema/aggregation_operations.py
@@ -1,0 +1,38 @@
+"""Durable, project-scoped explicit aggregation operations."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class SubmitPlaybookAggregationRequest(BaseModel):
+    request_id: str = Field(min_length=1, max_length=200, pattern=r".*\S.*")
+    agent_version: str = Field(min_length=1, max_length=200, pattern=r".*\S.*")
+
+
+class PlaybookAggregationResult(BaseModel):
+    clusters_found: int = 0
+    user_playbooks_processed: int = 0
+    playbooks_generated: int = 0
+    skipped: str | None = None
+
+
+class PlaybookAggregationOperation(BaseModel):
+    operation_id: str
+    request_id: str
+    agent_version: str
+    status: Literal["queued", "running", "retrying", "succeeded", "failed"]
+    created_at: int
+    updated_at: int
+    started_at: int | None = None
+    completed_at: int | None = None
+    attempts: int = 0
+    next_attempt_at: int | None = None
+    error: str | None = None
+    result: PlaybookAggregationResult | None = None
+
+
+class AggregationOperationConflictError(ValueError):
+    def __init__(self, operation_id: str, message: str):
+        super().__init__(message)
+        self.operation_id = operation_id

--- a/reflexio/server/routes/playbooks.py
+++ b/reflexio/server/routes/playbooks.py
@@ -682,5 +682,9 @@ def get_playbook_aggregation_operation(
         raise HTTPException(503, "Storage not configured")
     operation = storage.get_playbook_aggregation_operation(operation_id)
     if operation is None:
+        if not getattr(storage, "supports_incremental_playbook_aggregation", False):
+            raise HTTPException(
+                503, "Durable aggregation is unavailable on this storage"
+            )
         raise HTTPException(404, "Aggregation operation not found")
     return operation

--- a/reflexio/server/routes/playbooks.py
+++ b/reflexio/server/routes/playbooks.py
@@ -1,7 +1,7 @@
 """Playbook route handlers (extracted from api.py, Tier3 A2)."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 
 if TYPE_CHECKING:
     pass
@@ -10,9 +10,15 @@ from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    HTTPException,
     Request,
 )
 
+from reflexio.models.api_schema.aggregation_operations import (
+    AggregationOperationConflictError,
+    PlaybookAggregationOperation,
+    SubmitPlaybookAggregationRequest,
+)
 from reflexio.models.api_schema.retriever_schema import (
     GetAgentPlaybooksRequest,
     GetAgentPlaybooksViewResponse,
@@ -640,3 +646,41 @@ def downgrade_all_user_playbooks_endpoint(
 
     # Call downgrade_all_user_playbooks with request
     return reflexio.downgrade_all_user_playbooks(request=request)
+
+
+@router.post("/api/playbook_aggregation_operations", status_code=202)
+@limiter.limit("10/minute")
+def submit_playbook_aggregation_operation(
+    request: Request,
+    payload: SubmitPlaybookAggregationRequest,
+    org_id: Annotated[str, Depends(default_get_org_id)],
+) -> PlaybookAggregationOperation:
+    storage = publisher_api.get_reflexio(org_id=org_id).get_storage()
+    if storage is None or not getattr(
+        storage, "supports_incremental_playbook_aggregation", False
+    ):
+        raise HTTPException(503, "Durable aggregation is unavailable on this storage")
+    try:
+        return storage.submit_playbook_aggregation_operation(
+            payload.request_id, payload.agent_version
+        )
+    except AggregationOperationConflictError as exc:
+        raise HTTPException(
+            409, {"message": str(exc), "operation_id": exc.operation_id}
+        ) from exc
+
+
+@router.get("/api/playbook_aggregation_operations/{operation_id}")
+@limiter.limit("120/minute")
+def get_playbook_aggregation_operation(
+    request: Request,
+    operation_id: str,
+    org_id: Annotated[str, Depends(default_get_org_id)],
+) -> PlaybookAggregationOperation:
+    storage = publisher_api.get_reflexio(org_id=org_id).get_storage()
+    if storage is None:
+        raise HTTPException(503, "Storage not configured")
+    operation = storage.get_playbook_aggregation_operation(operation_id)
+    if operation is None:
+        raise HTTPException(404, "Aggregation operation not found")
+    return operation

--- a/reflexio/server/services/playbook/README.md
+++ b/reflexio/server/services/playbook/README.md
@@ -225,3 +225,19 @@ Inline consolidation always runs during generation (the legacy `deduplicator` fe
 
 - [Server README](../../README.md) -- FastAPI backend component overview
 - [Prompt Bank README](../../prompt/prompt_bank/README.md) -- versioned prompt template system used by playbook prompts
+
+
+## Durable explicit aggregation
+
+`aggregation_operations.py` executes persisted full-archive requests before the
+scheduler's automatic work. The POST/GET API and SDK return
+`PlaybookAggregationOperation` receipts from the shared schema module. Requests
+are idempotent within the organization/project and serialized with automatic and
+synchronous manual aggregation through the existing organization lease.
+
+The aggregator commits generated outputs, lineage, bookkeeping and the successful
+operation receipt in the same fenced storage transaction. Zero-output success is
+valid; transient generation failure retries (up to five attempts) rather than
+being mistaken for zero output. Restart recovery discovers persisted queued,
+running and retrying operations; completed operations are never resubmitted.
+Optional optimization/tagging is outside the successful receipt contract.

--- a/reflexio/server/services/playbook/aggregation_operations.py
+++ b/reflexio/server/services/playbook/aggregation_operations.py
@@ -1,0 +1,129 @@
+"""Execute explicit full aggregations on the existing scheduler and lease."""
+
+import logging
+
+from reflexio.lib.generation_client import create_generation_litellm_client
+from reflexio.server.api_endpoints.request_context import RequestContext
+from reflexio.server.extensions import get_service
+from reflexio.server.operation_limiter import operation_limit
+from reflexio.server.services.playbook.aggregation_prompt_processing import (
+    AGGREGATION_PROMPT_PROCESSOR,
+)
+from reflexio.server.services.playbook.components.aggregator import PlaybookAggregator
+from reflexio.server.services.playbook.playbook_service_utils import (
+    PlaybookAggregatorRequest,
+)
+from reflexio.server.services.storage.storage_base.playbook import (
+    AGGREGATION_RETRY_BASE_SECONDS,
+    AGGREGATION_RETRY_MAX_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run_explicit_operation(context: RequestContext, *, owner: str) -> bool:
+    """Return whether explicit work owns this scheduler turn (including contention)."""
+    from .aggregation_scheduler import (
+        AGGREGATION_BACKLOG_RETRY_SECONDS,
+        AGGREGATION_LEASE_SECONDS,
+        AGGREGATION_RETRY_SECONDS,
+        AggregationLeaseHeartbeat,
+        aggregation_min_interval_seconds,
+    )
+
+    storage = context.storage
+    if storage is None:
+        return False
+    operation = storage.next_playbook_aggregation_operation()
+    if operation is None:
+        return False
+    claim = storage.claim_due_playbook_aggregation(
+        owner=owner,
+        lease_seconds=AGGREGATION_LEASE_SECONDS,
+        agent_version=operation.agent_version,
+    )
+    if claim is None:
+        return True
+    exhausted = operation.attempts >= 5
+    heartbeat = AggregationLeaseHeartbeat(storage, claim)
+    heartbeat.start()
+    success = False
+    try:
+        with operation_limit(context.org_id, "aggregation"):
+            operation = storage.begin_playbook_aggregation_operation(
+                operation.operation_id, claim
+            )
+            if exhausted:
+                raise ValueError("attempts_exhausted")
+            config = context.configurator.get_config().user_playbook_extractor_config
+            if (
+                config is None
+                or config.aggregation_config is None
+                or config.aggregation_config.min_cluster_size < 2
+            ):
+                raise ValueError("invalid_aggregation_config")
+            aggregator = PlaybookAggregator(
+                llm_client=create_generation_litellm_client(context),
+                request_context=context,
+                agent_version=operation.agent_version,
+                aggregation_claim=claim,
+                explicit_operation_id=operation.operation_id,
+                aggregation_prompt_processor=get_service(AGGREGATION_PROMPT_PROCESSOR),
+            )
+            result = aggregator.run(
+                PlaybookAggregatorRequest(
+                    agent_version=operation.agent_version,
+                    rerun=True,
+                    operation_key=operation.operation_id,
+                )
+            )
+        heartbeat.require_live()
+        # Early successful no-ops have no output transaction. Complete them under
+        # the same fence; output-producing paths already committed the receipt.
+        with storage.commit_scope():
+            current = storage.get_playbook_aggregation_operation(operation.operation_id)
+            if current is None:
+                raise RuntimeError("aggregation operation disappeared")
+            if current.status != "succeeded":
+                storage.complete_playbook_aggregation_operation(
+                    operation.operation_id, heartbeat.claim, result
+                )
+        success = True
+    except Exception as exc:
+        terminal = (
+            isinstance(exc, ValueError)
+            or "safety cap" in str(exc).lower()
+            or operation.attempts >= 5
+        )
+        # Do not expose provider messages, credentials, or customer content in status.
+        error = (
+            "attempts_exhausted"
+            if exhausted or operation.attempts >= 5
+            else ("invalid_configuration_or_input" if terminal else "execution_failed")
+        )
+        storage.fail_playbook_aggregation_operation(
+            operation.operation_id,
+            heartbeat.claim,
+            error=error,
+            retry_seconds=None
+            if terminal
+            else min(
+                AGGREGATION_RETRY_MAX_SECONDS,
+                AGGREGATION_RETRY_BASE_SECONDS * 2 ** max(0, operation.attempts - 1),
+            ),
+        )
+        logger.exception(
+            "Explicit aggregation failed operation_id=%s attempt=%s",
+            operation.operation_id,
+            operation.attempts,
+        )
+    finally:
+        heartbeat.stop()
+        storage.finish_playbook_aggregation_claim(
+            heartbeat.claim,
+            success=success,
+            retry_after_seconds=AGGREGATION_RETRY_SECONDS,
+            backlog_retry_after_seconds=AGGREGATION_BACKLOG_RETRY_SECONDS,
+            min_interval_seconds=aggregation_min_interval_seconds(),
+        )
+    return True

--- a/reflexio/server/services/playbook/aggregation_scheduler.py
+++ b/reflexio/server/services/playbook/aggregation_scheduler.py
@@ -122,8 +122,6 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
         playbook_config = getattr(
             context.configurator.get_config(), "user_playbook_extractor_config", None
         )
-        if playbook_config is None or playbook_config.aggregation_config is None:
-            return
         if storage is None:
             return
         if not getattr(storage, "supports_incremental_playbook_aggregation", False):
@@ -137,6 +135,14 @@ class PlaybookAggregationScheduler(ThreadedScheduler):
                     context.org_id,
                     blocked_reason,
                 )
+            return
+        from reflexio.server.services.playbook.aggregation_operations import (
+            run_explicit_operation,
+        )
+
+        if run_explicit_operation(context, owner=f"explicit:{self._worker_id}"):
+            return
+        if playbook_config is None or playbook_config.aggregation_config is None:
             return
         repair_now = time.monotonic()
         last_repair_at = self._last_repair_at.get(context.org_id)

--- a/reflexio/server/services/playbook/components/aggregator.py
+++ b/reflexio/server/services/playbook/components/aggregator.py
@@ -247,6 +247,7 @@ class PlaybookAggregator:
         effect_coordinator: AggregationEffectCoordinator | None = None,
         aggregation_claim: PlaybookAggregationClaim | None = None,
         residual_batch_limit: int | None = None,
+        explicit_operation_id: str | None = None,
     ) -> None:
         self.client = llm_client
         storage = request_context.storage
@@ -260,6 +261,7 @@ class PlaybookAggregator:
         self.effect_coordinator = effect_coordinator
         self.aggregation_claim = aggregation_claim
         self.residual_batch_limit = residual_batch_limit
+        self.explicit_operation_id = explicit_operation_id
         # Cohesive pre/post-processing component (the enterprise redaction
         # Protocol seam). Constructed from the SAME injected instance stored
         # above — do NOT re-resolve the AGGREGATION_PROMPT_PROCESSOR ServiceKey.
@@ -1950,6 +1952,14 @@ class PlaybookAggregator:
                 raise RuntimeError(
                     "playbook aggregation rerun lost its invalidation fence"
                 )
+            if self.explicit_operation_id is not None:
+                if self.aggregation_claim is None or effect_scope is None:
+                    raise RuntimeError(
+                        "explicit aggregation requires a fenced output transaction"
+                    )
+                self.storage.complete_playbook_aggregation_operation(
+                    self.explicit_operation_id, self.aggregation_claim, stats
+                )
             if self.effect_coordinator is not None:
                 self.effect_coordinator.complete(stats)
                 if effect_scope is None:
@@ -2164,13 +2174,16 @@ class PlaybookAggregator:
         direction_overlap_threshold: float = 0.6,
     ) -> list[tuple[AgentPlaybook, list[UserPlaybook], ModelProvenance | None]]:
         """Compatibility view containing only generated outcomes."""
+        outcomes = self._generate_playbook_outcomes_with_source_clusters(
+            clusters, existing_approved_playbooks, direction_overlap_threshold
+        )
+        if self.explicit_operation_id is not None and any(
+            outcome.status == "retryable_failure" for outcome in outcomes
+        ):
+            raise RuntimeError("explicit aggregation generation failed")
         return [
             (outcome.playbook, outcome.source_cluster, outcome.provenance)
-            for outcome in self._generate_playbook_outcomes_with_source_clusters(
-                clusters,
-                existing_approved_playbooks,
-                direction_overlap_threshold,
-            )
+            for outcome in outcomes
             if outcome.status == "generated" and outcome.playbook is not None
         ]
 

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation.py
@@ -20,6 +20,11 @@ from reflexio.server.services.storage.storage_base.playbook import (
     PlaybookAggregationRerunSnapshot,
 )
 
+from ._aggregation_operations import (
+    AGGREGATION_OPERATIONS_DDL,
+    AggregationOperationsMixin,
+)
+
 AGGREGATION_DDL = """
 CREATE TABLE IF NOT EXISTS playbook_aggregation_state (
     agent_version TEXT PRIMARY KEY,
@@ -199,7 +204,7 @@ COMMIT;
 
 
 def init_playbook_aggregation_tables(conn: sqlite3.Connection) -> None:
-    conn.executescript(AGGREGATION_DDL)
+    conn.executescript(AGGREGATION_DDL + AGGREGATION_OPERATIONS_DDL)
     try:
         conn.executescript(AGGREGATION_TRIGGER_DDL)
     except Exception:
@@ -235,7 +240,7 @@ def init_playbook_aggregation_tables(conn: sqlite3.Connection) -> None:
     )
 
 
-class PlaybookAggregationStoreMixin:
+class PlaybookAggregationStoreMixin(AggregationOperationsMixin):
     conn: sqlite3.Connection
     _lock: threading.RLock
     _own_transaction: Any

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation_operations.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_aggregation_operations.py
@@ -1,0 +1,183 @@
+"""SQLite receipts for explicit aggregation, fenced by the existing lease."""
+
+import json
+import sqlite3
+import uuid
+from typing import Any
+
+from reflexio.models.api_schema.aggregation_operations import (
+    AggregationOperationConflictError,
+    PlaybookAggregationOperation,
+    PlaybookAggregationResult,
+)
+from reflexio.server.services.storage.storage_base.playbook import (
+    PlaybookAggregationClaim,
+)
+
+AGGREGATION_OPERATIONS_DDL = """
+CREATE TABLE IF NOT EXISTS playbook_aggregation_operations (
+    operation_id TEXT PRIMARY KEY,
+    request_id TEXT NOT NULL UNIQUE,
+    agent_version TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('queued','running','retrying','succeeded','failed')),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    started_at INTEGER,
+    completed_at INTEGER,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at INTEGER,
+    error TEXT,
+    result TEXT,
+    claim_fence INTEGER
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_aggregation_operation_active
+    ON playbook_aggregation_operations(agent_version)
+    WHERE status IN ('queued','running','retrying');
+CREATE TRIGGER IF NOT EXISTS cancel_erased_aggregation_operations BEFORE DELETE ON user_playbooks
+FOR EACH ROW BEGIN
+ UPDATE playbook_aggregation_operations SET status='failed',error='input_erased',
+ completed_at=unixepoch(),updated_at=unixepoch(),next_attempt_at=NULL
+ WHERE agent_version=OLD.agent_version AND status IN ('queued','running','retrying');
+END;
+"""
+
+
+def operation_from_row(row: Any) -> PlaybookAggregationOperation:
+    value = dict(row)
+    value.pop("claim_fence", None)
+    if isinstance(value.get("result"), str):
+        value["result"] = json.loads(value["result"])
+    return PlaybookAggregationOperation.model_validate(value)
+
+
+class AggregationOperationsMixin:
+    conn: sqlite3.Connection
+    commit_scope: Any
+    _lock: Any
+    validate_playbook_aggregation_claim: Any
+    schedule_playbook_aggregation: Any
+
+    def submit_playbook_aggregation_operation(
+        self, request_id: str, agent_version: str
+    ) -> PlaybookAggregationOperation:
+        with self.commit_scope():
+            old = self.conn.execute(
+                "SELECT * FROM playbook_aggregation_operations WHERE request_id=?",
+                (request_id,),
+            ).fetchone()
+            if old:
+                operation = operation_from_row(old)
+                if operation.agent_version != agent_version:
+                    raise AggregationOperationConflictError(
+                        operation.operation_id, "request_id parameters changed"
+                    )
+                return operation
+            active = self.conn.execute(
+                "SELECT operation_id FROM playbook_aggregation_operations WHERE agent_version=? "
+                "AND status IN ('queued','running','retrying')",
+                (agent_version,),
+            ).fetchone()
+            if active:
+                raise AggregationOperationConflictError(
+                    active[0], "aggregation operation already active"
+                )
+            operation_id = uuid.uuid4().hex
+            self.conn.execute(
+                "INSERT INTO playbook_aggregation_operations "
+                "(operation_id,request_id,agent_version,status,created_at,updated_at,next_attempt_at) "
+                "VALUES (?,?,?,'queued',unixepoch(),unixepoch(),unixepoch())",
+                (operation_id, request_id, agent_version),
+            )
+            self.schedule_playbook_aggregation(agent_version)
+            operation = self.get_playbook_aggregation_operation(operation_id)
+            if operation is None:
+                raise RuntimeError("aggregation operation receipt missing")
+            return operation
+
+    def get_playbook_aggregation_operation(
+        self, operation_id: str
+    ) -> PlaybookAggregationOperation | None:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT * FROM playbook_aggregation_operations WHERE operation_id=?",
+                (operation_id,),
+            ).fetchone()
+            return operation_from_row(row) if row else None
+
+    def next_playbook_aggregation_operation(
+        self,
+    ) -> PlaybookAggregationOperation | None:
+        with self._lock:
+            row = self.conn.execute(
+                "SELECT * FROM playbook_aggregation_operations "
+                "WHERE status IN ('queued','running','retrying') AND next_attempt_at<=unixepoch() "
+                "ORDER BY created_at,operation_id LIMIT 1"
+            ).fetchone()
+            return operation_from_row(row) if row else None
+
+    def begin_playbook_aggregation_operation(
+        self, operation_id: str, claim: PlaybookAggregationClaim
+    ) -> PlaybookAggregationOperation:
+        with self.commit_scope():
+            if not self.validate_playbook_aggregation_claim(claim):
+                raise RuntimeError("aggregation operation lease lost")
+            cursor = self.conn.execute(
+                "UPDATE playbook_aggregation_operations SET status='running', attempts=min(attempts+1,5), "
+                "claim_fence=?,started_at=COALESCE(started_at,unixepoch()),updated_at=unixepoch(),error=NULL "
+                "WHERE operation_id=? AND agent_version=? AND status IN ('queued','running','retrying')",
+                (claim.fence, operation_id, claim.agent_version),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("aggregation operation no longer runnable")
+            operation = self.get_playbook_aggregation_operation(operation_id)
+            if operation is None:
+                raise RuntimeError("aggregation operation receipt missing")
+            return operation
+
+    def complete_playbook_aggregation_operation(
+        self, operation_id: str, claim: PlaybookAggregationClaim, result: dict[str, Any]
+    ) -> None:
+        with self.commit_scope():
+            if not self.validate_playbook_aggregation_claim(claim):
+                raise RuntimeError("aggregation operation lease lost")
+            cursor = self.conn.execute(
+                "UPDATE playbook_aggregation_operations SET status='succeeded',result=?,error=NULL, "
+                "updated_at=unixepoch(),completed_at=unixepoch(),next_attempt_at=NULL "
+                "WHERE operation_id=? AND status='running' AND claim_fence=? AND agent_version=?",
+                (
+                    PlaybookAggregationResult.model_validate(result).model_dump_json(),
+                    operation_id,
+                    claim.fence,
+                    claim.agent_version,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise RuntimeError("aggregation operation completion fence lost")
+
+    def fail_playbook_aggregation_operation(
+        self,
+        operation_id: str,
+        claim: PlaybookAggregationClaim,
+        *,
+        error: str,
+        retry_seconds: int | None,
+    ) -> None:
+        with self.commit_scope():
+            if not self.validate_playbook_aggregation_claim(claim):
+                return
+            self.conn.execute(
+                "UPDATE playbook_aggregation_operations SET status=?,error=?,updated_at=unixepoch(), "
+                "completed_at=CASE WHEN ? IS NULL THEN unixepoch() ELSE NULL END, "
+                "next_attempt_at=CASE WHEN ? IS NULL THEN NULL ELSE unixepoch()+? END "
+                "WHERE operation_id=? AND status='running' AND claim_fence=? AND agent_version=?",
+                (
+                    "failed" if retry_seconds is None else "retrying",
+                    error,
+                    retry_seconds,
+                    retry_seconds,
+                    retry_seconds,
+                    operation_id,
+                    claim.fence,
+                    claim.agent_version,
+                ),
+            )

--- a/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
+++ b/reflexio/server/services/storage/storage_base/playbook/_aggregation.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
+from reflexio.models.api_schema.aggregation_operations import (
+    PlaybookAggregationOperation,
+)
 from reflexio.models.api_schema.service_schemas import UserPlaybook
 
 AggregationDisposition = Literal["residual", "cluster_member", "terminal_noop"]
@@ -97,6 +100,41 @@ class PlaybookAggregationStoreMixin:
     Tenant backends scope these records by schema; SQLite scopes them by the
     storage database.  Callers must not use a sequence watermark for discovery.
     """
+
+    def submit_playbook_aggregation_operation(
+        self, request_id: str, agent_version: str
+    ) -> PlaybookAggregationOperation:
+        raise NotImplementedError
+
+    def get_playbook_aggregation_operation(
+        self, operation_id: str
+    ) -> PlaybookAggregationOperation | None:
+        raise NotImplementedError
+
+    def next_playbook_aggregation_operation(
+        self,
+    ) -> PlaybookAggregationOperation | None:
+        raise NotImplementedError
+
+    def begin_playbook_aggregation_operation(
+        self, operation_id: str, claim: PlaybookAggregationClaim
+    ) -> PlaybookAggregationOperation:
+        raise NotImplementedError
+
+    def complete_playbook_aggregation_operation(
+        self, operation_id: str, claim: PlaybookAggregationClaim, result: dict[str, Any]
+    ) -> None:
+        raise NotImplementedError
+
+    def fail_playbook_aggregation_operation(
+        self,
+        operation_id: str,
+        claim: PlaybookAggregationClaim,
+        *,
+        error: str,
+        retry_seconds: int | None,
+    ) -> None:
+        raise NotImplementedError
 
     def schedule_playbook_aggregation(self, agent_version: str) -> None:
         """Durably mark a version pending without postponing existing work."""

--- a/tests/server/routes/test_aggregation_operation_capability.py
+++ b/tests/server/routes/test_aggregation_operation_capability.py
@@ -1,0 +1,52 @@
+"""Capability discovery must not hide previously committed receipts."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from reflexio.models.api_schema.aggregation_operations import (
+    PlaybookAggregationOperation,
+)
+from reflexio.server.api import create_app
+
+
+@pytest.mark.parametrize("available", [False, True])
+@pytest.mark.parametrize("existing", [False, True])
+def test_receipt_lookup_reports_capability_only_when_missing(available, existing):
+    receipt = PlaybookAggregationOperation(
+        operation_id="operation",
+        request_id="request",
+        agent_version="v1",
+        status="succeeded",
+        created_at=1,
+        updated_at=2,
+        completed_at=2,
+    )
+    reflexio = MagicMock()
+    storage = reflexio.get_storage.return_value
+    storage.supports_incremental_playbook_aggregation = available
+    storage.get_playbook_aggregation_operation.return_value = (
+        receipt if existing else None
+    )
+    app = create_app(get_org_id=lambda: "test-org")
+    app.state.limiter.enabled = False
+    with patch(
+        "reflexio.server.routes.playbooks.publisher_api.get_reflexio",
+        return_value=reflexio,
+    ) as resolve:
+        response = TestClient(app, headers={"User-Agent": "Mozilla/5.0"}).get(
+            "/api/playbook_aggregation_operations/operation"
+        )
+    resolve.assert_called_once_with(org_id="test-org")
+    storage.get_playbook_aggregation_operation.assert_called_once_with("operation")
+    if existing:
+        assert response.status_code == 200
+        assert response.json() == receipt.model_dump()
+    else:
+        assert response.status_code == (404 if available else 503)
+        assert response.json()["detail"] == (
+            "Aggregation operation not found"
+            if available
+            else "Durable aggregation is unavailable on this storage"
+        )

--- a/tests/server/services/playbook/test_aggregation_lineage_integration.py
+++ b/tests/server/services/playbook/test_aggregation_lineage_integration.py
@@ -655,3 +655,80 @@ def test_e2e_reconstruct_incremental_run_mode(
     assert "Run 1 content." in run1_added_contents, (
         f"Run 1's added playbook must survive supersession, got {run1_added_contents}"
     )
+
+
+@pytest.mark.parametrize("crash_before_commit", [False, True])
+def test_explicit_operation_receipt_commits_with_generated_outputs(
+    sqlite_storage, request_context, monkeypatch, crash_before_commit
+):
+    """Fault at receipt completion rolls back real outputs, lineage and bookkeeping."""
+    inputs = [
+        _seed_user_playbook(sqlite_storage, uid=i, org_id=request_context.org_id)
+        for i in (1, 2)
+    ]
+    operation = sqlite_storage.submit_playbook_aggregation_operation("explicit", "v0")
+    claim = sqlite_storage.claim_due_playbook_aggregation(
+        owner="explicit", lease_seconds=300, agent_version="v0"
+    )
+    sqlite_storage.begin_playbook_aggregation_operation(operation.operation_id, claim)
+    aggregator = PlaybookAggregator(
+        llm_client=MagicMock(),
+        request_context=request_context,
+        agent_version="v0",
+        aggregation_claim=claim,
+        explicit_operation_id=operation.operation_id,
+    )
+    output = AgentPlaybook(
+        agent_version="v0",
+        content="Generated guidance",
+        playbook_name="default",
+        embedding=[0.1] * 512,
+    )
+    monkeypatch.setattr(aggregator, "get_clusters", lambda *_a, **_k: {0: inputs})
+    monkeypatch.setattr(
+        aggregator,
+        "_generate_playbooks_with_source_clusters",
+        lambda *_a, **_k: [(output, inputs, None)],
+    )
+    complete = sqlite_storage.complete_playbook_aggregation_operation
+    if crash_before_commit:
+
+        def crash(*args, **kwargs):
+            complete(*args, **kwargs)
+            raise RuntimeError("crash before receipt commit")
+
+        monkeypatch.setattr(
+            sqlite_storage, "complete_playbook_aggregation_operation", crash
+        )
+        with pytest.raises(RuntimeError, match="crash before receipt commit"):
+            aggregator.run(
+                PlaybookAggregatorRequest(
+                    agent_version="v0", rerun=True, operation_key=operation.operation_id
+                )
+            )
+        assert sqlite_storage.get_agent_playbooks() == []
+        assert (
+            sqlite_storage.get_lineage_events(request_id=operation.operation_id) == []
+        )
+        assert (
+            sqlite_storage.get_playbook_aggregation_operation(
+                operation.operation_id
+            ).status
+            == "running"
+        )
+    else:
+        stats = aggregator.run(
+            PlaybookAggregatorRequest(
+                agent_version="v0", rerun=True, operation_key=operation.operation_id
+            )
+        )
+        assert stats["playbooks_generated"] == 1
+        assert (
+            sqlite_storage.get_playbook_aggregation_operation(
+                operation.operation_id
+            ).result.playbooks_generated
+            == 1
+        )
+        assert len(sqlite_storage.get_agent_playbooks()) == 1
+        assert sqlite_storage.get_lineage_events(request_id=operation.operation_id)
+        assert sqlite_storage.next_playbook_aggregation_operation() is None

--- a/tests/server/services/playbook/test_aggregation_operations_integration.py
+++ b/tests/server/services/playbook/test_aggregation_operations_integration.py
@@ -1,0 +1,172 @@
+"""Receipts survive restart and share the aggregation output transaction."""
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+import pytest
+
+from reflexio.models.api_schema.aggregation_operations import (
+    AggregationOperationConflictError,
+)
+from reflexio.server.services.storage.sqlite_storage import SQLiteStorage
+
+
+@pytest.fixture
+def storage(tmp_path):
+    instance = SQLiteStorage(
+        org_id="operations", db_path=str(tmp_path / "operations.db")
+    )
+    yield instance
+    instance.conn.close()
+
+
+def claim_operation(storage, operation):
+    claim = storage.claim_due_playbook_aggregation(
+        owner="test", lease_seconds=300, agent_version=operation.agent_version
+    )
+    assert claim is not None
+    storage.begin_playbook_aggregation_operation(operation.operation_id, claim)
+    return claim
+
+
+def test_idempotent_submission_and_active_conflicts(storage):
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        rows = list(
+            pool.map(
+                lambda _: storage.submit_playbook_aggregation_operation("same", "v1"),
+                range(8),
+            )
+        )
+    assert len({row.operation_id for row in rows}) == 1
+    with pytest.raises(AggregationOperationConflictError):
+        storage.submit_playbook_aggregation_operation("same", "changed")
+    with pytest.raises(AggregationOperationConflictError):
+        storage.submit_playbook_aggregation_operation("another", "v1")
+    assert (
+        storage.submit_playbook_aggregation_operation("other", "v2").operation_id
+        != rows[0].operation_id
+    )
+
+
+def test_completion_rolls_back_with_outputs_and_survives_restart(storage):
+    operation = storage.submit_playbook_aggregation_operation("atomic", "v1")
+    claim = claim_operation(storage, operation)
+    storage.conn.execute("CREATE TABLE test_output (value TEXT)")
+    storage.conn.commit()
+    with pytest.raises(RuntimeError, match="crash"), storage.commit_scope():
+        storage.conn.execute("INSERT INTO test_output VALUES ('first')")
+        storage.complete_playbook_aggregation_operation(
+            operation.operation_id, claim, {"playbooks_generated": 1}
+        )
+        raise RuntimeError("crash")
+    assert storage.conn.execute("SELECT count(*) FROM test_output").fetchone()[0] == 0
+    assert (
+        storage.get_playbook_aggregation_operation(operation.operation_id).status
+        == "running"
+    )
+    with storage.commit_scope():
+        storage.conn.execute("INSERT INTO test_output VALUES ('second')")
+        storage.complete_playbook_aggregation_operation(
+            operation.operation_id, claim, {"playbooks_generated": 1}
+        )
+    reopened = SQLiteStorage(org_id="operations", db_path=storage.db_path)
+    try:
+        receipt = reopened.get_playbook_aggregation_operation(operation.operation_id)
+        assert receipt is not None and receipt.status == "succeeded"
+        assert reopened.next_playbook_aggregation_operation() is None
+    finally:
+        reopened.conn.close()
+    assert storage.next_playbook_aggregation_operation() is None
+    assert (
+        storage.submit_playbook_aggregation_operation("atomic", "v1").status
+        == "succeeded"
+    )
+    assert (
+        storage.get_playbook_aggregation_operation(
+            operation.operation_id
+        ).result.playbooks_generated
+        == 1
+    )
+
+
+def test_stale_lease_cannot_complete_or_fail_success(storage):
+    operation = storage.submit_playbook_aggregation_operation("fenced", "v1")
+    claim = claim_operation(storage, operation)
+    with pytest.raises(RuntimeError, match="lease lost"):
+        storage.complete_playbook_aggregation_operation(
+            operation.operation_id, replace(claim, fence=claim.fence + 1), {}
+        )
+    storage.complete_playbook_aggregation_operation(operation.operation_id, claim, {})
+    storage.fail_playbook_aggregation_operation(
+        operation.operation_id, claim, error="late", retry_seconds=None
+    )
+    assert (
+        storage.get_playbook_aggregation_operation(operation.operation_id).status
+        == "succeeded"
+    )
+
+
+def test_retry_and_expired_lease_resume(storage):
+    operation = storage.submit_playbook_aggregation_operation("resume", "v1")
+    first = claim_operation(storage, operation)
+    storage.fail_playbook_aggregation_operation(
+        operation.operation_id, first, error="execution_failed", retry_seconds=30
+    )
+    assert storage.next_playbook_aggregation_operation() is None
+    storage.conn.execute("UPDATE playbook_aggregation_lease SET claim_expires_at=0")
+    storage.conn.execute("UPDATE playbook_aggregation_operations SET next_attempt_at=0")
+    storage.conn.commit()
+    second = claim_operation(storage, operation)
+    assert second.fence > first.fence
+    assert (
+        storage.get_playbook_aggregation_operation(operation.operation_id).attempts == 2
+    )
+    storage.complete_playbook_aggregation_operation(
+        operation.operation_id, second, {"skipped": "empty corpus"}
+    )
+    assert (
+        storage.get_playbook_aggregation_operation(
+            operation.operation_id
+        ).result.skipped
+        == "empty corpus"
+    )
+
+
+@pytest.mark.parametrize("outcome", ["success", "transient", "invalid"])
+def test_executor_terminal_zero_retry_exhaustion(storage, monkeypatch, outcome):
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from reflexio.server.services.playbook import aggregation_operations as executor
+
+    operation = storage.submit_playbook_aggregation_operation("worker", "v1")
+    context = MagicMock(storage=storage, org_id="operations", configurator=MagicMock())
+    context.configurator.get_config.return_value.user_playbook_extractor_config = (
+        SimpleNamespace(aggregation_config=SimpleNamespace(min_cluster_size=2))
+    )
+    aggregator = MagicMock()
+    aggregator.run.return_value = {"skipped": "empty corpus"}
+    if outcome != "success":
+        aggregator.run.side_effect = (
+            ValueError("invalid config")
+            if outcome == "invalid"
+            else RuntimeError("secret provider error")
+        )
+    monkeypatch.setattr(executor, "PlaybookAggregator", lambda **_kwargs: aggregator)
+    monkeypatch.setattr(
+        executor, "create_generation_litellm_client", lambda _ctx: MagicMock()
+    )
+    for attempt in range(1, 6 if outcome == "transient" else 2):
+        assert executor.run_explicit_operation(context, owner="worker")
+        current = storage.get_playbook_aggregation_operation(operation.operation_id)
+        assert current.attempts == attempt
+        if outcome == "transient" and attempt < 5:
+            assert current.status == "retrying"
+            assert current.next_attempt_at >= current.updated_at + 60
+            storage.conn.execute(
+                "UPDATE playbook_aggregation_operations SET next_attempt_at=0"
+            )
+            storage.conn.commit()
+    assert current.status == ("succeeded" if outcome == "success" else "failed")
+    assert current.error is None or "secret" not in current.error
+    assert storage.next_playbook_aggregation_operation() is None

--- a/tests/server/services/playbook/test_aggregation_scheduler.py
+++ b/tests/server/services/playbook/test_aggregation_scheduler.py
@@ -16,6 +16,8 @@ from reflexio.server.services.storage.storage_base.playbook import (
 
 
 def _context(storage: Any) -> Any:
+    if isinstance(storage, MagicMock):
+        storage.next_playbook_aggregation_operation.return_value = None
     aggregation_config = SimpleNamespace()
     config = SimpleNamespace(
         user_playbook_extractor_config=SimpleNamespace(
@@ -34,6 +36,7 @@ def test_scheduler_keeps_invalidation_and_clustering_budgets_separate(
 ) -> None:
     claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.next_playbook_aggregation_operation.return_value = None
     storage.repair_playbook_aggregation_pending_state.return_value = []
     storage.claim_due_playbook_aggregation.return_value = claim
     after = PlaybookAggregationBacklog(4, 1, 0, residual_retry_after_seconds=60)
@@ -93,6 +96,7 @@ def test_scheduler_drains_invalidation_page_before_llm_work(
 ) -> None:
     claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.next_playbook_aggregation_operation.return_value = None
     storage.repair_playbook_aggregation_pending_state.return_value = []
     storage.claim_due_playbook_aggregation.return_value = claim
     storage.get_playbook_aggregation_invalidations.return_value = [
@@ -130,6 +134,7 @@ def test_scheduler_drains_invalidation_page_before_llm_work(
 def test_scheduler_keeps_pending_on_limiter_deferral(monkeypatch) -> None:
     claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.next_playbook_aggregation_operation.return_value = None
     storage.repair_playbook_aggregation_pending_state.return_value = []
     storage.claim_due_playbook_aggregation.return_value = claim
     storage.get_playbook_aggregation_backlog.return_value = PlaybookAggregationBacklog(
@@ -159,6 +164,7 @@ def test_scheduler_keeps_pending_on_limiter_deferral(monkeypatch) -> None:
 
 def test_scheduler_throttles_idle_repair_scans(monkeypatch) -> None:
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.next_playbook_aggregation_operation.return_value = None
     storage.repair_playbook_aggregation_pending_state.return_value = []
     storage.claim_due_playbook_aggregation.return_value = None
     scheduler = aggregation_scheduler.PlaybookAggregationScheduler(
@@ -265,6 +271,7 @@ def test_org_failure_defers_only_that_org_and_recovers(
 
 def test_failed_repair_attempt_is_throttled(monkeypatch) -> None:
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.next_playbook_aggregation_operation.return_value = None
     storage.repair_playbook_aggregation_pending_state.side_effect = RuntimeError("down")
     storage.claim_due_playbook_aggregation.return_value = None
     monkeypatch.setattr(aggregation_scheduler.time, "monotonic", lambda: 1000.0)
@@ -360,6 +367,7 @@ def test_succeeded_log_distinguishes_a_starved_run_from_an_idle_one(
     """
     claim = PlaybookAggregationClaim("v1", "owner", 7, 3, 10_000)
     storage = MagicMock(supports_incremental_playbook_aggregation=True)
+    storage.next_playbook_aggregation_operation.return_value = None
     storage.repair_playbook_aggregation_pending_state.return_value = []
     storage.claim_due_playbook_aggregation.return_value = claim
     storage.get_playbook_aggregation_backlog.return_value = PlaybookAggregationBacklog(


### PR DESCRIPTION
## Summary

Explicit playbook aggregation currently relies on a synchronous response, leaving callers without a durable completion receipt after an HTTP timeout or restart. Add idempotent aggregation operations that clients can submit once and poll through completion while preserving the existing synchronous API.

## Changes

- Add shared request, receipt, and result schemas; HTTP 202 submission and scoped receipt lookup routes; and `submit_playbook_aggregation` / `get_playbook_aggregation_operation` SDK methods.
- Persist SQLite operations with scoped request-key idempotency and one unfinished operation per agent version. Expose the storage contract for other adapters.
- Execute explicit work through the existing aggregation scheduler, organization lease, heartbeat, limiter, and full-archive algorithm. Recover expired claims and retry transient execution failures up to five attempts; invalid configuration and safety-cap failures are terminal.
- Commit generated outputs, lineage, bookkeeping, and the successful receipt in the same fenced transaction, including legitimate zero-output results. Source erasure prevents unfinished work from committing.
- Report unsupported execution capability on missing-receipt lookup so callers can fail before admitting a workload. Previously committed receipts remain readable if execution support becomes unavailable.

`succeeded` means the explicit aggregation result committed; optional tagging and optimization can still be running. Ambiguous submissions must reuse the same request ID and parameters.

## Test Plan

- Shared playbook service suite: **640 passed, 3 skipped**, covering idempotency, lease contention, restart recovery, retries, zero-output completion, and fenced output/receipt rollback.
- HTTP capability regression tests: **4 passed**, covering existing/missing receipts with supported/unsupported storage.
- Ruff and focused Pyright passed for the changed production code and capability tests.

```bash
uv run pytest tests/server/services/playbook -o 'addopts=' -q
uv run pytest tests/server/routes/test_aggregation_operation_capability.py -o 'addopts=' -q
```

No deployment or paid model evaluation was performed.
