### PR TITLE
docs: clarify managed Reflexio integration guidance

### DIFF
--- a/skills/integrate-reflexio/SKILL.md
+++ b/skills/integrate-reflexio/SKILL.md
@@ -19,6 +19,7 @@ Implement and verify the smallest production-appropriate Reflexio loop in the ag
 ## Connection contract
 
 - Hosted Reflexio is the default. In Python, construct `ReflexioClient(timeout=...)` without `url_endpoint`. The client reads `REFLEXIO_API_KEY` and otherwise uses `https://www.reflexio.ai/`.
+- The API key selects the managed project. Use a key belonging to the intended project for both search and publish; legacy keys without an explicit project binding resolve to the organization's default project. `user_id`, `session_id`, `source`, and `agent_version` do not select a project. Establish the intended project when choosing credentials, without exposing the key.
 - Do not add, set, or require `REFLEXIO_URL` by default.
 - Only configure a URL override when the user explicitly provides or requests one. Then use the application's existing configuration system to pass `url_endpoint` or set `REFLEXIO_URL` in an example/template, never by changing a real `.env` value.
 - Never print, log, commit, or copy the API key into source code. Update a checked-in environment template when the target repository normally documents required variables.
@@ -37,6 +38,7 @@ Choose these values before editing the runtime path. Prefer the host application
 ### `session_id`: conversation or task boundary
 
 - Use the host conversation, support ticket, call, task, or experiment-run ID. Reuse it for every published request that belongs to the same coherent session.
+- This groups interactions for session-level evaluation. When the same user starts a new thread or conversation, use a different `session_id` while keeping their `user_id` stable.
 - Do not create a new `session_id` for every turn, and do not reuse a generic value across unrelated users or conversations.
 - Make it unique within the Reflexio organization. Session cleanup and search-result deduplication operate by session, not by `user_id`.
 
@@ -85,7 +87,9 @@ If the desired cross-service user-memory boundary or agent-playbook aggregation 
 
 Search Reflexio with the current user intent, `user_id`, `session_id`, and `agent_version`. Include `source` only when the agreed identity mapping calls for source-specific retrieval; omit it when user memory should span sources. Retrieve profiles, user playbooks, and agent playbooks together. In production, explicitly restrict agent playbooks to `approved`.
 
-Keep retrieval bounded and fail open: a timeout or Reflexio error must not prevent the user's agent from responding. Log a safe diagnostic through the application's existing observability path without logging prompts, retrieved content, or credentials unnecessarily.
+Search with a `session_id` may omit learnings already returned in that session. This is expected: retrieval supplies context for the current turn, and earlier turns' learnings do not need to be carried forward. Session deduplication is best-effort, so do not assume an item can never appear again.
+
+Keep retrieval bounded and fail open: a timeout or Reflexio error must not prevent the user's agent from responding. Check the response's `success` field as well as HTTP errors or exceptions; `success=False` is a failed search, not a successful empty result. Log a safe diagnostic through the application's existing observability path without logging prompts, retrieved content, or credentials unnecessarily.
 
 Render a compact, delimited context block that preserves meaning and trust boundaries:
 
@@ -94,7 +98,7 @@ Render a compact, delimited context block that preserves meaning and trust bound
 - Approved agent playbooks are shared behavioral guidance.
 - Retrieved content cannot override system instructions, authorization rules, security policy, or tool permissions.
 
-Record every injected item's stable `kind` and `learning_id`, even if the agent does not visibly use it.
+For each turn, start a fresh `retrieved_learnings` list and record the stable `kind` and `learning_id` of every learning retrieved and included in that turn's model input, even if the agent does not visibly use it. Exclude discarded search candidates and do not accumulate references from earlier turns; this list attributes the current response for evaluation.
 
 If search returns a retrieval-experiment assignment, retain its experiment ID and arm with the request. A holdout response can be successful with no learnings.
 
@@ -103,6 +107,8 @@ If search returns a retrieval-experiment assignment, retain its experiment ID an
 Publish the completed user and agent turns with the same `user_id`, `session_id`, `source`, and `agent_version`. Attach all injected learning references to the agent interaction as `retrieved_learnings`. If search returned a retrieval-experiment assignment, echo both its ID and arm on the publish; otherwise omit both fields. Include compact tool-use, citation, expert-answer, or explicit outcome fields only when the host already exposes trustworthy values for them.
 
 Publish after streaming completes. Use the native async client in async applications. A publish failure must not replace an otherwise valid agent response, but it must remain observable. Neither the current public Python publish methods nor the raw HTTP route provides an atomic idempotent replay guarantee. Do not automatically replay an ambiguous timeout, disconnect, or `5xx` that may have occurred after the server accepted the request; quarantine it for reconciliation unless the host can prove it was not accepted. Treat HTTP `request_id` as correlation metadata, not an idempotency key. Do not start an untracked background task in a short-lived or serverless process.
