### PR TITLE
fix(openclaw): remove clear-all's disk-storage handling

### DIFF
--- a/reflexio/integrations/openclaw/plugin/src/openclaw_smart/cli.py
+++ b/reflexio/integrations/openclaw/plugin/src/openclaw_smart/cli.py
@@ -364,8 +364,6 @@ def _storage_config_kind(storage_config: dict[str, object]) -> str:
     ).lower()
     if explicit_type in {"supabase", "postgres"}:
         return "remote"
-    if explicit_type == "disk":
-        return "disk"
     if explicit_type == "sqlite":
         return "sqlite"
     if (
@@ -376,10 +374,13 @@ def _storage_config_kind(storage_config: dict[str, object]) -> str:
         return "remote"
     if "db_url" in storage_config:
         return "remote"
-    if "dir_path" in storage_config:
-        return "disk"
     if "db_path" in storage_config or not storage_config:
         return "sqlite"
+    # Reached by any shape this build cannot interpret -- including a config
+    # left over from the removed disk backend (#98). `validate_stored_config`
+    # rejects those outright, so the server cannot load such an org either: we
+    # do not know what storage it uses, and guessing is not an option for a
+    # destructive command.
     raise _ClearAllError(
         "unsupported reflexio storage_config shape; refusing to delete local data"
     )
@@ -406,23 +407,6 @@ def _validate_deletion_target(path: Path) -> None:
     resolved = path.resolve(strict=False)
     if resolved in _dangerous_clear_all_paths():
         raise _ClearAllError(f"refusing to delete dangerous path: {resolved}")
-
-
-def _disk_org_targets(base_dir: Path) -> list[_ClearAllTarget]:
-    if base_dir.exists() and base_dir.is_symlink():
-        raise _ClearAllError(
-            f"refusing to inspect symlink disk storage dir: {base_dir}"
-        )
-    if not base_dir.exists():
-        return []
-    if not base_dir.is_dir():
-        raise _ClearAllError(
-            f"configured disk storage path is not a directory: {base_dir}"
-        )
-    return [
-        _ClearAllTarget(child, "dir", "disk org data")
-        for child in sorted(base_dir.glob("disk_*"))
-    ]
 
 
 def _derive_db_filename(org_id: str) -> str:
@@ -496,9 +480,9 @@ def _identity_owned_targets(root: Path, org_id: str) -> list[_ClearAllTarget]:
 
     The storage root is shared: after dataset isolation it holds one
     ``reflexio_<org>.db`` per identity, alongside artifacts this plugin does not
-    own (the enterprise ``sql_app.db``, ``disk_*`` trees). ``derive_db_path``
-    documents those siblings as untouched, so enumerate what we own instead of
-    deleting the directory that contains them.
+    own -- the enterprise ``sql_app.db``, for one. ``derive_db_path`` documents
+    those siblings as untouched, so enumerate what we own instead of deleting
+    the directory that contains them.
 
     Args:
         root (Path): The storage root.
@@ -563,14 +547,6 @@ def _resolve_clear_all_targets() -> list[_ClearAllTarget]:
                 targets.extend(
                     _sqlite_artifact_targets(db_path, "configured SQLite data")
                 )
-        elif kind == "disk":
-            raw_dir_path = storage_config.get("dir_path")
-            if not isinstance(raw_dir_path, str) or not raw_dir_path.strip():
-                raise _ClearAllError("configured disk storage is missing dir_path")
-            disk_base = _resolve_absolute_path(
-                raw_dir_path.strip(), source="configured disk dir_path"
-            )
-            targets.extend(_disk_org_targets(disk_base))
 
     deduped: list[_ClearAllTarget] = []
     seen: set[Path] = set()

--- a/reflexio/integrations/openclaw/plugin/tests/test_clear_all_targets.py
+++ b/reflexio/integrations/openclaw/plugin/tests/test_clear_all_targets.py
@@ -14,6 +14,7 @@ goes.
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 from pathlib import Path
@@ -182,6 +183,40 @@ def test_missing_root_resolves_without_creating_it(monkeypatch, tmp_path):
     cli._resolve_clear_all_targets()
 
     assert not absent.exists()
+
+
+@pytest.mark.parametrize(
+    "storage_config",
+    [
+        {"type": "disk", "dir_path": "/tmp/legacy"},
+        {"dir_path": "/tmp/legacy"},
+    ],
+    ids=["explicit-type", "bare-dir-path"],
+)
+def test_a_config_this_build_cannot_interpret_deletes_nothing(
+    monkeypatch, root, tmp_path, storage_config
+):
+    """A leftover disk config refuses, rather than being reinterpreted.
+
+    The disk backend was removed in #98 with no deprecation window, and
+    `validate_stored_config` rejects both of these shapes outright -- so the
+    server cannot load such an org either. We do not know what storage it uses.
+    Mapping them onto `sqlite` would assert something false and delete a
+    database on the strength of a guess; refusing is the existing behaviour for
+    any shape this build cannot interpret, and a destructive command should
+    take it.
+    """
+    ours = root / f"reflexio_{OUR_ORG}.db"
+    _make_db(ours, claimed_by=OUR_ORG)
+
+    config = tmp_path / "config.json"
+    config.write_text(json.dumps({"storage_config": storage_config}))
+    monkeypatch.setattr(cli, "_REFLEXIO_CONFIG_PATH", config)
+
+    with pytest.raises(cli._ClearAllError, match="unsupported"):
+        cli._resolve_clear_all_targets()
+
+    assert ours.exists(), "refused resolution must not have deleted anything"
 
 
 def test_derived_filename_matches_the_canonical_resolver():


### PR DESCRIPTION
Follow-up to #499, which flagged this and deliberately did not touch it.

## Answering the question #499 left open

#499 noted that `_disk_org_targets` globs every `disk_*` child rather than the caller's — the same shape as the bug it fixed — but left it alone, because there was no convention to verify a narrowing against.

There is no convention because **there is no backend**. #98 removed disk storage entirely on 2026-05-28, describing itself as a *"clean cold deletion (no deprecation window)"*. The plugin was never updated to match, so this handling has outlived what it served by three and a half months. The answer was delete, not narrow.

## It is unreachable

- `StorageConfig` is a union of `StorageConfigSQLite | StorageConfigSupabase | StorageConfigPostgres | StorageConfigManagedSupabase | None`. **No disk variant.**
- `_STORAGE_CONFIG_ADAPTER` rejects both legacy shapes outright — verified directly:

  ```
  {'type': 'disk', 'dir_path': '/tmp/x'} -> REJECTED
  {'dir_path': '/tmp/x'}                 -> REJECTED
  ```

- The only surviving `dir_path` reference in the package, in `_storage_labels.py`, is guarded on `cls_name == "StorageConfigLocal"` — a class that no longer exists either. (Left alone here; inert, and outside this file's scope.)
- No `DiskStorage` implementation exists anywhere in either package.

## What is removed

- `_disk_org_targets`
- the `kind == "disk"` branch in `_resolve_clear_all_targets`
- **both legacy shapes in `_storage_config_kind`**

No disk logic remains. The one surviving mention of the word is a comment explaining why the fallthrough below is correct.

## Leftover configs refuse, rather than being reinterpreted

A config left over from the disk backend now falls through to the refusal `_storage_config_kind` already has for shapes it cannot interpret:

> `unsupported reflexio storage_config shape; refusing to delete local data`

That is deliberate. `validate_stored_config` rejects those configs, so the server cannot load such an org either — we genuinely do not know what storage it uses, and a destructive command must not guess.

**An earlier revision of this PR mapped `disk` onto `sqlite` instead. That was wrong on two counts** and has been removed:

1. It asserts something false — a disk config is not a SQLite config — and would delete a database on the strength of that guess, while keeping a removed backend alive under a different name.
2. The reasoning behind it did not hold. I justified it with `resolve_storage_backend`'s fallback to SQLite, but that fallback applies to the **`REFLEXIO_STORAGE` environment variable**, not to a persisted `storage_config`. Different input, different path; the config is simply invalid.

## Test Plan

Local, as Actions has no budget:

- **Plugin suite**: **170 passed, 2 skipped**
- **Full OSS suite**: **6181 passed, 140 skipped**, coverage 83.38% (floor 65%)
- `ruff check` + `ruff format --check`: clean
- `pyright`: **0 errors, 0 warnings**

New test, parametrized over both legacy shapes: each refuses and deletes nothing.

**Mutation-tested**: reinstating the `disk` → `sqlite` mapping fails the `explicit-type` case. Mutation confirmed present before running; file restored by checksum afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `clear-all` now reports unsupported legacy disk storage configurations instead of attempting to remove them.
  - SQLite and remote storage handling remain available.
  - Unsupported storage configurations leave the current identity’s database unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->