### PR TITLE
fix(tests): stop a live-provider eval test from grading the mock

### DIFF
--- a/tests/eval/consolidation/test_consolidation_eval.py
+++ b/tests/eval/consolidation/test_consolidation_eval.py
@@ -21,6 +21,7 @@ from reflexio.server.services.playbook.components.consolidator import (
     RejectNewDecision,
     UnifyDecision,
 )
+from reflexio.test_support.llm_mock import assert_litellm_unpatched
 from reflexio.test_support.skip_decorators import skip_low_priority
 from tests.eval.consolidation.case import (
     ConsolidationEvalCase,
@@ -519,6 +520,10 @@ def test_live_consolidation_provider_real(tmp_path):  # pragma: no cover - manua
     the fixture. Asserts only pipeline mechanics (every case produced one of
     the four kinds), never exact kinds. Run manually with API keys +
     RUN_LOW_PRIORITY=1."""
+    # This test lives outside ``tests/e2e_tests/``, so the session-wide
+    # ``litellm.completion`` patch is installed for it. Without this it would
+    # grade canned mock text while reporting a real model.
+    assert_litellm_unpatched()
     from reflexio.server.api_endpoints.request_context import RequestContext
     from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 
@@ -544,6 +549,10 @@ def test_live_consolidation_provider_real(tmp_path):  # pragma: no cover - manua
 @skip_low_priority
 def test_real_judge_smoke():  # pragma: no cover - manual, costs money
     """Smoke test against a real judge model. Run manually with API keys."""
+    # This test lives outside ``tests/e2e_tests/``, so the session-wide
+    # ``litellm.completion`` patch is installed for it. Without this it would
+    # grade canned mock text while reporting a real model.
+    assert_litellm_unpatched()
     from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 
     client = LiteLLMClient(LiteLLMConfig(model="claude-haiku-4-5"))

--- a/tests/eval/extraction/test_extraction_eval.py
+++ b/tests/eval/extraction/test_extraction_eval.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 from pydantic import BaseModel
 
+from reflexio.test_support.llm_mock import assert_litellm_unpatched
 from reflexio.test_support.skip_decorators import skip_low_priority
 from tests.eval.conftest import _load, _load_rubric
 from tests.eval.extraction.providers import make_extraction_provider
@@ -180,6 +181,10 @@ def test_score_golden_case(extraction_case, extraction_judge):
 @skip_low_priority
 def test_real_judge_smoke():  # pragma: no cover - manual, costs money
     """Smoke test against a real judge model. Run manually with API keys."""
+    # This test lives outside ``tests/e2e_tests/``, so the session-wide
+    # ``litellm.completion`` patch is installed for it. Without this it would
+    # grade canned mock text while reporting a real model.
+    assert_litellm_unpatched()
     from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 
     rubric = _load_rubric("extraction_rubric.yaml")
@@ -298,6 +303,10 @@ def test_live_extraction_provider_real(tmp_path):  # pragma: no cover - manual
     in range), never exact scores. Run manually with API keys +
     RUN_LOW_PRIORITY=1.
     """
+    # This test lives outside ``tests/e2e_tests/``, so the session-wide
+    # ``litellm.completion`` patch is installed for it. Without this it would
+    # grade canned mock text while reporting a real model.
+    assert_litellm_unpatched()
     from reflexio.server.api_endpoints.request_context import RequestContext
     from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
 

--- a/tests/eval/scenarios/test_scenario_eval.py
+++ b/tests/eval/scenarios/test_scenario_eval.py
@@ -14,6 +14,7 @@ from reflexio.server.services.playbook.components.consolidator import (
     RejectNewDecision,
     UnifyDecision,
 )
+from reflexio.test_support.llm_mock import assert_litellm_unpatched
 from reflexio.test_support.skip_decorators import skip_low_priority
 from tests.eval.consolidation.judge import ConsolidationVerdict
 from tests.eval.scenarios.book import _next_id, apply_consolidation
@@ -172,6 +173,10 @@ def test_wrong_consolidation_verdict_fails_scenario() -> None:
 
 @skip_low_priority
 def test_scenario_real(tmp_path) -> None:  # pragma: no cover - manual, costs money
+    # This test lives outside ``tests/e2e_tests/``, so the session-wide
+    # ``litellm.completion`` patch is installed for it. Without this it would
+    # grade canned mock text while reporting a real model.
+    assert_litellm_unpatched()
     from reflexio.server.api_endpoints.request_context import RequestContext
     from reflexio.server.llm.litellm_client import LiteLLMClient, LiteLLMConfig
     from tests.eval.consolidation.providers import (


### PR DESCRIPTION
## The claim that was false

Five tests under `tests/eval/` build a real `LiteLLMClient` and say so in their docstrings — *"Real end-to-end smoke: live extractors + real LLM"*, *"Smoke test against a real judge model"*.

None of them can reach a provider. Per `.claude/rules/testing-conventions.md`, a live test does that only if it lives under `tests/e2e_tests/` **and** carries `requires_credentials`. These satisfy neither, so `_is_e2e_test_run` installs the session-wide `litellm.completion` patch and they grade canned text.

## Measured, not argued

`RUN_LOW_PRIORITY=1` is the only way these ever run. With it:

```
before: 4 failed, 44 passed
after:  5 failed, 43 passed
```

**One test flipped: `test_live_extraction_provider_real`. It was PASSING** — reporting a green live-LLM smoke while grading mock output. That is the bug.

The other four were already failing, but for a reason that named the wrong thing — `StructuredOutputParseError` / `StructuredOutputRepairError`, i.e. *"the canned response does not fit the schema"*, when the actual problem is that a canned response is in play at all.

## The fix

Each of the five now calls `assert_litellm_unpatched()` — the backstop this repo already ships for exactly this case, and which the e2e live tests already use. One false pass becomes an honest failure; four confusing failures name their real cause:

```
AssertionError: litellm.completion is patched, so this live-provider test would
assert against canned mock text. Live tests belong under tests/e2e_tests/ and
must carry the requires_credentials marker; the e2e conftest lifts the session
patch for those.
```

## What this deliberately does not do

It does not move them under `tests/e2e_tests/`. That is the other half of the documented recipe and would make them actually run — but they depend on `tests/eval/`'s own fixtures and provider factories, so relocating them is a larger change than making them honest. Worth doing separately if you want these live smokes to earn their keep.

They remain `@skip_low_priority`, so the default suite is unchanged.

## Test Plan

Local, as Actions has no budget:

| Check | Result |
| --- | --- |
| `ruff check` + `ruff format --check` on `tests/eval/` | clean |
| `pytest tests/eval` (normal run) | **93 passed, 5 skipped**, exit 0 |
| Full OSS suite | **6220 passed, 101 skipped**, exit 0 |

The before/after comparison above was produced by reverting the three files, re-running, and restoring them from byte-exact copies **verified by checksum** — not by trusting `git checkout --` to bring the work back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added safeguards to real-model evaluation tests to verify that test mocks are inactive before making live model calls.
  - Improved reliability of consolidation, extraction, and scenario evaluation smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->