### PR TITLE
feat(offline-tuner): land the terminal-outcome vocabulary enterprise main already depends on

### DIFF
--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -469,15 +469,15 @@ OptimizationJobStage = Literal[
 #: A member here is a TODO with a name, not a permanent state. When the writer
 #: lands it moves into the reachable set in
 #: ``tests/models/test_terminal_outcome_reachability.py`` and out of here.
-PENDING_WRITER_TERMINAL_OUTCOMES: frozenset[str] = frozenset(
-    {
-        # reflexio_ext offline_tuner/open_world scheduled-execution project:
-        # reclaim-or-terminalize before identity validation.
-        "abandoned",
-        # the same project's recorded manifest-conflict skip.
-        "evidence_manifest_conflict",
-    }
-)
+#:
+#: EMPTY, and that is the healthy state rather than a deleted set. Both former
+#: members -- ``abandoned`` and ``evidence_manifest_conflict`` -- now have
+#: writers in reflexio_ext and were moved into the reachable set, which is the
+#: exit this set was designed to have. It stays declared because the next
+#: shared-migration handoff will need it again, and because the reachability
+#: test asserts all three classifications are disjoint and cover the union: an
+#: empty third bucket keeps that assertion honest instead of removing it.
+PENDING_WRITER_TERMINAL_OUTCOMES: frozenset[str] = frozenset()
 
 RETAINED_UNREACHABLE_TERMINAL_OUTCOMES: frozenset[str] = frozenset(
     {
@@ -566,16 +566,26 @@ OptimizationTerminalOutcome = Literal[
     # Literal would make reading back a job row that carries one raise
     # ValidationError -- surfacing, through handle_exceptions, as the
     # 'infrastructure_failure' that gap has already produced once.
+    # The two below were admitted AHEAD OF THEIR WRITERS, from the shared
+    # migration that carries the vocabulary for two projects (see the header of
+    # supabase/data/tenant/20260910010000); both writers have since landed in
+    # reflexio_ext, and both moved out of PENDING_WRITER_TERMINAL_OUTCOMES when
+    # they did.
     #
-    # 'abandoned': a freeze that was abandoned rather than attempted. It
-    # replaces the FALSE 'generation_failed' the retention sweep used to stamp
-    # on such a row -- nothing was generated. Assigned by the tenant
+    # 'abandoned': a freeze that was abandoned rather than attempted. Written by
+    # reflexio_ext supabase_storage/playbook/_open_world_evidence_freeze.py
+    # (`_retake_stranded_job`), which terminalizes a prior day's stranded row
+    # BEFORE identity validation compares the rolled discovery/attempt keys.
+    # It replaces the FALSE 'generation_failed' the retention sweep used to
+    # stamp on such a row -- nothing was generated. Assigned by the tenant
     # stage-advance RPC's 'failed' arm.
     "abandoned",
-    # 'evidence_manifest_conflict': two sweep ticks collided on one playbook and
-    # the loser was refused at job creation, with no provider call. Recorded
-    # rather than skipped silently, because the conflict IS the concurrency
-    # signal. Also the 'failed' arm.
+    # 'evidence_manifest_conflict': two sweep ticks collided on one playbook's
+    # frozen evidence and the loser was refused at the manifest-membership
+    # check, with no provider call. Written by reflexio_ext
+    # open_world/runner.py (`run`'s OpenWorldInvocationManifestError handler,
+    # via _converge_terminal_failure). Recorded rather than skipped silently,
+    # because the conflict IS the concurrency signal. Also the 'failed' arm.
     "evidence_manifest_conflict",
 ]
 

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -117,6 +117,7 @@ __all__ = [
     "OpenWorldDeploymentLifecycleState",
     "OptimizationJobStage",
     "OptimizationTerminalOutcome",
+    "PENDING_WRITER_TERMINAL_OUTCOMES",
     "OptimizationArtifactKind",
     "OptimizationJobClaim",
     "PlaybookOptimizationJob",
@@ -455,6 +456,29 @@ OptimizationJobStage = Literal[
 # reflexio_ext capability_status.py, with ~40 live references. Those are a
 # different vocabulary on a different type, so "grep says it is used" does not
 # make this member reachable.
+#: Members admitted before the code that writes them exists.
+#:
+#: A THIRD classification, and it is not the same thing as
+#: ``RETAINED_UNREACHABLE_TERMINAL_OUTCOMES``. That set is historical -- outcomes
+#: an earlier era could record and no path can reach again. This set is the
+#: opposite direction in time: outcomes a project is about to start writing,
+#: admitted early because the tenant CHECK that admits them is shared between
+#: two projects and lands as ONE migration (two ``CREATE OR REPLACE FUNCTION``
+#: migrations do not merge -- the later silently drops the earlier's outcomes).
+#:
+#: A member here is a TODO with a name, not a permanent state. When the writer
+#: lands it moves into the reachable set in
+#: ``tests/models/test_terminal_outcome_reachability.py`` and out of here.
+PENDING_WRITER_TERMINAL_OUTCOMES: frozenset[str] = frozenset(
+    {
+        # reflexio_ext offline_tuner/open_world scheduled-execution project:
+        # reclaim-or-terminalize before identity validation.
+        "abandoned",
+        # the same project's recorded manifest-conflict skip.
+        "evidence_manifest_conflict",
+    }
+)
+
 RETAINED_UNREACHABLE_TERMINAL_OUTCOMES: frozenset[str] = frozenset(
     {
         "insufficient_negative_evidence",
@@ -502,6 +526,41 @@ OptimizationTerminalOutcome = Literal[
     # its playbook's identity for the rest of the UTC day. See
     # reflexio_ext open_world/models.py and identity.attempt_invocation_identity.
     "invocation_slot_pinned",
+    # Written by reflexio_ext offline_tuner/open_world/runner.py (`_abstain`,
+    # from the discovery-abstention branch) when the analyst reached no
+    # grounded hypothesis AND the frozen bundle's skipped-session receipt is
+    # non-empty -- i.e. the evidence view the analyst was shown was not the
+    # whole corpus. Assigned by the tenant stage-advance RPC's 'abstained' arm
+    # and admitted by playbook_optimization_jobs_terminal_outcome_check since
+    # 20260910010000.
+    #
+    # Split out of 'no_grounded_hypothesis', which carried two OPPOSITE
+    # operational signals: "the evidence carries no agent-side contrast" (stop
+    # tuning this playbook) and "the deciding session was not shown" (show
+    # more). A reader could not tell them apart, so the second read as the
+    # first and the corpus was never widened.
+    "evidence_view_incomplete",
+    # The two below are admitted AHEAD OF THEIR WRITERS. Both belong to the
+    # scheduled-execution project, whose Python lands separately, and both are
+    # here now because their tenant CHECK is here now: one shared migration
+    # carries the vocabulary for two projects (see the header of
+    # supabase/data/tenant/20260910010000), and
+    # test_the_enterprise_tree_agrees_with_the_contracted_oss_vocabulary
+    # asserts this union is SET-EQUAL to that CHECK. Leaving them out of the
+    # Literal would make reading back a job row that carries one raise
+    # ValidationError -- surfacing, through handle_exceptions, as the
+    # 'infrastructure_failure' that gap has already produced once.
+    #
+    # 'abandoned': a freeze that was abandoned rather than attempted. It
+    # replaces the FALSE 'generation_failed' the retention sweep used to stamp
+    # on such a row -- nothing was generated. Assigned by the tenant
+    # stage-advance RPC's 'failed' arm.
+    "abandoned",
+    # 'evidence_manifest_conflict': two sweep ticks collided on one playbook and
+    # the loser was refused at job creation, with no provider call. Recorded
+    # rather than skipped silently, because the conflict IS the concurrency
+    # signal. Also the 'failed' arm.
+    "evidence_manifest_conflict",
 ]
 
 OptimizationArtifactKind = Literal[

--- a/reflexio/models/api_schema/domain/entities.py
+++ b/reflexio/models/api_schema/domain/entities.py
@@ -540,6 +540,22 @@ OptimizationTerminalOutcome = Literal[
     # more). A reader could not tell them apart, so the second read as the
     # first and the corpus was never widened.
     "evidence_view_incomplete",
+    # Written by reflexio_ext offline_tuner/open_world/runner.py
+    # (_converge_terminal_failure, from the schema-unsupported handler) when the
+    # frozen evidence bundle declares an evidence-bundle schema version older
+    # than the image reading it. The bundle is validated as the EXACT derivation
+    # of its manifest, so an older bundle is UNLOADABLE rather than degraded and
+    # no retry on any host can change that. Assigned by the tenant stage-advance
+    # RPC's 'failed' arm; the 'abstained' arm deliberately does not, since the
+    # refusal happens before derivation and nothing was judged.
+    #
+    # Split out of 'infrastructure_failure', which promises "transient, we will
+    # try again" -- the opposite of the true instruction, which is to drain the
+    # row (the deploy precondition inherited from tenant 20260903010000) or
+    # terminalize it deliberately. Absent from the SQLite allowlist: SQLite
+    # carries no open-world evidence bundle store, so no bundle can be frozen
+    # there to go stale.
+    "bundle_schema_unsupported",
     # The two below are admitted AHEAD OF THEIR WRITERS. Both belong to the
     # scheduled-execution project, whose Python lands separately, and both are
     # here now because their tenant CHECK is here now: one shared migration

--- a/reflexio/server/services/storage/sqlite_storage/_base.py
+++ b/reflexio/server/services/storage/sqlite_storage/_base.py
@@ -2252,6 +2252,7 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
             "'stale_incumbent'",
             "'governance_invalidated'",
             "'infrastructure_failure'",
+            "'evidence_view_incomplete'",
         )
         if all(check in table_sql for check in required_checks) and not any(
             retired in table_sql for retired in _RETIRED_OPTIMIZER_JOB_LITERALS
@@ -2320,7 +2321,8 @@ class SQLiteStorageBase(RetentionMixin, BaseStorage):
                     'heldout_evidence_failed',
                     'stale_incumbent',
                     'governance_invalidated',
-                    'infrastructure_failure'
+                    'infrastructure_failure',
+                    'evidence_view_incomplete'
                 )),
                 expected_population_manifest_digest TEXT,
                 generation_selection_manifest_digest TEXT,
@@ -3582,7 +3584,8 @@ CREATE TABLE IF NOT EXISTS playbook_optimization_jobs (
         'heldout_evidence_failed',
         'stale_incumbent',
         'governance_invalidated',
-        'infrastructure_failure'
+        'infrastructure_failure',
+        'evidence_view_incomplete'
     )),
     expected_population_manifest_digest TEXT,
     generation_selection_manifest_digest TEXT,

--- a/reflexio/server/services/storage/sqlite_storage/playbook/_optimization.py
+++ b/reflexio/server/services/storage/sqlite_storage/playbook/_optimization.py
@@ -61,6 +61,11 @@ _TERMINAL_OUTCOMES_BY_OPTIMIZER = {
         },
         "abstained": {
             "no_grounded_hypothesis",
+            # The sibling of 'no_grounded_hypothesis': the analyst reached no
+            # hypothesis AND the bundle's skipped-session receipt says the view
+            # it was shown was incomplete. Same arm, same status, opposite
+            # operator instruction -- "show more" rather than "stop tuning".
+            "evidence_view_incomplete",
             "analyst_unqualified",
             "heldout_evidence_failed",
             "stale_incumbent",

--- a/tests/models/test_terminal_outcome_reachability.py
+++ b/tests/models/test_terminal_outcome_reachability.py
@@ -88,6 +88,25 @@ _REACHABLE_TERMINAL_OUTCOMES = frozenset(
         # there to go stale -- which is why it is named here rather than left
         # to the `writable <=` assertion.
         "bundle_schema_unsupported",
+        # the abandoned freeze: reflexio_ext
+        # supabase_storage/playbook/_open_world_evidence_freeze.py
+        # `_retake_stranded_job` terminalizes a prior day's stranded row with
+        # it, BEFORE `_validate_job_request` compares the rolled
+        # discovery/attempt keys -- the ordering fix that made the row
+        # reachable at all. The TENANT stage-advance RPC's 'failed' arm assigns
+        # it (tenant 20260910010000). Absent from the SQLite allowlist below
+        # for the same reason as 'regeneration_fenced' -- SQLite carries no
+        # open-world freeze -- which is why it is named here.
+        "abandoned",
+        # the recorded manifest conflict: reflexio_ext open_world/runner.py's
+        # OpenWorldInvocationManifestError handler calls
+        # _converge_terminal_failure with it when a second tick's attempt is
+        # refused at the manifest-membership check, having made no provider
+        # call. The TENANT stage-advance RPC's 'failed' arm assigns it (tenant
+        # 20260910010000); the 'abstained' arm deliberately does not, since
+        # nothing was judged. Absent from the SQLite allowlist for the same
+        # reason -- SQLite carries no open-world invocation table.
+        "evidence_manifest_conflict",
     }
 )
 
@@ -150,8 +169,13 @@ def test_the_union_is_exactly_the_reachable_set_plus_the_retained_set() -> None:
         == _REACHABLE_TERMINAL_OUTCOMES
     )
     assert len(members) == 23
-    assert len(_REACHABLE_TERMINAL_OUTCOMES) == 14
-    assert len(PENDING_WRITER_TERMINAL_OUTCOMES) == 2
+    assert len(_REACHABLE_TERMINAL_OUTCOMES) == 16
+    # EMPTY now, and that is the designed exit rather than a dead assertion:
+    # both former members gained writers in reflexio_ext (the retake's
+    # 'abandoned' and the runner's 'evidence_manifest_conflict') and moved into
+    # the reachable set above. Asserting zero is what forces the NEXT
+    # shared-migration handoff to clean up after itself too.
+    assert len(PENDING_WRITER_TERMINAL_OUTCOMES) == 0
 
 
 def test_no_retained_outcome_is_writable_through_the_stage_advance_allowlist() -> None:

--- a/tests/models/test_terminal_outcome_reachability.py
+++ b/tests/models/test_terminal_outcome_reachability.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from typing import get_args
 
 from reflexio.models.api_schema.domain.entities import (
+    PENDING_WRITER_TERMINAL_OUTCOMES,
     RETAINED_UNREACHABLE_TERMINAL_OUTCOMES,
     OptimizationTerminalOutcome,
 )
@@ -25,7 +26,7 @@ from reflexio.server.services.storage.sqlite_storage.playbook._optimization impo
     _TERMINAL_OUTCOMES_BY_OPTIMIZER,
 )
 
-# The twelve outcomes that survive Phase 7 with a path that can reach them. Six
+# The thirteen outcomes that survive Phase 7 with a path that can reach them. Six
 # are written by the stage-advance allowlist below; the other six are written
 # elsewhere and are named here with their writer so the split is auditable.
 _REACHABLE_TERMINAL_OUTCOMES = frozenset(
@@ -64,6 +65,15 @@ _REACHABLE_TERMINAL_OUTCOMES = frozenset(
         # stage-advance: 'abstained'
         "no_grounded_hypothesis",
         "heldout_evidence_failed",
+        # the incomplete-view abstention: reflexio_ext
+        # open_world/runner.py `_abstain` passes it when the analyst reached no
+        # grounded hypothesis AND the frozen bundle's skipped-session receipt
+        # is non-empty. The TENANT stage-advance RPC's 'abstained' arm assigns
+        # it (tenant 20260910010000), and unlike 'regeneration_fenced' /
+        # 'invocation_slot_pinned' it IS in the SQLite allowlist below: the
+        # abstain path exists on both engines, so the `writable <=` assertion
+        # covers it rather than this comment.
+        "evidence_view_incomplete",
     }
 )
 
@@ -94,20 +104,40 @@ def test_the_retained_unreachable_set_is_exactly_these_seven() -> None:
 
 
 def test_the_union_is_exactly_the_reachable_set_plus_the_retained_set() -> None:
-    """Every member is classified: reachable, or retained-and-recorded.
+    """Every member is classified: reachable, retained, or pending a writer.
 
-    A member added to the union with neither a writer nor a retention rationale
-    fails here rather than accumulating quietly.
+    A member added to the union with none of a writer, a retention rationale, or
+    a recorded pending-writer reason fails here rather than accumulating
+    quietly.
+
+    ``PENDING_WRITER_TERMINAL_OUTCOMES`` is the third bucket and the newest. It
+    exists because the tenant CHECK is shared between two projects and has to
+    land as one migration, so the Literal legitimately runs ahead of the code
+    that writes two of its members. That is a TODO with a name and an owner, not
+    a licence to add unwritten outcomes -- moving a member out of it when its
+    writer lands is the edit this assertion is here to force.
     """
     members = frozenset(get_args(OptimizationTerminalOutcome))
 
     assert members >= RETAINED_UNREACHABLE_TERMINAL_OUTCOMES
     assert members >= _REACHABLE_TERMINAL_OUTCOMES
-    assert (
-        members - RETAINED_UNREACHABLE_TERMINAL_OUTCOMES == _REACHABLE_TERMINAL_OUTCOMES
+    assert members >= PENDING_WRITER_TERMINAL_OUTCOMES
+    # The three classifications are disjoint, or "classified" would not mean
+    # anything: a member cannot be both retired and not yet born.
+    assert not (RETAINED_UNREACHABLE_TERMINAL_OUTCOMES & _REACHABLE_TERMINAL_OUTCOMES)
+    assert not (PENDING_WRITER_TERMINAL_OUTCOMES & _REACHABLE_TERMINAL_OUTCOMES)
+    assert not (
+        PENDING_WRITER_TERMINAL_OUTCOMES & RETAINED_UNREACHABLE_TERMINAL_OUTCOMES
     )
-    assert len(members) == 19
-    assert len(_REACHABLE_TERMINAL_OUTCOMES) == 12
+    assert (
+        members
+        - RETAINED_UNREACHABLE_TERMINAL_OUTCOMES
+        - PENDING_WRITER_TERMINAL_OUTCOMES
+        == _REACHABLE_TERMINAL_OUTCOMES
+    )
+    assert len(members) == 22
+    assert len(_REACHABLE_TERMINAL_OUTCOMES) == 13
+    assert len(PENDING_WRITER_TERMINAL_OUTCOMES) == 2
 
 
 def test_no_retained_outcome_is_writable_through_the_stage_advance_allowlist() -> None:
@@ -125,4 +155,7 @@ def test_no_retained_outcome_is_writable_through_the_stage_advance_allowlist() -
     }
 
     assert not (writable & RETAINED_UNREACHABLE_TERMINAL_OUTCOMES)
+    # A pending-writer member in the SQLite allowlist would mean the writer has
+    # in fact landed and the member was never moved out of the pending set.
+    assert not (writable & PENDING_WRITER_TERMINAL_OUTCOMES)
     assert writable <= _REACHABLE_TERMINAL_OUTCOMES

--- a/tests/models/test_terminal_outcome_reachability.py
+++ b/tests/models/test_terminal_outcome_reachability.py
@@ -26,9 +26,10 @@ from reflexio.server.services.storage.sqlite_storage.playbook._optimization impo
     _TERMINAL_OUTCOMES_BY_OPTIMIZER,
 )
 
-# The thirteen outcomes that survive Phase 7 with a path that can reach them. Six
-# are written by the stage-advance allowlist below; the other six are written
-# elsewhere and are named here with their writer so the split is auditable.
+# The fourteen outcomes that survive Phase 7 with a path that can reach them.
+# Six are written by the stage-advance allowlist below; the other eight are
+# written elsewhere and are named here with their writer so the split is
+# auditable.
 _REACHABLE_TERMINAL_OUTCOMES = frozenset(
     {
         # commit_user_playbook_publication (tenant 20260830020000:1293)
@@ -74,6 +75,19 @@ _REACHABLE_TERMINAL_OUTCOMES = frozenset(
         # abstain path exists on both engines, so the `writable <=` assertion
         # covers it rather than this comment.
         "evidence_view_incomplete",
+        # the stale-bundle refusal: reflexio_ext open_world/runner.py calls
+        # _converge_terminal_failure with it on
+        # OpenWorldEvidenceSchemaUnsupportedError -- the frozen bundle declares
+        # an evidence-bundle schema version this image cannot derive, so it is
+        # unloadable and no retry can help. The TENANT stage-advance RPC's
+        # 'failed' arm assigns it (tenant 20260910010000); the 'abstained' arm
+        # deliberately does not, since the refusal is before derivation and
+        # nothing was judged. Absent from the SQLite allowlist below for the
+        # same reason as 'regeneration_fenced' / 'invocation_slot_pinned' --
+        # SQLite carries no open-world bundle store, so nothing can be frozen
+        # there to go stale -- which is why it is named here rather than left
+        # to the `writable <=` assertion.
+        "bundle_schema_unsupported",
     }
 )
 
@@ -135,8 +149,8 @@ def test_the_union_is_exactly_the_reachable_set_plus_the_retained_set() -> None:
         - PENDING_WRITER_TERMINAL_OUTCOMES
         == _REACHABLE_TERMINAL_OUTCOMES
     )
-    assert len(members) == 22
-    assert len(_REACHABLE_TERMINAL_OUTCOMES) == 13
+    assert len(members) == 23
+    assert len(_REACHABLE_TERMINAL_OUTCOMES) == 14
     assert len(PENDING_WRITER_TERMINAL_OUTCOMES) == 2
 
 


### PR DESCRIPTION
## Why this needs to land

**`reflexio-enterprise` main is red right now, and this branch is the fix.**

These three commits were never opened as a PR, but enterprise main was pinned directly to this branch's tip (`920feb84`) by [reflexio-enterprise#1133](https://github.com/ReflexioAI/reflexio-enterprise/pull/1133). When [#1141](https://github.com/ReflexioAI/reflexio-enterprise/pull/1141) later moved the submodule pointer onto OSS main to pick up the durable-publish fix (#494), it necessarily dropped this work — it isn't on main — and took the enterprise tenant migration's contract with it.

Same enterprise tree, only the submodule pointer differs:

```
submodule @ e92ad785  (OSS main today)   →  1 failed, 23 passed
submodule @ 920feb84  (this branch)      →  24 passed
```

```
test_the_enterprise_tree_agrees_with_the_contracted_oss_vocabulary
Extra items in the right set:
  'abandoned'  'evidence_manifest_conflict'
  'evidence_view_incomplete'  'bundle_schema_unsupported'
```

The tenant migration's `terminal_outcome` CHECK admits four outcomes that OSS main's `OptimizationTerminalOutcome` does not declare. Those four are exactly what `c25d5ddb` and `06997834` add. Enterprise main is therefore depending on OSS code that only exists on an unmerged branch — a latent breakage on its own (delete or rebase this branch and `git submodule update` fails for everyone on main), and an active one now that the pointer has moved.

Neither enterprise merge was wrong in isolation. The gap is that this OSS work was consumed before it was landed.

## What is in it

Three commits, ~176 lines, already reviewed in effect by virtue of having shipped into enterprise main:

- `c25d5ddb` widen the terminal-outcome vocabulary
- `06997834` name the stale-bundle refusal
- `920feb84` retire the pending-writer terminal outcomes

I authored none of this — it is opened on someone else's branch because main is broken without it and it had no PR.

## Verification

OSS CI here runs artifact-install checks only, not the test suite (the enterprise `os-unit-tests` lane is the real gate), so this was verified locally against the merge of this branch into current main:

| Gate | Result |
| --- | --- |
| Full OSS suite (`-m "not requires_credentials"`) | **6220 passed, 0 failed** |
| Enterprise unit suite | **8404 passed, 9 skipped** |
| `test_replay_removal_allowlists.py` (main's red test) | **24 passed** — was 1 failed |
| `tests/models/test_terminal_outcome_reachability.py` | passed |
| Merge into main | clean, no conflicts |

The merge also preserves #494's durable-publish fix — both lineages coexist, confirmed by running `test_profile_workflows_unit.py` on the combination.

## After this merges

`reflexio-enterprise` needs a gitlink bump to the resulting main tip. That is what turns enterprise main green again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Optimization jobs now correctly recognize additional terminal outcomes, including incomplete evidence, unsupported bundle schemas, abandoned runs, and evidence manifest conflicts.
  - Improved handling of optimization jobs that end without producing complete evidence, preventing these states from being misclassified or rejected.
  - Updated validation to consistently accept and process supported terminal outcomes across storage and optimization workflows.

- **Tests**
  - Expanded coverage for terminal-outcome reachability and validation to ensure supported outcomes are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->