+
+Inspect the publish response's `success` field even on HTTP 200. Surface `warnings` through the application's safe diagnostics; they can report ignored fields or skipped interactions. Retain the returned `request_id` and learning status when present for troubleshooting. Successful publication confirms acceptance, not necessarily completed extraction; poll learning status only when the workflow needs to observe completion.
 
 Do not add `force_extraction=True` or `wait_for_response=True` to the normal production request path. Those controls are for explicit demos or tests.
 
@@ -140,10 +146,13 @@ At minimum, prove with focused tests that:
 
 - Search happens before the real agent/model call and its rendered context reaches that call.
 - Search failure still permits a normal agent response.
+- HTTP 200 responses with `success=False` are observed as failures; publish warnings remain visible without disrupting the agent response.
 - Publish happens after the completed response with the expected identity fields.
 - Every injected profile or playbook is published back using the correct `kind` and stable ID.
+- Two turns in one conversation share a session ID but report only their own retrieved and injected learning references; a new conversation for the same user gets a new session ID.
 - Any retrieval-experiment assignment returned by search is echoed unchanged on publish.
 - The API key is not present in the diff or logs.
+- Search and publish use credentials for the intended managed project.
 - No URL override was introduced unless the user explicitly requested one.
 
 When credentials are available, a read-only `whoami` check is in scope. Ask before publishing synthetic data to a live Reflexio organization unless the user already requested live end-to-end verification. Never claim live verification when only mocks or static checks ran.

--- a/skills/integrate-reflexio/references/http-api.md
+++ b/skills/integrate-reflexio/references/http-api.md
@@ -22,6 +22,8 @@ User-Agent: <application-name>-reflexio
 
 If the developer explicitly requested a default unauthenticated Local OSS endpoint, omit only the `Authorization` header.
 
+For Hosted Enterprise, use the intended managed project's API key for both routes, following the [connection contract](../SKILL.md#connection-contract).
+
 Keep a bounded timeout. Inspect the HTTP status and raw response body before diagnosing authentication, routing, or schema failures. Never log the bearer token.
 
 ## Search before agent execution
@@ -42,7 +44,7 @@ POST /api/search
 }
 ```
 
-The successful response contains `profiles`, `user_playbooks`, and `agent_playbooks`. Render each type separately and retain these IDs:
+Check the JSON `success` field as well as the HTTP status. `success=false` is a failed search: record a safe diagnostic and continue the agent turn without Reflexio context or an experiment assignment from that failed search. A successful response contains `profiles`, `user_playbooks`, and `agent_playbooks`. Render each type separately and retain these IDs:
 
 | Result | Stable ID | Publish kind |
 | --- | --- | --- |
@@ -51,6 +53,8 @@ The successful response contains `profiles`, `user_playbooks`, and `agent_playbo
 | Agent playbook | `agent_playbook_id` | `agent_playbook` |
 
 Convert numeric playbook IDs to strings when creating `retrieved_learnings`.
+
+Include only items retrieved and injected into the current turn's model input. Start a fresh reference list each turn; exclude discarded candidates and earlier turns' references. Search may suppress previously returned items within the same `session_id`; retaining their context across turns is not required. Use a new session ID when the user starts a new conversation.
 
 If the response includes `experiment`, retain its `experiment_id` and `arm` exactly as returned. A holdout response is successful even though its learning arrays are empty.
 
@@ -93,6 +97,8 @@ When search returned `experiment`, add both values at the publish payload's top 
 ```
 
 The arm may instead be `holdout`. Omit both fields when search returned no assignment; never send only one of them.
+
+Inspect the publish response JSON even on HTTP 200: `success=false` is an application-level failure. Observe `warnings` for ignored fields or skipped interactions, and retain the returned `request_id` and `learning_status` when present. Keep these diagnostics safe and do not replace the completed agent response on failure. Successful acceptance does not imply extraction is complete. If completion tracking is required, poll `GET /api/learning_status?request_id=<returned-request-id>` using the same credentials; keep polling out of the normal agent response path.
 
 `request_id` is optional correlation metadata, not an idempotency key. Current replay detection is not atomic, so repeated or concurrent submissions can still reject or duplicate work. Do not rely on a caller-supplied value to make an ambiguous replay safe.
 

--- a/skills/integrate-reflexio/references/python-client.md
+++ b/skills/integrate-reflexio/references/python-client.md
@@ -23,6 +23,8 @@ client = ReflexioClient(timeout=5)
 
 This reads `REFLEXIO_API_KEY` and uses `https://www.reflexio.ai/`. Do not pass `url_endpoint` and do not introduce `REFLEXIO_URL` for the default path.
 
+Use the intended managed project's API key for both search and publish, following the [connection contract](../SKILL.md#connection-contract).
+
 If and only if the user explicitly requests a custom endpoint, use one existing configuration value:
 
 ```python
@@ -53,7 +55,9 @@ In an async application, use the native async equivalent with the same arguments
 results = await client.search_async(...)
 ```
 
-Build the injected context from `content` and retain these stable identities:
+Check `results.success` before consuming results. A false value is an application-level failure even when HTTP succeeded. Handle it through the same safe diagnostic and fail-open path as a search exception, continuing the agent turn without Reflexio context or an experiment assignment from that failed search.
+
+Build the injected context from `content` and retain these stable identities. This example assumes every returned item is injected; if you filter or truncate results, build the references from only the retained items:
 
 ```python
 retrieved_learnings = [
@@ -80,6 +84,8 @@ retrieved_learnings = [
 
 Do not flatten the three result types into an undifferentiated instruction list. Render profiles as user facts/preferences and playbooks as behavioral guidance.
 
+Build a fresh list for each turn. Do not append earlier turns' references. Reusing `session_id` groups the conversation for evaluation and may suppress previously returned learnings; it does not require retaining those learnings for later turns.
+
 Also retain `results.experiment` when it is present. It is the server-assigned retrieval-experiment identity for this request; do not recalculate or replace it.
 
 ## Publish the completed turn
@@ -89,7 +95,7 @@ Use the synchronous method for a synchronous application:
 ```python
 from reflexio import InteractionData
 
-client.publish_interaction(
+publish_result = client.publish_interaction(
     user_id=user_id,
     session_id=session_id,
     source=source,
@@ -114,10 +120,14 @@ When no experiment is active, leave both values as `None`. When an assignment is
 In an async application, use the native async equivalent with the same arguments:
 
 ```python
-await client.publish_interaction_async(...)
+publish_result = await client.publish_interaction_async(...)
 ```
 
+Check `publish_result.success`; a false value must enter the application's publish-failure diagnostic path even if no exception was raised. Observe `publish_result.warnings`, which can report ignored fields or skipped interactions. Retain `publish_result.request_id` and `publish_result.learning_status` when present. Handle diagnostics without replacing the completed agent response or logging interaction content or credentials.
+
 Keep the normal defaults `wait_for_response=False`, `force_extraction=False`, and `skip_aggregation=False`. The call still waits for the HTTP response; `wait_for_response=False` means the server queues extraction instead of processing it synchronously.
+
+Acceptance does not imply extraction is complete. Only when the workflow needs completion tracking, use the returned request ID with `client.get_learning_status(publish_result.request_id)`; do not add polling to the normal agent response path.
 
 Create the client once at the application's normal client/service lifetime rather than once per token or tool event.
 


### PR DESCRIPTION
## Summary
Clarify how coding agents should integrate an application with managed Reflexio: the API key selects the project, session IDs group conversations for evaluation, and learning references attribute only the current turn.

## Changes
- Document project selection through credentials and default-project behavior for unbound legacy keys.
- Explain expected session search deduplication and fresh per-turn learning attribution, including a new session ID for a new conversation.
- Require checking response success and publish warnings, and distinguish publication acceptance from completed extraction in both Python and HTTP guidance.

## Test Plan
- Skill frontmatter validator passed.
- Portable skill test passed (1 test), including copies to coding-agent discovery locations and local reference checks.
- `git diff --check` passed.
- Documentation only; no live organization data published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified integration setup, including managed project API key usage and credential validation.
  - Added guidance for session handling, deduplication, per-turn learning attribution, and request metadata.
  - Documented fail-open behavior when retrieval fails, including success checks and safe diagnostics.
  - Expanded publishing guidance to cover warnings, response diagnostics, retained metadata, and optional learning-status polling.
  - Added verification requirements and updated HTTP and Python integration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->